### PR TITLE
Add mdBook build and GitHub Pages deployment

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -1,0 +1,56 @@
+name: Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/spec/**"
+      - "docs/guide/**"
+      - ".github/workflows/pages.yaml"
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build books
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install mdBook
+        uses: peaceiris/actions-mdbook@v2
+        with:
+          mdbook-version: latest
+
+      - name: Build spec book
+        run: mdbook build docs/spec
+
+      - name: Build guide book
+        run: mdbook build docs/guide
+
+      - name: Copy landing page
+        run: cp docs/index.html _site/index.html
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+
+  deploy:
+    name: Deploy to Pages
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ node_modules/
 dist/
 build/
 target/
+_site/
 
 # Deno
 .deno/

--- a/deno.json
+++ b/deno.json
@@ -7,5 +7,8 @@
   },
   "workspace": [
     "./packages/markspec"
-  ]
+  ],
+  "fmt": {
+    "exclude": ["docs/index.html"]
+  }
 }

--- a/docs/guide/book.toml
+++ b/docs/guide/book.toml
@@ -1,0 +1,13 @@
+[book]
+title = "MarkSpec User Guide"
+authors = ["DriftSys"]
+language = "en"
+src = "."
+
+[build]
+build-dir = "../../_site/guide"
+
+[output.html]
+no-section-label = true
+git-repository-url = "https://github.com/driftsys/markspec"
+edit-url-template = "https://github.com/driftsys/markspec/edit/main/docs/guide/{path}"

--- a/docs/index.html
+++ b/docs/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>MarkSpec Documentation</title>
   <style>
     body {

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>MarkSpec Documentation</title>
+  <style>
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+        Helvetica, Arial, sans-serif;
+      max-width: 600px;
+      margin: 80px auto;
+      padding: 0 20px;
+      color: #333;
+    }
+    h1 { font-size: 1.8rem; margin-bottom: 0.5rem; }
+    p { color: #666; margin-bottom: 2rem; }
+    a {
+      display: block;
+      padding: 16px 20px;
+      margin-bottom: 12px;
+      border: 1px solid #ddd;
+      border-radius: 6px;
+      text-decoration: none;
+      color: #0072b2;
+      font-weight: 500;
+    }
+    a:hover { background: #f8f8f8; border-color: #0072b2; }
+    a span { display: block; color: #888; font-size: 0.85rem; font-weight: 400; margin-top: 4px; }
+  </style>
+</head>
+<body>
+  <h1>MarkSpec</h1>
+  <p>Markdown flavor and toolchain for traceable industrial documentation.</p>
+  <a href="spec/">
+    Language Specification
+    <span>CommonMark + GFM/GLFM subset, entry format, attributes, directives</span>
+  </a>
+  <a href="guide/">
+    User Guide
+    <span>Getting started, configuration, CLI reference, recipes</span>
+  </a>
+</body>
+</html>

--- a/docs/spec/book.toml
+++ b/docs/spec/book.toml
@@ -1,0 +1,13 @@
+[book]
+title = "MarkSpec Language Specification"
+authors = ["DriftSys"]
+language = "en"
+src = "."
+
+[build]
+build-dir = "../../_site/spec"
+
+[output.html]
+no-section-label = true
+git-repository-url = "https://github.com/driftsys/markspec"
+edit-url-template = "https://github.com/driftsys/markspec/edit/main/docs/spec/{path}"

--- a/dprint.json
+++ b/dprint.json
@@ -23,6 +23,7 @@
     "**/target",
     "**/dist",
     "**/build",
+    "_site",
     "CHANGELOG.md"
   ],
   "plugins": [

--- a/justfile
+++ b/justfile
@@ -24,6 +24,16 @@ fmt:
     deno fmt
     dprint fmt
 
+# Build spec and guide books (requires mdbook)
+book:
+    mdbook build docs/spec
+    mdbook build docs/guide
+    cp docs/index.html _site/index.html
+
+# Serve books locally with live reload
+book-dev:
+    mdbook serve docs/spec --open
+
 # Remove build artifacts
 clean:
-    rm -rf node_modules .dprint
+    rm -rf node_modules .dprint _site

--- a/justfile
+++ b/justfile
@@ -30,9 +30,9 @@ book:
     mdbook build docs/guide
     cp docs/index.html _site/index.html
 
-# Serve books locally with live reload
-book-dev:
-    mdbook serve docs/spec --open
+# Serve a book locally with live reload (default: spec)
+book-dev book="spec":
+    mdbook serve docs/{{book}} --open
 
 # Remove build artifacts
 clean:


### PR DESCRIPTION
## Summary

- Add book.toml for docs/spec/ and docs/guide/ books using mdBook
- Add pages.yaml workflow that builds both books and deploys to GitHub Pages on push to main
- Add landing page (docs/index.html) linking to both books
- Add just book and just book-dev tasks for local builds
- Exclude _site/ from git and dprint

## Test plan

- [x] mdbook build docs/spec builds cleanly
- [x] mdbook build docs/guide builds cleanly
- [x] just build passes (check, test, lint, dprint)
- [ ] After merge, verify Pages deployment at the repo GitHub Pages URL
- [ ] Enable GitHub Pages source as GitHub Actions in repo settings if not already configured

Generated with [Claude Code](https://claude.com/claude-code)