### PR TITLE
Add release workflow, install script, and compile task

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,89 @@
+name: Release
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build (${{ matrix.target }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+            binary: markspec
+          - target: x86_64-apple-darwin
+            os: macos-latest
+            binary: markspec
+          - target: aarch64-apple-darwin
+            os: macos-latest
+            binary: markspec
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - name: Compile
+        run: |
+          deno compile --allow-read --allow-write --allow-run --allow-env \
+            --target ${{ matrix.target }} \
+            --output ${{ matrix.binary }} \
+            packages/markspec/main.ts
+
+      - name: Package
+        run: |
+          tar czf markspec-${{ matrix.target }}.tar.gz ${{ matrix.binary }}
+          shasum -a 256 markspec-${{ matrix.target }}.tar.gz > markspec-${{ matrix.target }}.tar.gz.sha256
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: markspec-${{ matrix.target }}
+          path: |
+            markspec-${{ matrix.target }}.tar.gz
+            markspec-${{ matrix.target }}.tar.gz.sha256
+
+  release:
+    name: GitHub Release
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: Create release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: |
+            artifacts/*.tar.gz
+            artifacts/*.sha256
+
+  publish:
+    name: Publish to JSR
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - name: Publish
+        run: deno publish --allow-dirty

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+# Install markspec — downloads the latest release binary for the current platform.
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/driftsys/markspec/main/install.sh | bash
+#
+# Environment variables:
+#   MARKSPEC_INSTALL_DIR  Installation directory (default: $HOME/.local/bin)
+#   MARKSPEC_VERSION      Version to install (default: latest)
+
+set -euo pipefail
+
+REPO="driftsys/markspec"
+INSTALL_DIR="${MARKSPEC_INSTALL_DIR:-$HOME/.local/bin}"
+BINARY="markspec"
+
+detect_target() {
+  local os arch
+  os="$(uname -s)"
+  arch="$(uname -m)"
+
+  case "$os" in
+    Linux)
+      case "$arch" in
+        x86_64) echo "x86_64-unknown-linux-gnu" ;;
+        *) echo "error: unsupported architecture: $arch" >&2; exit 1 ;;
+      esac
+      ;;
+    Darwin)
+      case "$arch" in
+        x86_64) echo "x86_64-apple-darwin" ;;
+        arm64)  echo "aarch64-apple-darwin" ;;
+        *) echo "error: unsupported architecture: $arch" >&2; exit 1 ;;
+      esac
+      ;;
+    *) echo "error: unsupported OS: $os" >&2; exit 1 ;;
+  esac
+}
+
+get_version() {
+  if [ -n "${MARKSPEC_VERSION:-}" ]; then
+    echo "$MARKSPEC_VERSION"
+  else
+    gh release view --repo "$REPO" --json tagName -q .tagName 2>/dev/null \
+      || curl -fsSL "https://api.github.com/repos/$REPO/releases/latest" \
+           | grep '"tag_name"' | head -1 | cut -d'"' -f4
+  fi
+}
+
+main() {
+  local target version tarball url checksum_url
+  target="$(detect_target)"
+  version="$(get_version)"
+  tarball="markspec-${target}.tar.gz"
+  url="https://github.com/$REPO/releases/download/$version/$tarball"
+  checksum_url="${url}.sha256"
+
+  echo "Installing markspec $version ($target)" >&2
+  echo "  to: $INSTALL_DIR" >&2
+
+  local tmpdir
+  tmpdir="$(mktemp -d)"
+  trap 'rm -rf "$tmpdir"' EXIT
+
+  curl -fsSL "$url" -o "$tmpdir/$tarball"
+  curl -fsSL "$checksum_url" -o "$tmpdir/$tarball.sha256"
+
+  echo "Verifying checksum..." >&2
+  (cd "$tmpdir" && shasum -a 256 -c "$tarball.sha256")
+
+  tar xzf "$tmpdir/$tarball" -C "$tmpdir"
+
+  mkdir -p "$INSTALL_DIR"
+  mv "$tmpdir/$BINARY" "$INSTALL_DIR/$BINARY"
+  chmod +x "$INSTALL_DIR/$BINARY"
+
+  echo "Installed $INSTALL_DIR/$BINARY" >&2
+
+  if ! echo "$PATH" | tr ':' '\n' | grep -qx "$INSTALL_DIR"; then
+    echo "" >&2
+    echo "Add to your PATH:" >&2
+    echo "  export PATH=\"$INSTALL_DIR:\$PATH\"" >&2
+  fi
+}
+
+main

--- a/justfile
+++ b/justfile
@@ -34,6 +34,25 @@ book:
 book-dev book="spec":
     mdbook serve docs/{{book}} --open
 
+# Bump version, update changelog, commit, and tag
+bump:
+    git std bump
+
+# Publish to JSR
+publish: build
+    deno publish
+
+# Compile the CLI binary for the current platform
+compile:
+    deno compile --allow-read --allow-write --allow-run --allow-env \
+        --output markspec \
+        packages/markspec/main.ts
+
+# Bump, push tag, and publish (full local release flow)
+release: bump
+    git push --follow-tags
+    just publish
+
 # Remove build artifacts
 clean:
-    rm -rf node_modules .dprint _site
+    rm -rf node_modules .dprint _site markspec


### PR DESCRIPTION
## Summary

- Add `release.yaml` workflow triggered on `v*` tags:
  - Compiles markspec via `deno compile` for 3 targets (Linux x86_64, macOS Intel, macOS Apple Silicon)
  - Creates GitHub Release with tarballs + SHA256 checksums
  - Publishes `@driftsys/markspec` to JSR
- Add `install.sh` for curl-pipe installation with platform detection and checksum verification
- Add `just release` (calls `git std bump`) and `just compile` tasks

## Release flow

1. `just release` — bumps version, updates changelog, commits, tags
2. `git push --follow-tags` — triggers release workflow
3. Workflow builds binaries, creates GitHub Release, publishes to JSR

## Test plan

- [ ] `just build` passes
- [ ] `just compile` produces a working binary
- [ ] After first tag push, verify release workflow creates GitHub Release with artifacts
- [ ] Verify `install.sh` downloads and installs correctly

Generated with [Claude Code](https://claude.com/claude-code)