### PR TITLE
Add ADR/SAD templates and cheat sheet

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -6,6 +6,8 @@ on:
     paths:
       - "docs/spec/**"
       - "docs/guide/**"
+      - "docs/markspec-cheatsheet.typ"
+      - "docs/index.html"
       - ".github/workflows/pages.yaml"
 
 permissions:
@@ -34,6 +36,20 @@ jobs:
 
       - name: Build guide book
         run: mdbook build docs/guide
+
+      - name: Install Typst
+        uses: typst-community/setup-typst@v4
+
+      - name: Install IBM Plex fonts
+        run: |
+          mkdir -p ~/.local/share/fonts
+          curl -fsSL https://github.com/IBM/plex/releases/download/v6.4.2/IBM-Plex-Sans.zip -o /tmp/sans.zip
+          curl -fsSL https://github.com/IBM/plex/releases/download/v6.4.2/IBM-Plex-Mono.zip -o /tmp/mono.zip
+          unzip -qo /tmp/sans.zip -d ~/.local/share/fonts/
+          unzip -qo /tmp/mono.zip -d ~/.local/share/fonts/
+
+      - name: Build cheat sheet
+        run: typst compile docs/markspec-cheatsheet.typ _site/markspec-cheatsheet.pdf
 
       - name: Copy landing page
         run: cp docs/index.html _site/index.html

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ build/
 target/
 _site/
 npm/
+*.pdf
 
 # Deno
 .deno/

--- a/docs/index.html
+++ b/docs/index.html
@@ -40,5 +40,9 @@
     User Guide
     <span>Getting started, configuration, CLI reference, recipes</span>
   </a>
+  <a href="markspec-cheatsheet.pdf">
+    Cheat Sheet (PDF)
+    <span>Two-page reference — flavor, entries, attributes, directives, books</span>
+  </a>
 </body>
 </html>

--- a/docs/markspec-cheatsheet.typ
+++ b/docs/markspec-cheatsheet.typ
@@ -1,0 +1,479 @@
+#set page(paper: "a4", flipped: true, margin: (x: 0.6cm, y: 0.6cm))
+#set text(font: "IBM Plex Sans", size: 8pt)
+#set par(leading: 0.4em, spacing: 0.6em)
+#show heading.where(level: 1): it => {
+  v(0.7em)
+  text(size: 10pt, weight: "bold", it.body)
+  v(0.15em)
+}
+#show heading.where(level: 2): it => {
+  v(0.3em)
+  text(size: 8pt, weight: "bold", it.body)
+  v(0.05em)
+}
+#show heading.where(level: 3): set text(size: 7.5pt, weight: "bold")
+#show raw: set text(font: "IBM Plex Mono", size: 7pt)
+
+#let code(body) = block(
+  fill: luma(245), radius: 2pt, inset: 4pt, width: 100%, body,
+)
+
+// ── Page 1: Markdown Flavor & Entries ──────────────────────────────────
+
+#align(center, text(14pt, weight: "bold")[MarkSpec Cheat Sheet — Flavor & Entries])
+#v(0.6em)
+
+#columns(3, gutter: 14pt)[
+
+= Markdown flavor
+
+#table(
+  columns: (1fr, 1fr),
+  stroke: 0.4pt + luma(180),
+  inset: 3pt,
+  table.header[*Feature*][*MarkSpec*],
+  [Headings], [`#` ATX only],
+  [Emphasis], [`_text_` underscores],
+  [Strong], [`**text**` asterisks],
+  [Lists], [`-` dashes only],
+  [Code fences], [Backticks + lang required],
+  [Line breaks], [Trailing `\` only],
+  [Horiz. rules], [`---` only],
+  [Inline HTML], [Comments only],
+  [H1], [First line, exactly one],
+  [Heading levels], [No skipping],
+  [Images], [Alt text required],
+  [Front matter], [Not allowed],
+)
+
+== GFM / GLFM shared
+
+Tables (pipe) · Strikethrough `~~text~~` · Task lists `- [x]` · Footnotes `[^1]` · Math `$x$` `$$x$$`
+
+== Alerts
+
+#code[```markdown
+> [!WARNING]
+> **Custom title** — Body.
+```]
+
+`NOTE` · `TIP` · `IMPORTANT` · `WARNING` · `CAUTION`
+
+== Formatting rules
+
+#table(
+  columns: (1fr, 1fr),
+  stroke: 0.4pt + luma(180),
+  inset: 3pt,
+  [Line width], [80 (configurable)],
+  [Prose wrap], [`always` (configurable)],
+  [Line endings], [`lf`],
+  [List indent], [2 spaces],
+  [Final newline], [Single `\n`],
+  [Formatter], [dprint (not Prettier)],
+)
+
+== Autolinks
+
+`<https://example.com>` · `<user@example.com>`
+
+= Captions
+
+== Table caption (above table)
+
+#code[```markdown
+_Table: Sensor thresholds_
+
+| Col | Col |
+| --- | --- |
+| val | val |
+```]
+
+Slug: `tbl.sensor-thresholds`
+
+== Figure caption (below image)
+
+#code[```markdown
+![Alt text](image.svg)
+
+_Figure: Architecture overview_
+```]
+
+Slug: `fig.architecture-overview`
+
+#colbreak()
+
+= Entry blocks
+
+#code[```markdown
+- [SRS_BRK_0107] Sensor debouncing
+
+  The sensor driver shall debounce
+  raw inputs to eliminate noise.
+
+  Id: SRS_01HGW2Q8MNP3\
+  Satisfies: SYS_BRK_0042\
+  Labels: ASIL-B
+```]
+
+No `_emphasis_` inside entries. `**Strong**` and `` `code` `` ok.
+
+== Display ID format
+
+`TYPE_XXX_NNNN`
+
+- *TYPE* — STK, SYS, SRS, SAD, ICD, VAL, SIT, SWT
+- *XXX* — 2–6 uppercase letters (project abbrev)
+- *NNNN* — zero-padded, unique in project
+
+== ULID
+
+`TYPE_01HGW2Q8MNP3` — 12–13 chars. Assigned by tooling, never changes.
+
+== Entry types
+
+#table(
+  columns: (auto, auto, 1fr),
+  stroke: 0.4pt + luma(180),
+  inset: 3pt,
+  table.header[*Cat.*][*Type*][*Name*],
+  [Req], [STK], [Stakeholder requirement],
+  [], [SYS], [System requirement],
+  [], [SRS], [Software requirement],
+  [Arch], [SAD], [Architecture description],
+  [], [ICD], [Interface control document],
+  [Test], [VAL], [Acceptance test],
+  [], [SIT], [System integration test],
+  [], [SWT], [Software test],
+)
+
+= In-code entries
+
+#code[```kotlin
+/**
+ * [SRS_BRK_0107] Sensor debouncing
+ *
+ * The sensor driver shall reject
+ * transient noise shorter than the
+ * configured debounce window.
+ *
+ * Id: SRS_01HGW2R9QLP4\
+ * Satisfies: SYS_BRK_0042\
+ * Labels: ASIL-B
+ */
+@Test
+fun `swt_brk_0107 debounce`() { }
+```]
+
+== Code annotations
+
+#code[```kotlin
+/** Verifies: SRS_BRK_0107 */
+/** Implements: SRS_BRK_0107 */
+```]
+
+Languages: Rust `///` · Kotlin `/** */` · C++ `///` · C `/** */` · Java 23+ `///`
+
+#colbreak()
+
+= Attributes
+
+== Authored (committed)
+
+#table(
+  columns: (auto, 1fr),
+  stroke: 0.4pt + luma(180),
+  inset: 3pt,
+  table.header[*Attr*][*Description*],
+  [`Id`], [ULID, mandatory],
+  [`Satisfies`], [Upstream parent ID(s)],
+  [`Derived-from`], [External ref + section],
+  [`Labels`], [Comma-separated tags],
+)
+
+== Generated (never in source)
+
+`Verified-by` · `Implemented-by`
+
+== SAD-specific
+
+#table(
+  columns: (auto, 1fr),
+  stroke: 0.4pt + luma(180),
+  inset: 3pt,
+  [`Allocates`], [SRS display ID(s)],
+  [`Component`], [Name or registry ID],
+  [`Constrains`], [Component name(s)],
+)
+
+== ICD-specific
+
+#table(
+  columns: (auto, 1fr),
+  stroke: 0.4pt + luma(180),
+  inset: 3pt,
+  [`Between`], [Two parties, comma-separated],
+  [`Interface`], [RIDL ref `{{ridl.id}}`],
+)
+
+== Derived-from format
+
+#code[```text
+Derived-from: ISO-26262-6 §9.4
+```]
+
+ID validated; section locator is free text.
+
+= ATDD example (Kotlin + Gherkin)
+
+#code[```kotlin
+/**
+ * [SYS_BRK_0042] Sensor noise filtering
+ *
+ * Scenario: Reject transient noise
+ *   Given a raw sensor input of 512
+ *   And a noise spike of 50 lasting 2ms
+ *   When the debounce window is 5ms
+ *   Then the output shall remain 512
+ *
+ * Id: SYS_01HGW2P4KFR7\
+ * Satisfies: STK_BRK_0001\
+ * Labels: ASIL-B
+ */
+@Test
+fun `sit_brk_0042 reject transient noise`() {
+    val sensor = SensorDriver(debounceMs = 5)
+    sensor.feed(512, spikeOf(50, durationMs = 2))
+    assertEquals(512, sensor.output())
+}
+```]
+
+]
+
+// ── Page 2: Directives, Books, References ──────────────────────────────
+
+#pagebreak()
+
+#align(center, text(14pt, weight: "bold")[MarkSpec Cheat Sheet — Directives, Books & References])
+#v(0.6em)
+
+#columns(3, gutter: 14pt)[
+
+= Directives
+
+HTML comments: `<!-- markspec:NAME -->`. Invisible on GitHub/GitLab.
+
+== Document directives (after H1)
+
+#table(
+  columns: (auto, 1fr),
+  stroke: 0.4pt + luma(180),
+  inset: 3pt,
+  table.header[*Directive*][*Purpose*],
+  [`glossary`], [Term definitions],
+  [`summary`], [Book table of contents],
+  [`deck`], [Slide deck],
+  [`references`], [Standards registry],
+  [`deprecated`], [Mark deprecated],
+  [`paginate`], [Pagination (deck)],
+)
+
+Auto-detected: `glossary` from `GLOSSARY.md`, `summary` from `SUMMARY.md`.
+
+== Inline directives
+
+#table(
+  columns: (auto, 1fr),
+  stroke: 0.4pt + luma(180),
+  inset: 3pt,
+  table.header[*Directive*][*Purpose*],
+  [`break page`], [Page break],
+  [`break column`], [Column break],
+  [`columns 2`], [Multi-column],
+  [`section Name`], [Deck section],
+  [`notes`], [Speaker notes],
+  [`disable ID`], [Suppress lint],
+  [`disable-next-line`], [Suppress next line],
+  [`ignore`], [Skip block],
+)
+
+Close range directives with `<!-- markspec:end NAME -->`.
+
+== Multi-column
+
+#code[```markdown
+<!-- markspec:columns 2 -->
+
+Left column.
+
+<!-- markspec:break column -->
+
+Right column.
+
+<!-- markspec:end columns -->
+```]
+
+== Speaker notes (deck)
+
+#code[```markdown
+<!--
+markspec:notes
+Mention the 150ms requirement.
+-->
+```]
+
+== Lint suppression
+
+#code[```markdown
+<!-- markspec:disable MSL-R011 -->
+
+- [SRS_BRK_0108] Legacy req
+
+<!-- markspec:end disable -->
+```]
+
+#colbreak()
+
+= Deck (presentations)
+
+`---` = slide break. H2 starts each slide.
+
+#code[```markdown
+# Presentation Title
+
+<!-- markspec:deck -->
+
+## First Slide
+
+Content here.
+
+---
+
+## Second Slide
+
+More content.
+
+<!-- markspec:section Demo -->
+
+## Demo Slide
+```]
+
+= Mustache references
+
+#code[```text
+{{namespace.id}}
+```]
+
+Two braces. No sections or partials. Not resolved inside code fences.
+
+== Namespaces
+
+#table(
+  columns: (auto, 1fr),
+  stroke: 0.4pt + luma(180),
+  inset: 3pt,
+  table.header[*NS*][*Example*],
+  [`req`], [`{{req.SRS_BRK_0107}}`],
+  [`arch`], [`{{arch.SAD_BRK_0001}}`],
+  [`test`], [`{{test.SWT_BRK_0107}}`],
+  [`ref`], [`{{ref.ISO-26262-6}}`],
+  [`fig`], [`{{fig.system-overview}}`],
+  [`tbl`], [`{{tbl.sensor-thresholds}}`],
+  [`h`], [`{{h.section-heading}}`],
+)
+
+= Reference entries
+
+Only in `references` document type. Display ID = slug.
+
+#code[```markdown
+- [ISO-26262-6] ISO 26262 Part 6
+
+  Road vehicles — Functional
+  safety — Part 6: Software.
+
+  Document: ISO 26262-6:2018\
+  URL: https://www.iso.org/...
+```]
+
+== Reference attributes
+
+#table(
+  columns: (auto, 1fr),
+  stroke: 0.4pt + luma(180),
+  inset: 3pt,
+  table.header[*Attribute*][*Description*],
+  [`Document`], [Full document ID],
+  [`URL`], [Canonical URL],
+  [`Status`], [active / withdrawn / superseded],
+  [`Superseded-by`], [Replacement entry ID],
+  [`Derived-from`], [Parent standard],
+)
+
+#colbreak()
+
+= Book structure
+
+== SUMMARY.md
+
+#code[```markdown
+# Book Title
+
+[Overview](overview.md)
+
+---
+
+# Part Name
+
+- [Chapter](chapter.md)
+  - [Sub](sub.md)
+
+# Another Part
+
+- [Chapter 2](chapter2.md)
+
+---
+
+[Glossary](GLOSSARY.md)
+[Contributing](CONTRIBUTING.md)
+```]
+
+- First H1 = book title
+- Other H1s = part headings (dividers)
+- `---` = separators
+- Front/back = unnested, no numbering
+- Every link target must exist
+- Human-authored, tooling validates
+
+== Glossary format
+
+H1 = title, H2 = letter groups, H3 = terms. Link refs at end, alphabetical.
+
+#code[```markdown
+# Glossary
+
+## A
+
+### ASIL
+
+Automotive Safety Integrity Level...
+
+[ASIL]: #asil
+```]
+
+= Document types
+
+#table(
+  columns: (auto, auto, 1fr),
+  stroke: 0.4pt + luma(180),
+  inset: 3pt,
+  table.header[*Type*][*Detection*][*Description*],
+  [`doc`], [default], [Any Markdown file],
+  [`glossary`], [name/directive], [Terms],
+  [`summary`], [name/directive], [Book TOC],
+  [`references`], [name/directive], [Standards],
+  [`deck`], [directive only], [Slides],
+  [`code`], [extension], [Source + doc comments],
+)
+
+]

--- a/docs/templates/adr-nnn-topic.md
+++ b/docs/templates/adr-nnn-topic.md
@@ -1,0 +1,85 @@
+# ADR-NNN: Title
+
+<!-- Replace NNN with the next sequential number.
+     Title should be a short noun phrase: "Message broker selection",
+     "Authentication strategy", "Sensor data pipeline". -->
+
+## Context
+
+<!-- What problem or need motivates this decision? Include constraints,
+     forces, and relevant background. Keep it factual — one or two paragraphs.
+
+     Example: "The braking ECU receives raw sensor data at 1 kHz. The current
+     polling architecture cannot meet the 150 ms response time requirement
+     under peak load. We need an interrupt-driven pipeline." -->
+
+## Decision
+
+<!-- State the decision, then capture each design choice as a SAD or ICD
+     requirement using MarkSpec entry blocks.
+
+     Use SAD for internal architecture decisions.
+     Use ICD for interface contracts between components or systems.
+     Replace XXX with your project/domain abbreviation (e.g., BRK, NAV, COM).
+     Replace NNNN with the next number in your project sequence.
+     Leave Id empty — tooling assigns the ULID on commit. -->
+
+- [SAD_XXX_NNNN] Decision title
+
+  <!-- One or two paragraphs describing what the system shall do and why.
+       Use "shall" for normative statements.
+
+       Example: "The sensor pipeline shall use an interrupt-driven architecture
+       with a lock-free ring buffer to decouple acquisition from processing." -->
+
+  Id:\
+  Satisfies:\
+  Labels:
+
+  <!-- Id: left empty, assigned by `markspec doc format`.
+       Satisfies: upstream requirement ID (e.g., STK_BRK_0001, SYS_BRK_0042).
+       Labels: classification tags (e.g., ASIL-B, security, performance).
+       Remove unused attributes rather than leaving them blank. -->
+
+<!-- Add more entry blocks as needed. One block per distinct decision point.
+     Mix SAD and ICD blocks when the decision spans both internal architecture
+     and external interfaces.
+
+- [ICD_XXX_NNNN] Interface title
+
+  Description of the interface contract.
+
+  Id: \
+  Satisfies: \
+  Labels:
+
+-->
+
+## Alternatives rejected
+
+<!-- List each alternative considered and why it was not chosen.
+     One heading per alternative, a short paragraph explaining the reason.
+
+     Example:
+
+### Polling architecture
+
+Simpler to implement but cannot meet the 150 ms latency target under peak
+load. Measured worst-case latency of 320 ms in prototype.
+
+### DMA-based pipeline
+
+Meets latency requirements but requires hardware support not available on
+all target ECUs. Would limit portability across the product line.
+
+-->
+
+## Consequences
+
+<!-- What changes as a result of this decision? List both positive and
+     negative implications. Keep it honest — every decision has trade-offs.
+
+     Example:
+     - Interrupt-driven pipeline meets the 150 ms latency target.
+     - Ring buffer adds memory overhead (configurable, default 4 KB).
+     - Team needs to learn lock-free programming patterns. -->

--- a/docs/templates/sad-nnn-topic.md
+++ b/docs/templates/sad-nnn-topic.md
@@ -1,0 +1,136 @@
+# SAD-NNN: Title
+
+<!-- Replace NNN with the next sequential number.
+     Title should name the system or subsystem: "Braking ECU",
+     "Telemetry gateway", "Sensor acquisition pipeline". -->
+
+## Context
+
+<!-- What is this system? What problem does it solve? What are the key
+     stakeholders and quality goals? Include a context diagram showing the
+     system boundary and its neighbours.
+     Keep it to one or two paragraphs + a diagram. -->
+
+<!-- ![Context diagram](diagrams/sad-nnn-context.svg) -->
+
+## Architecture
+
+<!-- How is the system built? Include a diagram showing components and
+     their relationships. One SAD entry per significant design decision. -->
+
+<!-- ![Architecture diagram](diagrams/sad-nnn-architecture.svg) -->
+
+- [SAD_XXX_NNNN] Architectural decision title
+
+  <!-- Example: "The acquisition module shall use a lock-free ring buffer
+       to decouple sensor sampling from processing." -->
+
+  Id:\
+  Satisfies:\
+  Labels:
+
+## Interfaces
+
+<!-- One ICD entry per external interface between the components above.
+     Describe protocol, data format, direction, rate, and constraints. -->
+
+- [ICD_XXX_NNNN] Interface title
+
+  <!-- Example: "The sensor gateway shall expose a CAN 2.0B interface
+       publishing filtered sensor frames at 100 Hz." -->
+
+  Id:\
+  Satisfies:\
+  Labels:
+
+## Constraints
+
+<!-- Non-functional requirements that shape the architecture.
+     Each subsection below is mandatory — state the applicable constraints
+     or explicitly write "Not applicable" with justification.
+     Use SYS_ for system-level constraints, SRS_ for software-level. -->
+
+### Regulation
+
+Not applicable.
+
+<!-- Replace with applicable standards, certifications, compliance requirements.
+     Examples: ISO 26262, IEC 61508, DO-178C, AUTOSAR, MISRA, EU MDR.
+
+- [SYS_XXX_NNNN] Regulation constraint
+
+  Description of the regulatory constraint.
+
+  Id:\
+  Satisfies:\
+  Labels:
+
+-->
+
+### Privacy
+
+Not applicable.
+
+<!-- Replace with data protection requirements: GDPR, CCPA, data residency,
+     PII handling, retention policies, anonymization, consent management.
+
+- [SYS_XXX_NNNN] Privacy constraint
+
+  Description of the privacy constraint.
+
+  Id:\
+  Satisfies:\
+  Labels:
+
+-->
+
+### Safety
+
+Not applicable.
+
+<!-- Replace with functional safety requirements: ASIL levels, safe states,
+     fault detection, degraded modes, watchdog strategies, independence.
+
+- [SYS_XXX_NNNN] Safety constraint
+
+  Description of the safety constraint.
+
+  Id:\
+  Satisfies:\
+  Labels:
+
+-->
+
+### Cybersecurity
+
+Not applicable.
+
+<!-- Replace with security requirements: authentication, encryption,
+     secure boot, key management, intrusion detection, update signing.
+
+- [SRS_XXX_NNNN] Cybersecurity constraint
+
+  Description of the cybersecurity constraint.
+
+  Id:\
+  Satisfies:\
+  Labels:
+
+-->
+
+### Performance and reliability
+
+Not applicable.
+
+<!-- Replace with performance/reliability requirements: latency, throughput,
+     availability, MTBF/MTTR, resource budgets, scalability, degradation.
+
+- [SRS_XXX_NNNN] Performance constraint
+
+  Description of the performance or reliability constraint.
+
+  Id:\
+  Satisfies:\
+  Labels:
+
+-->

--- a/justfile
+++ b/justfile
@@ -28,6 +28,7 @@ fmt:
 book:
     mdbook build docs/spec
     mdbook build docs/guide
+    typst compile docs/markspec-cheatsheet.typ _site/markspec-cheatsheet.pdf
     cp docs/index.html _site/index.html
 
 # Serve a book locally with live reload (default: spec)


### PR DESCRIPTION
## Summary

- Add `docs/templates/adr-nnn-topic.md` — ADR template with SAD/ICD entry blocks and alternatives rejected section
- Add `docs/templates/sad-nnn-topic.md` — Software architecture description template with Context, Architecture, Interfaces, and mandatory Constraints (Regulation, Privacy, Safety, Cybersecurity, Performance)
- Add `docs/markspec-cheatsheet.typ` — two-page Typst cheat sheet (Flavor & Entries + Directives, Books & References)
- Update Pages workflow to compile cheat sheet PDF with Typst and IBM Plex fonts
- Update landing page (`docs/index.html`) to link to cheat sheet
- Update `justfile` to include cheat sheet in `book` task
- Add `*.pdf` to `.gitignore`

## Test plan

- [ ] CI passes (format, lint, type check, test)
- [ ] Pages workflow builds cheat sheet PDF without font warnings
- [ ] Landing page links to spec, guide, and cheat sheet

🤖 Generated with [Claude Code](https://claude.com/claude-code)