### PR TITLE
fix(docs): remove Typst/Touying features from cheat sheet

### DIFF
--- a/docs/markspec-cheatsheet.typ
+++ b/docs/markspec-cheatsheet.typ
@@ -336,7 +336,7 @@ Mention the 150ms requirement.
 
 = Deck (presentations)
 
-`---` = slide break. `==` starts each slide. Powered by Touying.
+`---` = slide break. `==` starts each slide.
 
 == Markdown source
 
@@ -359,33 +359,6 @@ More content.
 
 ## Demo Slide
 ```]
-
-== Touying features (in Typst output)
-
-`#pause` · `#speaker-note[...]` · `#uncover("2-")[...]` · `#only("2-")[...]` · `#alternatives[a][b]`
-
-== Typst package usage
-
-#code[```typst
-#import "@preview/touying:0.6.1": *
-#import "@driftsys/markspec:0.1.0": *
-
-#show: markspec-deck.with(
-  aspect-ratio: "16-9",
-)
-
-#markspec-title-slide(
-  title: [My Presentation],
-)
-
-== First Slide
-
-Content with #pause animation.
-
-#speaker-note[Notes here.]
-```]
-
-Slide types: `markspec-title-slide` · `markspec-focus-slide`
 
 = Mustache references
 


### PR DESCRIPTION
## Summary

- Remove Touying API references (`#pause`, `#speaker-note`, `#uncover`, `#only`, `#alternatives`) from cheat sheet
- Remove Typst package import examples and `markspec-deck.with()` usage
- Keep Deck section with only the Markdown authoring syntax (`---` slide breaks, directives)

The cheat sheet should cover the MarkSpec Markdown flavor only, not the Typst rendering implementation.

## Test plan

- [x] `typst compile` builds the PDF without errors
- [x] Page 2 no longer contains Typst/Touying content

🤖 Generated with [Claude Code](https://claude.com/claude-code)