### PR TITLE
feat(parser): implement markdown entry extraction and attribute parsing

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -17,7 +17,11 @@
     "jsr:@std/text@^1.0.17": "1.0.17",
     "jsr:@std/yaml@1": "1.0.12",
     "jsr:@ts-morph/bootstrap@0.27": "0.27.0",
-    "jsr:@ts-morph/common@0.27": "0.27.0"
+    "jsr:@ts-morph/common@0.27": "0.27.0",
+    "npm:@types/mdast@4": "4.0.4",
+    "npm:remark-gfm@4": "4.0.1",
+    "npm:remark-parse@11": "11.0.0",
+    "npm:unified@11": "11.0.5"
   },
   "jsr": {
     "@cliffy/command@1.0.0": {
@@ -103,6 +107,514 @@
       ]
     }
   },
+  "npm": {
+    "@types/debug@4.1.13": {
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "dependencies": [
+        "@types/ms"
+      ]
+    },
+    "@types/mdast@4.0.4": {
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "dependencies": [
+        "@types/unist"
+      ]
+    },
+    "@types/ms@2.1.0": {
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="
+    },
+    "@types/unist@3.0.3": {
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="
+    },
+    "bail@2.0.2": {
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="
+    },
+    "ccount@2.0.1": {
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="
+    },
+    "character-entities@2.0.2": {
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ=="
+    },
+    "debug@4.4.3": {
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dependencies": [
+        "ms"
+      ]
+    },
+    "decode-named-character-reference@1.3.0": {
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "dependencies": [
+        "character-entities"
+      ]
+    },
+    "dequal@2.0.3": {
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="
+    },
+    "devlop@1.1.0": {
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "dependencies": [
+        "dequal"
+      ]
+    },
+    "escape-string-regexp@5.0.0": {
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="
+    },
+    "extend@3.0.2": {
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+    },
+    "is-plain-obj@4.1.0": {
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="
+    },
+    "longest-streak@3.1.0": {
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="
+    },
+    "markdown-table@3.0.4": {
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw=="
+    },
+    "mdast-util-find-and-replace@3.0.2": {
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "dependencies": [
+        "@types/mdast",
+        "escape-string-regexp",
+        "unist-util-is",
+        "unist-util-visit-parents"
+      ]
+    },
+    "mdast-util-from-markdown@2.0.3": {
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+      "dependencies": [
+        "@types/mdast",
+        "@types/unist",
+        "decode-named-character-reference",
+        "devlop",
+        "mdast-util-to-string",
+        "micromark",
+        "micromark-util-decode-numeric-character-reference",
+        "micromark-util-decode-string",
+        "micromark-util-normalize-identifier",
+        "micromark-util-symbol",
+        "micromark-util-types",
+        "unist-util-stringify-position"
+      ]
+    },
+    "mdast-util-gfm-autolink-literal@2.0.1": {
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "dependencies": [
+        "@types/mdast",
+        "ccount",
+        "devlop",
+        "mdast-util-find-and-replace",
+        "micromark-util-character"
+      ]
+    },
+    "mdast-util-gfm-footnote@2.1.0": {
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "dependencies": [
+        "@types/mdast",
+        "devlop",
+        "mdast-util-from-markdown",
+        "mdast-util-to-markdown",
+        "micromark-util-normalize-identifier"
+      ]
+    },
+    "mdast-util-gfm-strikethrough@2.0.0": {
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "dependencies": [
+        "@types/mdast",
+        "mdast-util-from-markdown",
+        "mdast-util-to-markdown"
+      ]
+    },
+    "mdast-util-gfm-table@2.0.0": {
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "dependencies": [
+        "@types/mdast",
+        "devlop",
+        "markdown-table",
+        "mdast-util-from-markdown",
+        "mdast-util-to-markdown"
+      ]
+    },
+    "mdast-util-gfm-task-list-item@2.0.0": {
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "dependencies": [
+        "@types/mdast",
+        "devlop",
+        "mdast-util-from-markdown",
+        "mdast-util-to-markdown"
+      ]
+    },
+    "mdast-util-gfm@3.1.0": {
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "dependencies": [
+        "mdast-util-from-markdown",
+        "mdast-util-gfm-autolink-literal",
+        "mdast-util-gfm-footnote",
+        "mdast-util-gfm-strikethrough",
+        "mdast-util-gfm-table",
+        "mdast-util-gfm-task-list-item",
+        "mdast-util-to-markdown"
+      ]
+    },
+    "mdast-util-phrasing@4.1.0": {
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "dependencies": [
+        "@types/mdast",
+        "unist-util-is"
+      ]
+    },
+    "mdast-util-to-markdown@2.1.2": {
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "dependencies": [
+        "@types/mdast",
+        "@types/unist",
+        "longest-streak",
+        "mdast-util-phrasing",
+        "mdast-util-to-string",
+        "micromark-util-classify-character",
+        "micromark-util-decode-string",
+        "unist-util-visit",
+        "zwitch"
+      ]
+    },
+    "mdast-util-to-string@4.0.0": {
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "dependencies": [
+        "@types/mdast"
+      ]
+    },
+    "micromark-core-commonmark@2.0.3": {
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "dependencies": [
+        "decode-named-character-reference",
+        "devlop",
+        "micromark-factory-destination",
+        "micromark-factory-label",
+        "micromark-factory-space",
+        "micromark-factory-title",
+        "micromark-factory-whitespace",
+        "micromark-util-character",
+        "micromark-util-chunked",
+        "micromark-util-classify-character",
+        "micromark-util-html-tag-name",
+        "micromark-util-normalize-identifier",
+        "micromark-util-resolve-all",
+        "micromark-util-subtokenize",
+        "micromark-util-symbol",
+        "micromark-util-types"
+      ]
+    },
+    "micromark-extension-gfm-autolink-literal@2.1.0": {
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "dependencies": [
+        "micromark-util-character",
+        "micromark-util-sanitize-uri",
+        "micromark-util-symbol",
+        "micromark-util-types"
+      ]
+    },
+    "micromark-extension-gfm-footnote@2.1.0": {
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "dependencies": [
+        "devlop",
+        "micromark-core-commonmark",
+        "micromark-factory-space",
+        "micromark-util-character",
+        "micromark-util-normalize-identifier",
+        "micromark-util-sanitize-uri",
+        "micromark-util-symbol",
+        "micromark-util-types"
+      ]
+    },
+    "micromark-extension-gfm-strikethrough@2.1.0": {
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "dependencies": [
+        "devlop",
+        "micromark-util-chunked",
+        "micromark-util-classify-character",
+        "micromark-util-resolve-all",
+        "micromark-util-symbol",
+        "micromark-util-types"
+      ]
+    },
+    "micromark-extension-gfm-table@2.1.1": {
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "dependencies": [
+        "devlop",
+        "micromark-factory-space",
+        "micromark-util-character",
+        "micromark-util-symbol",
+        "micromark-util-types"
+      ]
+    },
+    "micromark-extension-gfm-tagfilter@2.0.0": {
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "dependencies": [
+        "micromark-util-types"
+      ]
+    },
+    "micromark-extension-gfm-task-list-item@2.1.0": {
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "dependencies": [
+        "devlop",
+        "micromark-factory-space",
+        "micromark-util-character",
+        "micromark-util-symbol",
+        "micromark-util-types"
+      ]
+    },
+    "micromark-extension-gfm@3.0.0": {
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "dependencies": [
+        "micromark-extension-gfm-autolink-literal",
+        "micromark-extension-gfm-footnote",
+        "micromark-extension-gfm-strikethrough",
+        "micromark-extension-gfm-table",
+        "micromark-extension-gfm-tagfilter",
+        "micromark-extension-gfm-task-list-item",
+        "micromark-util-combine-extensions",
+        "micromark-util-types"
+      ]
+    },
+    "micromark-factory-destination@2.0.1": {
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "dependencies": [
+        "micromark-util-character",
+        "micromark-util-symbol",
+        "micromark-util-types"
+      ]
+    },
+    "micromark-factory-label@2.0.1": {
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "dependencies": [
+        "devlop",
+        "micromark-util-character",
+        "micromark-util-symbol",
+        "micromark-util-types"
+      ]
+    },
+    "micromark-factory-space@2.0.1": {
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "dependencies": [
+        "micromark-util-character",
+        "micromark-util-types"
+      ]
+    },
+    "micromark-factory-title@2.0.1": {
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "dependencies": [
+        "micromark-factory-space",
+        "micromark-util-character",
+        "micromark-util-symbol",
+        "micromark-util-types"
+      ]
+    },
+    "micromark-factory-whitespace@2.0.1": {
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "dependencies": [
+        "micromark-factory-space",
+        "micromark-util-character",
+        "micromark-util-symbol",
+        "micromark-util-types"
+      ]
+    },
+    "micromark-util-character@2.1.1": {
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "dependencies": [
+        "micromark-util-symbol",
+        "micromark-util-types"
+      ]
+    },
+    "micromark-util-chunked@2.0.1": {
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "dependencies": [
+        "micromark-util-symbol"
+      ]
+    },
+    "micromark-util-classify-character@2.0.1": {
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "dependencies": [
+        "micromark-util-character",
+        "micromark-util-symbol",
+        "micromark-util-types"
+      ]
+    },
+    "micromark-util-combine-extensions@2.0.1": {
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "dependencies": [
+        "micromark-util-chunked",
+        "micromark-util-types"
+      ]
+    },
+    "micromark-util-decode-numeric-character-reference@2.0.2": {
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "dependencies": [
+        "micromark-util-symbol"
+      ]
+    },
+    "micromark-util-decode-string@2.0.1": {
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "dependencies": [
+        "decode-named-character-reference",
+        "micromark-util-character",
+        "micromark-util-decode-numeric-character-reference",
+        "micromark-util-symbol"
+      ]
+    },
+    "micromark-util-encode@2.0.1": {
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw=="
+    },
+    "micromark-util-html-tag-name@2.0.1": {
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA=="
+    },
+    "micromark-util-normalize-identifier@2.0.1": {
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "dependencies": [
+        "micromark-util-symbol"
+      ]
+    },
+    "micromark-util-resolve-all@2.0.1": {
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "dependencies": [
+        "micromark-util-types"
+      ]
+    },
+    "micromark-util-sanitize-uri@2.0.1": {
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "dependencies": [
+        "micromark-util-character",
+        "micromark-util-encode",
+        "micromark-util-symbol"
+      ]
+    },
+    "micromark-util-subtokenize@2.1.0": {
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "dependencies": [
+        "devlop",
+        "micromark-util-chunked",
+        "micromark-util-symbol",
+        "micromark-util-types"
+      ]
+    },
+    "micromark-util-symbol@2.0.1": {
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q=="
+    },
+    "micromark-util-types@2.0.2": {
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA=="
+    },
+    "micromark@4.0.2": {
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "dependencies": [
+        "@types/debug",
+        "debug",
+        "decode-named-character-reference",
+        "devlop",
+        "micromark-core-commonmark",
+        "micromark-factory-space",
+        "micromark-util-character",
+        "micromark-util-chunked",
+        "micromark-util-combine-extensions",
+        "micromark-util-decode-numeric-character-reference",
+        "micromark-util-encode",
+        "micromark-util-normalize-identifier",
+        "micromark-util-resolve-all",
+        "micromark-util-sanitize-uri",
+        "micromark-util-subtokenize",
+        "micromark-util-symbol",
+        "micromark-util-types"
+      ]
+    },
+    "ms@2.1.3": {
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "remark-gfm@4.0.1": {
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "dependencies": [
+        "@types/mdast",
+        "mdast-util-gfm",
+        "micromark-extension-gfm",
+        "remark-parse",
+        "remark-stringify",
+        "unified"
+      ]
+    },
+    "remark-parse@11.0.0": {
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "dependencies": [
+        "@types/mdast",
+        "mdast-util-from-markdown",
+        "micromark-util-types",
+        "unified"
+      ]
+    },
+    "remark-stringify@11.0.0": {
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "dependencies": [
+        "@types/mdast",
+        "mdast-util-to-markdown",
+        "unified"
+      ]
+    },
+    "trough@2.2.0": {
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw=="
+    },
+    "unified@11.0.5": {
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "dependencies": [
+        "@types/unist",
+        "bail",
+        "devlop",
+        "extend",
+        "is-plain-obj",
+        "trough",
+        "vfile"
+      ]
+    },
+    "unist-util-is@6.0.1": {
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "dependencies": [
+        "@types/unist"
+      ]
+    },
+    "unist-util-stringify-position@4.0.0": {
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "dependencies": [
+        "@types/unist"
+      ]
+    },
+    "unist-util-visit-parents@6.0.2": {
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "dependencies": [
+        "@types/unist",
+        "unist-util-is"
+      ]
+    },
+    "unist-util-visit@5.1.0": {
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "dependencies": [
+        "@types/unist",
+        "unist-util-is",
+        "unist-util-visit-parents"
+      ]
+    },
+    "vfile-message@4.0.3": {
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "dependencies": [
+        "@types/unist",
+        "unist-util-stringify-position"
+      ]
+    },
+    "vfile@6.0.3": {
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "dependencies": [
+        "@types/unist",
+        "vfile-message"
+      ]
+    },
+    "zwitch@2.0.4": {
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="
+    }
+  },
   "workspace": {
     "dependencies": [
       "jsr:@deno/dnt@~0.42.3",
@@ -114,7 +626,11 @@
       "packages/markspec": {
         "dependencies": [
           "jsr:@cliffy/command@1",
-          "jsr:@std/assert@1"
+          "jsr:@std/assert@1",
+          "npm:@types/mdast@4",
+          "npm:remark-gfm@4",
+          "npm:remark-parse@11",
+          "npm:unified@11"
         ]
       }
     }

--- a/packages/markspec/core/mod_test.ts
+++ b/packages/markspec/core/mod_test.ts
@@ -103,17 +103,22 @@ Deno.test("ConfigError is constructible", () => {
 });
 
 // ---------------------------------------------------------------------------
-// parse() stub
+// parse() — extracts entries from markdown
 // ---------------------------------------------------------------------------
 
-Deno.test("parse returns empty array", () => {
+Deno.test("parse extracts entries from markdown", () => {
   const entries = parse("# Test\n\n- [SRS_BRK_0001] Title\n\n  Body.\n");
-  assertEquals(entries, []);
+  assertEquals(entries.length, 1);
+  assertEquals(entries[0].displayId, "SRS_BRK_0001");
 
   // Accepts options
   const opts: ParseOptions = { file: "test.md" };
-  const entries2 = parse("# Test", opts);
-  assertEquals(entries2, []);
+  const entries2 = parse("# Test\n\n- [SRS_BRK_0001] Title\n\n  Body.\n", opts);
+  assertEquals(entries2[0].location.file, "test.md");
+
+  // No entries in plain markdown
+  const entries3 = parse("# Test");
+  assertEquals(entries3, []);
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/markspec/core/parser/attributes.ts
+++ b/packages/markspec/core/parser/attributes.ts
@@ -1,0 +1,96 @@
+/**
+ * @module parser/attributes
+ *
+ * Parses `Key: Value` attribute blocks from entry bodies.
+ * Handles trailing backslash separators and distinguishes
+ * trailing attribute blocks from body prose.
+ */
+
+import type { Attribute } from "../model/mod.ts";
+
+/**
+ * Pattern matching a `Key: Value` attribute line.
+ * Key must start with an uppercase letter, may contain lowercase letters and hyphens.
+ * Value is everything after `: `, with optional trailing backslash stripped.
+ */
+const ATTRIBUTE_RE = /^([A-Z][A-Za-z-]*): (.+?)\\?$/;
+
+/**
+ * Parse an array of attribute lines into Attribute objects.
+ *
+ * Each line is expected to be in `Key: Value` format, with optional
+ * trailing backslash (`\`) as a continuation marker. Lines that do
+ * not match the pattern are silently skipped.
+ *
+ * @param lines - Raw attribute lines (already separated from body)
+ * @returns Parsed attributes
+ */
+export function parseAttributes(lines: readonly string[]): Attribute[] {
+  const attributes: Attribute[] = [];
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+
+    const match = ATTRIBUTE_RE.exec(trimmed);
+    if (match) {
+      attributes.push({
+        key: match[1],
+        value: match[2].trim(),
+      });
+    }
+  }
+
+  return attributes;
+}
+
+/**
+ * Pattern matching a `Key: Value` line (with or without trailing backslash).
+ * Used to detect attribute blocks at the end of entry bodies.
+ */
+const ATTR_LINE_RE = /^[A-Z][A-Za-z-]*: .+\\?$/;
+
+/**
+ * Split raw entry content into body text and attribute lines.
+ *
+ * Attributes are `Key: Value` lines at the **end** of the entry content,
+ * forming a contiguous block. A `Key: Value` line in the middle of body
+ * prose is NOT treated as an attribute — only the trailing block counts.
+ *
+ * @param content - Raw text content of an entry (after title line, indentation stripped)
+ * @returns Tuple of [body, attributeLines]
+ */
+export function splitBodyAndAttributes(
+  content: string,
+): [string, string[]] {
+  const lines = content.split("\n");
+
+  // Walk backwards to find the contiguous trailing attribute block
+  let attrStart = lines.length;
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const trimmed = lines[i].trim();
+    if (trimmed === "") {
+      // Empty line: if we haven't started collecting attributes, skip.
+      // If we have attributes below, this blank line is the boundary.
+      if (attrStart < lines.length) break;
+      continue;
+    }
+    if (ATTR_LINE_RE.test(trimmed)) {
+      attrStart = i;
+    } else {
+      // Non-attribute, non-empty line — stop scanning
+      break;
+    }
+  }
+
+  const bodyLines = lines.slice(0, attrStart);
+  const attrLines = lines.slice(attrStart);
+
+  // Trim trailing empty lines from body
+  const body = bodyLines.join("\n").replace(/\n+$/, "");
+  const filteredAttrLines = attrLines
+    .map((l) => l.trim())
+    .filter((l) => l !== "");
+
+  return [body, filteredAttrLines];
+}

--- a/packages/markspec/core/parser/attributes_test.ts
+++ b/packages/markspec/core/parser/attributes_test.ts
@@ -1,0 +1,132 @@
+/**
+ * @module parser/attributes_test
+ *
+ * Unit tests for attribute block parsing.
+ */
+
+import { assertEquals } from "@std/assert";
+import { parseAttributes } from "./attributes.ts";
+
+// ---------------------------------------------------------------------------
+// Backslash-separated attributes
+// ---------------------------------------------------------------------------
+
+Deno.test("parseAttributes: trailing backslash separators", () => {
+  const lines = [
+    "Id: SRS_01HGW2Q8MNP3\\",
+    "Satisfies: SYS_BRK_0042\\",
+    "Labels: ASIL-B",
+  ];
+
+  const attrs = parseAttributes(lines);
+  assertEquals(attrs.length, 3);
+  assertEquals(attrs[0], { key: "Id", value: "SRS_01HGW2Q8MNP3" });
+  assertEquals(attrs[1], { key: "Satisfies", value: "SYS_BRK_0042" });
+  assertEquals(attrs[2], { key: "Labels", value: "ASIL-B" });
+});
+
+// ---------------------------------------------------------------------------
+// Single attribute (no backslash)
+// ---------------------------------------------------------------------------
+
+Deno.test("parseAttributes: single attribute without backslash", () => {
+  const lines = ["Id: SRS_01HGW2Q8MNP3"];
+  const attrs = parseAttributes(lines);
+  assertEquals(attrs.length, 1);
+  assertEquals(attrs[0], { key: "Id", value: "SRS_01HGW2Q8MNP3" });
+});
+
+// ---------------------------------------------------------------------------
+// Reference entry attributes
+// ---------------------------------------------------------------------------
+
+Deno.test("parseAttributes: reference entry attributes (Document, URL)", () => {
+  const lines = [
+    "Document: ISO 26262-6:2018\\",
+    "URL: https://www.iso.org/standard/68383.html",
+  ];
+
+  const attrs = parseAttributes(lines);
+  assertEquals(attrs.length, 2);
+  assertEquals(attrs[0], { key: "Document", value: "ISO 26262-6:2018" });
+  assertEquals(attrs[1], {
+    key: "URL",
+    value: "https://www.iso.org/standard/68383.html",
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Whitespace handling
+// ---------------------------------------------------------------------------
+
+Deno.test("parseAttributes: trims leading/trailing whitespace from values", () => {
+  const lines = ["Id:   SRS_01HGW2Q8MNP3  \\", "Labels:  ASIL-B  "];
+  const attrs = parseAttributes(lines);
+  assertEquals(attrs[0].value, "SRS_01HGW2Q8MNP3");
+  assertEquals(attrs[1].value, "ASIL-B");
+});
+
+// ---------------------------------------------------------------------------
+// All known attribute keys
+// ---------------------------------------------------------------------------
+
+Deno.test("parseAttributes: all builtin typed entry attributes", () => {
+  const lines = [
+    "Id: SRS_01HGW2Q8MNP3\\",
+    "Satisfies: SYS_BRK_0042\\",
+    "Derived-from: ISO-26262-6 §9.4\\",
+    "Labels: ASIL-B, safety",
+  ];
+
+  const attrs = parseAttributes(lines);
+  assertEquals(attrs.length, 4);
+  assertEquals(attrs[0].key, "Id");
+  assertEquals(attrs[1].key, "Satisfies");
+  assertEquals(attrs[2].key, "Derived-from");
+  assertEquals(attrs[2].value, "ISO-26262-6 §9.4");
+  assertEquals(attrs[3].key, "Labels");
+  assertEquals(attrs[3].value, "ASIL-B, safety");
+});
+
+Deno.test("parseAttributes: reference entry specific attributes", () => {
+  const lines = [
+    "Document: RTCA DO-178C\\",
+    "URL: https://www.rtca.org/products/do-178c/\\",
+    "Status: active\\",
+    "Superseded-by: DO-178D",
+  ];
+
+  const attrs = parseAttributes(lines);
+  assertEquals(attrs.length, 4);
+  assertEquals(attrs[0].key, "Document");
+  assertEquals(attrs[1].key, "URL");
+  assertEquals(attrs[2].key, "Status");
+  assertEquals(attrs[2].value, "active");
+  assertEquals(attrs[3].key, "Superseded-by");
+  assertEquals(attrs[3].value, "DO-178D");
+});
+
+// ---------------------------------------------------------------------------
+// Empty / no attributes
+// ---------------------------------------------------------------------------
+
+Deno.test("parseAttributes: empty input returns empty array", () => {
+  assertEquals(parseAttributes([]), []);
+});
+
+// ---------------------------------------------------------------------------
+// Non-attribute lines are not parsed
+// ---------------------------------------------------------------------------
+
+Deno.test("parseAttributes: lines without Key: Value pattern are skipped", () => {
+  const lines = [
+    "This is just body text",
+    "Id: SRS_01HGW2Q8MNP3",
+  ];
+  // parseAttributes only receives already-identified attribute lines
+  // so this tests robustness — first line has no colon-space
+  const attrs = parseAttributes(lines);
+  // The first line doesn't match Key: Value, so it's skipped
+  assertEquals(attrs.length, 1);
+  assertEquals(attrs[0].key, "Id");
+});

--- a/packages/markspec/core/parser/markdown.ts
+++ b/packages/markspec/core/parser/markdown.ts
@@ -4,3 +4,196 @@
  * CommonMark + MarkSpec extension parser. Walks the mdast AST to detect
  * `- [TYPE_XYZ_NNNN]` entry blocks and extract structured attributes.
  */
+
+import { unified } from "unified";
+import remarkParse from "remark-parse";
+import remarkGfm from "remark-gfm";
+import type { List, ListItem, Paragraph, Text } from "mdast";
+import type { Entry, EntryType } from "../model/mod.ts";
+import { parseAttributes, splitBodyAndAttributes } from "./attributes.ts";
+
+/** Options for {@linkcode parseMarkdown}. */
+export interface ParseMarkdownOptions {
+  /** File path used in source locations. */
+  readonly file?: string;
+}
+
+/**
+ * Typed entry display ID pattern: `TYPE_XYZ_NNNN`.
+ * TYPE = 2-4 uppercase letters, XYZ = 2-6 uppercase letters, NNNN = zero-padded digits.
+ */
+const TYPED_ID_RE = /^([A-Z]{2,4})_[A-Z]{2,6}_\d{4}$/;
+
+/**
+ * Reference entry display ID pattern: letters, digits, hyphens.
+ */
+const REF_ID_RE = /^[A-Za-z0-9-]+$/;
+
+/**
+ * Match a display ID in `[...]` at the start of a list item paragraph.
+ * Captures: [1] = full display ID, [2] = title (rest of line).
+ */
+const ENTRY_START_RE = /^\[([^\]]+)\]\s*(.*)$/;
+
+/** Build the remark processor once. */
+const processor = unified().use(remarkParse).use(remarkGfm);
+
+/**
+ * Parse a Markdown string and return all MarkSpec entries found.
+ *
+ * Walks the mdast AST to detect `- [DISPLAY_ID] Title` list items
+ * with indented body content. Extracts display ID, title, body,
+ * and trailing attribute blocks.
+ *
+ * @param markdown - Markdown source text
+ * @param options - Parse options (file path for source locations)
+ * @returns Array of parsed entries
+ */
+export function parseMarkdown(
+  markdown: string,
+  options?: ParseMarkdownOptions,
+): Entry[] {
+  const file = options?.file ?? "<unknown>";
+  const tree = processor.parse(markdown);
+  const entries: Entry[] = [];
+
+  for (const node of tree.children) {
+    if (node.type !== "list") continue;
+    const list = node as List;
+
+    for (const item of list.children) {
+      const entry = extractEntry(item, markdown, file);
+      if (entry) entries.push(entry);
+    }
+  }
+
+  return entries;
+}
+
+/**
+ * Attempt to extract a MarkSpec entry from a list item.
+ * Returns undefined if the list item is not an entry block.
+ */
+function extractEntry(
+  item: ListItem,
+  markdown: string,
+  file: string,
+): Entry | undefined {
+  // An entry block must have children (body content).
+  // The first child must be a paragraph starting with `[DISPLAY_ID]`.
+  if (!item.children.length) return undefined;
+
+  const firstChild = item.children[0];
+  if (firstChild.type !== "paragraph") return undefined;
+
+  const paragraph = firstChild as Paragraph;
+  if (!paragraph.children.length) return undefined;
+
+  // The first inline must be a text node (mdast parses `[X]` as linkReference
+  // or text depending on context — check both patterns).
+  const firstInline = paragraph.children[0];
+
+  let displayId: string | undefined;
+  let title: string | undefined;
+
+  if (firstInline.type === "text") {
+    // remark may parse `[ID] Title` as a single text node
+    const match = ENTRY_START_RE.exec((firstInline as Text).value);
+    if (match) {
+      displayId = match[1];
+      title = match[2].trim();
+    }
+  }
+
+  // Try linkReference pattern: remark sometimes parses [ID] as a linkReference
+  if (!displayId && firstInline.type === "linkReference") {
+    const ref = firstInline as unknown as {
+      type: string;
+      label?: string;
+      children: Array<{ type: string; value: string }>;
+    };
+    displayId = ref.label ?? ref.children?.[0]?.value;
+    // Title comes from subsequent text nodes in the paragraph
+    if (displayId && paragraph.children.length > 1) {
+      const rest = paragraph.children.slice(1);
+      title = rest
+        .filter((n): n is Text => n.type === "text")
+        .map((n) => n.value)
+        .join("")
+        .trim();
+    }
+  }
+
+  if (!displayId) return undefined;
+
+  // Validate display ID format
+  if (!TYPED_ID_RE.test(displayId) && !REF_ID_RE.test(displayId)) {
+    return undefined;
+  }
+
+  // An entry block requires indented body content (more than just the title line).
+  // If there's only one child (the title paragraph) and no further content,
+  // it's not an entry block.
+  if (item.children.length < 2) return undefined;
+
+  // Extract entry type from typed display IDs
+  const typedMatch = TYPED_ID_RE.exec(displayId);
+  const entryType: EntryType | undefined = typedMatch
+    ? typedMatch[1] as EntryType
+    : undefined;
+
+  // Extract body content from remaining children
+  const bodyContent = extractBodyContent(item, markdown);
+
+  // Split body and attributes
+  const [body, attrLines] = splitBodyAndAttributes(bodyContent);
+  const attributes = parseAttributes(attrLines);
+
+  // Extract ULID from Id attribute
+  const idAttr = attributes.find((a) => a.key === "Id");
+  const id = idAttr?.value;
+
+  // Source location
+  const line = item.position?.start.line ?? 1;
+  const column = item.position?.start.column ?? 1;
+
+  return {
+    displayId,
+    title: title ?? "",
+    body,
+    attributes,
+    id,
+    entryType,
+    location: { file, line, column },
+    source: "markdown",
+  };
+}
+
+/**
+ * Extract body content from a list item's children (excluding the first paragraph
+ * which contains the display ID and title).
+ *
+ * Reconstructs the text content from the source markdown using position info.
+ */
+function extractBodyContent(item: ListItem, markdown: string): string {
+  const children = item.children.slice(1); // Skip title paragraph
+  if (!children.length) return "";
+
+  const lines = markdown.split("\n");
+
+  // Get the range from the second child's start to the last child's end
+  const startLine = children[0].position?.start.line;
+  const endLine = children[children.length - 1].position?.end.line;
+
+  if (!startLine || !endLine) return "";
+
+  // Extract the raw lines and strip the list item indentation (typically 2 spaces)
+  const rawLines = lines.slice(startLine - 1, endLine);
+  const stripped = rawLines.map((line) => {
+    // Remove up to 2 leading spaces (standard list continuation indent)
+    if (line.startsWith("  ")) return line.slice(2);
+    return line;
+  });
+
+  return stripped.join("\n").trim();
+}

--- a/packages/markspec/core/parser/markdown_test.ts
+++ b/packages/markspec/core/parser/markdown_test.ts
@@ -1,0 +1,292 @@
+/**
+ * @module parser/markdown_test
+ *
+ * Unit tests for Markdown entry extraction.
+ */
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { parseMarkdown } from "./markdown.ts";
+
+// ---------------------------------------------------------------------------
+// Typed entry extraction
+// ---------------------------------------------------------------------------
+
+Deno.test("parseMarkdown: extracts typed entry with display ID and title", () => {
+  const md = `# Test
+
+- [SRS_BRK_0001] Sensor input debouncing
+
+  Body text.
+
+  Id: SRS_01HGW2Q8MNP3
+`;
+  const entries = parseMarkdown(md, { file: "test.md" });
+  assertEquals(entries.length, 1);
+  assertEquals(entries[0].displayId, "SRS_BRK_0001");
+  assertEquals(entries[0].title, "Sensor input debouncing");
+  assertEquals(entries[0].entryType, "SRS");
+  assertEquals(entries[0].id, "SRS_01HGW2Q8MNP3");
+  assertEquals(entries[0].source, "markdown");
+});
+
+Deno.test("parseMarkdown: extracts body between title and attributes", () => {
+  const md = `# Test
+
+- [SRS_BRK_0001] Title
+
+  First paragraph of the body.
+
+  Second paragraph of the body.
+
+  Id: SRS_01HGW2Q8MNP3
+`;
+  const entries = parseMarkdown(md, { file: "test.md" });
+  assertStringIncludes(entries[0].body, "First paragraph of the body.");
+  assertStringIncludes(entries[0].body, "Second paragraph of the body.");
+});
+
+Deno.test("parseMarkdown: extracts body with alerts", () => {
+  const md = `# Test
+
+- [SRS_BRK_0001] Title
+
+  Body text.
+
+  > [!WARNING]
+  > Failure may occur.
+
+  Id: SRS_01HGW2Q8MNP3
+`;
+  const entries = parseMarkdown(md, { file: "test.md" });
+  assertStringIncludes(entries[0].body, "Body text.");
+  assertStringIncludes(entries[0].body, "[!WARNING]");
+});
+
+Deno.test("parseMarkdown: extracts multiple entries", () => {
+  const md = `# Test
+
+- [SRS_BRK_0001] First entry
+
+  Body one.
+
+  Id: SRS_01HGW2Q8MNP3
+
+- [SRS_BRK_0002] Second entry
+
+  Body two.
+
+  Id: SRS_01HGW2R9QLP4
+`;
+  const entries = parseMarkdown(md, { file: "test.md" });
+  assertEquals(entries.length, 2);
+  assertEquals(entries[0].displayId, "SRS_BRK_0001");
+  assertEquals(entries[1].displayId, "SRS_BRK_0002");
+});
+
+// ---------------------------------------------------------------------------
+// Reference entry extraction
+// ---------------------------------------------------------------------------
+
+Deno.test("parseMarkdown: extracts reference entry", () => {
+  const md = `# References
+
+- [ISO-26262-6] ISO 26262 Part 6
+
+  Road vehicles — Functional safety.
+
+  Document: ISO 26262-6:2018\\
+  URL: https://www.iso.org/standard/68383.html
+`;
+  const entries = parseMarkdown(md, { file: "refs.md" });
+  assertEquals(entries.length, 1);
+  assertEquals(entries[0].displayId, "ISO-26262-6");
+  assertEquals(entries[0].title, "ISO 26262 Part 6");
+  assertEquals(entries[0].entryType, undefined);
+  assertEquals(entries[0].id, undefined);
+  assertStringIncludes(entries[0].body, "Road vehicles");
+});
+
+// ---------------------------------------------------------------------------
+// Attribute parsing (stories #8 + #9 integration)
+// ---------------------------------------------------------------------------
+
+Deno.test("parseMarkdown: parses backslash-separated attributes", () => {
+  const md = `# Test
+
+- [SRS_BRK_0001] Title
+
+  Body.
+
+  Id: SRS_01HGW2Q8MNP3\\
+  Satisfies: SYS_BRK_0042\\
+  Labels: ASIL-B
+`;
+  const entries = parseMarkdown(md, { file: "test.md" });
+  assertEquals(entries[0].attributes.length, 3);
+  assertEquals(entries[0].attributes[0].key, "Id");
+  assertEquals(entries[0].attributes[0].value, "SRS_01HGW2Q8MNP3");
+  assertEquals(entries[0].attributes[1].key, "Satisfies");
+  assertEquals(entries[0].attributes[2].key, "Labels");
+});
+
+Deno.test("parseMarkdown: Key: Value in body middle is NOT an attribute", () => {
+  const md = `# Test
+
+- [SRS_BRK_0001] Title
+
+  The system uses Key: Value pairs in config files.
+  Another line of body text.
+
+  Id: SRS_01HGW2Q8MNP3
+`;
+  const entries = parseMarkdown(md, { file: "test.md" });
+  assertEquals(entries[0].attributes.length, 1);
+  assertEquals(entries[0].attributes[0].key, "Id");
+  assertStringIncludes(entries[0].body, "Key: Value pairs");
+});
+
+// ---------------------------------------------------------------------------
+// Source location
+// ---------------------------------------------------------------------------
+
+Deno.test("parseMarkdown: preserves source location", () => {
+  const md = `# Test
+
+- [SRS_BRK_0001] First
+
+  Body.
+
+  Id: SRS_01HGW2Q8MNP3
+
+- [SRS_BRK_0002] Second
+
+  Body.
+
+  Id: SRS_01HGW2R9QLP4
+`;
+  const entries = parseMarkdown(md, { file: "reqs.md" });
+  assertEquals(entries[0].location.file, "reqs.md");
+  assertEquals(entries[0].location.line, 3);
+  assertEquals(entries[0].location.column, 1);
+
+  assertEquals(entries[1].location.file, "reqs.md");
+  // Line 10 in the template string is line 9 (the `- [SRS_BRK_0002]` line)
+  // because template literals start content at the character after the backtick
+  assertEquals(entries[1].location.line, 9);
+});
+
+// ---------------------------------------------------------------------------
+// Non-entry list items ignored
+// ---------------------------------------------------------------------------
+
+Deno.test("parseMarkdown: list item without body is not an entry", () => {
+  const md = `# Test
+
+- [SRS_BRK_0001] Title without indented body
+- Just a normal list item
+- [See documentation] for details
+`;
+  const entries = parseMarkdown(md, { file: "test.md" });
+  assertEquals(entries.length, 0);
+});
+
+Deno.test("parseMarkdown: normal list items are ignored", () => {
+  const md = `# Test
+
+- Pressure sensor
+- Speed sensor
+
+- [SRS_BRK_0001] Real entry
+
+  Body text.
+
+  Id: SRS_01HGW2Q8MNP3
+`;
+  const entries = parseMarkdown(md, { file: "test.md" });
+  assertEquals(entries.length, 1);
+  assertEquals(entries[0].displayId, "SRS_BRK_0001");
+});
+
+// ---------------------------------------------------------------------------
+// Default file path
+// ---------------------------------------------------------------------------
+
+Deno.test("parseMarkdown: uses '<unknown>' when no file specified", () => {
+  const md = `# Test
+
+- [SRS_BRK_0001] Title
+
+  Body.
+
+  Id: SRS_01HGW2Q8MNP3
+`;
+  const entries = parseMarkdown(md);
+  assertEquals(entries[0].location.file, "<unknown>");
+});
+
+// ---------------------------------------------------------------------------
+// Entry without Id attribute
+// ---------------------------------------------------------------------------
+
+Deno.test("parseMarkdown: entry without Id attribute has undefined id", () => {
+  const md = `# Test
+
+- [SRS_BRK_0001] Title
+
+  Body text only, no attributes.
+`;
+  // Entry with body but no attributes — still a valid entry block
+  const entries = parseMarkdown(md, { file: "test.md" });
+  assertEquals(entries.length, 1);
+  assertEquals(entries[0].id, undefined);
+  assertEquals(entries[0].attributes.length, 0);
+});
+
+// ---------------------------------------------------------------------------
+// Fixture: braking requirements (from ADR-001 example)
+// ---------------------------------------------------------------------------
+
+Deno.test("parseMarkdown: fixture — braking requirements", () => {
+  const md = `# Braking System — Software Requirements
+
+## Sensor Processing
+
+- [SRS_BRK_0001] Sensor input debouncing
+
+  The sensor driver shall debounce raw inputs to eliminate electrical noise
+  before processing.
+
+  The debounce window shall be configurable per sensor type.
+
+  > [!WARNING]
+  > Failure to debounce may lead to spurious brake activation.
+
+  Id: SRS_01HGW2Q8MNP3\\
+  Satisfies: SYS_BRK_0042\\
+  Labels: ASIL-B
+
+- [SRS_BRK_0002] Sensor plausibility check
+
+  The sensor driver shall reject readings outside the physically plausible range
+  for each sensor type.
+
+  Id: SRS_01HGW2R9QLP4\\
+  Satisfies: SYS_BRK_0042\\
+  Labels: ASIL-B
+`;
+  const entries = parseMarkdown(md, { file: "braking.md" });
+  assertEquals(entries.length, 2);
+
+  assertEquals(entries[0].displayId, "SRS_BRK_0001");
+  assertEquals(entries[0].title, "Sensor input debouncing");
+  assertEquals(entries[0].id, "SRS_01HGW2Q8MNP3");
+  assertEquals(entries[0].entryType, "SRS");
+  assertStringIncludes(entries[0].body, "debounce raw inputs");
+  assertStringIncludes(entries[0].body, "[!WARNING]");
+  assertEquals(entries[0].attributes.length, 3);
+
+  assertEquals(entries[1].displayId, "SRS_BRK_0002");
+  assertEquals(entries[1].title, "Sensor plausibility check");
+  assertEquals(entries[1].id, "SRS_01HGW2R9QLP4");
+  assertEquals(entries[1].attributes.length, 3);
+});

--- a/packages/markspec/core/parser/mod.ts
+++ b/packages/markspec/core/parser/mod.ts
@@ -9,6 +9,7 @@
  */
 
 import type { Entry } from "../model/mod.ts";
+import { parseMarkdown } from "./markdown.ts";
 
 /** Options for {@linkcode parse}. */
 export interface ParseOptions {
@@ -24,8 +25,8 @@ export interface ParseOptions {
  * @returns Array of parsed entries
  */
 export function parse(
-  _markdown: string,
-  _options?: ParseOptions,
+  markdown: string,
+  options?: ParseOptions,
 ): Entry[] {
-  return [];
+  return parseMarkdown(markdown, options);
 }

--- a/packages/markspec/deno.json
+++ b/packages/markspec/deno.json
@@ -7,6 +7,10 @@
   },
   "imports": {
     "@cliffy/command": "jsr:@cliffy/command@^1",
-    "@std/assert": "jsr:@std/assert@^1"
+    "@std/assert": "jsr:@std/assert@^1",
+    "unified": "npm:unified@^11",
+    "remark-parse": "npm:remark-parse@^11",
+    "remark-gfm": "npm:remark-gfm@^4",
+    "mdast": "npm:@types/mdast@^4"
   }
 }

--- a/packages/markspec/main.ts
+++ b/packages/markspec/main.ts
@@ -117,11 +117,43 @@ const cli = new Command()
   })
   .command("compile <paths...:string>")
   .description("Parse files, build traceability graph, output JSON")
-  .action(async () => {
-    const { config } = await requireProjectConfig();
-    void config;
-    console.error("markspec compile: not yet implemented");
-    Deno.exit(1);
+  .option("--format <format:string>", "Output format (json|text)", {
+    default: "text",
+  })
+  .action(async (_options: { format?: string }, ...paths: string[]) => {
+    await requireProjectConfig();
+
+    const { parse } = await import("./core/mod.ts");
+    const allEntries: import("./core/mod.ts").Entry[] = [];
+    const allDiagnostics: import("./core/mod.ts").Diagnostic[] = [];
+
+    for (const filePath of paths) {
+      try {
+        const content = await Deno.readTextFile(filePath);
+        const entries = parse(content, { file: filePath });
+        allEntries.push(...entries);
+      } catch (err) {
+        allDiagnostics.push({
+          code: "MSL-E000",
+          severity: "error",
+          message: `Failed to read file: ${filePath}: ${err}`,
+          location: undefined,
+        });
+      }
+    }
+
+    const result = { entries: allEntries, diagnostics: allDiagnostics };
+
+    if (_options.format === "json") {
+      console.log(JSON.stringify(result, null, 2));
+    } else {
+      console.log(
+        `${result.entries.length} entries parsed from ${paths.length} files`,
+      );
+      for (const diag of result.diagnostics) {
+        console.error(`${diag.severity}: ${diag.message}`);
+      }
+    }
   })
   .command("export")
   .description("Compiled JSON → json, csv, reqif, yaml")

--- a/tests/e2e/compile_test.ts
+++ b/tests/e2e/compile_test.ts
@@ -1,0 +1,237 @@
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { markspec } from "./helpers.ts";
+
+// ---------------------------------------------------------------------------
+// Story #8 — Markdown entry extraction
+// ---------------------------------------------------------------------------
+
+Deno.test("compile: extracts typed entries with display IDs, titles, bodies, and attributes", async () => {
+  const input = `# Braking System — Software Requirements
+
+## Sensor Processing
+
+- [SRS_BRK_0001] Sensor input debouncing
+
+  The sensor driver shall debounce raw inputs to eliminate electrical noise
+  before processing.
+
+  The debounce window shall be configurable per sensor type.
+
+  > [!WARNING]
+  > Failure to debounce may lead to spurious brake activation.
+
+  Id: SRS_01HGW2Q8MNP3\\
+  Satisfies: SYS_BRK_0042\\
+  Labels: ASIL-B
+
+- [SRS_BRK_0002] Sensor plausibility check
+
+  The sensor driver shall reject readings outside the physically plausible range
+  for each sensor type.
+
+  Id: SRS_01HGW2R9QLP4\\
+  Satisfies: SYS_BRK_0042\\
+  Labels: ASIL-B
+
+- [SRS_BRK_0003] Brake force computation
+
+  The controller shall compute the required brake force from the validated
+  sensor inputs.
+
+  Id: SRS_01HGW2S0RMQ5\\
+  Satisfies: SYS_BRK_0050\\
+  Labels: ASIL-B
+`;
+
+  const { code, stdout } = await markspec(
+    ["compile", "--format", "json", "requirements.md"],
+    { "project.yaml": "name: test-project\n", "requirements.md": input },
+  );
+
+  assertEquals(code, 0);
+  const result = JSON.parse(stdout);
+  assertEquals(result.entries.length, 3);
+
+  // First entry
+  assertEquals(result.entries[0].displayId, "SRS_BRK_0001");
+  assertEquals(result.entries[0].title, "Sensor input debouncing");
+  assertEquals(result.entries[0].id, "SRS_01HGW2Q8MNP3");
+  assertEquals(result.entries[0].entryType, "SRS");
+  assertStringIncludes(result.entries[0].body, "debounce raw inputs");
+
+  // Second entry
+  assertEquals(result.entries[1].displayId, "SRS_BRK_0002");
+  assertEquals(result.entries[1].title, "Sensor plausibility check");
+  assertEquals(result.entries[1].id, "SRS_01HGW2R9QLP4");
+
+  // Third entry
+  assertEquals(result.entries[2].displayId, "SRS_BRK_0003");
+  assertEquals(result.entries[2].title, "Brake force computation");
+});
+
+Deno.test("compile: extracts reference entries with ID, title, and attributes", async () => {
+  const input = `# References
+
+- [ISO-26262-6] ISO 26262 Part 6
+
+  Road vehicles — Functional safety — Part 6: Product development at the
+  software level.
+
+  Document: ISO 26262-6:2018\\
+  URL: https://www.iso.org/standard/68383.html
+
+- [DO-178C] DO-178C
+
+  Software Considerations in Airborne Systems and Equipment Certification.
+
+  Document: RTCA DO-178C\\
+  URL: https://www.rtca.org/products/do-178c/
+`;
+
+  const { code, stdout } = await markspec(
+    ["compile", "--format", "json", "references.md"],
+    { "project.yaml": "name: test-project\n", "references.md": input },
+  );
+
+  assertEquals(code, 0);
+  const result = JSON.parse(stdout);
+  assertEquals(result.entries.length, 2);
+
+  // First reference
+  assertEquals(result.entries[0].displayId, "ISO-26262-6");
+  assertEquals(result.entries[0].title, "ISO 26262 Part 6");
+  assertEquals(result.entries[0].entryType, undefined);
+  assertStringIncludes(result.entries[0].body, "Road vehicles");
+
+  // Check attributes
+  const doc = result.entries[0].attributes.find(
+    (a: { key: string }) => a.key === "Document",
+  );
+  assertEquals(doc?.value, "ISO 26262-6:2018");
+
+  const url = result.entries[0].attributes.find(
+    (a: { key: string }) => a.key === "URL",
+  );
+  assertEquals(url?.value, "https://www.iso.org/standard/68383.html");
+
+  // Second reference
+  assertEquals(result.entries[1].displayId, "DO-178C");
+});
+
+Deno.test("compile: preserves source location for entries", async () => {
+  const input = `# Requirements
+
+- [SRS_BRK_0001] First entry
+
+  Body text.
+
+  Id: SRS_01HGW2Q8MNP3
+
+- [SRS_BRK_0002] Second entry
+
+  More body text.
+
+  Id: SRS_01HGW2R9QLP4
+`;
+
+  const { code, stdout } = await markspec(
+    ["compile", "--format", "json", "reqs.md"],
+    { "project.yaml": "name: test-project\n", "reqs.md": input },
+  );
+
+  assertEquals(code, 0);
+  const result = JSON.parse(stdout);
+  assertEquals(result.entries.length, 2);
+
+  // First entry starts at line 3
+  assertEquals(result.entries[0].location.file, "reqs.md");
+  assertEquals(result.entries[0].location.line, 3);
+
+  // Second entry starts at line 9
+  assertEquals(result.entries[1].location.file, "reqs.md");
+  assertEquals(result.entries[1].location.line, 9);
+});
+
+// ---------------------------------------------------------------------------
+// Story #9 — Attribute parser
+// ---------------------------------------------------------------------------
+
+Deno.test("compile: parses attributes with trailing backslash separators", async () => {
+  const input = `# Requirements
+
+- [SRS_BRK_0001] Entry with backslash attributes
+
+  Body.
+
+  Id: SRS_01HGW2Q8MNP3\\
+  Satisfies: SYS_BRK_0042\\
+  Labels: ASIL-B
+`;
+
+  const { code, stdout } = await markspec(
+    ["compile", "--format", "json", "reqs.md"],
+    { "project.yaml": "name: test-project\n", "reqs.md": input },
+  );
+
+  assertEquals(code, 0);
+  const result = JSON.parse(stdout);
+  const attrs = result.entries[0].attributes;
+
+  assertEquals(attrs.length, 3);
+  assertEquals(attrs[0].key, "Id");
+  assertEquals(attrs[0].value, "SRS_01HGW2Q8MNP3");
+  assertEquals(attrs[1].key, "Satisfies");
+  assertEquals(attrs[1].value, "SYS_BRK_0042");
+  assertEquals(attrs[2].key, "Labels");
+  assertEquals(attrs[2].value, "ASIL-B");
+});
+
+Deno.test("compile: parses attributes without trailing backslash (last line)", async () => {
+  const input = `# Requirements
+
+- [SRS_BRK_0001] Entry with final attribute no backslash
+
+  Body.
+
+  Id: SRS_01HGW2Q8MNP3
+`;
+
+  const { code, stdout } = await markspec(
+    ["compile", "--format", "json", "reqs.md"],
+    { "project.yaml": "name: test-project\n", "reqs.md": input },
+  );
+
+  assertEquals(code, 0);
+  const result = JSON.parse(stdout);
+  const attrs = result.entries[0].attributes;
+
+  assertEquals(attrs.length, 1);
+  assertEquals(attrs[0].key, "Id");
+  assertEquals(attrs[0].value, "SRS_01HGW2Q8MNP3");
+});
+
+Deno.test("compile: Key: Value in middle of body is not an attribute", async () => {
+  const input = `# Requirements
+
+- [SRS_BRK_0001] Entry with inline key-value
+
+  The system uses Key: Value pairs in configuration files.
+  This is body text, not an attribute.
+
+  Id: SRS_01HGW2Q8MNP3
+`;
+
+  const { code, stdout } = await markspec(
+    ["compile", "--format", "json", "reqs.md"],
+    { "project.yaml": "name: test-project\n", "reqs.md": input },
+  );
+
+  assertEquals(code, 0);
+  const result = JSON.parse(stdout);
+  const entry = result.entries[0];
+
+  // Only the trailing "Id:" is an attribute, not the "Key: Value" in the body
+  assertEquals(entry.attributes.length, 1);
+  assertEquals(entry.attributes[0].key, "Id");
+  assertStringIncludes(entry.body, "Key: Value pairs");
+});


### PR DESCRIPTION
## What

Implement the Markdown entry extraction parser and attribute block parser — the foundation of the MarkSpec toolchain's parsing pipeline.

## Why

Closes #8
Closes #9

These are the first two parser stories: #8 (Markdown entry extraction) extracts `- [DISPLAY_ID] Title` entry blocks from Markdown files, and #9 (Attribute parser) parses `Key: Value` trailing attribute blocks with backslash separators.

## How

**Attribute parser** (`core/parser/attributes.ts`):
- `parseAttributes(lines)` — parses `Key: Value` lines with optional trailing `\`, recognizes all builtin attribute keys (Id, Satisfies, Derived-from, Labels, Document, URL, Status, Superseded-by)
- `splitBodyAndAttributes(content)` — walks backwards from the end of entry content to find the contiguous trailing attribute block, ensuring `Key: Value` in the middle of body prose is NOT mistaken for an attribute

**Markdown parser** (`core/parser/markdown.ts`):
- Uses unified/remark-parse/remark-gfm to parse CommonMark+GFM into mdast AST
- Walks list items to detect `- [DISPLAY_ID] Title` patterns (handles both text nodes and linkReference nodes from remark)
- Validates display ID format: typed (`TYPE_XYZ_NNNN`) and reference (`[A-Za-z0-9-]+`) patterns
- Extracts body content using source position info, strips list continuation indent
- Delegates attribute extraction to `splitBodyAndAttributes` + `parseAttributes`
- Resolves entry type from typed display IDs, ULID from `Id:` attribute

**Integration**:
- `parser/mod.ts` delegates `parse()` to `parseMarkdown()`
- `compile` CLI command now reads files, parses entries, outputs JSON with `--format json`

**Test coverage** (27 new tests):
- 8 unit tests for attribute parser (backslash separators, whitespace, all known keys, edge cases)
- 13 unit tests for markdown parser (typed entries, reference entries, body extraction, alerts, source location, non-entry items, fixture-based braking requirements)
- 6 E2E acceptance tests (all acceptance criteria from both stories)

## Checklist

- [x] Tests added or updated
- [x] Documentation updated
- [x] All checks pass