### PR TITLE
feat(core): entry exclusion checks from AST spec §1

### DIFF
--- a/packages/markspec/core/parser/markdown.ts
+++ b/packages/markspec/core/parser/markdown.ts
@@ -8,7 +8,7 @@
 import { unified } from "unified";
 import remarkParse from "remark-parse";
 import remarkGfm from "remark-gfm";
-import type { List, ListItem, Paragraph, Text } from "mdast";
+import type { Definition, List, ListItem, Paragraph, Text } from "mdast";
 import type { Entry, EntryType } from "../model/mod.ts";
 import { parseAttributes, splitBodyAndAttributes } from "./attributes.ts";
 
@@ -57,12 +57,22 @@ export function parseMarkdown(
   const tree = processor.parse(markdown);
   const entries: Entry[] = [];
 
+  // Collect link definition identifiers for shortcut reference exclusion.
+  const definitions = new Set(
+    tree.children
+      .filter((n): n is Definition => n.type === "definition")
+      .map((n) => n.identifier),
+  );
+
   for (const node of tree.children) {
     if (node.type !== "list") continue;
     const list = node as List;
 
+    // Ordered lists never contain entry blocks.
+    if (list.ordered) continue;
+
     for (const item of list.children) {
-      const entry = extractEntry(item, markdown, file);
+      const entry = extractEntry(item, markdown, file, definitions);
       if (entry) entries.push(entry);
     }
   }
@@ -78,6 +88,7 @@ function extractEntry(
   item: ListItem,
   markdown: string,
   file: string,
+  definitions: Set<string>,
 ): Entry | undefined {
   // Task list items (remark-gfm sets checked to true/false) are not entries.
   if (item.checked != null) return undefined;
@@ -92,9 +103,10 @@ function extractEntry(
   const paragraph = firstChild as Paragraph;
   if (!paragraph.children.length) return undefined;
 
-  // The first inline must be a text node (mdast parses `[X]` as linkReference
-  // or text depending on context — check both patterns).
   const firstInline = paragraph.children[0];
+
+  // Inline link: [text](url) — not an entry.
+  if (firstInline.type === "link") return undefined;
 
   let displayId: string | undefined;
   let title: string | undefined;
@@ -112,9 +124,22 @@ function extractEntry(
   if (!displayId && firstInline.type === "linkReference") {
     const ref = firstInline as unknown as {
       type: string;
+      referenceType?: string;
       label?: string;
+      identifier?: string;
       children: Array<{ type: string; value: string }>;
     };
+
+    // Full [text][ref] and collapsed [text][] references are links, not entries.
+    if (ref.referenceType === "full" || ref.referenceType === "collapsed") {
+      return undefined;
+    }
+
+    // Shortcut [text] with a matching definition is a resolved link, not an entry.
+    if (ref.referenceType === "shortcut" && ref.identifier != null) {
+      if (definitions.has(ref.identifier)) return undefined;
+    }
+
     displayId = ref.label ?? ref.children?.[0]?.value;
     // Title comes from subsequent text nodes in the paragraph
     if (displayId && paragraph.children.length > 1) {

--- a/packages/markspec/core/parser/markdown_test.ts
+++ b/packages/markspec/core/parser/markdown_test.ts
@@ -251,6 +251,101 @@ Deno.test("parseMarkdown: long type prefix is valid", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Entry exclusion checks (AST spec §1)
+// ---------------------------------------------------------------------------
+
+Deno.test("parseMarkdown: ordered list items are not entries", () => {
+  const md = `# Test
+
+1. [SRS_BRK_0001] Ordered list item
+
+   Body text.
+
+   Id: SRS_01HGW2Q8MNP3
+`;
+  const entries = parseMarkdown(md, { file: "test.md" });
+  assertEquals(entries.length, 0);
+});
+
+Deno.test("parseMarkdown: nested list items are not entries", () => {
+  const md = `# Test
+
+- Parent item
+  - [SRS_BRK_0001] Nested entry
+
+    Body text.
+
+    Id: SRS_01HGW2Q8MNP3
+`;
+  const entries = parseMarkdown(md, { file: "test.md" });
+  assertEquals(entries.length, 0);
+});
+
+Deno.test("parseMarkdown: inline link is not an entry", () => {
+  const md = `# Test
+
+- [See documentation](https://example.com) for details
+
+  This has indented body content.
+`;
+  const entries = parseMarkdown(md, { file: "test.md" });
+  assertEquals(entries.length, 0);
+});
+
+Deno.test("parseMarkdown: full linkReference is not an entry", () => {
+  const md = `# Test
+
+- [See docs][ref-id] for details
+
+  This has indented body content.
+
+[ref-id]: https://example.com
+`;
+  const entries = parseMarkdown(md, { file: "test.md" });
+  assertEquals(entries.length, 0);
+});
+
+Deno.test("parseMarkdown: collapsed linkReference is not an entry", () => {
+  const md = `# Test
+
+- [CommonMark][] is the baseline
+
+  This has indented body content.
+
+[CommonMark]: https://commonmark.org
+`;
+  const entries = parseMarkdown(md, { file: "test.md" });
+  assertEquals(entries.length, 0);
+});
+
+Deno.test("parseMarkdown: shortcut ref with definition is not an entry", () => {
+  const md = `# Test
+
+- [CommonMark] is the baseline grammar
+
+  This has indented body content.
+
+[CommonMark]: https://commonmark.org
+`;
+  const entries = parseMarkdown(md, { file: "test.md" });
+  assertEquals(entries.length, 0);
+});
+
+Deno.test("parseMarkdown: shortcut ref without definition is still an entry", () => {
+  const md = `# Test
+
+- [ISO-26262-6] ISO 26262 Part 6
+
+  Road vehicles — Functional safety.
+
+  Document: ISO 26262-6:2018
+`;
+  const entries = parseMarkdown(md, { file: "test.md" });
+  assertEquals(entries.length, 1);
+  assertEquals(entries[0].displayId, "ISO-26262-6");
+});
+
+// ---------------------------------------------------------------------------
 // Body indent stripping (#94)
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Skip ordered lists (`list.ordered === true`)
- Skip inline links (`[text](url)`) via `link` node type check
- Skip full and collapsed linkReferences (`[text][ref]`, `[text][]`)
- Skip shortcut linkReferences when a matching `definition` exists in the document
- Collect `definition` identifiers before entry extraction loop
- Nested lists already excluded by top-level-only walk (test added to lock behavior)

Implements the full entry detection decision tree from `docs/spec/ast.md` §1.

## Test plan

- [x] 7 new unit tests covering ordered list, nested list, inline link, full/collapsed/shortcut linkReference exclusions, and regression for shortcut refs without definitions
- [x] All 80 tests pass
- [x] `just build` passes (check + test + lint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)