### PR TITLE
feat(core): caption detection for tables and figures

### DIFF
--- a/packages/markspec/core/mod.ts
+++ b/packages/markspec/core/mod.ts
@@ -19,6 +19,7 @@ export {
 export type {
   Attribute,
   BuiltinType,
+  Caption,
   ConfigFieldError,
   Diagnostic,
   DisplayId,
@@ -40,7 +41,7 @@ export {
 export type { LoadConfigResult, ReadFile } from "./config/mod.ts";
 
 // Parser
-export { parse } from "./parser/mod.ts";
+export { detectCaptions, parse } from "./parser/mod.ts";
 export type { ParseOptions } from "./parser/mod.ts";
 
 // Formatter

--- a/packages/markspec/core/model/mod.ts
+++ b/packages/markspec/core/model/mod.ts
@@ -173,6 +173,18 @@ export interface ConfigFieldError {
   readonly line: number | undefined;
 }
 
+// ---------------------------------------------------------------------------
+// Caption
+// ---------------------------------------------------------------------------
+
+/** A detected table or figure caption in a Markdown document. */
+export interface Caption {
+  readonly kind: "table" | "figure";
+  readonly slug: string;
+  readonly text: string;
+  readonly location: SourceLocation;
+}
+
 /** Error thrown when `project.yaml` is invalid. */
 export class ConfigError extends Error {
   /** Path to the `project.yaml` file. */

--- a/packages/markspec/core/parser/captions.ts
+++ b/packages/markspec/core/parser/captions.ts
@@ -1,0 +1,176 @@
+/**
+ * @module parser/captions
+ *
+ * Detects table and figure captions in Markdown documents.
+ *
+ * Caption patterns:
+ * - **Table**: `_Table: text_` paragraph immediately followed by a `table` sibling.
+ * - **Figure**: `image` node followed by `_Figure: text_` paragraph.
+ * - **Figure fallback**: `image` with non-empty alt text and no explicit caption.
+ */
+
+import type { Emphasis, Image, Paragraph, Text } from "mdast";
+import type { Caption } from "../model/mod.ts";
+import { processor } from "./remark.ts";
+
+/** Options for {@linkcode detectCaptions}. */
+export interface DetectCaptionsOptions {
+  /** File path used in source locations. */
+  readonly file?: string;
+}
+
+/**
+ * Convert caption text to a GFM-style anchor slug.
+ *
+ * Lowercase, spaces to hyphens, strip non-alphanumeric except hyphens.
+ */
+function toSlug(prefix: string, text: string): string {
+  const anchor = text
+    .toLowerCase()
+    .replace(/\s+/g, "-")
+    .replace(/[^a-z0-9-]/g, "");
+  return `${prefix}.${anchor}`;
+}
+
+/**
+ * Extract plain text from an emphasis node (single emphasis child
+ * containing text children).
+ */
+function getEmphasisText(node: Emphasis): string | undefined {
+  if (node.children.length === 0) return undefined;
+  return node.children
+    .filter((c): c is Text => c.type === "text")
+    .map((c) => c.value)
+    .join("");
+}
+
+/**
+ * Check if a paragraph contains a single emphasis child whose text
+ * starts with the given prefix (e.g., "Table:" or "Figure:").
+ * Returns the text after the prefix, or undefined.
+ */
+function getCaptionText(
+  paragraph: Paragraph,
+  prefix: string,
+): string | undefined {
+  // A caption paragraph has exactly one child: an emphasis node.
+  if (paragraph.children.length !== 1) return undefined;
+  const child = paragraph.children[0];
+  if (child.type !== "emphasis") return undefined;
+
+  const text = getEmphasisText(child as Emphasis);
+  if (!text) return undefined;
+  if (!text.startsWith(prefix)) return undefined;
+
+  return text.slice(prefix.length).trim();
+}
+
+/**
+ * Check if a node is an image or a paragraph containing only an image.
+ * Returns the image node if found.
+ */
+function getImage(
+  node: { type: string; children?: unknown[] },
+): Image | undefined {
+  if (node.type === "image") return node as Image;
+  if (node.type === "paragraph") {
+    const para = node as Paragraph;
+    if (para.children.length === 1 && para.children[0].type === "image") {
+      return para.children[0] as Image;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Detect table and figure captions in a Markdown string.
+ *
+ * @param markdown - Markdown source text
+ * @param options - Detection options (file path for source locations)
+ * @returns Array of detected captions
+ */
+export function detectCaptions(
+  markdown: string,
+  options?: DetectCaptionsOptions,
+): Caption[] {
+  const file = options?.file ?? "<unknown>";
+  const tree = processor.parse(markdown);
+  const captions: Caption[] = [];
+  const children = tree.children;
+
+  // Track which image nodes have explicit figure captions so we can
+  // apply the alt-text fallback only to uncaptioned images.
+  const captionedImageIndices = new Set<number>();
+
+  // First pass: detect explicit captions.
+  for (let i = 0; i < children.length; i++) {
+    const node = children[i];
+
+    // Table caption: paragraph with _Table: text_ followed by a table.
+    if (node.type === "paragraph") {
+      const text = getCaptionText(node as Paragraph, "Table:");
+      if (text && i + 1 < children.length && children[i + 1].type === "table") {
+        captions.push({
+          kind: "table",
+          slug: toSlug("tbl", text),
+          text,
+          location: {
+            file,
+            line: node.position?.start.line ?? 1,
+            column: node.position?.start.column ?? 1,
+          },
+        });
+        continue;
+      }
+    }
+
+    // Figure caption: image (or paragraph containing image) followed by
+    // paragraph with _Figure: text_.
+    const image = getImage(
+      node as { type: string; children?: unknown[] },
+    );
+    if (image && i + 1 < children.length) {
+      const next = children[i + 1];
+      if (next.type === "paragraph") {
+        const text = getCaptionText(next as Paragraph, "Figure:");
+        if (text) {
+          captionedImageIndices.add(i);
+          captions.push({
+            kind: "figure",
+            slug: toSlug("fig", text),
+            text,
+            location: {
+              file,
+              line: image.position?.start.line ?? 1,
+              column: image.position?.start.column ?? 1,
+            },
+          });
+          continue;
+        }
+      }
+    }
+  }
+
+  // Second pass: alt-text fallback for uncaptioned images.
+  for (let i = 0; i < children.length; i++) {
+    if (captionedImageIndices.has(i)) continue;
+
+    const image = getImage(
+      children[i] as { type: string; children?: unknown[] },
+    );
+    if (image && image.alt && image.alt.trim() !== "") {
+      captions.push({
+        kind: "figure",
+        slug: toSlug("fig", image.alt),
+        text: image.alt,
+        location: {
+          file,
+          line: image.position?.start.line ?? 1,
+          column: image.position?.start.column ?? 1,
+        },
+      });
+    }
+  }
+
+  return captions;
+}

--- a/packages/markspec/core/parser/captions_test.ts
+++ b/packages/markspec/core/parser/captions_test.ts
@@ -1,0 +1,101 @@
+/**
+ * @module parser/captions_test
+ *
+ * Unit tests for table and figure caption detection.
+ */
+
+import { assertEquals } from "@std/assert";
+import { detectCaptions } from "./captions.ts";
+
+// ---------------------------------------------------------------------------
+// Table captions
+// ---------------------------------------------------------------------------
+
+Deno.test("detectCaptions: table caption before pipe table", () => {
+  const md = `# Sensor Config
+
+_Table: Sensor thresholds_
+
+| Sensor   | Min | Max |
+| -------- | --- | --- |
+| Pressure | 0   | 100 |
+| Speed    | 0   | 300 |
+`;
+  const captions = detectCaptions(md, { file: "config.md" });
+  assertEquals(captions.length, 1);
+  assertEquals(captions[0].kind, "table");
+  assertEquals(captions[0].slug, "tbl.sensor-thresholds");
+  assertEquals(captions[0].text, "Sensor thresholds");
+  assertEquals(captions[0].location.file, "config.md");
+});
+
+// ---------------------------------------------------------------------------
+// Figure captions
+// ---------------------------------------------------------------------------
+
+Deno.test("detectCaptions: figure caption after image", () => {
+  const md = `# Architecture
+
+![](architecture.svg)
+
+_Figure: Architecture overview_
+`;
+  const captions = detectCaptions(md, { file: "arch.md" });
+  assertEquals(captions.length, 1);
+  assertEquals(captions[0].kind, "figure");
+  assertEquals(captions[0].slug, "fig.architecture-overview");
+  assertEquals(captions[0].text, "Architecture overview");
+  assertEquals(captions[0].location.file, "arch.md");
+});
+
+// ---------------------------------------------------------------------------
+// Alt text fallback
+// ---------------------------------------------------------------------------
+
+Deno.test("detectCaptions: alt text fallback when no explicit caption", () => {
+  const md = `# Diagrams
+
+![System overview](img.svg)
+`;
+  const captions = detectCaptions(md, { file: "diag.md" });
+  assertEquals(captions.length, 1);
+  assertEquals(captions[0].kind, "figure");
+  assertEquals(captions[0].slug, "fig.system-overview");
+  assertEquals(captions[0].text, "System overview");
+});
+
+// ---------------------------------------------------------------------------
+// Non-caption emphasis ignored
+// ---------------------------------------------------------------------------
+
+Deno.test("detectCaptions: emphasis not starting with Table: is ignored", () => {
+  const md = `# Notes
+
+_Important: read this carefully_
+
+| Col A | Col B |
+| ----- | ----- |
+| 1     | 2     |
+`;
+  const captions = detectCaptions(md, { file: "notes.md" });
+  assertEquals(captions.length, 0);
+});
+
+// ---------------------------------------------------------------------------
+// Caption not immediately followed by table
+// ---------------------------------------------------------------------------
+
+Deno.test("detectCaptions: caption not immediately followed by table is ignored", () => {
+  const md = `# Notes
+
+_Table: Orphan caption_
+
+Some intervening paragraph.
+
+| Col A | Col B |
+| ----- | ----- |
+| 1     | 2     |
+`;
+  const captions = detectCaptions(md, { file: "notes.md" });
+  assertEquals(captions.length, 0);
+});

--- a/packages/markspec/core/parser/markdown.ts
+++ b/packages/markspec/core/parser/markdown.ts
@@ -5,12 +5,10 @@
  * `- [TYPE_XYZ_NNN[N]]` entry blocks and extract structured attributes.
  */
 
-import { unified } from "unified";
-import remarkParse from "remark-parse";
-import remarkGfm from "remark-gfm";
 import type { Definition, List, ListItem, Paragraph, Text } from "mdast";
 import type { Entry, EntryType } from "../model/mod.ts";
 import { parseAttributes, splitBodyAndAttributes } from "./attributes.ts";
+import { processor } from "./remark.ts";
 
 /** Options for {@linkcode parseMarkdown}. */
 export interface ParseMarkdownOptions {
@@ -34,9 +32,6 @@ const REF_ID_RE = /^[A-Za-z0-9-]+$/;
  * Captures: [1] = full display ID, [2] = title (rest of line).
  */
 const ENTRY_START_RE = /^\[([^\]]+)\]\s*(.*)$/;
-
-/** Build the remark processor once. */
-const processor = unified().use(remarkParse).use(remarkGfm);
 
 /**
  * Parse a Markdown string and return all MarkSpec entries found.

--- a/packages/markspec/core/parser/mod.ts
+++ b/packages/markspec/core/parser/mod.ts
@@ -3,13 +3,18 @@
  *
  * MarkSpec parser — file → Entry[].
  *
- * Two sub-modules:
+ * Three sub-modules:
  * - markdown: CommonMark AST walk, entry block detection, attribute extraction
+ * - captions: table and figure caption detection
  * - source: doc comment extraction from Rust, Kotlin, C, C++, Java
  */
 
-import type { Entry } from "../model/mod.ts";
+import type { Caption, Entry } from "../model/mod.ts";
 import { parseMarkdown } from "./markdown.ts";
+import {
+  detectCaptions as detectCaptionsImpl,
+  type DetectCaptionsOptions,
+} from "./captions.ts";
 
 /** Options for {@linkcode parse}. */
 export interface ParseOptions {
@@ -29,4 +34,18 @@ export function parse(
   options?: ParseOptions,
 ): Entry[] {
   return parseMarkdown(markdown, options);
+}
+
+/**
+ * Detect table and figure captions in a Markdown string.
+ *
+ * @param markdown - Markdown source text
+ * @param options - Detection options (file path for source locations)
+ * @returns Array of detected captions
+ */
+export function detectCaptions(
+  markdown: string,
+  options?: DetectCaptionsOptions,
+): Caption[] {
+  return detectCaptionsImpl(markdown, options);
 }

--- a/packages/markspec/core/parser/remark.ts
+++ b/packages/markspec/core/parser/remark.ts
@@ -1,0 +1,13 @@
+/**
+ * @module parser/remark
+ *
+ * Shared remark processor instance for Markdown parsing.
+ * Used by both the entry parser and the caption detector.
+ */
+
+import { unified } from "unified";
+import remarkParse from "remark-parse";
+import remarkGfm from "remark-gfm";
+
+/** Shared remark + GFM processor. Built once, reused across modules. */
+export const processor = unified().use(remarkParse).use(remarkGfm);


### PR DESCRIPTION
## What

Add `detectCaptions()` function to the core parser that identifies table and figure captions in Markdown documents, returning typed `Caption` objects with kind, slug, text, and source location.

## Why

Closes #14

Caption detection is needed for figure/table numbering and cross-referencing in rendered output.

## How

- **New type `Caption`** in `core/model/mod.ts` with `kind`, `slug`, `text`, and `location` fields.
- **New module `core/parser/captions.ts`** that walks the remark AST looking for:
  - Table captions: `_Table: text_` paragraph immediately followed by a `table` sibling
  - Figure captions: image node followed by `_Figure: text_` paragraph
  - Fallback: image with non-empty alt text and no explicit caption
- **Shared remark processor** extracted to `core/parser/remark.ts` (was inline in `markdown.ts`).
- **Exported** from `core/parser/mod.ts` and `core/mod.ts`.

## Checklist

- [x] Tests added or updated
- [x] Documentation updated
- [x] All checks pass