### PR TITLE
feat(core): attribute block normalization

### DIFF
--- a/packages/markspec/core/formatter/mod.ts
+++ b/packages/markspec/core/formatter/mod.ts
@@ -6,7 +6,32 @@
  * and requirement block insertion.
  */
 
-import type { Diagnostic } from "../model/mod.ts";
+import type { Attribute, Diagnostic } from "../model/mod.ts";
+import { parseMarkdown } from "../parser/markdown.ts";
+
+/** Canonical attribute ordering. Unknown keys go before Labels. */
+const CANONICAL_ORDER: readonly string[] = [
+  "Id",
+  "Satisfies",
+  "Derived-from",
+  "Allocates",
+  "Component",
+  "Constrains",
+  "Between",
+  "Interface",
+  "Labels",
+];
+
+/** Pattern matching a `Key: Value` line with optional trailing backslash. */
+const ATTR_LINE_RE = /^[A-Z][A-Za-z-]*: .+\\?$/;
+
+/** Options for {@linkcode format}. */
+export interface FormatOptions {
+  /** File path for diagnostic messages. */
+  readonly file?: string;
+  /** ULID generator override (for testing). */
+  readonly generateUlid?: () => string;
+}
 
 /** Result of a format operation. */
 export interface FormatResult {
@@ -19,12 +44,158 @@ export interface FormatResult {
 }
 
 /**
- * Format a Markdown string — stamp ULIDs, normalize attributes,
- * fix indentation.
+ * Format a Markdown string — normalize attribute blocks,
+ * fix indentation, enforce canonical ordering.
  *
  * @param markdown - Markdown source text
+ * @param options - Format options
  * @returns Format result with output text and diagnostics
  */
-export function format(markdown: string): FormatResult {
-  return { output: markdown, diagnostics: [], changed: false };
+export function format(
+  markdown: string,
+  options?: FormatOptions,
+): FormatResult {
+  const file = options?.file ?? "<unknown>";
+  const entries = parseMarkdown(markdown, { file });
+
+  if (entries.length === 0) {
+    return { output: markdown, diagnostics: [], changed: false };
+  }
+
+  const lines = markdown.split("\n");
+  const diagnostics: Diagnostic[] = [];
+  let changed = false;
+
+  // Process bottom-to-top so line splicing doesn't shift earlier entries.
+  const sorted = [...entries].sort((a, b) => b.location.line - a.location.line);
+
+  for (const entry of sorted) {
+    if (entry.attributes.length === 0) continue;
+
+    const indent = (entry.location.column - 1) + 2;
+    const range = findAttributeBlockRange(lines, entry.location.line, indent);
+    if (!range) continue;
+
+    const normalized = sortAttributes([...entry.attributes]);
+    const newBlock = renderAttributeBlock(normalized, indent);
+    const oldBlock = lines.slice(range.start, range.end).join("\n");
+
+    if (newBlock !== oldBlock) {
+      lines.splice(range.start, range.end - range.start, ...newBlock.split("\n"));
+      changed = true;
+    }
+  }
+
+  return { output: lines.join("\n"), diagnostics, changed };
+}
+
+/**
+ * Sort attributes to canonical order.
+ * Unknown keys are placed before Labels, preserving their relative order.
+ */
+export function sortAttributes(attributes: Attribute[]): Attribute[] {
+  const known: (Attribute | undefined)[] = new Array(CANONICAL_ORDER.length);
+  const unknown: Attribute[] = [];
+
+  for (const attr of attributes) {
+    const idx = CANONICAL_ORDER.indexOf(attr.key);
+    if (idx >= 0) {
+      known[idx] = attr;
+    } else {
+      unknown.push(attr);
+    }
+  }
+
+  const result: Attribute[] = [];
+  const labelsIdx = CANONICAL_ORDER.indexOf("Labels");
+
+  for (let i = 0; i < known.length; i++) {
+    // Insert unknown attributes just before Labels
+    if (i === labelsIdx) {
+      result.push(...unknown);
+    }
+    if (known[i] != null) {
+      result.push(known[i]!);
+    }
+  }
+
+  // If Labels was not present, unknown attrs go at the end
+  if (!known[labelsIdx]) {
+    result.push(...unknown);
+  }
+
+  return result;
+}
+
+/**
+ * Render attributes as indented `Key: Value\` lines.
+ * Trailing backslash on all lines except the last.
+ */
+export function renderAttributeBlock(
+  attributes: Attribute[],
+  indent: number,
+): string {
+  const prefix = " ".repeat(indent);
+  return attributes
+    .map((attr, i) => {
+      const sep = i < attributes.length - 1 ? "\\" : "";
+      return `${prefix}${attr.key}: ${attr.value}${sep}`;
+    })
+    .join("\n");
+}
+
+/**
+ * Find the 0-based line range [start, end) of the attribute block
+ * for an entry starting at the given line.
+ *
+ * Scans forward from the entry start to find the list item boundary,
+ * then walks backwards to find the contiguous trailing attribute block.
+ */
+export function findAttributeBlockRange(
+  lines: readonly string[],
+  entryStartLine: number,
+  indent: number,
+): { start: number; end: number } | undefined {
+  const startIdx = entryStartLine - 1; // Convert 1-based to 0-based
+  const indentStr = " ".repeat(indent);
+
+  // Find the end of this list item's content.
+  // The list item ends when we hit: a line at the entry's indent level starting
+  // with `- `, or a non-blank line with less indent, or end of file.
+  let itemEnd = lines.length;
+  for (let i = startIdx + 1; i < lines.length; i++) {
+    const line = lines[i];
+    // Blank lines within the list item are OK
+    if (line.trim() === "") continue;
+    // If the line doesn't start with the continuation indent, the item is over
+    if (!line.startsWith(indentStr)) {
+      itemEnd = i;
+      break;
+    }
+  }
+
+  // Walk backwards from itemEnd to find the contiguous attribute block.
+  // Skip trailing blank lines first.
+  let scanEnd = itemEnd;
+  while (scanEnd > startIdx && lines[scanEnd - 1].trim() === "") {
+    scanEnd--;
+  }
+
+  if (scanEnd <= startIdx) return undefined;
+
+  // Now walk backwards collecting attribute lines
+  let attrStart = scanEnd;
+  for (let i = scanEnd - 1; i > startIdx; i--) {
+    const trimmed = lines[i].trim();
+    if (trimmed === "") break; // blank line = boundary
+    if (ATTR_LINE_RE.test(trimmed)) {
+      attrStart = i;
+    } else {
+      break;
+    }
+  }
+
+  if (attrStart >= scanEnd) return undefined;
+
+  return { start: attrStart, end: scanEnd };
 }

--- a/packages/markspec/core/formatter/mod_test.ts
+++ b/packages/markspec/core/formatter/mod_test.ts
@@ -1,0 +1,215 @@
+/**
+ * @module formatter/mod_test
+ *
+ * Unit tests for attribute block normalization.
+ */
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { format } from "./mod.ts";
+
+// ---------------------------------------------------------------------------
+// Canonical order
+// ---------------------------------------------------------------------------
+
+Deno.test("format: attributes already in canonical order are unchanged", () => {
+  const md = `# Test
+
+- [SRS_BRK_0001] Title
+
+  Body text.
+
+  Id: SRS_01HGW2Q8MNP3\\
+  Satisfies: SYS_BRK_0042\\
+  Labels: ASIL-B
+`;
+  const result = format(md);
+  assertEquals(result.changed, false);
+  assertEquals(result.output, md);
+});
+
+Deno.test("format: out-of-order attributes are sorted", () => {
+  const md = `# Test
+
+- [SRS_BRK_0001] Title
+
+  Body text.
+
+  Labels: ASIL-B\\
+  Id: SRS_01HGW2Q8MNP3
+`;
+  const result = format(md);
+  assertEquals(result.changed, true);
+  assertStringIncludes(result.output, "Id: SRS_01HGW2Q8MNP3\\");
+  assertStringIncludes(result.output, "Labels: ASIL-B");
+  // Id should come before Labels
+  const idIdx = result.output.indexOf("Id:");
+  const labelsIdx = result.output.indexOf("Labels:");
+  assertEquals(idIdx < labelsIdx, true);
+});
+
+Deno.test("format: full canonical reorder", () => {
+  const md = `# Test
+
+- [SRS_BRK_0001] Title
+
+  Body text.
+
+  Labels: ASIL-B\\
+  Satisfies: SYS_BRK_0042\\
+  Id: SRS_01HGW2Q8MNP3
+`;
+  const result = format(md);
+  assertEquals(result.changed, true);
+  const lines = result.output.split("\n");
+  const attrLines = lines.filter((l) => l.trim().match(/^[A-Z][a-z-]*: /));
+  assertEquals(attrLines.length, 3);
+  assertStringIncludes(attrLines[0], "Id:");
+  assertStringIncludes(attrLines[1], "Satisfies:");
+  assertStringIncludes(attrLines[2], "Labels:");
+});
+
+Deno.test("format: trailing backslashes normalized", () => {
+  const md = `# Test
+
+- [SRS_BRK_0001] Title
+
+  Body text.
+
+  Id: SRS_01HGW2Q8MNP3
+  Satisfies: SYS_BRK_0042\\
+  Labels: ASIL-B\\
+`;
+  const result = format(md);
+  assertEquals(result.changed, true);
+  // Id line should have backslash (not last), Labels should NOT
+  assertStringIncludes(result.output, "Id: SRS_01HGW2Q8MNP3\\");
+  assertStringIncludes(result.output, "Satisfies: SYS_BRK_0042\\");
+  // Labels is last — no backslash
+  const labelsLine = result.output.split("\n").find((l) =>
+    l.trim().startsWith("Labels:")
+  );
+  assertEquals(labelsLine?.endsWith("\\"), false);
+});
+
+Deno.test("format: indentation fixed to 2-space", () => {
+  const md = `# Test
+
+- [SRS_BRK_0001] Title
+
+  Body text.
+
+    Id: SRS_01HGW2Q8MNP3\\
+    Labels: ASIL-B
+`;
+  const result = format(md);
+  assertEquals(result.changed, true);
+  const idLine = result.output.split("\n").find((l) => l.includes("Id:"));
+  // Should be indented with exactly 2 spaces (column 1 entry + 2 for "- ")
+  assertEquals(idLine?.startsWith("  Id:"), true);
+});
+
+Deno.test("format: surrounding content untouched", () => {
+  const md = `# Braking System
+
+Some intro paragraph.
+
+- [SRS_BRK_0001] Title
+
+  Body text with **bold** and \`code\`.
+
+  > [!WARNING]
+  > Important note.
+
+  Labels: ASIL-B\\
+  Id: SRS_01HGW2Q8MNP3
+
+## Next Section
+
+More content here.
+`;
+  const result = format(md);
+  assertEquals(result.changed, true);
+  // Heading, body, alert, and trailing section should be byte-identical
+  assertStringIncludes(result.output, "# Braking System");
+  assertStringIncludes(result.output, "Some intro paragraph.");
+  assertStringIncludes(result.output, "Body text with **bold** and `code`.");
+  assertStringIncludes(result.output, "> [!WARNING]");
+  assertStringIncludes(result.output, "## Next Section");
+  assertStringIncludes(result.output, "More content here.");
+});
+
+Deno.test("format: multiple entries normalized", () => {
+  const md = `# Test
+
+- [SRS_BRK_0001] First
+
+  Body one.
+
+  Labels: ASIL-B\\
+  Id: SRS_01HGW2Q8MNP3
+
+- [SRS_BRK_0002] Second
+
+  Body two.
+
+  Labels: ASIL-A\\
+  Id: SRS_01HGW2R9QLP4
+`;
+  const result = format(md);
+  assertEquals(result.changed, true);
+  // Both entries should have Id before Labels
+  const idPositions = [...result.output.matchAll(/Id:/g)].map((m) => m.index);
+  const labelPositions = [...result.output.matchAll(/Labels:/g)].map((m) =>
+    m.index
+  );
+  assertEquals(idPositions.length, 2);
+  assertEquals(labelPositions.length, 2);
+  assertEquals(idPositions[0]! < labelPositions[0]!, true);
+  assertEquals(idPositions[1]! < labelPositions[1]!, true);
+});
+
+Deno.test("format: entry without attributes is unchanged", () => {
+  const md = `# Test
+
+- [SRS_BRK_0001] Title
+
+  Body text only, no attributes.
+`;
+  const result = format(md);
+  assertEquals(result.changed, false);
+  assertEquals(result.output, md);
+});
+
+Deno.test("format: unknown attributes preserved before Labels", () => {
+  const md = `# Test
+
+- [ISO-26262-6] ISO 26262 Part 6
+
+  Road vehicles — Functional safety.
+
+  URL: https://www.iso.org/standard/68383.html\\
+  Document: ISO 26262-6:2018
+`;
+  const result = format(md);
+  // Unknown keys (Document, URL) should preserve relative order
+  // Both are unknown, so they stay in original order before any known keys
+  assertEquals(result.output.includes("URL:"), true);
+  assertEquals(result.output.includes("Document:"), true);
+});
+
+Deno.test("format: idempotent on already-formatted input", () => {
+  const md = `# Test
+
+- [SRS_BRK_0001] Title
+
+  Body text.
+
+  Id: SRS_01HGW2Q8MNP3\\
+  Satisfies: SYS_BRK_0042\\
+  Labels: ASIL-B
+`;
+  const first = format(md);
+  const second = format(first.output);
+  assertEquals(second.changed, false);
+  assertEquals(second.output, first.output);
+});

--- a/packages/markspec/core/mod.ts
+++ b/packages/markspec/core/mod.ts
@@ -57,7 +57,7 @@ export type {
 
 // Formatter
 export { format } from "./formatter/mod.ts";
-export type { FormatResult } from "./formatter/mod.ts";
+export type { FormatOptions, FormatResult } from "./formatter/mod.ts";
 
 // Validator
 export { validate } from "./validator/mod.ts";


### PR DESCRIPTION
## Summary

- Implement in-place attribute block normalization with canonical ordering
- Sort attributes: Id, Satisfies, Derived-from, Allocates, Component, Constrains, Between, Interface, Labels
- Unknown attributes preserved before Labels in relative order
- Trailing backslash enforcement (all lines except last)
- Indentation normalized to match list item continuation indent
- Line-based replacement, entries processed bottom-to-top
- Surrounding markdown untouched (lossless write-back)

Closes #16

## Test plan

- [x] 10 unit tests covering canonical order, reorder, backslashes, indent, surrounding content, multiple entries, no attributes, unknown keys, idempotency
- [x] All 109 tests pass
- [x] `just build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)