### PR TITLE
feat(core): ULID assignment for entries missing Id

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -8,6 +8,7 @@
   "imports": {
     "@deno/dnt": "jsr:@deno/dnt@^0.42.3",
     "@std/assert": "jsr:@std/assert@^1",
+    "@std/ulid": "jsr:@std/ulid@^1",
     "@std/yaml": "jsr:@std/yaml@^1",
     "@std/path": "jsr:@std/path@^1"
   },

--- a/packages/markspec/core/formatter/mod.ts
+++ b/packages/markspec/core/formatter/mod.ts
@@ -6,7 +6,8 @@
  * and requirement block insertion.
  */
 
-import type { Attribute, Diagnostic } from "../model/mod.ts";
+import { ulid as defaultUlid } from "@std/ulid";
+import type { Attribute, Diagnostic, Entry } from "../model/mod.ts";
 import { parseMarkdown } from "../parser/markdown.ts";
 
 /** Canonical attribute ordering. Unknown keys go before Labels. */
@@ -69,19 +70,47 @@ export function format(
   // Process bottom-to-top so line splicing doesn't shift earlier entries.
   const sorted = [...entries].sort((a, b) => b.location.line - a.location.line);
 
+  const genUlid = options?.generateUlid ?? defaultUlid;
+
   for (const entry of sorted) {
-    if (entry.attributes.length === 0) continue;
-
     const indent = (entry.location.column - 1) + 2;
+    let attrs = [...entry.attributes];
+
+    // Assign ULID to typed entries missing Id.
+    if (entry.entryType && !attrs.some((a) => a.key === "Id")) {
+      const newId = `${entry.entryType}_${genUlid()}`;
+      attrs = [{ key: "Id", value: newId }, ...attrs];
+      diagnostics.push({
+        code: "MSL-F001",
+        severity: "info",
+        message: `assigned Id: ${newId} to ${entry.displayId}`,
+        location: entry.location,
+      });
+    }
+
+    if (attrs.length === 0) continue;
+
+    const normalized = sortAttributes(attrs);
     const range = findAttributeBlockRange(lines, entry.location.line, indent);
-    if (!range) continue;
 
-    const normalized = sortAttributes([...entry.attributes]);
-    const newBlock = renderAttributeBlock(normalized, indent);
-    const oldBlock = lines.slice(range.start, range.end).join("\n");
+    if (range) {
+      // Replace existing attribute block.
+      const newBlock = renderAttributeBlock(normalized, indent);
+      const oldBlock = lines.slice(range.start, range.end).join("\n");
 
-    if (newBlock !== oldBlock) {
-      lines.splice(range.start, range.end - range.start, ...newBlock.split("\n"));
+      if (newBlock !== oldBlock) {
+        lines.splice(
+          range.start,
+          range.end - range.start,
+          ...newBlock.split("\n"),
+        );
+        changed = true;
+      }
+    } else {
+      // No attribute block — insert one after the entry body.
+      const insertLine = findEntryBodyEnd(lines, entry, indent);
+      const newBlock = renderAttributeBlock(normalized, indent);
+      lines.splice(insertLine, 0, "", ...newBlock.split("\n"));
       changed = true;
     }
   }
@@ -198,4 +227,36 @@ export function findAttributeBlockRange(
   if (attrStart >= scanEnd) return undefined;
 
   return { start: attrStart, end: scanEnd };
+}
+
+/**
+ * Find the 0-based line index where a new attribute block should be inserted
+ * (after the last non-blank body line of the entry).
+ */
+function findEntryBodyEnd(
+  lines: readonly string[],
+  entry: Entry,
+  indent: number,
+): number {
+  const startIdx = entry.location.line - 1;
+  const indentStr = " ".repeat(indent);
+
+  // Find the end of this list item's content.
+  let itemEnd = lines.length;
+  for (let i = startIdx + 1; i < lines.length; i++) {
+    const line = lines[i];
+    if (line.trim() === "") continue;
+    if (!line.startsWith(indentStr)) {
+      itemEnd = i;
+      break;
+    }
+  }
+
+  // Walk back past trailing blank lines
+  let insertAt = itemEnd;
+  while (insertAt > startIdx && lines[insertAt - 1].trim() === "") {
+    insertAt--;
+  }
+
+  return insertAt;
 }

--- a/packages/markspec/core/formatter/mod_test.ts
+++ b/packages/markspec/core/formatter/mod_test.ts
@@ -168,12 +168,12 @@ Deno.test("format: multiple entries normalized", () => {
   assertEquals(idPositions[1]! < labelPositions[1]!, true);
 });
 
-Deno.test("format: entry without attributes is unchanged", () => {
+Deno.test("format: reference entry without attributes is unchanged", () => {
   const md = `# Test
 
-- [SRS_BRK_0001] Title
+- [ISO-26262-6] ISO 26262 Part 6
 
-  Body text only, no attributes.
+  Road vehicles — Functional safety.
 `;
   const result = format(md);
   assertEquals(result.changed, false);
@@ -212,4 +212,122 @@ Deno.test("format: idempotent on already-formatted input", () => {
   const second = format(first.output);
   assertEquals(second.changed, false);
   assertEquals(second.output, first.output);
+});
+
+// ---------------------------------------------------------------------------
+// ULID assignment (#15)
+// ---------------------------------------------------------------------------
+
+const MOCK_ULID = "01HGW2Q8MNTEST";
+const mockUlid = () => MOCK_ULID;
+
+Deno.test("format: missing Id gets ULID with correct type prefix", () => {
+  const md = `# Test
+
+- [SRS_BRK_0001] Title
+
+  Body text.
+
+  Satisfies: SYS_BRK_0042\\
+  Labels: ASIL-B
+`;
+  const result = format(md, { generateUlid: mockUlid });
+  assertEquals(result.changed, true);
+  assertStringIncludes(result.output, `Id: SRS_${MOCK_ULID}`);
+  // Id should be first attribute
+  const idIdx = result.output.indexOf("Id:");
+  const satIdx = result.output.indexOf("Satisfies:");
+  assertEquals(idIdx < satIdx, true);
+});
+
+Deno.test("format: existing Id unchanged", () => {
+  const md = `# Test
+
+- [SRS_BRK_0001] Title
+
+  Body text.
+
+  Id: SRS_01EXISTING123\\
+  Labels: ASIL-B
+`;
+  const result = format(md, { generateUlid: mockUlid });
+  assertStringIncludes(result.output, "Id: SRS_01EXISTING123");
+  // Mock ULID should NOT appear
+  assertEquals(result.output.includes(MOCK_ULID), false);
+});
+
+Deno.test("format: idempotent after ULID assignment", () => {
+  const md = `# Test
+
+- [SRS_BRK_0001] Title
+
+  Body text.
+
+  Labels: ASIL-B
+`;
+  const first = format(md, { generateUlid: mockUlid });
+  assertEquals(first.changed, true);
+  const second = format(first.output, { generateUlid: mockUlid });
+  assertEquals(second.changed, false);
+});
+
+Deno.test("format: reference entries skip ULID", () => {
+  const md = `# Test
+
+- [ISO-26262-6] ISO 26262 Part 6
+
+  Road vehicles — Functional safety.
+
+  Document: ISO 26262-6:2018
+`;
+  const result = format(md, { generateUlid: mockUlid });
+  assertEquals(result.output.includes("Id:"), false);
+});
+
+Deno.test("format: diagnostic emitted on ULID assignment", () => {
+  const md = `# Test
+
+- [SRS_BRK_0001] Title
+
+  Body text.
+
+  Labels: ASIL-B
+`;
+  const result = format(md, { generateUlid: mockUlid });
+  assertEquals(result.diagnostics.length, 1);
+  assertEquals(result.diagnostics[0].severity, "info");
+  assertStringIncludes(result.diagnostics[0].message, "SRS_BRK_0001");
+  assertStringIncludes(result.diagnostics[0].message, `SRS_${MOCK_ULID}`);
+});
+
+Deno.test("format: entry with no attributes gets new block with Id", () => {
+  const md = `# Test
+
+- [SRS_BRK_0001] Title
+
+  Body text only, no attributes.
+`;
+  const result = format(md, { generateUlid: mockUlid });
+  assertEquals(result.changed, true);
+  assertStringIncludes(result.output, `Id: SRS_${MOCK_ULID}`);
+  // Body should still be there
+  assertStringIncludes(result.output, "Body text only, no attributes.");
+});
+
+Deno.test("format: mock generateUlid produces deterministic output", () => {
+  const md = `# Test
+
+- [SRS_BRK_0001] First
+
+  Body one.
+
+- [SRS_BRK_0002] Second
+
+  Body two.
+`;
+  const result = format(md, { generateUlid: mockUlid });
+  assertEquals(result.changed, true);
+  // Both should get the same mock ULID (in real usage they'd differ)
+  const idMatches = [...result.output.matchAll(/Id: SRS_01HGW2Q8MNTEST/g)];
+  assertEquals(idMatches.length, 2);
 });


### PR DESCRIPTION
## Summary

- Add `@std/ulid` dependency
- Typed entries without `Id:` attribute get a generated `TYPE_ULID` inserted as the first attribute
- Entries with no attribute block get a new block inserted after the body
- Reference entries are skipped (no entryType)
- Injectable `generateUlid` option for test determinism
- Diagnostic emitted on each ULID assignment (`MSL-F001`)

Closes #15

## Test plan

- [x] 7 new unit tests covering ULID assignment, existing Id preservation, idempotency, reference skip, diagnostics, no-attribute entries, deterministic mock
- [x] All 116 tests pass
- [x] `just build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)