### PR TITLE
feat(cli): format subcommand with file args and --check mode

### DIFF
--- a/packages/markspec/main.ts
+++ b/packages/markspec/main.ts
@@ -98,13 +98,49 @@ const cli = new Command()
     { default: "text" },
   )
   // Core commands
-  .command("format")
+  .command("format [...files:string]")
   .description("Stamp ULIDs, fix indentation, normalize attributes")
-  .action(async () => {
+  .option("--check", "Check mode: report but don't write (exit 1 if changes needed)")
+  .action(async (options: { check?: boolean }, ...files: string[]) => {
+    if (files.length === 0) {
+      console.error("error: no files specified");
+      console.error("usage: markspec format <file...>");
+      Deno.exit(1);
+    }
+
     const { format } = await import("./core/mod.ts");
-    const result = format("");
-    if (!result.changed) {
-      console.error("0 files formatted");
+
+    let totalFormatted = 0;
+    let totalUnchanged = 0;
+
+    for (const filePath of files) {
+      const content = await Deno.readTextFile(filePath);
+      const result = format(content, { file: filePath });
+
+      for (const d of result.diagnostics) {
+        const loc = d.location
+          ? `${d.location.file}:${d.location.line}`
+          : "";
+        console.error(`${d.severity}: ${loc} ${d.message}`);
+      }
+
+      if (result.changed) {
+        totalFormatted++;
+        if (!options.check) {
+          await Deno.writeTextFile(filePath, result.output);
+        }
+      } else {
+        totalUnchanged++;
+      }
+    }
+
+    const total = totalFormatted + totalUnchanged;
+    console.error(
+      `${totalFormatted} file(s) formatted, ${totalUnchanged} unchanged (${total} total)`,
+    );
+
+    if (options.check && totalFormatted > 0) {
+      Deno.exit(1);
     }
   })
   .command("validate")

--- a/tests/e2e/config_test.ts
+++ b/tests/e2e/config_test.ts
@@ -18,14 +18,14 @@ Deno.test("validate in nested dir finds project.yaml two levels up", async () =>
 });
 
 Deno.test("format outside project works with defaults", async () => {
-  const { code, stderr } = await markspec(["format"], {
+  const { code, stderr } = await markspec(["format", "req.md"], {
     files: {
       "req.md": "# Test\n",
     },
     // No project.yaml — format should work anyway
   });
   assertEquals(code, 0);
-  assertStringIncludes(stderr, "0 files formatted");
+  assertStringIncludes(stderr, "0 file(s) formatted");
 });
 
 Deno.test("compile without project.yaml produces clear error", async () => {

--- a/tests/e2e/format_test.ts
+++ b/tests/e2e/format_test.ts
@@ -1,0 +1,216 @@
+/**
+ * @module tests/e2e/format_test
+ *
+ * E2E tests for `markspec format` subcommand.
+ */
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+
+const CLI_ENTRY = new URL(
+  "../../packages/markspec/main.ts",
+  import.meta.url,
+).pathname;
+
+/** Run markspec format in a temp dir, return result + file contents. */
+async function runFormat(
+  files: Record<string, string>,
+  args: string[] = [],
+): Promise<{
+  code: number;
+  stdout: string;
+  stderr: string;
+  readFile: (name: string) => Promise<string>;
+}> {
+  const dir = await Deno.makeTempDir();
+  const filePaths: string[] = [];
+
+  for (const [name, content] of Object.entries(files)) {
+    const fullPath = `${dir}/${name}`;
+    await Deno.writeTextFile(fullPath, content);
+    filePaths.push(fullPath);
+  }
+
+  const cmd = new Deno.Command("deno", {
+    args: [
+      "run",
+      "--allow-read",
+      "--allow-write",
+      CLI_ENTRY,
+      "format",
+      ...args,
+      ...filePaths,
+    ],
+    cwd: dir,
+    stdout: "piped",
+    stderr: "piped",
+  });
+  const result = await cmd.output();
+
+  return {
+    code: result.code,
+    stdout: new TextDecoder().decode(result.stdout),
+    stderr: new TextDecoder().decode(result.stderr),
+    readFile: (name: string) => Deno.readTextFile(`${dir}/${name}`),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Attribute normalization
+// ---------------------------------------------------------------------------
+
+Deno.test("format: normalizes attribute order in file", async () => {
+  const input = `# Test
+
+- [SRS_BRK_0001] Title
+
+  Body text.
+
+  Labels: ASIL-B\\
+  Id: SRS_01HGW2Q8MNP3\\
+  Satisfies: SYS_BRK_0042
+`;
+  const { code, stderr } = await runFormat({ "req.md": input });
+  assertEquals(code, 0);
+  assertStringIncludes(stderr, "1 file(s) formatted");
+});
+
+Deno.test("format: writes normalized attributes back to file", async () => {
+  const input = `# Test
+
+- [SRS_BRK_0001] Title
+
+  Body text.
+
+  Labels: ASIL-B\\
+  Id: SRS_01HGW2Q8MNP3
+`;
+  const { readFile } = await runFormat({ "req.md": input });
+  const output = await readFile("req.md");
+  // Id should come before Labels
+  const idIdx = output.indexOf("Id:");
+  const labelsIdx = output.indexOf("Labels:");
+  assertEquals(idIdx < labelsIdx, true, "Id should come before Labels");
+});
+
+// ---------------------------------------------------------------------------
+// ULID assignment
+// ---------------------------------------------------------------------------
+
+Deno.test("format: assigns ULID to entry missing Id", async () => {
+  const input = `# Test
+
+- [SRS_BRK_0001] Title
+
+  Body text.
+
+  Satisfies: SYS_BRK_0042\\
+  Labels: ASIL-B
+`;
+  const { code, stderr, readFile } = await runFormat({ "req.md": input });
+  assertEquals(code, 0);
+  assertStringIncludes(stderr, "assigned Id:");
+  const output = await readFile("req.md");
+  assertStringIncludes(output, "Id: SRS_");
+});
+
+// ---------------------------------------------------------------------------
+// Idempotent
+// ---------------------------------------------------------------------------
+
+Deno.test("format: second run reports 0 formatted", async () => {
+  const input = `# Test
+
+- [SRS_BRK_0001] Title
+
+  Body text.
+
+  Id: SRS_01HGW2Q8MNP3\\
+  Satisfies: SYS_BRK_0042\\
+  Labels: ASIL-B
+`;
+  const { stderr } = await runFormat({ "req.md": input });
+  assertStringIncludes(stderr, "0 file(s) formatted");
+});
+
+// ---------------------------------------------------------------------------
+// --check mode
+// ---------------------------------------------------------------------------
+
+Deno.test("format: --check exits 1 when changes needed", async () => {
+  const input = `# Test
+
+- [SRS_BRK_0001] Title
+
+  Body text.
+
+  Labels: ASIL-B\\
+  Id: SRS_01HGW2Q8MNP3
+`;
+  const { code, readFile } = await runFormat({ "req.md": input }, ["--check"]);
+  assertEquals(code, 1);
+  // File should NOT be modified in check mode
+  const output = await readFile("req.md");
+  assertEquals(output, input);
+});
+
+Deno.test("format: --check exits 0 when clean", async () => {
+  const input = `# Test
+
+- [SRS_BRK_0001] Title
+
+  Body text.
+
+  Id: SRS_01HGW2Q8MNP3\\
+  Satisfies: SYS_BRK_0042\\
+  Labels: ASIL-B
+`;
+  const { code } = await runFormat({ "req.md": input }, ["--check"]);
+  assertEquals(code, 0);
+});
+
+// ---------------------------------------------------------------------------
+// No args
+// ---------------------------------------------------------------------------
+
+Deno.test("format: no files exits 1", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const cmd = new Deno.Command("deno", {
+      args: [
+        "run",
+        "--allow-read",
+        "--allow-write",
+        CLI_ENTRY,
+        "format",
+      ],
+      cwd: dir,
+      stdout: "piped",
+      stderr: "piped",
+    });
+    const result = await cmd.output();
+    assertEquals(result.code, 1);
+    const stderr = new TextDecoder().decode(result.stderr);
+    assertStringIncludes(stderr, "no files specified");
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+
+Deno.test("format: reports summary to stderr", async () => {
+  const input = `# Test
+
+- [SRS_BRK_0001] Title
+
+  Body text.
+
+  Id: SRS_01HGW2Q8MNP3\\
+  Labels: ASIL-B
+`;
+  const { stderr } = await runFormat({ "req.md": input });
+  assertStringIncludes(stderr, "file(s) formatted");
+  assertStringIncludes(stderr, "total)");
+});

--- a/tests/e2e/help_test.ts
+++ b/tests/e2e/help_test.ts
@@ -27,10 +27,10 @@ Deno.test("--version flag prints version", async () => {
   assertStringIncludes(stdout, "0.0.1");
 });
 
-Deno.test("format runs and exits 0", async () => {
+Deno.test("format with no args exits 1", async () => {
   const { code, stderr } = await markspec(["format"]);
-  assertEquals(code, 0);
-  assertStringIncludes(stderr, "0 files formatted");
+  assertEquals(code, 1);
+  assertStringIncludes(stderr, "no files specified");
 });
 
 Deno.test("book build prints not yet implemented", async () => {


### PR DESCRIPTION
## Summary

- `markspec format <file...>` reads files, normalizes attributes, assigns ULIDs, writes back
- `--check` flag for CI (exit 1 if changes needed, don't write)
- Per-file diagnostics and summary to stderr
- Exit 1 if no files specified

Closes #17

## Test plan

- [x] 8 E2E tests
- [x] 124 tests pass
- [x] `just build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)