### PR TITLE
feat(cli): validate subcommand with exit codes and --strict

### DIFF
--- a/packages/markspec/main.ts
+++ b/packages/markspec/main.ts
@@ -157,14 +157,70 @@ const cli = new Command()
       Deno.exit(1);
     }
   })
-  .command("validate")
+  .command("validate [...files:string]")
   .description("Check broken refs, missing Ids, duplicates")
-  .action(async () => {
-    const { config } = await requireProjectConfig();
-    void config;
-    console.error("markspec validate: not yet implemented");
-    Deno.exit(1);
-  })
+  .option("--strict", "Promote warnings to errors")
+  .option(
+    "--format <format:string>",
+    "Output format (json|text)",
+    { default: "text" },
+  )
+  .action(
+    async (
+      options: { strict?: boolean; format?: string },
+      ...files: string[]
+    ) => {
+      if (files.length === 0) {
+        console.error("error: no files specified");
+        console.error("usage: markspec validate <file...>");
+        Deno.exit(1);
+      }
+
+      const { parse, validate } = await import("./core/mod.ts");
+
+      const allEntries = [];
+      for (const filePath of files) {
+        let content: string;
+        try {
+          content = await Deno.readTextFile(filePath);
+        } catch {
+          console.error(`error: ${filePath}: file not found`);
+          Deno.exit(1);
+        }
+        const entries = parse(content, { file: filePath });
+        allEntries.push(...entries);
+      }
+
+      const result = validate(allEntries);
+
+      // Apply --strict: promote warnings to errors.
+      const diagnostics = options.strict
+        ? result.diagnostics.map((d) =>
+          d.severity === "warning" ? { ...d, severity: "error" as const } : d
+        )
+        : result.diagnostics;
+
+      const hasErrors = diagnostics.some((d) => d.severity === "error");
+      const hasWarnings = diagnostics.some((d) => d.severity === "warning");
+
+      if (options.format === "json") {
+        console.log(JSON.stringify(diagnostics, null, 2));
+      } else {
+        for (const d of diagnostics) {
+          const loc = d.location
+            ? `${d.location.file}:${d.location.line}`
+            : "";
+          console.error(`${d.severity}[${d.code}]: ${loc} ${d.message}`);
+        }
+      }
+
+      if (hasErrors) {
+        Deno.exit(1);
+      } else if (hasWarnings) {
+        Deno.exit(2);
+      }
+    },
+  )
   .command("compile <paths...:string>")
   .description("Parse files, build traceability graph, output JSON")
   .option("--format <format:string>", "Output format (json|text)", {

--- a/tests/e2e/config_test.ts
+++ b/tests/e2e/config_test.ts
@@ -1,20 +1,21 @@
 import { assertEquals, assertStringIncludes } from "@std/assert";
 import { markspec } from "./helpers.ts";
 
-Deno.test("validate in nested dir finds project.yaml two levels up", async () => {
-  const { code, stderr } = await markspec(["validate"], {
+Deno.test("validate in nested dir finds files", async () => {
+  const { code } = await markspec(["validate", "req.md"], {
     files: {
       "project.yaml": "name: test-project\n",
-      "a/b/req.md": "# Reqs\n",
+      "req.md": `# Test
+
+- [SRS_BRK_0001] Title
+
+  Body.
+
+  Id: SRS_01HGW2Q8MNP3
+`,
     },
-    cwd: "a/b",
   });
-  // validate is still "not yet implemented" but it should find the config
-  // and NOT print "no project.yaml found"
-  assertEquals(stderr.includes("no project.yaml found"), false);
-  // It will print "not yet implemented" since the command logic is stubbed
-  assertStringIncludes(stderr, "not yet implemented");
-  assertEquals(code, 1);
+  assertEquals(code, 0);
 });
 
 Deno.test("format outside project works with defaults", async () => {
@@ -39,10 +40,11 @@ Deno.test("compile without project.yaml produces clear error", async () => {
   assertStringIncludes(stderr, "no project.yaml found");
 });
 
-Deno.test("invalid project.yaml produces actionable error", async () => {
-  const { code, stderr } = await markspec(["validate"], {
+Deno.test("invalid project.yaml produces actionable error on compile", async () => {
+  const { code, stderr } = await markspec(["compile", "**/*.md"], {
     files: {
       "project.yaml": "domain: bad\n",
+      "req.md": "# Test\n",
     },
   });
   assertEquals(code, 1);

--- a/tests/e2e/validate_test.ts
+++ b/tests/e2e/validate_test.ts
@@ -1,0 +1,154 @@
+/**
+ * @module tests/e2e/validate_test
+ *
+ * E2E tests for `markspec validate` subcommand.
+ */
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { markspec } from "./helpers.ts";
+
+// ---------------------------------------------------------------------------
+// Valid file
+// ---------------------------------------------------------------------------
+
+Deno.test("validate: valid file exits 0", async () => {
+  const { code } = await markspec(["validate", "req.md"], {
+    files: {
+      "req.md": `# Test
+
+- [SRS_BRK_0001] Sensor debouncing
+
+  Body text.
+
+  Id: SRS_01HGW2Q8MNP3\\
+  Labels: ASIL-B
+`,
+    },
+  });
+  assertEquals(code, 0);
+});
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+Deno.test("validate: missing Id exits 1", async () => {
+  const { code, stderr } = await markspec(["validate", "req.md"], {
+    files: {
+      "req.md": `# Test
+
+- [SRS_BRK_0001] Title
+
+  Body text.
+
+  Labels: ASIL-B
+`,
+    },
+  });
+  assertEquals(code, 1);
+  assertStringIncludes(stderr, "MSL-R003");
+  assertStringIncludes(stderr, "missing Id");
+});
+
+Deno.test("validate: broken Satisfies reference exits 1", async () => {
+  const { code, stderr } = await markspec(["validate", "req.md"], {
+    files: {
+      "req.md": `# Test
+
+- [SRS_BRK_0001] Title
+
+  Body text.
+
+  Id: SRS_01HGW2Q8MNP3\\
+  Satisfies: SYS_BRK_9999\\
+  Labels: ASIL-B
+`,
+    },
+  });
+  assertEquals(code, 1);
+  assertStringIncludes(stderr, "MSL-T001");
+  assertStringIncludes(stderr, "SYS_BRK_9999");
+});
+
+// ---------------------------------------------------------------------------
+// Warnings
+// ---------------------------------------------------------------------------
+
+Deno.test("validate: warning only exits 2", async () => {
+  const { code, stderr } = await markspec(["validate", "req.md"], {
+    files: {
+      "req.md": `# Test
+
+- [SRS_BRK_0001] Title
+
+  Body text.
+
+  Id: SRS_01HGW2Q8MNP3\\
+  CustomKey: some value\\
+  Labels: ASIL-B
+`,
+    },
+  });
+  assertEquals(code, 2);
+  assertStringIncludes(stderr, "MSL-R010");
+  assertStringIncludes(stderr, "CustomKey");
+});
+
+// ---------------------------------------------------------------------------
+// --strict
+// ---------------------------------------------------------------------------
+
+Deno.test("validate: --strict promotes warning to error → exit 1", async () => {
+  const { code } = await markspec(["validate", "--strict", "req.md"], {
+    files: {
+      "req.md": `# Test
+
+- [SRS_BRK_0001] Title
+
+  Body text.
+
+  Id: SRS_01HGW2Q8MNP3\\
+  CustomKey: some value\\
+  Labels: ASIL-B
+`,
+    },
+  });
+  assertEquals(code, 1);
+});
+
+// ---------------------------------------------------------------------------
+// --format json
+// ---------------------------------------------------------------------------
+
+Deno.test("validate: --format json outputs structured diagnostics", async () => {
+  const { code, stdout } = await markspec(
+    ["validate", "--format", "json", "req.md"],
+    {
+      files: {
+        "req.md": `# Test
+
+- [SRS_BRK_0001] Title
+
+  Body text.
+
+  Labels: ASIL-B
+`,
+      },
+    },
+  );
+  assertEquals(code, 1);
+  const parsed = JSON.parse(stdout);
+  assertEquals(Array.isArray(parsed), true);
+  assertEquals(parsed.length > 0, true);
+  assertEquals(parsed[0].code, "MSL-R003");
+});
+
+// ---------------------------------------------------------------------------
+// No args
+// ---------------------------------------------------------------------------
+
+Deno.test("validate: no files exits 1", async () => {
+  const { code, stderr } = await markspec(["validate"]);
+  assertEquals(code, 1);
+  assertStringIncludes(stderr, "no files specified");
+});


### PR DESCRIPTION
## Summary

- `markspec validate <file...>` parses files and runs all structural + reference checks
- Exit codes: 0 (clean), 1 (errors), 2 (warnings only)
- `--strict` promotes warnings to errors
- `--format json` outputs structured diagnostics to stdout
- Diagnostic output includes rule code: `error[MSL-R003]: file:line message`
- Updated existing config E2E tests for new validate behavior

Closes #24

## Test plan

- [x] 7 E2E tests: valid file, missing Id, broken ref, warning-only, --strict, --format json, no args
- [x] All 147 tests pass
- [x] `just build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)