### PR TITLE
feat(cli): show, context, and dependents query commands

### DIFF
--- a/packages/markspec/core/validator/mod_test.ts
+++ b/packages/markspec/core/validator/mod_test.ts
@@ -188,7 +188,10 @@ Deno.test("validate: multiple errors accumulated", () => {
   ];
   const result = validate(entries);
   assertEquals(result.valid, false);
-  assertEquals(result.diagnostics.filter((d) => d.severity === "error").length >= 2, true);
+  assertEquals(
+    result.diagnostics.filter((d) => d.severity === "error").length >= 2,
+    true,
+  );
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/markspec/main.ts
+++ b/packages/markspec/main.ts
@@ -217,9 +217,7 @@ const cli = new Command()
         console.log(JSON.stringify(diagnostics, null, 2));
       } else {
         for (const d of diagnostics) {
-          const loc = d.location
-            ? `${d.location.file}:${d.location.line}`
-            : "";
+          const loc = d.location ? `${d.location.file}:${d.location.line}` : "";
           console.error(`${d.severity}[${d.code}]: ${loc} ${d.message}`);
         }
       }

--- a/packages/markspec/main.ts
+++ b/packages/markspec/main.ts
@@ -10,7 +10,7 @@
 
 import { Command } from "@cliffy/command";
 import { ConfigError, VERSION } from "./core/mod.ts";
-import type { ReadFile } from "./core/mod.ts";
+import type { CompileResult, ReadFile } from "./core/mod.ts";
 
 /** Print "not yet implemented" to stderr and exit 1. */
 function notImplemented(name: string): () => void {
@@ -55,6 +55,16 @@ async function requireProjectConfig() {
     }
     throw err;
   }
+}
+
+/**
+ * Compile project files and return the result.
+ * Shared helper for commands that need the compiled graph.
+ */
+async function compileProject(paths: string[]): Promise<CompileResult> {
+  await requireProjectConfig();
+  const { compile } = await import("./core/mod.ts");
+  return await compile(paths);
 }
 
 // ── Nested subcommands (composed as separate Command instances) ───────
@@ -271,15 +281,158 @@ const cli = new Command()
   .command("next-id")
   .description("Print the next available display ID for a type")
   .action(notImplemented("next-id"))
-  .command("show")
+  .command("show <id:string> <paths...:string>")
   .description("Show details of a single entry by ID")
-  .action(notImplemented("show"))
-  .command("context")
-  .description("Print context for an entry (parents, children, links)")
-  .action(notImplemented("context"))
-  .command("dependents")
+  .option("--format <format:string>", "Output format (json|text)", {
+    default: "text",
+  })
+  .action(
+    async (options: { format?: string }, id: string, ...paths: string[]) => {
+      const result = await compileProject(paths);
+      const entry = result.entries.get(id);
+
+      if (!entry) {
+        console.error(`error: entry not found: ${id}`);
+        Deno.exit(1);
+      }
+
+      const forwardLinks = result.forward.get(id) ?? [];
+      const reverseLinks = result.reverse.get(id) ?? [];
+
+      if (options.format === "json") {
+        const output = {
+          ...entry,
+          forwardLinks,
+          reverseLinks,
+        };
+        console.log(JSON.stringify(output, null, 2));
+      } else {
+        console.log(`${entry.displayId}  ${entry.title}`);
+        if (entry.entryType) {
+          console.log(`  Type: ${entry.entryType}`);
+        }
+        for (const attr of entry.attributes) {
+          console.log(`  ${attr.key}: ${attr.value}`);
+        }
+        console.log(
+          `  Source: ${entry.location.file}:${entry.location.line}:${entry.location.column}`,
+        );
+        if (forwardLinks.length > 0) {
+          console.log("  Outgoing links:");
+          for (const link of forwardLinks) {
+            console.log(`    ${link.kind} → ${link.to}`);
+          }
+        }
+        if (reverseLinks.length > 0) {
+          console.log("  Incoming links:");
+          for (const link of reverseLinks) {
+            console.log(`    ${link.kind} ← ${link.from}`);
+          }
+        }
+      }
+    },
+  )
+  .command("context <id:string> <paths...:string>")
+  .description("Walk the Satisfies chain upward from an entry")
+  .option("--depth <depth:number>", "Maximum depth to walk", { default: 10 })
+  .option("--format <format:string>", "Output format (json|text)", {
+    default: "text",
+  })
+  .action(
+    async (
+      options: { depth: number; format?: string },
+      id: string,
+      ...paths: string[]
+    ) => {
+      const result = await compileProject(paths);
+      const entry = result.entries.get(id);
+
+      if (!entry) {
+        console.error(`error: entry not found: ${id}`);
+        Deno.exit(1);
+      }
+
+      // Walk the Satisfies chain upward.
+      const chain: Array<{ displayId: string; title: string; depth: number }> =
+        [];
+      const visited = new Set<string>();
+      let currentIds = [id];
+      let depth = 0;
+
+      // Add the starting entry at depth 0.
+      chain.push({ displayId: entry.displayId, title: entry.title, depth: 0 });
+      visited.add(id);
+
+      while (depth < options.depth && currentIds.length > 0) {
+        const nextIds: string[] = [];
+        for (const currentId of currentIds) {
+          const links = result.forward.get(currentId) ?? [];
+          for (const link of links) {
+            if (link.kind === "satisfies" && !visited.has(link.to)) {
+              visited.add(link.to);
+              const target = result.entries.get(link.to);
+              if (target) {
+                chain.push({
+                  displayId: target.displayId,
+                  title: target.title,
+                  depth: depth + 1,
+                });
+                nextIds.push(link.to);
+              }
+            }
+          }
+        }
+        currentIds = nextIds;
+        depth++;
+      }
+
+      if (options.format === "json") {
+        console.log(JSON.stringify(chain, null, 2));
+      } else {
+        for (const item of chain) {
+          const indent = "  ".repeat(item.depth);
+          console.log(`${indent}${item.displayId}  ${item.title}`);
+        }
+      }
+    },
+  )
+  .command("dependents <id:string> <paths...:string>")
   .description("List all entries that depend on a given entry")
-  .action(notImplemented("dependents"))
+  .option("--format <format:string>", "Output format (json|text)", {
+    default: "text",
+  })
+  .action(
+    async (options: { format?: string }, id: string, ...paths: string[]) => {
+      const result = await compileProject(paths);
+      const entry = result.entries.get(id);
+
+      if (!entry) {
+        console.error(`error: entry not found: ${id}`);
+        Deno.exit(1);
+      }
+
+      const reverseLinks = result.reverse.get(id) ?? [];
+
+      if (options.format === "json") {
+        const output = reverseLinks.map((link) => ({
+          from: link.from,
+          kind: link.kind,
+          title: result.entries.get(link.from)?.title ?? "",
+        }));
+        console.log(JSON.stringify(output, null, 2));
+      } else {
+        if (reverseLinks.length === 0) {
+          console.log(`No dependents for ${id}`);
+        } else {
+          for (const link of reverseLinks) {
+            const source = result.entries.get(link.from);
+            const title = source ? `  ${source.title}` : "";
+            console.log(`${link.from}  ${link.kind}${title}`);
+          }
+        }
+      }
+    },
+  )
   .command("report")
   .description("Generate traceability matrix or coverage report")
   .action(notImplemented("report"))

--- a/tests/e2e/query_test.ts
+++ b/tests/e2e/query_test.ts
@@ -1,0 +1,95 @@
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { markspec } from "./helpers.ts";
+
+// ---------------------------------------------------------------------------
+// Fixtures shared across tests
+// ---------------------------------------------------------------------------
+
+const PROJECT_YAML = "name: test-project\n";
+
+const REQUIREMENTS = `# Requirements
+
+- [SYS_BRK_0042] System braking requirement
+
+  The system shall provide emergency braking capability.
+
+  Id: SYS_01HGW2Q8MNP3
+
+- [SRS_BRK_0001] Sensor input debouncing
+
+  The sensor driver shall debounce raw inputs to eliminate electrical noise.
+
+  Id: SRS_01HGW2R9QLP4\\
+  Satisfies: SYS_BRK_0042\\
+  Labels: ASIL-B
+`;
+
+// ---------------------------------------------------------------------------
+// show
+// ---------------------------------------------------------------------------
+
+Deno.test("show: displays entry details by ID", async () => {
+  const { code, stdout } = await markspec(
+    ["show", "SRS_BRK_0001", "reqs.md"],
+    { "project.yaml": PROJECT_YAML, "reqs.md": REQUIREMENTS },
+  );
+
+  assertEquals(code, 0);
+  assertStringIncludes(stdout, "SRS_BRK_0001");
+  assertStringIncludes(stdout, "Sensor input debouncing");
+  assertStringIncludes(stdout, "Satisfies");
+  assertStringIncludes(stdout, "SYS_BRK_0042");
+});
+
+Deno.test("show: exits 1 for nonexistent entry", async () => {
+  const { code, stderr } = await markspec(
+    ["show", "NONEXISTENT", "reqs.md"],
+    { "project.yaml": PROJECT_YAML, "reqs.md": REQUIREMENTS },
+  );
+
+  assertEquals(code, 1);
+  assertStringIncludes(stderr, "entry not found");
+  assertStringIncludes(stderr, "NONEXISTENT");
+});
+
+// ---------------------------------------------------------------------------
+// context
+// ---------------------------------------------------------------------------
+
+Deno.test("context: shows Satisfies chain upward", async () => {
+  const { code, stdout } = await markspec(
+    ["context", "SRS_BRK_0001", "reqs.md"],
+    { "project.yaml": PROJECT_YAML, "reqs.md": REQUIREMENTS },
+  );
+
+  assertEquals(code, 0);
+  assertStringIncludes(stdout, "SRS_BRK_0001");
+  assertStringIncludes(stdout, "SYS_BRK_0042");
+});
+
+Deno.test("context: respects --depth 0 showing only the entry itself", async () => {
+  const { code, stdout } = await markspec(
+    ["context", "SRS_BRK_0001", "--depth", "0", "reqs.md"],
+    { "project.yaml": PROJECT_YAML, "reqs.md": REQUIREMENTS },
+  );
+
+  assertEquals(code, 0);
+  assertStringIncludes(stdout, "SRS_BRK_0001");
+  // SYS_BRK_0042 should NOT appear since depth is 0
+  assertEquals(stdout.includes("SYS_BRK_0042"), false);
+});
+
+// ---------------------------------------------------------------------------
+// dependents
+// ---------------------------------------------------------------------------
+
+Deno.test("dependents: lists entries that reference the given ID", async () => {
+  const { code, stdout } = await markspec(
+    ["dependents", "SYS_BRK_0042", "reqs.md"],
+    { "project.yaml": PROJECT_YAML, "reqs.md": REQUIREMENTS },
+  );
+
+  assertEquals(code, 0);
+  assertStringIncludes(stdout, "SRS_BRK_0001");
+  assertStringIncludes(stdout, "satisfies");
+});


### PR DESCRIPTION
## Summary

- Implement `markspec show <id> <paths...>` to display entry details, attributes, outgoing/incoming links, and source location (#32)
- Implement `markspec context <id> <paths...> [--depth N]` to walk the Satisfies chain upward from an entry (#33)
- Implement `markspec dependents <id> <paths...>` to list all entries referencing a given entry via reverse links (#34)
- All three commands support `--format json` for structured output
- Factor out shared `compileProject` helper for the compile-then-query pattern

## Test plan

- [x] E2E: `show SRS_BRK_0001` displays title, ID, Satisfies link
- [x] E2E: `show NONEXISTENT` exits 1 with error message
- [x] E2E: `context SRS_BRK_0001` shows both SRS and SYS levels
- [x] E2E: `context SRS_BRK_0001 --depth 0` shows only the entry itself
- [x] E2E: `dependents SYS_BRK_0042` lists the SRS entry with satisfies kind

Closes #32, closes #33, closes #34

Generated with [Claude Code](https://claude.com/claude-code)