### PR TITLE
feat(core): JSON export schema and serialization helper

### DIFF
--- a/docs/spec/compile-schema.json
+++ b/docs/spec/compile-schema.json
@@ -1,0 +1,203 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://markspec.dev/schemas/compile-result.json",
+  "title": "MarkSpec Compile Result",
+  "description": "Serialized output of the MarkSpec compiler — entries, traceability links, adjacency maps, and diagnostics.",
+  "type": "object",
+  "required": ["entries", "links", "forward", "reverse", "diagnostics"],
+  "additionalProperties": false,
+  "properties": {
+    "entries": {
+      "description": "All entries keyed by display ID.",
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/$defs/entry"
+      }
+    },
+    "links": {
+      "description": "All traceability links.",
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/link"
+      }
+    },
+    "forward": {
+      "description": "Outgoing links per entry (entry → targets), keyed by display ID.",
+      "type": "object",
+      "additionalProperties": {
+        "type": "array",
+        "items": {
+          "$ref": "#/$defs/link"
+        }
+      }
+    },
+    "reverse": {
+      "description": "Incoming links per entry (entry → sources pointing to it), keyed by display ID.",
+      "type": "object",
+      "additionalProperties": {
+        "type": "array",
+        "items": {
+          "$ref": "#/$defs/link"
+        }
+      }
+    },
+    "diagnostics": {
+      "description": "Diagnostics from parsing and validation.",
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/diagnostic"
+      }
+    }
+  },
+  "$defs": {
+    "sourceLocation": {
+      "description": "Points to a span within a source file.",
+      "type": "object",
+      "required": ["file", "line", "column"],
+      "additionalProperties": false,
+      "properties": {
+        "file": {
+          "type": "string",
+          "description": "Absolute or project-relative file path."
+        },
+        "line": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "1-based line number."
+        },
+        "column": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "1-based column number."
+        }
+      }
+    },
+    "attribute": {
+      "description": "A single Key: Value pair from an attribute block.",
+      "type": "object",
+      "required": ["key", "value"],
+      "additionalProperties": false,
+      "properties": {
+        "key": {
+          "type": "string",
+          "description": "Attribute name (e.g., Id, Satisfies, Labels)."
+        },
+        "value": {
+          "type": "string",
+          "description": "Raw attribute value string."
+        }
+      }
+    },
+    "entry": {
+      "description": "A parsed MarkSpec entry.",
+      "type": "object",
+      "required": [
+        "displayId",
+        "title",
+        "body",
+        "attributes",
+        "location",
+        "source"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "displayId": {
+          "type": "string",
+          "description": "Human-readable display ID from the [...] marker."
+        },
+        "title": {
+          "type": "string",
+          "description": "Entry title — text after the closing ] on the first line."
+        },
+        "body": {
+          "type": "string",
+          "description": "Body content between title and attributes."
+        },
+        "attributes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/attribute"
+          },
+          "description": "Parsed attribute block."
+        },
+        "id": {
+          "type": ["string", "null"],
+          "description": "ULID from the Id: attribute, if present."
+        },
+        "entryType": {
+          "type": ["string", "null"],
+          "description": "Resolved entry type prefix (e.g., SRS), if this is a typed entry."
+        },
+        "location": {
+          "$ref": "#/$defs/sourceLocation",
+          "description": "Where the entry was found."
+        },
+        "source": {
+          "type": "string",
+          "enum": ["markdown", "doc-comment"],
+          "description": "Whether this came from a Markdown file or a doc comment."
+        }
+      }
+    },
+    "link": {
+      "description": "A directional link between two entries in the traceability graph.",
+      "type": "object",
+      "required": ["from", "to", "kind", "location"],
+      "additionalProperties": false,
+      "properties": {
+        "from": {
+          "type": "string",
+          "description": "Source entry display ID."
+        },
+        "to": {
+          "type": "string",
+          "description": "Target entry display ID."
+        },
+        "kind": {
+          "type": "string",
+          "enum": [
+            "satisfies",
+            "derived-from",
+            "allocates",
+            "constrains",
+            "verifies",
+            "implements"
+          ],
+          "description": "Kind of directional link."
+        },
+        "location": {
+          "$ref": "#/$defs/sourceLocation",
+          "description": "Source location of the link declaration."
+        }
+      }
+    },
+    "diagnostic": {
+      "description": "A diagnostic message from parsing or validation.",
+      "type": "object",
+      "required": ["code", "severity", "message"],
+      "additionalProperties": false,
+      "properties": {
+        "code": {
+          "type": "string",
+          "description": "Unique rule ID (e.g., MSL-E001)."
+        },
+        "severity": {
+          "type": "string",
+          "enum": ["error", "warning", "info"],
+          "description": "Severity level."
+        },
+        "message": {
+          "type": "string",
+          "description": "Human-readable message."
+        },
+        "location": {
+          "oneOf": [
+            { "$ref": "#/$defs/sourceLocation" },
+            { "type": "null" }
+          ],
+          "description": "Source location, if applicable."
+        }
+      }
+    }
+  }
+}

--- a/packages/markspec/core/compiler/mod.ts
+++ b/packages/markspec/core/compiler/mod.ts
@@ -172,6 +172,10 @@ function buildAdjacency(
   return map;
 }
 
+// Re-export serialization helper.
+export { serializeCompileResult } from "./schema.ts";
+export type { SerializedCompileResult } from "./schema.ts";
+
 /** Default file reader. Uses Deno API (CLI entry points only). */
 function defaultReadFile(path: string): Promise<string> {
   return Deno.readTextFile(path);

--- a/packages/markspec/core/compiler/schema.ts
+++ b/packages/markspec/core/compiler/schema.ts
@@ -1,0 +1,49 @@
+/**
+ * @module schema
+ *
+ * Serialization helper that converts {@linkcode CompileResult} (which uses
+ * Maps) to a plain JSON-serializable object suitable for export and
+ * interchange.
+ */
+
+import type { CompileResult } from "./mod.ts";
+
+/**
+ * Serialized form of {@linkcode CompileResult}.
+ *
+ * All `ReadonlyMap` fields are converted to plain objects keyed by display ID.
+ * Arrays and scalar fields are passed through unchanged.
+ */
+export interface SerializedCompileResult {
+  /** Entries keyed by display ID. */
+  readonly entries: Record<string, unknown>;
+  /** All traceability links. */
+  readonly links: readonly unknown[];
+  /** Outgoing links per entry (entry -> targets). */
+  readonly forward: Record<string, readonly unknown[]>;
+  /** Incoming links per entry (entry -> sources pointing to it). */
+  readonly reverse: Record<string, readonly unknown[]>;
+  /** Diagnostics from parsing and validation. */
+  readonly diagnostics: readonly unknown[];
+}
+
+/**
+ * Convert a {@linkcode CompileResult} to a plain JSON-serializable object.
+ *
+ * Maps are converted to `Record` objects keyed by display ID; arrays and
+ * scalars pass through unchanged.
+ *
+ * @param result - The compiled project output
+ * @returns A plain object safe for `JSON.stringify`
+ */
+export function serializeCompileResult(
+  result: CompileResult,
+): SerializedCompileResult {
+  return {
+    entries: Object.fromEntries(result.entries),
+    links: result.links,
+    forward: Object.fromEntries(result.forward),
+    reverse: Object.fromEntries(result.reverse),
+    diagnostics: result.diagnostics,
+  };
+}

--- a/packages/markspec/core/compiler/schema_test.ts
+++ b/packages/markspec/core/compiler/schema_test.ts
@@ -1,0 +1,148 @@
+import { assertEquals } from "@std/assert";
+import { serializeCompileResult } from "./schema.ts";
+import type { CompileResult } from "./mod.ts";
+import type { Entry, Link } from "../model/mod.ts";
+
+/** Build a minimal Entry for testing. */
+function makeEntry(displayId: string): Entry {
+  return {
+    displayId,
+    title: `Title for ${displayId}`,
+    body: "",
+    attributes: [],
+    id: undefined,
+    entryType: displayId.split("_")[0],
+    location: { file: "test.md", line: 1, column: 1 },
+    source: "markdown",
+  };
+}
+
+/** Build a minimal Link for testing. */
+function makeLink(from: string, to: string): Link {
+  return {
+    from,
+    to,
+    kind: "satisfies",
+    location: { file: "test.md", line: 1, column: 1 },
+  };
+}
+
+Deno.test("serializeCompileResult: converts Maps to plain objects", () => {
+  const entry = makeEntry("SRS_BRK_0001");
+  const entries = new Map([[entry.displayId, entry]]);
+  const link = makeLink("SRS_BRK_0001", "SYS_BRK_0042");
+  const forward = new Map([["SRS_BRK_0001", [link]]]);
+  const reverse = new Map([["SYS_BRK_0042", [link]]]);
+
+  const result: CompileResult = {
+    entries,
+    links: [link],
+    forward,
+    reverse,
+    diagnostics: [],
+  };
+
+  const serialized = serializeCompileResult(result);
+
+  // Entries should be a plain object, not a Map.
+  assertEquals(typeof serialized.entries, "object");
+  assertEquals(serialized.entries instanceof Map, false);
+
+  // Forward/reverse should be plain objects.
+  assertEquals(serialized.forward instanceof Map, false);
+  assertEquals(serialized.reverse instanceof Map, false);
+});
+
+Deno.test("serializeCompileResult: entries keyed by displayId", () => {
+  const entryA = makeEntry("SRS_BRK_0001");
+  const entryB = makeEntry("SRS_BRK_0002");
+  const entries = new Map([
+    [entryA.displayId, entryA],
+    [entryB.displayId, entryB],
+  ]);
+
+  const result: CompileResult = {
+    entries,
+    links: [],
+    forward: new Map(),
+    reverse: new Map(),
+    diagnostics: [],
+  };
+
+  const serialized = serializeCompileResult(result);
+
+  assertEquals(Object.keys(serialized.entries).sort(), [
+    "SRS_BRK_0001",
+    "SRS_BRK_0002",
+  ]);
+  assertEquals(
+    (serialized.entries["SRS_BRK_0001"] as Entry).displayId,
+    "SRS_BRK_0001",
+  );
+  assertEquals(
+    (serialized.entries["SRS_BRK_0002"] as Entry).displayId,
+    "SRS_BRK_0002",
+  );
+});
+
+Deno.test("serializeCompileResult: links preserved as-is", () => {
+  const link = makeLink("SRS_BRK_0001", "SYS_BRK_0042");
+
+  const result: CompileResult = {
+    entries: new Map(),
+    links: [link],
+    forward: new Map(),
+    reverse: new Map(),
+    diagnostics: [],
+  };
+
+  const serialized = serializeCompileResult(result);
+
+  assertEquals(serialized.links.length, 1);
+  assertEquals(serialized.links[0], link);
+});
+
+Deno.test("serializeCompileResult: round-trip via JSON.parse", () => {
+  const entry = makeEntry("SRS_BRK_0001");
+  const link = makeLink("SRS_BRK_0001", "SYS_BRK_0042");
+
+  const result: CompileResult = {
+    entries: new Map([[entry.displayId, entry]]),
+    links: [link],
+    forward: new Map([["SRS_BRK_0001", [link]]]),
+    reverse: new Map([["SYS_BRK_0042", [link]]]),
+    diagnostics: [
+      {
+        code: "MSL-W001",
+        severity: "warning",
+        message: "test warning",
+        location: undefined,
+      },
+    ],
+  };
+
+  const serialized = serializeCompileResult(result);
+  const json = JSON.stringify(serialized);
+  const parsed = JSON.parse(json);
+
+  // Verify structural expectations after round-trip.
+  assertEquals(typeof parsed.entries, "object");
+  assertEquals(parsed.entries["SRS_BRK_0001"].displayId, "SRS_BRK_0001");
+  assertEquals(parsed.entries["SRS_BRK_0001"].title, "Title for SRS_BRK_0001");
+
+  assertEquals(Array.isArray(parsed.links), true);
+  assertEquals(parsed.links.length, 1);
+  assertEquals(parsed.links[0].from, "SRS_BRK_0001");
+  assertEquals(parsed.links[0].to, "SYS_BRK_0042");
+  assertEquals(parsed.links[0].kind, "satisfies");
+
+  assertEquals(typeof parsed.forward, "object");
+  assertEquals(parsed.forward["SRS_BRK_0001"].length, 1);
+
+  assertEquals(typeof parsed.reverse, "object");
+  assertEquals(parsed.reverse["SYS_BRK_0042"].length, 1);
+
+  assertEquals(Array.isArray(parsed.diagnostics), true);
+  assertEquals(parsed.diagnostics.length, 1);
+  assertEquals(parsed.diagnostics[0].code, "MSL-W001");
+});

--- a/packages/markspec/core/mod.ts
+++ b/packages/markspec/core/mod.ts
@@ -66,8 +66,12 @@ export { validate } from "./validator/mod.ts";
 export type { ValidateResult } from "./validator/mod.ts";
 
 // Compiler
-export { compile } from "./compiler/mod.ts";
-export type { CompileOptions, CompileResult } from "./compiler/mod.ts";
+export { compile, serializeCompileResult } from "./compiler/mod.ts";
+export type {
+  CompileOptions,
+  CompileResult,
+  SerializedCompileResult,
+} from "./compiler/mod.ts";
 
 // Reporter
 export { report } from "./reporter/mod.ts";

--- a/packages/markspec/core/validator/mod_test.ts
+++ b/packages/markspec/core/validator/mod_test.ts
@@ -188,7 +188,10 @@ Deno.test("validate: multiple errors accumulated", () => {
   ];
   const result = validate(entries);
   assertEquals(result.valid, false);
-  assertEquals(result.diagnostics.filter((d) => d.severity === "error").length >= 2, true);
+  assertEquals(
+    result.diagnostics.filter((d) => d.severity === "error").length >= 2,
+    true,
+  );
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/markspec/main.ts
+++ b/packages/markspec/main.ts
@@ -207,9 +207,7 @@ const cli = new Command()
         console.log(JSON.stringify(diagnostics, null, 2));
       } else {
         for (const d of diagnostics) {
-          const loc = d.location
-            ? `${d.location.file}:${d.location.line}`
-            : "";
+          const loc = d.location ? `${d.location.file}:${d.location.line}` : "";
           console.error(`${d.severity}[${d.code}]: ${loc} ${d.message}`);
         }
       }
@@ -229,7 +227,7 @@ const cli = new Command()
   .action(async (_options: { format?: string }, ...paths: string[]) => {
     await requireProjectConfig();
 
-    const { compile } = await import("./core/mod.ts");
+    const { compile, serializeCompileResult } = await import("./core/mod.ts");
     const result = await compile(paths);
 
     for (const diag of result.diagnostics) {
@@ -240,18 +238,7 @@ const cli = new Command()
     }
 
     if (_options.format === "json") {
-      // Serialize Maps to plain objects for JSON output.
-      const output = {
-        entries: Object.fromEntries(result.entries),
-        links: result.links,
-        forward: Object.fromEntries(
-          [...result.forward].map(([k, v]) => [k, v]),
-        ),
-        reverse: Object.fromEntries(
-          [...result.reverse].map(([k, v]) => [k, v]),
-        ),
-        diagnostics: result.diagnostics,
-      };
+      const output = serializeCompileResult(result);
       console.log(JSON.stringify(output, null, 2));
     } else {
       console.log(


### PR DESCRIPTION
## What

Add `serializeCompileResult()` helper and a JSON Schema (draft 2020-12) for the compiled output format.

## Why

The compile command had inline Map-to-object conversion. Extracting it into a reusable helper enables downstream consumers (export, MCP, LSP) to serialize compile results consistently, and the JSON Schema documents the interchange format.

Closes #31

## How

- **`packages/markspec/core/compiler/schema.ts`** — `serializeCompileResult()` converts `CompileResult` Maps to plain `Record` objects.
- **`docs/spec/compile-schema.json`** — JSON Schema (draft 2020-12) validating entries, links, forward/reverse adjacency, and diagnostics.
- **`packages/markspec/main.ts`** — compile command now calls `serializeCompileResult` instead of inline conversion.
- **`packages/markspec/core/compiler/mod.ts`** and **`core/mod.ts`** — re-export the new function and type.
- **`packages/markspec/core/compiler/schema_test.ts`** — 4 unit tests: Map conversion, displayId keying, links pass-through, JSON round-trip.

## Checklist

- [x] Tests added or updated
- [x] Documentation updated
- [x] All checks pass