### PR TITLE
fix(core): phase 1 review fixes — types, portability, data integrity

### DIFF
--- a/packages/markspec/core/compiler/mod.ts
+++ b/packages/markspec/core/compiler/mod.ts
@@ -18,8 +18,8 @@ import { validate } from "../validator/mod.ts";
 
 /** Options for {@linkcode compile}. */
 export interface CompileOptions {
-  /** Override file reading (for testing). */
-  readonly readFile?: (path: string) => Promise<string>;
+  /** File reader function. Required — no default to avoid Deno dependency in library code. */
+  readonly readFile: (path: string) => Promise<string>;
 }
 
 /** Compiled project output with resolved traceability graph. */
@@ -46,9 +46,9 @@ export interface CompileResult {
  */
 export async function compile(
   paths: readonly string[],
-  options?: CompileOptions,
+  options: CompileOptions,
 ): Promise<CompileResult> {
-  const read = options?.readFile ?? defaultReadFile;
+  const read = options.readFile;
   const allEntries: Entry[] = [];
   const parseDiagnostics: Diagnostic[] = [];
 
@@ -74,9 +74,12 @@ export async function compile(
   const validationResult = validate(allEntries);
 
   // Phase 3: Build traceability graph.
+  // Keep first occurrence of each display ID (validator catches duplicates).
   const entries = new Map<DisplayId, Entry>();
   for (const entry of allEntries) {
-    entries.set(entry.displayId, entry);
+    if (!entries.has(entry.displayId)) {
+      entries.set(entry.displayId, entry);
+    }
   }
 
   const links = extractLinks(allEntries);
@@ -146,12 +149,15 @@ function extractLinksFromAttribute(
     .map((to) => ({ from, to, kind, location }));
 }
 
-/** Attribute keys that produce traceability links. */
+/**
+ * Attribute keys that produce traceability links.
+ * Note: Constrains targets are component names (free text), not entry IDs,
+ * so they are not included here. They would produce dangling links.
+ */
 const ATTR_TO_LINK_KIND: Record<string, LinkKind | undefined> = {
   "Satisfies": "satisfies",
   "Derived-from": "derived-from",
   "Allocates": "allocates",
-  "Constrains": "constrains",
 };
 
 /** Build an adjacency map from links using a key selector. */
@@ -176,7 +182,3 @@ function buildAdjacency(
 export { serializeCompileResult } from "./schema.ts";
 export type { SerializedCompileResult } from "./schema.ts";
 
-/** Default file reader. Uses Deno API (CLI entry points only). */
-function defaultReadFile(path: string): Promise<string> {
-  return Deno.readTextFile(path);
-}

--- a/packages/markspec/core/compiler/schema.ts
+++ b/packages/markspec/core/compiler/schema.ts
@@ -7,6 +7,7 @@
  */
 
 import type { CompileResult } from "./mod.ts";
+import type { Diagnostic, Entry, Link } from "../model/mod.ts";
 
 /**
  * Serialized form of {@linkcode CompileResult}.
@@ -16,15 +17,15 @@ import type { CompileResult } from "./mod.ts";
  */
 export interface SerializedCompileResult {
   /** Entries keyed by display ID. */
-  readonly entries: Record<string, unknown>;
+  readonly entries: Record<string, Entry>;
   /** All traceability links. */
-  readonly links: readonly unknown[];
+  readonly links: readonly Link[];
   /** Outgoing links per entry (entry -> targets). */
-  readonly forward: Record<string, readonly unknown[]>;
+  readonly forward: Record<string, readonly Link[]>;
   /** Incoming links per entry (entry -> sources pointing to it). */
-  readonly reverse: Record<string, readonly unknown[]>;
+  readonly reverse: Record<string, readonly Link[]>;
   /** Diagnostics from parsing and validation. */
-  readonly diagnostics: readonly unknown[];
+  readonly diagnostics: readonly Diagnostic[];
 }
 
 /**

--- a/packages/markspec/core/parser/attributes_test.ts
+++ b/packages/markspec/core/parser/attributes_test.ts
@@ -4,8 +4,8 @@
  * Unit tests for attribute block parsing.
  */
 
-import { assertEquals } from "@std/assert";
-import { parseAttributes } from "./attributes.ts";
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { parseAttributes, splitBodyAndAttributes } from "./attributes.ts";
 
 // ---------------------------------------------------------------------------
 // Backslash-separated attributes
@@ -117,6 +117,14 @@ Deno.test("parseAttributes: empty input returns empty array", () => {
 // ---------------------------------------------------------------------------
 // Non-attribute lines are not parsed
 // ---------------------------------------------------------------------------
+
+Deno.test("splitBodyAndAttributes: no blank line between body and attributes", () => {
+  const content = "Body text directly adjacent to attributes.\nId: SRS_01HGW2Q8MNP3";
+  const [body, attrs] = splitBodyAndAttributes(content);
+  assertStringIncludes(body, "Body text directly adjacent");
+  assertEquals(attrs.length, 1);
+  assertEquals(attrs[0], "Id: SRS_01HGW2Q8MNP3");
+});
 
 Deno.test("parseAttributes: lines without Key: Value pattern are skipped", () => {
   const lines = [

--- a/packages/markspec/core/reporter/mod.ts
+++ b/packages/markspec/core/reporter/mod.ts
@@ -133,9 +133,9 @@ function formatTraceability(
         r.id,
         csvEscape(r.title),
         r.entryType,
-        r.satisfies,
-        r.satisfiedBy,
-        r.verifiedBy,
+        csvEscape(r.satisfies),
+        csvEscape(r.satisfiedBy),
+        csvEscape(r.verifiedBy),
       ].join(",")
     );
     return [header, ...lines].join("\n");

--- a/packages/markspec/main.ts
+++ b/packages/markspec/main.ts
@@ -64,7 +64,7 @@ async function requireProjectConfig() {
 async function compileProject(paths: string[]): Promise<CompileResult> {
   await requireProjectConfig();
   const { compile } = await import("./core/mod.ts");
-  return await compile(paths);
+  return await compile(paths, { readFile: (p) => Deno.readTextFile(p) });
 }
 
 // ── Nested subcommands (composed as separate Command instances) ───────
@@ -238,7 +238,9 @@ const cli = new Command()
     await requireProjectConfig();
 
     const { compile, serializeCompileResult } = await import("./core/mod.ts");
-    const result = await compile(paths);
+    const result = await compile(paths, {
+      readFile: (p) => Deno.readTextFile(p),
+    });
 
     for (const diag of result.diagnostics) {
       const loc = diag.location


### PR DESCRIPTION
## Summary

Fixes from thorough Phase 1 review:

**Critical:**
- **C1:** `SerializedCompileResult` uses concrete `Entry`/`Link`/`Diagnostic` types instead of `unknown`
- **C2:** Remove `Deno.readTextFile` from compiler library code. `readFile` is now required in `CompileOptions`, passed by CLI
- **C3:** Compiler keeps first occurrence of duplicate display IDs instead of silently overwriting

**Important:**
- **I3:** Remove `Constrains` from link extraction — targets are component names, not entry IDs
- **I5:** CSV escape all fields with commas in reporter traceability output
- **I1:** Add test for `splitBodyAndAttributes` with no blank separator

## Test plan

- [x] 179 tests pass (1 new)
- [x] `just build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)