### PR TITLE
fix(core): debt quickwins — REF_ID_RE, CLI options, exports, diagnostics, schema

### DIFF
--- a/docs/spec/compile-schema.json
+++ b/docs/spec/compile-schema.json
@@ -121,11 +121,11 @@
           "description": "Parsed attribute block."
         },
         "id": {
-          "type": ["string", "null"],
+          "type": "string",
           "description": "ULID from the Id: attribute, if present."
         },
         "entryType": {
-          "type": ["string", "null"],
+          "type": "string",
           "description": "Resolved entry type prefix (e.g., SRS), if this is a typed entry."
         },
         "location": {

--- a/packages/markspec/core/mod.ts
+++ b/packages/markspec/core/mod.ts
@@ -52,6 +52,7 @@ export {
   parse,
 } from "./parser/mod.ts";
 export type {
+  DetectCaptionsOptions,
   DetectDirectivesOptions,
   DetectInlineRefsOptions,
   ParseOptions,

--- a/packages/markspec/core/parser/markdown.ts
+++ b/packages/markspec/core/parser/markdown.ts
@@ -25,7 +25,7 @@ const TYPED_ID_RE = /^([A-Z]{2,})_[A-Z]{2,12}_\d{3,4}$/;
 /**
  * Reference entry display ID pattern: letters, digits, hyphens.
  */
-const REF_ID_RE = /^[A-Za-z0-9-]+$/;
+const REF_ID_RE = /^[A-Za-z0-9-]{2,}$/;
 
 /**
  * Match a display ID in `[...]` at the start of a list item paragraph.

--- a/packages/markspec/core/parser/mod.ts
+++ b/packages/markspec/core/parser/mod.ts
@@ -17,6 +17,8 @@ import {
   type DetectCaptionsOptions,
 } from "./captions.ts";
 
+export type { DetectCaptionsOptions } from "./captions.ts";
+
 export { detectDirectives } from "./directives.ts";
 export type { DetectDirectivesOptions } from "./directives.ts";
 

--- a/packages/markspec/main.ts
+++ b/packages/markspec/main.ts
@@ -64,7 +64,16 @@ async function requireProjectConfig() {
 async function compileProject(paths: string[]): Promise<CompileResult> {
   await requireProjectConfig();
   const { compile } = await import("./core/mod.ts");
-  return await compile(paths, { readFile: (p) => Deno.readTextFile(p) });
+  const result = await compile(paths, { readFile: (p) => Deno.readTextFile(p) });
+
+  for (const diag of result.diagnostics) {
+    const loc = diag.location
+      ? `${diag.location.file}:${diag.location.line}`
+      : "";
+    console.error(`${diag.severity}[${diag.code}]: ${loc} ${diag.message}`);
+  }
+
+  return result;
 }
 
 // ── Nested subcommands (composed as separate Command instances) ───────
@@ -102,11 +111,6 @@ const cli = new Command()
     "Markdown flavor and toolchain for traceable industrial documentation",
   )
   .globalOption("-q, --quiet", "Suppress non-error output")
-  .globalOption(
-    "--output-format <format:string>",
-    "Output format (json|text)",
-    { default: "text" },
-  )
   // Core commands
   .command("format [...files:string]")
   .description("Stamp ULIDs, fix indentation, normalize attributes")


### PR DESCRIPTION
## Summary

- **#111** — `REF_ID_RE` now requires 2+ characters, preventing single-char bracket content from matching as reference entries
- **#112** — Removed unused global `--output-format` option from the root CLI command (each subcommand defines its own `--format`)
- **#113** — Exported `DetectCaptionsOptions` type from `core/parser/mod.ts` and `core/mod.ts`
- **#118** — `compileProject` helper now prints compile diagnostics to stderr before returning, so query commands (show, context, dependents) surface warnings/errors
- **#119** — Schema `id` and `entryType` changed from `["string", "null"]` to `"string"` — these fields are optional (not in `required`), and `JSON.stringify` omits `undefined` values

## Test plan

- [x] `just build` passes (check + test + lint + fmt)
- [ ] Verify `markspec show` surfaces compile diagnostics on stderr
- [ ] Verify single-char `[x]` list items no longer match as entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)