### PR TITLE
feat(core): wire parseSource into compiler and CLI validate (#148)

### DIFF
--- a/packages/markspec/core/compiler/mod.ts
+++ b/packages/markspec/core/compiler/mod.ts
@@ -13,7 +13,7 @@ import type {
   LinkKind,
   SourceLocation,
 } from "../model/mod.ts";
-import { parseMarkdown } from "../parser/markdown.ts";
+import { parseFile } from "../parser/mod.ts";
 import { validate } from "../validator/mod.ts";
 
 /** Options for {@linkcode compile}. */
@@ -66,7 +66,7 @@ export async function compile(
       });
       continue;
     }
-    const entries = parseMarkdown(content, { file: filePath });
+    const entries = await parseFile(content, { file: filePath });
     allEntries.push(...entries);
   }
 

--- a/packages/markspec/core/mod.ts
+++ b/packages/markspec/core/mod.ts
@@ -52,6 +52,7 @@ export {
   isSupportedExtension,
   loadGrammar,
   parse,
+  parseFile,
   parseSource,
 } from "./parser/mod.ts";
 export type {

--- a/packages/markspec/core/parser/mod.ts
+++ b/packages/markspec/core/parser/mod.ts
@@ -10,8 +10,11 @@
  * - source: doc comment extraction from Rust, Kotlin, C, C++, Java
  */
 
+import { extname } from "@std/path";
 import type { Caption, Entry } from "../model/mod.ts";
 import { parseMarkdown } from "./markdown.ts";
+import { isSupportedExtension, loadGrammar } from "./grammars.ts";
+import { parseSource } from "./source.ts";
 import {
   detectCaptions as detectCaptionsImpl,
   type DetectCaptionsOptions,
@@ -48,6 +51,31 @@ export function parse(
   options?: ParseOptions,
 ): Entry[] {
   return parseMarkdown(markdown, options);
+}
+
+/**
+ * Parse a file and return all MarkSpec entries, dispatching by file type.
+ *
+ * Source files (`.rs`, `.java`, `.c`, `.cpp`, etc.) are parsed with
+ * tree-sitter to extract doc comment entries. All other files are
+ * parsed as Markdown.
+ *
+ * @param content - File content
+ * @param options - Must include `file` path for extension detection
+ * @returns Array of parsed entries
+ */
+export async function parseFile(
+  content: string,
+  options: { readonly file: string },
+): Promise<Entry[]> {
+  const ext = extname(options.file);
+
+  if (isSupportedExtension(ext)) {
+    const language = await loadGrammar(ext);
+    return parseSource(content, { file: options.file, language });
+  }
+
+  return parseMarkdown(content, options);
 }
 
 /**

--- a/packages/markspec/main.ts
+++ b/packages/markspec/main.ts
@@ -192,7 +192,7 @@ const cli = new Command()
         Deno.exit(1);
       }
 
-      const { parse, validate } = await import("./core/mod.ts");
+      const { parseFile, validate } = await import("./core/mod.ts");
 
       const allEntries = [];
       for (const filePath of files) {
@@ -203,7 +203,7 @@ const cli = new Command()
           console.error(`error: ${filePath}: file not found`);
           Deno.exit(1);
         }
-        const entries = parse(content, { file: filePath });
+        const entries = await parseFile(content, { file: filePath });
         allEntries.push(...entries);
       }
 

--- a/tests/e2e/compile_test.ts
+++ b/tests/e2e/compile_test.ts
@@ -250,3 +250,74 @@ Deno.test("compile: Satisfies produces links in output", async () => {
   assertEquals(result.links[0].to, "SYS_BRK_0042");
   assertEquals(result.links[0].kind, "satisfies");
 });
+
+// ---------------------------------------------------------------------------
+// Source file compilation (Epic #127)
+// ---------------------------------------------------------------------------
+
+Deno.test("compile: extracts entries from Rust source files", async () => {
+  const rustSource = `/// [SRS_BRK_0001] Sensor input debouncing
+///
+/// The sensor driver shall reject transient noise.
+///
+/// Id: SRS_01HGW2Q8MNP3 \\
+/// Satisfies: SYS_BRK_0042 \\
+/// Labels: ASIL-B
+#[test]
+fn swt_brk_0001() {}
+`;
+
+  const { code, stdout } = await markspec(
+    ["compile", "--format", "json", "src/braking_test.rs"],
+    {
+      "project.yaml": "name: test-project\n",
+      "src/braking_test.rs": rustSource,
+    },
+  );
+
+  assertEquals(code, 0);
+  const result = JSON.parse(stdout);
+  const entry = result.entries["SRS_BRK_0001"];
+  assertEquals(entry.displayId, "SRS_BRK_0001");
+  assertEquals(entry.source, "doc-comment");
+  assertEquals(entry.id, "SRS_01HGW2Q8MNP3");
+  assertStringIncludes(entry.body, "reject transient noise");
+});
+
+Deno.test("compile: mixed .md and .rs files in single invocation", async () => {
+  const mdContent = `# System Requirements
+
+- [SYS_BRK_0042] System braking requirement
+
+  The braking system shall stop the vehicle.
+
+  Id: SYS_01HGW2Q8MNP3
+`;
+
+  const rsContent = `/// [SRS_BRK_0001] Sensor debouncing
+///
+/// Body text.
+///
+/// Id: SRS_01HGW2R9QLP4 \\
+/// Satisfies: SYS_BRK_0042
+fn debounce() {}
+`;
+
+  const { code, stdout } = await markspec(
+    ["compile", "--format", "json", "docs/reqs.md", "src/braking.rs"],
+    {
+      "project.yaml": "name: test-project\n",
+      "docs/reqs.md": mdContent,
+      "src/braking.rs": rsContent,
+    },
+  );
+
+  assertEquals(code, 0);
+  const result = JSON.parse(stdout);
+  assertEquals(Object.keys(result.entries).length, 2);
+  assertEquals(result.entries["SYS_BRK_0042"].source, "markdown");
+  assertEquals(result.entries["SRS_BRK_0001"].source, "doc-comment");
+  assertEquals(result.links.length, 1);
+  assertEquals(result.links[0].from, "SRS_BRK_0001");
+  assertEquals(result.links[0].to, "SYS_BRK_0042");
+});


### PR DESCRIPTION
## Summary

- Compiler uses `parseFile()` dispatcher: detects file extension, routes to `parseSource()` for source files or `parseMarkdown()` for markdown
- CLI validate command uses `parseFile()` instead of `parse()`
- E2E tests for `markspec compile` with `.rs` files

Closes #148

## Test plan
- [x] 199 tests pass (including 14 source parser + new E2E)
- [x] `just build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)