### PR TITLE
fix(core): CI grammar cache, concurrent-safe loadGrammar, validate E2E

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,6 +52,10 @@ jobs:
       - uses: denoland/setup-deno@v2
         with:
           deno-version: v2.x
+      - uses: actions/cache@v4
+        with:
+          path: grammars/
+          key: grammars-${{ hashFiles('scripts/fetch_grammars.ts') }}
       - run: deno run --allow-net --allow-write --allow-read scripts/fetch_grammars.ts
       - run: deno test --allow-read --allow-write --allow-run
 

--- a/packages/markspec/core/parser/grammars.ts
+++ b/packages/markspec/core/parser/grammars.ts
@@ -34,7 +34,7 @@ const GRAMMARS_DIR = join(
 );
 
 let initialized = false;
-const cache = new Map<string, Parser.Language>();
+const cache = new Map<string, Promise<Parser.Language>>();
 
 /** Check whether a file extension has a supported grammar. */
 export function isSupportedExtension(ext: string): boolean {
@@ -46,27 +46,31 @@ export function isSupportedExtension(ext: string): boolean {
  *
  * Initializes the Parser WASM runtime on first call. Grammar languages
  * are cached — repeated calls with the same extension return the
- * same `Parser.Language` instance.
+ * same `Parser.Language` instance. Concurrent-safe: stores the loading
+ * promise so parallel calls await the same load.
  *
  * @param ext - File extension including the dot (e.g., `.rs`, `.java`)
  * @throws If the extension is unsupported or the WASM file cannot be loaded
  */
-export async function loadGrammar(ext: string): Promise<Parser.Language> {
+export function loadGrammar(ext: string): Promise<Parser.Language> {
   const grammarName = EXT_TO_GRAMMAR[ext];
   if (!grammarName) {
     throw new Error(`unsupported file extension: ${ext}`);
   }
 
-  const cached = cache.get(grammarName);
-  if (cached) return cached;
+  let pending = cache.get(grammarName);
+  if (!pending) {
+    pending = doLoad(grammarName);
+    cache.set(grammarName, pending);
+  }
+  return pending;
+}
 
+async function doLoad(grammarName: string): Promise<Parser.Language> {
   if (!initialized) {
     await Parser.init();
     initialized = true;
   }
-
   const wasmPath = join(GRAMMARS_DIR, `${grammarName}.wasm`);
-  const language = await Parser.Language.load(wasmPath);
-  cache.set(grammarName, language);
-  return language;
+  return Parser.Language.load(wasmPath);
 }

--- a/tests/e2e/validate_test.ts
+++ b/tests/e2e/validate_test.ts
@@ -144,6 +144,65 @@ Deno.test("validate: --format json outputs structured diagnostics", async () => 
 });
 
 // ---------------------------------------------------------------------------
+// Source file validation
+// ---------------------------------------------------------------------------
+
+Deno.test("validate: valid Rust source file exits 0", async () => {
+  const { code } = await markspec(["validate", "lib.rs"], {
+    files: {
+      "lib.rs": `/// [SRS_BRK_0001] Sensor debouncing
+///
+/// The sensor driver shall debounce.
+///
+/// Id: SRS_01HGW2Q8MNP3A1B2C3D4E5
+fn debounce() {}
+`,
+    },
+  });
+  assertEquals(code, 0);
+});
+
+Deno.test("validate: Rust source file missing Id exits 1", async () => {
+  const { code, stderr } = await markspec(["validate", "lib.rs"], {
+    files: {
+      "lib.rs": `/// [SRS_BRK_0001] Sensor debouncing
+///
+/// The sensor driver shall debounce.
+///
+/// Labels: ASIL-B
+fn debounce() {}
+`,
+    },
+  });
+  assertEquals(code, 1);
+  assertStringIncludes(stderr, "MSL-R003");
+});
+
+Deno.test("validate: mixed .md and .rs files", async () => {
+  const { code } = await markspec(["validate", "req.md", "lib.rs"], {
+    files: {
+      "req.md": `# Test
+
+- [SYS_BRK_0042] System requirement
+
+  Body.
+
+  Id: SYS_01HGW2Q8MNP3A1B2C3D4E5
+`,
+      "lib.rs": `/// [SRS_BRK_0001] Software requirement
+///
+/// Body.
+///
+/// Id: SRS_01HGW2R9QLP4A1B2C3D4E5\\
+/// Satisfies: SYS_BRK_0042
+fn impl_debounce() {}
+`,
+    },
+  });
+  assertEquals(code, 0);
+});
+
+// ---------------------------------------------------------------------------
 // No args
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- **#150**: Cache grammar WASM files in CI with `actions/cache` keyed by fetch script hash
- **#151**: Make `loadGrammar` concurrent-safe by caching the Promise instead of resolved value
- **#149**: E2E tests for `markspec validate` with `.rs` files (valid, missing Id, mixed .md + .rs)

Closes #149, closes #150, closes #151

## Test plan
- [x] 202 tests pass (3 new E2E)
- [x] `just build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)