### PR TITLE
fix(core): debt cleanup — regex escape, version warning, help subcommand (#91, #90, #89)

### DIFF
--- a/packages/markspec/core/config/mod.ts
+++ b/packages/markspec/core/config/mod.ts
@@ -59,12 +59,17 @@ export async function discoverProjectRoot(
 // Parsing and validation
 // ---------------------------------------------------------------------------
 
+/** Escape special regex characters for safe interpolation into RegExp. */
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 /** Find the 1-based line number where `^fieldName:` appears in raw YAML. */
 function findLineNumber(
   rawYaml: string,
   fieldName: string,
 ): number | undefined {
-  const pattern = new RegExp(`^${fieldName}\\s*:`, "m");
+  const pattern = new RegExp(`^${escapeRegex(fieldName)}\\s*:`, "m");
   const match = pattern.exec(rawYaml);
   if (!match) return undefined;
   return rawYaml.slice(0, match.index).split("\n").length;
@@ -144,6 +149,13 @@ export function parseProjectConfig(
   // version: optional string
   let version = DEFAULT_PROJECT_CONFIG.version;
   if (obj.version !== undefined && obj.version !== null) {
+    if (typeof obj.version === "number") {
+      console.error(
+        `warning: ${filePath}: version is a number (${obj.version}), ` +
+          `coerced to "${String(obj.version)}". ` +
+          `Quote it in YAML: version: "${obj.version}"`,
+      );
+    }
     version = String(obj.version);
   }
 

--- a/packages/markspec/core/config/mod_test.ts
+++ b/packages/markspec/core/config/mod_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, assertThrows } from "@std/assert";
+import { assertEquals, assertStringIncludes, assertThrows } from "@std/assert";
 import {
   ConfigError,
   DEFAULT_PROJECT_CONFIG,
@@ -145,6 +145,16 @@ Deno.test("parseProjectConfig: parent-fallback kebab-case maps to parentFallback
   assertEquals(config.parentFallback, "https://example.com/fallback");
 });
 
+Deno.test("parseProjectConfig: findLineNumber handles regex metacharacters in field names", () => {
+  const yaml = "name: test\nparent-fallback: not-a-url\n";
+  const err = assertThrows(
+    () => parseProjectConfig(yaml, "project.yaml"),
+    ConfigError,
+  );
+  assertEquals(err.fieldErrors[0].field, "parent-fallback");
+  assertEquals(err.fieldErrors[0].line, 2);
+});
+
 Deno.test("parseProjectConfig: ignores unknown fields", () => {
   const yaml =
     "name: test\ncategory: [tool]\ndescription: something\nlicense: MIT\n";
@@ -155,6 +165,20 @@ Deno.test("parseProjectConfig: ignores unknown fields", () => {
 Deno.test("parseProjectConfig: numeric version is coerced to string", () => {
   const config = parseProjectConfig("name: test\nversion: 1.0\n", "p.yaml");
   assertEquals(config.version, "1");
+});
+
+Deno.test("parseProjectConfig: numeric version emits coercion warning", () => {
+  const warnings: string[] = [];
+  const origError = console.error;
+  console.error = (msg: string) => warnings.push(msg);
+  try {
+    parseProjectConfig("name: test\nversion: 1.0\n", "p.yaml");
+  } finally {
+    console.error = origError;
+  }
+  assertEquals(warnings.length, 1);
+  assertStringIncludes(warnings[0], "version");
+  assertStringIncludes(warnings[0], "Quote");
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/markspec/main.ts
+++ b/packages/markspec/main.ts
@@ -241,21 +241,10 @@ const cli = new Command()
     default: "text",
   })
   .action(async (_options: { format?: string }, ...paths: string[]) => {
-    await requireProjectConfig();
-
-    const { compile, serializeCompileResult } = await import("./core/mod.ts");
-    const result = await compile(paths, {
-      readFile: (p) => Deno.readTextFile(p),
-    });
-
-    for (const diag of result.diagnostics) {
-      const loc = diag.location
-        ? `${diag.location.file}:${diag.location.line}`
-        : "";
-      console.error(`${diag.severity}[${diag.code}]: ${loc} ${diag.message}`);
-    }
+    const result = await compileProject(paths);
 
     if (_options.format === "json") {
+      const { serializeCompileResult } = await import("./core/mod.ts");
       const output = serializeCompileResult(result);
       console.log(JSON.stringify(output, null, 2));
     } else {
@@ -501,6 +490,26 @@ const cli = new Command()
   .description("Print version")
   .action(() => {
     console.log(`markspec ${VERSION}`);
+  })
+  // Help subcommand: enables `markspec help show`, etc. (clig.dev)
+  .command("help [...command:string]")
+  .description("Show help for a command")
+  .action(async (_options: Record<string, unknown>, ...args: string[]) => {
+    // deno-lint-ignore no-explicit-any
+    let target: any = cli;
+    for (const name of args) {
+      const commands = target.getCommands() as Array<{ getName(): string }>;
+      const found = commands.find((c: { getName(): string }) =>
+        c.getName() === name
+      );
+      if (!found) {
+        console.error(`error: unknown command '${name}'`);
+        console.error("Run 'markspec --help' to see available commands.");
+        Deno.exit(1);
+      }
+      target = found;
+    }
+    await target.showHelp();
   });
 
 if (import.meta.main) {

--- a/tests/e2e/help_test.ts
+++ b/tests/e2e/help_test.ts
@@ -39,6 +39,25 @@ Deno.test("book build prints not yet implemented", async () => {
   assertStringIncludes(stderr, "not yet implemented");
 });
 
+Deno.test("help subcommand shows root help", async () => {
+  const { code, stdout } = await markspec(["help"]);
+  assertEquals(code, 0);
+  assertStringIncludes(stdout, "markspec");
+  assertStringIncludes(stdout, "format");
+});
+
+Deno.test("help show prints show subcommand help", async () => {
+  const { code, stdout } = await markspec(["help", "show"]);
+  assertEquals(code, 0);
+  assertStringIncludes(stdout, "show");
+});
+
+Deno.test("help nonexistent exits with error", async () => {
+  const { code, stderr } = await markspec(["help", "nonexistent"]);
+  assertEquals(code, 1);
+  assertStringIncludes(stderr, "unknown command");
+});
+
 Deno.test("unknown subcommand fails with non-zero exit", async () => {
   const { code } = await markspec(["nonexistent"]);
   assertEquals(code !== 0, true);


### PR DESCRIPTION
## Summary
- **#91**: Escape regex metacharacters in `findLineNumber` field name lookup to prevent broken patterns with names like `parent-fallback`
- **#90**: Emit a warning to stderr when `version:` in `project.yaml` is a YAML number (coerced silently to string — e.g. `1.0` → `"1"`)
- **#89**: Register `help` subcommand so `markspec help show`, `markspec help validate`, etc. work per clig.dev
- **Bonus**: DRY up `compile` command action to use the shared `compileProject()` helper

Also closes 5 issues already resolved in PR #124 (commit `8177909`):
- Closes #111, #112, #113, #118, #119

## Test plan
- [x] 257 tests passing (5 new: 2 config unit tests, 3 help E2E tests)
- [x] `deno fmt`, `deno lint`, `deno check`, `dprint check` all clean
- [x] `markspec help` shows root help
- [x] `markspec help show` shows show subcommand help
- [x] `markspec help nonexistent` exits 1 with error

Closes #91, #90, #89, #111, #112, #113, #118, #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)