### PR TITLE
feat(core): extract Verifies/Implements annotations from source doc comments (#11)

### DIFF
--- a/packages/markspec/core/compiler/mod.ts
+++ b/packages/markspec/core/compiler/mod.ts
@@ -50,6 +50,7 @@ export async function compile(
 ): Promise<CompileResult> {
   const read = options.readFile;
   const allEntries: Entry[] = [];
+  const annotationLinks: Link[] = [];
   const parseDiagnostics: Diagnostic[] = [];
 
   // Phase 1: Read and parse all files.
@@ -66,8 +67,9 @@ export async function compile(
       });
       continue;
     }
-    const entries = await parseFile(content, { file: filePath });
-    allEntries.push(...entries);
+    const result = await parseFile(content, { file: filePath });
+    allEntries.push(...result.entries);
+    annotationLinks.push(...result.links);
   }
 
   // Phase 2: Validate all entries.
@@ -82,7 +84,7 @@ export async function compile(
     }
   }
 
-  const links = extractLinks(allEntries);
+  const links = [...extractLinks(allEntries), ...annotationLinks];
   const forward = buildAdjacency(links, (l) => l.from);
   const reverse = buildAdjacency(links, (l) => l.to);
 

--- a/packages/markspec/core/mod.ts
+++ b/packages/markspec/core/mod.ts
@@ -59,8 +59,10 @@ export type {
   DetectCaptionsOptions,
   DetectDirectivesOptions,
   DetectInlineRefsOptions,
+  ParseFileResult,
   ParseOptions,
   ParseSourceOptions,
+  ParseSourceResult,
 } from "./parser/mod.ts";
 
 // Formatter

--- a/packages/markspec/core/parser/mod.ts
+++ b/packages/markspec/core/parser/mod.ts
@@ -11,7 +11,7 @@
  */
 
 import { extname } from "@std/path";
-import type { Caption, Entry } from "../model/mod.ts";
+import type { Caption, Entry, Link } from "../model/mod.ts";
 import { parseMarkdown } from "./markdown.ts";
 import { isSupportedExtension, loadGrammar } from "./grammars.ts";
 import { parseSource } from "./source.ts";
@@ -29,7 +29,7 @@ export { detectInlineRefs } from "./references.ts";
 export type { DetectInlineRefsOptions } from "./references.ts";
 
 export { parseSource } from "./source.ts";
-export type { ParseSourceOptions } from "./source.ts";
+export type { ParseSourceOptions, ParseSourceResult } from "./source.ts";
 
 export { isSupportedExtension, loadGrammar } from "./grammars.ts";
 
@@ -53,21 +53,29 @@ export function parse(
   return parseMarkdown(markdown, options);
 }
 
+/** Result of parsing a file (entries + annotation links). */
+export interface ParseFileResult {
+  /** Parsed entries. */
+  readonly entries: Entry[];
+  /** Standalone annotation links (from source file doc comments). */
+  readonly links: Link[];
+}
+
 /**
- * Parse a file and return all MarkSpec entries, dispatching by file type.
+ * Parse a file and return entries and annotation links, dispatching by type.
  *
  * Source files (`.rs`, `.java`, `.c`, `.cpp`, etc.) are parsed with
- * tree-sitter to extract doc comment entries. All other files are
- * parsed as Markdown.
+ * tree-sitter to extract doc comment entries and standalone annotations.
+ * All other files are parsed as Markdown (no annotation links).
  *
  * @param content - File content
  * @param options - Must include `file` path for extension detection
- * @returns Array of parsed entries
+ * @returns Parsed entries and annotation links
  */
 export async function parseFile(
   content: string,
   options: { readonly file: string },
-): Promise<Entry[]> {
+): Promise<ParseFileResult> {
   const ext = extname(options.file);
 
   if (isSupportedExtension(ext)) {
@@ -75,7 +83,7 @@ export async function parseFile(
     return parseSource(content, { file: options.file, language });
   }
 
-  return parseMarkdown(content, options);
+  return { entries: parseMarkdown(content, options), links: [] };
 }
 
 /**

--- a/packages/markspec/core/parser/source.ts
+++ b/packages/markspec/core/parser/source.ts
@@ -8,7 +8,7 @@
 
 import type { SyntaxNode } from "web-tree-sitter";
 import Parser from "web-tree-sitter";
-import type { Entry } from "../model/mod.ts";
+import type { Entry, Link, LinkKind } from "../model/mod.ts";
 import { parseMarkdown } from "./markdown.ts";
 
 /** Options for {@linkcode parseSource}. */
@@ -19,6 +19,14 @@ export interface ParseSourceOptions {
   readonly language: Parser.Language;
 }
 
+/** Result of parsing a source file. */
+export interface ParseSourceResult {
+  /** Entries found in doc comment blocks. */
+  readonly entries: Entry[];
+  /** Standalone annotation links (Verifies/Implements) outside entry blocks. */
+  readonly links: Link[];
+}
+
 /** A contiguous doc comment block extracted from source. */
 interface DocCommentBlock {
   /** Cleaned lines (comment prefix stripped). */
@@ -27,23 +35,32 @@ interface DocCommentBlock {
   readonly startLine: number;
   /** 1-based column of the first comment line. */
   readonly startColumn: number;
+  /** Name of the function/item following this doc comment, if extractable. */
+  readonly followingItem?: string;
 }
 
 /**
- * Parse a source file and return all MarkSpec entries found in doc comments.
+ * Standalone annotation pattern: `Verifies: ID1, ID2` or `Implements: ID1`.
+ * Matches a single line that is NOT inside an entry block.
+ */
+const ANNOTATION_RE = /^(Verifies|Implements):\s+(.+)$/;
+
+/**
+ * Parse a source file and return entries and annotation links from doc comments.
  *
  * Uses tree-sitter to parse the source, walks the AST to find doc comment
  * nodes, strips comment prefixes, and delegates to the markdown parser
- * for entry extraction.
+ * for entry extraction. Doc comments that don't contain entries are scanned
+ * for standalone `Verifies:` / `Implements:` annotations.
  *
  * @param content - Source file text
  * @param options - Parse options (language grammar, file path)
- * @returns Array of parsed entries with `source: "doc-comment"`
+ * @returns Parsed entries and annotation links
  */
 export function parseSource(
   content: string,
   options: ParseSourceOptions,
-): Entry[] {
+): ParseSourceResult {
   const file = options.file ?? "<unknown>";
   const parser = new Parser();
   parser.setLanguage(options.language);
@@ -52,27 +69,54 @@ export function parseSource(
   const blocks: DocCommentBlock[] = [];
   walkForDocComments(tree.rootNode, blocks);
   const entries: Entry[] = [];
+  const links: Link[] = [];
 
   for (const block of blocks) {
     const markdown = wrapAsListItem(block.lines);
     const parsed = parseMarkdown(markdown, { file });
 
-    for (const entry of parsed) {
-      entries.push({
-        ...entry,
-        source: "doc-comment",
-        location: {
-          file,
-          line: block.startLine,
-          column: block.startColumn,
-        },
-      });
+    if (parsed.length > 0) {
+      // Block contains entry blocks — extract entries.
+      for (const entry of parsed) {
+        entries.push({
+          ...entry,
+          source: "doc-comment",
+          location: {
+            file,
+            line: block.startLine,
+            column: block.startColumn,
+          },
+        });
+      }
+    } else {
+      // No entries — scan for standalone annotations.
+      const from = block.followingItem ?? `${file}:${block.startLine}`;
+      for (const line of block.lines) {
+        const match = ANNOTATION_RE.exec(line.trim());
+        if (!match) continue;
+        const kind = match[1].toLowerCase() as LinkKind;
+        const targets = match[2].split(",").map((s) => s.trim()).filter((s) =>
+          s.length > 0
+        );
+        for (const to of targets) {
+          links.push({
+            from,
+            to,
+            kind,
+            location: {
+              file,
+              line: block.startLine,
+              column: block.startColumn,
+            },
+          });
+        }
+      }
     }
   }
 
   tree.delete();
   parser.delete();
-  return entries;
+  return { entries, links };
 }
 
 /**
@@ -93,12 +137,13 @@ function walkForDocComments(
   let currentStartColumn = 0;
   let lastRow = -2;
 
-  function flushLineBlock() {
+  function flushLineBlock(followingItem?: string) {
     if (currentLines.length > 0) {
       blocks.push({
         lines: currentLines,
         startLine: currentStartLine,
         startColumn: currentStartColumn,
+        followingItem,
       });
       currentLines = [];
       lastRow = -2;
@@ -136,8 +181,12 @@ function walkForDocComments(
       continue;
     }
 
-    // Non-comment node — flush pending line comments, then recurse
-    flushLineBlock();
+    // Non-comment node — flush pending line comments (capturing item name),
+    // then recurse.
+    if (currentLines.length > 0) {
+      const itemName = extractItemName(child);
+      flushLineBlock(itemName);
+    }
     if (child.childCount > 0) {
       walkForDocComments(child, blocks);
     }
@@ -152,6 +201,29 @@ function isOuterDocComment(node: SyntaxNode): boolean {
     if (node.child(i)!.type === "outer_doc_comment_marker") return true;
   }
   return false;
+}
+
+/**
+ * Extract the identifier name from a function/item AST node.
+ * Walks through attribute nodes (e.g., `#[test]`) to find the actual
+ * item, then looks for its `name` or `identifier` child.
+ */
+function extractItemName(node: SyntaxNode): string | undefined {
+  // Skip attribute nodes — the item may be a sibling after attributes.
+  let target = node;
+  if (target.type === "attribute_item" || target.type === "annotation") {
+    const next = target.nextSibling;
+    if (next) target = next;
+    else return undefined;
+  }
+  // Look for identifier/name child.
+  for (let i = 0; i < target.childCount; i++) {
+    const child = target.child(i)!;
+    if (child.type === "identifier" || child.type === "name") {
+      return child.text;
+    }
+  }
+  return undefined;
 }
 
 /**

--- a/packages/markspec/core/parser/source_test.ts
+++ b/packages/markspec/core/parser/source_test.ts
@@ -49,16 +49,16 @@ Deno.test("parseSource: extracts Rust doc comment entry", async () => {
 fn swt_brk_0001() {}
 `;
 
-  const entries = parseSource(source, { file: "src/braking.rs", language });
-  assertEquals(entries.length, 1);
-  assertEquals(entries[0].displayId, "SRS_BRK_0001");
-  assertEquals(entries[0].title, "Sensor input debouncing");
-  assertEquals(entries[0].id, "SRS_01HGW2Q8MNP3");
-  assertEquals(entries[0].entryType, "SRS");
-  assertEquals(entries[0].source, "doc-comment");
-  assertEquals(entries[0].location.file, "src/braking.rs");
-  assertEquals(entries[0].location.line, 1);
-  assertEquals(entries[0].location.column, 1);
+  const result = parseSource(source, { file: "src/braking.rs", language });
+  assertEquals(result.entries.length, 1);
+  assertEquals(result.entries[0].displayId, "SRS_BRK_0001");
+  assertEquals(result.entries[0].title, "Sensor input debouncing");
+  assertEquals(result.entries[0].id, "SRS_01HGW2Q8MNP3");
+  assertEquals(result.entries[0].entryType, "SRS");
+  assertEquals(result.entries[0].source, "doc-comment");
+  assertEquals(result.entries[0].location.file, "src/braking.rs");
+  assertEquals(result.entries[0].location.line, 1);
+  assertEquals(result.entries[0].location.column, 1);
 });
 
 Deno.test("parseSource: extracts body from Rust doc comment", async () => {
@@ -71,7 +71,7 @@ Deno.test("parseSource: extracts body from Rust doc comment", async () => {
 fn foo() {}
 `;
 
-  const entries = parseSource(source, { file: "test.rs", language });
+  const { entries } = parseSource(source, { file: "test.rs", language });
   assertEquals(entries.length, 1);
   assertStringIncludes(entries[0].body, "reject transient noise");
 });
@@ -88,7 +88,7 @@ Deno.test("parseSource: extracts attributes from Rust doc comment", async () => 
 fn foo() {}
 `;
 
-  const entries = parseSource(source, { file: "test.rs", language });
+  const { entries } = parseSource(source, { file: "test.rs", language });
   assertEquals(entries[0].attributes.length, 3);
   assertEquals(entries[0].attributes[0].key, "Id");
   assertEquals(entries[0].attributes[0].value, "SRS_01HGW2Q8MNP3");
@@ -119,7 +119,7 @@ fn first() {}
 fn second() {}
 `;
 
-  const entries = parseSource(source, { file: "test.rs", language });
+  const { entries } = parseSource(source, { file: "test.rs", language });
   assertEquals(entries.length, 2);
   assertEquals(entries[0].displayId, "SRS_BRK_0001");
   assertEquals(entries[1].displayId, "SRS_BRK_0002");
@@ -141,7 +141,7 @@ Deno.test("parseSource: preserves source location for offset entries", async () 
 fn foo() {}
 `;
 
-  const entries = parseSource(source, { file: "test.rs", language });
+  const { entries } = parseSource(source, { file: "test.rs", language });
   assertEquals(entries.length, 1);
   assertEquals(entries[0].location.line, 3);
   assertEquals(entries[0].location.column, 1);
@@ -165,7 +165,7 @@ fn documented() {}
 fn entry() {}
 `;
 
-  const entries = parseSource(source, { file: "test.rs", language });
+  const { entries } = parseSource(source, { file: "test.rs", language });
   assertEquals(entries.length, 1);
   assertEquals(entries[0].displayId, "SRS_BRK_0001");
 });
@@ -184,7 +184,7 @@ fn foo() {}
 fn bar() {}
 `;
 
-  const entries = parseSource(source, { file: "test.rs", language });
+  const { entries } = parseSource(source, { file: "test.rs", language });
   assertEquals(entries.length, 1);
   assertEquals(entries[0].displayId, "SRS_BRK_0001");
 });
@@ -209,7 +209,7 @@ Deno.test("parseSource: handles doc comment with code block", async () => {
 fn foo() {}
 `;
 
-  const entries = parseSource(source, { file: "test.rs", language });
+  const { entries } = parseSource(source, { file: "test.rs", language });
   assertEquals(entries.length, 1);
   assertEquals(entries[0].displayId, "SRS_BRK_0001");
   assertStringIncludes(entries[0].body, "gherkin");
@@ -221,13 +221,13 @@ Deno.test("parseSource: returns empty for file with no doc comments", async () =
 fn bar() {}
 `;
 
-  const entries = parseSource(source, { file: "test.rs", language });
+  const { entries } = parseSource(source, { file: "test.rs", language });
   assertEquals(entries.length, 0);
 });
 
 Deno.test("parseSource: returns empty for empty source", async () => {
   const language = await getRustLanguage();
-  const entries = parseSource("", { file: "test.rs", language });
+  const { entries } = parseSource("", { file: "test.rs", language });
   assertEquals(entries.length, 0);
 });
 
@@ -248,7 +248,10 @@ Deno.test("parseSource: fixture — in-code-rust.rs", async () => {
     "in-code-rust.rs",
   );
   const content = await Deno.readTextFile(fixturePath);
-  const entries = parseSource(content, { file: "in-code-rust.rs", language });
+  const { entries } = parseSource(content, {
+    file: "in-code-rust.rs",
+    language,
+  });
 
   assertEquals(entries.length, 1);
   assertEquals(entries[0].displayId, "SRS_BRK_0001");
@@ -276,7 +279,7 @@ Deno.test("parseSource: extracts entries inside mod blocks", async () => {
 }
 `;
 
-  const entries = parseSource(source, { file: "test.rs", language });
+  const { entries } = parseSource(source, { file: "test.rs", language });
   assertEquals(entries.length, 1);
   assertEquals(entries[0].displayId, "SRS_BRK_0001");
   assertStringIncludes(entries[0].body, "inside mod");
@@ -306,7 +309,7 @@ mod tests {
 }
 `;
 
-    const entries = parseSource(source, { file: "test.rs", language });
+    const { entries } = parseSource(source, { file: "test.rs", language });
     assertEquals(entries.length, 2);
     assertEquals(entries[0].displayId, "SRS_BRK_0001");
     assertEquals(entries[1].displayId, "SRS_BRK_0002");
@@ -327,6 +330,134 @@ Deno.test("parseSource: uses '<unknown>' when no file specified", async () => {
 fn foo() {}
 `;
 
-  const entries = parseSource(source, { language });
+  const { entries } = parseSource(source, { language });
   assertEquals(entries[0].location.file, "<unknown>");
+});
+
+// ---------------------------------------------------------------------------
+// Rust: standalone annotations (Verifies/Implements)
+// ---------------------------------------------------------------------------
+
+Deno.test("parseSource: extracts Verifies annotation", async () => {
+  const language = await getRustLanguage();
+  const source = `/// Verifies: STK_AEB_0001
+#[test]
+fn val_aeb_0001_vehicle_stops() {}
+`;
+
+  const { entries, links } = parseSource(source, { file: "test.rs", language });
+  assertEquals(entries.length, 0);
+  assertEquals(links.length, 1);
+  assertEquals(links[0].kind, "verifies");
+  assertEquals(links[0].to, "STK_AEB_0001");
+  assertEquals(links[0].from, "val_aeb_0001_vehicle_stops");
+});
+
+Deno.test("parseSource: extracts Implements annotation", async () => {
+  const language = await getRustLanguage();
+  const source = `/// Implements: SRS_BRK_0001
+fn impl_braking() {}
+`;
+
+  const { entries, links } = parseSource(source, { file: "test.rs", language });
+  assertEquals(entries.length, 0);
+  assertEquals(links.length, 1);
+  assertEquals(links[0].kind, "implements");
+  assertEquals(links[0].to, "SRS_BRK_0001");
+  assertEquals(links[0].from, "impl_braking");
+});
+
+Deno.test("parseSource: extracts comma-separated annotation targets", async () => {
+  const language = await getRustLanguage();
+  const source = `/// Verifies: STK_AEB_0001, STK_AEB_0002
+#[test]
+fn val_aeb_both() {}
+`;
+
+  const { links } = parseSource(source, { file: "test.rs", language });
+  assertEquals(links.length, 2);
+  assertEquals(links[0].to, "STK_AEB_0001");
+  assertEquals(links[1].to, "STK_AEB_0002");
+});
+
+Deno.test("parseSource: mixed entries and annotations", async () => {
+  const language = await getRustLanguage();
+  const source = `/// [SRS_BRK_0001] Brake pressure
+///
+/// Body text.
+///
+/// Id: SRS_01HGW2Q8MNP3
+fn brake() {}
+
+/// Verifies: SRS_BRK_0001
+#[test]
+fn swt_brk_0001() {}
+`;
+
+  const { entries, links } = parseSource(source, { file: "test.rs", language });
+  assertEquals(entries.length, 1);
+  assertEquals(entries[0].displayId, "SRS_BRK_0001");
+  assertEquals(links.length, 1);
+  assertEquals(links[0].kind, "verifies");
+  assertEquals(links[0].to, "SRS_BRK_0001");
+});
+
+Deno.test("parseSource: annotation inside entry block is attribute, not link", async () => {
+  const language = await getRustLanguage();
+  const source = `/// [SRS_BRK_0001] Title
+///
+/// Body text.
+///
+/// Id: SRS_01HGW2Q8MNP3 \\
+/// Verifies: STK_BRK_0001
+fn foo() {}
+`;
+
+  const { entries, links } = parseSource(source, { file: "test.rs", language });
+  assertEquals(entries.length, 1);
+  assertEquals(links.length, 0);
+  // Verifies is an attribute on the entry, not a standalone link.
+  const verifies = entries[0].attributes.find((a) => a.key === "Verifies");
+  assertEquals(verifies?.value, "STK_BRK_0001");
+});
+
+Deno.test("parseSource: annotation fallback from when no function name", async () => {
+  const language = await getRustLanguage();
+  const source = `/// Verifies: STK_AEB_0001
+`;
+
+  const { links } = parseSource(source, { file: "test.rs", language });
+  assertEquals(links.length, 1);
+  assertEquals(links[0].from, "test.rs:1");
+});
+
+Deno.test("parseSource: fixture — in-code-rust-annotations.rs", async () => {
+  const language = await getRustLanguage();
+  const fixturePath = join(
+    import.meta.dirname!,
+    "..",
+    "..",
+    "..",
+    "..",
+    "tests",
+    "fixtures",
+    "in-code-rust-annotations.rs",
+  );
+  const content = await Deno.readTextFile(fixturePath);
+  const { entries, links } = parseSource(content, {
+    file: "in-code-rust-annotations.rs",
+    language,
+  });
+
+  assertEquals(entries.length, 1);
+  assertEquals(entries[0].displayId, "SRS_BRK_0010");
+  assertEquals(links.length, 4); // 1 Verifies + 2 Implements + 1 Verifies
+  assertEquals(links[0].kind, "verifies");
+  assertEquals(links[0].to, "STK_AEB_0001");
+  assertEquals(links[1].kind, "implements");
+  assertEquals(links[1].to, "SRS_BRK_0001");
+  assertEquals(links[2].kind, "implements");
+  assertEquals(links[2].to, "SRS_BRK_0002");
+  assertEquals(links[3].kind, "verifies");
+  assertEquals(links[3].to, "SRS_BRK_0010");
 });

--- a/packages/markspec/main.ts
+++ b/packages/markspec/main.ts
@@ -203,8 +203,8 @@ const cli = new Command()
           console.error(`error: ${filePath}: file not found`);
           Deno.exit(1);
         }
-        const entries = await parseFile(content, { file: filePath });
-        allEntries.push(...entries);
+        const result = await parseFile(content, { file: filePath });
+        allEntries.push(...result.entries);
       }
 
       const result = validate(allEntries);

--- a/tests/fixtures/in-code-rust-annotations.rs
+++ b/tests/fixtures/in-code-rust-annotations.rs
@@ -1,0 +1,19 @@
+/// Verifies: STK_AEB_0001
+#[test]
+fn val_aeb_0001_vehicle_stops() {}
+
+/// Implements: SRS_BRK_0001, SRS_BRK_0002
+fn impl_braking() {}
+
+/// [SRS_BRK_0010] Brake pressure calculation
+///
+/// The brake module shall compute pressure from pedal input.
+///
+/// Id: SRS_01HGW2Q8MNP3 \
+/// Satisfies: SYS_BRK_0042 \
+/// Labels: ASIL-B
+fn brake_pressure() {}
+
+/// Verifies: SRS_BRK_0010
+#[test]
+fn swt_brk_0010_pressure() {}


### PR DESCRIPTION
## Summary
- parseSource() now returns ParseSourceResult { entries, links } instead of Entry[]
- Standalone Verifies:/Implements: annotations in doc comments produce Link[]
- Function name following the doc comment captured from AST as link.from
- Fallback to file:line when function name unavailable
- parseFile() returns ParseFileResult { entries, links } — callers updated
- Compiler merges annotation links into traceability graph
- New fixture: tests/fixtures/in-code-rust-annotations.rs

## Test plan
- [x] 264 tests passing (7 new annotation tests)
- [x] deno fmt, deno lint, deno check, dprint check all clean

Closes #11