### PR TITLE
feat(core): add grammar lockfile and auto-update workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,7 +55,9 @@ jobs:
       - uses: actions/cache@v4
         with:
           path: grammars/
-          key: grammars-${{ hashFiles('scripts/fetch_grammars.ts') }}
+          key: grammars-${{ hashFiles('grammars/grammars.lock') }}
+          restore-keys: |
+            grammars-
       - run: deno run --allow-net --allow-write --allow-read scripts/fetch_grammars.ts
       - run: deno test --allow-read --allow-write --allow-run
 

--- a/.github/workflows/update-grammars.yaml
+++ b/.github/workflows/update-grammars.yaml
@@ -1,0 +1,52 @@
+name: Update grammars
+
+on:
+  schedule:
+    - cron: "0 6 * * 1" # Monday 06:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update:
+    name: Check and update grammars
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - name: Check for updates
+        id: check
+        run: |
+          output=$(deno run --allow-net --allow-read --allow-env scripts/update_grammars.ts)
+          echo "$output"
+          up_to_date=$(echo "$output" | jq -r '.up_to_date')
+          echo "up_to_date=$up_to_date" >> "$GITHUB_OUTPUT"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Apply updates
+        if: steps.check.outputs.up_to_date == 'false'
+        run: deno run --allow-net --allow-read --allow-write --allow-env --allow-run scripts/update_grammars.ts --apply
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create pull request
+        if: steps.check.outputs.up_to_date == 'false'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore(auto): update tree-sitter grammar versions"
+          branch: chore/update-grammars
+          title: "chore(auto): update tree-sitter grammar versions"
+          body: |
+            Automated update of tree-sitter WASM grammar versions.
+
+            Review the changes to `scripts/fetch_grammars.ts` and `grammars/grammars.lock`.
+          labels: dependencies
+          delete-branch: true

--- a/deno.json
+++ b/deno.json
@@ -4,7 +4,8 @@
     "compile": "deno compile --allow-read --allow-write --allow-run --allow-env --include grammars/ --output markspec packages/markspec/main.ts",
     "test": "deno test --allow-read --allow-write --allow-run",
     "lint": "deno lint",
-    "fmt": "deno fmt"
+    "fmt": "deno fmt",
+    "fetch-grammars": "deno run --allow-net --allow-write --allow-read scripts/fetch_grammars.ts"
   },
   "imports": {
     "@deno/dnt": "jsr:@deno/dnt@^0.42.3",

--- a/grammars/README.md
+++ b/grammars/README.md
@@ -18,3 +18,9 @@ Supported grammars:
 | `tree-sitter-java.wasm`   | Java     |
 | `tree-sitter-c.wasm`      | C        |
 | `tree-sitter-cpp.wasm`    | C++      |
+
+## Lockfile
+
+`grammars.lock` records the source, version, and SHA-256 hash of each fetched
+grammar. It is committed to git for traceability and used as the CI cache key.
+The fetch script regenerates it on every run.

--- a/grammars/grammars.lock
+++ b/grammars/grammars.lock
@@ -1,0 +1,40 @@
+{
+  "generated": "2026-03-30T21:08:33.912Z",
+  "grammars": [
+    {
+      "file": "tree-sitter-rust.wasm",
+      "source": "npm",
+      "package": "tree-sitter-rust",
+      "version": "0.24.0",
+      "sha256": "f65f354215611fd94ad34134b3427eb3d58cbb745df7b6509ba722184db73d57"
+    },
+    {
+      "file": "tree-sitter-kotlin.wasm",
+      "source": "github",
+      "package": "fwcd/tree-sitter-kotlin",
+      "version": "0.3.8",
+      "sha256": "c624e7443b371c28adc5d81674e73067564c12555ebe3ed96a6c8db814b7602d"
+    },
+    {
+      "file": "tree-sitter-java.wasm",
+      "source": "npm",
+      "package": "tree-sitter-java",
+      "version": "0.23.5",
+      "sha256": "4fdeac4ca6ca089f06c6f7e562abcac1733cd465728cc7031ebb73c2019122c4"
+    },
+    {
+      "file": "tree-sitter-c.wasm",
+      "source": "npm",
+      "package": "tree-sitter-c",
+      "version": "0.23.5",
+      "sha256": "146f85977800935f18b06940518b16ded13cf4007ef0e3190573b969a98b9adc"
+    },
+    {
+      "file": "tree-sitter-cpp.wasm",
+      "source": "npm",
+      "package": "tree-sitter-cpp",
+      "version": "0.23.4",
+      "sha256": "174eb0deb75b2ec7881bcacda9f995648d8e683956e5c2267e69ab6dc503fcbf"
+    }
+  ]
+}

--- a/justfile
+++ b/justfile
@@ -64,6 +64,10 @@ release: bump
     git push --follow-tags
     just publish
 
+# Fetch tree-sitter WASM grammars
+fetch-grammars:
+    deno task fetch-grammars
+
 # Remove build artifacts
 clean:
     rm -rf node_modules .dprint _site npm markspec

--- a/scripts/fetch_grammars.ts
+++ b/scripts/fetch_grammars.ts
@@ -1,10 +1,13 @@
 /**
  * Download pre-built tree-sitter WASM grammar files to grammars/.
  *
- * Usage: deno run --allow-net --allow-write scripts/fetch_grammars.ts
+ * Usage: deno run --allow-net --allow-write --allow-read scripts/fetch_grammars.ts
  *
  * Most grammars are fetched from npm via jsdelivr CDN. Kotlin is fetched
  * from its GitHub Release (upstream npm package does not include WASM).
+ *
+ * After fetching, writes grammars/grammars.lock with SHA-256 hashes
+ * for traceability and CI cache keying.
  */
 
 interface NpmGrammar {
@@ -20,6 +23,14 @@ interface GithubGrammar {
 }
 
 type Grammar = NpmGrammar | GithubGrammar;
+
+interface LockEntry {
+  file: string;
+  source: "npm" | "github";
+  package: string;
+  version: string;
+  sha256: string;
+}
 
 const GRAMMARS: Record<string, Grammar> = {
   "tree-sitter-rust.wasm": {
@@ -58,11 +69,22 @@ function grammarUrl(file: string, grammar: Grammar): string {
   return `https://github.com/${grammar.repo}/releases/download/${grammar.tag}/${file}`;
 }
 
-async function fetchGrammar(file: string, grammar: Grammar) {
+async function sha256(data: Uint8Array): Promise<string> {
+  const hash = await crypto.subtle.digest("SHA-256", data);
+  return Array.from(new Uint8Array(hash))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+async function fetchGrammar(
+  file: string,
+  grammar: Grammar,
+): Promise<LockEntry> {
   const url = grammarUrl(file, grammar);
-  const label = grammar.source === "npm"
-    ? `${grammar.pkg}@${grammar.version}`
-    : `${grammar.repo}@${grammar.tag}`;
+  const pkg = grammar.source === "npm" ? grammar.pkg : grammar.repo;
+  const version = grammar.source === "npm" ? grammar.version : grammar.tag;
+  const label = `${pkg}@${version}`;
+
   console.error(`  fetching ${file} from ${label}...`);
   const response = await fetch(url);
   if (!response.ok) {
@@ -70,13 +92,33 @@ async function fetchGrammar(file: string, grammar: Grammar) {
   }
   const data = new Uint8Array(await response.arrayBuffer());
   await Deno.writeFile(`${GRAMMARS_DIR}/${file}`, data);
-  console.error(`  wrote ${file} (${(data.length / 1024).toFixed(0)} KB)`);
+  const digest = await sha256(data);
+  console.error(
+    `  wrote ${file} (${(data.length / 1024).toFixed(0)} KB) sha256:${
+      digest.slice(0, 12)
+    }...`,
+  );
+
+  return {
+    file,
+    source: grammar.source,
+    package: pkg,
+    version,
+    sha256: digest,
+  };
 }
 
 console.error("Fetching tree-sitter WASM grammars...\n");
 
+const entries: LockEntry[] = [];
 for (const [file, grammar] of Object.entries(GRAMMARS)) {
-  await fetchGrammar(file, grammar);
+  entries.push(await fetchGrammar(file, grammar));
 }
 
-console.error("\nDone.");
+const lock = { generated: new Date().toISOString(), grammars: entries };
+await Deno.writeTextFile(
+  `${GRAMMARS_DIR}/grammars.lock`,
+  JSON.stringify(lock, null, 2) + "\n",
+);
+console.error("\nWrote grammars/grammars.lock");
+console.error("Done.");

--- a/scripts/update_grammars.ts
+++ b/scripts/update_grammars.ts
@@ -1,0 +1,167 @@
+/**
+ * Check for grammar version updates and optionally apply them.
+ *
+ * Usage:
+ *   deno run --allow-net --allow-read --allow-env scripts/update_grammars.ts
+ *   deno run --allow-net --allow-read --allow-write --allow-env --allow-run scripts/update_grammars.ts --apply
+ *
+ * Default (dry-run): prints a JSON summary of available updates to stdout.
+ * With --apply: rewrites version strings in fetch_grammars.ts, then runs
+ * the fetch script to download updated grammars and regenerate the lockfile.
+ */
+
+interface Update {
+  file: string;
+  source: "npm" | "github";
+  package: string;
+  current: string;
+  latest: string;
+}
+
+interface GrammarEntry {
+  source: "npm" | "github";
+  package: string;
+  version: string;
+}
+
+const FETCH_SCRIPT = new URL("./fetch_grammars.ts", import.meta.url).pathname;
+
+/** Parse the GRAMMARS config from fetch_grammars.ts source text. */
+function parseGrammars(source: string): Record<string, GrammarEntry> {
+  const grammars: Record<string, GrammarEntry> = {};
+
+  // Match npm entries: "file.wasm": { source: "npm", pkg: "...", version: "..." }
+  const npmRe =
+    /"([^"]+\.wasm)":\s*\{[^}]*source:\s*"npm"[^}]*pkg:\s*"([^"]+)"[^}]*version:\s*"([^"]+)"/g;
+  for (const m of source.matchAll(npmRe)) {
+    grammars[m[1]] = { source: "npm", package: m[2], version: m[3] };
+  }
+
+  // Match github entries: "file.wasm": { source: "github", repo: "...", tag: "..." }
+  const ghRe =
+    /"([^"]+\.wasm)":\s*\{[^}]*source:\s*"github"[^}]*repo:\s*"([^"]+)"[^}]*tag:\s*"([^"]+)"/g;
+  for (const m of source.matchAll(ghRe)) {
+    grammars[m[1]] = { source: "github", package: m[2], version: m[3] };
+  }
+
+  return grammars;
+}
+
+/** Get the latest version from npm registry. */
+async function latestNpmVersion(pkg: string): Promise<string> {
+  const res = await fetch(`https://registry.npmjs.org/${pkg}/latest`);
+  if (!res.ok) throw new Error(`npm registry error for ${pkg}: ${res.status}`);
+  const json = await res.json();
+  return json.version;
+}
+
+/** Get the latest release tag from GitHub. */
+async function latestGithubTag(repo: string): Promise<string> {
+  const headers: Record<string, string> = {
+    "Accept": "application/vnd.github+json",
+  };
+  const token = Deno.env.get("GITHUB_TOKEN");
+  if (token) headers["Authorization"] = `Bearer ${token}`;
+
+  const res = await fetch(
+    `https://api.github.com/repos/${repo}/releases/latest`,
+    { headers },
+  );
+  if (!res.ok) throw new Error(`GitHub API error for ${repo}: ${res.status}`);
+  const json = await res.json();
+  return json.tag_name;
+}
+
+/** Apply version updates to the fetch script source text. */
+function applyUpdates(source: string, updates: Update[]): string {
+  let result = source;
+  for (const u of updates) {
+    if (u.source === "npm") {
+      // Replace: pkg: "tree-sitter-rust", version: "0.24.0"
+      const pattern = new RegExp(
+        `(pkg:\\s*"${u.package.replace("/", "\\/")}"[^}]*version:\\s*")${
+          u.current.replace(".", "\\.")
+        }(")`,
+      );
+      result = result.replace(pattern, `$1${u.latest}$2`);
+    } else {
+      // Replace: repo: "fwcd/tree-sitter-kotlin", tag: "0.3.8"
+      const pattern = new RegExp(
+        `(repo:\\s*"${u.package.replace("/", "\\/")}"[^}]*tag:\\s*")${
+          u.current.replace(".", "\\.")
+        }(")`,
+      );
+      result = result.replace(pattern, `$1${u.latest}$2`);
+    }
+  }
+  return result;
+}
+
+// --- main ---
+
+const source = await Deno.readTextFile(FETCH_SCRIPT);
+const grammars = parseGrammars(source);
+
+if (Object.keys(grammars).length === 0) {
+  console.error("error: could not parse any grammars from fetch_grammars.ts");
+  Deno.exit(1);
+}
+
+console.error("Checking for grammar updates...\n");
+
+const updates: Update[] = [];
+
+for (const [file, g] of Object.entries(grammars)) {
+  const latest = g.source === "npm"
+    ? await latestNpmVersion(g.package)
+    : await latestGithubTag(g.package);
+
+  if (latest !== g.version) {
+    console.error(`  ${file}: ${g.version} → ${latest}`);
+    updates.push({
+      file,
+      source: g.source,
+      package: g.package,
+      current: g.version,
+      latest,
+    });
+  } else {
+    console.error(`  ${file}: ${g.version} (up to date)`);
+  }
+}
+
+const summary = { up_to_date: updates.length === 0, updates };
+console.log(JSON.stringify(summary, null, 2));
+
+if (updates.length === 0) {
+  console.error("\nAll grammars are up to date.");
+  Deno.exit(0);
+}
+
+if (!Deno.args.includes("--apply")) {
+  console.error(
+    `\n${updates.length} update(s) available. Run with --apply to update.`,
+  );
+  Deno.exit(0);
+}
+
+// Apply updates
+console.error("\nApplying updates...");
+const updated = applyUpdates(source, updates);
+await Deno.writeTextFile(FETCH_SCRIPT, updated);
+console.error("  updated scripts/fetch_grammars.ts");
+
+// Run fetch to download new versions and regenerate lockfile
+console.error("  running fetch...\n");
+const cmd = new Deno.Command("deno", {
+  args: ["task", "fetch-grammars"],
+  stdout: "inherit",
+  stderr: "inherit",
+});
+const result = await cmd.output();
+if (!result.success) {
+  console.error("error: fetch failed");
+  Deno.exit(1);
+}
+
+console.error("\nDone.");


### PR DESCRIPTION
## Summary
- `fetch_grammars.ts` now writes `grammars/grammars.lock` with SHA-256 hashes for traceability
- New `update_grammars.ts` script checks npm/GitHub for newer grammar versions (dry-run by default, `--apply` to update)
- Weekly `update-grammars.yaml` workflow auto-opens a PR when new versions are detected
- CI cache key updated to use lockfile hash
- Added `fetch-grammars` task to `deno.json` and `justfile`

## Test plan
- [x] `deno task fetch-grammars` fetches all 5 grammars and writes lockfile with SHA-256 hashes
- [x] `update_grammars.ts` dry-run detects `tree-sitter-c` 0.23.5 → 0.24.1
- [x] 213 tests pass
- [x] `dprint check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)