### PR TITLE
feat(render): add caption numbering

### DIFF
--- a/packages/markspec/render/captions/mod.ts
+++ b/packages/markspec/render/captions/mod.ts
@@ -2,4 +2,155 @@
  * @module render/captions
  *
  * Table and figure caption extraction and numbering.
+ *
+ * Assigns chapter-relative numbers to figures and tables detected by
+ * the core parser's {@linkcode detectCaptions}. H1 headings (`# …`)
+ * define chapter boundaries; each chapter has independent figure and
+ * table counters.
  */
+
+import type { Caption } from "../../core/mod.ts";
+import { detectCaptions } from "../../core/mod.ts";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/** A numbered caption with chapter-relative numbering. */
+export interface NumberedCaption {
+  /** The original caption. */
+  readonly caption: Caption;
+  /** Chapter number (1-based, from H1 headings). */
+  readonly chapter: number;
+  /** Sequential number within the chapter (1-based). */
+  readonly sequence: number;
+  /** Formatted label: "Figure 3.2" or "Table 3.1". */
+  readonly label: string;
+}
+
+/** Caption registry for a document. */
+export interface CaptionRegistry {
+  /** All numbered captions, keyed by slug. */
+  readonly captions: ReadonlyMap<string, NumberedCaption>;
+}
+
+// ---------------------------------------------------------------------------
+// Internals
+// ---------------------------------------------------------------------------
+
+/** ATX heading pattern — `# Title` at the start of a line. */
+const H1_PATTERN = /^# /;
+
+/**
+ * Collect 1-based line numbers of every H1 heading in the source.
+ * Only ATX-style headings (`# …`) are considered — setext headings
+ * (underlined with `===`) are intentionally excluded because they are
+ * uncommon in MarkSpec documents.
+ */
+function findH1Lines(markdown: string): number[] {
+  const lines = markdown.split("\n");
+  const h1Lines: number[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    if (H1_PATTERN.test(lines[i])) {
+      h1Lines.push(i + 1); // 1-based
+    }
+  }
+  return h1Lines;
+}
+
+/**
+ * Determine the chapter number for a given 1-based line.
+ *
+ * The chapter is the count of H1 headings at or before the line.
+ * If no H1 precedes the line, the caption belongs to chapter 1
+ * (implicit first chapter).
+ */
+function chapterForLine(h1Lines: number[], line: number): number {
+  let chapter = 0;
+  for (const h1Line of h1Lines) {
+    if (h1Line <= line) {
+      chapter++;
+    } else {
+      break;
+    }
+  }
+  // If no H1 before this line, treat as chapter 1.
+  return Math.max(chapter, 1);
+}
+
+/** Capitalize first letter of a kind ("figure" → "Figure"). */
+function kindLabel(kind: "figure" | "table"): string {
+  return kind === "figure" ? "Figure" : "Table";
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a caption registry from a Markdown document.
+ * Assigns chapter-relative numbers to all figures and tables.
+ */
+export function buildCaptionRegistry(
+  markdown: string,
+  options?: { file?: string },
+): CaptionRegistry {
+  const captions = detectCaptions(markdown, options);
+  const h1Lines = findH1Lines(markdown);
+
+  // Per-chapter, per-kind counters.
+  const counters = new Map<string, number>();
+  const registry = new Map<string, NumberedCaption>();
+
+  // Sort captions by line number to ensure stable ordering regardless
+  // of the order detectCaptions returns them (it may do two passes).
+  const sorted = [...captions].sort(
+    (a, b) => a.location.line - b.location.line,
+  );
+
+  for (const caption of sorted) {
+    const chapter = chapterForLine(h1Lines, caption.location.line);
+    const counterKey = `${chapter}:${caption.kind}`;
+    const seq = (counters.get(counterKey) ?? 0) + 1;
+    counters.set(counterKey, seq);
+
+    const label = `${kindLabel(caption.kind)} ${chapter}.${seq}`;
+
+    registry.set(caption.slug, {
+      caption,
+      chapter,
+      sequence: seq,
+      label,
+    });
+  }
+
+  return { captions: registry };
+}
+
+/**
+ * Replace caption text in Markdown with numbered labels.
+ *
+ * Transforms emphasis captions in-place:
+ * - `_Figure: Sensor layout_` → `_Figure 3.2: Sensor layout_`
+ * - `_Table: Thresholds_`     → `_Table 1.1: Thresholds_`
+ */
+export function numberCaptions(
+  markdown: string,
+  registry: CaptionRegistry,
+): string {
+  let result = markdown;
+
+  for (const numbered of registry.captions.values()) {
+    const { caption, label } = numbered;
+    const prefix = kindLabel(caption.kind);
+
+    // The source pattern is `_Figure: text_` or `_Table: text_`.
+    // Replace with `_Figure N.M: text_` or `_Table N.M: text_`.
+    const original = `_${prefix}: ${caption.text}_`;
+    const replacement = `_${label}: ${caption.text}_`;
+
+    result = result.replace(original, replacement);
+  }
+
+  return result;
+}

--- a/packages/markspec/render/captions/mod_test.ts
+++ b/packages/markspec/render/captions/mod_test.ts
@@ -1,0 +1,198 @@
+/**
+ * @module render/captions_test
+ *
+ * Unit tests for caption numbering.
+ */
+
+import { assertEquals } from "@std/assert";
+import {
+  buildCaptionRegistry,
+  type CaptionRegistry,
+  numberCaptions,
+} from "./mod.ts";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Shorthand to get a numbered caption by slug from a registry. */
+function get(registry: CaptionRegistry, slug: string) {
+  const nc = registry.captions.get(slug);
+  if (!nc) throw new Error(`slug "${slug}" not found in registry`);
+  return nc;
+}
+
+// ---------------------------------------------------------------------------
+// buildCaptionRegistry
+// ---------------------------------------------------------------------------
+
+Deno.test("buildCaptionRegistry: single chapter with two figures", () => {
+  const md = `# Introduction
+
+![](img1.svg)
+
+_Figure: First diagram_
+
+![](img2.svg)
+
+_Figure: Second diagram_
+`;
+  const registry = buildCaptionRegistry(md);
+  const first = get(registry, "fig.first-diagram");
+  const second = get(registry, "fig.second-diagram");
+
+  assertEquals(first.label, "Figure 1.1");
+  assertEquals(first.chapter, 1);
+  assertEquals(first.sequence, 1);
+
+  assertEquals(second.label, "Figure 1.2");
+  assertEquals(second.chapter, 1);
+  assertEquals(second.sequence, 2);
+});
+
+Deno.test("buildCaptionRegistry: two chapters each with a figure", () => {
+  const md = `# Chapter One
+
+![](a.svg)
+
+_Figure: Alpha_
+
+# Chapter Two
+
+![](b.svg)
+
+_Figure: Beta_
+`;
+  const registry = buildCaptionRegistry(md);
+  const alpha = get(registry, "fig.alpha");
+  const beta = get(registry, "fig.beta");
+
+  assertEquals(alpha.label, "Figure 1.1");
+  assertEquals(alpha.chapter, 1);
+  assertEquals(alpha.sequence, 1);
+
+  assertEquals(beta.label, "Figure 2.1");
+  assertEquals(beta.chapter, 2);
+  assertEquals(beta.sequence, 1);
+});
+
+Deno.test("buildCaptionRegistry: mixed figures and tables have independent counters", () => {
+  const md = `# Design
+
+![](arch.svg)
+
+_Figure: Architecture_
+
+_Table: Parameters_
+
+| Key   | Value |
+| ----- | ----- |
+| Speed | 100   |
+
+![](flow.svg)
+
+_Figure: Data flow_
+`;
+  const registry = buildCaptionRegistry(md);
+  const arch = get(registry, "fig.architecture");
+  const params = get(registry, "tbl.parameters");
+  const flow = get(registry, "fig.data-flow");
+
+  assertEquals(arch.label, "Figure 1.1");
+  assertEquals(params.label, "Table 1.1");
+  assertEquals(flow.label, "Figure 1.2");
+});
+
+Deno.test("buildCaptionRegistry: document without H1 headings treats all as chapter 1", () => {
+  const md = `Some intro text.
+
+![](img.svg)
+
+_Figure: Standalone_
+
+_Table: Config_
+
+| A | B |
+| - | - |
+| 1 | 2 |
+`;
+  const registry = buildCaptionRegistry(md);
+  const fig = get(registry, "fig.standalone");
+  const tbl = get(registry, "tbl.config");
+
+  assertEquals(fig.label, "Figure 1.1");
+  assertEquals(fig.chapter, 1);
+
+  assertEquals(tbl.label, "Table 1.1");
+  assertEquals(tbl.chapter, 1);
+});
+
+Deno.test("buildCaptionRegistry: empty document returns empty registry", () => {
+  const registry = buildCaptionRegistry("");
+  assertEquals(registry.captions.size, 0);
+});
+
+Deno.test("buildCaptionRegistry: registry lookup by slug works", () => {
+  const md = `# Specs
+
+_Table: Voltage limits_
+
+| Rail  | Min | Max |
+| ----- | --- | --- |
+| 3.3 V | 3.1 | 3.5 |
+`;
+  const registry = buildCaptionRegistry(md);
+  const nc = registry.captions.get("tbl.voltage-limits");
+
+  assertEquals(nc !== undefined, true);
+  assertEquals(nc!.label, "Table 1.1");
+  assertEquals(nc!.caption.kind, "table");
+  assertEquals(nc!.caption.text, "Voltage limits");
+});
+
+// ---------------------------------------------------------------------------
+// numberCaptions
+// ---------------------------------------------------------------------------
+
+Deno.test("numberCaptions: replaces caption text correctly", () => {
+  const md = `# Overview
+
+![](sensor.svg)
+
+_Figure: Sensor layout_
+
+# Data
+
+_Table: Thresholds_
+
+| Sensor | Value |
+| ------ | ----- |
+| Temp   | 85    |
+
+![](flow.svg)
+
+_Figure: Processing flow_
+`;
+  const registry = buildCaptionRegistry(md);
+  const result = numberCaptions(md, registry);
+
+  assertEquals(result.includes("_Figure 1.1: Sensor layout_"), true);
+  assertEquals(result.includes("_Table 2.1: Thresholds_"), true);
+  assertEquals(result.includes("_Figure 2.1: Processing flow_"), true);
+
+  // Originals should no longer be present.
+  assertEquals(result.includes("_Figure: Sensor layout_"), false);
+  assertEquals(result.includes("_Table: Thresholds_"), false);
+  assertEquals(result.includes("_Figure: Processing flow_"), false);
+});
+
+Deno.test("numberCaptions: no-op on document without captions", () => {
+  const md = `# Just text
+
+Nothing to number here.
+`;
+  const registry = buildCaptionRegistry(md);
+  const result = numberCaptions(md, registry);
+
+  assertEquals(result, md);
+});


### PR DESCRIPTION
## Summary

Closes #45.

- Add buildCaptionRegistry() and numberCaptions() in render/captions/mod.ts
- Chapter-relative numbering: H1 headings define chapter boundaries
- Independent counters per kind per chapter (Figure 3.1, Table 3.2, etc.)
- Documents without H1 headings default to chapter 1
- Registry keyed by slug for cross-reference resolution (used by #43 mustache)

## Test plan

- [x] 8 unit tests covering single/multi chapter, mixed kinds, no-H1, empty doc, slug lookup, and text replacement

Generated with [Claude Code](https://claude.com/claude-code)