### PR TITLE
feat(core): grammar lockfile, LFS, and auto-update workflow

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+grammars/*.wasm filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,16 +49,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          lfs: true
       - uses: denoland/setup-deno@v2
         with:
           deno-version: v2.x
-      - uses: actions/cache@v4
-        with:
-          path: grammars/
-          key: grammars-${{ hashFiles('grammars/grammars.lock') }}
-          restore-keys: |
-            grammars-
-      - run: deno run --allow-net --allow-write --allow-read scripts/fetch_grammars.ts
       - run: deno test --allow-read --allow-write --allow-run --allow-env --allow-ffi
 
   tokens:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,6 +25,8 @@ jobs:
             binary: markspec
     steps:
       - uses: actions/checkout@v4
+        with:
+          lfs: true
 
       - uses: denoland/setup-deno@v2
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,3 @@ Thumbs.db
 
 # dprint
 .dprint/
-
-# Tree-sitter WASM grammars (fetched by scripts/fetch_grammars.ts)
-grammars/*.wasm

--- a/bootstrap
+++ b/bootstrap
@@ -108,4 +108,13 @@ ensure_git_std() {
 }
 
 ensure_git_std
-exec git std bootstrap
+git std bootstrap
+
+# Fetch tree-sitter WASM grammars if Deno is available.
+if command -v deno >/dev/null 2>&1; then
+  printf '\nFetching tree-sitter WASM grammars...\n'
+  deno task fetch-grammars
+else
+  printf '\nwarning: deno not found — skipping grammar fetch\n' >&2
+  printf 'run "deno task fetch-grammars" after installing deno\n' >&2
+fi

--- a/grammars/README.md
+++ b/grammars/README.md
@@ -3,10 +3,10 @@
 This directory holds pre-built tree-sitter WASM grammar files used by the source
 parser to extract doc comments from code.
 
-WASM files are **not** checked into git. Run the fetch script to download them:
+WASM files are committed via Git LFS. To update them, run:
 
 ```bash
-deno run --allow-net --allow-write scripts/fetch_grammars.ts
+deno task fetch-grammars
 ```
 
 Supported grammars:
@@ -21,6 +21,5 @@ Supported grammars:
 
 ## Lockfile
 
-`grammars.lock` records the source, version, and SHA-256 hash of each fetched
-grammar. It is committed to git for traceability and used as the CI cache key.
+`grammars.lock` records the source, version, and SHA-256 hash of each grammar.
 The fetch script regenerates it on every run.

--- a/grammars/tree-sitter-c.wasm
+++ b/grammars/tree-sitter-c.wasm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:146f85977800935f18b06940518b16ded13cf4007ef0e3190573b969a98b9adc
+size 620090

--- a/grammars/tree-sitter-cpp.wasm
+++ b/grammars/tree-sitter-cpp.wasm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:174eb0deb75b2ec7881bcacda9f995648d8e683956e5c2267e69ab6dc503fcbf
+size 3434931

--- a/grammars/tree-sitter-java.wasm
+++ b/grammars/tree-sitter-java.wasm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4fdeac4ca6ca089f06c6f7e562abcac1733cd465728cc7031ebb73c2019122c4
+size 414641

--- a/grammars/tree-sitter-kotlin.wasm
+++ b/grammars/tree-sitter-kotlin.wasm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c624e7443b371c28adc5d81674e73067564c12555ebe3ed96a6c8db814b7602d
+size 4052625

--- a/grammars/tree-sitter-rust.wasm
+++ b/grammars/tree-sitter-rust.wasm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f65f354215611fd94ad34134b3427eb3d58cbb745df7b6509ba722184db73d57
+size 1102547


### PR DESCRIPTION
## Summary
- Commit WASM grammars to git via **Git LFS** (no more fetch-at-build-time)
- `fetch_grammars.ts` writes `grammars/grammars.lock` with SHA-256 hashes for traceability
- New `update_grammars.ts` script checks npm/GitHub for newer grammar versions
- Weekly `update-grammars.yaml` workflow auto-opens a PR when updates are available
- Add `fetch-grammars` task to `deno.json` and `justfile`
- Bootstrap script fetches grammars on project setup
- CI test + release build use `lfs: true` checkout (no cache/fetch step needed)

## Test plan
- [x] `git lfs ls-files` shows all 5 `.wasm` files tracked
- [x] `deno task fetch-grammars` regenerates lockfile with matching SHA-256 hashes
- [x] `update_grammars.ts` dry-run detects `tree-sitter-c` 0.23.5 → 0.24.1
- [x] All tests pass
- [x] `dprint check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)