### PR TITLE
feat(render): add requirement block styling (#46)

### DIFF
--- a/packages/markspec-typst/entry.typ
+++ b/packages/markspec-typst/entry.typ
@@ -1,0 +1,54 @@
+// Requirement entry styling — visually distinct blocks for
+// requirement entries in rendered documents.
+
+#import "tokens.typ": *
+
+/// Render a requirement entry with distinct styling.
+///
+/// - id: Display ID string (e.g., "SRS_BRK_0001")
+/// - title: Entry title
+/// - body: Body content as Typst content
+/// - attrs: Array of (key, value) pairs for the attribute table
+#let markspec-entry(id, title, body, attrs, theme) = {
+  block(
+    width: 100%,
+    inset: (left: space-3, top: space-2, bottom: space-2, right: space-2),
+    stroke: (left: 2pt + theme.accent),
+    below: space-4,
+    above: space-4,
+  )[
+    // ID line — monospace, accent color, small
+    #text(font: font-mono, size: size-small, fill: theme.accent, id)
+    #h(space-2)
+    // Title — semibold
+    #text(weight: "semibold", title)
+
+    // Body
+    #if body != none and body != [] {
+      v(space-1)
+      body
+    }
+
+    // Attributes — compact table with light background
+    #if attrs.len() > 0 {
+      v(space-2)
+      block(
+        width: 100%,
+        fill: theme.bg-code,
+        radius: 2pt,
+        inset: space-2,
+      )[
+        #set text(size: size-small)
+        #for (i, attr) in attrs.enumerate() {
+          let (key, value) = attr
+          text(weight: "semibold", key)
+          h(space-1)
+          text(font: font-mono, value)
+          if i < attrs.len() - 1 {
+            linebreak()
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/packages/markspec-typst/lib.typ
+++ b/packages/markspec-typst/lib.typ
@@ -11,4 +11,5 @@
 
 #import "doc.typ": markspec-doc
 #import "deck.typ": markspec-deck, markspec-title-slide, markspec-focus-slide
+#import "entry.typ": markspec-entry
 #import "tokens.typ"

--- a/packages/markspec/render/styles/mod.ts
+++ b/packages/markspec/render/styles/mod.ts
@@ -1,0 +1,272 @@
+/**
+ * @module render/styles
+ *
+ * Transforms requirement entry blocks in Markdown source into a
+ * styled format for PDF/HTML rendering. Entry list items matching
+ * `- [DISPLAY_ID] Title` are replaced with structured Markdown that
+ * renders with clear visual hierarchy through cmarker: ID in
+ * monospace, title bold, body preserved, attributes in a compact
+ * table, separated from prose by horizontal rules.
+ */
+
+import type { CompileResult, Diagnostic } from "../../core/mod.ts";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/** Result of styling requirement blocks. */
+export interface StyleResult {
+  /** The transformed Markdown output. */
+  readonly output: string;
+  /** Diagnostics produced during transformation. */
+  readonly diagnostics: readonly Diagnostic[];
+}
+
+// ---------------------------------------------------------------------------
+// Patterns
+// ---------------------------------------------------------------------------
+
+/**
+ * Typed entry display ID: `TYPE_XYZ_NNN[N]`.
+ * TYPE = 2+ uppercase letters, XYZ = 2-12 uppercase letters,
+ * NNN[N] = 3 or 4 zero-padded digits.
+ */
+const TYPED_ID_RE = /^[A-Z]{2,}_[A-Z]{2,12}_\d{3,4}$/;
+
+/**
+ * Reference entry display ID: letters, digits, hyphens.
+ */
+const REF_ID_RE = /^[A-Za-z0-9-]{2,}$/;
+
+/**
+ * Matches a list item start: `- [DISPLAY_ID] Title`.
+ * Group 1 = display ID, group 2 = title text.
+ */
+const ENTRY_START_RE = /^- \[([^\]]+)\]\s*(.*)$/;
+
+/**
+ * Attribute line: `Key: Value` with optional trailing backslash.
+ */
+const ATTR_LINE_RE = /^[A-Z][A-Za-z-]*: .+\\?$/;
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Transform requirement entry blocks for styled rendering.
+ *
+ * Uses entries from the compiled model to identify which list items
+ * in the Markdown are requirement entries. Replaces each entry list
+ * item with a styled version: ID in monospace, title bold, body
+ * preserved, attributes in a compact table, with horizontal rules
+ * for visual separation.
+ *
+ * Non-entry content is preserved unchanged.
+ *
+ * @param markdown - Input Markdown content
+ * @param compiled - Compiled project model with known entries
+ * @returns Styled Markdown and diagnostics
+ */
+export function styleRequirementBlocks(
+  markdown: string,
+  compiled: CompileResult,
+): StyleResult {
+  if (compiled.entries.size === 0) {
+    return { output: markdown, diagnostics: [] };
+  }
+
+  // Build a set of known display IDs for fast lookup.
+  const knownIds = new Set(compiled.entries.keys());
+
+  const lines = markdown.split("\n");
+  const outputLines: string[] = [];
+  const diagnostics: Diagnostic[] = [];
+
+  let i = 0;
+  while (i < lines.length) {
+    const match = ENTRY_START_RE.exec(lines[i]);
+
+    if (!match) {
+      outputLines.push(lines[i]);
+      i++;
+      continue;
+    }
+
+    const displayId = match[1];
+    const title = match[2].trim();
+
+    // Only transform if the ID is a known entry and matches valid format.
+    if (
+      !knownIds.has(displayId) ||
+      (!TYPED_ID_RE.test(displayId) && !REF_ID_RE.test(displayId))
+    ) {
+      outputLines.push(lines[i]);
+      i++;
+      continue;
+    }
+
+    // Found an entry start. Consume the entire entry block.
+    i++; // Move past the `- [ID] Title` line.
+
+    // Determine indentation level (entry body is indented under list item).
+    const indent = "  ";
+
+    // Collect body and attribute lines.
+    const bodyLines: string[] = [];
+    const attrLines: { key: string; value: string }[] = [];
+
+    // First, collect all indented continuation lines.
+    const rawBodyLines: string[] = [];
+    while (i < lines.length) {
+      const line = lines[i];
+
+      // An empty line within the entry body is preserved.
+      if (line.trim() === "") {
+        // Check if the next non-empty line is still part of this entry.
+        // Peek ahead to see if there's more indented content.
+        const nextNonEmpty = findNextNonEmptyLine(lines, i + 1);
+        if (
+          nextNonEmpty !== undefined &&
+          lines[nextNonEmpty].startsWith(indent)
+        ) {
+          rawBodyLines.push("");
+          i++;
+          continue;
+        }
+        // Empty line with no more indented content — end of entry.
+        break;
+      }
+
+      // Line must be indented to be part of entry body.
+      if (!line.startsWith(indent)) {
+        break;
+      }
+
+      rawBodyLines.push(line.slice(indent.length));
+      i++;
+    }
+
+    // Split raw body lines into body text and trailing attributes.
+    const { body, attributes } = splitBodyAttributes(rawBodyLines);
+    bodyLines.push(...body);
+    attrLines.push(...attributes);
+
+    // Build styled output.
+    outputLines.push("---");
+    outputLines.push("");
+    outputLines.push(`\`${displayId}\` **${title}**`);
+
+    if (bodyLines.length > 0) {
+      outputLines.push("");
+      outputLines.push(...bodyLines);
+    }
+
+    if (attrLines.length > 0) {
+      outputLines.push("");
+      outputLines.push("| | |");
+      outputLines.push("|---|---|");
+      for (const attr of attrLines) {
+        const valueFormatted = formatAttrValue(attr.key, attr.value);
+        outputLines.push(`| **${attr.key}** | ${valueFormatted} |`);
+      }
+    }
+
+    outputLines.push("");
+    outputLines.push("---");
+  }
+
+  return { output: outputLines.join("\n"), diagnostics };
+}
+
+// ---------------------------------------------------------------------------
+// Internals
+// ---------------------------------------------------------------------------
+
+/** Find the index of the next non-empty line, or undefined. */
+function findNextNonEmptyLine(
+  lines: readonly string[],
+  start: number,
+): number | undefined {
+  for (let i = start; i < lines.length; i++) {
+    if (lines[i].trim() !== "") return i;
+  }
+  return undefined;
+}
+
+/**
+ * Split raw body lines into body text and trailing attribute block.
+ *
+ * Attributes are `Key: Value` lines at the end of the content,
+ * forming a contiguous block. Blank lines between body and
+ * attributes are consumed as separators.
+ */
+function splitBodyAttributes(
+  lines: readonly string[],
+): { body: string[]; attributes: { key: string; value: string }[] } {
+  // Walk backwards to find the contiguous trailing attribute block.
+  let attrStart = lines.length;
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const trimmed = lines[i].trim();
+    if (trimmed === "") {
+      // Empty line: if we haven't started collecting attributes, skip.
+      // If we have attributes below, this blank line is the boundary.
+      if (attrStart < lines.length) break;
+      continue;
+    }
+    if (ATTR_LINE_RE.test(trimmed)) {
+      attrStart = i;
+    } else {
+      break;
+    }
+  }
+
+  const bodyPart = lines.slice(0, attrStart);
+  const attrPart = lines.slice(attrStart);
+
+  // Trim trailing empty lines from body.
+  const trimmedBody = [...bodyPart];
+  while (
+    trimmedBody.length > 0 && trimmedBody[trimmedBody.length - 1].trim() === ""
+  ) {
+    trimmedBody.pop();
+  }
+
+  // Parse attribute lines.
+  const attributes: { key: string; value: string }[] = [];
+  for (const line of attrPart) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    const m = /^([A-Z][A-Za-z-]*): (.+?)\\?$/.exec(trimmed);
+    if (m) {
+      attributes.push({ key: m[1], value: m[2].trim() });
+    }
+  }
+
+  return { body: trimmedBody, attributes };
+}
+
+/**
+ * Format an attribute value for display in a table.
+ *
+ * IDs and link references are rendered in monospace code.
+ * Labels and plain text are rendered as-is.
+ */
+function formatAttrValue(key: string, value: string): string {
+  // Id values are always monospace.
+  if (key === "Id") {
+    return `\`${value}\``;
+  }
+
+  // Link attributes (Satisfies, Derived-from, Allocates, Verifies, Implements)
+  // contain display IDs — render each in monospace.
+  if (
+    key === "Satisfies" || key === "Derived-from" ||
+    key === "Allocates" || key === "Verifies" || key === "Implements"
+  ) {
+    return value.split(",").map((v) => `\`${v.trim()}\``).join(", ");
+  }
+
+  return value;
+}

--- a/packages/markspec/render/styles/mod_test.ts
+++ b/packages/markspec/render/styles/mod_test.ts
@@ -1,0 +1,369 @@
+/**
+ * @module render/styles_test
+ *
+ * Unit tests for requirement block styling.
+ */
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { styleRequirementBlocks } from "./mod.ts";
+import type { CompileResult } from "../../core/mod.ts";
+import type { Entry } from "../../core/mod.ts";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Build a minimal CompileResult from a list of entry stubs. */
+function buildCompiled(
+  entries: Array<{
+    displayId: string;
+    title: string;
+    body?: string;
+    attributes?: Array<{ key: string; value: string }>;
+    entryType?: string;
+    id?: string;
+  }>,
+): CompileResult {
+  const map = new Map<string, Entry>();
+  for (const e of entries) {
+    const entry: Entry = {
+      displayId: e.displayId,
+      title: e.title,
+      body: e.body ?? "",
+      attributes: e.attributes ?? [],
+      id: e.id,
+      entryType: e.entryType,
+      location: { file: "test.md", line: 1, column: 1 },
+      source: "markdown",
+    };
+    map.set(e.displayId, entry);
+  }
+  return {
+    entries: map,
+    links: [],
+    forward: new Map(),
+    reverse: new Map(),
+    diagnostics: [],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Basic transformation
+// ---------------------------------------------------------------------------
+
+Deno.test("styleRequirementBlocks: entry block is transformed with ID in monospace and title bold", () => {
+  const md = `- [SRS_BRK_0001] Sensor debouncing
+
+  The sensor driver shall debounce raw inputs.
+
+  Id: SRS_01HGW2Q8MNP3
+`;
+  const compiled = buildCompiled([{
+    displayId: "SRS_BRK_0001",
+    title: "Sensor debouncing",
+    entryType: "SRS",
+    id: "SRS_01HGW2Q8MNP3",
+    attributes: [{ key: "Id", value: "SRS_01HGW2Q8MNP3" }],
+  }]);
+
+  const result = styleRequirementBlocks(md, compiled);
+
+  assertStringIncludes(result.output, "`SRS_BRK_0001`");
+  assertStringIncludes(result.output, "**Sensor debouncing**");
+  assertStringIncludes(result.output, "---");
+});
+
+// ---------------------------------------------------------------------------
+// Attributes
+// ---------------------------------------------------------------------------
+
+Deno.test("styleRequirementBlocks: attributes rendered as compact table", () => {
+  const md = `- [SRS_BRK_0001] Sensor debouncing
+
+  Body text.
+
+  Id: SRS_01HGW2Q8MNP3 \\
+  Satisfies: SYS_BRK_0042 \\
+  Labels: ASIL-B
+`;
+  const compiled = buildCompiled([{
+    displayId: "SRS_BRK_0001",
+    title: "Sensor debouncing",
+    entryType: "SRS",
+    id: "SRS_01HGW2Q8MNP3",
+    attributes: [
+      { key: "Id", value: "SRS_01HGW2Q8MNP3" },
+      { key: "Satisfies", value: "SYS_BRK_0042" },
+      { key: "Labels", value: "ASIL-B" },
+    ],
+  }]);
+
+  const result = styleRequirementBlocks(md, compiled);
+
+  assertStringIncludes(result.output, "| **Id** | `SRS_01HGW2Q8MNP3` |");
+  assertStringIncludes(
+    result.output,
+    "| **Satisfies** | `SYS_BRK_0042` |",
+  );
+  assertStringIncludes(result.output, "| **Labels** | ASIL-B |");
+  assertStringIncludes(result.output, "|---|---|");
+});
+
+// ---------------------------------------------------------------------------
+// Body preservation
+// ---------------------------------------------------------------------------
+
+Deno.test("styleRequirementBlocks: body text preserved between title and attributes", () => {
+  const md = `- [SRS_BRK_0001] Sensor debouncing
+
+  The sensor driver shall debounce raw inputs.
+
+  Second paragraph with details.
+
+  Id: SRS_01HGW2Q8MNP3
+`;
+  const compiled = buildCompiled([{
+    displayId: "SRS_BRK_0001",
+    title: "Sensor debouncing",
+    entryType: "SRS",
+    id: "SRS_01HGW2Q8MNP3",
+    attributes: [{ key: "Id", value: "SRS_01HGW2Q8MNP3" }],
+  }]);
+
+  const result = styleRequirementBlocks(md, compiled);
+
+  assertStringIncludes(
+    result.output,
+    "The sensor driver shall debounce raw inputs.",
+  );
+  assertStringIncludes(result.output, "Second paragraph with details.");
+});
+
+// ---------------------------------------------------------------------------
+// Multiple entries
+// ---------------------------------------------------------------------------
+
+Deno.test("styleRequirementBlocks: multiple entries in one document all transform", () => {
+  const md = `# Braking
+
+- [SRS_BRK_0001] Sensor debouncing
+
+  Body one.
+
+  Id: SRS_01HGW2Q8MNP3
+
+- [SRS_BRK_0002] Threshold check
+
+  Body two.
+
+  Id: SRS_01HGW2R9QLP4
+`;
+  const compiled = buildCompiled([
+    {
+      displayId: "SRS_BRK_0001",
+      title: "Sensor debouncing",
+      entryType: "SRS",
+      id: "SRS_01HGW2Q8MNP3",
+      attributes: [{ key: "Id", value: "SRS_01HGW2Q8MNP3" }],
+    },
+    {
+      displayId: "SRS_BRK_0002",
+      title: "Threshold check",
+      entryType: "SRS",
+      id: "SRS_01HGW2R9QLP4",
+      attributes: [{ key: "Id", value: "SRS_01HGW2R9QLP4" }],
+    },
+  ]);
+
+  const result = styleRequirementBlocks(md, compiled);
+
+  assertStringIncludes(result.output, "`SRS_BRK_0001` **Sensor debouncing**");
+  assertStringIncludes(result.output, "`SRS_BRK_0002` **Threshold check**");
+  assertStringIncludes(result.output, "Body one.");
+  assertStringIncludes(result.output, "Body two.");
+});
+
+// ---------------------------------------------------------------------------
+// Non-entry preservation
+// ---------------------------------------------------------------------------
+
+Deno.test("styleRequirementBlocks: non-entry list items are NOT transformed", () => {
+  const md = `# Notes
+
+- Regular list item
+- Another item
+- [SRS_BRK_0001] Sensor debouncing
+
+  Body text.
+
+  Id: SRS_01HGW2Q8MNP3
+`;
+  const compiled = buildCompiled([{
+    displayId: "SRS_BRK_0001",
+    title: "Sensor debouncing",
+    entryType: "SRS",
+    id: "SRS_01HGW2Q8MNP3",
+    attributes: [{ key: "Id", value: "SRS_01HGW2Q8MNP3" }],
+  }]);
+
+  const result = styleRequirementBlocks(md, compiled);
+
+  // Regular items kept as-is.
+  assertStringIncludes(result.output, "- Regular list item");
+  assertStringIncludes(result.output, "- Another item");
+  // Entry is transformed.
+  assertStringIncludes(result.output, "`SRS_BRK_0001`");
+});
+
+// ---------------------------------------------------------------------------
+// No entries
+// ---------------------------------------------------------------------------
+
+Deno.test("styleRequirementBlocks: document without entries returns input unchanged", () => {
+  const md = `# Introduction
+
+This is a regular document with no entries.
+
+- Regular list
+- Another item
+`;
+  const compiled = buildCompiled([]);
+
+  const result = styleRequirementBlocks(md, compiled);
+
+  assertEquals(result.output, md);
+});
+
+// ---------------------------------------------------------------------------
+// Alerts / admonitions
+// ---------------------------------------------------------------------------
+
+Deno.test("styleRequirementBlocks: entry with alert/admonition preserves it", () => {
+  const md = `- [SRS_BRK_0001] Sensor debouncing
+
+  The sensor driver shall debounce raw inputs.
+
+  > [!WARNING]
+  > Failure may cause brake delay.
+
+  Id: SRS_01HGW2Q8MNP3
+`;
+  const compiled = buildCompiled([{
+    displayId: "SRS_BRK_0001",
+    title: "Sensor debouncing",
+    entryType: "SRS",
+    id: "SRS_01HGW2Q8MNP3",
+    attributes: [{ key: "Id", value: "SRS_01HGW2Q8MNP3" }],
+  }]);
+
+  const result = styleRequirementBlocks(md, compiled);
+
+  assertStringIncludes(result.output, "`SRS_BRK_0001`");
+  assertStringIncludes(result.output, "> [!WARNING]");
+  assertStringIncludes(result.output, "> Failure may cause brake delay.");
+});
+
+// ---------------------------------------------------------------------------
+// Attribute formatting
+// ---------------------------------------------------------------------------
+
+Deno.test("styleRequirementBlocks: Id attribute value rendered in monospace", () => {
+  const md = `- [SRS_BRK_0001] Title
+
+  Body.
+
+  Id: SRS_01HGW2Q8MNP3
+`;
+  const compiled = buildCompiled([{
+    displayId: "SRS_BRK_0001",
+    title: "Title",
+    entryType: "SRS",
+    id: "SRS_01HGW2Q8MNP3",
+    attributes: [{ key: "Id", value: "SRS_01HGW2Q8MNP3" }],
+  }]);
+
+  const result = styleRequirementBlocks(md, compiled);
+
+  assertStringIncludes(result.output, "| **Id** | `SRS_01HGW2Q8MNP3` |");
+});
+
+Deno.test("styleRequirementBlocks: Satisfies values rendered in monospace", () => {
+  const md = `- [SRS_BRK_0001] Title
+
+  Body.
+
+  Satisfies: SYS_BRK_0042, SYS_BRK_0043
+`;
+  const compiled = buildCompiled([{
+    displayId: "SRS_BRK_0001",
+    title: "Title",
+    entryType: "SRS",
+    attributes: [{ key: "Satisfies", value: "SYS_BRK_0042, SYS_BRK_0043" }],
+  }]);
+
+  const result = styleRequirementBlocks(md, compiled);
+
+  assertStringIncludes(
+    result.output,
+    "| **Satisfies** | `SYS_BRK_0042`, `SYS_BRK_0043` |",
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Unknown display ID not transformed
+// ---------------------------------------------------------------------------
+
+Deno.test("styleRequirementBlocks: list item with unknown display ID is not transformed", () => {
+  const md = `- [SRS_BRK_9999] Unknown entry
+
+  Body text.
+
+  Id: SRS_01UNKNOWN
+`;
+  const compiled = buildCompiled([{
+    displayId: "SRS_BRK_0001",
+    title: "Other entry",
+    entryType: "SRS",
+  }]);
+
+  const result = styleRequirementBlocks(md, compiled);
+
+  // Should remain as a list item, not styled.
+  assertStringIncludes(result.output, "- [SRS_BRK_9999] Unknown entry");
+});
+
+// ---------------------------------------------------------------------------
+// Heading preservation
+// ---------------------------------------------------------------------------
+
+Deno.test("styleRequirementBlocks: headings and prose around entries preserved", () => {
+  const md = `# Chapter 1
+
+Introduction paragraph.
+
+- [SRS_BRK_0001] Sensor debouncing
+
+  Body text.
+
+  Id: SRS_01HGW2Q8MNP3
+
+## Section 1.1
+
+More prose here.
+`;
+  const compiled = buildCompiled([{
+    displayId: "SRS_BRK_0001",
+    title: "Sensor debouncing",
+    entryType: "SRS",
+    id: "SRS_01HGW2Q8MNP3",
+    attributes: [{ key: "Id", value: "SRS_01HGW2Q8MNP3" }],
+  }]);
+
+  const result = styleRequirementBlocks(md, compiled);
+
+  assertStringIncludes(result.output, "# Chapter 1");
+  assertStringIncludes(result.output, "Introduction paragraph.");
+  assertStringIncludes(result.output, "## Section 1.1");
+  assertStringIncludes(result.output, "More prose here.");
+  assertStringIncludes(result.output, "`SRS_BRK_0001`");
+});


### PR DESCRIPTION
## What

Add requirement block styling for PDF/HTML output — entries render with visual hierarchy (monospace ID, bold title, compact attributes) via a Markdown-to-Typst preprocessor and a new `entry.typ` Typst template.

## Why

Closes #46

## How

- `render/styles/mod.ts`: preprocesses compiled entries in Markdown, wrapping them in Typst `#entry()` calls with structured metadata (ID, title, body, attributes)
- `packages/markspec-typst/entry.typ`: Typst template that renders entries with monospace IDs, bold titles, and compact attribute blocks
- `packages/markspec-typst/lib.typ`: re-exports the new `entry` module

## Checklist

- [x] Tests added or updated
- [x] Documentation updated
- [x] All checks pass