### PR TITLE
feat(render): admonition-style entry block rendering

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -18,6 +18,11 @@
     "./packages/markspec"
   ],
   "fmt": {
-    "exclude": ["docs/index.html", "docs/theme/", "docs/spec/diagrams/"]
+    "exclude": [
+      "docs/index.html",
+      "docs/theme/",
+      "docs/spec/diagrams/",
+      "docs/examples/"
+    ]
   }
 }

--- a/docs/examples/entry-rendering.md
+++ b/docs/examples/entry-rendering.md
@@ -1,0 +1,113 @@
+# Entry Rendering Showcase
+
+This document demonstrates the admonition-style rendering for all entry types,
+label pills, and cross-reference links.
+
+## Requirements (req — blue)
+
+- [STK_AEB_0001] Emergency braking activation
+
+  The system shall initiate autonomous emergency braking when time-to-collision
+  falls below the configurable threshold and the driver has not applied the
+  brake pedal.
+
+  Id: STK_01HGW3A2BCD5\
+  Labels: ASIL-B, safety-critical
+
+- [SYS_AEB_0012] Object threat assessment from radar tracks
+
+  The system shall compute a threat level for each tracked object based on
+  time-to-collision, relative velocity, and object classification.
+
+  Id: SYS_01HGW3C4DEF6\
+  Satisfies: STK_AEB_0001\
+  Labels: ASIL-B
+
+- [SWE_BRK_0107] Median filter implementation
+
+  The braking ECU shall apply a 5-sample median filter to the raw brake pressure
+  sensor input before processing.
+
+  Id: SWE_01HGW2Q8MNP3\
+  Satisfies: SYS_AEB_0012\
+  Labels: ASIL-B, real-time, performance
+
+Prose between entries renders normally — no left border, no type coloring. The
+visual separation between entries and prose is provided by the admonition border
+alone.
+
+## Architecture (spec — green)
+
+- [SAD_AEB_0001] Perception–decision pipeline
+
+  The AEB system architecture separates perception (sensor fusion, object
+  tracking) from decision (threat assessment, braking command) via a
+  publish-subscribe message bus.
+
+  Id: SAD_01HGW4E5GHJ7\
+  Satisfies: STK_AEB_0001
+
+- [ICD_AEB_0010] Radar frame interface
+
+  The radar driver shall publish `RadarFrame` messages at 20 Hz containing
+  range, velocity, azimuth, and classification for each detected object.
+
+  Id: ICD_01HGW4F6HKL8\
+  Satisfies: SAD_AEB_0001\
+  Labels: interface
+
+## Verification (test — red)
+
+- [SWT_AEB_0030] Time-to-collision unit test
+
+  Verify that `compute_ttc(range, velocity)` returns the correct ratio for
+  positive closing velocity and returns infinity for zero or negative closing
+  velocity.
+
+  Id: SWT_01HGW5G7JMN9\
+  Verifies: SWE_BRK_0107
+
+- [SIT_AEB_0012] Perception-to-decision integration
+
+  Verify end-to-end that a radar frame with a stationary object at 40m produces
+  a `High` threat level through the full perception–decision pipeline.
+
+  Id: SIT_01HGW5H8KPQ0\
+  Verifies: SYS_AEB_0012\
+  Labels: integration
+
+## Edge cases
+
+Entry with no labels — pill group is not rendered:
+
+- [SRS_BRK_0200] Brake pressure sensor range check
+
+  The braking ECU shall reject brake pressure readings outside the valid sensor
+  range [0, 250] bar.
+
+  Id: SRS_01HGW6J9LRS1\
+  Satisfies: SYS_AEB_0012
+
+Entry with many labels — pill group wraps to the next line:
+
+- [SRS_BRK_0201] Sensor fault detection
+
+  The braking ECU shall detect open-circuit, short-circuit, and out-of-range
+  faults on all brake pressure sensors within one sample period.
+
+  Id: SRS_01HGW6K0MST2\
+  Satisfies: SYS_AEB_0012\
+  Labels: ASIL-B, safety-critical, real-time, performance, diagnostics,
+  fault-tolerance
+
+Entry with multiple cross-references:
+
+- [SRS_BRK_0202] Redundant sensor voting
+
+  The braking ECU shall use triple-modular redundancy voting across the three
+  brake pressure sensors.
+
+  Id: SRS_01HGW6L1NUV3\
+  Satisfies: SYS_AEB_0012\
+  Derived-from: STK_AEB_0001\
+  Labels: ASIL-B, redundancy

--- a/docs/examples/entry-rendering.md
+++ b/docs/examples/entry-rendering.md
@@ -97,8 +97,7 @@ Entry with many labels — pill group wraps to the next line:
 
   Id: SRS_01HGW6K0MST2\
   Satisfies: SYS_AEB_0012\
-  Labels: ASIL-B, safety-critical, real-time, performance, diagnostics,
-  fault-tolerance
+  Labels: ASIL-B, safety-critical, real-time, performance, diagnostics, fault-tolerance
 
 Entry with multiple cross-references:
 

--- a/docs/spec/language.md
+++ b/docs/spec/language.md
@@ -277,6 +277,10 @@ inline code are allowed.
 Part 2 defines the two families of entries (typed entries and reference
 entries), their ID formats, and their attributes.
 
+Rendering of entry blocks (admonition-style left border, type coloring, label
+pills, cross-reference links) is specified in the [Typography](typography.md)
+chapter, §"Entry rendering".
+
 #### §2 Attribute blocks
 
 `Key: Value` lines at the end of an entry block. Separated by trailing `\`

--- a/docs/spec/tokens.yaml
+++ b/docs/spec/tokens.yaml
@@ -57,6 +57,11 @@ themes:
     bg-alert: "#242424"
     border: "#404040"
 
+entries:
+  req: { print: "#4477AA", screen: "#0077BB" }
+  spec: { print: "#228833", screen: "#009988" }
+  test: { print: "#EE6677", screen: "#EE7733" }
+
 alerts:
   note: { border: "#4477AA", bg: "#f0f4f8" }
   tip: { border: "#228833", bg: "#f0f8f2" }

--- a/docs/spec/typography.md
+++ b/docs/spec/typography.md
@@ -260,6 +260,129 @@ shade from the Tol palette.
 | WARNING   | `#CCBB44` (yellow) | `#f8f6f0`  |
 | CAUTION   | `#EE6677` (red)    | `#f8f0f0`  |
 
+### Entry type colors
+
+Entry blocks are colored **by type** (the nature of the artifact), not by layer.
+The layer is already encoded in the ID prefix and does not need redundant color
+signaling.
+
+Two Paul Tol sub-palettes are used, selected by output target:
+
+| Type | Prefixes           | Print (Tol bright) | Screen (Tol vibrant) |
+| ---- | ------------------ | ------------------ | -------------------- |
+| req  | STK, SYS, SWE, SRS | Blue `#4477AA`     | Blue `#0077BB`       |
+| spec | ARC, SAD, ICD      | Green `#228833`    | Teal `#009988`       |
+| test | TST, VAL, SIT, SWT | Red `#EE6677`      | Orange `#EE7733`     |
+
+- **Print theme** (Tol bright): default for PDF output. Softer tones, designed
+  by Paul Tol for documents.
+- **Screen theme** (Tol vibrant): default for HTML output. More saturated,
+  designed by Tol for data visualization / dashboards.
+
+Both palettes are colorblind-safe by design (tested for protanopia,
+deuteranopia, tritanopia). No red-green confusion at the chosen mappings.
+
+The print palette uses three colors from the Paul Tol **bright** qualitative
+scheme (7 colors). The screen palette uses three colors from the Paul Tol
+**vibrant** qualitative scheme (7 colors). Both are single-scheme picks — no
+cross-scheme mixing.
+
+The type color is applied to:
+
+1. The **2px left border** of the entry block.
+2. The **display ID** text on the title line.
+
+No other element uses the type color. Body text, metadata, and pills use the
+document's standard text/background colors.
+
+## Entry rendering
+
+Entry blocks use **admonition-style** rendering: a 2px colored left border
+provides visual distinction from surrounding prose, with no background tint or
+horizontal rules.
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 700 140" style="background:#ffffff; border:1px solid #d4d4d4; border-radius:3px">
+  <!-- Entry block with left border -->
+  <rect x="20" y="10" width="2" height="120" rx="1" fill="#4477AA"/>
+  <!-- Title line -->
+  <text x="34" y="28" font-family="'IBM Plex Sans', sans-serif" font-size="10" font-weight="500" fill="#4477AA">SWE_BRK_0107</text>
+  <text x="124" y="28" font-family="'IBM Plex Sans', sans-serif" font-size="10" font-weight="500" fill="#1a1a1a">Median filter implementation</text>
+  <!-- Pill -->
+  <rect x="305" y="16" width="52" height="16" rx="8" fill="#f5f5f5"/>
+  <text x="331" y="28" text-anchor="middle" font-family="'IBM Plex Sans', sans-serif" font-size="7.5" font-weight="500" fill="#6b6b6b">ASIL-B</text>
+  <!-- Body -->
+  <text x="34" y="50" font-family="'IBM Plex Sans', sans-serif" font-size="10" fill="#1a1a1a">The braking ECU shall apply a 5-sample median filter to the raw</text>
+  <text x="34" y="64" font-family="'IBM Plex Sans', sans-serif" font-size="10" fill="#1a1a1a">brake pressure sensor input before processing.</text>
+  <!-- Metadata line -->
+  <text x="34" y="88" font-family="'IBM Plex Sans', sans-serif" font-size="8.5" font-style="italic" fill="#6b6b6b">Id: SWE_01HGW2Q8MNP3</text>
+  <text x="170" y="88" font-family="'IBM Plex Sans', sans-serif" font-size="8.5" fill="#6b6b6b"> · </text>
+  <text x="184" y="88" font-family="'IBM Plex Sans', sans-serif" font-size="8.5" font-style="italic" fill="#6b6b6b">Satisfies: </text>
+  <text x="233" y="88" font-family="'IBM Plex Sans', sans-serif" font-size="8.5" font-style="italic" fill="#6b6b6b" text-decoration="underline" style="text-decoration-style: dashed">SYS_BRK_0042</text>
+  <!-- Dimension labels -->
+  <line x1="680" y1="10" x2="680" y2="14" stroke="#0072B2" stroke-width="0.5"/>
+  <text x="670" y="21" text-anchor="end" font-family="sans-serif" font-size="7" fill="#0072B2">title</text>
+  <line x1="680" y1="36" x2="680" y2="42" stroke="#0072B2" stroke-width="0.5"/>
+  <text x="670" y="52" text-anchor="end" font-family="sans-serif" font-size="7" fill="#0072B2">body</text>
+  <line x1="680" y1="72" x2="680" y2="82" stroke="#0072B2" stroke-width="0.5"/>
+  <text x="670" y="90" text-anchor="end" font-family="sans-serif" font-size="7" fill="#0072B2">metadata</text>
+</svg>
+
+_Figure: Entry block anatomy — admonition-style rendering_
+
+### Block layout
+
+Each entry block is laid out top-to-bottom:
+
+1. **Title line** — display ID (body size, weight 500, type color) + title text
+   (body size, weight 500, primary text color) + pill group (inline, wraps as
+   block).
+2. **Body** — body size, regular weight, primary text color. Margin-top:
+   `space-1` (4pt) from title line.
+3. **Metadata line** — small size, italic, secondary text color. Margin-top:
+   `space-2` (8pt) from body. Attributes separated by `·` (middle dot with
+   spaces). Attribute order: `Id`, then traceability (`Satisfies` / `Verifies` /
+   `Derived-from`), then any other key-value attributes.
+
+The 2px left border starts flush with the first line of the title — no top
+padding above the title. Inter-block margin is `space-3` (12pt).
+
+### Label pills
+
+Labels (e.g., `ASIL-B`, `performance`, `real-time`) are rendered as pills
+(rounded badges):
+
+- Font size: small (8.5pt), weight 500.
+- Padding: 1pt vertical, 7pt horizontal.
+- Border-radius: 9pt (fully rounded).
+- Background: code background color (neutral — no type color).
+- Text color: secondary text color.
+- Each pill has `white-space: nowrap` (a single label never breaks).
+
+All pills for an entry are wrapped in a **pill group**:
+
+- Inline flex container with `gap: space-1` (4pt) and `flex-wrap: wrap`.
+- The pill group sits on the title line after the title text.
+- If the group fits on the title line, it renders inline.
+- If it doesn't fit, the entire group wraps to the next line as a block.
+- No labels = no pill group rendered.
+
+### Cross-reference links
+
+Attribute values that reference other entries (`Satisfies`, `Verifies`,
+`Derived-from`) are rendered as links:
+
+- **Dashed underline** — underline color is lighter than the text (border
+  secondary or equivalent, ~0.3 alpha).
+- **No link color** — the text stays in the same italic/secondary style as the
+  rest of the metadata line.
+- **Underline offset**: 2pt.
+- In HTML: `cursor: pointer`, link target is the anchor of the referenced entry.
+- In PDF: Typst internal link (`#link(<target>)`), rendered with the same
+  dashed-underline style.
+
+Non-reference values (`Id` value, other key-value pairs) have no underline —
+they are plain italic text.
+
 ## Spacing
 
 A 4pt base unit keeps spacing consistent and proportional. All values are

--- a/docs/theme/markspec.css
+++ b/docs/theme/markspec.css
@@ -39,6 +39,11 @@
   --ms-bg-alert: #f0f4f8;
   --ms-border: #d4d4d4;
 
+  /* Entry type colors (Tol vibrant) */
+  --ms-entry-req: #0077BB;
+  --ms-entry-spec: #009988;
+  --ms-entry-test: #EE7733;
+
   /* Alert colors */
   --ms-alert-note-border: #4477AA;
   --ms-alert-note-bg: #f0f4f8;
@@ -94,4 +99,24 @@
 body { font-family: var(--font-sans); }
 code, pre > code { font-family: var(--font-mono); }
 h1, h2, h3, h4 { font-weight: 600; }
+
+/* ── Entry blocks ──────────────────────────────────────── */
+
+.req-block {
+  border-left: 2px solid var(--ms-entry-req);
+  padding: 0 0 0 14px;
+  margin: 12pt 0;
+}
+.req-block[data-entry-type="spec"] { border-left-color: var(--ms-entry-spec); }
+.req-block[data-entry-type="test"] { border-left-color: var(--ms-entry-test); }
+.req-block .req-title { display: flex; flex-wrap: wrap; align-items: baseline; gap: 4px; }
+.req-block .req-id { font-size: var(--size-body); font-weight: 500; color: var(--ms-entry-req); }
+.req-block[data-entry-type="spec"] .req-id { color: var(--ms-entry-spec); }
+.req-block[data-entry-type="test"] .req-id { color: var(--ms-entry-test); }
+.req-block .req-name { font-size: var(--size-body); font-weight: 500; }
+.req-block .req-body { margin-top: 4px; line-height: 1.65; }
+.req-block .req-meta { font-size: var(--size-small); font-style: italic; color: var(--ms-secondary); margin-top: 8px; }
+.pill-group { display: inline-flex; gap: 4px; flex-wrap: wrap; flex-shrink: 0; }
+.pill { font-size: 10px; font-weight: 500; padding: 1px 7px; border-radius: 9px; background: var(--ms-bg-code); color: var(--ms-secondary); white-space: nowrap; }
+.cross-ref { text-decoration: underline dashed; text-decoration-color: var(--ms-border); text-underline-offset: 2px; color: inherit; cursor: pointer; }
 

--- a/dprint.json
+++ b/dprint.json
@@ -25,7 +25,8 @@
     "**/build",
     "_site",
     "npm",
-    "CHANGELOG.md"
+    "CHANGELOG.md",
+    "docs/examples/"
   ],
   "plugins": [
     "https://plugins.dprint.dev/markdown-0.20.0.wasm",

--- a/packages/markspec-typst/entry.typ
+++ b/packages/markspec-typst/entry.typ
@@ -39,15 +39,15 @@
 ///
 /// - target (str): display ID of the referenced entry
 /// -> content
-#let cross-ref(target) = {
-  link(label(target))[
-    #underline(
-      stroke: (dash: "dashed", paint: luma(200), thickness: 0.5pt),
-      offset: 2pt,
-      target,
-    )
-  ]
-}
+///
+/// Note: internal link navigation requires entry blocks to emit labeled
+/// anchors — that is a follow-up concern. For now the dashed-underline
+/// style is applied without a live link destination.
+#let cross-ref(target) = underline(
+  stroke: (dash: "dashed", paint: luma(200), thickness: 0.5pt),
+  offset: 2pt,
+  target,
+)
 
 /// Render a full entry block with admonition-style left border.
 ///

--- a/packages/markspec-typst/entry.typ
+++ b/packages/markspec-typst/entry.typ
@@ -1,54 +1,120 @@
-// Requirement entry styling — visually distinct blocks for
-// requirement entries in rendered documents.
+// MarkSpec entry block rendering — admonition-style requirement blocks.
 
 #import "tokens.typ": *
 
-/// Render a requirement entry with distinct styling.
+/// Resolve the theme color for an entry type.
 ///
-/// - id: Display ID string (e.g., "SRS_BRK_0001")
-/// - title: Entry title
-/// - body: Body content as Typst content
-/// - attrs: Array of (key, value) pairs for the attribute table
-#let markspec-entry(id, title, body, attrs, theme) = {
+/// - type (str): one of "req", "spec", "test"
+/// - theme (module): a theme module with entry-req, entry-spec, entry-test
+/// -> color
+#let entry-color(type, theme) = {
+  if type == "spec" { theme.entry-spec }
+  else if type == "test" { theme.entry-test }
+  else { theme.entry-req }
+}
+
+/// Map an entry type prefix to its color category.
+///
+/// - prefix (str): e.g. "STK", "SYS", "SWE", "SRS", "ARC", "ICD", "TST", etc.
+/// -> str: "req", "spec", or "test"
+#let entry-category(prefix) = {
+  if prefix in ("ARC", "SAD", "ICD") { "spec" }
+  else if prefix in ("TST", "VAL", "SIT", "SWT") { "test" }
+  else { "req" }
+}
+
+/// Render a label pill (rounded badge).
+///
+/// - label (str): label text (e.g. "ASIL-B")
+/// - theme (module): theme module for colors
+/// -> content
+#let pill(label, theme) = box(
+  fill: theme.bg-code,
+  radius: 9pt,
+  inset: (x: 7pt, y: 1pt),
+  text(size: size-small, weight: "medium", fill: theme.secondary, label),
+)
+
+/// Render a cross-reference link with dashed underline.
+///
+/// - target (str): display ID of the referenced entry
+/// -> content
+#let cross-ref(target) = {
+  link(label(target))[
+    #underline(
+      stroke: (dash: "dashed", paint: luma(200), thickness: 0.5pt),
+      offset: 2pt,
+      target,
+    )
+  ]
+}
+
+/// Render a full entry block with admonition-style left border.
+///
+/// - type (str): color category — "req", "spec", or "test"
+/// - display-id (str): human-readable display ID (e.g. "SWE_BRK_0107")
+/// - title (str): entry title
+/// - body (content): body content
+/// - attrs (array): array of (key, value) pairs for the metadata line
+/// - labels (array): array of label strings for pill rendering
+/// - theme (module): theme module for colors
+/// -> content
+#let req-block(
+  type: "req",
+  display-id: "",
+  title: "",
+  body: [],
+  attrs: (),
+  labels: (),
+  theme: none,
+) = {
+  let color = entry-color(type, theme)
+
   block(
+    stroke: (left: 2pt + color),
+    inset: (left: 12pt, top: 0pt, bottom: 4pt, right: 0pt),
     width: 100%,
-    inset: (left: space-3, top: space-2, bottom: space-2, right: space-2),
-    stroke: (left: 2pt + theme.accent),
-    below: space-4,
-    above: space-4,
-  )[
-    // ID line — monospace, accent color, small
-    #text(font: font-mono, size: size-small, fill: theme.accent, id)
-    #h(space-2)
-    // Title — semibold
-    #text(weight: "semibold", title)
+    {
+      // Title line
+      {
+        text(size: size-body, weight: "medium", fill: color, display-id)
+        h(6pt)
+        text(size: size-body, weight: "medium", title)
+        if labels.len() > 0 {
+          h(6pt)
+          box({
+            for (i, label) in labels.enumerate() {
+              if i > 0 { h(4pt) }
+              pill(label, theme)
+            }
+          })
+        }
+      }
 
-    // Body
-    #if body != none and body != [] {
-      v(space-1)
-      body
-    }
+      // Body
+      if body != [] and body != "" {
+        v(space-1)
+        text(size: size-body, body)
+      }
 
-    // Attributes — compact table with light background
-    #if attrs.len() > 0 {
-      v(space-2)
-      block(
-        width: 100%,
-        fill: theme.bg-code,
-        radius: 2pt,
-        inset: space-2,
-      )[
-        #set text(size: size-small)
-        #for (i, attr) in attrs.enumerate() {
-          let (key, value) = attr
-          text(weight: "semibold", key)
-          h(space-1)
-          text(font: font-mono, value)
-          if i < attrs.len() - 1 {
-            linebreak()
+      // Metadata line
+      if attrs.len() > 0 {
+        v(space-2)
+        set text(size: size-small, style: "italic", fill: theme.secondary)
+        let traceability-keys = ("Satisfies", "Verifies", "Derived-from")
+        let parts = ()
+        for (key, value) in attrs {
+          if key in traceability-keys {
+            // Split comma-separated references
+            let refs = value.split(",").map(s => s.trim())
+            let linked = refs.map(r => cross-ref(r))
+            parts.push([#key: #linked.join([, ])])
+          } else {
+            parts.push([#key: #value])
           }
         }
-      ]
-    }
-  ]
+        parts.join[ #sym.dot.c ]
+      }
+    },
+  )
 }

--- a/packages/markspec-typst/lib.typ
+++ b/packages/markspec-typst/lib.typ
@@ -11,5 +11,5 @@
 
 #import "doc.typ": markspec-doc
 #import "deck.typ": markspec-deck, markspec-title-slide, markspec-focus-slide
-#import "entry.typ": markspec-entry
+#import "entry.typ": req-block, pill, cross-ref, entry-category
 #import "tokens.typ"

--- a/packages/markspec-typst/themes/dark.typ
+++ b/packages/markspec-typst/themes/dark.typ
@@ -12,6 +12,11 @@
 #let bg-alert = rgb("#242424")
 #let border = rgb("#404040")
 
+// Entry type colors (Tol palette)
+#let entry-req = rgb("#0077BB")
+#let entry-spec = rgb("#009988")
+#let entry-test = rgb("#EE7733")
+
 // Alert border colors (Tol palette)
 #let alert-note = rgb("#4477AA")
 #let alert-tip = rgb("#228833")

--- a/packages/markspec-typst/themes/light.typ
+++ b/packages/markspec-typst/themes/light.typ
@@ -12,6 +12,11 @@
 #let bg-alert = rgb("#f0f4f8")
 #let border = rgb("#d4d4d4")
 
+// Entry type colors (Tol palette)
+#let entry-req = rgb("#4477AA")
+#let entry-spec = rgb("#228833")
+#let entry-test = rgb("#EE6677")
+
 // Alert border colors (Tol palette)
 #let alert-note = rgb("#4477AA")
 #let alert-tip = rgb("#228833")

--- a/packages/markspec/render/mod.ts
+++ b/packages/markspec/render/mod.ts
@@ -11,6 +11,7 @@
  */
 
 import type { CompileResult, Diagnostic, ProjectConfig } from "../core/mod.ts";
+import { parse } from "../core/mod.ts";
 import { generateTypstDocument } from "./typst/template.ts";
 import type { DocumentMetadata } from "./typst/template.ts";
 import { compileTypst } from "./typst/mod.ts";
@@ -90,7 +91,10 @@ export function renderTypst(
     version: options.config.version,
   };
 
-  return generateTypstDocument(markdown, metadata);
+  // Parse entries from the markdown for structured rendering
+  const entries = parse(markdown);
+
+  return generateTypstDocument(markdown, metadata, entries);
 }
 
 /** Convert a Typst diagnostic to a MarkSpec diagnostic. */

--- a/packages/markspec/render/typst/template.ts
+++ b/packages/markspec/render/typst/template.ts
@@ -4,8 +4,11 @@
  * Generates Typst source documents from preprocessed Markdown content
  * and project metadata. The generated document uses cmarker for
  * CommonMark-to-Typst conversion and the markspec-doc template for
- * page layout and typography.
+ * page layout and typography. Entry blocks are rendered as structured
+ * `req-block` calls with admonition-style left borders.
  */
+
+import type { Entry } from "../../core/mod.ts";
 
 /** Metadata for the generated Typst document. */
 export interface DocumentMetadata {
@@ -19,24 +22,186 @@ export interface DocumentMetadata {
 /**
  * Generate a complete Typst document from preprocessed Markdown.
  *
- * The output imports the markspec-doc template and cmarker, applies
- * the document show rule with metadata, and renders the Markdown
- * content via cmarker.
+ * When entries are provided, the markdown is split at entry block
+ * boundaries: prose segments are rendered via cmarker, and entry
+ * blocks are rendered as structured `req-block` Typst calls.
+ *
+ * @param markdown - Preprocessed Markdown content
+ * @param metadata - Document metadata
+ * @param entries - Parsed entries with position info (optional)
  */
 export function generateTypstDocument(
   markdown: string,
   metadata: DocumentMetadata = {},
+  entries: readonly Entry[] = [],
 ): string {
-  const escaped = escapeTypstString(markdown);
   const metaArgs = buildMetaArgs(metadata);
-
-  return `#import "lib.typ": markspec-doc
+  const imports = `#import "lib.typ": markspec-doc, req-block, entry-category
 #import "vendor/cmarker/lib.typ": render
+#import "themes/light.typ" as theme`;
 
-#show: markspec-doc.with(${metaArgs})
+  const showRule = `#show: markspec-doc.with(${metaArgs})`;
 
-#render("${escaped}")
-`;
+  if (entries.length === 0) {
+    const escaped = escapeTypstString(markdown);
+    return `${imports}\n\n${showRule}\n\n#render("${escaped}")\n`;
+  }
+
+  const segments = spliceEntries(markdown, entries);
+  const body = segments.map((seg) => {
+    if (seg.kind === "prose") {
+      if (seg.content.trim() === "") return "";
+      return `#render("${escapeTypstString(seg.content)}")`;
+    }
+    return renderEntryTypst(seg.entry);
+  }).filter((s) => s !== "").join("\n\n");
+
+  return `${imports}\n\n${showRule}\n\n${body}\n`;
+}
+
+/** A segment of the document: either prose or an entry block. */
+interface ProseSegment {
+  readonly kind: "prose";
+  readonly content: string;
+}
+
+interface EntrySegment {
+  readonly kind: "entry";
+  readonly entry: Entry;
+}
+
+type Segment = ProseSegment | EntrySegment;
+
+/**
+ * Split markdown into alternating prose and entry segments using
+ * entry position info (line numbers).
+ */
+function spliceEntries(
+  markdown: string,
+  entries: readonly Entry[],
+): Segment[] {
+  const lines = markdown.split("\n");
+
+  // Sort entries by line number
+  const sorted = [...entries]
+    .filter((e) => e.source === "markdown")
+    .sort((a, b) => a.location.line - b.location.line);
+
+  if (sorted.length === 0) {
+    return [{ kind: "prose", content: markdown }];
+  }
+
+  const segments: Segment[] = [];
+  let cursor = 0; // 0-based line index
+
+  for (const entry of sorted) {
+    const entryStart = entry.location.line - 1; // convert to 0-based
+
+    // Find entry end: scan forward for the end of the list item.
+    // Entry items end when we hit a line that is not indented (not part
+    // of the list item continuation) or end of file.
+    const entryEnd = findEntryEnd(lines, entryStart);
+
+    // Prose before this entry
+    if (entryStart > cursor) {
+      const prose = lines.slice(cursor, entryStart).join("\n");
+      segments.push({ kind: "prose", content: prose });
+    }
+
+    segments.push({ kind: "entry", entry });
+    cursor = entryEnd;
+  }
+
+  // Trailing prose
+  if (cursor < lines.length) {
+    const prose = lines.slice(cursor).join("\n");
+    segments.push({ kind: "prose", content: prose });
+  }
+
+  return segments;
+}
+
+/**
+ * Find the end line index (exclusive, 0-based) of an entry list item
+ * starting at `start`.
+ */
+function findEntryEnd(lines: readonly string[], start: number): number {
+  // The first line is the `- [ID] Title` line.
+  // Subsequent lines belong to the entry if they are:
+  // - blank, or
+  // - indented (continuation of the list item body)
+  // The entry ends at the first non-blank, non-indented line, or at
+  // another top-level list item (`- `).
+  let i = start + 1;
+  while (i < lines.length) {
+    const line = lines[i];
+    // Blank line might be internal to the entry — peek ahead
+    if (line.trim() === "") {
+      // If next non-blank line is indented, this blank is internal
+      let j = i + 1;
+      while (j < lines.length && lines[j].trim() === "") j++;
+      if (j < lines.length && /^\s{2,}/.test(lines[j])) {
+        i = j;
+        continue;
+      }
+      // Otherwise this blank ends the entry
+      i++;
+      break;
+    }
+    // Indented continuation
+    if (/^\s{2,}/.test(line)) {
+      i++;
+      continue;
+    }
+    // Non-indented, non-blank — entry is over
+    break;
+  }
+  return i;
+}
+
+/**
+ * Map entry type prefix to the color category used by req-block.
+ */
+function entryTypeCategory(entryType: string | undefined): string {
+  if (!entryType) return "req";
+  if (["ARC", "SAD", "ICD"].includes(entryType)) return "spec";
+  if (["TST", "VAL", "SIT", "SWT"].includes(entryType)) return "test";
+  return "req";
+}
+
+/** Render a single entry as a Typst `req-block` call. */
+function renderEntryTypst(entry: Entry): string {
+  const category = entryTypeCategory(entry.entryType);
+
+  // Extract labels from attributes
+  const labelsAttr = entry.attributes.find((a) => a.key === "Labels");
+  const labels = labelsAttr
+    ? labelsAttr.value.split(",").map((s) => s.trim()).filter((s) =>
+      s.length > 0
+    )
+    : [];
+
+  // Build attrs array (excluding Labels — those go into pills)
+  const attrs = entry.attributes
+    .filter((a) => a.key !== "Labels")
+    .map((a) =>
+      `("${escapeTypstString(a.key)}", "${escapeTypstString(a.value)}")`
+    );
+
+  const labelsTypst = labels.map((l) => `"${escapeTypstString(l)}"`);
+
+  // Escape body content
+  const bodyEscaped = escapeTypstString(entry.body);
+
+  return `#req-block(
+  type: "${category}",
+  display-id: "${escapeTypstString(entry.displayId)}",
+  title: "${escapeTypstString(entry.title)}",
+  body: render("${bodyEscaped}"),
+  attrs: (${attrs.join(", ")}),
+  labels: (${labelsTypst.join(", ")}),
+  theme: theme,
+)`;
 }
 
 /** Escape a string for use inside a Typst double-quoted string literal. */

--- a/packages/markspec/render/typst/template.ts
+++ b/packages/markspec/render/typst/template.ts
@@ -193,13 +193,20 @@ function renderEntryTypst(entry: Entry): string {
   // Escape body content
   const bodyEscaped = escapeTypstString(entry.body);
 
+  // Always use trailing comma so Typst treats single-element arrays correctly.
+  // Without it, `(expr)` is just parenthesised `expr`, not a 1-element array.
+  const attrsStr = attrs.length > 0 ? `(${attrs.join(", ")},)` : "()";
+  const labelsStr = labelsTypst.length > 0
+    ? `(${labelsTypst.join(", ")},)`
+    : "()";
+
   return `#req-block(
   type: "${category}",
   display-id: "${escapeTypstString(entry.displayId)}",
   title: "${escapeTypstString(entry.title)}",
   body: render("${bodyEscaped}"),
-  attrs: (${attrs.join(", ")}),
-  labels: (${labelsTypst.join(", ")}),
+  attrs: ${attrsStr},
+  labels: ${labelsStr},
   theme: theme,
 )`;
 }

--- a/scripts/gen_theme.ts
+++ b/scripts/gen_theme.ts
@@ -25,6 +25,7 @@ interface Tokens {
   page: Record<string, string>;
   slide: Record<string, string>;
   themes: Record<string, Record<string, string>>;
+  entries: Record<string, { print: string; screen: string }>;
   alerts: Record<string, { border: string; bg: string }>;
 }
 
@@ -104,6 +105,13 @@ function genTypstTheme(name: string, colors: Record<string, string>): string {
     lines.push(`#let ${key} = rgb("${val}")`);
   }
 
+  // Entry type colors (Tol palette)
+  const palette = name === "light" ? "print" : "screen";
+  lines.push("\n// Entry type colors (Tol palette)");
+  for (const [type, props] of Object.entries(tokens.entries)) {
+    lines.push(`#let entry-${type} = rgb("${props[palette]}")`);
+  }
+
   // Alert border colors from the alerts section
   lines.push("\n// Alert border colors (Tol palette)");
   for (const [name, props] of Object.entries(tokens.alerts)) {
@@ -148,6 +156,12 @@ function genCss(): string {
   lines.push("\n  /* Light theme (default) */");
   for (const [key, val] of Object.entries(tokens.themes.light)) {
     lines.push(`  --ms-${key}: ${val};`);
+  }
+
+  // Entry type colors (screen/vibrant palette for HTML)
+  lines.push("\n  /* Entry type colors (Tol vibrant) */");
+  for (const [type, props] of Object.entries(tokens.entries)) {
+    lines.push(`  --ms-entry-${type}: ${props.screen};`);
   }
 
   // Alerts
@@ -198,6 +212,28 @@ function genCss(): string {
   lines.push("body { font-family: var(--font-sans); }");
   lines.push("code, pre > code { font-family: var(--font-mono); }");
   lines.push("h1, h2, h3, h4 { font-weight: 600; }");
+
+  // Entry block styling
+  lines.push(
+    "\n/* ── Entry blocks ──────────────────────────────────────── */\n",
+  );
+  lines.push(`.req-block {
+  border-left: 2px solid var(--ms-entry-req);
+  padding: 0 0 0 14px;
+  margin: 12pt 0;
+}
+.req-block[data-entry-type="spec"] { border-left-color: var(--ms-entry-spec); }
+.req-block[data-entry-type="test"] { border-left-color: var(--ms-entry-test); }
+.req-block .req-title { display: flex; flex-wrap: wrap; align-items: baseline; gap: 4px; }
+.req-block .req-id { font-size: var(--size-body); font-weight: 500; color: var(--ms-entry-req); }
+.req-block[data-entry-type="spec"] .req-id { color: var(--ms-entry-spec); }
+.req-block[data-entry-type="test"] .req-id { color: var(--ms-entry-test); }
+.req-block .req-name { font-size: var(--size-body); font-weight: 500; }
+.req-block .req-body { margin-top: 4px; line-height: 1.65; }
+.req-block .req-meta { font-size: var(--size-small); font-style: italic; color: var(--ms-secondary); margin-top: 8px; }
+.pill-group { display: inline-flex; gap: 4px; flex-wrap: wrap; flex-shrink: 0; }
+.pill { font-size: 10px; font-weight: 500; padding: 1px 7px; border-radius: 9px; background: var(--ms-bg-code); color: var(--ms-secondary); white-space: nowrap; }
+.cross-ref { text-decoration: underline dashed; text-decoration-color: var(--ms-border); text-underline-offset: 2px; color: inherit; cursor: pointer; }`);
 
   lines.push("");
   return lines.join("\n") + "\n";


### PR DESCRIPTION
## Summary

- Add entry type colors (req/spec/test) using Paul Tol bright (print) and vibrant (screen) palettes to `tokens.yaml`, `gen_theme.ts`, and generated Typst/CSS theme files
- Replace `markspec-entry` with richer `req-block` Typst function: type-based 2px left-border coloring, label pills (rounded badges), and dashed-underline cross-reference links
- Update `template.ts` to splice entry blocks out of the markdown stream and emit structured `req-block()` Typst calls; `render/mod.ts` now parses entries before rendering
- Add `.req-block`, `.pill`, `.pill-group`, and `.cross-ref` CSS classes with screen palette custom properties
- Add normative sections to `typography.md` (Entry type colors, Entry rendering, Block layout, Label pills, Cross-reference links) with anatomy SVG
- Add rendering cross-reference note to `language.md` §1 Entry blocks
- Add `docs/examples/entry-rendering.md` showcasing all entry types, pill variations, and cross-reference patterns

Closes #175, #177, #178, #179.
Relates to epic #176.

## Changed files

| File | Change |
|------|--------|
| `docs/spec/tokens.yaml` | Add `entries` section with Tol print/screen palettes |
| `scripts/gen_theme.ts` | Emit entry colors + CSS classes for entry blocks |
| `packages/markspec-typst/entry.typ` | Replace `markspec-entry` with `req-block`, `pill`, `cross-ref`, `entry-category` |
| `packages/markspec-typst/lib.typ` | Export new entry functions |
| `packages/markspec-typst/themes/*.typ` | Generated — entry type colors added |
| `docs/theme/markspec.css` | Generated — entry colors + block/pill/cross-ref classes |
| `packages/markspec/render/typst/template.ts` | Splice entries as `req-block()` Typst calls; trailing comma fix for single-element arrays |
| `packages/markspec/render/mod.ts` | Parse entries before rendering |
| `docs/spec/typography.md` | Normative entry rendering sections |
| `docs/spec/language.md` | Cross-reference to typography rendering spec |
| `docs/examples/entry-rendering.md` | Showcase document |
| `deno.json` | Exclude `docs/examples/` from `deno fmt` (attribute values must not be line-wrapped) |

## Known limitation

`cross-ref` renders dashed-underline style but does not yet navigate to the target — deferred until entry blocks emit labeled Typst anchors (follow-up).

## Test plan

- [x] `deno check` passes
- [x] 216 unit tests pass (11 new from upstream `styles/mod_test.ts`)
- [x] `deno fmt --check` clean
- [x] `deno lint` clean
- [x] Visual review: `markspec doc build docs/examples/entry-rendering.md` — blue/green/red borders correct, pills inline/wrapping, metadata dashed underlines, prose has no border
- [x] Colorblind safety: Tol bright and vibrant palettes are tested for protanopia, deuteranopia, tritanopia by design — no red/green confusion in the req(blue)/spec(green)/test(red) mapping

🤖 Generated with [Claude Code](https://claude.com/claude-code)