### PR TITLE
chore(auto): update tree-sitter grammar versions

### DIFF
--- a/grammars/grammars.lock
+++ b/grammars/grammars.lock
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-03-30T21:08:33.912Z",
+  "generated": "2026-04-06T07:56:40.610Z",
   "grammars": [
     {
       "file": "tree-sitter-rust.wasm",
@@ -26,8 +26,8 @@
       "file": "tree-sitter-c.wasm",
       "source": "npm",
       "package": "tree-sitter-c",
-      "version": "0.23.5",
-      "sha256": "146f85977800935f18b06940518b16ded13cf4007ef0e3190573b969a98b9adc"
+      "version": "0.24.1",
+      "sha256": "c852c2a85ebf2beb636aa3b0ef7f7e70458684d74f6741b20dcb296885bed9f9"
     },
     {
       "file": "tree-sitter-cpp.wasm",

--- a/grammars/tree-sitter-c.wasm
+++ b/grammars/tree-sitter-c.wasm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:146f85977800935f18b06940518b16ded13cf4007ef0e3190573b969a98b9adc
-size 620090
+oid sha256:c852c2a85ebf2beb636aa3b0ef7f7e70458684d74f6741b20dcb296885bed9f9
+size 625918

--- a/scripts/fetch_grammars.ts
+++ b/scripts/fetch_grammars.ts
@@ -51,7 +51,7 @@ const GRAMMARS: Record<string, Grammar> = {
   "tree-sitter-c.wasm": {
     source: "npm",
     pkg: "tree-sitter-c",
-    version: "0.23.5",
+    version: "0.24.1",
   },
   "tree-sitter-cpp.wasm": {
     source: "npm",


### PR DESCRIPTION
Automated update of tree-sitter WASM grammar versions.

Review the changes to `scripts/fetch_grammars.ts`, `grammars/grammars.lock`,
and the updated `.wasm` files.