### PR TITLE
feat(core): implement ADR-002 entry model with family discrimination

### DIFF
--- a/docs/adr/adr-entry-model.md
+++ b/docs/adr/adr-entry-model.md
@@ -1,0 +1,403 @@
+# ADR-002: Entry Model — Spec and Reference Entries
+
+Status: Proposed\
+Date: 2026-04-12\
+Scope: MarkSpec
+
+## Context
+
+ADR-001 introduced entry blocks as MarkSpec's mechanism for authoring traceable
+artifacts alongside prose. It hardcoded an automotive V-model vocabulary (STK,
+SYS, SRS, SAD, ICD, VAL, SIT, SWT) directly into the core specification, which
+ties MarkSpec to a single domain and limits adoption in aerospace, medical,
+railway, and other safety-critical contexts.
+
+This ADR separates the **entry format** from the **domain vocabulary**. The core
+defines a universal entry model with two families — **spec entries** and
+**reference entries** — each with a precise format, a minimal set of required
+attributes, and well-defined validation rules. Concrete type vocabularies
+(automotive V-model, DO-178C, IEC 62304) move out of the core into profiles.
+
+A third family for system elements (components, units, interfaces) is
+anticipated but defined in a separate ADR.
+
+---
+
+## Part 1 — Entry (Common Base)
+
+All entry families share a common syntactic form and a common set of universal
+properties. `Entry` is an abstract concept — every concrete entry is either a
+spec or a reference.
+
+### Syntactic form
+
+```
+- [DISPLAY_ID] Title
+
+  Body paragraphs.
+
+  Key: Value\
+  Key: Value
+```
+
+An entry block is a Markdown list item whose content between `[` and `]` is a
+display ID, followed by a non-empty title on the same line, followed by indented
+body content, optionally terminated by `Key: Value` trailers following the
+git-trailers convention.
+
+### Required structural properties
+
+| Property       | Rule                                                           |
+| -------------- | -------------------------------------------------------------- |
+| **Display ID** | Non-empty, format defined by specialization                    |
+| **Title**      | Non-empty text on the bullet line after `]`                    |
+| **Body**       | At least one indented paragraph (exception: reference entries) |
+
+A bullet without an indented body is a normal list item, not an entry.
+
+### Core universal attributes
+
+| Attribute | Description                                    |
+| --------- | ---------------------------------------------- |
+| `Labels`  | Free-form classification tags, comma-separated |
+
+`Labels` is the only attribute universally available on all entry families. All
+other attributes are specific to a family or declared by a profile.
+
+---
+
+## Part 2 — Spec Entries
+
+### Intent
+
+A spec entry is a **canonical declaration of a numbered object of reasoning**
+produced by the project: requirements, tests, architecture descriptions,
+hazards, ADRs, and similar traceable artifacts. The project is the authority on
+the content.
+
+### Display ID format
+
+```
+^[A-Z]{2,6}_[A-Z][A-Z0-9]{2,7}(_[A-Z][A-Z0-9]{2,7})?_\d{3,6}$
+```
+
+| Segment       | Constraint                                                   | Role                                        |
+| ------------- | ------------------------------------------------------------ | ------------------------------------------- |
+| **TYPE**      | 2 to 6 uppercase letters                                     | Entry category (STK, SYS, SRS, HAZ, SYREQ…) |
+| **DOMAIN**    | 3 to 8 characters, first letter, rest alphanumeric uppercase | Subsystem abbreviation (BRK, NAV, PWR…)     |
+| **SUBDOMAIN** | Optional, same format as DOMAIN                              | Subdivision of a domain (CTRL, SENSOR…)     |
+| **NNNN**      | 3 to 6 digits, number ≥ 1                                    | Sequential number within scope              |
+
+**Scope** for uniqueness and numbering is the full `TYPE_DOMAIN[_SUBDOMAIN]`
+prefix. Maximum of 999 999 entries per scope.
+
+Concrete TYPE values (STK, SYS, SRS, VAL, SIT, SWT…) are not defined by the
+core. They come from a profile loaded by the project.
+
+### Examples
+
+Valid:
+
+- `SRS_BRK_0107` — software requirement, braking domain, entry 107
+- `SRS_BRK_001` — same scope, entry 1 in 3-digit padding
+- `SRS_BRK_CTRL_0042` — with subdomain CTRL
+- `SYREQ_BRK_100` — 5-letter type
+- `HAZ_PWR_99999` — 5-digit padding
+
+Invalid:
+
+- `srs_brk_0001` — lowercase not allowed
+- `SRS_BRK_12` — NNNN too short (minimum 3 digits)
+- `SRS_BRK_000` — number zero not allowed
+- `S_BRK_001` — TYPE too short (minimum 2 letters)
+- `SRS_B_001` — DOMAIN too short (minimum 3 characters)
+
+### ULID
+
+Every spec entry carries a mandatory `Id` attribute containing a ULID prefixed
+with the entry type.
+
+```
+Id: SRS_01HGW2Q8MNP3RSTVWXYZABCDE
+```
+
+**Format**: `^[A-Z]{2,6}_[0-9A-Z]{26}$`
+
+The TYPE prefix must match the TYPE prefix of the display ID. The ULID itself is
+a standard 26-character Crockford base32 ULID.
+
+**Rules**:
+
+- The ULID is assigned by `markspec format` (typically via pre-commit hook). It
+  is never hand-authored.
+- Once assigned, the ULID is immutable. It survives display ID renumbering.
+- The ULID is globally unique in the repository.
+
+### Core attributes
+
+| Attribute      | Required | Description                                                      |
+| -------------- | -------- | ---------------------------------------------------------------- |
+| `Id`           | yes      | Prefixed ULID, assigned by tooling                               |
+| `Satisfies`    | no       | Upstream link to parent spec entry/entries                       |
+| `Derived-from` | no       | Upstream link to a reference entry with optional section locator |
+| `Labels`       | no       | Free-form tags (inherited from Entry base)                       |
+
+Additional relations (`Verifies`, `Implements`, `Allocates`, `Between`…) are
+declared by profiles, not by the core. The validation rule "the target must
+exist" applies to all relations at the core level; direction rules come from the
+loaded profile.
+
+### Validation rules (errors)
+
+1. Display ID matches the spec regex.
+2. `Id` attribute is present and well-formed.
+3. TYPE of `Id` matches TYPE of display ID.
+4. Display ID is unique within the project.
+5. ULID is unique within the repository.
+6. Subdomain presence is consistent within a `TYPE_DOMAIN` scope: either all
+   entries in the scope use a subdomain or none do.
+7. NNNN is a positive integer (no `000`, `0000`, etc.).
+8. `Satisfies` and `Derived-from` targets exist in the resolution scope.
+
+### Creation and autocompletion rule
+
+When tooling generates a new display ID in a given scope:
+
+```
+N_max   = largest number currently in scope (0 if empty)
+padding = max(3, len(str(N_max)))
+new_id  = TYPE_DOMAIN[_SUBDOMAIN]_<N_next zero-padded to `padding` digits>
+```
+
+Existing entries are never automatically renumbered.
+
+Examples:
+
+- Empty scope → `SRS_BRK_001`
+- Scope `{001, 042}` → next is `SRS_BRK_043`
+- Scope `{001, 999}` → next is `SRS_BRK_1000`
+- Scope `{001, 042, 1000}` → next is `SRS_BRK_1001` (existing 001 and 042 left
+  as-is)
+
+A scope may contain a mix of padding widths. No error, no warning.
+
+---
+
+## Part 3 — Reference Entries
+
+### Intent
+
+A reference entry is a **bibliographic notice citing a document or publication
+external to MarkSpec**. The cited work exists independently — published by a
+standards organization, an authority, a corporate entity, or an academic venue.
+The reference entry is the record that identifies the work and allows the
+project to cite it. The project is **not** the authority on the content of the
+cited work.
+
+Examples: ISO 26262-6, DO-178C, RFC 2119, UNECE R155, MISRA C:2012, academic
+papers, corporate specifications.
+
+### Display ID format (slug)
+
+```
+^[A-Za-z][A-Za-z0-9]*([.-][A-Za-z0-9]+)*$
+```
+
+Rules:
+
+- Starts with a letter (uppercase or lowercase).
+- Contains alphanumerics, with hyphens and dots as internal separators.
+- Punctuation must be **internal**: never at the start, never at the end, never
+  repeated consecutively.
+
+This regex aligns with the Pandoc citation key convention, a de facto standard
+in the Markdown ecosystem.
+
+### Style guide conventions (non-normative)
+
+| Use case                            | Convention             | Examples                                                           |
+| ----------------------------------- | ---------------------- | ------------------------------------------------------------------ |
+| Technical standards and regulations | Uppercase with hyphens | `ISO-26262-6`, `DO-178C`, `RFC-2119`, `UNECE-R155`, `MISRA-C-2012` |
+| Academic citations and DOI-derived  | Lowercase              | `smith2021`, `knuth1984`, `patashnik-bibtexing`                    |
+| Standard versions with dots         | Either dots or hyphens | `ASPICE.4.0` or `ASPICE-4-0`                                       |
+
+Within a single `references` document, consistency is recommended.
+
+### Discrimination from spec entries
+
+Spec and reference regexes are disjoint by construction:
+
+- Spec IDs always contain underscores.
+- Reference slugs never contain underscores.
+
+The parser discriminates in O(1) on the presence of an underscore.
+
+### Recognition
+
+A reference entry is recognized only inside a document of type `references`,
+detected by filename (`references.md` or a file inside a `references/`
+directory) or by the `<!-- markspec:references -->` document directive.
+
+Outside of this context, a bullet with a slug in brackets is not parsed as a
+reference entry.
+
+### ULID
+
+Reference entries have **no ULID**. The slug is the canonical identifier and is
+stable by construction — cited works have canonical names assigned by their
+publishing authority. The `Id` attribute is forbidden on a reference entry.
+
+### Core attributes
+
+| Attribute       | Required  | Description                                                        |
+| --------------- | --------- | ------------------------------------------------------------------ |
+| `URI`           | see below | Canonical resource identifier (URN, DOI, ISBN…)                    |
+| `URL`           | see below | Web locator (HTTP/HTTPS)                                           |
+| `Document`      | no        | Full formal bibliographic citation. Falls back to title if absent. |
+| `Superseded-by` | no        | Slug of the reference that replaces this one                       |
+| `Labels`        | no        | Free-form tags (inherited from Entry base)                         |
+
+**At least one of `URI` or `URL` must be present.** A reference entry without
+any external identifier is not usable and is rejected.
+
+**Model fallback**: the `entry.uri` field exposed to consumers is computed as
+`raw.URI ?? raw.URL`. When only `URL` is provided, the model exposes it as `uri`
+because a URL is technically a URI per RFC 3986. This ensures that every valid
+reference entry has an identifier, simplifying cross-registry tooling.
+
+**Document fallback**: when `Document` is absent, the title serves as the formal
+citation. Authors use `Document` only when the title diverges from the formal
+citation (for example, a short human-readable title plus a formal citation with
+edition and year).
+
+### Examples
+
+Standard with URN and URL:
+
+```markdown
+- [ISO-26262-6] ISO 26262 Part 6
+
+  Road vehicles — Functional safety — Part 6: Product development at the
+  software level. Defines requirements for software unit design, implementation,
+  and verification across ASIL levels A through D.
+
+  URI: urn:iso:std:iso:26262:-6:ed-2\
+  URL: https://www.iso.org/standard/68383.html
+```
+
+Regulation with URL only (no official URN exists):
+
+```markdown
+- [UNECE-R155] UNECE Regulation No. 155
+
+  Cybersecurity and cybersecurity management system approval.
+
+  URL:
+  https://unece.org/transport/documents/2021/03/standards/un-regulation-no-155
+```
+
+Book with ISBN URN:
+
+```markdown
+- [KNUTH-TAOCP-1] The Art of Computer Programming, Vol. 1
+
+  Fundamental algorithms. Classic reference on computer science algorithms by
+  Donald Knuth.
+
+  URI: urn:isbn:978-0-201-89683-4
+```
+
+Minimal stub (valid but discouraged):
+
+```markdown
+- [RFC-2119] RFC 2119
+
+  URL: https://www.rfc-editor.org/rfc/rfc2119
+```
+
+### Validation rules (errors)
+
+1. Display ID matches the reference slug regex.
+2. Title is present and non-empty.
+3. At least one of `URI` or `URL` is present.
+4. `URI` and `URL` are syntactically well-formed (RFC 3986 minimal check).
+5. Slug is unique within the resolution scope (local project plus registry
+   chain).
+6. `Superseded-by` points to a reference entry that exists in the resolution
+   scope.
+
+Reference entries are an explicit exception to the Entry base rule that requires
+a body paragraph. A minimal reference entry may consist of only a display ID, a
+title, and a `URI` or `URL`.
+
+### Style guide recommendations (warnings)
+
+1. Body contains a substantive abstract of 1 to 3 sentences describing the
+   intent and scope of the cited publication.
+2. `URI` is explicit when the slug corresponds to a standard with an official
+   URN (ISO, IETF, ISBN, DOI).
+3. `Document` is explicit when the title diverges from the formal bibliographic
+   citation.
+
+---
+
+## Consequences
+
+### Core stays minimal
+
+The core specification defines:
+
+- The entry block grammar (shared).
+- The `Labels` universal attribute.
+- The spec display ID regex and the ULID format.
+- The reference slug regex and bibliographic attributes.
+- The validation rules listed above.
+
+It does **not** define concrete type vocabularies, traceability graph
+constraints, or domain-specific attributes. These are the responsibility of
+profiles.
+
+### Fast Track becomes a profile
+
+The automotive V-model vocabulary (STK, SYS, SRS, SAD, ICD, VAL, SIT, SWT) and
+its traceability rules move from the core specification to a
+`fast-track-profile` or similar profile document. Existing Fast Track projects
+continue to work by declaring this profile. New projects targeting other domains
+(DO-178C, IEC 62304, EN 50128) declare their own profile.
+
+### Registry chain applies uniformly
+
+Both spec and reference entries can be imported from an external project via the
+registry chain. The import mechanism is the same for both families. The
+distinction between the families is about their **role** (canonical declaration
+vs. bibliographic notice), not about whether they are local or external.
+
+### Element entries deferred
+
+A third family for system elements (components, units, interfaces, hardware
+items) is anticipated but defined in a subsequent ADR. This ADR focuses on spec
+and reference entries, which have stable definitions and existing tooling.
+
+### Migration from ADR-001
+
+- Existing spec entries in Fast Track projects remain valid. The display ID
+  regex is a relaxation of what ADR-001 allowed (TYPE up to 6 characters instead
+  of 2+, explicit subdomain support, NNNN up to 6 digits).
+- Existing reference entries in RefHub remain valid. The slug regex is
+  compatible with the existing convention of uppercase hyphenated slugs.
+- The `Status` attribute on reference entries (ADR-001 referenced) is removed in
+  favor of `Labels` for withdrawn/superseded/draft classification.
+- The `Derived-from` attribute on reference entries is removed. The relation
+  between standards is captured in prose or labels, not as a structural
+  attribute.
+- The new `URI` attribute is introduced on reference entries to support
+  canonical identifiers beyond web URLs.
+
+### Open points
+
+- **Traceability direction rules** (MSL-T002, MSL-T007) become
+  profile-parameterized. Their core definitions shift from "SRS → SYS → STK" to
+  "edges declared by the loaded profile". This is a separate concern to be
+  addressed when profiles are specified.
+- **Element entry family** is deferred to a subsequent ADR.
+- **Profile document format** is deferred to a subsequent ADR.

--- a/docs/adr/entry-model-diagram_1.md
+++ b/docs/adr/entry-model-diagram_1.md
@@ -1,0 +1,483 @@
+# MarkSpec Entry Model — Class Diagram
+
+> Reference diagram for [ADR-002 — Entry Model](./adr-002-entry-model.md).
+> Monochrome, colorblind-safe, aligned with ADR-001 Annex A.
+
+## Diagram
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1280 1420" font-family="'IBM Plex Sans', Arial, sans-serif">
+  <style>
+    .title { font-size: 18px; font-weight: 600; }
+    .subtitle { font-size: 11px; fill: #555; font-style: italic; }
+    .class-name { font-size: 14px; font-weight: 700; }
+    .class-note { font-size: 10px; fill: #555; font-style: italic; }
+    .section { font-size: 10px; font-weight: 600; fill: #555; font-style: italic; }
+    .attr { font-size: 11px; font-family: 'IBM Plex Mono', 'Courier New', monospace; }
+    .attr-inf { font-size: 11px; font-family: 'IBM Plex Mono', 'Courier New', monospace; fill: #333; }
+    .attr-gen { font-size: 11px; font-family: 'IBM Plex Mono', 'Courier New', monospace; fill: #888; }
+    .edge-label { font-size: 10px; font-family: 'IBM Plex Mono', 'Courier New', monospace; fill: #000; }
+    .card { font-size: 9px; font-family: 'IBM Plex Mono', 'Courier New', monospace; fill: #555; }
+    .legend-text { font-size: 10px; fill: #333; }
+    .legend-mono { font-size: 10px; font-family: 'IBM Plex Mono', 'Courier New', monospace; }
+    .box { fill: #FFFFFF; stroke: #000000; stroke-width: 1.5; }
+    .sep { stroke: #000000; stroke-width: 0.75; }
+    .arrow { stroke: #000000; stroke-width: 1.5; fill: none; }
+  </style>
+
+<defs>
+    <marker id="arrow-head" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#000"/>
+    </marker>
+  </defs>
+
+<!-- Title -->
+
+<text x="640" y="38" text-anchor="middle" class="title">MarkSpec Entry
+Model</text>
+<text x="640" y="58" text-anchor="middle" class="subtitle">Core attributes and
+traceability relations — ADR-002 — 4 families</text>
+
+<!-- Layout: 2x2 grid
+       Spec (top-left)       Test (top-right)
+       Reference (bot-left)  Element (bot-right)
+  -->
+
+<!-- SPEC class box -->
+<g>
+    <rect x="60" y="110" width="290" height="400" class="box" rx="2"/>
+    <text x="205" y="132" text-anchor="middle" class="class-name">Spec</text>
+    <text x="205" y="148" text-anchor="middle" class="class-note">A declaration the project formulates:</text>
+    <text x="205" y="162" text-anchor="middle" class="class-note">requirement, architecture, decision, hazard</text>
+    <line x1="60" y1="172" x2="350" y2="172" class="sep"/>
+    <text x="72" y="188" class="section">« identity »</text>
+    <text x="72" y="204" class="attr">+ Spec-id : ULID</text>
+    <line x1="60" y1="214" x2="350" y2="214" class="sep"/>
+    <text x="72" y="230" class="section">« traceability — authored »</text>
+    <text x="72" y="246" class="attr">+ Derived-from : Spec [0..*]</text>
+    <text x="72" y="262" class="attr">+ Satisfies : Spec [0..*]</text>
+    <text x="72" y="278" class="attr">+ References : Reference [0..*]</text>
+    <text x="72" y="294" class="attr">+ Allocated-to : Element [0..*]</text>
+    <line x1="60" y1="304" x2="350" y2="304" class="sep"/>
+    <text x="72" y="320" class="section">« traceability — generated »</text>
+    <text x="72" y="336" class="attr-gen"># Derives : Spec [0..*]</text>
+    <text x="72" y="352" class="attr-gen"># Satisfied-by : Spec [0..*]</text>
+    <text x="72" y="368" class="attr-gen"># Realized-by : Element [0..*]</text>
+    <text x="72" y="384" class="attr-gen"># Verified-by : Test [0..*]</text>
+    <line x1="60" y1="394" x2="350" y2="394" class="sep"/>
+    <text x="72" y="410" class="section">« classification »</text>
+    <text x="72" y="426" class="attr">+ Labels : string [0..*]</text>
+  </g>
+
+<!-- TEST class box -->
+<g>
+    <rect x="930" y="110" width="290" height="400" class="box" rx="2"/>
+    <text x="1075" y="132" text-anchor="middle" class="class-name">Test</text>
+    <text x="1075" y="148" text-anchor="middle" class="class-note">A verification — executable or manual.</text>
+    <text x="1075" y="162" text-anchor="middle" class="class-note">Specifies behavior + has execution lifecycle.</text>
+    <line x1="930" y1="172" x2="1220" y2="172" class="sep"/>
+    <text x="942" y="188" class="section">« identity »</text>
+    <text x="942" y="204" class="attr">+ Test-id : ULID</text>
+    <line x1="930" y1="214" x2="1220" y2="214" class="sep"/>
+    <text x="942" y="230" class="section">« classification »</text>
+    <text x="942" y="246" class="attr">+ Level : {unit, integration,</text>
+    <text x="1026" y="262" class="attr">system, acceptance}</text>
+    <text x="942" y="278" class="attr">+ Labels : string [0..*]</text>
+    <line x1="930" y1="288" x2="1220" y2="288" class="sep"/>
+    <text x="942" y="304" class="section">« location »</text>
+    <text x="942" y="320" class="attr-inf">~ Source : path</text>
+    <line x1="930" y1="330" x2="1220" y2="330" class="sep"/>
+    <text x="942" y="346" class="section">« traceability — authored »</text>
+    <text x="942" y="362" class="attr">+ Verifies : Spec [0..*]</text>
+    <text x="942" y="378" class="attr">+ Tests : Element [0..*]</text>
+  </g>
+
+<!-- REFERENCE class box -->
+<g>
+    <rect x="60" y="700" width="290" height="260" class="box" rx="2"/>
+    <text x="205" y="722" text-anchor="middle" class="class-name">Reference</text>
+    <text x="205" y="738" text-anchor="middle" class="class-note">An external bibliographic citation:</text>
+    <text x="205" y="752" text-anchor="middle" class="class-note">standard, regulation, paper, contract</text>
+    <line x1="60" y1="762" x2="350" y2="762" class="sep"/>
+    <text x="72" y="778" class="section">« identity »</text>
+    <text x="72" y="794" class="attr">+ Reference-id : URI</text>
+    <line x1="60" y1="804" x2="350" y2="804" class="sep"/>
+    <text x="72" y="820" class="section">« metadata »</text>
+    <text x="72" y="836" class="attr">+ Url : URL</text>
+    <text x="72" y="852" class="attr">+ Document : string</text>
+    <text x="72" y="868" class="attr">+ Superseded-by :</text>
+    <text x="154" y="884" class="attr">Reference [0..1]</text>
+    <text x="72" y="900" class="attr">+ Labels : string [0..*]</text>
+    <line x1="60" y1="910" x2="350" y2="910" class="sep"/>
+    <text x="72" y="926" class="section">« traceability — generated »</text>
+    <text x="72" y="942" class="attr-gen"># Cited-by : Entry [0..*]</text>
+  </g>
+
+<!-- ELEMENT class box -->
+<g>
+    <rect x="930" y="600" width="290" height="540" class="box" rx="2"/>
+    <text x="1075" y="622" text-anchor="middle" class="class-name">Element</text>
+    <text x="1075" y="638" text-anchor="middle" class="class-note">A tracked material entity: code unit, build</text>
+    <text x="1075" y="652" text-anchor="middle" class="class-note">artifact, dependency, or hardware</text>
+    <line x1="930" y1="662" x2="1220" y2="662" class="sep"/>
+    <text x="942" y="678" class="section">« identity »</text>
+    <text x="942" y="694" class="attr">+ Element-id : ULID</text>
+    <text x="942" y="710" class="attr">+ External-id : URI [0..*]</text>
+    <line x1="930" y1="720" x2="1220" y2="720" class="sep"/>
+    <text x="942" y="736" class="section">« classification »</text>
+    <text x="942" y="752" class="attr">+ Kind : {item, artifact,</text>
+    <text x="1026" y="768" class="attr">dependency, unit}</text>
+    <text x="942" y="784" class="attr">+ Labels : string [0..*]</text>
+    <line x1="930" y1="794" x2="1220" y2="794" class="sep"/>
+    <text x="942" y="810" class="section">« location »</text>
+    <text x="942" y="826" class="attr-inf">~ Source : path</text>
+    <line x1="930" y1="836" x2="1220" y2="836" class="sep"/>
+    <text x="942" y="852" class="section">« traceability — authored »</text>
+    <text x="942" y="868" class="attr">+ Part-of : Element [0..1]</text>
+    <text x="942" y="884" class="attr">+ Realizes : Spec [0..*]</text>
+    <text x="942" y="900" class="attr">+ Depends-on : Element [0..*]</text>
+    <text x="942" y="916" class="attr-inf">~ Generated-from :</text>
+    <text x="1026" y="932" class="attr-inf">path | Element [0..*]</text>
+    <line x1="930" y1="942" x2="1220" y2="942" class="sep"/>
+    <text x="942" y="958" class="section">« traceability — generated »</text>
+    <text x="942" y="974" class="attr-gen"># Contains : Element [0..*]</text>
+    <text x="942" y="990" class="attr-gen"># Used-by : Element [0..*]</text>
+    <text x="942" y="1006" class="attr-gen"># Allocated : Spec [0..*]</text>
+    <text x="942" y="1022" class="attr-gen"># Tested-by : Test [0..*]</text>
+  </g>
+
+<!-- EDGES -->
+
+<!-- Spec self-loops: Derived-from and Satisfies -->
+<g>
+    <path d="M 60 135 C -10 100, -10 175, 60 165" class="arrow" marker-end="url(#arrow-head)"/>
+    <text x="-5" y="125" class="edge-label" text-anchor="end">Derived-from</text>
+    <text x="-5" y="138" class="card" text-anchor="end">0..*</text>
+  </g>
+
+<g>
+    <path d="M 60 260 C -10 230, -10 295, 60 290" class="arrow" marker-end="url(#arrow-head)"/>
+    <text x="-5" y="250" class="edge-label" text-anchor="end">Satisfies</text>
+    <text x="-5" y="263" class="card" text-anchor="end">0..*</text>
+  </g>
+
+<!-- Test.Verifies → Spec (test specifies what spec is verified) -->
+<g>
+    <path d="M 930 360 L 350 360" class="arrow" marker-end="url(#arrow-head)"/>
+    <text x="640" y="352" class="edge-label" text-anchor="middle">Verifies</text>
+    <text x="640" y="366" class="card" text-anchor="middle">0..*</text>
+  </g>
+
+<!-- Spec.Allocated-to → Element -->
+<g>
+    <path d="M 350 290 L 930 710" class="arrow" marker-end="url(#arrow-head)"/>
+    <text x="640" y="485" class="edge-label" text-anchor="middle">Allocated-to</text>
+    <text x="640" y="499" class="card" text-anchor="middle">0..*</text>
+  </g>
+
+<!-- Element.Realizes → Spec -->
+<g>
+    <path d="M 930 885 L 350 280" class="arrow" marker-end="url(#arrow-head)"/>
+    <text x="580" y="590" class="edge-label" text-anchor="middle">Realizes</text>
+    <text x="580" y="604" class="card" text-anchor="middle">0..*</text>
+  </g>
+
+<!-- Test.Tests → Element (test → unit) -->
+<g>
+    <path d="M 1075 510 L 1075 600" class="arrow" marker-end="url(#arrow-head)"/>
+    <text x="1085" y="545" class="edge-label">Tests</text>
+    <text x="1085" y="558" class="card">0..*</text>
+  </g>
+
+<!-- Spec.References → Reference -->
+<g>
+    <path d="M 205 510 L 205 700" class="arrow" marker-end="url(#arrow-head)"/>
+    <text x="215" y="595" class="edge-label">References</text>
+    <text x="215" y="608" class="card">0..*</text>
+  </g>
+
+<!-- Element self-loops -->
+<g>
+    <path d="M 1220 705 C 1275 670, 1275 740, 1220 735" class="arrow" marker-end="url(#arrow-head)"/>
+    <text x="1225" y="695" class="edge-label">Part-of</text>
+    <text x="1235" y="708" class="card">0..1</text>
+  </g>
+  <g>
+    <path d="M 1220 900 C 1275 865, 1275 935, 1220 930" class="arrow" marker-end="url(#arrow-head)"/>
+    <text x="1225" y="890" class="edge-label">Depends-on</text>
+    <text x="1235" y="903" class="card">0..*</text>
+  </g>
+  <g>
+    <path d="M 1220 920 C 1275 965, 1275 895, 1220 900" class="arrow" marker-end="url(#arrow-head)"/>
+    <text x="1225" y="960" class="edge-label">Generated-from</text>
+    <text x="1235" y="973" class="card">0..*</text>
+  </g>
+
+<!-- LEGEND -->
+<g transform="translate(60, 1180)">
+    <rect x="0" y="0" width="1160" height="220" class="box" rx="2"/>
+    <text x="15" y="22" class="section">« legend »</text>
+    <line x1="0" y1="32" x2="1160" y2="32" class="sep"/>
+
+    <!-- Column 1: Attribute origin -->
+    <text x="15" y="52" class="section">Attribute origin</text>
+    <text x="15" y="72" class="legend-mono">+</text>
+    <text x="40" y="72" class="legend-text"><tspan font-weight="700">Authored</tspan> — written by the author, committed to repo</text>
+    <text x="15" y="90" class="legend-mono">~</text>
+    <text x="40" y="90" class="legend-text"><tspan font-weight="700">Inferred</tspan> — pre-filled by tooling from convention,</text>
+    <text x="40" y="104" class="legend-text">author-overridable, committed to repo</text>
+    <text x="15" y="122" class="legend-mono">#</text>
+    <text x="40" y="122" class="legend-text"><tspan font-weight="700">Generated</tspan> — computed at build time, never committed</text>
+
+    <text x="15" y="150" class="section">Cardinality</text>
+    <text x="15" y="170" class="legend-mono">[0..*]</text>
+    <text x="60" y="170" class="legend-text">Optional, repeatable</text>
+    <text x="15" y="186" class="legend-mono">[0..1]</text>
+    <text x="60" y="186" class="legend-text">Optional, single</text>
+    <text x="15" y="202" class="legend-mono">(none)</text>
+    <text x="60" y="202" class="legend-text">Required</text>
+
+    <line x1="290" y1="40" x2="290" y2="210" class="sep"/>
+
+    <!-- Column 2: Entry families -->
+    <text x="305" y="52" class="section">Entry families — distinct by identity attribute</text>
+    <text x="305" y="72" class="legend-text"><tspan font-weight="700">Spec</tspan> — a declaration the project formulates (Spec-id)</text>
+    <text x="305" y="88" class="legend-text"><tspan font-weight="700">Test</tspan> — a verification, executable or manual (Test-id)</text>
+    <text x="305" y="104" class="legend-text"><tspan font-weight="700">Element</tspan> — a tracked material entity (Element-id)</text>
+    <text x="305" y="120" class="legend-text"><tspan font-weight="700">Reference</tspan> — an external citation (Reference-id, URI)</text>
+
+    <text x="305" y="148" class="section">Authoring direction</text>
+    <text x="305" y="168" class="legend-text"><tspan font-weight="700">Bottom-up</tspan> (emergent design): Realizes declared on code</text>
+    <text x="305" y="184" class="legend-text"><tspan font-weight="700">Top-down</tspan> (intentional architecture): Allocated-to on Spec</text>
+    <text x="305" y="200" class="legend-text"><tspan font-weight="700">Verification</tspan>: Verifies + Tests on Test (ASPICE SWE.4 BP5)</text>
+
+    <line x1="700" y1="40" x2="700" y2="210" class="sep"/>
+
+    <!-- Column 3: Relations -->
+    <text x="715" y="52" class="section">Traceability relations</text>
+
+    <text x="715" y="72" class="legend-mono">Derived-from</text>
+    <text x="840" y="72" class="legend-text">spec → spec (V-model decomposition)</text>
+
+    <text x="715" y="88" class="legend-mono">Satisfies</text>
+    <text x="840" y="88" class="legend-text">spec → spec (complete fulfillment)</text>
+
+    <text x="715" y="104" class="legend-mono">References</text>
+    <text x="840" y="104" class="legend-text">spec → reference (normative or informative)</text>
+
+    <text x="715" y="120" class="legend-mono">Allocated-to</text>
+    <text x="840" y="120" class="legend-text">spec → element (architect allocates, ASPICE SWE.2)</text>
+
+    <text x="715" y="136" class="legend-mono">Realizes</text>
+    <text x="840" y="136" class="legend-text">element → spec (code realizes — ASPICE SWE.3)</text>
+
+    <text x="715" y="152" class="legend-mono">Verifies</text>
+    <text x="840" y="152" class="legend-text">test → spec (test verifies requirement — SWE.4 BP5)</text>
+
+    <text x="715" y="168" class="legend-mono">Tests</text>
+    <text x="840" y="168" class="legend-text">test → element (test exercises unit — SWE.4 BP5)</text>
+
+    <text x="715" y="184" class="legend-mono">Part-of</text>
+    <text x="840" y="184" class="legend-text">element → element (containment)</text>
+
+    <text x="715" y="200" class="legend-mono">Depends-on</text>
+    <text x="840" y="200" class="legend-text">element → element (usage, SoUP tracking)</text>
+
+</g>
+
+</svg>
+
+## PlantUML source
+
+Canonical source for the diagram.
+
+```plantuml
+@startuml entry-model
+' MarkSpec Entry Model - Core attributes and relations
+' ADR-002 — 4 families (Spec, Test, Element, Reference)
+
+skinparam monochrome true
+skinparam shadowing false
+skinparam defaultFontName Arial
+skinparam defaultFontSize 12
+skinparam backgroundColor #FFFFFF
+skinparam ArrowColor #000000
+skinparam ArrowThickness 1.5
+skinparam classBorderThickness 1.5
+skinparam classBackgroundColor #FFFFFF
+
+skinparam class {
+  AttributeFontSize 11
+  AttributeFontColor #000000
+}
+
+title MarkSpec Entry Model — Four Families
+
+class Spec {
+  == identity ==
+  + Spec-id : ULID
+  == traceability (authored) ==
+  + Derived-from : Spec [0..*]
+  + Satisfies : Spec [0..*]
+  + References : Reference [0..*]
+  + Allocated-to : Element [0..*]
+  == traceability (generated) ==
+  # Derives : Spec [0..*]
+  # Satisfied-by : Spec [0..*]
+  # Realized-by : Element [0..*]
+  # Verified-by : Test [0..*]
+  == classification ==
+  + Labels : string [0..*]
+}
+
+class Test {
+  == identity ==
+  + Test-id : ULID
+  == classification ==
+  + Level : {unit, integration, system, acceptance}
+  + Labels : string [0..*]
+  == location ==
+  ~ Source : path
+  == traceability (authored) ==
+  + Verifies : Spec [0..*]
+  + Tests : Element [0..*]
+}
+
+class Element {
+  == identity ==
+  + Element-id : ULID
+  + External-id : URI [0..*]
+  == classification ==
+  + Kind : {item, artifact, dependency, unit}
+  + Labels : string [0..*]
+  == location ==
+  ~ Source : path
+  == traceability (authored) ==
+  + Part-of : Element [0..1]
+  + Realizes : Spec [0..*]
+  + Depends-on : Element [0..*]
+  ~ Generated-from : path | Element [0..*]
+  == traceability (generated) ==
+  # Contains : Element [0..*]
+  # Used-by : Element [0..*]
+  # Allocated : Spec [0..*]
+  # Tested-by : Test [0..*]
+}
+
+class Reference {
+  == identity ==
+  + Reference-id : URI
+  == metadata ==
+  + Url : URL
+  + Document : string
+  + Superseded-by : Reference [0..1]
+  + Labels : string [0..*]
+  == traceability (generated) ==
+  # Cited-by : Entry [0..*]
+}
+
+' Spec -> Spec
+Spec "child" --> "parent\n0..*" Spec : Derived-from
+Spec "child" --> "parent\n0..*" Spec : Satisfies
+
+' Spec -> Reference
+Spec "0..*" --> "0..*" Reference : References
+
+' Spec -> Element (top-down allocation)
+Spec "0..*" --> "0..*" Element : Allocated-to
+
+' Test -> Spec (verifies)
+Test "0..*" --> "0..*" Spec : Verifies
+
+' Test -> Element (tests)
+Test "0..*" --> "0..*" Element : Tests
+
+' Element -> Spec (bottom-up realization)
+Element "0..*" --> "0..*" Spec : Realizes
+
+' Element -> Element
+Element "child" --> "parent\n0..1" Element : Part-of
+Element "0..*" --> "0..*" Element : Depends-on
+Element "0..*" --> "0..*" Element : Generated-from
+
+legend bottom
+  |= Symbol |= Meaning |
+  | + | Authored — written by the author, committed to repo |
+  | ~ | Inferred — pre-filled by tooling from convention, author-overridable |
+  | # | Generated — computed at build time, never committed |
+  | [0..*] | Optional, repeatable |
+  | [0..1] | Optional, single |
+  | no cardinality | Required |
+endlegend
+
+@enduml
+```
+
+## Summary
+
+The core model defines four entry families — **Spec**, **Test**, **Element**,
+and **Reference** — each identified by a dedicated identity attribute
+(`Spec-id`, `Test-id`, `Element-id`, `Reference-id`). Every entry carries
+exactly one of these, which disambiguates its family without relying on display
+ID regex or document context.
+
+### Attribute origin
+
+Attributes fall into three categories depending on how they are populated:
+
+- **`+` Authored** — written by the author, committed to the repository.
+- **`~` Inferred** — pre-filled by `markspec format` from project conventions
+  (file paths, directory structure, generation annotations, profile-defined TYPE
+  → Level mapping). Committed to the repository and author-overridable when the
+  convention does not fit.
+- **`#` Generated** — computed by tooling from the registry at build time, never
+  committed.
+
+### Traceability relations at a glance
+
+| Relation         | From → To                 | Purpose                                        | ASPICE coverage       |
+| ---------------- | ------------------------- | ---------------------------------------------- | --------------------- |
+| `Derived-from`   | spec → spec               | V-model decomposition (broad)                  | SWE.1, SYS.2          |
+| `Satisfies`      | spec → spec               | Complete fulfillment of a parent               | —                     |
+| `References`     | spec → reference          | External source (normative, regulatory)        | SWE.1                 |
+| `Allocated-to`   | spec → element            | Architect allocates spec to element (top-down) | SWE.2 BP2             |
+| `Realizes`       | element → spec            | Code realizes a requirement (bottom-up)        | SWE.3 BP5             |
+| `Verifies`       | test → spec               | Test verifies a requirement                    | SWE.4 BP5             |
+| `Tests`          | test → element            | Test exercises a unit                          | SWE.4 BP5             |
+| `Part-of`        | element → element         | Containment hierarchy                          | SWE.2, SWE.3          |
+| `Depends-on`     | element → element         | Usage, call, import, SoUP tracking             | SWE.3, IEC 62304 SoUP |
+| `Generated-from` | element → path \| element | Tool-generated provenance                      | ISO 26262 TCL         |
+
+### Two authoring directions
+
+Traceability supports two engineering modes that coexist:
+
+- **Bottom-up (emergent design)** — the developer declares what the code does.
+  `Realizes` is written on the Element as the code is implemented.
+- **Top-down (intentional architecture)** — the architect declares who must
+  implement what. `Allocated-to` is written on the Spec before the code exists.
+
+When both are present, tooling verifies consistency: a Spec allocated to Element
+A should also be realized by Element A.
+
+### Core vocabularies
+
+**Element Kind** (4 values): `item`, `artifact`, `dependency`, `unit`.
+
+**Test Level** (4 values): `unit`, `integration`, `system`, `acceptance` —
+aligned with ISO/IEC/IEEE 29119 and recognized across all safety-critical
+standards (ASPICE, DO-178C, IEC 62304, EN 50128).
+
+Both vocabularies are **extensible by profile** with domain-specific values
+(automotive: `ecu`, `sensor`; aerospace: `lrm`, `csci`; security:
+`penetration-test`, etc.).
+
+### Profile mappings
+
+Profiles define how domain-specific test activities map to the core `Level`
+vocabulary. See ADR-002 Part 4 for an illustrative mapping table covering ASPICE
+4.0, DO-178C, IEC 62304, and ISO/IEC/IEEE 29119.
+
+## Related documents
+
+- [ADR-001 — Documentation Format](./adr-001-documentation-format.md)
+- [ADR-002 — Entry Model](./adr-002-entry-model.md)

--- a/docs/adr/entry-model.svg
+++ b/docs/adr/entry-model.svg
@@ -1,0 +1,464 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 1280 1420"
+  font-family="'IBM Plex Sans', Arial, sans-serif"
+>
+  <style>.title { font-size: 18px; font-weight: 600; }
+    .subtitle { font-size: 11px; fill: #555; font-style: italic; }
+    .class-name { font-size: 14px; font-weight: 700; }
+    .class-note { font-size: 10px; fill: #555; font-style: italic; }
+    .section { font-size: 10px; font-weight: 600; fill: #555; font-style: italic; }
+    .attr { font-size: 11px; font-family: 'IBM Plex Mono', 'Courier New', monospace; }
+    .attr-inf { font-size: 11px; font-family: 'IBM Plex Mono', 'Courier New', monospace; fill: #333; }
+    .attr-gen { font-size: 11px; font-family: 'IBM Plex Mono', 'Courier New', monospace; fill: #888; }
+    .edge-label { font-size: 10px; font-family: 'IBM Plex Mono', 'Courier New', monospace; fill: #000; }
+    .card { font-size: 9px; font-family: 'IBM Plex Mono', 'Courier New', monospace; fill: #555; }
+    .legend-text { font-size: 10px; fill: #333; }
+    .legend-mono { font-size: 10px; font-family: 'IBM Plex Mono', 'Courier New', monospace; }
+    .box { fill: #FFFFFF; stroke: #000000; stroke-width: 1.5; }
+    .sep { stroke: #000000; stroke-width: 0.75; }
+    .arrow { stroke: #000000; stroke-width: 1.5; fill: none; }</style>
+
+  <defs>
+    <marker
+      id="arrow-head"
+      viewBox="0 0 10 10"
+      refX="9"
+      refY="5"
+      markerWidth="8"
+      markerHeight="8"
+      orient="auto-start-reverse"
+    >
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#000" />
+    </marker>
+  </defs>
+
+  <!-- Title -->
+  <text
+    x="640"
+    y="38"
+    text-anchor="middle"
+    class="title"
+  >MarkSpec Entry Model</text>
+  <text
+    x="640"
+    y="58"
+    text-anchor="middle"
+    class="subtitle"
+  >Core attributes and traceability relations — ADR-002 — 4 families</text>
+
+  <!-- Layout: 2x2 grid
+       Spec (top-left)       Test (top-right)
+       Reference (bot-left)  Element (bot-right)
+  -->
+
+  <!-- SPEC class box -->
+  <g>
+    <rect x="60" y="110" width="290" height="400" class="box" rx="2" />
+    <text x="205" y="132" text-anchor="middle" class="class-name">Spec</text>
+    <text
+      x="205"
+      y="148"
+      text-anchor="middle"
+      class="class-note"
+    >A declaration the project formulates:</text>
+    <text
+      x="205"
+      y="162"
+      text-anchor="middle"
+      class="class-note"
+    >requirement, architecture, decision, hazard</text>
+    <line x1="60" y1="172" x2="350" y2="172" class="sep" />
+    <text x="72" y="188" class="section">« identity »</text>
+    <text x="72" y="204" class="attr">+ Spec-id : ULID</text>
+    <line x1="60" y1="214" x2="350" y2="214" class="sep" />
+    <text x="72" y="230" class="section">« traceability — authored »</text>
+    <text x="72" y="246" class="attr">+ Derived-from : Spec [0..*]</text>
+    <text x="72" y="262" class="attr">+ Satisfies : Spec [0..*]</text>
+    <text x="72" y="278" class="attr">+ References : Reference [0..*]</text>
+    <text x="72" y="294" class="attr">+ Allocated-to : Element [0..*]</text>
+    <line x1="60" y1="304" x2="350" y2="304" class="sep" />
+    <text x="72" y="320" class="section">« traceability — generated »</text>
+    <text x="72" y="336" class="attr-gen"># Derives : Spec [0..*]</text>
+    <text x="72" y="352" class="attr-gen"># Satisfied-by : Spec [0..*]</text>
+    <text x="72" y="368" class="attr-gen"># Realized-by : Element [0..*]</text>
+    <text x="72" y="384" class="attr-gen"># Verified-by : Test [0..*]</text>
+    <line x1="60" y1="394" x2="350" y2="394" class="sep" />
+    <text x="72" y="410" class="section">« classification »</text>
+    <text x="72" y="426" class="attr">+ Labels : string [0..*]</text>
+  </g>
+
+  <!-- TEST class box -->
+  <g>
+    <rect x="930" y="110" width="290" height="400" class="box" rx="2" />
+    <text x="1075" y="132" text-anchor="middle" class="class-name">Test</text>
+    <text
+      x="1075"
+      y="148"
+      text-anchor="middle"
+      class="class-note"
+    >A verification — executable or manual.</text>
+    <text
+      x="1075"
+      y="162"
+      text-anchor="middle"
+      class="class-note"
+    >Specifies behavior + has execution lifecycle.</text>
+    <line x1="930" y1="172" x2="1220" y2="172" class="sep" />
+    <text x="942" y="188" class="section">« identity »</text>
+    <text x="942" y="204" class="attr">+ Test-id : ULID</text>
+    <line x1="930" y1="214" x2="1220" y2="214" class="sep" />
+    <text x="942" y="230" class="section">« classification »</text>
+    <text x="942" y="246" class="attr">+ Level : {unit, integration,</text>
+    <text x="1026" y="262" class="attr">system, acceptance}</text>
+    <text x="942" y="278" class="attr">+ Labels : string [0..*]</text>
+    <line x1="930" y1="288" x2="1220" y2="288" class="sep" />
+    <text x="942" y="304" class="section">« location »</text>
+    <text x="942" y="320" class="attr-inf">~ Source : path</text>
+    <line x1="930" y1="330" x2="1220" y2="330" class="sep" />
+    <text x="942" y="346" class="section">« traceability — authored »</text>
+    <text x="942" y="362" class="attr">+ Verifies : Spec [0..*]</text>
+    <text x="942" y="378" class="attr">+ Tests : Element [0..*]</text>
+  </g>
+
+  <!-- REFERENCE class box -->
+  <g>
+    <rect x="60" y="700" width="290" height="260" class="box" rx="2" />
+    <text
+      x="205"
+      y="722"
+      text-anchor="middle"
+      class="class-name"
+    >Reference</text>
+    <text
+      x="205"
+      y="738"
+      text-anchor="middle"
+      class="class-note"
+    >An external bibliographic citation:</text>
+    <text
+      x="205"
+      y="752"
+      text-anchor="middle"
+      class="class-note"
+    >standard, regulation, paper, contract</text>
+    <line x1="60" y1="762" x2="350" y2="762" class="sep" />
+    <text x="72" y="778" class="section">« identity »</text>
+    <text x="72" y="794" class="attr">+ Reference-id : URI</text>
+    <line x1="60" y1="804" x2="350" y2="804" class="sep" />
+    <text x="72" y="820" class="section">« metadata »</text>
+    <text x="72" y="836" class="attr">+ Url : URL</text>
+    <text x="72" y="852" class="attr">+ Document : string</text>
+    <text x="72" y="868" class="attr">+ Superseded-by :</text>
+    <text x="154" y="884" class="attr">Reference [0..1]</text>
+    <text x="72" y="900" class="attr">+ Labels : string [0..*]</text>
+    <line x1="60" y1="910" x2="350" y2="910" class="sep" />
+    <text x="72" y="926" class="section">« traceability — generated »</text>
+    <text x="72" y="942" class="attr-gen"># Cited-by : Entry [0..*]</text>
+  </g>
+
+  <!-- ELEMENT class box -->
+  <g>
+    <rect x="930" y="600" width="290" height="540" class="box" rx="2" />
+    <text
+      x="1075"
+      y="622"
+      text-anchor="middle"
+      class="class-name"
+    >Element</text>
+    <text
+      x="1075"
+      y="638"
+      text-anchor="middle"
+      class="class-note"
+    >A tracked material entity: code unit, build</text>
+    <text
+      x="1075"
+      y="652"
+      text-anchor="middle"
+      class="class-note"
+    >artifact, dependency, or hardware</text>
+    <line x1="930" y1="662" x2="1220" y2="662" class="sep" />
+    <text x="942" y="678" class="section">« identity »</text>
+    <text x="942" y="694" class="attr">+ Element-id : ULID</text>
+    <text x="942" y="710" class="attr">+ External-id : URI [0..*]</text>
+    <line x1="930" y1="720" x2="1220" y2="720" class="sep" />
+    <text x="942" y="736" class="section">« classification »</text>
+    <text x="942" y="752" class="attr">+ Kind : {item, artifact,</text>
+    <text x="1026" y="768" class="attr">dependency, unit}</text>
+    <text x="942" y="784" class="attr">+ Labels : string [0..*]</text>
+    <line x1="930" y1="794" x2="1220" y2="794" class="sep" />
+    <text x="942" y="810" class="section">« location »</text>
+    <text x="942" y="826" class="attr-inf">~ Source : path</text>
+    <line x1="930" y1="836" x2="1220" y2="836" class="sep" />
+    <text x="942" y="852" class="section">« traceability — authored »</text>
+    <text x="942" y="868" class="attr">+ Part-of : Element [0..1]</text>
+    <text x="942" y="884" class="attr">+ Realizes : Spec [0..*]</text>
+    <text x="942" y="900" class="attr">+ Depends-on : Element [0..*]</text>
+    <text x="942" y="916" class="attr-inf">~ Generated-from :</text>
+    <text x="1026" y="932" class="attr-inf">path | Element [0..*]</text>
+    <line x1="930" y1="942" x2="1220" y2="942" class="sep" />
+    <text x="942" y="958" class="section">« traceability — generated »</text>
+    <text x="942" y="974" class="attr-gen"># Contains : Element [0..*]</text>
+    <text x="942" y="990" class="attr-gen"># Used-by : Element [0..*]</text>
+    <text x="942" y="1006" class="attr-gen"># Allocated : Spec [0..*]</text>
+    <text x="942" y="1022" class="attr-gen"># Tested-by : Test [0..*]</text>
+  </g>
+
+  <!-- EDGES -->
+
+  <!-- Spec self-loops: Derived-from and Satisfies -->
+  <g>
+    <path
+      d="M 60 135 C -10 100, -10 175, 60 165"
+      class="arrow"
+      marker-end="url(#arrow-head)"
+    />
+    <text
+      x="-5"
+      y="125"
+      class="edge-label"
+      text-anchor="end"
+    >Derived-from</text>
+    <text x="-5" y="138" class="card" text-anchor="end">0..*</text>
+  </g>
+
+  <g>
+    <path
+      d="M 60 260 C -10 230, -10 295, 60 290"
+      class="arrow"
+      marker-end="url(#arrow-head)"
+    />
+    <text x="-5" y="250" class="edge-label" text-anchor="end">Satisfies</text>
+    <text x="-5" y="263" class="card" text-anchor="end">0..*</text>
+  </g>
+
+  <!-- Test.Verifies → Spec (test specifies what spec is verified) -->
+  <g>
+    <path d="M 930 360 L 350 360" class="arrow" marker-end="url(#arrow-head)" />
+    <text
+      x="640"
+      y="352"
+      class="edge-label"
+      text-anchor="middle"
+    >Verifies</text>
+    <text x="640" y="366" class="card" text-anchor="middle">0..*</text>
+  </g>
+
+  <!-- Spec.Allocated-to → Element -->
+  <g>
+    <path d="M 350 290 L 930 710" class="arrow" marker-end="url(#arrow-head)" />
+    <text
+      x="640"
+      y="485"
+      class="edge-label"
+      text-anchor="middle"
+    >Allocated-to</text>
+    <text x="640" y="499" class="card" text-anchor="middle">0..*</text>
+  </g>
+
+  <!-- Element.Realizes → Spec -->
+  <g>
+    <path d="M 930 885 L 350 280" class="arrow" marker-end="url(#arrow-head)" />
+    <text
+      x="580"
+      y="590"
+      class="edge-label"
+      text-anchor="middle"
+    >Realizes</text>
+    <text x="580" y="604" class="card" text-anchor="middle">0..*</text>
+  </g>
+
+  <!-- Test.Tests → Element (test → unit) -->
+  <g>
+    <path
+      d="M 1075 510 L 1075 600"
+      class="arrow"
+      marker-end="url(#arrow-head)"
+    />
+    <text x="1085" y="545" class="edge-label">Tests</text>
+    <text x="1085" y="558" class="card">0..*</text>
+  </g>
+
+  <!-- Spec.References → Reference -->
+  <g>
+    <path d="M 205 510 L 205 700" class="arrow" marker-end="url(#arrow-head)" />
+    <text x="215" y="595" class="edge-label">References</text>
+    <text x="215" y="608" class="card">0..*</text>
+  </g>
+
+  <!-- Element self-loops -->
+  <g>
+    <path
+      d="M 1220 705 C 1275 670, 1275 740, 1220 735"
+      class="arrow"
+      marker-end="url(#arrow-head)"
+    />
+    <text x="1225" y="695" class="edge-label">Part-of</text>
+    <text x="1235" y="708" class="card">0..1</text>
+  </g>
+  <g>
+    <path
+      d="M 1220 900 C 1275 865, 1275 935, 1220 930"
+      class="arrow"
+      marker-end="url(#arrow-head)"
+    />
+    <text x="1225" y="890" class="edge-label">Depends-on</text>
+    <text x="1235" y="903" class="card">0..*</text>
+  </g>
+  <g>
+    <path
+      d="M 1220 920 C 1275 965, 1275 895, 1220 900"
+      class="arrow"
+      marker-end="url(#arrow-head)"
+    />
+    <text x="1225" y="960" class="edge-label">Generated-from</text>
+    <text x="1235" y="973" class="card">0..*</text>
+  </g>
+
+  <!-- LEGEND -->
+  <g transform="translate(60, 1180)">
+    <rect x="0" y="0" width="1160" height="220" class="box" rx="2" />
+    <text x="15" y="22" class="section">« legend »</text>
+    <line x1="0" y1="32" x2="1160" y2="32" class="sep" />
+
+    <!-- Column 1: Attribute origin -->
+    <text x="15" y="52" class="section">Attribute origin</text>
+    <text x="15" y="72" class="legend-mono">+</text>
+    <text x="40" y="72" class="legend-text">
+      <tspan font-weight="700">Authored</tspan>
+      — written by the author, committed to repo
+    </text>
+    <text x="15" y="90" class="legend-mono">~</text>
+    <text x="40" y="90" class="legend-text">
+      <tspan font-weight="700">Inferred</tspan>
+      — pre-filled by tooling from convention,
+    </text>
+    <text
+      x="40"
+      y="104"
+      class="legend-text"
+    >author-overridable, committed to repo</text>
+    <text x="15" y="122" class="legend-mono">#</text>
+    <text x="40" y="122" class="legend-text">
+      <tspan font-weight="700">Generated</tspan>
+      — computed at build time, never committed
+    </text>
+
+    <text x="15" y="150" class="section">Cardinality</text>
+    <text x="15" y="170" class="legend-mono">[0..*]</text>
+    <text x="60" y="170" class="legend-text">Optional, repeatable</text>
+    <text x="15" y="186" class="legend-mono">[0..1]</text>
+    <text x="60" y="186" class="legend-text">Optional, single</text>
+    <text x="15" y="202" class="legend-mono">(none)</text>
+    <text x="60" y="202" class="legend-text">Required</text>
+
+    <line x1="290" y1="40" x2="290" y2="210" class="sep" />
+
+    <!-- Column 2: Entry families -->
+    <text
+      x="305"
+      y="52"
+      class="section"
+    >Entry families — distinct by identity attribute</text>
+    <text x="305" y="72" class="legend-text">
+      <tspan font-weight="700">Spec</tspan>
+      — a declaration the project formulates (Spec-id)
+    </text>
+    <text x="305" y="88" class="legend-text">
+      <tspan font-weight="700">Test</tspan>
+      — a verification, executable or manual (Test-id)
+    </text>
+    <text x="305" y="104" class="legend-text">
+      <tspan font-weight="700">Element</tspan>
+      — a tracked material entity (Element-id)
+    </text>
+    <text x="305" y="120" class="legend-text">
+      <tspan font-weight="700">Reference</tspan>
+      — an external citation (Reference-id, URI)
+    </text>
+
+    <text x="305" y="148" class="section">Authoring direction</text>
+    <text x="305" y="168" class="legend-text">
+      <tspan font-weight="700">Bottom-up</tspan>
+      (emergent design): Realizes declared on code
+    </text>
+    <text x="305" y="184" class="legend-text">
+      <tspan font-weight="700">Top-down</tspan>
+      (intentional architecture): Allocated-to on Spec
+    </text>
+    <text x="305" y="200" class="legend-text">
+      <tspan
+        font-weight="700"
+      >Verification</tspan>: Verifies + Tests on Test (ASPICE SWE.4 BP5)
+    </text>
+
+    <line x1="700" y1="40" x2="700" y2="210" class="sep" />
+
+    <!-- Column 3: Relations -->
+    <text x="715" y="52" class="section">Traceability relations</text>
+
+    <text x="715" y="72" class="legend-mono">Derived-from</text>
+    <text
+      x="840"
+      y="72"
+      class="legend-text"
+    >spec → spec (V-model decomposition)</text>
+
+    <text x="715" y="88" class="legend-mono">Satisfies</text>
+    <text
+      x="840"
+      y="88"
+      class="legend-text"
+    >spec → spec (complete fulfillment)</text>
+
+    <text x="715" y="104" class="legend-mono">References</text>
+    <text
+      x="840"
+      y="104"
+      class="legend-text"
+    >spec → reference (normative or informative)</text>
+
+    <text x="715" y="120" class="legend-mono">Allocated-to</text>
+    <text
+      x="840"
+      y="120"
+      class="legend-text"
+    >spec → element (architect allocates, ASPICE SWE.2)</text>
+
+    <text x="715" y="136" class="legend-mono">Realizes</text>
+    <text
+      x="840"
+      y="136"
+      class="legend-text"
+    >element → spec (code realizes — ASPICE SWE.3)</text>
+
+    <text x="715" y="152" class="legend-mono">Verifies</text>
+    <text
+      x="840"
+      y="152"
+      class="legend-text"
+    >test → spec (test verifies requirement — SWE.4 BP5)</text>
+
+    <text x="715" y="168" class="legend-mono">Tests</text>
+    <text
+      x="840"
+      y="168"
+      class="legend-text"
+    >test → element (test exercises unit — SWE.4 BP5)</text>
+
+    <text x="715" y="184" class="legend-mono">Part-of</text>
+    <text
+      x="840"
+      y="184"
+      class="legend-text"
+    >element → element (containment)</text>
+
+    <text x="715" y="200" class="legend-mono">Depends-on</text>
+    <text
+      x="840"
+      y="200"
+      class="legend-text"
+    >element → element (usage, SoUP tracking)</text>
+  </g>
+</svg>

--- a/docs/spec/language/language.md
+++ b/docs/spec/language/language.md
@@ -403,23 +403,30 @@ Part 1 defines the format — how to write entry blocks and attribute blocks. Th
 part defines the vocabulary — the builtin types, their attributes, and their
 traceability rules.
 
-### 2.1 Typed entries
+### 2.1 Typed entries (Spec family)
 
-An entry whose display ID matches `TYPE_XYZ_NNN[N]` (uppercase letters,
-underscore, 2–12 uppercase letters, underscore, zero-padded number of 3 or 4
-digits starting from `001`) is a typed entry. Typed entries are recognized in
-any MarkSpec file.
+An entry whose display ID matches the spec pattern per ADR-002 is a typed
+**spec** entry. Spec entries are recognized in any MarkSpec file.
 
-Typed entries have two identifiers:
+**Display ID format (ADR-002):**
 
-- **Display ID** — human-readable, in the `[...]` marker. `TYPE` is the entry
-  type. `XYZ` is a 2–12 letter project or domain abbreviation. `NNN[N]` is
-  zero-padded from `001` (3 digits) or `0001` (4 digits), unique within the
-  project.
+- `TYPE` — 2–6 uppercase letters (e.g., `SRS`, `SYS`, `STK`)
+- `DOMAIN` — 3–8 uppercase alphanumeric, first char uppercase (e.g., `BRK`,
+  `SENSOR`)
+- `SUBDOMAIN` — optional, same as DOMAIN
+- `NNNN` — 3–6 decimal digits, must be > 0 (e.g., `001`, `0042`)
+
+Example: `SRS_BRK_0001`, `SYS_SENSOR_DETECTOR_0042`
+
+Spec entries have two identifiers:
+
+- **Display ID** — human-readable, in the `[...]` marker. Used for
+  cross-document references and traceability matrices.
 - **ULID** — universally unique, in the `Id:` attribute. Formatted as
-  `TYPE_ULID` (e.g., `SRS_01HGW2Q8MNP3`). The ULID ensures global uniqueness
-  across projects and survives renumbering. Mandatory. Assigned by tooling,
-  never hand-authored. Once assigned, it never changes.
+  `TYPE_ALPHANUMERIC` (26 alphanumeric chars, e.g.,
+  `SRS_00000000000000000000000001`). The ULID ensures global uniqueness across
+  projects and survives renumbering. Mandatory. Assigned by tooling, never
+  hand-authored. Once assigned, it never changes.
 
 **Builtin types:**
 
@@ -437,14 +444,16 @@ Typed entries have two identifiers:
 Non-builtin types are valid — tooling validates entry format but not
 traceability direction or level.
 
-### 2.2 Typed entry attributes
+### 2.2 Spec entry attributes (ADR-002)
 
-| Attribute      | Required | Format                                  |
-| -------------- | -------- | --------------------------------------- |
-| `Id`           | yes      | `TYPE_ULID`                             |
-| `Satisfies`    | no       | Parent entry display ID(s)              |
-| `Derived-from` | no       | Reference ID + optional section locator |
-| `Labels`       | no       | Comma-separated tags                    |
+| Attribute      | Required | Format                                    |
+| -------------- | -------- | ----------------------------------------- |
+| `Id`           | yes      | 26-char ULID: `TYPE_[0-9A-Z]{26}`         |
+| `Satisfies`    | no       | Spec entry display ID(s), comma-separated |
+| `Derived-from` | no       | Reference ID + optional section locator   |
+| `References`   | no       | Reference ID(s), comma-separated          |
+| `Allocated-to` | no       | Element/architecture ID(s)                |
+| `Labels`       | no       | Comma-separated tags                      |
 
 **`Derived-from` format:**
 
@@ -452,15 +461,16 @@ traceability direction or level.
 Derived-from: ISO-26262-6 §9.4
 ```
 
-The ID before the space (`ISO-26262-6`) is validated against the registry chain.
+The ID before the space (`ISO-26262-6`) is validated against reference entries.
 The section locator after it (`§9.4`) is free text — tooling warns on unknown
 sections when lists are available but does not error.
 
-### 2.3 Reference entries
+### 2.3 Reference entries (Reference family per ADR-002)
 
-An entry whose display ID does not match `TYPE_XYZ_NNNN` is a reference entry.
-Reference IDs are slugs: letters, digits, and hyphens (`[A-Za-z0-9-]+`).
-Reference entries are recognized only in documents of type `references`.
+An entry whose display ID does not match the spec pattern is a **reference**
+entry. Reference IDs are slugs: letters, digits, hyphens, and dots
+(`[A-Za-z][A-Za-z0-9]*([.-][A-Za-z0-9]+)*`). Reference entries are recognized
+only in documents named `references.md` or in `references/` directories.
 
 **ID conventions:**
 
@@ -493,18 +503,18 @@ AUTOSAR-R22-11     ← AUTOSAR R22-11
   URL: https://www.rtca.org/products/do-178c/
 ```
 
-**Reference entry attributes:**
+**Reference entry attributes (ADR-002):**
 
-| Attribute       | Required | Format                              |
-| --------------- | -------- | ----------------------------------- |
-| `Document`      | no       | Full document identifier            |
-| `URL`           | no       | Canonical URL                       |
-| `Status`        | no       | `active`, `withdrawn`, `superseded` |
-| `Superseded-by` | no       | Replacement entry ID                |
-| `Derived-from`  | no       | Parent standard or regulation       |
+| Attribute       | Required | Format                |
+| --------------- | -------- | --------------------- |
+| `URI`           | no       | Canonical URI         |
+| `URL`           | no       | Canonical HTTP(S) URL |
+| `Document`      | no       | Full document title   |
+| `Superseded-by` | no       | Replacement entry ID  |
+| `Labels`        | no       | Comma-separated tags  |
 
-Reference IDs are used in `{{ref.ISO-26262-6}}` inline references and in
-`Derived-from:` attributes on typed entries.
+At least one of `URI` or `URL` is required. Reference IDs are used in
+`Derived-from:` and `References:` attributes on spec entries.
 
 ### 2.4 Requirement types
 

--- a/packages/markspec/core/compiler/mod.ts
+++ b/packages/markspec/core/compiler/mod.ts
@@ -143,16 +143,17 @@ function extractLinksFromAttribute(
 }
 
 /**
- * Attribute keys that produce traceability links.
- * Note: Constrains targets are component names (free text), not entry IDs,
- * so they are not included here. They would produce dangling links.
+ * Attribute keys that produce traceability links per ADR-002.
+ * Spec attributes: Satisfies, Derived-from, References, Allocated-to.
+ * Reference attributes: none.
+ * Element attributes: (not yet specified; deferred to future ADR).
+ * Test attributes: (not yet specified; deferred to future ADR).
  */
 const ATTR_TO_LINK_KIND: Record<string, LinkKind | undefined> = {
   "Satisfies": "satisfies",
   "Derived-from": "derived-from",
-  "Allocates": "allocates",
-  "Verifies": "verifies",
-  "Implements": "implements",
+  "References": "references",
+  "Allocated-to": "allocated-to",
 };
 
 /** Build an adjacency map from links using a key selector. */

--- a/packages/markspec/core/compiler/mod_test.ts
+++ b/packages/markspec/core/compiler/mod_test.ts
@@ -29,7 +29,7 @@ Deno.test("compile: single entry with no links", async () => {
 
   Body text.
 
-  Id: SRS_01HGW2Q8MNP3\\
+  Id: SRS_00000000000000000000000001\\
   Labels: ASIL-B
 `,
     }),
@@ -53,13 +53,13 @@ Deno.test("compile: Satisfies produces forward and reverse links", async () => {
 
   Body.
 
-  Id: SYS_01HGW2Q8MNP3
+  Id: SYS_00000000000000000000000001
 
 - [SRS_BRK_0001] Software requirement
 
   Body.
 
-  Id: SRS_01HGW2R9QLP4\\
+  Id: SRS_00000000000000000000000002\\
   Satisfies: SYS_BRK_0042
 `,
     }),
@@ -89,7 +89,7 @@ Deno.test("compile: multi-value Satisfies produces multiple links", async () => 
 
   Body.
 
-  Id: SYS_01HGW2Q8MNP3
+  Id: SYS_00000000000000000000000001
 
 - [SYS_BRK_0002] Second system req
 
@@ -101,7 +101,7 @@ Deno.test("compile: multi-value Satisfies produces multiple links", async () => 
 
   Body.
 
-  Id: SRS_01HGW2S0ABC5\\
+  Id: SRS_00000000000000000000000003\\
   Satisfies: SYS_BRK_0001, SYS_BRK_0002
 `,
     }),
@@ -127,7 +127,7 @@ Deno.test("compile: Derived-from extracts ID part only", async () => {
 
   Body.
 
-  Id: SRS_01HGW2Q8MNP3\\
+  Id: SRS_00000000000000000000000001\\
   Derived-from: ISO-26262-6 §9.4
 `,
     }),
@@ -139,7 +139,7 @@ Deno.test("compile: Derived-from extracts ID part only", async () => {
   assertEquals(dfLinks[0].to, "ISO-26262-6");
 });
 
-Deno.test("compile: Allocates produces allocates link", async () => {
+Deno.test("compile: Allocated-to produces allocated-to link", async () => {
   const result = await compile(["arch.md"], {
     readFile: mockFs({
       "arch.md": `# Architecture
@@ -148,20 +148,20 @@ Deno.test("compile: Allocates produces allocates link", async () => {
 
   Body.
 
-  Id: SRS_01HGW2Q8MNP3
+  Id: SRS_00000000000000000000000001
 
 - [SAD_BRK_0010] Allocation
 
   Sensor debouncing allocated to braking ECU.
 
-  Id: SAD_01HGW3A2EFG3\\
-  Allocates: SRS_BRK_0001\\
+  Id: SAD_0000000000000000000000000010\\
+  Allocated-to: SRS_BRK_0001\\
   Component: BRK-ECU-SENSOR
 `,
     }),
   });
 
-  const allocLinks = result.links.filter((l) => l.kind === "allocates");
+  const allocLinks = result.links.filter((l) => l.kind === "allocated-to");
   assertEquals(allocLinks.length, 1);
   assertEquals(allocLinks[0].from, "SAD_BRK_0010");
   assertEquals(allocLinks[0].to, "SRS_BRK_0001");

--- a/packages/markspec/core/compiler/schema_test.ts
+++ b/packages/markspec/core/compiler/schema_test.ts
@@ -12,6 +12,7 @@ function makeEntry(displayId: string): Entry {
     attributes: [],
     id: undefined,
     entryType: displayId.split("_")[0],
+    family: "spec",
     location: { file: "test.md", line: 1, column: 1 },
     source: "markdown",
   };

--- a/packages/markspec/core/formatter/mod.ts
+++ b/packages/markspec/core/formatter/mod.ts
@@ -7,20 +7,31 @@
  */
 
 import { ulid as defaultUlid } from "@std/ulid";
-import type { Attribute, Diagnostic, Entry } from "../model/mod.ts";
+import type {
+  Attribute,
+  Diagnostic,
+  Entry,
+  EntryFamily,
+} from "../model/mod.ts";
 import { ATTR_LINE_RE } from "../parser/attributes.ts";
 import { parseMarkdown } from "../parser/markdown.ts";
 
-/** Canonical attribute ordering. Unknown keys go before Labels. */
-const CANONICAL_ORDER: readonly string[] = [
+/** Canonical attribute ordering for spec entries. Unknown keys go before Labels. */
+const SPEC_CANONICAL_ORDER: readonly string[] = [
   "Id",
   "Satisfies",
   "Derived-from",
-  "Allocates",
-  "Component",
-  "Constrains",
-  "Between",
-  "Interface",
+  "References",
+  "Allocated-to",
+  "Labels",
+];
+
+/** Canonical attribute ordering for reference entries. Unknown keys go before Labels. */
+const REF_CANONICAL_ORDER: readonly string[] = [
+  "URI",
+  "URL",
+  "Document",
+  "Superseded-by",
   "Labels",
 ];
 
@@ -74,8 +85,8 @@ export function format(
     const indent = (entry.location.column - 1) + 2;
     let attrs = [...entry.attributes];
 
-    // Assign ULID to typed entries missing Id.
-    if (entry.entryType && !attrs.some((a) => a.key === "Id")) {
+    // Assign ULID to spec entries missing Id.
+    if (entry.family === "spec" && !attrs.some((a) => a.key === "Id")) {
       const newId = `${entry.entryType}_${genUlid()}`;
       attrs = [{ key: "Id", value: newId }, ...attrs];
       diagnostics.push({
@@ -88,7 +99,7 @@ export function format(
 
     if (attrs.length === 0) continue;
 
-    const normalized = sortAttributes(attrs);
+    const normalized = sortAttributes(attrs, entry.family);
     const range = findAttributeBlockRange(lines, entry.location.line, indent);
 
     if (range) {
@@ -117,10 +128,17 @@ export function format(
 }
 
 /**
- * Sort attributes to canonical order.
+ * Sort attributes to canonical order based on entry family.
  * Unknown keys are placed before Labels, preserving their relative order.
  */
-export function sortAttributes(attributes: Attribute[]): Attribute[] {
+export function sortAttributes(
+  attributes: Attribute[],
+  family: EntryFamily,
+): Attribute[] {
+  const CANONICAL_ORDER = family === "reference"
+    ? REF_CANONICAL_ORDER
+    : SPEC_CANONICAL_ORDER;
+
   const known: (Attribute[] | undefined)[] = new Array(CANONICAL_ORDER.length);
   const unknown: Attribute[] = [];
 

--- a/packages/markspec/core/mod_test.ts
+++ b/packages/markspec/core/mod_test.ts
@@ -56,8 +56,9 @@ Deno.test("model types are constructible", () => {
     title: "Sensor debouncing",
     body: "The sensor driver shall debounce raw inputs.",
     attributes: [attr],
-    id: "SRS_01HGW2Q8MNP3",
+    id: "SRS_00000000000000000000000001",
     entryType: "SRS",
+    family: "spec",
     location: loc,
     source: "markdown",
   };

--- a/packages/markspec/core/model/mod.ts
+++ b/packages/markspec/core/model/mod.ts
@@ -81,12 +81,15 @@ export interface Attribute {
 /** The origin format of the entry. */
 export type EntrySource = "markdown" | "doc-comment";
 
+/** Entry family — spec entries are project declarations; reference entries are external citations. */
+export type EntryFamily = "spec" | "reference";
+
 /**
  * A parsed MarkSpec entry — the core AST node.
  *
- * Covers both typed entries (`SRS_BRK_0001`) and reference entries
- * (`ISO-26262-6`). The `entryType` field is set for typed entries,
- * `undefined` for reference entries.
+ * Covers both spec entries (`SRS_BRK_0001`) and reference entries
+ * (`ISO-26262-6`). The `family` field discriminates; `entryType` is the
+ * TYPE prefix for spec entries, `undefined` for reference entries.
  */
 export interface Entry {
   /** Human-readable display ID from the `[...]` marker. */
@@ -97,10 +100,12 @@ export interface Entry {
   readonly body: string;
   /** Parsed attribute block (`Key: Value` lines). */
   readonly attributes: readonly Attribute[];
-  /** ULID from the `Id:` attribute, if present. */
+  /** ULID from the `Id:` attribute, if present (spec entries only). */
   readonly id: Ulid | undefined;
-  /** Resolved entry type prefix (e.g., `SRS`), if this is a typed entry. */
+  /** Resolved entry type prefix (e.g., `SRS`), if this is a spec entry. */
   readonly entryType: EntryType | undefined;
+  /** Entry family: spec (project declaration) or reference (external citation). */
+  readonly family: EntryFamily;
   /** Where the entry was found. */
   readonly location: SourceLocation;
   /** Whether this came from a Markdown file or a doc comment. */
@@ -240,10 +245,8 @@ export interface InlineRef {
 export type LinkKind =
   | "satisfies"
   | "derived-from"
-  | "allocates"
-  | "constrains"
-  | "verifies"
-  | "implements";
+  | "references"
+  | "allocated-to";
 
 /** A directional link between two entries in the traceability graph. */
 export interface Link {

--- a/packages/markspec/core/parser/markdown.ts
+++ b/packages/markspec/core/parser/markdown.ts
@@ -6,7 +6,7 @@
  */
 
 import type { Definition, List, ListItem, Paragraph, Text } from "mdast";
-import type { Entry, EntryType } from "../model/mod.ts";
+import type { Entry, EntryFamily, EntryType } from "../model/mod.ts";
 import { parseAttributes, splitBodyAndAttributes } from "./attributes.ts";
 import { processor } from "./remark.ts";
 
@@ -14,18 +14,25 @@ import { processor } from "./remark.ts";
 export interface ParseMarkdownOptions {
   /** File path used in source locations. */
   readonly file?: string;
+  /** Is this a references document? If undefined, auto-detect from file path. */
+  readonly isReferencesDoc?: boolean;
 }
 
 /**
- * Typed entry display ID pattern: `TYPE_XYZ_NNN[N]`.
- * TYPE = 2+ uppercase letters, XYZ = 2-12 uppercase letters, NNN[N] = 3 or 4 zero-padded digits.
+ * Spec entry display ID pattern per ADR-002.
+ * TYPE = 2-6 uppercase letters
+ * DOMAIN = 3-8 uppercase alphanumeric (first letter uppercase)
+ * SUBDOMAIN = optional, same as DOMAIN
+ * NNNN = 3-6 digits, must be > 0
  */
-const TYPED_ID_RE = /^([A-Z]{2,})_[A-Z]{2,12}_\d{3,4}$/;
+const TYPED_ID_RE =
+  /^([A-Z]{2,6})_[A-Z][A-Z0-9]{2,7}(_[A-Z][A-Z0-9]{2,7})?_\d{3,6}$/;
 
 /**
- * Reference entry display ID pattern: letters, digits, hyphens.
+ * Reference entry slug pattern per ADR-002.
+ * Starts with letter, alphanumeric + internal hyphens/dots.
  */
-const REF_ID_RE = /^[A-Za-z0-9-]{2,}$/;
+const REF_SLUG_RE = /^[A-Za-z][A-Za-z0-9]*([.-][A-Za-z0-9]+)*$/;
 
 /**
  * Match a display ID in `[...]` at the start of a list item paragraph.
@@ -49,6 +56,10 @@ export function parseMarkdown(
   options?: ParseMarkdownOptions,
 ): Entry[] {
   const file = options?.file ?? "<unknown>";
+  const isReferencesDoc = detectReferencesDocument(
+    file,
+    options?.isReferencesDoc,
+  );
   const tree = processor.parse(markdown);
   const entries: Entry[] = [];
 
@@ -67,12 +78,33 @@ export function parseMarkdown(
     if (list.ordered) continue;
 
     for (const item of list.children) {
-      const entry = extractEntry(item, markdown, file, definitions);
+      const entry = extractEntry(
+        item,
+        markdown,
+        file,
+        definitions,
+        isReferencesDoc,
+      );
       if (entry) entries.push(entry);
     }
   }
 
   return entries;
+}
+
+/**
+ * Detect if a file is a references document.
+ * References context enables recognition of reference entries (slugs).
+ * @param file - File path
+ * @param explicit - Explicit override (undefined = auto-detect)
+ */
+function detectReferencesDocument(
+  file: string,
+  explicit: boolean | undefined,
+): boolean {
+  if (explicit !== undefined) return explicit;
+  const basename = file.split("/").pop() ?? "";
+  return basename === "references.md" || file.includes("/references/");
 }
 
 /**
@@ -84,6 +116,7 @@ function extractEntry(
   markdown: string,
   file: string,
   definitions: Set<string>,
+  isReferencesDoc: boolean,
 ): Entry | undefined {
   // Task list items (remark-gfm sets checked to true/false) are not entries.
   if (item.checked != null) return undefined;
@@ -149,21 +182,25 @@ function extractEntry(
 
   if (!displayId) return undefined;
 
-  // Validate display ID format
-  if (!TYPED_ID_RE.test(displayId) && !REF_ID_RE.test(displayId)) {
+  // Discriminate spec vs reference entry
+  let family: EntryFamily | undefined;
+  let entryType: EntryType | undefined;
+
+  const typedMatch = TYPED_ID_RE.exec(displayId);
+  if (typedMatch) {
+    family = "spec";
+    entryType = typedMatch[1] as EntryType;
+  } else if (isReferencesDoc && REF_SLUG_RE.test(displayId)) {
+    family = "reference";
+    entryType = undefined;
+  } else {
     return undefined;
   }
 
-  // An entry block requires indented body content (more than just the title line).
+  // Body requirement: spec entries require body; reference entries optionally have body.
   // If there's only one child (the title paragraph) and no further content,
-  // it's not an entry block.
-  if (item.children.length < 2) return undefined;
-
-  // Extract entry type from typed display IDs
-  const typedMatch = TYPED_ID_RE.exec(displayId);
-  const entryType: EntryType | undefined = typedMatch
-    ? typedMatch[1] as EntryType
-    : undefined;
+  // it's only valid for reference entries.
+  if (family === "spec" && item.children.length < 2) return undefined;
 
   // Extract body content from remaining children
   const bodyContent = extractBodyContent(item, markdown);
@@ -187,6 +224,7 @@ function extractEntry(
     attributes,
     id,
     entryType,
+    family,
     location: { file, line, column },
     source: "markdown",
   };

--- a/packages/markspec/core/parser/markdown_test.ts
+++ b/packages/markspec/core/parser/markdown_test.ts
@@ -97,12 +97,13 @@ Deno.test("parseMarkdown: extracts reference entry", () => {
   Document: ISO 26262-6:2018\\
   URL: https://www.iso.org/standard/68383.html
 `;
-  const entries = parseMarkdown(md, { file: "refs.md" });
+  const entries = parseMarkdown(md, { file: "refs.md", isReferencesDoc: true });
   assertEquals(entries.length, 1);
   assertEquals(entries[0].displayId, "ISO-26262-6");
   assertEquals(entries[0].title, "ISO 26262 Part 6");
   assertEquals(entries[0].entryType, undefined);
   assertEquals(entries[0].id, undefined);
+  assertEquals(entries[0].family, "reference");
   assertStringIncludes(entries[0].body, "Road vehicles");
 });
 
@@ -224,15 +225,16 @@ Deno.test("parseMarkdown: 3-digit display ID is valid", () => {
 Deno.test("parseMarkdown: long domain abbreviation is valid", () => {
   const md = `# Test
 
-- [SRS_LONGDOMAIN_0001] Long domain entry
+- [SRS_LONGDOM_0001] Long domain entry
 
   Body text.
 
-  Id: SRS_01HGW2Q8MNP3
+  Id: SRS_00000000000000000000000001
 `;
   const entries = parseMarkdown(md, { file: "test.md" });
   assertEquals(entries.length, 1);
-  assertEquals(entries[0].displayId, "SRS_LONGDOMAIN_0001");
+  assertEquals(entries[0].displayId, "SRS_LONGDOM_0001");
+  assertEquals(entries[0].family, "spec");
 });
 
 Deno.test("parseMarkdown: long type prefix is valid", () => {
@@ -340,9 +342,10 @@ Deno.test("parseMarkdown: shortcut ref without definition is still an entry", ()
 
   Document: ISO 26262-6:2018
 `;
-  const entries = parseMarkdown(md, { file: "test.md" });
+  const entries = parseMarkdown(md, { file: "references.md" });
   assertEquals(entries.length, 1);
   assertEquals(entries[0].displayId, "ISO-26262-6");
+  assertEquals(entries[0].family, "reference");
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/markspec/core/parser/mod.ts
+++ b/packages/markspec/core/parser/mod.ts
@@ -62,6 +62,16 @@ export interface ParseFileResult {
 }
 
 /**
+ * Detect if a file is a references document.
+ * References context enables recognition of reference entries (slugs).
+ * @param file - File path
+ */
+function isReferencesDocument(file: string): boolean {
+  const basename = file.split("/").pop() ?? "";
+  return basename === "references.md" || file.includes("/references/");
+}
+
+/**
  * Parse a file and return entries and annotation links, dispatching by type.
  *
  * Source files (`.rs`, `.java`, `.c`, `.cpp`, etc.) are parsed with
@@ -83,7 +93,11 @@ export async function parseFile(
     return parseSource(content, { file: options.file, language });
   }
 
-  return { entries: parseMarkdown(content, options), links: [] };
+  const isReferencesDoc = isReferencesDocument(options.file);
+  return {
+    entries: parseMarkdown(content, { file: options.file, isReferencesDoc }),
+    links: [],
+  };
 }
 
 /**

--- a/packages/markspec/core/reporter/mod.ts
+++ b/packages/markspec/core/reporter/mod.ts
@@ -84,7 +84,6 @@ interface TraceRow {
   entryType: string;
   satisfies: string;
   satisfiedBy: string;
-  verifiedBy: string;
 }
 
 function buildTraceRows(
@@ -107,10 +106,6 @@ function buildTraceRows(
         .filter((l) => l.kind === "satisfies")
         .map((l) => l.from)
         .join(", "),
-      verifiedBy: rev
-        .filter((l) => l.kind === "verifies")
-        .map((l) => l.from)
-        .join(", "),
     };
   });
 }
@@ -127,7 +122,7 @@ function formatTraceability(
   }
 
   if (format === "csv") {
-    const header = "ID,Title,Type,Satisfies,Satisfied-by,Verified-by";
+    const header = "ID,Title,Type,Satisfies,Satisfied-by";
     const lines = rows.map((r) =>
       [
         r.id,
@@ -135,21 +130,19 @@ function formatTraceability(
         r.entryType,
         csvEscape(r.satisfies),
         csvEscape(r.satisfiedBy),
-        csvEscape(r.verifiedBy),
       ].join(",")
     );
     return [header, ...lines].join("\n");
   }
 
   // Markdown table
-  const header =
-    "| ID | Title | Type | Satisfies | Satisfied-by | Verified-by |";
-  const sep = "| -- | ----- | ---- | --------- | ------------ | ----------- |";
+  const header = "| ID | Title | Type | Satisfies | Satisfied-by |";
+  const sep = "| -- | ----- | ---- | --------- | ------------ |";
   const lines = rows.map(
     (r) =>
       `| ${r.id} | ${r.title} | ${r.entryType} | ${r.satisfies || "\u2014"} | ${
         r.satisfiedBy || "\u2014"
-      } | ${r.verifiedBy || "\u2014"} |`,
+      } |`,
   );
   return [header, sep, ...lines].join("\n");
 }
@@ -166,7 +159,6 @@ interface CoverageStats {
   gaps: {
     orphans: DisplayId[];
     unsatisfied: DisplayId[];
-    unverified: DisplayId[];
   };
 }
 
@@ -177,7 +169,6 @@ function computeCoverage(
   const byType: Record<string, number> = {};
   const orphans: DisplayId[] = [];
   const unsatisfied: DisplayId[] = [];
-  const unverified: DisplayId[] = [];
   let withSatisfies = 0;
   let withoutSatisfies = 0;
 
@@ -205,12 +196,6 @@ function computeCoverage(
     ) {
       unsatisfied.push(entry.displayId);
     }
-
-    // Typed entries without verification
-    const hasVerification = rev.some((l) => l.kind === "verifies");
-    if (entry.entryType && !hasVerification) {
-      unverified.push(entry.displayId);
-    }
   }
 
   return {
@@ -218,7 +203,7 @@ function computeCoverage(
     byType,
     withSatisfies,
     withoutSatisfies,
-    gaps: { orphans, unsatisfied, unverified },
+    gaps: { orphans, unsatisfied },
   };
 }
 
@@ -242,7 +227,6 @@ function formatCoverage(
       `Without Satisfies,${stats.withoutSatisfies}`,
       `Orphans,${stats.gaps.orphans.length}`,
       `Unsatisfied parents,${stats.gaps.unsatisfied.length}`,
-      `Unverified,${stats.gaps.unverified.length}`,
     ];
     return lines.join("\n");
   }
@@ -278,15 +262,6 @@ function formatCoverage(
       "## Unsatisfied parents (STK/SYS with no children)",
       "",
       ...stats.gaps.unsatisfied.map((id) => `- ${id}`),
-      "",
-    );
-  }
-
-  if (stats.gaps.unverified.length > 0) {
-    lines.push(
-      "## Unverified requirements",
-      "",
-      ...stats.gaps.unverified.map((id) => `- ${id}`),
       "",
     );
   }

--- a/packages/markspec/core/reporter/mod_test.ts
+++ b/packages/markspec/core/reporter/mod_test.ts
@@ -36,8 +36,9 @@ function entry(
     title: `Title of ${id}`,
     body: "Body.",
     attributes: attrs,
-    id: type ? `${type}_01HGW2Q8MNP3` : undefined,
+    id: type ? `${type}_00000000000000000000000001` : undefined,
     entryType: type,
+    family: type ? "spec" : "reference",
     location: { file: "test.md", line: 1, column: 1 },
     source: "markdown",
   };
@@ -167,11 +168,11 @@ Deno.test("report: scope filter matches domain", () => {
 
 Deno.test("report: label filter matches entry labels", () => {
   const a = entry("SRS_BRK_0001", "SRS", [
-    { key: "Id", value: "SRS_01HGW2Q8MNP3" },
+    { key: "Id", value: "SRS_00000000000000000000000001" },
     { key: "Labels", value: "ASIL-B" },
   ]);
   const b = entry("SRS_BRK_0002", "SRS", [
-    { key: "Id", value: "SRS_01HGW2R9QLP4" },
+    { key: "Id", value: "SRS_00000000000000000000000002" },
     { key: "Labels", value: "ASIL-D" },
   ]);
   const result = makeResult([a, b]);

--- a/packages/markspec/core/validator/mod.ts
+++ b/packages/markspec/core/validator/mod.ts
@@ -7,32 +7,27 @@
 
 import type { Attribute, Diagnostic, Entry } from "../model/mod.ts";
 
-/** Known attribute keys for typed entries. */
-const TYPED_ATTR_KEYS = new Set([
+/** Known attribute keys for spec entries per ADR-002. */
+const SPEC_ATTR_KEYS = new Set([
   "Id",
   "Satisfies",
   "Derived-from",
-  "Allocates",
-  "Component",
-  "Constrains",
-  "Between",
-  "Interface",
-  "Verifies",
-  "Implements",
+  "References",
+  "Allocated-to",
   "Labels",
 ]);
 
-/** Known attribute keys for reference entries. */
+/** Known attribute keys for reference entries per ADR-002. */
 const REF_ATTR_KEYS = new Set([
-  "Document",
+  "URI",
   "URL",
-  "Status",
+  "Document",
   "Superseded-by",
-  "Derived-from",
+  "Labels",
 ]);
 
-/** ULID format: TYPE prefix + underscore + 12-26 alphanumeric chars. */
-const ULID_RE = /^[A-Z]+_[0-9A-Z]{12,26}$/;
+/** ULID format per ADR-002: TYPE prefix (2-6 chars) + underscore + 26 alphanumeric chars. */
+const ULID_RE = /^[A-Z]{2,6}_[0-9A-Z]{26}$/;
 
 /** Result of a validation pass. */
 export interface ValidateResult {
@@ -68,10 +63,10 @@ function checkStructural(
   const ulids = new Map<string, Entry>();
 
   for (const entry of entries) {
-    const isTyped = entry.entryType != null;
+    const isSpec = entry.family === "spec";
 
-    // MSL-R003: Typed entry must have Id attribute with valid ULID format.
-    if (isTyped) {
+    // MSL-R003: Spec entry must have Id attribute with valid ULID format.
+    if (isSpec) {
       if (!entry.id) {
         diagnostics.push({
           code: "MSL-R003",
@@ -90,7 +85,7 @@ function checkStructural(
     }
 
     // MSL-R004: Exactly one Id per entry.
-    if (isTyped) {
+    if (isSpec) {
       const idCount = entry.attributes.filter((a) => a.key === "Id").length;
       if (idCount > 1) {
         diagnostics.push({
@@ -103,7 +98,7 @@ function checkStructural(
     }
 
     // MSL-R007: Display ID type prefix must match ULID type prefix.
-    if (isTyped && entry.id && ULID_RE.test(entry.id)) {
+    if (isSpec && entry.id && ULID_RE.test(entry.id)) {
       const displayPrefix = entry.entryType!;
       const ulidPrefix = entry.id.split("_")[0];
       if (displayPrefix !== ulidPrefix) {
@@ -114,6 +109,38 @@ function checkStructural(
             `${entry.displayId}: type prefix '${displayPrefix}' does not match Id prefix '${ulidPrefix}'`,
           location: entry.location,
         });
+      }
+    }
+
+    // MSL-R008: Reference entry must have URI or URL attribute.
+    if (!isSpec) {
+      const hasUri = entry.attributes.some((a) => a.key === "URI");
+      const hasUrl = entry.attributes.some((a) => a.key === "URL");
+      if (!hasUri && !hasUrl) {
+        diagnostics.push({
+          code: "MSL-R008",
+          severity: "error",
+          message:
+            `${entry.displayId}: reference entry must have URI or URL attribute`,
+          location: entry.location,
+        });
+      }
+    }
+
+    // MSL-R009: Spec entry NNNN must be > 0 (no 000, 0000, etc.).
+    if (isSpec) {
+      // Extract NNNN from display ID (last segment after last underscore)
+      const parts = entry.displayId.split("_");
+      if (parts.length >= 3) {
+        const nnnn = parts[parts.length - 1];
+        if (/^\d+$/.test(nnnn) && parseInt(nnnn, 10) === 0) {
+          diagnostics.push({
+            code: "MSL-R009",
+            severity: "error",
+            message: `${entry.displayId}: NNNN must be > 0`,
+            location: entry.location,
+          });
+        }
       }
     }
 
@@ -148,7 +175,7 @@ function checkStructural(
     }
 
     // MSL-R010: Unknown attribute keys.
-    const knownKeys = isTyped ? TYPED_ATTR_KEYS : REF_ATTR_KEYS;
+    const knownKeys = isSpec ? SPEC_ATTR_KEYS : REF_ATTR_KEYS;
     for (const attr of entry.attributes) {
       if (!knownKeys.has(attr.key)) {
         diagnostics.push({
@@ -203,38 +230,39 @@ function checkReferences(
       }
     }
 
-    // MSL-T008: Allocates targets must be SRS entries (resolve against known IDs).
-    const allocates = findAttr(entry.attributes, "Allocates");
-    if (allocates) {
-      const targets = allocates.value.split(",").map((s) => s.trim());
+    // MSL-T005: References targets must exist.
+    const references = findAttr(entry.attributes, "References");
+    if (references) {
+      const targets = references.value.split(",").map((s) => s.trim());
       for (const target of targets) {
         if (!target) continue;
         if (!knownIds.has(target)) {
           diagnostics.push({
-            code: "MSL-T008",
+            code: "MSL-T005",
             severity: "error",
             message:
-              `${entry.displayId}: unresolved reference '${target}' in Allocates`,
+              `${entry.displayId}: unresolved reference '${target}' in References`,
             location: entry.location,
           });
         }
       }
     }
 
-    // MSL-T009: Between must list exactly two parties.
-    const between = findAttr(entry.attributes, "Between");
-    if (between) {
-      const parties = between.value.split(",").map((s) => s.trim()).filter(
-        (s) => s.length > 0,
-      );
-      if (parties.length !== 2) {
-        diagnostics.push({
-          code: "MSL-T009",
-          severity: "error",
-          message:
-            `${entry.displayId}: Between must list exactly 2 parties, found ${parties.length}`,
-          location: entry.location,
-        });
+    // MSL-T006: Allocated-to targets must exist.
+    const allocatedTo = findAttr(entry.attributes, "Allocated-to");
+    if (allocatedTo) {
+      const targets = allocatedTo.value.split(",").map((s) => s.trim());
+      for (const target of targets) {
+        if (!target) continue;
+        if (!knownIds.has(target)) {
+          diagnostics.push({
+            code: "MSL-T006",
+            severity: "error",
+            message:
+              `${entry.displayId}: unresolved reference '${target}' in Allocated-to`,
+            location: entry.location,
+          });
+        }
       }
     }
   }

--- a/packages/markspec/core/validator/mod_test.ts
+++ b/packages/markspec/core/validator/mod_test.ts
@@ -8,7 +8,7 @@ import { assertEquals, assertStringIncludes } from "@std/assert";
 import { validate } from "./mod.ts";
 import type { Entry } from "../model/mod.ts";
 
-/** Helper to build a typed entry. */
+/** Helper to build a spec entry. */
 function typedEntry(
   overrides: Partial<Entry> & { displayId: string },
 ): Entry {
@@ -17,6 +17,7 @@ function typedEntry(
     body: "Body.",
     attributes: [],
     entryType: "SRS",
+    family: "spec",
     source: "markdown",
     location: { file: "test.md", line: 1, column: 1 },
     ...overrides,
@@ -33,6 +34,7 @@ function refEntry(
     body: "Body.",
     attributes: [],
     entryType: undefined,
+    family: "reference",
     id: undefined,
     source: "markdown",
     location: { file: "refs.md", line: 1, column: 1 },
@@ -48,8 +50,8 @@ Deno.test("validate: valid entries pass", () => {
   const entries: Entry[] = [
     typedEntry({
       displayId: "SRS_BRK_0001",
-      id: "SRS_01HGW2Q8MNP3",
-      attributes: [{ key: "Id", value: "SRS_01HGW2Q8MNP3" }],
+      id: "SRS_00000000000000000000000001",
+      attributes: [{ key: "Id", value: "SRS_00000000000000000000000001" }],
     }),
   ];
   const result = validate(entries);
@@ -85,14 +87,14 @@ Deno.test("validate: duplicate display ID → MSL-R006", () => {
   const entries: Entry[] = [
     typedEntry({
       displayId: "SRS_BRK_0001",
-      id: "SRS_01HGW2Q8MNP3",
-      attributes: [{ key: "Id", value: "SRS_01HGW2Q8MNP3" }],
+      id: "SRS_00000000000000000000000001",
+      attributes: [{ key: "Id", value: "SRS_00000000000000000000000001" }],
       location: { file: "a.md", line: 3, column: 1 },
     }),
     typedEntry({
       displayId: "SRS_BRK_0001",
-      id: "SRS_01HGW2R9QLP4",
-      attributes: [{ key: "Id", value: "SRS_01HGW2R9QLP4" }],
+      id: "SRS_00000000000000000000000002",
+      attributes: [{ key: "Id", value: "SRS_00000000000000000000000002" }],
       location: { file: "b.md", line: 5, column: 1 },
     }),
   ];
@@ -108,14 +110,14 @@ Deno.test("validate: duplicate ULID → MSL-R005", () => {
   const entries: Entry[] = [
     typedEntry({
       displayId: "SRS_BRK_0001",
-      id: "SRS_01HGW2Q8MNP3",
-      attributes: [{ key: "Id", value: "SRS_01HGW2Q8MNP3" }],
+      id: "SRS_00000000000000000000000001",
+      attributes: [{ key: "Id", value: "SRS_00000000000000000000000001" }],
       location: { file: "a.md", line: 3, column: 1 },
     }),
     typedEntry({
       displayId: "SRS_BRK_0002",
-      id: "SRS_01HGW2Q8MNP3",
-      attributes: [{ key: "Id", value: "SRS_01HGW2Q8MNP3" }],
+      id: "SRS_00000000000000000000000001",
+      attributes: [{ key: "Id", value: "SRS_00000000000000000000000001" }],
       location: { file: "b.md", line: 5, column: 1 },
     }),
   ];
@@ -131,8 +133,8 @@ Deno.test("validate: type prefix mismatch → MSL-R007", () => {
     typedEntry({
       displayId: "SRS_BRK_0001",
       entryType: "SRS",
-      id: "SYS_01HGW2Q8MNP3",
-      attributes: [{ key: "Id", value: "SYS_01HGW2Q8MNP3" }],
+      id: "SYS_00000000000000000000000001",
+      attributes: [{ key: "Id", value: "SYS_00000000000000000000000001" }],
     }),
   ];
   const result = validate(entries);
@@ -146,9 +148,9 @@ Deno.test("validate: unknown attribute key → MSL-R010 warning", () => {
   const entries: Entry[] = [
     typedEntry({
       displayId: "SRS_BRK_0001",
-      id: "SRS_01HGW2Q8MNP3",
+      id: "SRS_00000000000000000000000001",
       attributes: [
-        { key: "Id", value: "SRS_01HGW2Q8MNP3" },
+        { key: "Id", value: "SRS_00000000000000000000000001" },
         { key: "CustomKey", value: "some value" },
       ],
     }),
@@ -203,14 +205,14 @@ Deno.test("validate: Satisfies target exists → passes", () => {
     typedEntry({
       displayId: "SYS_BRK_0042",
       entryType: "SYS",
-      id: "SYS_01HGW2Q8MNP3",
-      attributes: [{ key: "Id", value: "SYS_01HGW2Q8MNP3" }],
+      id: "SYS_00000000000000000000000001",
+      attributes: [{ key: "Id", value: "SYS_00000000000000000000000001" }],
     }),
     typedEntry({
       displayId: "SRS_BRK_0001",
-      id: "SRS_01HGW2R9QLP4",
+      id: "SRS_00000000000000000000000002",
       attributes: [
-        { key: "Id", value: "SRS_01HGW2R9QLP4" },
+        { key: "Id", value: "SRS_00000000000000000000000002" },
         { key: "Satisfies", value: "SYS_BRK_0042" },
       ],
       location: { file: "test.md", line: 10, column: 1 },
@@ -228,9 +230,9 @@ Deno.test("validate: Satisfies target missing → MSL-T001", () => {
   const entries: Entry[] = [
     typedEntry({
       displayId: "SRS_BRK_0001",
-      id: "SRS_01HGW2Q8MNP3",
+      id: "SRS_00000000000000000000000001",
       attributes: [
-        { key: "Id", value: "SRS_01HGW2Q8MNP3" },
+        { key: "Id", value: "SRS_00000000000000000000000001" },
         { key: "Satisfies", value: "SYS_BRK_9999" },
       ],
     }),
@@ -247,14 +249,14 @@ Deno.test("validate: multi-value Satisfies with one missing", () => {
     typedEntry({
       displayId: "SYS_BRK_0001",
       entryType: "SYS",
-      id: "SYS_01HGW2Q8MNP3",
-      attributes: [{ key: "Id", value: "SYS_01HGW2Q8MNP3" }],
+      id: "SYS_00000000000000000000000001",
+      attributes: [{ key: "Id", value: "SYS_00000000000000000000000001" }],
     }),
     typedEntry({
       displayId: "SRS_BRK_0001",
-      id: "SRS_01HGW2R9QLP4",
+      id: "SRS_00000000000000000000000002",
       attributes: [
-        { key: "Id", value: "SRS_01HGW2R9QLP4" },
+        { key: "Id", value: "SRS_00000000000000000000000002" },
         { key: "Satisfies", value: "SYS_BRK_0001, SYS_BRK_9999" },
       ],
       location: { file: "test.md", line: 10, column: 1 },
@@ -275,9 +277,9 @@ Deno.test("validate: Derived-from ID checked against entries", () => {
     }),
     typedEntry({
       displayId: "SRS_BRK_0001",
-      id: "SRS_01HGW2Q8MNP3",
+      id: "SRS_00000000000000000000000001",
       attributes: [
-        { key: "Id", value: "SRS_01HGW2Q8MNP3" },
+        { key: "Id", value: "SRS_00000000000000000000000001" },
         { key: "Derived-from", value: "ISO-26262-6 §9.4" },
       ],
     }),
@@ -292,9 +294,9 @@ Deno.test("validate: Derived-from unresolved → MSL-T004 warning", () => {
   const entries: Entry[] = [
     typedEntry({
       displayId: "SRS_BRK_0001",
-      id: "SRS_01HGW2Q8MNP3",
+      id: "SRS_00000000000000000000000001",
       attributes: [
-        { key: "Id", value: "SRS_01HGW2Q8MNP3" },
+        { key: "Id", value: "SRS_00000000000000000000000001" },
         { key: "Derived-from", value: "UNKNOWN-REF §1.2" },
       ],
     }),
@@ -307,83 +309,136 @@ Deno.test("validate: Derived-from unresolved → MSL-T004 warning", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Allocates and Between (MSL-T008, MSL-T009)
+// ADR-002 new checks (MSL-R008, MSL-R009, MSL-T005, MSL-T006)
 // ---------------------------------------------------------------------------
 
-Deno.test("validate: Allocates target missing → MSL-T008", () => {
+Deno.test("validate: reference entry missing URI and URL → MSL-R008", () => {
+  const entries: Entry[] = [
+    refEntry({
+      displayId: "ISO-26262-6",
+      attributes: [{ key: "Document", value: "ISO 26262-6:2018" }],
+    }),
+  ];
+  const result = validate(entries);
+  assertEquals(result.valid, false);
+  const r008 = result.diagnostics.find((d) => d.code === "MSL-R008");
+  assertEquals(r008 != null, true);
+  assertStringIncludes(r008!.message, "URI or URL");
+});
+
+Deno.test("validate: reference entry with URL → passes", () => {
+  const entries: Entry[] = [
+    refEntry({
+      displayId: "ISO-26262-6",
+      attributes: [
+        { key: "Document", value: "ISO 26262-6:2018" },
+        { key: "URL", value: "https://www.iso.org/standard/68383.html" },
+      ],
+    }),
+  ];
+  const result = validate(entries);
+  assertEquals(result.valid, true);
+});
+
+Deno.test("validate: spec entry NNNN = 0 → MSL-R009", () => {
   const entries: Entry[] = [
     typedEntry({
-      displayId: "SAD_BRK_0010",
-      entryType: "SAD",
-      id: "SAD_01HGW3A2EFG3",
+      displayId: "SRS_BRK_000",
+      id: "SRS_00000000000000000000000001RSTVWXYZABCDE",
+      attributes: [{
+        key: "Id",
+        value: "SRS_00000000000000000000000001RSTVWXYZABCDE",
+      }],
+    }),
+  ];
+  const result = validate(entries);
+  assertEquals(result.valid, false);
+  const r009 = result.diagnostics.find((d) => d.code === "MSL-R009");
+  assertEquals(r009 != null, true);
+  assertStringIncludes(r009!.message, "NNNN must be > 0");
+});
+
+Deno.test("validate: References target exists → passes", () => {
+  const entries: Entry[] = [
+    refEntry({
+      displayId: "ISO-26262-6",
       attributes: [
-        { key: "Id", value: "SAD_01HGW3A2EFG3" },
-        { key: "Allocates", value: "SRS_NONEXISTENT" },
+        { key: "URL", value: "https://www.iso.org/standard/68383.html" },
+      ],
+    }),
+    typedEntry({
+      displayId: "SRS_BRK_0001",
+      id: "SRS_00000000000000000000000001",
+      attributes: [
+        { key: "Id", value: "SRS_00000000000000000000000001" },
+        { key: "References", value: "ISO-26262-6" },
+      ],
+      location: { file: "test.md", line: 10, column: 1 },
+    }),
+  ];
+  const result = validate(entries);
+  assertEquals(result.valid, true);
+});
+
+Deno.test("validate: References target missing → MSL-T005", () => {
+  const entries: Entry[] = [
+    typedEntry({
+      displayId: "SRS_BRK_0001",
+      id: "SRS_00000000000000000000000001RSTVWXYZABCDE",
+      attributes: [
+        { key: "Id", value: "SRS_00000000000000000000000001RSTVWXYZABCDE" },
+        { key: "References", value: "UNKNOWN-REF" },
       ],
     }),
   ];
   const result = validate(entries);
   assertEquals(result.valid, false);
-  const t008 = result.diagnostics.find((d) => d.code === "MSL-T008");
-  assertEquals(t008 != null, true);
-  assertStringIncludes(t008!.message, "SRS_NONEXISTENT");
+  const t005 = result.diagnostics.find((d) => d.code === "MSL-T005");
+  assertEquals(t005 != null, true);
+  assertStringIncludes(t005!.message, "UNKNOWN-REF");
 });
 
-Deno.test("validate: Allocates target exists → passes", () => {
+Deno.test("validate: Allocated-to target missing → MSL-T006", () => {
+  const entries: Entry[] = [
+    typedEntry({
+      displayId: "SAD_BRK_0010",
+      entryType: "SAD",
+      id: "SAD_00000000000000000000000010",
+      attributes: [
+        { key: "Id", value: "SAD_00000000000000000000000010" },
+        { key: "Allocated-to", value: "SRS_NONEXISTENT" },
+      ],
+    }),
+  ];
+  const result = validate(entries);
+  assertEquals(result.valid, false);
+  const t006 = result.diagnostics.find((d) => d.code === "MSL-T006");
+  assertEquals(t006 != null, true);
+  assertStringIncludes(t006!.message, "SRS_NONEXISTENT");
+});
+
+Deno.test("validate: Allocated-to target exists → passes", () => {
   const entries: Entry[] = [
     typedEntry({
       displayId: "SRS_BRK_0001",
-      id: "SRS_01HGW2Q8MNP3",
-      attributes: [{ key: "Id", value: "SRS_01HGW2Q8MNP3" }],
+      id: "SRS_00000000000000000000000001RSTVWXYZABCDE",
+      attributes: [{
+        key: "Id",
+        value: "SRS_00000000000000000000000001RSTVWXYZABCDE",
+      }],
     }),
     typedEntry({
       displayId: "SAD_BRK_0010",
       entryType: "SAD",
-      id: "SAD_01HGW3A2EFG3",
+      id: "SAD_00000000000000000000000010",
       attributes: [
-        { key: "Id", value: "SAD_01HGW3A2EFG3" },
-        { key: "Allocates", value: "SRS_BRK_0001" },
+        { key: "Id", value: "SAD_00000000000000000000000010" },
+        { key: "Allocated-to", value: "SRS_BRK_0001" },
       ],
       location: { file: "arch.md", line: 10, column: 1 },
     }),
   ];
   const result = validate(entries);
-  const t008 = result.diagnostics.filter((d) => d.code === "MSL-T008");
-  assertEquals(t008.length, 0);
-});
-
-Deno.test("validate: Between with 2 parties → passes", () => {
-  const entries: Entry[] = [
-    typedEntry({
-      displayId: "ICD_BRK_0001",
-      entryType: "ICD",
-      id: "ICD_01HGW4A1BCD2",
-      attributes: [
-        { key: "Id", value: "ICD_01HGW4A1BCD2" },
-        { key: "Between", value: "braking-ecu, vehicle-dynamics-ecu" },
-      ],
-    }),
-  ];
-  const result = validate(entries);
-  const t009 = result.diagnostics.filter((d) => d.code === "MSL-T009");
-  assertEquals(t009.length, 0);
-});
-
-Deno.test("validate: Between with 1 party → MSL-T009", () => {
-  const entries: Entry[] = [
-    typedEntry({
-      displayId: "ICD_BRK_0001",
-      entryType: "ICD",
-      id: "ICD_01HGW4A1BCD2",
-      attributes: [
-        { key: "Id", value: "ICD_01HGW4A1BCD2" },
-        { key: "Between", value: "braking-ecu" },
-      ],
-    }),
-  ];
-  const result = validate(entries);
-  assertEquals(result.valid, false);
-  const t009 = result.diagnostics.find((d) => d.code === "MSL-T009");
-  assertEquals(t009 != null, true);
-  assertStringIncludes(t009!.message, "found 1");
+  const t006 = result.diagnostics.filter((d) => d.code === "MSL-T006");
+  assertEquals(t006.length, 0);
 });

--- a/packages/markspec/render/includes/mod_test.ts
+++ b/packages/markspec/render/includes/mod_test.ts
@@ -14,12 +14,13 @@ function testEntry(overrides: Partial<Entry> = {}): Entry {
     title: "Sensor debouncing",
     body: "The sensor driver shall debounce raw inputs.",
     attributes: [
-      { key: "Id", value: "SRS_01HGW2Q8MNP3" },
+      { key: "Id", value: "SRS_00000000000000000000000001" },
       { key: "Satisfies", value: "SYS_BRK_0001" },
       { key: "Labels", value: "ASIL-B" },
     ],
-    id: "SRS_01HGW2Q8MNP3",
+    id: "SRS_00000000000000000000000001",
     entryType: "SRS",
+    family: "spec",
     location: { file: "test.md", line: 1, column: 1 },
     source: "markdown",
     ...overrides,
@@ -73,7 +74,7 @@ Deno.test("processIncludes: display ID resolves to full entry", async () => {
       "",
       "  The sensor driver shall debounce raw inputs.",
       "",
-      "  Id: SRS_01HGW2Q8MNP3 \\",
+      "  Id: SRS_00000000000000000000000001 \\",
       "  Satisfies: SYS_BRK_0001 \\",
       "  Labels: ASIL-B",
       "",
@@ -146,8 +147,8 @@ Deno.test("processIncludes: multiple includes all resolve", async () => {
     displayId: "SRS_BRK_0002",
     title: "Brake pressure",
     body: "Brake pressure shall be monitored.",
-    attributes: [{ key: "Id", value: "SRS_01HGW2Q8MNP4" }],
-    id: "SRS_01HGW2Q8MNP4",
+    attributes: [{ key: "Id", value: "SRS_00000000000000000000000002" }],
+    id: "SRS_00000000000000000000000002",
   });
 
   const input = [

--- a/packages/markspec/render/mustache/mod_test.ts
+++ b/packages/markspec/render/mustache/mod_test.ts
@@ -37,6 +37,7 @@ function makeEntry(displayId: string): Entry {
     attributes: [],
     id: undefined,
     entryType: displayId.split("_")[0],
+    family: "spec",
     location: { file: "test.md", line: 1, column: 1 },
     source: "markdown",
   };

--- a/packages/markspec/render/styles/mod_test.ts
+++ b/packages/markspec/render/styles/mod_test.ts
@@ -33,6 +33,7 @@ function buildCompiled(
       attributes: e.attributes ?? [],
       id: e.id,
       entryType: e.entryType,
+      family: e.entryType ? "spec" : "reference",
       location: { file: "test.md", line: 1, column: 1 },
       source: "markdown",
     };

--- a/tests/e2e/config_test.ts
+++ b/tests/e2e/config_test.ts
@@ -11,7 +11,7 @@ Deno.test("validate in nested dir finds files", async () => {
 
   Body.
 
-  Id: SRS_01HGW2Q8MNP3
+  Id: SRS_00000000000000000000000001
 `,
     },
   });

--- a/tests/e2e/validate_test.ts
+++ b/tests/e2e/validate_test.ts
@@ -20,7 +20,7 @@ Deno.test("validate: valid file exits 0", async () => {
 
   Body text.
 
-  Id: SRS_01HGW2Q8MNP3\\
+  Id: SRS_00000000000000000000000001\\
   Labels: ASIL-B
 `,
     },
@@ -59,7 +59,7 @@ Deno.test("validate: broken Satisfies reference exits 1", async () => {
 
   Body text.
 
-  Id: SRS_01HGW2Q8MNP3\\
+  Id: SRS_00000000000000000000000001\\
   Satisfies: SYS_BRK_9999\\
   Labels: ASIL-B
 `,
@@ -83,7 +83,7 @@ Deno.test("validate: warning only exits 2", async () => {
 
   Body text.
 
-  Id: SRS_01HGW2Q8MNP3\\
+  Id: SRS_00000000000000000000000001\\
   CustomKey: some value\\
   Labels: ASIL-B
 `,
@@ -107,7 +107,7 @@ Deno.test("validate: --strict promotes warning to error → exit 1", async () =>
 
   Body text.
 
-  Id: SRS_01HGW2Q8MNP3\\
+  Id: SRS_00000000000000000000000001\\
   CustomKey: some value\\
   Labels: ASIL-B
 `,
@@ -154,7 +154,7 @@ Deno.test("validate: valid Rust source file exits 0", async () => {
 ///
 /// The sensor driver shall debounce.
 ///
-/// Id: SRS_01HGW2Q8MNP3A1B2C3D4E5
+/// Id: SRS_00000000000000000000000001
 fn debounce() {}
 `,
     },
@@ -187,13 +187,13 @@ Deno.test("validate: mixed .md and .rs files", async () => {
 
   Body.
 
-  Id: SYS_01HGW2Q8MNP3A1B2C3D4E5
+  Id: SYS_00000000000000000000000001
 `,
       "lib.rs": `/// [SRS_BRK_0001] Software requirement
 ///
 /// Body.
 ///
-/// Id: SRS_01HGW2R9QLP4A1B2C3D4E5\\
+/// Id: SRS_00000000000000000000000002\\
 /// Satisfies: SYS_BRK_0042
 fn impl_debounce() {}
 `,


### PR DESCRIPTION
## What

Implement ADR-002 entry model specification, introducing formal family discrimination (Spec vs Reference) with updated regexes, validation rules, and documentation.

## Why

ADR-002 establishes a formalized entry model separating core format from domain vocabulary, enabling future extension to Test and Element families while maintaining backward compatibility at the format level.

## How

- Added `EntryFamily` type to Entry interface
- Updated display ID regexes per ADR-002 exact spec
- Implemented automatic reference context detection
- New 26-character ULID format validation
- Family-aware attribute vocabularies and canonical ordering
- Updated LinkKind: added "references"/"allocated-to", removed deprecated kinds
- New MSL validation rules: MSL-R008, MSL-R009, MSL-T005, MSL-T006
- Updated reporter to remove verification tracking (Test family deferred)
- Comprehensive test updates and spec documentation

## Checklist

- [x] Tests added or updated (277 tests passing)
- [x] Documentation updated (spec language.md + new ADR doc)
- [x] All checks pass (type check, lint, format, tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)