### PR TITLE
feat(core): entry-model v2 phase 1 — model foundations

### DIFF
--- a/packages/markspec/core/model/attributes.ts
+++ b/packages/markspec/core/model/attributes.ts
@@ -1,0 +1,345 @@
+/**
+ * @module model/attributes
+ *
+ * Built-in attribute catalog per ADR-002 Annex C.
+ *
+ * Every attribute the core language recognizes appears here with its value
+ * type, origin, applicable families, and enum vocabulary (where relevant).
+ * Profile-declared attributes extend this catalog at runtime; the validator,
+ * formatter, and compiler consult it to drive parsing, canonicalization, and
+ * cross-reference checks.
+ */
+
+import type {
+  AttributeOrigin,
+  AttributeValueType,
+  EntryFamily,
+} from "./mod.ts";
+
+// ---------------------------------------------------------------------------
+// Enum vocabularies
+// ---------------------------------------------------------------------------
+
+/** `Status` vocabulary per ADR-002 §Universal attributes. */
+export const STATUS_VALUES: readonly string[] = [
+  "draft",
+  "approved",
+  "deprecated",
+  "withdrawn",
+];
+
+/** `Test-level` vocabulary per ADR-002 Part 4. */
+export const TEST_LEVEL_VALUES: readonly string[] = [
+  "unit",
+  "integration",
+  "system",
+  "acceptance",
+];
+
+/** `Element-kind` core vocabulary per ADR-002 Part 5. */
+export const ELEMENT_KIND_VALUES: readonly string[] = [
+  "item",
+  "artifact",
+  "dependency",
+  "unit",
+];
+
+// ---------------------------------------------------------------------------
+// Attribute specification
+// ---------------------------------------------------------------------------
+
+/** Specification of a single built-in attribute. */
+export interface AttributeSpec {
+  /** Canonical Title-Case key (e.g., `Derived-from`). */
+  readonly key: string;
+  /** Value type from the 14-type system. */
+  readonly type: AttributeValueType;
+  /** How the value arrives in the model. */
+  readonly origin: AttributeOrigin;
+  /** Families on which the attribute may appear. */
+  readonly families: readonly EntryFamily[];
+  /** Whether the attribute is required by the family. */
+  readonly required: boolean;
+  /** Closed vocabulary — set when `type === "enum"`. */
+  readonly enumValues?: readonly string[];
+}
+
+// ---------------------------------------------------------------------------
+// ATTRIBUTE_CATALOG — ADR-002 Annex C
+// ---------------------------------------------------------------------------
+
+const ALL_FAMILIES: readonly EntryFamily[] = [
+  "spec",
+  "test",
+  "element",
+  "reference",
+];
+
+/** Families that carry `References:` — universal minus Reference per ADR-002 §Part 3. */
+const CITING_FAMILIES: readonly EntryFamily[] = ["spec", "test", "element"];
+
+/**
+ * Full catalog of built-in attributes per ADR-002 Annex C.
+ *
+ * Order within the array has no semantic meaning; consumers look up by key via
+ * {@linkcode attributeSpec} or filter by family via
+ * {@linkcode attributesForFamily}.
+ */
+export const ATTRIBUTE_CATALOG: readonly AttributeSpec[] = [
+  // Universal — all four families
+  {
+    key: "Labels",
+    type: "tag-list",
+    origin: "authored",
+    families: ALL_FAMILIES,
+    required: false,
+  },
+  {
+    key: "Status",
+    type: "enum",
+    origin: "authored",
+    families: ALL_FAMILIES,
+    required: false,
+    enumValues: STATUS_VALUES,
+  },
+  {
+    key: "References",
+    type: "citation",
+    origin: "authored",
+    families: CITING_FAMILIES,
+    required: false,
+  },
+  {
+    key: "External-id",
+    type: "external-id",
+    origin: "authored",
+    families: ALL_FAMILIES,
+    required: false,
+  },
+  {
+    key: "Supersedes",
+    type: "id",
+    origin: "authored",
+    families: ALL_FAMILIES,
+    required: false,
+  },
+  {
+    key: "Superseded-by",
+    type: "id",
+    origin: "generated",
+    families: ALL_FAMILIES,
+    required: false,
+  },
+
+  // Spec family
+  {
+    key: "Spec-id",
+    type: "id",
+    origin: "assigned",
+    families: ["spec"],
+    required: true,
+  },
+  {
+    key: "Derived-from",
+    type: "id-list",
+    origin: "authored",
+    families: ["spec"],
+    required: false,
+  },
+  {
+    key: "Satisfies",
+    type: "id-list",
+    origin: "authored",
+    families: ["spec"],
+    required: false,
+  },
+  {
+    key: "Allocated-to",
+    type: "id-list",
+    origin: "authored",
+    families: ["spec"],
+    required: false,
+  },
+  {
+    key: "Derives",
+    type: "id-list",
+    origin: "generated",
+    families: ["spec"],
+    required: false,
+  },
+  {
+    key: "Satisfied-by",
+    type: "id-list",
+    origin: "generated",
+    families: ["spec"],
+    required: false,
+  },
+  {
+    key: "Realized-by",
+    type: "id-list",
+    origin: "generated",
+    families: ["spec"],
+    required: false,
+  },
+  {
+    key: "Verified-by",
+    type: "id-list",
+    origin: "generated",
+    families: ["spec"],
+    required: false,
+  },
+
+  // Test family
+  {
+    key: "Test-id",
+    type: "id",
+    origin: "assigned",
+    families: ["test"],
+    required: true,
+  },
+  {
+    key: "Test-level",
+    type: "enum",
+    origin: "inferred",
+    families: ["test"],
+    required: false,
+    enumValues: TEST_LEVEL_VALUES,
+  },
+  {
+    key: "Verifies",
+    type: "id-list",
+    origin: "authored",
+    families: ["test"],
+    required: false,
+  },
+  {
+    key: "Tests",
+    type: "id-list",
+    origin: "authored",
+    families: ["test"],
+    required: false,
+  },
+
+  // Element family
+  {
+    key: "Element-id",
+    type: "id",
+    origin: "assigned",
+    families: ["element"],
+    required: true,
+  },
+  {
+    key: "Element-kind",
+    type: "enum",
+    origin: "inferred",
+    families: ["element"],
+    required: false,
+    enumValues: ELEMENT_KIND_VALUES,
+  },
+  {
+    key: "Part-of",
+    type: "id",
+    origin: "inferred",
+    families: ["element"],
+    required: false,
+  },
+  {
+    key: "Realizes",
+    type: "id-list",
+    origin: "authored",
+    families: ["element"],
+    required: false,
+  },
+  {
+    key: "Depends-on",
+    type: "id-list",
+    origin: "authored",
+    families: ["element"],
+    required: false,
+  },
+  {
+    key: "Generated-from",
+    type: "path-or-id",
+    origin: "authored",
+    families: ["element"],
+    required: false,
+  },
+  {
+    key: "Contains",
+    type: "id-list",
+    origin: "generated",
+    families: ["element"],
+    required: false,
+  },
+  {
+    key: "Used-by",
+    type: "id-list",
+    origin: "generated",
+    families: ["element"],
+    required: false,
+  },
+  {
+    key: "Allocated",
+    type: "id-list",
+    origin: "generated",
+    families: ["element"],
+    required: false,
+  },
+  {
+    key: "Tested-by",
+    type: "id-list",
+    origin: "generated",
+    families: ["element"],
+    required: false,
+  },
+
+  // Reference family
+  {
+    key: "Reference-id",
+    type: "uri",
+    origin: "authored",
+    families: ["reference"],
+    required: true,
+  },
+  {
+    key: "Reference-url",
+    type: "url",
+    origin: "authored",
+    families: ["reference"],
+    required: false,
+  },
+  {
+    key: "Reference-document",
+    type: "text",
+    origin: "authored",
+    families: ["reference"],
+    required: false,
+  },
+  {
+    key: "Cited-by",
+    type: "id-list",
+    origin: "generated",
+    families: ["reference"],
+    required: false,
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Lookup helpers
+// ---------------------------------------------------------------------------
+
+const SPEC_BY_KEY: ReadonlyMap<string, AttributeSpec> = new Map(
+  ATTRIBUTE_CATALOG.map((spec) => [spec.key, spec]),
+);
+
+/** Look up an attribute specification by its canonical key. */
+export function attributeSpec(key: string): AttributeSpec | undefined {
+  return SPEC_BY_KEY.get(key);
+}
+
+/** All attribute specifications that apply to the given family. */
+export function attributesForFamily(
+  family: EntryFamily,
+): readonly AttributeSpec[] {
+  return ATTRIBUTE_CATALOG.filter((spec) => spec.families.includes(family));
+}

--- a/packages/markspec/core/model/attributes_test.ts
+++ b/packages/markspec/core/model/attributes_test.ts
@@ -1,0 +1,91 @@
+/**
+ * @module model/attributes_test
+ *
+ * Catalog-shape invariants per ADR-002 Annex C.
+ */
+
+import { assert, assertEquals, assertExists } from "@std/assert";
+import {
+  ATTRIBUTE_CATALOG,
+  attributesForFamily,
+  attributeSpec,
+  ELEMENT_KIND_VALUES,
+  STATUS_VALUES,
+  TEST_LEVEL_VALUES,
+} from "./attributes.ts";
+import {
+  type EntryFamily,
+  FAMILY_BY_IDENTITY_KEY,
+  IDENTITY_KEY_BY_FAMILY,
+} from "./mod.ts";
+
+Deno.test("ATTRIBUTE_CATALOG: keys are unique", () => {
+  const keys = ATTRIBUTE_CATALOG.map((s) => s.key);
+  assertEquals(keys.length, new Set(keys).size);
+});
+
+Deno.test("ATTRIBUTE_CATALOG: identity attributes appear exactly once per family", () => {
+  for (const family of ["spec", "test", "element", "reference"] as const) {
+    const key = IDENTITY_KEY_BY_FAMILY[family];
+    const spec = attributeSpec(key);
+    assertExists(spec, `${key} missing from catalog`);
+    assertEquals(spec.families, [family]);
+    assertEquals(spec.required, true);
+  }
+});
+
+Deno.test("ATTRIBUTE_CATALOG: enum attributes declare enumValues", () => {
+  for (const spec of ATTRIBUTE_CATALOG) {
+    if (spec.type === "enum") {
+      assertExists(
+        spec.enumValues,
+        `enum attribute ${spec.key} missing enumValues`,
+      );
+      assert(spec.enumValues.length > 0);
+    }
+  }
+});
+
+Deno.test("ATTRIBUTE_CATALOG: Status is universal and carries the four-value vocabulary", () => {
+  const status = attributeSpec("Status");
+  assertExists(status);
+  assertEquals(status.families.length, 4);
+  assertEquals(status.enumValues, STATUS_VALUES);
+});
+
+Deno.test("ATTRIBUTE_CATALOG: References applies to spec/test/element, not reference", () => {
+  const refs = attributeSpec("References");
+  assertExists(refs);
+  assertEquals([...refs.families].sort(), ["element", "spec", "test"]);
+});
+
+Deno.test("ATTRIBUTE_CATALOG: Test-level enum matches ADR-002 Part 4", () => {
+  const level = attributeSpec("Test-level");
+  assertExists(level);
+  assertEquals(level.enumValues, TEST_LEVEL_VALUES);
+  assertEquals(level.origin, "inferred");
+});
+
+Deno.test("ATTRIBUTE_CATALOG: Element-kind enum matches ADR-002 Part 5", () => {
+  const kind = attributeSpec("Element-kind");
+  assertExists(kind);
+  assertEquals(kind.enumValues, ELEMENT_KIND_VALUES);
+});
+
+Deno.test("attributesForFamily: every family sees its identity attribute", () => {
+  const families: EntryFamily[] = ["spec", "test", "element", "reference"];
+  for (const family of families) {
+    const specs = attributesForFamily(family);
+    const identityKey = IDENTITY_KEY_BY_FAMILY[family];
+    assert(
+      specs.some((s) => s.key === identityKey),
+      `${family} catalog missing ${identityKey}`,
+    );
+  }
+});
+
+Deno.test("FAMILY_BY_IDENTITY_KEY and IDENTITY_KEY_BY_FAMILY are inverse", () => {
+  for (const [key, family] of Object.entries(FAMILY_BY_IDENTITY_KEY)) {
+    assertEquals(IDENTITY_KEY_BY_FAMILY[family as EntryFamily], key);
+  }
+});

--- a/packages/markspec/core/model/mod.ts
+++ b/packages/markspec/core/model/mod.ts
@@ -4,6 +4,16 @@
  * MarkSpec document model — AST types, ID types, and project configuration.
  */
 
+export {
+  ATTRIBUTE_CATALOG,
+  attributesForFamily,
+  attributeSpec,
+  ELEMENT_KIND_VALUES,
+  STATUS_VALUES,
+  TEST_LEVEL_VALUES,
+} from "./attributes.ts";
+export type { AttributeSpec } from "./attributes.ts";
+
 // ---------------------------------------------------------------------------
 // Builtin entry types
 // ---------------------------------------------------------------------------
@@ -81,8 +91,131 @@ export interface Attribute {
 /** The origin format of the entry. */
 export type EntrySource = "markdown" | "doc-comment";
 
-/** Entry family — spec entries are project declarations; reference entries are external citations. */
-export type EntryFamily = "spec" | "reference";
+/**
+ * Entry family per ADR-002.
+ *
+ * Four families, each with a dedicated identity attribute:
+ * - `spec` — project declaration (requirement, architecture, decision, hazard)
+ * - `test` — verification of declared behavior (automated or manual)
+ * - `element` — canonical system object (code unit, artifact, dependency, hardware)
+ * - `reference` — bibliographic citation of an external artifact
+ *
+ * Family is determined by the identity attribute the entry carries
+ * (`Spec-id` / `Test-id` / `Element-id` / `Reference-id`), not by display-ID
+ * pattern or document context. See {@linkcode IdentityAttribute}.
+ */
+export type EntryFamily = "spec" | "test" | "element" | "reference";
+
+/**
+ * Identity attribute key per ADR-002 Part 6.
+ *
+ * Every entry carries exactly one of these; its presence determines the family.
+ */
+export type IdentityAttribute =
+  | "Spec-id"
+  | "Test-id"
+  | "Element-id"
+  | "Reference-id";
+
+/** Map from identity attribute key to family. */
+export const FAMILY_BY_IDENTITY_KEY: Readonly<
+  Record<IdentityAttribute, EntryFamily>
+> = {
+  "Spec-id": "spec",
+  "Test-id": "test",
+  "Element-id": "element",
+  "Reference-id": "reference",
+};
+
+/** Map from family to identity attribute key. */
+export const IDENTITY_KEY_BY_FAMILY: Readonly<
+  Record<EntryFamily, IdentityAttribute>
+> = {
+  spec: "Spec-id",
+  test: "Test-id",
+  element: "Element-id",
+  reference: "Reference-id",
+};
+
+/**
+ * Origin of an attribute value per ADR-002 Part 1.
+ *
+ * - `authored` — written by the author in the source file.
+ * - `inferred` — pre-filled by `markspec format` from a heuristic,
+ *   committed to source, author-overridable.
+ * - `assigned` — generated fresh by `markspec format` at creation time
+ *   (identity attributes). Never derived, never changes after assignment.
+ * - `generated` — computed at build time from inverse relations.
+ *   Never committed to source.
+ */
+export type AttributeOrigin =
+  | "authored"
+  | "inferred"
+  | "assigned"
+  | "generated";
+
+/**
+ * Attribute value type per ADR-002 Part 1 (14 types).
+ *
+ * Cardinality is encoded in the type:
+ * - Repeatable: `id-list`, `tag-list`, `citation`, `external-id`.
+ * - Single-valued: everything else.
+ *
+ * Repeatable types accept multi-line and (except `citation`) CSV on input;
+ * the formatter always emits multi-line form.
+ */
+export type AttributeValueType =
+  | "id"
+  | "id-list"
+  | "uri"
+  | "url"
+  | "path"
+  | "path-or-id"
+  | "enum"
+  | "tag-list"
+  | "text"
+  | "citation"
+  | "external-id"
+  | "integer"
+  | "date"
+  | "boolean";
+
+/**
+ * Observed properties of an entry per ADR-002 Part 1 and ADR-006 (stub).
+ *
+ * Properties are model-level observations — never authored in source, never
+ * round-trip through `markspec format`, not in git diffs. Each category is
+ * optional; absence means "not observed (yet)".
+ *
+ * Observation contracts for git/sync/build are deferred to ADR-006. Only
+ * `file.path` is populated today (set by the parser from the parse options).
+ */
+export interface EntryProperties {
+  /** Repository location. */
+  readonly file?: {
+    readonly path: string;
+    readonly line?: number;
+    readonly column?: number;
+  };
+  /** Version-control observations. */
+  readonly git?: {
+    readonly createdAt?: string;
+    readonly modifiedAt?: string;
+    readonly contributors?: readonly string[];
+    readonly revision?: string;
+  };
+  /** External connector state. */
+  readonly sync?: {
+    readonly lastSyncedAt?: string;
+    readonly remoteState?: string;
+    readonly externalSource?: string;
+  };
+  /** Compilation-time provenance. */
+  readonly build?: {
+    readonly resolutionSource?: string;
+    readonly registryOrigin?: string;
+  };
+}
 
 /**
  * A parsed MarkSpec entry — the core AST node.
@@ -110,6 +243,13 @@ export interface Entry {
   readonly location: SourceLocation;
   /** Whether this came from a Markdown file or a doc comment. */
   readonly source: EntrySource;
+  /**
+   * Observed properties (file path, git history, sync state, build origin).
+   *
+   * Populated progressively: Phase 2 wires `file.path`; ADR-006 work wires
+   * the rest. Consumers must tolerate missing values.
+   */
+  readonly properties?: EntryProperties;
 }
 
 // ---------------------------------------------------------------------------
@@ -241,12 +381,25 @@ export interface InlineRef {
 // Traceability graph
 // ---------------------------------------------------------------------------
 
-/** Kind of directional link between entries. */
+/**
+ * Kind of directional link between entries.
+ *
+ * Extends the four-link spec/reference model to cover all ADR-002 relations:
+ * Test.`Verifies`, Test.`Tests`, Element.`Realizes`, Element.`Depends-on`,
+ * Element.`Part-of`, Element.`Generated-from`, universal `Supersedes`.
+ */
 export type LinkKind =
   | "satisfies"
   | "derived-from"
   | "references"
-  | "allocated-to";
+  | "allocated-to"
+  | "realizes"
+  | "verifies"
+  | "tests"
+  | "depends-on"
+  | "part-of"
+  | "generated-from"
+  | "supersedes";
 
 /** A directional link between two entries in the traceability graph. */
 export interface Link {
@@ -254,4 +407,74 @@ export interface Link {
   readonly to: DisplayId;
   readonly kind: LinkKind;
   readonly location: SourceLocation;
+}
+
+// ---------------------------------------------------------------------------
+// Document
+// ---------------------------------------------------------------------------
+
+/**
+ * Document-level attributes authored in YAML front matter per ADR-007.
+ *
+ * Keys use kebab-case (YAML-ecosystem convention). Core keys below; profiles
+ * declare additional keys; `.markspec.yaml` → `frontMatter.allowedKeys`
+ * allowlists ecosystem keys (Hugo, Jekyll, Docusaurus). Keys forbidden by
+ * ADR-007 (`title`, `description`, `date`, `authors`, …) are rejected by
+ * MSL-D001 and never reach this map.
+ */
+export interface DocumentAttributes {
+  /** Document ULID — bare 26-char Crockford base32. */
+  readonly "document-id"?: string;
+  /** Overrides filename/directive-based type detection. */
+  readonly "document-type"?: string;
+  /** Classification tags (`tag-list`). */
+  readonly labels?: readonly string[];
+  /** Lifecycle state (`draft` / `approved` / `deprecated` / `withdrawn`). */
+  readonly status?: string;
+  /** Cross-system identifier(s) (`external-id`). */
+  readonly "external-id"?: readonly string[];
+  /** `document-id` of a document this one replaces. */
+  readonly supersedes?: string;
+  /** External reference citations with optional locator (`citation`). */
+  readonly references?: readonly string[];
+  /** Org free-form metadata, never validated. */
+  readonly metadata?: Readonly<Record<string, unknown>>;
+  /** Allowlisted ecosystem keys (preserved verbatim, not validated). */
+  readonly extra?: Readonly<Record<string, unknown>>;
+}
+
+/**
+ * Observed document properties per ADR-007 §6.2 — derived, never authored.
+ *
+ * The H1, first paragraph, git history, and filesystem are the authoritative
+ * sources. These fields are populated progressively as observation support
+ * lands.
+ */
+export interface DocumentProperties {
+  /** H1 heading, or filename stem fallback. */
+  readonly title?: string;
+  /** Merge-to-main count (starts at `0`). */
+  readonly revision?: number;
+  /** Contributors from `project.yaml` or git history. */
+  readonly authors?: readonly string[];
+  /** First commit timestamp, or filesystem ctime fallback. */
+  readonly createdAt?: string;
+  /** Last merge-commit timestamp, or filesystem mtime fallback. */
+  readonly modifiedAt?: string;
+}
+
+/**
+ * A parsed MarkSpec document per ADR-007.
+ *
+ * A Markdown (or source) file containing entries, optionally preceded by YAML
+ * front matter. Document metadata is split into authored `attributes` (front
+ * matter) and observed `properties` (H1, git, filesystem).
+ */
+export interface Document {
+  /** File path (absolute or project-relative). */
+  readonly file: string;
+  /** Document-level attributes from front matter. */
+  readonly attributes: DocumentAttributes;
+  /** Observed document properties. */
+  readonly properties: DocumentProperties;
 }


### PR DESCRIPTION
## What

Phase 1 of the ADR-002 v2 rewrite: extend the core model with four-family types, identity attributes, the 14-type attribute value system, origin verbs, entry/document property namespaces, and the full ADR-002 Annex C attribute catalog. Additive only — no parser / validator / formatter / compiler behavior changes.

## Why

Tracked in #198. The docs for the four-family entry model landed in #197; the code still implements the old two-family design. This PR lays the foundation (types + catalog) that Phases 2–5 build on top of.

Refs #198

## How

- `model/mod.ts` — extend `EntryFamily` to four values; add `IdentityAttribute` + family↔key maps, `AttributeOrigin`, `AttributeValueType`, `EntryProperties`, `DocumentAttributes` / `DocumentProperties` / `Document`; extend `LinkKind` with 7 new kinds; add optional `Entry.properties` for Phase 2 to populate.
- `model/attributes.ts` (new) — `AttributeSpec` shape + `ATTRIBUTE_CATALOG` (complete Annex C) + enum vocabularies (`STATUS_VALUES`, `TEST_LEVEL_VALUES`, `ELEMENT_KIND_VALUES`) + `attributeSpec(key)` / `attributesForFamily(family)` helpers.
- `model/attributes_test.ts` (new) — 9 catalog-invariant tests (key uniqueness, identity attribute presence per family, enum coverage, family scoping).

No exhaustive-switch consumers of `EntryFamily` / `LinkKind` exist, so extending the unions is genuinely additive. The existing `Entry` shape and `family: "spec" | "reference"` branches in the parser / validator / formatter keep working — Phase 2 will switch them over.

One spec inconsistency surfaced and logged as debt on #198: ADR-002 §2.6 lists `path-or-id` as single-valued, but Part 5 describes `Generated-from` as repeatable. Modeled as single for now; revisit when Phase 2/3 hit real fixtures.

## Checklist

- [x] Tests added (9 new catalog tests; 302/302 total pass)
- [x] No documentation changes needed for this phase
- [x] `just check` passes locally
