### PR TITLE
feat(core): entry-model v2 phase 2a — front-matter parser and additive parser changes

### DIFF
--- a/packages/markspec/core/parser/frontmatter.ts
+++ b/packages/markspec/core/parser/frontmatter.ts
@@ -1,0 +1,229 @@
+/**
+ * @module parser/frontmatter
+ *
+ * YAML front-matter parser per ADR-007.
+ *
+ * Extracts a `---`-delimited YAML block at the top of a Markdown file,
+ * classifies keys into core / `metadata` / allowlisted ecosystem, and rejects
+ * forbidden keys (MSL-D001). Returns a {@linkcode DocumentAttributes} record
+ * and the markdown content with the front matter stripped.
+ *
+ * Full validation of core-key value types is deferred to the validator
+ * (Phase 3); this module handles extraction and key-category classification.
+ */
+
+import { parse as parseYaml } from "@std/yaml";
+import type { Diagnostic, DocumentAttributes } from "../model/mod.ts";
+
+/**
+ * YAML front-matter delimiter — `---` at start of file, closing `---`, then
+ * any number of trailing newlines so the stripped markdown begins cleanly.
+ * Empty YAML body (`---\n---\n`) is accepted.
+ */
+const FRONT_MATTER_RE = /^---\r?\n([\s\S]*?)(?:\r?\n)?---\r?\n?(?:\r?\n)*/;
+
+/**
+ * Core document-level attribute keys per ADR-007. Kebab-case by convention.
+ */
+const CORE_KEYS: ReadonlySet<string> = new Set([
+  "document-id",
+  "document-type",
+  "labels",
+  "status",
+  "external-id",
+  "supersedes",
+  "references",
+  "metadata",
+]);
+
+/**
+ * Keys forbidden in front matter per ADR-007 — already expressed natively in
+ * Markdown (H1, body, images) or in git history (authors, dates).
+ */
+const FORBIDDEN_KEYS: ReadonlySet<string> = new Set([
+  "title",
+  "description",
+  "toc",
+  "authors",
+  "author",
+  "date",
+  "created",
+  "modified",
+  "cover",
+  "images",
+  "sections",
+]);
+
+/** Options for {@linkcode extractFrontMatter}. */
+export interface ExtractFrontMatterOptions {
+  /** File path used in diagnostic source locations. */
+  readonly file?: string;
+  /**
+   * Profile-declared keys. Accepted alongside core keys, passed through on
+   * {@linkcode FrontMatterResult.attributes.extra}.
+   */
+  readonly profileKeys?: readonly string[];
+  /**
+   * Allowlisted ecosystem keys from `.markspec.yaml`
+   * (`frontMatter.allowedKeys`). Accepted and passed through on
+   * {@linkcode FrontMatterResult.attributes.extra}.
+   */
+  readonly allowedKeys?: readonly string[];
+}
+
+/** Result of front-matter extraction. */
+export interface FrontMatterResult {
+  /** Parsed document attributes. Empty when no front matter is present. */
+  readonly attributes: DocumentAttributes;
+  /** Diagnostics (forbidden keys, unknown keys, YAML errors). */
+  readonly diagnostics: readonly Diagnostic[];
+  /** Markdown content with front matter stripped. */
+  readonly markdown: string;
+  /** Whether front matter was present. */
+  readonly hadFrontMatter: boolean;
+}
+
+/**
+ * Extract YAML front matter from a Markdown source, validate its keys, and
+ * return structured attributes plus the stripped markdown.
+ *
+ * No front matter → {@linkcode FrontMatterResult.hadFrontMatter} is `false`
+ * and attributes are empty.
+ *
+ * @param markdown - Full source text, including any leading front matter.
+ * @param options - Key allowlists and file path for diagnostics.
+ */
+export function extractFrontMatter(
+  markdown: string,
+  options?: ExtractFrontMatterOptions,
+): FrontMatterResult {
+  const file = options?.file ?? "<unknown>";
+
+  const match = FRONT_MATTER_RE.exec(markdown);
+  if (!match) {
+    return {
+      attributes: {},
+      diagnostics: [],
+      markdown,
+      hadFrontMatter: false,
+    };
+  }
+
+  const yamlBody = match[1];
+  const remaining = markdown.slice(match[0].length);
+  const diagnostics: Diagnostic[] = [];
+
+  let raw: unknown;
+  try {
+    raw = parseYaml(yamlBody);
+  } catch (err) {
+    diagnostics.push({
+      code: "MSL-D001",
+      severity: "error",
+      message: `front matter: invalid YAML — ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+      location: { file, line: 1, column: 1 },
+    });
+    return {
+      attributes: {},
+      diagnostics,
+      markdown: remaining,
+      hadFrontMatter: true,
+    };
+  }
+
+  if (raw == null) {
+    return {
+      attributes: {},
+      diagnostics,
+      markdown: remaining,
+      hadFrontMatter: true,
+    };
+  }
+
+  if (typeof raw !== "object" || Array.isArray(raw)) {
+    diagnostics.push({
+      code: "MSL-D001",
+      severity: "error",
+      message: "front matter must be a YAML mapping",
+      location: { file, line: 1, column: 1 },
+    });
+    return {
+      attributes: {},
+      diagnostics,
+      markdown: remaining,
+      hadFrontMatter: true,
+    };
+  }
+
+  const entries = raw as Record<string, unknown>;
+  const profileKeys = new Set(options?.profileKeys ?? []);
+  const allowedKeys = new Set(options?.allowedKeys ?? []);
+
+  const core: Record<string, unknown> = {};
+  const extra: Record<string, unknown> = {};
+  let metadata: Record<string, unknown> | undefined;
+
+  for (const [key, value] of Object.entries(entries)) {
+    if (FORBIDDEN_KEYS.has(key)) {
+      diagnostics.push({
+        code: "MSL-D001",
+        severity: "error",
+        message:
+          `front matter key '${key}' is forbidden — express it in Markdown or git history instead`,
+        location: { file, line: 1, column: 1 },
+      });
+      continue;
+    }
+
+    if (key === "metadata") {
+      if (
+        value == null || typeof value !== "object" || Array.isArray(value)
+      ) {
+        diagnostics.push({
+          code: "MSL-D001",
+          severity: "error",
+          message: "front matter 'metadata' must be a mapping",
+          location: { file, line: 1, column: 1 },
+        });
+        continue;
+      }
+      metadata = value as Record<string, unknown>;
+      continue;
+    }
+
+    if (CORE_KEYS.has(key)) {
+      core[key] = value;
+      continue;
+    }
+
+    if (profileKeys.has(key) || allowedKeys.has(key)) {
+      extra[key] = value;
+      continue;
+    }
+
+    diagnostics.push({
+      code: "MSL-D001",
+      severity: "error",
+      message:
+        `unknown front matter key '${key}' — must be core, profile-declared, 'metadata', or allowlisted in .markspec.yaml`,
+      location: { file, line: 1, column: 1 },
+    });
+  }
+
+  const attributes: DocumentAttributes = {};
+  const mutable = attributes as Record<string, unknown>;
+  for (const [key, value] of Object.entries(core)) {
+    mutable[key] = value;
+  }
+  if (metadata !== undefined) mutable.metadata = metadata;
+  if (Object.keys(extra).length > 0) mutable.extra = extra;
+
+  return {
+    attributes,
+    diagnostics,
+    markdown: remaining,
+    hadFrontMatter: true,
+  };
+}

--- a/packages/markspec/core/parser/frontmatter_test.ts
+++ b/packages/markspec/core/parser/frontmatter_test.ts
@@ -1,0 +1,164 @@
+/**
+ * @module parser/frontmatter_test
+ */
+
+import { assert, assertEquals } from "@std/assert";
+import { extractFrontMatter } from "./frontmatter.ts";
+
+Deno.test("extractFrontMatter: no front matter returns input unchanged", () => {
+  const md = "# Title\n\nBody.\n";
+  const result = extractFrontMatter(md);
+  assertEquals(result.hadFrontMatter, false);
+  assertEquals(result.markdown, md);
+  assertEquals(result.attributes, {});
+  assertEquals(result.diagnostics.length, 0);
+});
+
+Deno.test("extractFrontMatter: extracts core keys", () => {
+  const md = `---
+document-id: 01HGW2D0DOCPQ4FGHIJKLMNOPQR
+document-type: requirements
+status: approved
+---
+
+# Title
+`;
+  const result = extractFrontMatter(md);
+  assert(result.hadFrontMatter);
+  assertEquals(
+    result.attributes["document-id"],
+    "01HGW2D0DOCPQ4FGHIJKLMNOPQR",
+  );
+  assertEquals(result.attributes["document-type"], "requirements");
+  assertEquals(result.attributes.status, "approved");
+  assertEquals(result.markdown, "# Title\n");
+});
+
+Deno.test("extractFrontMatter: preserves metadata map verbatim", () => {
+  const md = `---
+document-id: 01HGW...
+metadata:
+  owner: safety-team
+  cost-center: ENG-042
+  nested:
+    jira-epic: PROJ-123
+---
+
+# Title
+`;
+  const result = extractFrontMatter(md);
+  assertEquals(result.attributes.metadata, {
+    owner: "safety-team",
+    "cost-center": "ENG-042",
+    nested: { "jira-epic": "PROJ-123" },
+  });
+});
+
+Deno.test("extractFrontMatter: rejects forbidden keys", () => {
+  const md = `---
+title: My Document
+author: Alice
+date: 2026-04-18
+---
+
+# Title
+`;
+  const result = extractFrontMatter(md);
+  assertEquals(result.diagnostics.length, 3);
+  for (const diag of result.diagnostics) {
+    assertEquals(diag.code, "MSL-D001");
+    assertEquals(diag.severity, "error");
+  }
+  assertEquals(result.attributes, {});
+});
+
+Deno.test("extractFrontMatter: rejects unknown keys", () => {
+  const md = `---
+document-id: 01HGW...
+bogus: something
+---
+`;
+  const result = extractFrontMatter(md);
+  assertEquals(result.diagnostics.length, 1);
+  assertEquals(result.diagnostics[0].code, "MSL-D001");
+  assert(result.diagnostics[0].message.includes("bogus"));
+});
+
+Deno.test("extractFrontMatter: accepts allowlisted ecosystem keys into extra", () => {
+  const md = `---
+document-id: 01HGW...
+layout: page
+sidebar_position: 3
+---
+`;
+  const result = extractFrontMatter(md, {
+    allowedKeys: ["layout", "sidebar_position"],
+  });
+  assertEquals(result.diagnostics.length, 0);
+  assertEquals(result.attributes.extra, {
+    layout: "page",
+    sidebar_position: 3,
+  });
+});
+
+Deno.test("extractFrontMatter: accepts profile keys into extra", () => {
+  const md = `---
+document-id: 01HGW...
+asil: B
+---
+`;
+  const result = extractFrontMatter(md, { profileKeys: ["asil"] });
+  assertEquals(result.diagnostics.length, 0);
+  assertEquals(result.attributes.extra, { asil: "B" });
+});
+
+Deno.test("extractFrontMatter: CRLF line endings work", () => {
+  const md = "---\r\ndocument-id: 01HGW...\r\n---\r\n# Title\r\n";
+  const result = extractFrontMatter(md);
+  assert(result.hadFrontMatter);
+  assertEquals(result.attributes["document-id"], "01HGW...");
+});
+
+Deno.test("extractFrontMatter: malformed YAML emits a diagnostic", () => {
+  const md = `---
+document-id: [unclosed
+---
+
+# Title
+`;
+  const result = extractFrontMatter(md);
+  assertEquals(result.diagnostics.length, 1);
+  assertEquals(result.diagnostics[0].code, "MSL-D001");
+  assertEquals(result.diagnostics[0].severity, "error");
+  assertEquals(result.attributes, {});
+});
+
+Deno.test("extractFrontMatter: non-mapping YAML is rejected", () => {
+  const md = `---
+- just
+- a
+- list
+---
+
+# Title
+`;
+  const result = extractFrontMatter(md);
+  assertEquals(result.diagnostics.length, 1);
+  assertEquals(result.diagnostics[0].code, "MSL-D001");
+  assert(result.diagnostics[0].message.includes("mapping"));
+});
+
+Deno.test("extractFrontMatter: non-leading --- is not front matter", () => {
+  const md = "# Title\n\n---\nnot-front-matter: true\n---\n";
+  const result = extractFrontMatter(md);
+  assertEquals(result.hadFrontMatter, false);
+  assertEquals(result.markdown, md);
+});
+
+Deno.test("extractFrontMatter: empty front matter is valid", () => {
+  const md = "---\n---\n# Title\n";
+  const result = extractFrontMatter(md);
+  assert(result.hadFrontMatter);
+  assertEquals(result.attributes, {});
+  assertEquals(result.diagnostics.length, 0);
+});

--- a/packages/markspec/core/parser/markdown.ts
+++ b/packages/markspec/core/parser/markdown.ts
@@ -19,20 +19,22 @@ export interface ParseMarkdownOptions {
 }
 
 /**
- * Spec entry display ID pattern per ADR-002.
+ * Spec / test entry display ID pattern per ADR-002 §Annex B.
  * TYPE = 2-6 uppercase letters
  * DOMAIN = 3-8 uppercase alphanumeric (first letter uppercase)
  * SUBDOMAIN = optional, same as DOMAIN
  * NNNN = 3-6 digits, must be > 0
+ * Shared by spec and test families — discriminated by identity attribute.
  */
 const TYPED_ID_RE =
   /^([A-Z]{2,6})_[A-Z][A-Z0-9]{2,7}(_[A-Z][A-Z0-9]{2,7})?_\d{3,6}$/;
 
 /**
- * Reference entry slug pattern per ADR-002.
- * Starts with letter, alphanumeric + internal hyphens/dots.
+ * Reference entry slug pattern per ADR-002 §Part 3 (widened from the old
+ * narrow subset to include `.`, `/`, `_`, and `-` inside the slug, matching
+ * Pandoc citation-key convention's disciplined subset).
  */
-const REF_SLUG_RE = /^[A-Za-z][A-Za-z0-9]*([.-][A-Za-z0-9]+)*$/;
+const REF_SLUG_RE = /^[A-Za-z]([A-Za-z0-9._/-]*[A-Za-z0-9])?$/;
 
 /**
  * Match a display ID in `[...]` at the start of a list item paragraph.
@@ -182,6 +184,10 @@ function extractEntry(
 
   if (!displayId) return undefined;
 
+  // Strip optional leading `@` on reference display IDs for Pandoc citation
+  // compatibility (ADR-002 §Part 3). Canonical slug never contains `@`.
+  if (displayId.startsWith("@")) displayId = displayId.slice(1);
+
   // Discriminate spec vs reference entry
   let family: EntryFamily | undefined;
   let entryType: EntryType | undefined;
@@ -227,6 +233,7 @@ function extractEntry(
     family,
     location: { file, line, column },
     source: "markdown",
+    properties: { file: { path: file, line, column } },
   };
 }
 

--- a/packages/markspec/core/parser/markdown_test.ts
+++ b/packages/markspec/core/parser/markdown_test.ts
@@ -492,3 +492,67 @@ Deno.test("parseMarkdown: fixture — braking requirements", () => {
   assertEquals(entries[1].id, "SRS_01HGW2R9QLP4");
   assertEquals(entries[1].attributes.length, 3);
 });
+
+// ---------------------------------------------------------------------------
+// Phase 2a additions — @ stripping, widened reference slug, file.path property
+// ---------------------------------------------------------------------------
+
+Deno.test("parseMarkdown: strips optional leading @ from reference display ID", () => {
+  const md = `# References
+
+- [@ISO-26262-6] ISO 26262 Part 6
+
+  Road vehicles — Functional safety.
+
+  URI: urn:iso:std:iso:26262:-6:ed-2
+`;
+  const entries = parseMarkdown(md, { file: "references.md" });
+  assertEquals(entries.length, 1);
+  assertEquals(entries[0].displayId, "ISO-26262-6");
+  assertEquals(entries[0].family, "reference");
+});
+
+Deno.test("parseMarkdown: widened reference slug accepts slashes and dots", () => {
+  const md = `# References
+
+- [ISO/IEC-25010] ISO/IEC 25010
+
+  Systems and software engineering — quality models.
+
+  URI: urn:iso:std:iso-iec:25010
+`;
+  const entries = parseMarkdown(md, { file: "references.md" });
+  assertEquals(entries.length, 1);
+  assertEquals(entries[0].displayId, "ISO/IEC-25010");
+  assertEquals(entries[0].family, "reference");
+});
+
+Deno.test("parseMarkdown: widened reference slug accepts underscores", () => {
+  const md = `# References
+
+- [smith_2021] Smith 2021 paper
+
+  Citation body.
+
+  URI: doi:10.1000/example
+`;
+  const entries = parseMarkdown(md, { file: "references.md" });
+  assertEquals(entries.length, 1);
+  assertEquals(entries[0].displayId, "smith_2021");
+  assertEquals(entries[0].family, "reference");
+});
+
+Deno.test("parseMarkdown: entry properties carry file.path from options", () => {
+  const md = `# Test
+
+- [SRS_BRK_0001] Entry with properties
+
+  Body text.
+
+  Id: SRS_01HGW2Q8MNP3
+`;
+  const entries = parseMarkdown(md, { file: "docs/braking.md" });
+  assertEquals(entries.length, 1);
+  assertEquals(entries[0].properties?.file?.path, "docs/braking.md");
+  assertEquals(entries[0].properties?.file?.line, entries[0].location.line);
+});

--- a/packages/markspec/core/parser/mod.ts
+++ b/packages/markspec/core/parser/mod.ts
@@ -25,6 +25,12 @@ export type { DetectCaptionsOptions } from "./captions.ts";
 export { detectDirectives } from "./directives.ts";
 export type { DetectDirectivesOptions } from "./directives.ts";
 
+export { extractFrontMatter } from "./frontmatter.ts";
+export type {
+  ExtractFrontMatterOptions,
+  FrontMatterResult,
+} from "./frontmatter.ts";
+
 export { detectInlineRefs } from "./references.ts";
 export type { DetectInlineRefsOptions } from "./references.ts";
 

--- a/packages/markspec/core/parser/source.ts
+++ b/packages/markspec/core/parser/source.ts
@@ -78,13 +78,21 @@ export function parseSource(
     if (parsed.length > 0) {
       // Block contains entry blocks — extract entries.
       for (const entry of parsed) {
+        const location = {
+          file,
+          line: block.startLine,
+          column: block.startColumn,
+        };
         entries.push({
           ...entry,
           source: "doc-comment",
-          location: {
-            file,
-            line: block.startLine,
-            column: block.startColumn,
+          location,
+          properties: {
+            file: {
+              path: file,
+              line: block.startLine,
+              column: block.startColumn,
+            },
           },
         });
       }


### PR DESCRIPTION
## What

Phase 2 of the ADR-002 v2 rewrite, split into two PRs to keep `main` green. This is **2a — fully additive** parser changes. 2b (breaking) follows separately.

## Why

Tracked in #198. Phase 2 as originally scoped was large (front-matter parsing + identity-based family discrimination + attribute collation + source-parser cleanup). Splitting keeps each PR focused and reviewable.

Refs #198

## How

**`parser/frontmatter.ts` (new)** — YAML front-matter extraction per ADR-007:
- Classifies keys into core / `metadata` / profile / allowlisted ecosystem
- Rejects forbidden keys (MSL-D001): `title`, `description`, `toc`, `authors`, `author`, `date`, `created`, `modified`, `cover`, `images`, `sections`
- Returns `DocumentAttributes` + stripped markdown + diagnostics
- Handles empty FM, CRLF, malformed YAML, non-mapping YAML, non-leading `---`

**`parser/markdown.ts`** — widen `REF_SLUG_RE` per ADR-002 Part 3 to accept `.`, `/`, `_`, `-` inside slugs; strip optional leading `@` on reference display IDs for Pandoc citation compatibility; wire `Entry.properties.file.path` at parse time (per decision #4 on #198).

**`parser/source.ts`** — same `file.path` property wiring for doc-comment entries.

**`parser/mod.ts`** — re-export `extractFrontMatter` + types.

## Deferred to phase 2b

- Identity-attribute-based family discrimination (requires validator rewrite to not break on bare-ULID identity values)
- Removal of `isReferencesDoc` gating
- Removal of standalone `Verifies:` / `Implements:` annotation path in `source.ts`
- Repeatable-attribute collation (multi-line + CSV → canonical list)

These are breaking changes to parser output / remove legacy paths; they're coupled to Phase 3 validator work and will ship in their own PR.

## Checklist

- [x] Tests added (12 new front-matter tests + 4 new markdown tests; 318/318 total pass)
- [x] `just check` passes locally
- [x] No documentation changes needed for this phase
