### PR TITLE
feat(core): entry-model v2 phase 2b-ii — identity-attribute family discrimination

### DIFF
--- a/packages/markspec/core/parser/markdown.ts
+++ b/packages/markspec/core/parser/markdown.ts
@@ -6,7 +6,14 @@
  */
 
 import type { Definition, List, ListItem, Paragraph, Text } from "mdast";
-import type { Entry, EntryFamily, EntryType } from "../model/mod.ts";
+import type {
+  Attribute,
+  Entry,
+  EntryFamily,
+  EntryType,
+  IdentityAttribute,
+} from "../model/mod.ts";
+import { FAMILY_BY_IDENTITY_KEY } from "../model/mod.ts";
 import { parseAttributes, splitBodyAndAttributes } from "./attributes.ts";
 import { processor } from "./remark.ts";
 
@@ -35,6 +42,62 @@ const TYPED_ID_RE =
  * Pandoc citation-key convention's disciplined subset).
  */
 const REF_SLUG_RE = /^[A-Za-z]([A-Za-z0-9._/-]*[A-Za-z0-9])?$/;
+
+/**
+ * Element entry display ID pattern per ADR-002 §Part 5.
+ * Optional leading `::` marks an absolute path; `::` is the hierarchy
+ * separator between segments; `.` and `/` may appear inside a segment.
+ */
+const ELEMENT_ID_RE =
+  /^(::)?[A-Za-z]([A-Za-z0-9._/-]*[A-Za-z0-9])?(::[A-Za-z]([A-Za-z0-9._/-]*[A-Za-z0-9])?)*$/;
+
+/** Identity-attribute keys per ADR-002 Part 6. */
+const IDENTITY_KEYS: readonly IdentityAttribute[] = [
+  "Spec-id",
+  "Test-id",
+  "Element-id",
+  "Reference-id",
+];
+
+/** Display-ID regex for each family (post-identity-attribute discrimination). */
+function displayIdMatchesFamily(
+  displayId: string,
+  family: EntryFamily,
+): { matches: boolean; entryType: EntryType | undefined } {
+  switch (family) {
+    case "spec":
+    case "test": {
+      const m = TYPED_ID_RE.exec(displayId);
+      return {
+        matches: m !== null,
+        entryType: m?.[1] as EntryType | undefined,
+      };
+    }
+    case "element":
+      return {
+        matches: ELEMENT_ID_RE.test(displayId),
+        entryType: undefined,
+      };
+    case "reference":
+      return { matches: REF_SLUG_RE.test(displayId), entryType: undefined };
+  }
+}
+
+/**
+ * Find the sole identity attribute on an entry. Returns undefined when none
+ * present; returns the first attribute when more than one is present (a
+ * condition the validator flags as MSL-R003 in Phase 3).
+ */
+function findIdentityAttribute(
+  attributes: readonly Attribute[],
+): Attribute | undefined {
+  for (const attr of attributes) {
+    if ((IDENTITY_KEYS as readonly string[]).includes(attr.key)) {
+      return attr;
+    }
+  }
+  return undefined;
+}
 
 /**
  * Match a display ID in `[...]` at the start of a list item paragraph.
@@ -188,36 +251,51 @@ function extractEntry(
   // compatibility (ADR-002 §Part 3). Canonical slug never contains `@`.
   if (displayId.startsWith("@")) displayId = displayId.slice(1);
 
-  // Discriminate spec vs reference entry
-  let family: EntryFamily | undefined;
-  let entryType: EntryType | undefined;
-
-  const typedMatch = TYPED_ID_RE.exec(displayId);
-  if (typedMatch) {
-    family = "spec";
-    entryType = typedMatch[1] as EntryType;
-  } else if (isReferencesDoc && REF_SLUG_RE.test(displayId)) {
-    family = "reference";
-    entryType = undefined;
-  } else {
-    return undefined;
-  }
-
-  // Body requirement: spec entries require body; reference entries optionally have body.
-  // If there's only one child (the title paragraph) and no further content,
-  // it's only valid for reference entries.
-  if (family === "spec" && item.children.length < 2) return undefined;
-
-  // Extract body content from remaining children
+  // Extract body content and attributes first — identity-attribute-based
+  // family discrimination per ADR-002 Part 6 depends on the attribute block.
   const bodyContent = extractBodyContent(item, markdown);
-
-  // Split body and attributes
   const [body, attrLines] = splitBodyAndAttributes(bodyContent);
   const attributes = parseAttributes(attrLines);
 
-  // Extract ULID from Id attribute
-  const idAttr = attributes.find((a) => a.key === "Id");
-  const id = idAttr?.value;
+  let family: EntryFamily | undefined;
+  let entryType: EntryType | undefined;
+  let id: string | undefined;
+
+  const identityAttr = findIdentityAttribute(attributes);
+  if (identityAttr) {
+    // Family is determined by the identity attribute (ADR-002 Part 6).
+    family = FAMILY_BY_IDENTITY_KEY[identityAttr.key as IdentityAttribute];
+    id = identityAttr.value;
+    const match = displayIdMatchesFamily(displayId, family);
+    if (!match.matches) {
+      // Display ID doesn't match the declared family's format. Accept the
+      // entry anyway — the validator (Phase 3) surfaces MSL-R007 for this
+      // mismatch rather than silently dropping the entry here.
+    }
+    entryType = match.entryType;
+  } else {
+    // Legacy fallback: discriminate by display-ID regex + references-doc
+    // heuristic. Used while source files still carry `Id:` instead of the
+    // new family-specific identity attributes.
+    const typedMatch = TYPED_ID_RE.exec(displayId);
+    if (typedMatch) {
+      family = "spec";
+      entryType = typedMatch[1] as EntryType;
+    } else if (isReferencesDoc && REF_SLUG_RE.test(displayId)) {
+      family = "reference";
+      entryType = undefined;
+    } else {
+      return undefined;
+    }
+    // Legacy ULID comes from the `Id` attribute.
+    const idAttr = attributes.find((a) => a.key === "Id");
+    id = idAttr?.value;
+  }
+
+  // Body requirement: non-reference entries require body. If there's only
+  // one child (the title paragraph) and no further content, accept only
+  // reference entries.
+  if (family !== "reference" && item.children.length < 2) return undefined;
 
   // Source location
   const line = item.position?.start.line ?? 1;

--- a/packages/markspec/core/parser/markdown_test.ts
+++ b/packages/markspec/core/parser/markdown_test.ts
@@ -556,3 +556,106 @@ Deno.test("parseMarkdown: entry properties carry file.path from options", () => 
   assertEquals(entries[0].properties?.file?.path, "docs/braking.md");
   assertEquals(entries[0].properties?.file?.line, entries[0].location.line);
 });
+
+// ---------------------------------------------------------------------------
+// Phase 2b-ii — identity-attribute-based family discrimination
+// ---------------------------------------------------------------------------
+
+Deno.test("parseMarkdown: Spec-id attribute sets family=spec and id", () => {
+  const md = `# Test
+
+- [SRS_BRK_0001] Sensor input debouncing
+
+  Body text.
+
+  Spec-id: 01HGW2Q8MNP3RSTVWXYZABCDE
+`;
+  const entries = parseMarkdown(md, { file: "braking.md" });
+  assertEquals(entries.length, 1);
+  assertEquals(entries[0].family, "spec");
+  assertEquals(entries[0].id, "01HGW2Q8MNP3RSTVWXYZABCDE");
+  assertEquals(entries[0].entryType, "SRS");
+});
+
+Deno.test("parseMarkdown: Test-id attribute sets family=test", () => {
+  const md = `# Test
+
+- [SWT_BRK_0107] Debounce unit test
+
+  Given a 10ms window, a 5ms spike must not alter output.
+
+  Test-id: 01HGW3R9QLP4ABCDEFGHJKMNPQ
+`;
+  const entries = parseMarkdown(md, { file: "tests.md" });
+  assertEquals(entries.length, 1);
+  assertEquals(entries[0].family, "test");
+  assertEquals(entries[0].id, "01HGW3R9QLP4ABCDEFGHJKMNPQ");
+  assertEquals(entries[0].entryType, "SWT");
+});
+
+Deno.test("parseMarkdown: Element-id attribute sets family=element", () => {
+  const md = `# Elements
+
+- [braking_core::controller::debounce_input] Debounce function
+
+  Rejects transient noise on raw sensor readings.
+
+  Element-id: 01HGW3D6QRST7IJKLMNOPQRSTUV
+`;
+  const entries = parseMarkdown(md, { file: "elements.md" });
+  assertEquals(entries.length, 1);
+  assertEquals(entries[0].family, "element");
+  assertEquals(
+    entries[0].displayId,
+    "braking_core::controller::debounce_input",
+  );
+  assertEquals(entries[0].id, "01HGW3D6QRST7IJKLMNOPQRSTUV");
+  assertEquals(entries[0].entryType, undefined);
+});
+
+Deno.test("parseMarkdown: Reference-id attribute sets family=reference (any doc)", () => {
+  // Reference-id makes a reference entry even outside a references.md doc.
+  const md = `# Random doc
+
+- [ISO-26262-6] ISO 26262 Part 6
+
+  Functional safety standard.
+
+  Reference-id: urn:iso:std:iso:26262:-6:ed-2
+`;
+  const entries = parseMarkdown(md, { file: "random.md" });
+  assertEquals(entries.length, 1);
+  assertEquals(entries[0].family, "reference");
+  assertEquals(entries[0].id, "urn:iso:std:iso:26262:-6:ed-2");
+});
+
+Deno.test("parseMarkdown: legacy Id attribute still works (back-compat)", () => {
+  const md = `# Test
+
+- [SRS_BRK_0001] Title
+
+  Body.
+
+  Id: SRS_01HGW2Q8MNP3
+`;
+  const entries = parseMarkdown(md, { file: "test.md" });
+  assertEquals(entries.length, 1);
+  assertEquals(entries[0].family, "spec");
+  assertEquals(entries[0].id, "SRS_01HGW2Q8MNP3");
+  assertEquals(entries[0].entryType, "SRS");
+});
+
+Deno.test("parseMarkdown: element display ID with :: hierarchy is recognized via Element-id", () => {
+  const md = `# Test
+
+- [::vehicle::braking::ecu-sensor] ECU sensor
+
+  Hardware element.
+
+  Element-id: 01HGW2R9QLP4ABCDEFGHJKMNPQ
+`;
+  const entries = parseMarkdown(md, { file: "test.md" });
+  assertEquals(entries.length, 1);
+  assertEquals(entries[0].family, "element");
+  assertEquals(entries[0].displayId, "::vehicle::braking::ecu-sensor");
+});


### PR DESCRIPTION
## What

Parser now discriminates entry family from the identity attribute (`Spec-id` / `Test-id` / `Element-id` / `Reference-id`) per ADR-002 Part 6. Element entries are parseable for the first time. Legacy `Id:`-based discrimination retained as a back-compat fallback.

## Why

Tracked in #198. The four-family model's defining design decision is "family by identity attribute, not display-ID pattern or document context". This PR wires that into the parser. Element display IDs (e.g., `braking_core::controller::debounce_input`) have no equivalent in the old model and could not be parsed before this change.

Refs #198

## How

**`parser/markdown.ts`**:
- Import `IdentityAttribute`, `FAMILY_BY_IDENTITY_KEY` from the model
- Add `ELEMENT_ID_RE` per ADR-002 §Part 5
- Add `IDENTITY_KEYS` constant and `findIdentityAttribute` helper
- Add `displayIdMatchesFamily` helper for family-specific regex validation
- Two-path `extractEntry`:
  1. **Identity-attribute path** (preferred): family from the identity attribute, bypass legacy `Id` + `isReferencesDoc` logic
  2. **Legacy fallback**: old display-ID regex + `isReferencesDoc` gating, plus legacy `Id:` attribute reading
- Display-ID/family mismatches are **accepted at parse time**; the validator (Phase 3) will surface MSL-R007 rather than silently dropping the entry

**`parser/markdown_test.ts`**: +6 tests covering the new identity-attribute path for all four families plus legacy back-compat.

## Notes

- `Entry.id` now stores the bare ULID or URI directly when an identity attribute is present. The Phase 3 validator will replace `ULID_RE` (currently TYPE-prefixed) with the bare Crockford base32 regex so identity-bearing fixtures can round-trip through `validate` cleanly.
- Validator / formatter / compiler behavior for **test** and **element** families isn't wired yet. Fixtures for those families are deferred to Phase 3 when the rules catch up.
- 319/319 tests pass.

## Checklist

- [x] Tests added (+6)
- [x] `just check` passes locally
- [x] No documentation changes needed
