### PR TITLE
feat(core): entry-model v2 phase 2b-iii — attribute collation

### DIFF
--- a/packages/markspec/core/model/mod.ts
+++ b/packages/markspec/core/model/mod.ts
@@ -84,6 +84,22 @@ export interface Attribute {
   readonly value: string;
 }
 
+/**
+ * Collated attributes keyed by Title-Case attribute name per ADR-002 §2.6.
+ *
+ * Repeatable types (`id-list`, `tag-list`, `external-id`) carry one entry
+ * per value after CSV-splitting and multi-line merging; `citation` carries
+ * one entry per occurrence (no CSV-splitting, locators may contain `,`).
+ * Single-valued types carry a one-element array; if the author wrote the
+ * attribute twice, the later value wins but both appear in
+ * {@linkcode Entry.attributes} for round-trip fidelity.
+ *
+ * This is the representation the validator, formatter, and compiler consult
+ * for typed processing; {@linkcode Entry.attributes} is the source of truth
+ * for exact round-trip through `markspec format`.
+ */
+export type TypedAttributes = ReadonlyMap<string, readonly string[]>;
+
 // ---------------------------------------------------------------------------
 // Entry
 // ---------------------------------------------------------------------------
@@ -231,8 +247,16 @@ export interface Entry {
   readonly title: string;
   /** Body content (paragraphs, alerts, code blocks) between title and attributes. */
   readonly body: string;
-  /** Parsed attribute block (`Key: Value` lines). */
+  /** Parsed attribute block (`Key: Value` lines), in source order. */
   readonly attributes: readonly Attribute[];
+  /**
+   * Collated, typed view of {@linkcode Entry.attributes} per ADR-002 §2.6.
+   *
+   * Populated by the parser alongside `attributes`. Downstream layers
+   * (validator, compiler) consult this map for typed processing; the
+   * formatter still reads `attributes` for exact round-trip.
+   */
+  readonly typedAttributes?: TypedAttributes;
   /** ULID from the `Id:` attribute, if present (spec entries only). */
   readonly id: Ulid | undefined;
   /** Resolved entry type prefix (e.g., `SRS`), if this is a spec entry. */

--- a/packages/markspec/core/parser/attributes.ts
+++ b/packages/markspec/core/parser/attributes.ts
@@ -6,7 +6,8 @@
  * trailing attribute blocks from body prose.
  */
 
-import type { Attribute } from "../model/mod.ts";
+import type { Attribute, TypedAttributes } from "../model/mod.ts";
+import { attributeSpec } from "../model/attributes.ts";
 
 /**
  * Pattern matching a `Key: Value` attribute line.
@@ -49,6 +50,60 @@ export function parseAttributes(lines: readonly string[]): Attribute[] {
  * Used to detect attribute blocks at the end of entry bodies.
  */
 export const ATTR_LINE_RE = /^[A-Z][A-Za-z-]*: .+\\?$/;
+
+/**
+ * Types whose values may be CSV-split on input per ADR-002 §2.6.
+ * `citation` is deliberately excluded because locators may contain commas.
+ */
+const CSV_SPLITTABLE_TYPES = new Set([
+  "id-list",
+  "tag-list",
+  "external-id",
+]);
+
+/**
+ * Collate a flat list of parsed attributes into a typed, keyed map per
+ * ADR-002 §2.6.
+ *
+ * - Repeatable types (`id-list` / `tag-list` / `external-id`): multi-line
+ *   entries merge; CSV values on a single line split on `,`.
+ * - `citation`: multi-line only (locators may contain commas).
+ * - Single-valued types: all occurrences are preserved in-order; the
+ *   validator decides what to do about duplicates.
+ * - Unknown keys: preserved as-is, one entry per occurrence.
+ */
+export function collateAttributes(
+  attributes: readonly Attribute[],
+): TypedAttributes {
+  const map = new Map<string, string[]>();
+
+  for (const attr of attributes) {
+    const spec = attributeSpec(attr.key);
+    const type = spec?.type;
+
+    let values: string[];
+    if (type && CSV_SPLITTABLE_TYPES.has(type) && attr.value.includes(",")) {
+      values = attr.value
+        .split(",")
+        .map((s) => s.trim())
+        .filter((s) => s.length > 0);
+    } else {
+      values = [attr.value];
+    }
+
+    const existing = map.get(attr.key);
+    if (existing) {
+      existing.push(...values);
+    } else {
+      map.set(attr.key, values);
+    }
+  }
+
+  // Freeze value arrays to match the readonly contract.
+  return new Map(
+    Array.from(map, ([key, values]) => [key, Object.freeze([...values])]),
+  );
+}
 
 /**
  * Split raw entry content into body text and attribute lines.

--- a/packages/markspec/core/parser/attributes_test.ts
+++ b/packages/markspec/core/parser/attributes_test.ts
@@ -139,3 +139,80 @@ Deno.test("parseAttributes: lines without Key: Value pattern are skipped", () =>
   assertEquals(attrs.length, 1);
   assertEquals(attrs[0].key, "Id");
 });
+
+// ---------------------------------------------------------------------------
+// collateAttributes — ADR-002 §2.6 repeatable attribute handling
+// ---------------------------------------------------------------------------
+
+import { collateAttributes } from "./attributes.ts";
+
+Deno.test("collateAttributes: single-valued attribute is kept as-is", () => {
+  const collated = collateAttributes([
+    { key: "Spec-id", value: "01HGW2Q8MNP3" },
+  ]);
+  assertEquals(collated.get("Spec-id"), ["01HGW2Q8MNP3"]);
+});
+
+Deno.test("collateAttributes: id-list multi-line values merge", () => {
+  const collated = collateAttributes([
+    { key: "Derived-from", value: "SYS_BRK_0042" },
+    { key: "Derived-from", value: "SYS_BRK_0043" },
+  ]);
+  assertEquals(collated.get("Derived-from"), ["SYS_BRK_0042", "SYS_BRK_0043"]);
+});
+
+Deno.test("collateAttributes: id-list CSV on one line splits", () => {
+  const collated = collateAttributes([
+    { key: "Derived-from", value: "SYS_BRK_0042, SYS_BRK_0043" },
+  ]);
+  assertEquals(collated.get("Derived-from"), ["SYS_BRK_0042", "SYS_BRK_0043"]);
+});
+
+Deno.test("collateAttributes: tag-list CSV splits", () => {
+  const collated = collateAttributes([
+    { key: "Labels", value: "ASIL-B, safety, automotive" },
+  ]);
+  assertEquals(collated.get("Labels"), ["ASIL-B", "safety", "automotive"]);
+});
+
+Deno.test("collateAttributes: citation does not CSV-split (locators may contain commas)", () => {
+  const collated = collateAttributes([
+    { key: "References", value: "ISO-26262-6 §9.4, Table 7" },
+    { key: "References", value: "UNECE-R155" },
+  ]);
+  assertEquals(collated.get("References"), [
+    "ISO-26262-6 §9.4, Table 7",
+    "UNECE-R155",
+  ]);
+});
+
+Deno.test("collateAttributes: external-id CSV splits", () => {
+  const collated = collateAttributes([
+    { key: "External-id", value: "doors:VHC:001, codebeamer:42" },
+  ]);
+  assertEquals(collated.get("External-id"), [
+    "doors:VHC:001",
+    "codebeamer:42",
+  ]);
+});
+
+Deno.test("collateAttributes: unknown keys preserved one entry per occurrence", () => {
+  const collated = collateAttributes([
+    { key: "Bespoke", value: "alpha" },
+    { key: "Bespoke", value: "beta" },
+  ]);
+  assertEquals(collated.get("Bespoke"), ["alpha", "beta"]);
+});
+
+Deno.test("collateAttributes: mixes multi-line and CSV correctly", () => {
+  const collated = collateAttributes([
+    { key: "Labels", value: "ASIL-B, safety" },
+    { key: "Labels", value: "automotive" },
+  ]);
+  assertEquals(collated.get("Labels"), ["ASIL-B", "safety", "automotive"]);
+});
+
+Deno.test("collateAttributes: empty input returns empty map", () => {
+  const collated = collateAttributes([]);
+  assertEquals(collated.size, 0);
+});

--- a/packages/markspec/core/parser/markdown.ts
+++ b/packages/markspec/core/parser/markdown.ts
@@ -14,7 +14,11 @@ import type {
   IdentityAttribute,
 } from "../model/mod.ts";
 import { FAMILY_BY_IDENTITY_KEY } from "../model/mod.ts";
-import { parseAttributes, splitBodyAndAttributes } from "./attributes.ts";
+import {
+  collateAttributes,
+  parseAttributes,
+  splitBodyAndAttributes,
+} from "./attributes.ts";
 import { processor } from "./remark.ts";
 
 /** Options for {@linkcode parseMarkdown}. */
@@ -306,6 +310,7 @@ function extractEntry(
     title: title ?? "",
     body,
     attributes,
+    typedAttributes: collateAttributes(attributes),
     id,
     entryType,
     family,


### PR DESCRIPTION
## What

Adds ADR-002 §2.6 repeatable-attribute collation semantics to the parser, exposed as a new `Entry.typedAttributes` field (`ReadonlyMap<string, readonly string[]>`). The existing `Entry.attributes` (raw source-order list) is preserved — the formatter will continue reading it for round-trip fidelity.

## Why

The spec defines 14 attribute value types, 4 of which are repeatable (`id-list`, `tag-list`, `external-id`, `citation`). Authors may write them either as multi-line (canonical) or CSV (`id-list`/`tag-list`/`external-id` only — not `citation` because locators may contain commas). Downstream layers need a single, typed view regardless of author form. This PR produces that view.

Refs #198

## How

**`model/mod.ts`**: add `TypedAttributes` alias + optional `Entry.typedAttributes` field. Field stays optional until Phases 3–5 migrate their consumers.

**`parser/attributes.ts`**: add `collateAttributes(attrs)` helper. Consults `ATTRIBUTE_CATALOG` to resolve the type per key. Splits CSV for `id-list`/`tag-list`/`external-id` when the value contains a comma; leaves `citation` values intact. Merges multi-line occurrences of the same key.

**`parser/markdown.ts`**: populate `typedAttributes: collateAttributes(attributes)` on each parsed entry.

## Notes

- Unknown keys are preserved with one entry per occurrence. Phase 3 validator emits MSL-R010 for them.
- Citation values are stored as raw strings including any locator (`"ISO-26262-6 §9.4"`). Phase 5 compiler parses slug/locator when building `Cited-by` inverse relations.
- 328/328 tests pass (319 before + 9 new collator tests).

## Downstream migration

- **Phase 3 validator** → consume `typedAttributes` for type-aware checks
- **Phase 4 formatter** → keep reading `attributes` for exact round-trip
- **Phase 5 compiler** → migrate link extraction to `typedAttributes`
- `typedAttributes` stays optional on `Entry` until all consumers migrate

## Checklist

- [x] Tests added (+9 collator tests)
- [x] `just check` passes locally
- [x] No documentation changes needed
