### PR TITLE
feat(core): entry-model v2 phase 3a — validator rules for new identity attributes

### DIFF
--- a/packages/markspec/core/validator/mod.ts
+++ b/packages/markspec/core/validator/mod.ts
@@ -2,32 +2,114 @@
  * @module validator
  *
  * ID graph validator. Performs file-local checks and cross-file checks:
- * broken references, missing Ids, malformed entries, duplicate IDs.
+ * broken references, missing identity attributes, malformed entries,
+ * duplicate IDs.
+ *
+ * Supports two entry shapes during the ADR-002 v2 transition:
+ * - **New identity path**: entry carries `Spec-id` / `Test-id` /
+ *   `Element-id` / `Reference-id` (bare ULID or URI per ADR-002 Annex B).
+ * - **Legacy path**: entry carries `Id:` with TYPE-prefixed ULID (pre-v2
+ *   fixtures). Still accepted until Phase 6 migration.
  */
 
 import type { Attribute, Diagnostic, Entry } from "../model/mod.ts";
+import { IDENTITY_KEY_BY_FAMILY } from "../model/mod.ts";
 
-/** Known attribute keys for spec entries per ADR-002. */
+/** Known attribute keys for spec entries (legacy set kept for back-compat). */
 const SPEC_ATTR_KEYS = new Set([
   "Id",
+  "Spec-id",
   "Satisfies",
   "Derived-from",
   "References",
   "Allocated-to",
   "Labels",
+  "Status",
+  "External-id",
+  "Supersedes",
 ]);
 
-/** Known attribute keys for reference entries per ADR-002. */
+/** Known attribute keys for test entries. */
+const TEST_ATTR_KEYS = new Set([
+  "Test-id",
+  "Test-level",
+  "Verifies",
+  "Tests",
+  "References",
+  "Labels",
+  "Status",
+  "External-id",
+  "Supersedes",
+]);
+
+/** Known attribute keys for element entries. */
+const ELEMENT_ATTR_KEYS = new Set([
+  "Element-id",
+  "Element-kind",
+  "Part-of",
+  "Realizes",
+  "Depends-on",
+  "Generated-from",
+  "References",
+  "Labels",
+  "Status",
+  "External-id",
+  "Supersedes",
+]);
+
+/** Known attribute keys for reference entries (legacy + new). */
 const REF_ATTR_KEYS = new Set([
+  "Reference-id",
+  "Reference-url",
+  "Reference-document",
   "URI",
   "URL",
   "Document",
   "Superseded-by",
   "Labels",
+  "Status",
+  "External-id",
+  "Supersedes",
 ]);
 
-/** ULID format per ADR-002: TYPE prefix (2-6 chars) + underscore + 26 alphanumeric chars. */
-const ULID_RE = /^[A-Z]{2,6}_[0-9A-Z]{26}$/;
+function knownKeysFor(family: Entry["family"]): Set<string> {
+  switch (family) {
+    case "spec":
+      return SPEC_ATTR_KEYS;
+    case "test":
+      return TEST_ATTR_KEYS;
+    case "element":
+      return ELEMENT_ATTR_KEYS;
+    case "reference":
+      return REF_ATTR_KEYS;
+  }
+}
+
+/** Legacy TYPE-prefixed ULID format: `SRS_01HGW2Q8MNP3`. */
+const LEGACY_ULID_RE = /^[A-Z]{2,6}_[0-9A-Z]{26}$/;
+
+/** Bare ULID per ADR-002 Annex B: 26 chars in Crockford base32 (no I,L,O,U). */
+const BARE_ULID_RE = /^[0-9A-HJKMNP-TV-Z]{26}$/;
+
+/** Minimal URI check per RFC 3986 — scheme followed by colon. */
+const URI_RE = /^[a-z][a-z0-9+.-]*:/i;
+
+/** All four identity attribute keys per ADR-002 Part 6. */
+const IDENTITY_KEYS: readonly string[] = [
+  "Spec-id",
+  "Test-id",
+  "Element-id",
+  "Reference-id",
+];
+
+/** Family-specific display-ID regexes per ADR-002 §Annex B. */
+const DISPLAY_ID_RE: Record<Entry["family"], RegExp> = {
+  spec: /^[A-Z]{2,6}_[A-Z][A-Z0-9]{2,7}(_[A-Z][A-Z0-9]{2,7})?_\d{3,6}$/,
+  test: /^[A-Z]{2,6}_[A-Z][A-Z0-9]{2,7}(_[A-Z][A-Z0-9]{2,7})?_\d{3,6}$/,
+  element:
+    /^(::)?[A-Za-z]([A-Za-z0-9._/-]*[A-Za-z0-9])?(::[A-Za-z]([A-Za-z0-9._/-]*[A-Za-z0-9])?)*$/,
+  reference: /^[A-Za-z]([A-Za-z0-9._/-]*[A-Za-z0-9])?$/,
+};
 
 /** Result of a validation pass. */
 export interface ValidateResult {
@@ -42,7 +124,6 @@ export interface ValidateResult {
  * and reference integrity.
  *
  * @param entries - Parsed entries to validate
- * @returns Validation result with diagnostics
  */
 export function validate(entries: readonly Entry[]): ValidateResult {
   const diagnostics: Diagnostic[] = [];
@@ -63,73 +144,20 @@ function checkStructural(
   const ulids = new Map<string, Entry>();
 
   for (const entry of entries) {
+    const identityAttrs = entry.attributes.filter((a) =>
+      IDENTITY_KEYS.includes(a.key)
+    );
+    const hasNewIdentity = identityAttrs.length > 0;
     const isSpec = entry.family === "spec";
 
-    // MSL-R003: Spec entry must have Id attribute with valid ULID format.
-    if (isSpec) {
-      if (!entry.id) {
-        diagnostics.push({
-          code: "MSL-R003",
-          severity: "error",
-          message: `${entry.displayId}: missing Id attribute`,
-          location: entry.location,
-        });
-      } else if (!ULID_RE.test(entry.id)) {
-        diagnostics.push({
-          code: "MSL-R003",
-          severity: "error",
-          message: `${entry.displayId}: malformed Id '${entry.id}'`,
-          location: entry.location,
-        });
-      }
+    if (hasNewIdentity) {
+      validateNewIdentity(entry, identityAttrs, diagnostics);
+    } else {
+      validateLegacyIdentity(entry, isSpec, diagnostics);
     }
 
-    // MSL-R004: Exactly one Id per entry.
-    if (isSpec) {
-      const idCount = entry.attributes.filter((a) => a.key === "Id").length;
-      if (idCount > 1) {
-        diagnostics.push({
-          code: "MSL-R004",
-          severity: "error",
-          message: `${entry.displayId}: multiple Id attributes (${idCount})`,
-          location: entry.location,
-        });
-      }
-    }
-
-    // MSL-R007: Display ID type prefix must match ULID type prefix.
-    if (isSpec && entry.id && ULID_RE.test(entry.id)) {
-      const displayPrefix = entry.entryType!;
-      const ulidPrefix = entry.id.split("_")[0];
-      if (displayPrefix !== ulidPrefix) {
-        diagnostics.push({
-          code: "MSL-R007",
-          severity: "error",
-          message:
-            `${entry.displayId}: type prefix '${displayPrefix}' does not match Id prefix '${ulidPrefix}'`,
-          location: entry.location,
-        });
-      }
-    }
-
-    // MSL-R008: Reference entry must have URI or URL attribute.
-    if (!isSpec) {
-      const hasUri = entry.attributes.some((a) => a.key === "URI");
-      const hasUrl = entry.attributes.some((a) => a.key === "URL");
-      if (!hasUri && !hasUrl) {
-        diagnostics.push({
-          code: "MSL-R008",
-          severity: "error",
-          message:
-            `${entry.displayId}: reference entry must have URI or URL attribute`,
-          location: entry.location,
-        });
-      }
-    }
-
-    // MSL-R009: Spec entry NNNN must be > 0 (no 000, 0000, etc.).
-    if (isSpec) {
-      // Extract NNNN from display ID (last segment after last underscore)
+    // MSL-R009: Spec/Test entry NNNN must be > 0 (no 000, 0000, etc.).
+    if (entry.family === "spec" || entry.family === "test") {
       const parts = entry.displayId.split("_");
       if (parts.length >= 3) {
         const nnnn = parts[parts.length - 1];
@@ -158,7 +186,7 @@ function checkStructural(
       displayIds.set(entry.displayId, entry);
     }
 
-    // MSL-R005: ULID unique across all entries.
+    // MSL-R005: identity value unique across all entries.
     if (entry.id) {
       const existingUlid = ulids.get(entry.id);
       if (existingUlid) {
@@ -174,8 +202,8 @@ function checkStructural(
       }
     }
 
-    // MSL-R010: Unknown attribute keys.
-    const knownKeys = isSpec ? SPEC_ATTR_KEYS : REF_ATTR_KEYS;
+    // MSL-R010: Unknown attribute keys per family.
+    const knownKeys = knownKeysFor(entry.family);
     for (const attr of entry.attributes) {
       if (!knownKeys.has(attr.key)) {
         diagnostics.push({
@@ -185,6 +213,146 @@ function checkStructural(
           location: entry.location,
         });
       }
+    }
+  }
+}
+
+/** Run new-identity-path rules per ADR-002 Part 6. */
+function validateNewIdentity(
+  entry: Entry,
+  identityAttrs: readonly Attribute[],
+  diagnostics: Diagnostic[],
+): void {
+  // MSL-R003: exactly one identity attribute per entry.
+  if (identityAttrs.length > 1) {
+    const keys = identityAttrs.map((a) => a.key).join(", ");
+    diagnostics.push({
+      code: "MSL-R003",
+      severity: "error",
+      message:
+        `${entry.displayId}: multiple identity attributes present (${keys}) — only one of Spec-id/Test-id/Element-id/Reference-id is allowed`,
+      location: entry.location,
+    });
+  }
+
+  // MSL-R003: identity attribute must match family — the parser uses the
+  // attribute to derive family, so a mismatch here means a legacy Id was
+  // also present. Flag the legacy Id as a migration conflict.
+  const hasLegacyId = entry.attributes.some((a) => a.key === "Id");
+  if (hasLegacyId) {
+    diagnostics.push({
+      code: "MSL-R003",
+      severity: "error",
+      message:
+        `${entry.displayId}: legacy 'Id:' attribute is present alongside a new identity attribute — remove Id: and keep only ${
+          IDENTITY_KEY_BY_FAMILY[entry.family]
+        }`,
+      location: entry.location,
+    });
+  }
+
+  // MSL-R004: identity value format per family.
+  const identity = identityAttrs[0];
+  if (identity.key === "Reference-id") {
+    if (!URI_RE.test(identity.value)) {
+      diagnostics.push({
+        code: "MSL-R004",
+        severity: "error",
+        message:
+          `${entry.displayId}: Reference-id '${identity.value}' is not a URI (expected a scheme like urn:, doi:, or https:)`,
+        location: entry.location,
+      });
+    }
+  } else {
+    if (!BARE_ULID_RE.test(identity.value)) {
+      diagnostics.push({
+        code: "MSL-R004",
+        severity: "error",
+        message:
+          `${entry.displayId}: ${identity.key} '${identity.value}' is not a bare 26-char Crockford base32 ULID`,
+        location: entry.location,
+      });
+    }
+  }
+
+  // MSL-R007: display ID must match the family's format.
+  const regex = DISPLAY_ID_RE[entry.family];
+  if (!regex.test(entry.displayId)) {
+    diagnostics.push({
+      code: "MSL-R007",
+      severity: "error",
+      message:
+        `${entry.displayId}: display ID does not match the ${entry.family} family format`,
+      location: entry.location,
+    });
+  }
+}
+
+/** Run legacy-Id path rules (pre-v2 fixtures). */
+function validateLegacyIdentity(
+  entry: Entry,
+  isSpec: boolean,
+  diagnostics: Diagnostic[],
+): void {
+  // MSL-R003: Spec entry must have Id attribute with valid ULID format.
+  if (isSpec) {
+    if (!entry.id) {
+      diagnostics.push({
+        code: "MSL-R003",
+        severity: "error",
+        message: `${entry.displayId}: missing Id attribute`,
+        location: entry.location,
+      });
+    } else if (!LEGACY_ULID_RE.test(entry.id)) {
+      diagnostics.push({
+        code: "MSL-R003",
+        severity: "error",
+        message: `${entry.displayId}: malformed Id '${entry.id}'`,
+        location: entry.location,
+      });
+    }
+  }
+
+  // MSL-R004: Exactly one Id per entry.
+  if (isSpec) {
+    const idCount = entry.attributes.filter((a) => a.key === "Id").length;
+    if (idCount > 1) {
+      diagnostics.push({
+        code: "MSL-R004",
+        severity: "error",
+        message: `${entry.displayId}: multiple Id attributes (${idCount})`,
+        location: entry.location,
+      });
+    }
+  }
+
+  // MSL-R007: Display ID type prefix must match ULID type prefix.
+  if (isSpec && entry.id && LEGACY_ULID_RE.test(entry.id)) {
+    const displayPrefix = entry.entryType!;
+    const ulidPrefix = entry.id.split("_")[0];
+    if (displayPrefix !== ulidPrefix) {
+      diagnostics.push({
+        code: "MSL-R007",
+        severity: "error",
+        message:
+          `${entry.displayId}: type prefix '${displayPrefix}' does not match Id prefix '${ulidPrefix}'`,
+        location: entry.location,
+      });
+    }
+  }
+
+  // MSL-R008: Reference entry must have URI or URL attribute.
+  if (!isSpec && entry.family === "reference") {
+    const hasUri = entry.attributes.some((a) => a.key === "URI");
+    const hasUrl = entry.attributes.some((a) => a.key === "URL");
+    if (!hasUri && !hasUrl) {
+      diagnostics.push({
+        code: "MSL-R008",
+        severity: "error",
+        message:
+          `${entry.displayId}: reference entry must have URI or URL attribute`,
+        location: entry.location,
+      });
     }
   }
 }

--- a/packages/markspec/core/validator/mod_test.ts
+++ b/packages/markspec/core/validator/mod_test.ts
@@ -442,3 +442,192 @@ Deno.test("validate: Allocated-to target exists → passes", () => {
   const t006 = result.diagnostics.filter((d) => d.code === "MSL-T006");
   assertEquals(t006.length, 0);
 });
+
+// ---------------------------------------------------------------------------
+// Phase 3a — new identity-attribute path (ADR-002 Part 6)
+// ---------------------------------------------------------------------------
+
+Deno.test("validate: new Spec-id with bare ULID passes", () => {
+  const entries: Entry[] = [
+    typedEntry({
+      displayId: "SRS_BRK_0001",
+      id: "01HGW2Q8MNP3RSTVWXYZABCDEF",
+      attributes: [
+        { key: "Spec-id", value: "01HGW2Q8MNP3RSTVWXYZABCDEF" },
+      ],
+    }),
+  ];
+  const result = validate(entries);
+  assertEquals(
+    result.diagnostics.filter((d) => d.severity === "error").length,
+    0,
+  );
+});
+
+Deno.test("validate: Spec-id with legacy TYPE-prefixed ULID → MSL-R004", () => {
+  const entries: Entry[] = [
+    typedEntry({
+      displayId: "SRS_BRK_0001",
+      id: "SRS_01HGW2Q8MNP3",
+      attributes: [{ key: "Spec-id", value: "SRS_01HGW2Q8MNP3" }],
+    }),
+  ];
+  const result = validate(entries);
+  const r004 = result.diagnostics.find((d) => d.code === "MSL-R004");
+  assertEquals(r004 != null, true);
+  assertStringIncludes(r004!.message, "bare 26-char Crockford base32");
+});
+
+Deno.test("validate: Spec-id with lowercase letter in ULID → MSL-R004", () => {
+  // Crockford base32 is uppercase only; lowercase is malformed.
+  const entries: Entry[] = [
+    typedEntry({
+      displayId: "SRS_BRK_0001",
+      id: "01hgw2q8mnp3rstvwxyzabcdef",
+      attributes: [
+        { key: "Spec-id", value: "01hgw2q8mnp3rstvwxyzabcdef" },
+      ],
+    }),
+  ];
+  const result = validate(entries);
+  const r004 = result.diagnostics.find((d) => d.code === "MSL-R004");
+  assertEquals(r004 != null, true);
+});
+
+Deno.test("validate: Reference-id with URI passes", () => {
+  const entries: Entry[] = [
+    refEntry({
+      displayId: "ISO-26262-6",
+      id: "urn:iso:std:iso:26262:-6:ed-2",
+      attributes: [
+        { key: "Reference-id", value: "urn:iso:std:iso:26262:-6:ed-2" },
+      ],
+    }),
+  ];
+  const result = validate(entries);
+  assertEquals(
+    result.diagnostics.filter((d) => d.severity === "error").length,
+    0,
+  );
+});
+
+Deno.test("validate: Reference-id without scheme → MSL-R004", () => {
+  const entries: Entry[] = [
+    refEntry({
+      displayId: "BOGUS",
+      id: "not a uri",
+      attributes: [{ key: "Reference-id", value: "not a uri" }],
+    }),
+  ];
+  const result = validate(entries);
+  const r004 = result.diagnostics.find((d) => d.code === "MSL-R004");
+  assertEquals(r004 != null, true);
+  assertStringIncludes(r004!.message, "not a URI");
+});
+
+Deno.test("validate: both legacy Id: and new Spec-id → MSL-R003 migration conflict", () => {
+  const entries: Entry[] = [
+    typedEntry({
+      displayId: "SRS_BRK_0001",
+      id: "01HGW2Q8MNP3RSTVWXYZABCDEF",
+      attributes: [
+        { key: "Id", value: "SRS_01HGW2Q8MNP3" },
+        { key: "Spec-id", value: "01HGW2Q8MNP3RSTVWXYZABCDEF" },
+      ],
+    }),
+  ];
+  const result = validate(entries);
+  const r003 = result.diagnostics.find((d) => d.code === "MSL-R003");
+  assertEquals(r003 != null, true);
+  assertStringIncludes(r003!.message, "legacy");
+});
+
+Deno.test("validate: two new identity attributes → MSL-R003", () => {
+  const entries: Entry[] = [
+    typedEntry({
+      displayId: "SRS_BRK_0001",
+      id: "01HGW2Q8MNP3RSTVWXYZABCDEF",
+      attributes: [
+        { key: "Spec-id", value: "01HGW2Q8MNP3RSTVWXYZABCDEF" },
+        { key: "Test-id", value: "01HGW3R9Q2P4ABCDEFGHJKMNPQ" },
+      ],
+    }),
+  ];
+  const result = validate(entries);
+  const r003 = result.diagnostics.find((d) => d.code === "MSL-R003");
+  assertEquals(r003 != null, true);
+  assertStringIncludes(r003!.message, "multiple identity attributes");
+});
+
+Deno.test("validate: Spec-id with element-format display ID → MSL-R007", () => {
+  const entries: Entry[] = [
+    typedEntry({
+      displayId: "braking::controller::debounce",
+      id: "01HGW2Q8MNP3RSTVWXYZABCDEF",
+      entryType: undefined,
+      attributes: [
+        { key: "Spec-id", value: "01HGW2Q8MNP3RSTVWXYZABCDEF" },
+      ],
+    }),
+  ];
+  const result = validate(entries);
+  const r007 = result.diagnostics.find((d) => d.code === "MSL-R007");
+  assertEquals(r007 != null, true);
+  assertStringIncludes(r007!.message, "does not match the spec family format");
+});
+
+Deno.test("validate: Element-id entry with :: display ID passes", () => {
+  const entries: Entry[] = [
+    typedEntry({
+      displayId: "braking_core::controller::debounce_input",
+      id: "01HGW3D6QRST7JKMNPQRSTVWXY",
+      family: "element",
+      entryType: undefined,
+      attributes: [
+        { key: "Element-id", value: "01HGW3D6QRST7JKMNPQRSTVWXY" },
+      ],
+    }),
+  ];
+  const result = validate(entries);
+  assertEquals(
+    result.diagnostics.filter((d) => d.severity === "error").length,
+    0,
+  );
+});
+
+Deno.test("validate: Test-id entry with TYPED display ID passes", () => {
+  const entries: Entry[] = [
+    typedEntry({
+      displayId: "SWT_BRK_0107",
+      id: "01HGW3R9Q2P4ABCDEFGHJKMNPQ",
+      family: "test",
+      entryType: "SWT",
+      attributes: [
+        { key: "Test-id", value: "01HGW3R9Q2P4ABCDEFGHJKMNPQ" },
+      ],
+    }),
+  ];
+  const result = validate(entries);
+  assertEquals(
+    result.diagnostics.filter((d) => d.severity === "error").length,
+    0,
+  );
+});
+
+Deno.test("validate: legacy Id path still works for back-compat", () => {
+  const entries: Entry[] = [
+    typedEntry({
+      displayId: "SRS_BRK_0001",
+      id: "SRS_00000000000000000000000001",
+      attributes: [{
+        key: "Id",
+        value: "SRS_00000000000000000000000001",
+      }],
+    }),
+  ];
+  const result = validate(entries);
+  assertEquals(
+    result.diagnostics.filter((d) => d.severity === "error").length,
+    0,
+  );
+});


### PR DESCRIPTION
## What

Adds validator rules for the new four-family identity attributes (`Spec-id` / `Test-id` / `Element-id` / `Reference-id`) per ADR-002 Part 6, while keeping the legacy `Id:` path intact for back-compat during the transition.

## Why

Parser Phase 2b-ii (PR #202) made identity-attribute-based discrimination work at parse time but left the validator blind to new identity-bearing entries. Without this PR, a new `Spec-id: 01HGW…` entry would parse correctly but fail validation with false-positive diagnostics ("malformed Id", "unknown attribute Spec-id", etc.).

Refs #198

## How

**`validator/mod.ts`**:
- Four per-family known-attribute sets (`SPEC_ATTR_KEYS`, `TEST_ATTR_KEYS`, `ELEMENT_ATTR_KEYS`, `REF_ATTR_KEYS`) replace the old two-set design. Each includes universal keys (`Labels`, `Status`, `External-id`, `Supersedes`, `References`) plus the new identity keys plus legacy keys (`Id`, `URI`, `URL`, `Document`) for transition.
- `BARE_ULID_RE` per ADR-002 §Annex B (`/^[0-9A-HJKMNP-TV-Z]{26}$/`, Crockford base32 excluding `I L O U`).
- `URI_RE` — minimal RFC 3986 scheme check.
- `DISPLAY_ID_RE` per family for MSL-R007 matching.
- `checkStructural` split into `validateNewIdentity` (new path) and `validateLegacyIdentity` (old path); per-entry detection of which applies.

**New identity path** (any of `Spec-id` / `Test-id` / `Element-id` / `Reference-id` present):
- **MSL-R003**: exactly one identity attribute; error if `Id:` also present (migration conflict)
- **MSL-R004**: bare ULID for Spec/Test/Element; URI scheme for Reference
- **MSL-R007**: display ID must match the declared family's regex

**Legacy path** (no new identity attribute): preserve existing rules exactly.

Behavior changes:
- MSL-R008 (URI/URL required) now only fires on the legacy reference path.
- MSL-R009 (NNNN > 0) now also applies to the test family (was spec-only).

## Tests

11 new validator tests:
- Bare ULID passes; legacy TYPE-prefixed ULID in `Spec-id:` rejected with MSL-R004
- Lowercase ULID rejected (Crockford is uppercase)
- `Reference-id` URI passes; non-URI rejected
- `Id:` + `Spec-id:` together → MSL-R003 migration conflict
- Two new identity attributes → MSL-R003
- `Spec-id` with element-format display ID → MSL-R007
- `Element-id` with `::` display ID passes
- `Test-id` with TYPED display ID passes
- Legacy `Id:` back-compat still passes

339/339 total tests pass (328 before + 11).

## Debt surfaced

Logged on #198: ADR-002 has several example ULIDs containing `L` (e.g., `01HGW3R9QLP4…` in the Test entry example), which violates the §Annex B Crockford regex. Validator is authoritative; examples should be fixed in a docs-only PR.

## Phase 3 remaining

- **3b**: family-aware attribute value-type validation (consult `ATTRIBUTE_CATALOG`)
- **3c**: traceability target-family checks (MSL-T001–T011 scoped per target family)

## Checklist

- [x] Tests added (+11)
- [x] `just check` passes locally
- [x] No documentation changes needed
