### PR TITLE
feat(core): entry-model v2 phase 3b — enum attribute value validation (MSL-R014)

### DIFF
--- a/packages/markspec/core/validator/mod.ts
+++ b/packages/markspec/core/validator/mod.ts
@@ -13,7 +13,7 @@
  */
 
 import type { Attribute, Diagnostic, Entry } from "../model/mod.ts";
-import { IDENTITY_KEY_BY_FAMILY } from "../model/mod.ts";
+import { attributeSpec, IDENTITY_KEY_BY_FAMILY } from "../model/mod.ts";
 
 /** Known attribute keys for spec entries (legacy set kept for back-compat). */
 const SPEC_ATTR_KEYS = new Set([
@@ -202,6 +202,11 @@ function checkStructural(
       }
     }
 
+    // MSL-R014: Attribute value matches its declared type's vocabulary.
+    // Scoped to enum types today (Status / Test-level / Element-kind);
+    // other value-type checks follow in later phases.
+    validateEnumValues(entry, diagnostics);
+
     // MSL-R010: Unknown attribute keys per family.
     const knownKeys = knownKeysFor(entry.family);
     for (const attr of entry.attributes) {
@@ -283,6 +288,35 @@ function validateNewIdentity(
       severity: "error",
       message:
         `${entry.displayId}: display ID does not match the ${entry.family} family format`,
+      location: entry.location,
+    });
+  }
+}
+
+/**
+ * Validate enum-type attribute values against their catalog vocabulary.
+ *
+ * Per ADR-002 §2.6, each attribute carries a declared value type. Enum
+ * attributes (`Status`, `Test-level`, `Element-kind`) have a closed
+ * vocabulary; anything outside it emits MSL-R014.
+ */
+function validateEnumValues(
+  entry: Entry,
+  diagnostics: Diagnostic[],
+): void {
+  for (const attr of entry.attributes) {
+    const spec = attributeSpec(attr.key);
+    if (!spec) continue;
+    if (spec.type !== "enum") continue;
+    if (!spec.enumValues) continue;
+    if (spec.enumValues.includes(attr.value)) continue;
+    diagnostics.push({
+      code: "MSL-R014",
+      severity: "error",
+      message:
+        `${entry.displayId}: ${attr.key} value '${attr.value}' is not one of ${
+          spec.enumValues.join(", ")
+        }`,
       location: entry.location,
     });
   }

--- a/packages/markspec/core/validator/mod_test.ts
+++ b/packages/markspec/core/validator/mod_test.ts
@@ -631,3 +631,139 @@ Deno.test("validate: legacy Id path still works for back-compat", () => {
     0,
   );
 });
+
+// ---------------------------------------------------------------------------
+// Phase 3b — enum-type attribute value validation (MSL-R014)
+// ---------------------------------------------------------------------------
+
+Deno.test("validate: valid Status passes", () => {
+  const entries: Entry[] = [
+    typedEntry({
+      displayId: "SRS_BRK_0001",
+      id: "01HGW2Q8MNP3RSTVWXYZABCDEF",
+      attributes: [
+        { key: "Spec-id", value: "01HGW2Q8MNP3RSTVWXYZABCDEF" },
+        { key: "Status", value: "approved" },
+      ],
+    }),
+  ];
+  const result = validate(entries);
+  const r014 = result.diagnostics.find((d) => d.code === "MSL-R014");
+  assertEquals(r014, undefined);
+});
+
+Deno.test("validate: unknown Status value → MSL-R014", () => {
+  const entries: Entry[] = [
+    typedEntry({
+      displayId: "SRS_BRK_0001",
+      id: "01HGW2Q8MNP3RSTVWXYZABCDEF",
+      attributes: [
+        { key: "Spec-id", value: "01HGW2Q8MNP3RSTVWXYZABCDEF" },
+        { key: "Status", value: "bogus" },
+      ],
+    }),
+  ];
+  const result = validate(entries);
+  const r014 = result.diagnostics.find((d) => d.code === "MSL-R014");
+  assertEquals(r014 != null, true);
+  assertStringIncludes(r014!.message, "Status");
+  assertStringIncludes(r014!.message, "bogus");
+  assertStringIncludes(r014!.message, "approved");
+});
+
+Deno.test("validate: unknown Test-level → MSL-R014", () => {
+  const entries: Entry[] = [
+    typedEntry({
+      displayId: "SWT_BRK_0001",
+      family: "test",
+      entryType: "SWT",
+      id: "01HGW3R9Q2P4ABCDEFGHJKMNPQ",
+      attributes: [
+        { key: "Test-id", value: "01HGW3R9Q2P4ABCDEFGHJKMNPQ" },
+        { key: "Test-level", value: "hardware" },
+      ],
+    }),
+  ];
+  const result = validate(entries);
+  const r014 = result.diagnostics.find((d) => d.code === "MSL-R014");
+  assertEquals(r014 != null, true);
+  assertStringIncludes(r014!.message, "Test-level");
+  assertStringIncludes(r014!.message, "unit");
+});
+
+Deno.test("validate: valid Test-level (unit, integration, system, acceptance) passes", () => {
+  for (const level of ["unit", "integration", "system", "acceptance"]) {
+    const entries: Entry[] = [
+      typedEntry({
+        displayId: "SWT_BRK_0001",
+        family: "test",
+        entryType: "SWT",
+        id: "01HGW3R9Q2P4ABCDEFGHJKMNPQ",
+        attributes: [
+          { key: "Test-id", value: "01HGW3R9Q2P4ABCDEFGHJKMNPQ" },
+          { key: "Test-level", value: level },
+        ],
+      }),
+    ];
+    const result = validate(entries);
+    const r014 = result.diagnostics.find((d) => d.code === "MSL-R014");
+    assertEquals(r014, undefined, `level '${level}' should pass`);
+  }
+});
+
+Deno.test("validate: unknown Element-kind → MSL-R014", () => {
+  const entries: Entry[] = [
+    typedEntry({
+      displayId: "braking::foo",
+      family: "element",
+      entryType: undefined,
+      id: "01HGW3D6QRST7JKMNPQRSTVWXY",
+      attributes: [
+        { key: "Element-id", value: "01HGW3D6QRST7JKMNPQRSTVWXY" },
+        { key: "Element-kind", value: "widget" },
+      ],
+    }),
+  ];
+  const result = validate(entries);
+  const r014 = result.diagnostics.find((d) => d.code === "MSL-R014");
+  assertEquals(r014 != null, true);
+  assertStringIncludes(r014!.message, "Element-kind");
+});
+
+Deno.test("validate: all four Element-kind vocab values pass", () => {
+  for (const kind of ["item", "artifact", "dependency", "unit"]) {
+    const entries: Entry[] = [
+      typedEntry({
+        displayId: "braking::foo",
+        family: "element",
+        entryType: undefined,
+        id: "01HGW3D6QRST7JKMNPQRSTVWXY",
+        attributes: [
+          { key: "Element-id", value: "01HGW3D6QRST7JKMNPQRSTVWXY" },
+          { key: "Element-kind", value: kind },
+        ],
+      }),
+    ];
+    const result = validate(entries);
+    const r014 = result.diagnostics.find((d) => d.code === "MSL-R014");
+    assertEquals(r014, undefined, `kind '${kind}' should pass`);
+  }
+});
+
+Deno.test("validate: Status withdrawn and deprecated are valid", () => {
+  for (const status of ["draft", "approved", "deprecated", "withdrawn"]) {
+    const entries: Entry[] = [
+      typedEntry({
+        displayId: "SRS_BRK_0001",
+        id: "01HGW2Q8MNP3RSTVWXYZABCDEF",
+        attributes: [
+          { key: "Spec-id", value: "01HGW2Q8MNP3RSTVWXYZABCDEF" },
+          { key: "Status", value: status },
+        ],
+      }),
+    ];
+    const result = validate(entries);
+    const r014 = result.diagnostics.find((d) => d.code === "MSL-R014");
+    assertEquals(r014, undefined, `status '${status}' should pass`);
+  }
+});


### PR DESCRIPTION
## What

Validator now checks that enum-type attribute values are drawn from their declared vocabulary. New diagnostic code **MSL-R014**. Scoped to the three enum attributes in the core catalog: `Status`, `Test-level`, `Element-kind`.

## Why

The Phase 1 `ATTRIBUTE_CATALOG` (ADR-002 Annex C) carries `enumValues` for these three attributes, but nothing consumed it. A misspelled `Status: aproved` or a non-standard `Test-level: functional` passed validation silently. This PR wires the enforcement.

Refs #198

## How

`validator/mod.ts`:
- Import `attributeSpec` helper
- Add `validateEnumValues(entry, diagnostics)` — iterates entry attributes, looks up the spec by key, and if `spec.type === "enum"` checks `value ∈ spec.enumValues`
- Called from `checkStructural` alongside the existing per-entry rules
- Emits **MSL-R014** (error severity) on mismatch with a message listing the valid alternatives

Other 11 value types (`uri`, `url`, `path`, `path-or-id`, `date`, `integer`, `boolean`, `citation`, `external-id`, `tag-list`, `text`, `id`, `id-list`) are deferred. Most are context-dependent or too permissive to validate usefully without a profile; the `citation` / `external-id` formats warrant their own follow-up.

## Tests

7 new tests:
- Valid `Status: approved` passes
- Unknown `Status: bogus` → MSL-R014, message cites alternatives
- Unknown `Test-level: hardware` → MSL-R014
- All four core `Test-level` vocab (`unit` / `integration` / `system` / `acceptance`) pass
- Unknown `Element-kind: widget` → MSL-R014
- All four `Element-kind` vocab (`item` / `artifact` / `dependency` / `unit`) pass
- All four `Status` vocab (`draft` / `approved` / `deprecated` / `withdrawn`) pass

346/346 total pass (339 before + 7).

## Notes

**MSL-R014 is not yet listed in language.md §8.2.** The spec table today caps at MSL-R013. Adding the new code is a docs-only follow-up; consistent with the phased migration, code lands first and `language.md` updates in a dedicated cleanup PR.

## Phase 3 remaining

- **3c**: traceability target-family checks (MSL-T001–T011 — e.g., `Verifies` target must be spec, `Tests` target must be element, `Supersedes` must be same-family)

## Checklist

- [x] Tests added (+7)
- [x] `just check` passes locally
- [x] Follow-up: add MSL-R014 to `language.md §8.2` in a docs PR
