### PR TITLE
feat(core): entry-model v2 phase 3c — family-aware traceability checks

### DIFF
--- a/packages/markspec/core/validator/mod.ts
+++ b/packages/markspec/core/validator/mod.ts
@@ -391,79 +391,177 @@ function validateLegacyIdentity(
   }
 }
 
-/** MSL-T reference integrity checks. */
+/**
+ * Family-aware traceability rule per ADR-002 §Part 2-5 / language.md §8.3.
+ *
+ * Each attribute that carries cross-entry references specifies which family
+ * its targets must belong to. The relation names here use the on-wire
+ * codes MSL-T001/T004/T005/T006 + T007-T013 for the new rules; note the
+ * numbering diverges from language.md §8.3 (a docs PR will re-align).
+ */
+interface TraceabilityRule {
+  /** Attribute key (e.g., `Satisfies`, `Realizes`). */
+  readonly key: string;
+  /** Expected target family, or `"same"` for Supersedes. */
+  readonly target: Entry["family"] | "same";
+  /** MSL diagnostic code. */
+  readonly code: string;
+  /** Diagnostic severity when target is missing or wrong family. */
+  readonly severity: "error" | "warning";
+  /** Which source families may carry this attribute (optional). */
+  readonly source?: readonly Entry["family"][];
+  /**
+   * Whether the value may carry a free-text locator after the slug
+   * (`"ID §locator"`). Only `Derived-from` historically permitted this
+   * shape; the catalog treats it as `id-list`, so locators are no longer
+   * valid but we keep tolerance for legacy fixtures.
+   */
+  readonly tolerateLocator?: boolean;
+}
+
+const TRACEABILITY_RULES: readonly TraceabilityRule[] = [
+  {
+    key: "Satisfies",
+    target: "spec",
+    code: "MSL-T001",
+    severity: "error",
+    source: ["spec"],
+  },
+  {
+    key: "Derived-from",
+    target: "spec",
+    code: "MSL-T004",
+    severity: "warning",
+    source: ["spec"],
+    tolerateLocator: true,
+  },
+  {
+    key: "References",
+    target: "reference",
+    code: "MSL-T005",
+    severity: "error",
+    source: ["spec", "test", "element"],
+  },
+  {
+    key: "Allocated-to",
+    target: "element",
+    code: "MSL-T006",
+    severity: "error",
+    source: ["spec"],
+  },
+  {
+    key: "Realizes",
+    target: "spec",
+    code: "MSL-T007",
+    severity: "error",
+    source: ["element"],
+  },
+  {
+    key: "Verifies",
+    target: "spec",
+    code: "MSL-T008",
+    severity: "error",
+    source: ["test"],
+  },
+  {
+    key: "Tests",
+    target: "element",
+    code: "MSL-T009",
+    severity: "error",
+    source: ["test"],
+  },
+  {
+    key: "Part-of",
+    target: "element",
+    code: "MSL-T010",
+    severity: "error",
+    source: ["element"],
+  },
+  {
+    key: "Depends-on",
+    target: "element",
+    code: "MSL-T011",
+    severity: "error",
+    source: ["element"],
+  },
+  {
+    key: "Supersedes",
+    target: "same",
+    code: "MSL-T012",
+    severity: "error",
+  },
+];
+
+/** Split a repeatable attribute value into individual target identifiers. */
+function splitTargets(value: string, tolerateLocator: boolean): string[] {
+  if (tolerateLocator) {
+    // Legacy form accepted locator suffix after the ID (e.g., "SYS_X §1.2").
+    const first = value.split(/\s/)[0];
+    return first ? [first] : [];
+  }
+  return value.split(",").map((s) => s.trim()).filter((s) => s.length > 0);
+}
+
+/** MSL-T traceability integrity checks. */
 function checkReferences(
   entries: readonly Entry[],
   diagnostics: Diagnostic[],
 ): void {
-  const knownIds = new Set(entries.map((e) => e.displayId));
+  const byDisplayId = new Map<string, Entry>();
+  for (const entry of entries) {
+    if (!byDisplayId.has(entry.displayId)) {
+      byDisplayId.set(entry.displayId, entry);
+    }
+  }
 
   for (const entry of entries) {
-    // MSL-T001: Satisfies targets must exist.
-    const satisfies = findAttr(entry.attributes, "Satisfies");
-    if (satisfies) {
-      const targets = satisfies.value.split(",").map((s) => s.trim());
+    for (const rule of TRACEABILITY_RULES) {
+      if (rule.source && !rule.source.includes(entry.family)) continue;
+      const attr = findAttr(entry.attributes, rule.key);
+      if (!attr) continue;
+
+      const targets = splitTargets(attr.value, rule.tolerateLocator ?? false);
       for (const target of targets) {
-        if (!target) continue;
-        if (!knownIds.has(target)) {
+        const resolved = byDisplayId.get(target);
+        if (!resolved) {
           diagnostics.push({
-            code: "MSL-T001",
-            severity: "error",
+            code: rule.code,
+            severity: rule.severity,
             message:
-              `${entry.displayId}: unresolved reference '${target}' in Satisfies`,
+              `${entry.displayId}: unresolved reference '${target}' in ${rule.key}`,
             location: entry.location,
           });
+          continue;
         }
-      }
-    }
 
-    // MSL-T004: Derived-from ID portion checked against known entries.
-    const derivedFrom = findAttr(entry.attributes, "Derived-from");
-    if (derivedFrom) {
-      const idPart = derivedFrom.value.split(/\s/)[0];
-      if (idPart && !knownIds.has(idPart)) {
-        diagnostics.push({
-          code: "MSL-T004",
-          severity: "warning",
-          message:
-            `${entry.displayId}: unresolved Derived-from reference '${idPart}'`,
-          location: entry.location,
-        });
-      }
-    }
-
-    // MSL-T005: References targets must exist.
-    const references = findAttr(entry.attributes, "References");
-    if (references) {
-      const targets = references.value.split(",").map((s) => s.trim());
-      for (const target of targets) {
-        if (!target) continue;
-        if (!knownIds.has(target)) {
+        // Family check
+        const expected = rule.target === "same" ? entry.family : rule.target;
+        if (resolved.family !== expected) {
           diagnostics.push({
-            code: "MSL-T005",
-            severity: "error",
+            code: rule.code,
+            severity: rule.severity,
             message:
-              `${entry.displayId}: unresolved reference '${target}' in References`,
+              `${entry.displayId}: ${rule.key} target '${target}' is family '${resolved.family}', expected '${expected}'`,
             location: entry.location,
           });
+          continue;
         }
-      }
-    }
 
-    // MSL-T006: Allocated-to targets must exist.
-    const allocatedTo = findAttr(entry.attributes, "Allocated-to");
-    if (allocatedTo) {
-      const targets = allocatedTo.value.split(",").map((s) => s.trim());
-      for (const target of targets) {
-        if (!target) continue;
-        if (!knownIds.has(target)) {
-          diagnostics.push({
-            code: "MSL-T006",
-            severity: "error",
-            message:
-              `${entry.displayId}: unresolved reference '${target}' in Allocated-to`,
-            location: entry.location,
-          });
+        // MSL-T013: warn when upstream target is deprecated or withdrawn.
+        if (
+          rule.key === "Satisfies" || rule.key === "Derived-from" ||
+          rule.key === "Realizes" || rule.key === "Verifies"
+        ) {
+          const status = findAttr(resolved.attributes, "Status")?.value;
+          if (status === "deprecated" || status === "withdrawn") {
+            diagnostics.push({
+              code: "MSL-T013",
+              severity: "warning",
+              message:
+                `${entry.displayId}: ${rule.key} target '${target}' has Status: ${status}`,
+              location: entry.location,
+            });
+          }
         }
       }
     }

--- a/packages/markspec/core/validator/mod_test.ts
+++ b/packages/markspec/core/validator/mod_test.ts
@@ -270,22 +270,25 @@ Deno.test("validate: multi-value Satisfies with one missing", () => {
 });
 
 Deno.test("validate: Derived-from ID checked against entries", () => {
+  // Derived-from is spec→spec per ADR-002 §Part 2. Target must be a spec.
   const entries: Entry[] = [
-    refEntry({
-      displayId: "ISO-26262-6",
-      attributes: [{ key: "Document", value: "ISO 26262-6:2018" }],
+    typedEntry({
+      displayId: "SYS_BRK_0042",
+      entryType: "SYS",
+      id: "SYS_00000000000000000000000042",
+      attributes: [{ key: "Id", value: "SYS_00000000000000000000000042" }],
     }),
     typedEntry({
       displayId: "SRS_BRK_0001",
       id: "SRS_00000000000000000000000001",
       attributes: [
         { key: "Id", value: "SRS_00000000000000000000000001" },
-        { key: "Derived-from", value: "ISO-26262-6 §9.4" },
+        { key: "Derived-from", value: "SYS_BRK_0042" },
       ],
+      location: { file: "test.md", line: 10, column: 1 },
     }),
   ];
   const result = validate(entries);
-  // ISO-26262-6 exists as a display ID → no warning
   const t004 = result.diagnostics.filter((d) => d.code === "MSL-T004");
   assertEquals(t004.length, 0);
 });
@@ -418,13 +421,16 @@ Deno.test("validate: Allocated-to target missing → MSL-T006", () => {
 });
 
 Deno.test("validate: Allocated-to target exists → passes", () => {
+  // Allocated-to targets elements per ADR-002 §Part 2.
   const entries: Entry[] = [
     typedEntry({
-      displayId: "SRS_BRK_0001",
-      id: "SRS_00000000000000000000000001RSTVWXYZABCDE",
+      displayId: "braking_core::controller",
+      family: "element",
+      entryType: undefined,
+      id: "01HGW3D6QRST7JKMNPQRSTVWXY",
       attributes: [{
-        key: "Id",
-        value: "SRS_00000000000000000000000001RSTVWXYZABCDE",
+        key: "Element-id",
+        value: "01HGW3D6QRST7JKMNPQRSTVWXY",
       }],
     }),
     typedEntry({
@@ -433,7 +439,7 @@ Deno.test("validate: Allocated-to target exists → passes", () => {
       id: "SAD_00000000000000000000000010",
       attributes: [
         { key: "Id", value: "SAD_00000000000000000000000010" },
-        { key: "Allocated-to", value: "SRS_BRK_0001" },
+        { key: "Allocated-to", value: "braking_core::controller" },
       ],
       location: { file: "arch.md", line: 10, column: 1 },
     }),
@@ -766,4 +772,252 @@ Deno.test("validate: Status withdrawn and deprecated are valid", () => {
     const r014 = result.diagnostics.find((d) => d.code === "MSL-R014");
     assertEquals(r014, undefined, `status '${status}' should pass`);
   }
+});
+
+// ---------------------------------------------------------------------------
+// Phase 3c — traceability target-family checks (MSL-T001, T004-T013)
+// ---------------------------------------------------------------------------
+
+Deno.test("validate: Satisfies target with wrong family → MSL-T001", () => {
+  // Satisfies must target a spec entry; target below is a reference.
+  const entries: Entry[] = [
+    refEntry({
+      displayId: "ISO-26262-6",
+      id: "urn:iso:std:iso:26262:-6:ed-2",
+      attributes: [
+        { key: "Reference-id", value: "urn:iso:std:iso:26262:-6:ed-2" },
+      ],
+    }),
+    typedEntry({
+      displayId: "SRS_BRK_0001",
+      id: "SRS_00000000000000000000000001",
+      attributes: [
+        { key: "Id", value: "SRS_00000000000000000000000001" },
+        { key: "Satisfies", value: "ISO-26262-6" },
+      ],
+    }),
+  ];
+  const result = validate(entries);
+  const t001 = result.diagnostics.find((d) => d.code === "MSL-T001");
+  assertEquals(t001 != null, true);
+  assertStringIncludes(t001!.message, "family 'reference'");
+  assertStringIncludes(t001!.message, "expected 'spec'");
+});
+
+Deno.test("validate: Realizes target must be spec → MSL-T007", () => {
+  const entries: Entry[] = [
+    typedEntry({
+      displayId: "braking::one",
+      family: "element",
+      entryType: undefined,
+      id: "01HGW3D6QRST7JKMNPQRSTVWXY",
+      attributes: [{ key: "Element-id", value: "01HGW3D6QRST7JKMNPQRSTVWXY" }],
+    }),
+    typedEntry({
+      displayId: "braking::controller",
+      family: "element",
+      entryType: undefined,
+      id: "01HGW3D6QRST7JKMNPQRSTVWXZ",
+      attributes: [
+        { key: "Element-id", value: "01HGW3D6QRST7JKMNPQRSTVWXZ" },
+        { key: "Realizes", value: "braking::one" },
+      ],
+    }),
+  ];
+  const result = validate(entries);
+  const t007 = result.diagnostics.find((d) => d.code === "MSL-T007");
+  assertEquals(t007 != null, true);
+  assertStringIncludes(t007!.message, "expected 'spec'");
+});
+
+Deno.test("validate: Verifies (on test) target must be spec → MSL-T008", () => {
+  const entries: Entry[] = [
+    typedEntry({
+      displayId: "braking::unit",
+      family: "element",
+      entryType: undefined,
+      id: "01HGW3D6QRST7JKMNPQRSTVWXY",
+      attributes: [{ key: "Element-id", value: "01HGW3D6QRST7JKMNPQRSTVWXY" }],
+    }),
+    typedEntry({
+      displayId: "SWT_BRK_0001",
+      family: "test",
+      entryType: "SWT",
+      id: "01HGW3R9Q2P4ABCDEFGHJKMNPQ",
+      attributes: [
+        { key: "Test-id", value: "01HGW3R9Q2P4ABCDEFGHJKMNPQ" },
+        { key: "Verifies", value: "braking::unit" },
+      ],
+    }),
+  ];
+  const result = validate(entries);
+  const t008 = result.diagnostics.find((d) => d.code === "MSL-T008");
+  assertEquals(t008 != null, true);
+});
+
+Deno.test("validate: Tests (on test) target must be element → MSL-T009", () => {
+  const entries: Entry[] = [
+    typedEntry({
+      displayId: "SRS_BRK_0001",
+      id: "SRS_00000000000000000000000001",
+      attributes: [{ key: "Id", value: "SRS_00000000000000000000000001" }],
+    }),
+    typedEntry({
+      displayId: "SWT_BRK_0001",
+      family: "test",
+      entryType: "SWT",
+      id: "01HGW3R9Q2P4ABCDEFGHJKMNPQ",
+      attributes: [
+        { key: "Test-id", value: "01HGW3R9Q2P4ABCDEFGHJKMNPQ" },
+        { key: "Tests", value: "SRS_BRK_0001" },
+      ],
+    }),
+  ];
+  const result = validate(entries);
+  const t009 = result.diagnostics.find((d) => d.code === "MSL-T009");
+  assertEquals(t009 != null, true);
+});
+
+Deno.test("validate: Part-of target must be element → MSL-T010", () => {
+  const entries: Entry[] = [
+    typedEntry({
+      displayId: "SRS_BRK_0001",
+      id: "SRS_00000000000000000000000001",
+      attributes: [{ key: "Id", value: "SRS_00000000000000000000000001" }],
+    }),
+    typedEntry({
+      displayId: "braking::child",
+      family: "element",
+      entryType: undefined,
+      id: "01HGW3D6QRST7JKMNPQRSTVWXY",
+      attributes: [
+        { key: "Element-id", value: "01HGW3D6QRST7JKMNPQRSTVWXY" },
+        { key: "Part-of", value: "SRS_BRK_0001" },
+      ],
+    }),
+  ];
+  const result = validate(entries);
+  const t010 = result.diagnostics.find((d) => d.code === "MSL-T010");
+  assertEquals(t010 != null, true);
+});
+
+Deno.test("validate: Supersedes must target same family → MSL-T012", () => {
+  const entries: Entry[] = [
+    refEntry({
+      displayId: "ISO-26262-6",
+      id: "urn:iso:std:iso:26262:-6:ed-2",
+      attributes: [
+        { key: "Reference-id", value: "urn:iso:std:iso:26262:-6:ed-2" },
+      ],
+    }),
+    typedEntry({
+      displayId: "SRS_BRK_0001",
+      id: "SRS_00000000000000000000000001",
+      attributes: [
+        { key: "Id", value: "SRS_00000000000000000000000001" },
+        { key: "Supersedes", value: "ISO-26262-6" },
+      ],
+    }),
+  ];
+  const result = validate(entries);
+  const t012 = result.diagnostics.find((d) => d.code === "MSL-T012");
+  assertEquals(t012 != null, true);
+  assertStringIncludes(t012!.message, "expected 'spec'");
+});
+
+Deno.test("validate: Supersedes same family passes", () => {
+  const entries: Entry[] = [
+    typedEntry({
+      displayId: "SRS_BRK_0001",
+      id: "SRS_00000000000000000000000001",
+      attributes: [{ key: "Id", value: "SRS_00000000000000000000000001" }],
+    }),
+    typedEntry({
+      displayId: "SRS_BRK_0002",
+      id: "SRS_00000000000000000000000002",
+      attributes: [
+        { key: "Id", value: "SRS_00000000000000000000000002" },
+        { key: "Supersedes", value: "SRS_BRK_0001" },
+      ],
+    }),
+  ];
+  const result = validate(entries);
+  const t012 = result.diagnostics.find((d) => d.code === "MSL-T012");
+  assertEquals(t012, undefined);
+});
+
+Deno.test("validate: upstream target with Status: deprecated → MSL-T013 warning", () => {
+  const entries: Entry[] = [
+    typedEntry({
+      displayId: "SYS_BRK_0042",
+      entryType: "SYS",
+      id: "SYS_00000000000000000000000042",
+      attributes: [
+        { key: "Id", value: "SYS_00000000000000000000000042" },
+        { key: "Status", value: "deprecated" },
+      ],
+    }),
+    typedEntry({
+      displayId: "SRS_BRK_0001",
+      id: "SRS_00000000000000000000000001",
+      attributes: [
+        { key: "Id", value: "SRS_00000000000000000000000001" },
+        { key: "Satisfies", value: "SYS_BRK_0042" },
+      ],
+    }),
+  ];
+  const result = validate(entries);
+  const t013 = result.diagnostics.find((d) => d.code === "MSL-T013");
+  assertEquals(t013 != null, true);
+  assertStringIncludes(t013!.message, "deprecated");
+});
+
+Deno.test("validate: upstream target with Status: approved → no MSL-T013", () => {
+  const entries: Entry[] = [
+    typedEntry({
+      displayId: "SYS_BRK_0042",
+      entryType: "SYS",
+      id: "SYS_00000000000000000000000042",
+      attributes: [
+        { key: "Id", value: "SYS_00000000000000000000000042" },
+        { key: "Status", value: "approved" },
+      ],
+    }),
+    typedEntry({
+      displayId: "SRS_BRK_0001",
+      id: "SRS_00000000000000000000000001",
+      attributes: [
+        { key: "Id", value: "SRS_00000000000000000000000001" },
+        { key: "Satisfies", value: "SYS_BRK_0042" },
+      ],
+    }),
+  ];
+  const result = validate(entries);
+  const t013 = result.diagnostics.find((d) => d.code === "MSL-T013");
+  assertEquals(t013, undefined);
+});
+
+Deno.test("validate: Depends-on to element passes", () => {
+  const entries: Entry[] = [
+    typedEntry({
+      displayId: "braking::lib",
+      family: "element",
+      entryType: undefined,
+      id: "01HGW3D6QRST7JKMNPQRSTVWXY",
+      attributes: [{ key: "Element-id", value: "01HGW3D6QRST7JKMNPQRSTVWXY" }],
+    }),
+    typedEntry({
+      displayId: "braking::main",
+      family: "element",
+      entryType: undefined,
+      id: "01HGW3D6QRST7JKMNPQRSTVWXZ",
+      attributes: [
+        { key: "Element-id", value: "01HGW3D6QRST7JKMNPQRSTVWXZ" },
+        { key: "Depends-on", value: "braking::lib" },
+      ],
+    }),
+  ];
+  const result = validate(entries);
+  const t011 = result.diagnostics.find((d) => d.code === "MSL-T011");
+  assertEquals(t011, undefined);
 });


### PR DESCRIPTION
## What

Traceability validation now enforces target-family constraints per ADR-002. Previously cross-reference checks only verified target existence; they now also verify family per relation. Seven new MSL-T rules (T007–T013) for the relations Phase 1 introduced (`Realizes`, `Verifies`, `Tests`, `Part-of`, `Depends-on`, `Supersedes`, plus a deprecated-target warning).

## Why

Tracked in #198. Without this PR, a `Verifies: SRS_BRK_0001` on a test would validate even if `SRS_BRK_0001` were a reference or an element. ADR-002 §§Parts 2–5 specify exactly which family each relation targets — this PR wires that in.

Refs #198

## How

`validator/mod.ts`:
- Replace ad-hoc per-attribute check blocks with a declarative `TRACEABILITY_RULES` table. Each rule specifies: attribute key, expected target family (or `"same"` for `Supersedes`), MSL code, severity, and optional source-family scope.
- `checkReferences` iterates the table, resolves each target through `byDisplayId`, reports (a) missing target, (b) wrong target family.
- Added `"supersedes"` semantics: target must be the same family as the source.
- Added MSL-T013 — warning when an upstream `Satisfies` / `Derived-from` / `Realizes` / `Verifies` target has `Status: deprecated` or `withdrawn`.
- `splitTargets(value, tolerateLocator)` preserves the legacy free-text-locator tolerance only on `Derived-from` where it was the historical shape.

## Rule table

| Code | Attribute | Target | Severity | Source families |
|---|---|---|---|---|
| MSL-T001 | `Satisfies` | spec | error | spec |
| MSL-T004 | `Derived-from` | spec | warning | spec |
| MSL-T005 | `References` | reference | error | spec / test / element |
| MSL-T006 | `Allocated-to` | element | error | spec |
| MSL-T007 | `Realizes` | spec | error | element |
| MSL-T008 | `Verifies` | spec | error | test |
| MSL-T009 | `Tests` | element | error | test |
| MSL-T010 | `Part-of` | element | error | element |
| MSL-T011 | `Depends-on` | element | error | element |
| MSL-T012 | `Supersedes` | same-family | error | any |
| MSL-T013 | deprecated/withdrawn target | — | warning | any |

## Tests

10 new tests cover each new rule plus status-warning behavior. 2 existing tests updated to ADR-correct targets:
- `Derived-from` test now uses a spec target (was a reference)
- `Allocated-to` test now uses an element target (was a spec)

356/356 pass (346 before + 10 new; 2 existing tests updated in-place).

## Divergence from language.md §8.3

The spec table numbers `Derived-from` as T002 (code uses T004) and `References` as T003 (code uses T005). The code kept existing numbers to avoid churning tests across phases. A docs-only PR will re-align language.md §8.3 with the implementation — tracked on #198 debt ledger.

## Phase 3 complete after this merge

Phase 4 (formatter rewrite) follows. Remaining debt from #198 is listed in the comment history.

## Checklist

- [x] Tests added (+10); 2 existing updated
- [x] `just check` passes locally
- [x] Follow-up: align language.md §8.3 with code numbering (docs PR)
