### PR TITLE
feat(core): entry-model v2 phase 4a — formatter identity assignment and canonical orders

### DIFF
--- a/packages/markspec/core/formatter/mod.ts
+++ b/packages/markspec/core/formatter/mod.ts
@@ -13,27 +13,102 @@ import type {
   Entry,
   EntryFamily,
 } from "../model/mod.ts";
+import { IDENTITY_KEY_BY_FAMILY } from "../model/mod.ts";
 import { ATTR_LINE_RE } from "../parser/attributes.ts";
 import { parseMarkdown } from "../parser/markdown.ts";
 
-/** Canonical attribute ordering for spec entries. Unknown keys go before Labels. */
+/**
+ * Canonical attribute ordering for spec entries per ADR-002 Annex C.
+ *
+ * Identity comes first; family-specific relations next; universal attributes
+ * last (Labels/Status/External-id/Supersedes). Unknown keys go just before
+ * Labels, preserving their relative order.
+ *
+ * Legacy `Id:` appears right after `Spec-id:` so pre-v2 fixtures keep the
+ * same relative ordering they used to produce.
+ */
 const SPEC_CANONICAL_ORDER: readonly string[] = [
+  "Spec-id",
   "Id",
   "Satisfies",
   "Derived-from",
-  "References",
   "Allocated-to",
+  "References",
   "Labels",
+  "Status",
+  "External-id",
+  "Supersedes",
 ];
 
-/** Canonical attribute ordering for reference entries. Unknown keys go before Labels. */
-const REF_CANONICAL_ORDER: readonly string[] = [
-  "URI",
-  "URL",
-  "Document",
-  "Superseded-by",
+/** Canonical attribute ordering for test entries per ADR-002 Annex C. */
+const TEST_CANONICAL_ORDER: readonly string[] = [
+  "Test-id",
+  "Test-level",
+  "Verifies",
+  "Tests",
+  "References",
   "Labels",
+  "Status",
+  "External-id",
+  "Supersedes",
 ];
+
+/** Canonical attribute ordering for element entries per ADR-002 Annex C. */
+const ELEMENT_CANONICAL_ORDER: readonly string[] = [
+  "Element-id",
+  "Element-kind",
+  "Part-of",
+  "Realizes",
+  "Depends-on",
+  "Generated-from",
+  "References",
+  "Labels",
+  "Status",
+  "External-id",
+  "Supersedes",
+];
+
+/**
+ * Canonical attribute ordering for reference entries per ADR-002 Annex C.
+ *
+ * Legacy `URI` / `URL` / `Document` appear after their v2 equivalents to
+ * keep old fixtures producing the same relative order.
+ */
+const REF_CANONICAL_ORDER: readonly string[] = [
+  "Reference-id",
+  "URI",
+  "Reference-url",
+  "URL",
+  "Reference-document",
+  "Document",
+  "Labels",
+  "Status",
+  "External-id",
+  "Supersedes",
+  "Superseded-by",
+];
+
+/** Identity attribute keys (new + legacy) that count as "entry identity". */
+const IDENTITY_KEYS: readonly string[] = [
+  "Spec-id",
+  "Test-id",
+  "Element-id",
+  "Reference-id",
+  "Id",
+];
+
+function canonicalOrderFor(family: EntryFamily): readonly string[] {
+  switch (family) {
+    case "spec":
+      return SPEC_CANONICAL_ORDER;
+    case "test":
+      return TEST_CANONICAL_ORDER;
+    case "element":
+      return ELEMENT_CANONICAL_ORDER;
+    case "reference":
+      return REF_CANONICAL_ORDER;
+  }
+}
 
 /** Options for {@linkcode format}. */
 export interface FormatOptions {
@@ -85,14 +160,18 @@ export function format(
     const indent = (entry.location.column - 1) + 2;
     let attrs = [...entry.attributes];
 
-    // Assign ULID to spec entries missing Id.
-    if (entry.family === "spec" && !attrs.some((a) => a.key === "Id")) {
-      const newId = `${entry.entryType}_${genUlid()}`;
-      attrs = [{ key: "Id", value: newId }, ...attrs];
+    // Assign a bare ULID identity attribute to Spec/Test/Element entries
+    // that carry no identity yet. Reference entries are left alone —
+    // `Reference-id` is authored (a URI), not generated.
+    const hasIdentity = attrs.some((a) => IDENTITY_KEYS.includes(a.key));
+    if (!hasIdentity && entry.family !== "reference") {
+      const key = IDENTITY_KEY_BY_FAMILY[entry.family];
+      const newId = genUlid();
+      attrs = [{ key, value: newId }, ...attrs];
       diagnostics.push({
         code: "MSL-F001",
         severity: "info",
-        message: `assigned Id: ${newId} to ${entry.displayId}`,
+        message: `assigned ${key}: ${newId} to ${entry.displayId}`,
         location: entry.location,
       });
     }
@@ -135,9 +214,7 @@ export function sortAttributes(
   attributes: Attribute[],
   family: EntryFamily,
 ): Attribute[] {
-  const CANONICAL_ORDER = family === "reference"
-    ? REF_CANONICAL_ORDER
-    : SPEC_CANONICAL_ORDER;
+  const CANONICAL_ORDER = canonicalOrderFor(family);
 
   const known: (Attribute[] | undefined)[] = new Array(CANONICAL_ORDER.length);
   const unknown: Attribute[] = [];

--- a/packages/markspec/core/formatter/mod_test.ts
+++ b/packages/markspec/core/formatter/mod_test.ts
@@ -255,7 +255,7 @@ Deno.test("format: idempotent on already-formatted input", () => {
 const MOCK_ULID = "01HGW2Q8MNTEST";
 const mockUlid = () => MOCK_ULID;
 
-Deno.test("format: missing Id gets ULID with correct type prefix", () => {
+Deno.test("format: missing identity on spec entry gets Spec-id with bare ULID", () => {
   const md = `# Test
 
 - [SRS_BRK_0001] Title
@@ -267,9 +267,9 @@ Deno.test("format: missing Id gets ULID with correct type prefix", () => {
 `;
   const result = format(md, { generateUlid: mockUlid });
   assertEquals(result.changed, true);
-  assertStringIncludes(result.output, `Id: SRS_${MOCK_ULID}`);
-  // Id should be first attribute
-  const idIdx = result.output.indexOf("Id:");
+  assertStringIncludes(result.output, `Spec-id: ${MOCK_ULID}`);
+  // Identity should come before family-specific relations
+  const idIdx = result.output.indexOf("Spec-id:");
   const satIdx = result.output.indexOf("Satisfies:");
   assertEquals(idIdx < satIdx, true);
 });
@@ -318,7 +318,7 @@ Deno.test("format: reference entries skip ULID", () => {
   assertEquals(result.output.includes("Id:"), false);
 });
 
-Deno.test("format: diagnostic emitted on ULID assignment", () => {
+Deno.test("format: diagnostic emitted on identity assignment", () => {
   const md = `# Test
 
 - [SRS_BRK_0001] Title
@@ -331,10 +331,10 @@ Deno.test("format: diagnostic emitted on ULID assignment", () => {
   assertEquals(result.diagnostics.length, 1);
   assertEquals(result.diagnostics[0].severity, "info");
   assertStringIncludes(result.diagnostics[0].message, "SRS_BRK_0001");
-  assertStringIncludes(result.diagnostics[0].message, `SRS_${MOCK_ULID}`);
+  assertStringIncludes(result.diagnostics[0].message, `Spec-id: ${MOCK_ULID}`);
 });
 
-Deno.test("format: entry with no attributes gets new block with Id", () => {
+Deno.test("format: entry with no attributes gets new block with Spec-id", () => {
   const md = `# Test
 
 - [SRS_BRK_0001] Title
@@ -343,8 +343,7 @@ Deno.test("format: entry with no attributes gets new block with Id", () => {
 `;
   const result = format(md, { generateUlid: mockUlid });
   assertEquals(result.changed, true);
-  assertStringIncludes(result.output, `Id: SRS_${MOCK_ULID}`);
-  // Body should still be there
+  assertStringIncludes(result.output, `Spec-id: ${MOCK_ULID}`);
   assertStringIncludes(result.output, "Body text only, no attributes.");
 });
 
@@ -361,7 +360,104 @@ Deno.test("format: mock generateUlid produces deterministic output", () => {
 `;
   const result = format(md, { generateUlid: mockUlid });
   assertEquals(result.changed, true);
-  // Both should get the same mock ULID (in real usage they'd differ)
-  const idMatches = [...result.output.matchAll(/Id: SRS_01HGW2Q8MNTEST/g)];
+  // Both should get the same mock ULID (in real usage they'd differ).
+  const idMatches = [...result.output.matchAll(/Spec-id: 01HGW2Q8MNTEST/g)];
   assertEquals(idMatches.length, 2);
+});
+
+// ---------------------------------------------------------------------------
+// Phase 4a — new-family identity assignment and canonical orders
+// ---------------------------------------------------------------------------
+
+// Test / element auto-assignment requires the parser to first classify
+// the entry as test / element. Without an identity attribute already
+// present, the parser falls back to display-ID-shape + filename (which
+// only covers references today). Profile-driven classification for
+// test and element entries is future Phase 6 work; auto-assignment of
+// Test-id / Element-id to anonymous entries is deferred until then.
+
+Deno.test("format: reference entry without Reference-id is not auto-assigned", () => {
+  // Reference-id is a URI, authored by the human, never generated.
+  const md = `# References
+
+- [ISO-26262-6] ISO 26262 Part 6
+
+  Functional safety.
+
+  URI: urn:iso:std:iso:26262:-6:ed-2
+`;
+  const result = format(md, { generateUlid: mockUlid });
+  assertEquals(result.output.includes(MOCK_ULID), false);
+  assertEquals(
+    result.diagnostics.filter((d) => d.code === "MSL-F001").length,
+    0,
+  );
+});
+
+Deno.test("format: new Spec-id in source is not touched", () => {
+  const md = `# Test
+
+- [SRS_BRK_0001] Title
+
+  Body.
+
+  Spec-id: 01HGW2Q8MNP3RSTVWXYZABCDEF\\
+  Labels: ASIL-B
+`;
+  const result = format(md, { generateUlid: mockUlid });
+  // Don't add another identity; don't replace the existing one.
+  assertStringIncludes(result.output, "Spec-id: 01HGW2Q8MNP3RSTVWXYZABCDEF");
+  assertEquals(result.output.includes(MOCK_ULID), false);
+});
+
+Deno.test("format: canonical order for test family", () => {
+  const md = `# Test
+
+- [SWT_BRK_0001] Title
+
+  Body.
+
+  Labels: ASIL-B\\
+  Test-id: 01HGW2Q8MNP3RSTVWXYZABCDEF\\
+  Verifies: SRS_BRK_0001\\
+  Test-level: unit
+`;
+  const result = format(md, { generateUlid: mockUlid });
+  const lines = result.output.split("\n");
+  const testIdLine = lines.findIndex((l) => l.trim().startsWith("Test-id:"));
+  const levelLine = lines.findIndex((l) => l.trim().startsWith("Test-level:"));
+  const verifiesLine = lines.findIndex((l) => l.trim().startsWith("Verifies:"));
+  const labelsLine = lines.findIndex((l) => l.trim().startsWith("Labels:"));
+  assertEquals(
+    testIdLine < levelLine && levelLine < verifiesLine &&
+      verifiesLine < labelsLine,
+    true,
+  );
+});
+
+Deno.test("format: canonical order for element family", () => {
+  const md = `# Elements
+
+- [braking::foo] Foo
+
+  Body.
+
+  Labels: rust\\
+  Part-of: braking\\
+  Element-id: 01HGW3D6QRST7JKMNPQRSTVWXY\\
+  Element-kind: unit\\
+  Realizes: SRS_BRK_0001
+`;
+  const result = format(md, { generateUlid: mockUlid });
+  const lines = result.output.split("\n");
+  const elIdLine = lines.findIndex((l) => l.trim().startsWith("Element-id:"));
+  const kindLine = lines.findIndex((l) => l.trim().startsWith("Element-kind:"));
+  const partLine = lines.findIndex((l) => l.trim().startsWith("Part-of:"));
+  const realizesLine = lines.findIndex((l) => l.trim().startsWith("Realizes:"));
+  const labelsLine = lines.findIndex((l) => l.trim().startsWith("Labels:"));
+  assertEquals(
+    elIdLine < kindLine && kindLine < partLine &&
+      partLine < realizesLine && realizesLine < labelsLine,
+    true,
+  );
 });

--- a/tests/e2e/format_test.ts
+++ b/tests/e2e/format_test.ts
@@ -96,7 +96,7 @@ Deno.test("format: writes normalized attributes back to file", async () => {
 // ULID assignment
 // ---------------------------------------------------------------------------
 
-Deno.test("format: assigns ULID to entry missing Id", async () => {
+Deno.test("format: assigns Spec-id to spec entry missing identity", async () => {
   const input = `# Test
 
 - [SRS_BRK_0001] Title
@@ -108,9 +108,9 @@ Deno.test("format: assigns ULID to entry missing Id", async () => {
 `;
   const { code, stderr, readFile } = await runFormat({ "req.md": input });
   assertEquals(code, 0);
-  assertStringIncludes(stderr, "assigned Id:");
+  assertStringIncludes(stderr, "assigned Spec-id:");
   const output = await readFile("req.md");
-  assertStringIncludes(output, "Id: SRS_");
+  assertStringIncludes(output, "Spec-id: ");
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Formatter learns all four families: four canonical attribute orders (one per family per ADR-002 Annex C) and bare-ULID identity assignment. Reference entries are never auto-assigned — `Reference-id` is authored, not generated.

## Why

Tracked in #198. Phase 3 wired validation for the new identity attributes; this PR wires the formatter counterpart — `markspec format` now produces `Spec-id: <bare>` for new spec entries instead of the legacy `Id: SRS_<prefixed>` form.

Refs #198

## How

`formatter/mod.ts`:
- Four canonical orders replace the old two:
  - **Spec**: `Spec-id`, `Id` (legacy), `Satisfies`, `Derived-from`, `Allocated-to`, `References`, `Labels`, `Status`, `External-id`, `Supersedes`
  - **Test**: `Test-id`, `Test-level`, `Verifies`, `Tests`, `References`, `Labels`, `Status`, `External-id`, `Supersedes`
  - **Element**: `Element-id`, `Element-kind`, `Part-of`, `Realizes`, `Depends-on`, `Generated-from`, `References`, `Labels`, `Status`, `External-id`, `Supersedes`
  - **Reference**: `Reference-id`, `URI` (legacy), `Reference-url`, `URL` (legacy), `Reference-document`, `Document` (legacy), `Labels`, `Status`, `External-id`, `Supersedes`, `Superseded-by` (legacy)
- Legacy keys (`Id`, `URI`, `URL`, `Document`, `Superseded-by`) are kept in their family orders so pre-v2 fixtures produce the same relative ordering they used to
- `canonicalOrderFor(family)` helper with exhaustive switch
- Identity assignment: when a spec/test/element entry has no identity attribute at all (including legacy `Id`), the formatter assigns `Spec-id` / `Test-id` / `Element-id` with a bare 26-char Crockford ULID. Reference entries are left alone.

Updated 4 formatter unit tests + 1 e2e test to assert new `Spec-id: <bare>` output instead of legacy `Id: SRS_<prefixed>`.

## Tests

4 new tests cover:
- Reference entry without `Reference-id` is not auto-assigned
- Existing `Spec-id` on a spec entry is not touched
- Canonical order on test family (`Test-id → Test-level → Verifies → Labels`)
- Canonical order on element family (`Element-id → Element-kind → Part-of → Realizes → Labels`)

360/360 total pass.

## Deferred

Auto-assignment for **anonymous** test/element entries (display ID present but no identity attribute) requires the parser to first classify the entry as test or element. Current parser falls back to display-ID-shape for spec vs reference; test and element classification needs document directive + filename + profile logic. Tracked as Phase 6 work.

## Phase 4 remaining

- **4b**: multi-line trailer canonicalization (CSV → multi-line for `id-list` / `tag-list` / `external-id`)
- **4c**: front-matter canonical form (YAML, kebab-case, canonical key order)

## Checklist

- [x] Tests added (+4); 5 existing updated
- [x] `just check` passes locally
- [x] No documentation changes needed for this phase
