### PR TITLE
feat(core): entry-model v2 phase 4b — multi-line trailer canonicalization

### DIFF
--- a/packages/markspec/core/formatter/mod.ts
+++ b/packages/markspec/core/formatter/mod.ts
@@ -13,9 +13,20 @@ import type {
   Entry,
   EntryFamily,
 } from "../model/mod.ts";
-import { IDENTITY_KEY_BY_FAMILY } from "../model/mod.ts";
+import { attributeSpec, IDENTITY_KEY_BY_FAMILY } from "../model/mod.ts";
 import { ATTR_LINE_RE } from "../parser/attributes.ts";
 import { parseMarkdown } from "../parser/markdown.ts";
+
+/**
+ * Value types that accept CSV on input but must be emitted as multi-line
+ * per ADR-002 §2.6. `citation` is deliberately excluded because locators
+ * may contain commas.
+ */
+const CSV_SPLITTABLE_TYPES: ReadonlySet<string> = new Set([
+  "id-list",
+  "tag-list",
+  "external-id",
+]);
 
 /**
  * Canonical attribute ordering for spec entries per ADR-002 Annex C.
@@ -178,7 +189,7 @@ export function format(
 
     if (attrs.length === 0) continue;
 
-    const normalized = sortAttributes(attrs, entry.family);
+    const normalized = sortAttributes(expandCsvValues(attrs), entry.family);
     const range = findAttributeBlockRange(lines, entry.location.line, indent);
 
     if (range) {
@@ -204,6 +215,33 @@ export function format(
   }
 
   return { output: lines.join("\n"), diagnostics, changed };
+}
+
+/**
+ * Expand CSV values on repeatable-type attributes into one entry per value
+ * per ADR-002 §2.6. `id-list` / `tag-list` / `external-id` accept CSV input
+ * but must round-trip as multi-line output; `citation` is left alone
+ * because locators may contain commas.
+ */
+export function expandCsvValues(attrs: Attribute[]): Attribute[] {
+  const result: Attribute[] = [];
+  for (const attr of attrs) {
+    const spec = attributeSpec(attr.key);
+    if (
+      spec && CSV_SPLITTABLE_TYPES.has(spec.type) && attr.value.includes(",")
+    ) {
+      const values = attr.value
+        .split(",")
+        .map((s) => s.trim())
+        .filter((s) => s.length > 0);
+      for (const value of values) {
+        result.push({ key: attr.key, value });
+      }
+    } else {
+      result.push(attr);
+    }
+  }
+  return result;
 }
 
 /**

--- a/packages/markspec/core/formatter/mod_test.ts
+++ b/packages/markspec/core/formatter/mod_test.ts
@@ -461,3 +461,118 @@ Deno.test("format: canonical order for element family", () => {
     true,
   );
 });
+
+// ---------------------------------------------------------------------------
+// Phase 4b — CSV → multi-line canonicalization for repeatable types
+// ---------------------------------------------------------------------------
+
+Deno.test("format: Derived-from CSV splits into multi-line", () => {
+  const md = `# Test
+
+- [SRS_BRK_0001] Title
+
+  Body.
+
+  Spec-id: 01HGW2Q8MNP3RSTVWXYZABCDEF\\
+  Derived-from: SYS_BRK_0042, SYS_BRK_0043
+`;
+  const result = format(md);
+  assertEquals(result.changed, true);
+  const derivedLines = result.output.split("\n").filter((l) =>
+    l.trim().startsWith("Derived-from:")
+  );
+  assertEquals(derivedLines.length, 2);
+  assertStringIncludes(derivedLines[0], "SYS_BRK_0042");
+  assertStringIncludes(derivedLines[1], "SYS_BRK_0043");
+});
+
+Deno.test("format: Labels CSV splits into multi-line", () => {
+  const md = `# Test
+
+- [SRS_BRK_0001] Title
+
+  Body.
+
+  Spec-id: 01HGW2Q8MNP3RSTVWXYZABCDEF\\
+  Labels: ASIL-B, safety, automotive
+`;
+  const result = format(md);
+  assertEquals(result.changed, true);
+  const labelLines = result.output.split("\n").filter((l) =>
+    l.trim().startsWith("Labels:")
+  );
+  assertEquals(labelLines.length, 3);
+});
+
+Deno.test("format: References (citation) does NOT CSV-split", () => {
+  // References is a citation type — locators may contain commas, so the
+  // formatter must keep the value intact.
+  const md = `# Test
+
+- [SRS_BRK_0001] Title
+
+  Body.
+
+  Spec-id: 01HGW2Q8MNP3RSTVWXYZABCDEF\\
+  References: ISO-26262-6 §9.4, Table 7
+`;
+  const result = format(md);
+  const refLines = result.output.split("\n").filter((l) =>
+    l.trim().startsWith("References:")
+  );
+  assertEquals(refLines.length, 1);
+  assertStringIncludes(refLines[0], "§9.4, Table 7");
+});
+
+Deno.test("format: multi-line repeatable attributes are preserved", () => {
+  // Input is already multi-line; formatter keeps it that way (idempotent).
+  const md = `# Test
+
+- [SRS_BRK_0001] Title
+
+  Body.
+
+  Spec-id: 01HGW2Q8MNP3RSTVWXYZABCDEF\\
+  Derived-from: SYS_BRK_0042\\
+  Derived-from: SYS_BRK_0043
+`;
+  const result = format(md);
+  assertEquals(result.changed, false);
+  assertEquals(result.output, md);
+});
+
+Deno.test("format: CSV + multi-line mixed input canonicalizes to all multi-line", () => {
+  const md = `# Test
+
+- [SRS_BRK_0001] Title
+
+  Body.
+
+  Spec-id: 01HGW2Q8MNP3RSTVWXYZABCDEF\\
+  Labels: ASIL-B, safety\\
+  Labels: automotive
+`;
+  const result = format(md);
+  assertEquals(result.changed, true);
+  const labelLines = result.output.split("\n").filter((l) =>
+    l.trim().startsWith("Labels:")
+  );
+  assertEquals(labelLines.length, 3);
+});
+
+Deno.test("format: CSV expansion is idempotent (double-format = single)", () => {
+  const md = `# Test
+
+- [SRS_BRK_0001] Title
+
+  Body.
+
+  Spec-id: 01HGW2Q8MNP3RSTVWXYZABCDEF\\
+  Derived-from: SYS_BRK_0042, SYS_BRK_0043\\
+  Labels: ASIL-B, safety
+`;
+  const first = format(md);
+  const second = format(first.output);
+  assertEquals(second.changed, false);
+  assertEquals(second.output, first.output);
+});


### PR DESCRIPTION
## What

Formatter converts CSV-valued repeatable-type attributes to multi-line trailers per ADR-002 §2.6. CSV is accepted as input; multi-line is the canonical output.

## Why

Tracked in #198. The ADR mandates multi-line for `id-list` / `tag-list` / `external-id` for diff-friendliness, grep-friendliness, and strict alignment with git-trailer convention. `citation` (used by `References:`) is deliberately left alone because locators may contain commas (\"ISO-26262-6 §9.4, Table 7\").

Refs #198

## How

- Add \`CSV_SPLITTABLE_TYPES\` = { \`id-list\`, \`tag-list\`, \`external-id\` }
- Add \`expandCsvValues(attrs)\` — consults \`attributeSpec(key)\`, splits CSV values into per-value entries for repeatable types, leaves others (including \`citation\`) untouched
- Wire into \`format()\` between \`sortAttributes\` and \`renderAttributeBlock\`:
  \`\`\`
  sortAttributes(expandCsvValues(attrs), family)
  \`\`\`
- Unknown keys pass through unchanged

## Tests

+6 tests cover: Derived-from CSV splits; Labels CSV splits; References (citation) does NOT split; multi-line preserved; mixed CSV + multi-line canonicalizes; double-format idempotent.

366/366 pass.

## Phase 4 remaining

- **4c**: front-matter canonical form (YAML, kebab-case, canonical key order)

## Checklist

- [x] Tests added (+6)
- [x] \`just check\` passes locally
- [x] No documentation changes needed