### PR TITLE
feat(core): entry-model v2 phase 4c — front-matter canonical form

### DIFF
--- a/packages/markspec/core/formatter/mod.ts
+++ b/packages/markspec/core/formatter/mod.ts
@@ -7,14 +7,17 @@
  */
 
 import { ulid as defaultUlid } from "@std/ulid";
+import { stringify as stringifyYaml } from "@std/yaml";
 import type {
   Attribute,
   Diagnostic,
+  DocumentAttributes,
   Entry,
   EntryFamily,
 } from "../model/mod.ts";
 import { attributeSpec, IDENTITY_KEY_BY_FAMILY } from "../model/mod.ts";
 import { ATTR_LINE_RE } from "../parser/attributes.ts";
+import { extractFrontMatter } from "../parser/frontmatter.ts";
 import { parseMarkdown } from "../parser/markdown.ts";
 
 /**
@@ -27,6 +30,21 @@ const CSV_SPLITTABLE_TYPES: ReadonlySet<string> = new Set([
   "tag-list",
   "external-id",
 ]);
+
+/**
+ * Canonical front-matter key order per ADR-007. Core keys first, then
+ * `metadata` (reserved free-form map), then `extra` (allowlisted ecosystem
+ * keys / profile keys) are emitted verbatim at the end.
+ */
+const FRONT_MATTER_CORE_ORDER: readonly string[] = [
+  "document-id",
+  "document-type",
+  "labels",
+  "status",
+  "external-id",
+  "supersedes",
+  "references",
+];
 
 /**
  * Canonical attribute ordering for spec entries per ADR-002 Annex C.
@@ -152,14 +170,19 @@ export function format(
   options?: FormatOptions,
 ): FormatResult {
   const file = options?.file ?? "<unknown>";
-  const entries = parseMarkdown(markdown, { file });
 
-  if (entries.length === 0) {
-    return { output: markdown, diagnostics: [], changed: false };
+  // Extract any YAML front matter first so entries are parsed against the
+  // body only (front-matter `---` could be confused with horizontal rules).
+  const fm = extractFrontMatter(markdown, { file });
+  const body = fm.hadFrontMatter ? fm.markdown : markdown;
+  const entries = parseMarkdown(body, { file });
+  const diagnostics: Diagnostic[] = [...fm.diagnostics];
+
+  if (entries.length === 0 && !fm.hadFrontMatter) {
+    return { output: markdown, diagnostics, changed: false };
   }
 
-  const lines = markdown.split("\n");
-  const diagnostics: Diagnostic[] = [];
+  const lines = body.split("\n");
   let changed = false;
 
   // Process bottom-to-top so line splicing doesn't shift earlier entries.
@@ -214,7 +237,44 @@ export function format(
     }
   }
 
-  return { output: lines.join("\n"), diagnostics, changed };
+  const formattedBody = lines.join("\n");
+
+  if (fm.hadFrontMatter) {
+    const canonicalFm = renderFrontMatter(fm.attributes);
+    const output = canonicalFm + formattedBody;
+    if (output !== markdown) changed = true;
+    return { output, diagnostics, changed };
+  }
+
+  return { output: formattedBody, diagnostics, changed };
+}
+
+/**
+ * Render {@linkcode DocumentAttributes} as a canonical YAML front matter
+ * block. Keys are emitted in canonical order (core → metadata → extra);
+ * an `extra` subtree is flattened to top-level keys per ADR-007
+ * allowlist conventions.
+ */
+function renderFrontMatter(attrs: DocumentAttributes): string {
+  const ordered: Record<string, unknown> = {};
+  const a = attrs as Record<string, unknown>;
+
+  for (const key of FRONT_MATTER_CORE_ORDER) {
+    if (a[key] !== undefined) ordered[key] = a[key];
+  }
+  if (a.metadata !== undefined) ordered.metadata = a.metadata;
+  if (a.extra && typeof a.extra === "object") {
+    for (const [key, value] of Object.entries(a.extra)) {
+      ordered[key] = value;
+    }
+  }
+
+  if (Object.keys(ordered).length === 0) {
+    return "---\n---\n\n";
+  }
+
+  const yaml = stringifyYaml(ordered).trimEnd();
+  return `---\n${yaml}\n---\n\n`;
 }
 
 /**

--- a/packages/markspec/core/formatter/mod_test.ts
+++ b/packages/markspec/core/formatter/mod_test.ts
@@ -576,3 +576,121 @@ Deno.test("format: CSV expansion is idempotent (double-format = single)", () => 
   assertEquals(second.changed, false);
   assertEquals(second.output, first.output);
 });
+
+// ---------------------------------------------------------------------------
+// Phase 4c — front-matter canonical form
+// ---------------------------------------------------------------------------
+
+Deno.test("format: front matter with core keys is canonicalized", () => {
+  const md = `---
+status: approved
+document-id: 01HGW2D0DOCPQ4FGHIJKLMNOPQR
+document-type: requirements
+---
+
+# Title
+
+- [SRS_BRK_0001] Entry
+
+  Body.
+
+  Spec-id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+`;
+  const result = format(md);
+  assertEquals(result.changed, true);
+  // document-id should come before document-type, then status.
+  const docIdIdx = result.output.indexOf("document-id:");
+  const docTypeIdx = result.output.indexOf("document-type:");
+  const statusIdx = result.output.indexOf("status:");
+  assertEquals(docIdIdx < docTypeIdx, true);
+  assertEquals(docTypeIdx < statusIdx, true);
+});
+
+Deno.test("format: front matter forbidden key removed with diagnostic", () => {
+  const md = `---
+document-id: 01HGW2D0DOCPQ4FGHIJKLMNOPQR
+title: Should be stripped
+---
+
+# Title
+
+- [SRS_BRK_0001] Entry
+
+  Body.
+
+  Spec-id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+`;
+  const result = format(md);
+  assertEquals(result.output.includes("title:"), false);
+  const d001 = result.diagnostics.find((d) => d.code === "MSL-D001");
+  assertEquals(d001 != null, true);
+});
+
+Deno.test("format: front matter metadata map is preserved verbatim", () => {
+  const md = `---
+document-id: 01HGW2D0DOCPQ4FGHIJKLMNOPQR
+metadata:
+  owner: safety-team
+  jira-epic: PROJ-123
+---
+
+# Title
+
+- [SRS_BRK_0001] Entry
+
+  Body.
+
+  Spec-id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+`;
+  const result = format(md);
+  assertStringIncludes(result.output, "owner: safety-team");
+  assertStringIncludes(result.output, "jira-epic: PROJ-123");
+});
+
+Deno.test("format: front matter without any body entries still canonicalizes", () => {
+  const md = `---
+status: draft
+document-id: 01HGW2D0DOCPQ4FGHIJKLMNOPQR
+---
+
+# Just a heading
+
+Some prose.
+`;
+  const result = format(md);
+  assertEquals(result.changed, true);
+  const docIdIdx = result.output.indexOf("document-id:");
+  const statusIdx = result.output.indexOf("status:");
+  assertEquals(docIdIdx < statusIdx, true);
+});
+
+Deno.test("format: no front matter leaves input untouched", () => {
+  const md = `# Just a heading
+
+Some prose.
+`;
+  const result = format(md);
+  assertEquals(result.changed, false);
+  assertEquals(result.output, md);
+});
+
+Deno.test("format: front matter idempotent on already-canonical input", () => {
+  const md = `---
+document-id: 01HGW2D0DOCPQ4FGHIJKLMNOPQR
+document-type: requirements
+status: approved
+---
+
+# Title
+
+- [SRS_BRK_0001] Entry
+
+  Body.
+
+  Spec-id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+`;
+  const first = format(md);
+  const second = format(first.output);
+  assertEquals(second.changed, false);
+  assertEquals(second.output, first.output);
+});


### PR DESCRIPTION
## What

Formatter canonicalizes YAML front matter per ADR-007: core keys sorted, `metadata:` map preserved verbatim, allowlisted/profile keys flattened back to the top, forbidden keys removed by extraction.

## Why

Tracked in #198. ADR-007 makes front matter the canonical document-metadata home. Without this PR, an author writing `status: draft` above `document-id: ...` would stay in that order forever. Canonicalization makes diffs predictable.

Refs #198

## How

`formatter/mod.ts`:
- Add `FRONT_MATTER_CORE_ORDER`: `document-id`, `document-type`, `labels`, `status`, `external-id`, `supersedes`, `references`
- At the top of `format()`, call `extractFrontMatter()` — if present, the body markdown (without the front matter block) is used for entry formatting; diagnostics from extraction flow through
- After body formatting, `renderFrontMatter()` emits a canonical YAML block: core keys in order, then `metadata`, then `extra` keys flattened
- Reassemble: `canonicalFm + formattedBody`
- Empty front matter → emits `---\n---\n\n`

Forbidden-key handling: the `extractFrontMatter()` pass (Phase 2a) already rejects forbidden keys (`title`, `description`, `date`, `authors`, …) and emits MSL-D001. They never reach `renderFrontMatter`, so the effect is "forbidden keys are removed with a diagnostic" — exactly the ADR-007 behavior.

## Tests

6 new tests:
- Core keys reordered to canonical (`document-id`, `document-type`, `status`)
- Forbidden `title:` removed + MSL-D001 diagnostic
- `metadata:` map round-trips with nested keys preserved
- Front-matter canonicalization runs on files without body entries
- No front matter → input unchanged (back-compat)
- Idempotent: double-format = single

372/372 total pass.

## Phase 4 complete after this merge

Phase 5 (compiler updates: extend `ATTR_TO_LINK_KIND`, expose `entry.properties`, expose `CompileResult.documents`) follows.

## Checklist

- [x] Tests added (+6)
- [x] `just check` passes locally
- [x] No documentation changes needed
