### PR TITLE
feat(core): entry-model v2 phase 5b — integrate front matter into parseFile and compile

### DIFF
--- a/packages/markspec/core/compiler/mod.ts
+++ b/packages/markspec/core/compiler/mod.ts
@@ -8,6 +8,7 @@
 import type {
   Diagnostic,
   DisplayId,
+  Document,
   Entry,
   Link,
   LinkKind,
@@ -32,6 +33,12 @@ export interface CompileResult {
   readonly forward: ReadonlyMap<DisplayId, readonly Link[]>;
   /** Incoming links per entry (entry → sources pointing to it). */
   readonly reverse: ReadonlyMap<DisplayId, readonly Link[]>;
+  /**
+   * Documents keyed by file path. A file appears here only when it carried
+   * YAML front matter per ADR-007. Optional during the v2 migration;
+   * consumers should treat absence as an empty map.
+   */
+  readonly documents?: ReadonlyMap<string, Document>;
   /** Diagnostics from parsing and validation. */
   readonly diagnostics: readonly Diagnostic[];
 }
@@ -52,6 +59,7 @@ export async function compile(
   const allEntries: Entry[] = [];
   const annotationLinks: Link[] = [];
   const parseDiagnostics: Diagnostic[] = [];
+  const documents = new Map<string, Document>();
 
   // Phase 1: Read and parse all files.
   for (const filePath of paths) {
@@ -70,6 +78,8 @@ export async function compile(
     const result = await parseFile(content, { file: filePath });
     allEntries.push(...result.entries);
     annotationLinks.push(...result.links);
+    parseDiagnostics.push(...result.diagnostics);
+    if (result.document) documents.set(filePath, result.document);
   }
 
   // Phase 2: Validate all entries.
@@ -93,7 +103,7 @@ export async function compile(
     ...validationResult.diagnostics,
   ];
 
-  return { entries, links, forward, reverse, diagnostics };
+  return { entries, links, forward, reverse, documents, diagnostics };
 }
 
 /** Extract traceability links from entry attributes. */

--- a/packages/markspec/core/compiler/mod_test.ts
+++ b/packages/markspec/core/compiler/mod_test.ts
@@ -396,3 +396,94 @@ Deno.test("compile: multiple Verifies produces multiple links", async () => {
     "SRS_BRK_0002",
   ]);
 });
+
+// ---------------------------------------------------------------------------
+// Phase 5b — front matter exposed via CompileResult.documents
+// ---------------------------------------------------------------------------
+
+Deno.test("compile: front matter is extracted into CompileResult.documents", async () => {
+  const result = await compile(["req.md"], {
+    readFile: mockFs({
+      "req.md": `---
+document-id: 01HGW2D0DOCPQ4FGHIJKLMNOPQR
+document-type: requirements
+status: approved
+---
+
+# Title
+
+- [SRS_BRK_0001] Entry
+
+  Body.
+
+  Spec-id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+`,
+    }),
+  });
+  assertEquals(result.documents?.size, 1);
+  const doc = result.documents?.get("req.md");
+  assertEquals(doc?.attributes["document-id"], "01HGW2D0DOCPQ4FGHIJKLMNOPQR");
+  assertEquals(doc?.attributes["document-type"], "requirements");
+  assertEquals(doc?.attributes.status, "approved");
+});
+
+Deno.test("compile: file without front matter produces no Document entry", async () => {
+  const result = await compile(["req.md"], {
+    readFile: mockFs({
+      "req.md": `# Title
+
+- [SRS_BRK_0001] Entry
+
+  Body.
+
+  Id: SRS_00000000000000000000000001
+`,
+    }),
+  });
+  assertEquals(result.documents?.size, 0);
+});
+
+Deno.test("compile: forbidden front-matter key surfaces MSL-D001", async () => {
+  const result = await compile(["req.md"], {
+    readFile: mockFs({
+      "req.md": `---
+document-id: 01HGW2D0DOCPQ4FGHIJKLMNOPQR
+title: Should be rejected
+---
+
+# Title
+
+- [SRS_BRK_0001] Entry
+
+  Body.
+
+  Spec-id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+`,
+    }),
+  });
+  const d001 = result.diagnostics.find((d) => d.code === "MSL-D001");
+  assertEquals(d001 != null, true);
+});
+
+Deno.test("compile: front matter separates body for entry parsing", async () => {
+  // The --- in front matter should not be mistaken for a horizontal rule
+  // in the entry-extraction pass.
+  const result = await compile(["req.md"], {
+    readFile: mockFs({
+      "req.md": `---
+document-id: 01HGW2D0DOCPQ4FGHIJKLMNOPQR
+---
+
+# Title
+
+- [SRS_BRK_0001] Entry
+
+  Body.
+
+  Id: SRS_00000000000000000000000001
+`,
+    }),
+  });
+  assertEquals(result.entries.size, 1);
+  assertEquals(result.entries.has("SRS_BRK_0001"), true);
+});

--- a/packages/markspec/core/parser/mod.ts
+++ b/packages/markspec/core/parser/mod.ts
@@ -11,10 +11,17 @@
  */
 
 import { extname } from "@std/path";
-import type { Caption, Entry, Link } from "../model/mod.ts";
+import type {
+  Caption,
+  Diagnostic,
+  Document,
+  Entry,
+  Link,
+} from "../model/mod.ts";
 import { parseMarkdown } from "./markdown.ts";
 import { isSupportedExtension, loadGrammar } from "./grammars.ts";
 import { parseSource } from "./source.ts";
+import { extractFrontMatter } from "./frontmatter.ts";
 import {
   detectCaptions as detectCaptionsImpl,
   type DetectCaptionsOptions,
@@ -59,12 +66,24 @@ export function parse(
   return parseMarkdown(markdown, options);
 }
 
-/** Result of parsing a file (entries + annotation links). */
+/** Result of parsing a file (entries + annotation links + document). */
 export interface ParseFileResult {
   /** Parsed entries. */
   readonly entries: Entry[];
   /** Standalone annotation links (from source file doc comments). */
   readonly links: Link[];
+  /**
+   * Document-level metadata parsed from YAML front matter. `undefined` for
+   * source files (Rust/Kotlin/C/...) and for Markdown files without front
+   * matter; present otherwise so downstream consumers can resolve
+   * `{{document.*}}` inline references.
+   */
+  readonly document?: Document;
+  /**
+   * Parse-level diagnostics (forbidden front-matter keys, malformed YAML).
+   * Merged into the compile result's diagnostics.
+   */
+  readonly diagnostics: readonly Diagnostic[];
 }
 
 /**
@@ -78,15 +97,12 @@ function isReferencesDocument(file: string): boolean {
 }
 
 /**
- * Parse a file and return entries and annotation links, dispatching by type.
+ * Parse a file and return entries, annotation links, and (for Markdown
+ * files) a Document with front-matter attributes.
  *
  * Source files (`.rs`, `.java`, `.c`, `.cpp`, etc.) are parsed with
- * tree-sitter to extract doc comment entries and standalone annotations.
- * All other files are parsed as Markdown (no annotation links).
- *
- * @param content - File content
- * @param options - Must include `file` path for extension detection
- * @returns Parsed entries and annotation links
+ * tree-sitter to extract doc comment entries; no front matter is
+ * recognized on source files.
  */
 export async function parseFile(
   content: string,
@@ -96,13 +112,34 @@ export async function parseFile(
 
   if (isSupportedExtension(ext)) {
     const language = await loadGrammar(ext);
-    return parseSource(content, { file: options.file, language });
+    const result = await parseSource(content, {
+      file: options.file,
+      language,
+    });
+    return { ...result, diagnostics: [] };
   }
 
+  const fm = extractFrontMatter(content, { file: options.file });
+  const body = fm.hadFrontMatter ? fm.markdown : content;
   const isReferencesDoc = isReferencesDocument(options.file);
+  const entries = parseMarkdown(body, {
+    file: options.file,
+    isReferencesDoc,
+  });
+
+  const document: Document | undefined = fm.hadFrontMatter
+    ? {
+      file: options.file,
+      attributes: fm.attributes,
+      properties: {},
+    }
+    : undefined;
+
   return {
-    entries: parseMarkdown(content, { file: options.file, isReferencesDoc }),
+    entries,
     links: [],
+    document,
+    diagnostics: fm.diagnostics,
   };
 }
 


### PR DESCRIPTION
## What

`parseFile` now extracts YAML front matter from Markdown files and returns a `Document`; the compiler surfaces the collected documents via `CompileResult.documents`.

## Why

Tracked in #198 (debt #1). The Phase 2a front-matter parser was standalone — exported from `parser/mod.ts` but never called by `parseFile` or the compile pipeline. Result: `markspec compile` had no access to document-level metadata. This PR wires it up.

Refs #198

## How

`parser/mod.ts`:
- `ParseFileResult` gains optional `document: Document` + `diagnostics: readonly Diagnostic[]`
- `parseFile` on Markdown: extracts front matter first, passes stripped body to `parseMarkdown`, builds `Document { file, attributes, properties: {} }`, forwards FM diagnostics
- `parseFile` on source files (Rust/Kotlin/C/...): unchanged, empty diagnostics (source files don't carry front matter)

`compiler/mod.ts`:
- `CompileResult` gains optional `documents: ReadonlyMap<string, Document>` — kept optional during the v2 migration so the 10 existing test-only `CompileResult` literals compile without empty-map stubs
- Compiler accumulates documents per file path, merges `parseFile.diagnostics` into the final result

## Tests

+4 compiler tests:
- Front matter parsed into `CompileResult.documents`
- File without front matter produces no Document entry
- Forbidden key surfaces MSL-D001 through the compile pipeline
- `---` front-matter delimiter isn't confused with a horizontal-rule in entry parsing

383/383 pass.

## Phase 5 remaining

- **5c**: remove dead `ParseSourceResult.links` plumbing (debt #6)

Phase 6 (fixture migration + e2e coverage) follows.

## Checklist

- [x] Tests added (+4)
- [x] `just check` passes locally
- [x] No documentation changes needed
