### PR TITLE
refactor(core): entry-model v2 phase 5c — remove dead links plumbing

### DIFF
--- a/packages/markspec/core/compiler/mod.ts
+++ b/packages/markspec/core/compiler/mod.ts
@@ -57,7 +57,6 @@ export async function compile(
 ): Promise<CompileResult> {
   const read = options.readFile;
   const allEntries: Entry[] = [];
-  const annotationLinks: Link[] = [];
   const parseDiagnostics: Diagnostic[] = [];
   const documents = new Map<string, Document>();
 
@@ -77,7 +76,6 @@ export async function compile(
     }
     const result = await parseFile(content, { file: filePath });
     allEntries.push(...result.entries);
-    annotationLinks.push(...result.links);
     parseDiagnostics.push(...result.diagnostics);
     if (result.document) documents.set(filePath, result.document);
   }
@@ -94,7 +92,7 @@ export async function compile(
     }
   }
 
-  const links = [...extractLinks(allEntries), ...annotationLinks];
+  const links = extractLinks(allEntries);
   const forward = buildAdjacency(links, (l) => l.from);
   const reverse = buildAdjacency(links, (l) => l.to);
 

--- a/packages/markspec/core/parser/mod.ts
+++ b/packages/markspec/core/parser/mod.ts
@@ -11,13 +11,7 @@
  */
 
 import { extname } from "@std/path";
-import type {
-  Caption,
-  Diagnostic,
-  Document,
-  Entry,
-  Link,
-} from "../model/mod.ts";
+import type { Caption, Diagnostic, Document, Entry } from "../model/mod.ts";
 import { parseMarkdown } from "./markdown.ts";
 import { isSupportedExtension, loadGrammar } from "./grammars.ts";
 import { parseSource } from "./source.ts";
@@ -66,12 +60,10 @@ export function parse(
   return parseMarkdown(markdown, options);
 }
 
-/** Result of parsing a file (entries + annotation links + document). */
+/** Result of parsing a file (entries + optional document + diagnostics). */
 export interface ParseFileResult {
   /** Parsed entries. */
   readonly entries: Entry[];
-  /** Standalone annotation links (from source file doc comments). */
-  readonly links: Link[];
   /**
    * Document-level metadata parsed from YAML front matter. `undefined` for
    * source files (Rust/Kotlin/C/...) and for Markdown files without front
@@ -112,11 +104,11 @@ export async function parseFile(
 
   if (isSupportedExtension(ext)) {
     const language = await loadGrammar(ext);
-    const result = await parseSource(content, {
+    const result = parseSource(content, {
       file: options.file,
       language,
     });
-    return { ...result, diagnostics: [] };
+    return { entries: result.entries, diagnostics: [] };
   }
 
   const fm = extractFrontMatter(content, { file: options.file });
@@ -137,7 +129,6 @@ export async function parseFile(
 
   return {
     entries,
-    links: [],
     document,
     diagnostics: fm.diagnostics,
   };

--- a/packages/markspec/core/parser/source.ts
+++ b/packages/markspec/core/parser/source.ts
@@ -8,7 +8,7 @@
 
 import type { SyntaxNode } from "web-tree-sitter";
 import Parser from "web-tree-sitter";
-import type { Entry, Link } from "../model/mod.ts";
+import type { Entry } from "../model/mod.ts";
 import { parseMarkdown } from "./markdown.ts";
 
 /** Options for {@linkcode parseSource}. */
@@ -23,13 +23,6 @@ export interface ParseSourceOptions {
 export interface ParseSourceResult {
   /** Entries found in doc comment blocks. */
   readonly entries: Entry[];
-  /**
-   * Traceability links extracted outside entry blocks. Always empty under
-   * the four-family model — test entries carry `Verifies:` / `Tests:` inside
-   * entry blocks; element entries carry `Realizes:` / `Depends-on:`. Kept for
-   * API stability with {@linkcode Link[]}.
-   */
-  readonly links: Link[];
 }
 
 /** A contiguous doc comment block extracted from source. */
@@ -92,7 +85,7 @@ export function parseSource(
 
   tree.delete();
   parser.delete();
-  return { entries, links: [] };
+  return { entries };
 }
 
 /**

--- a/packages/markspec/core/parser/source_test.ts
+++ b/packages/markspec/core/parser/source_test.ts
@@ -349,22 +349,20 @@ Deno.test("parseSource: links is always empty under the four-family model", asyn
 fn foo() {}
 `;
 
-  const { entries, links } = parseSource(source, { file: "test.rs", language });
+  const { entries } = parseSource(source, { file: "test.rs", language });
   assertEquals(entries.length, 1);
-  assertEquals(links.length, 0);
-  // Verifies inside the entry block becomes an attribute, not a standalone link.
+  // Verifies inside the entry block becomes an attribute.
   const verifies = entries[0].attributes.find((a) => a.key === "Verifies");
   assertEquals(verifies?.value, "STK_BRK_0001");
 });
 
-Deno.test("parseSource: doc comments without entry blocks produce no entries or links", async () => {
+Deno.test("parseSource: doc comments without entry blocks produce no entries", async () => {
   const language = await getRustLanguage();
   const source = `/// Verifies: STK_AEB_0001
 #[test]
 fn val_aeb_0001_vehicle_stops() {}
 `;
 
-  const { entries, links } = parseSource(source, { file: "test.rs", language });
+  const { entries } = parseSource(source, { file: "test.rs", language });
   assertEquals(entries.length, 0);
-  assertEquals(links.length, 0);
 });


### PR DESCRIPTION
## What

Cleanup of debt #6 on issue #198. Phase 2b-i removed the standalone annotation extraction from `source.ts` but kept the `ParseSourceResult.links` field (empty) plus the compiler's `annotationLinks` accumulator. This PR deletes all of it.

## Why

Tracked in #198. Pre-1.0 package; no external consumers read these fields. Keeping API stability for internal code adds complexity without upside.

Refs #198

## How

Removed:
- `ParseSourceResult.links` (always empty)
- `ParseFileResult.links` (always empty)
- `compiler/mod.ts`: `annotationLinks` accumulator and its spread — links now `= extractLinks(allEntries)` directly

Also simplified `parseFile`: `parseSource` returns `{ entries }` only, so we build `ParseFileResult` locally instead of spreading an unused field.

2 source_test.ts tests updated to destructure only `{ entries }` from `parseSource`.

## Tests
383/383 pass.

## Checklist
- [x] Tests updated (2 tests, -4 lines)
- [x] `just check` passes locally
- [x] No documentation changes
