### PR TITLE
feat(core): entry-model v2 phase 6a — end-to-end four-family fixture + citation slug fix

### DIFF
--- a/packages/markspec/core/compiler/mod.ts
+++ b/packages/markspec/core/compiler/mod.ts
@@ -123,6 +123,16 @@ function extractLinks(entries: readonly Entry[]): Link[] {
   return links;
 }
 
+/**
+ * Attributes whose value is `slug + optional free-text locator` per
+ * ADR-002 §2.6 (citation type + legacy Derived-from tolerance). The link
+ * target is the leading non-whitespace token only.
+ */
+const LOCATOR_BEARING_ATTRS: ReadonlySet<string> = new Set([
+  "Derived-from",
+  "References",
+]);
+
 /** Map an attribute key+value to zero or more links. */
 function extractLinksFromAttribute(
   from: DisplayId,
@@ -133,7 +143,7 @@ function extractLinksFromAttribute(
   const kind = ATTR_TO_LINK_KIND[key];
   if (!kind) return [];
 
-  if (key === "Derived-from") {
+  if (LOCATOR_BEARING_ATTRS.has(key)) {
     // Format: "ID §section" — extract ID part only.
     const idPart = value.split(/\s/)[0];
     if (idPart) {
@@ -142,7 +152,7 @@ function extractLinksFromAttribute(
     return [];
   }
 
-  // Comma-separated targets (Satisfies, Allocates, Verifies, Implements).
+  // Comma-separated targets for id-list attributes.
   return value
     .split(",")
     .map((s) => s.trim())

--- a/packages/markspec/core/compiler/mod_test.ts
+++ b/packages/markspec/core/compiler/mod_test.ts
@@ -487,3 +487,110 @@ document-id: 01HGW2D0DOCPQ4FGHIJKLMNOPQR
   assertEquals(result.entries.size, 1);
   assertEquals(result.entries.has("SRS_BRK_0001"), true);
 });
+
+// ---------------------------------------------------------------------------
+// Phase 6a — end-to-end four-family traceability
+// ---------------------------------------------------------------------------
+
+Deno.test("compile: end-to-end four-family traceability graph", async () => {
+  // Exercise the full model: Reference cited by Spec, Spec allocated to
+  // Element, Element realizes Spec, Test verifies Spec, Test tests Element,
+  // all with the new identity attributes, all in their own documents.
+  const result = await compile(
+    ["specs.md", "tests.md", "elements.md", "references.md"],
+    {
+      readFile: mockFs({
+        "references.md": `# References
+
+- [@ISO-26262-6] ISO 26262 Part 6
+
+  Road vehicles — Functional safety — Part 6: Software level.
+
+  Reference-id: urn:iso:std:iso:26262:-6:ed-2
+`,
+        "specs.md": `---
+document-id: 01HGW2D0DOCPQ4FGHIJKLMNOPQR
+document-type: requirements
+status: approved
+---
+
+# Braking requirements
+
+- [SRS_BRK_0107] Sensor input debouncing
+
+  The sensor driver shall debounce raw inputs.
+
+  Spec-id: 01HGW2Q8MNP3RSTVWXYZABCDEF\\
+  Allocated-to: braking_core::controller::debounce\\
+  References: ISO-26262-6 §9.4.5\\
+  Labels: ASIL-B
+`,
+        "tests.md": `# Tests
+
+- [SWT_BRK_0107] Debounce unit test
+
+  Given a 10ms window, a 5ms spike must not alter output.
+
+  Test-id: 01HGW3R9Q2P4ABCDEFGHJKMNPQ\\
+  Test-level: unit\\
+  Verifies: SRS_BRK_0107\\
+  Tests: braking_core::controller::debounce
+`,
+        "elements.md": `# Elements
+
+- [braking_core::controller::debounce] Debounce function
+
+  Rejects transient noise on raw sensor readings.
+
+  Element-id: 01HGW3D6QRST7JKMNPQRSTVWXY\\
+  Element-kind: unit\\
+  Realizes: SRS_BRK_0107
+`,
+      }),
+    },
+  );
+
+  // All four entries parsed
+  assertEquals(result.entries.size, 4);
+  assertEquals(result.entries.has("SRS_BRK_0107"), true);
+  assertEquals(result.entries.has("SWT_BRK_0107"), true);
+  assertEquals(result.entries.has("braking_core::controller::debounce"), true);
+  assertEquals(result.entries.has("ISO-26262-6"), true);
+
+  // Each entry has the correct family
+  assertEquals(result.entries.get("SRS_BRK_0107")?.family, "spec");
+  assertEquals(result.entries.get("SWT_BRK_0107")?.family, "test");
+  assertEquals(
+    result.entries.get("braking_core::controller::debounce")?.family,
+    "element",
+  );
+  assertEquals(result.entries.get("ISO-26262-6")?.family, "reference");
+
+  // Traceability graph: 5 links (Allocated-to, References, Verifies, Tests, Realizes)
+  assertEquals(result.links.length, 5);
+
+  // Spot-check each link kind
+  const byKind = (k: string) => result.links.filter((l) => l.kind === k);
+  assertEquals(byKind("allocated-to").length, 1);
+  assertEquals(byKind("references").length, 1);
+  assertEquals(byKind("verifies").length, 1);
+  assertEquals(byKind("tests").length, 1);
+  assertEquals(byKind("realizes").length, 1);
+
+  // Element is reached by both Realizes and Tests
+  const incomingToElement = result.reverse
+    .get("braking_core::controller::debounce") ?? [];
+  const incomingKinds = incomingToElement.map((l) => l.kind).sort();
+  assertEquals(incomingKinds, ["allocated-to", "tests"]);
+
+  // Document surface
+  assertEquals(result.documents?.size, 1);
+  assertEquals(
+    result.documents?.get("specs.md")?.attributes["document-type"],
+    "requirements",
+  );
+
+  // No validation errors
+  const errors = result.diagnostics.filter((d) => d.severity === "error");
+  assertEquals(errors.length, 0, JSON.stringify(errors, null, 2));
+});

--- a/packages/markspec/core/validator/mod.ts
+++ b/packages/markspec/core/validator/mod.ts
@@ -441,6 +441,9 @@ const TRACEABILITY_RULES: readonly TraceabilityRule[] = [
     code: "MSL-T005",
     severity: "error",
     source: ["spec", "test", "element"],
+    // References is a `citation` type per ADR-002 §2.6: "slug + optional
+    // free-text locator". Strip the locator before resolution.
+    tolerateLocator: true,
   },
   {
     key: "Allocated-to",


### PR DESCRIPTION
## What

End-to-end fixture that exercises the complete four-family model through parser → validator → compiler. Surfaces and fixes a citation-slug bug in both validator and compiler: `"ISO-26262-6 §9.4.5"` was being treated as a display ID, never resolving.

## Why

Tracked in #198 (debt #12: no end-to-end integration test). First full-pipeline test was always the most likely to find composition bugs — and it did.

Refs #198

## How

**New test** (`compiler/mod_test.ts`): `compile: end-to-end four-family traceability graph`. Uses in-memory fixture files covering all four families with cross-family links:
- Reference `@ISO-26262-6` with `Reference-id` URI
- Spec `SRS_BRK_0107` with `Spec-id`, `Allocated-to` → element, `References` → reference
- Test `SWT_BRK_0107` with `Test-id`, `Test-level`, `Verifies` → spec, `Tests` → element
- Element `braking_core::controller::debounce` with `Element-id`, `Element-kind`, `Realizes` → spec
- Front matter on the spec document

Asserts: 4 families parse with correct classification; 5 traceability links (allocated-to, references, verifies, tests, realizes); bidirectional graph correctly reports element incoming links from both allocated-to and tests; documents map exposes front-matter attributes; zero validation errors.

**Bug fix — citation slug extraction**:

Per ADR-002 §2.6, `citation` values carry "slug + optional free-text locator" (`"ISO-26262-6 §9.4.5"`). Both validator and compiler were treating the full string as the target display ID.

- `validator/mod.ts`: set `tolerateLocator: true` on the `References` rule (was previously only on `Derived-from`)
- `compiler/mod.ts`: introduce `LOCATOR_BEARING_ATTRS = { Derived-from, References }` and share the slug-extraction path; the old `key === "Derived-from"` special case becomes declarative

## Tests

+1 end-to-end test; 384/384 total pass.

## Phase 6 remaining

- **6b**: language.md §8.3 re-align with code's MSL-T numbering; fix ADR-002 example ULIDs (debt items on #198)

## Checklist

- [x] Tests added (+1, big one)
- [x] `just check` passes locally
- [x] No documentation changes in this PR (6b follows)
