### PR TITLE
docs(docs): migrate user-facing entry examples to four-family model

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -408,13 +408,13 @@ Deno.test("parseRequirementBlock: extracts display ID", () => {
 
   The sensor driver shall debounce raw inputs.
 
-  Id: SRS_01HGW2Q8MNP3 \\
+  Spec-id: 01HGW2Q8MNP3RSTVWXYZABCDEF \\
   Labels: ASIL-B`;
 
   const req = parseRequirementBlock(block);
   assertEquals(req.displayId, "SRS_BRK_0001");
   assertEquals(req.title, "Sensor debouncing");
-  assertEquals(req.id, "SRS_01HGW2Q8MNP3");
+  assertEquals(req.id, "01HGW2Q8MNP3RSTVWXYZABCDEF");
   assertEquals(req.labels, ["ASIL-B"]);
 });
 ```
@@ -484,7 +484,7 @@ Deno.test("validate: broken upstream link fails", async () => {
   const input = `
 - [SRS_BRK_0001] Sensor debouncing
 
-  Id: SRS_01HGW2Q8MNP3 \\
+  Spec-id: 01HGW2Q8MNP3RSTVWXYZABCDEF \\
   Satisfies: SYS_NONEXISTENT \\
   Labels: ASIL-B
 `;

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ GitHub and GitLab — no tooling required to read.
   The sensor driver shall debounce raw inputs to eliminate electrical noise
   before processing.
 
-  Id: SRS_01HGW2Q8MNP3\
+  Spec-id: 01HGW2Q8MNP3RSTVWXYZABCDEF\
   Satisfies: SYS_BRK_0042\
   Labels: ASIL-B
 ```

--- a/docs/cheatsheet/markspec-cheatsheet.typ
+++ b/docs/cheatsheet/markspec-cheatsheet.typ
@@ -111,7 +111,7 @@ Slug: `fig.architecture-overview`
   The sensor driver shall debounce
   raw inputs to eliminate noise.
 
-  Id: SRS_01HGW2Q8MNP3\
+  Spec-id: 01HGW2Q8MNP3RSTVWXYZABCDEF\
   Satisfies: SYS_BRK_0042\
   Labels: ASIL-B
 ```]
@@ -128,7 +128,9 @@ No `_emphasis_` inside entries. `**Strong**` and `` `code` `` ok.
 
 == ULID
 
-`TYPE_01HGW2Q8MNP3` — 12–13 chars. Assigned by tooling, never changes.
+Bare 26-char Crockford base32, e.g. `01HGW2Q8MNP3RSTVWXYZABCDEF`.
+Lives in the family-specific identity attribute (`Spec-id`, `Test-id`,
+`Element-id`). Assigned by tooling, never changes.
 
 == Entry types
 
@@ -151,102 +153,101 @@ No `_emphasis_` inside entries. `**Strong**` and `` `code` `` ok.
 
 #code[```kotlin
 /**
- * [SRS_BRK_0107] Sensor debouncing
+ * [SWT_BRK_0107] Debounce unit test
  *
- * The sensor driver shall reject
- * transient noise shorter than the
- * configured debounce window.
+ * Given a 10ms debounce window,
+ * a 5ms noise spike must not alter
+ * the stable output.
  *
- * Id: SRS_01HGW2R9QLP4\
- * Satisfies: SYS_BRK_0042\
- * Labels: ASIL-B
+ * Test-id: 01HGW3R9QNP4ABCDEFGHJKMNPQ\
+ * Test-level: unit\
+ * Verifies: SRS_BRK_0107\
+ * Tests: braking_core::controller::debounce
  */
 @Test
 fun `swt_brk_0107 debounce`() { }
 ```]
 
-== Code annotations
-
-#code[```kotlin
-/** Verifies: SRS_BRK_0107 */
-/** Implements: SRS_BRK_0107 */
-```]
+Traceability lives inside entry blocks: test entries declare `Verifies`
+and `Tests` directly; there is no standalone annotation path.
 
 Languages: Rust `///` · Kotlin `/** */` · C++ `///` · C `/** */` · Java 23+ `///`
 
 #colbreak()
 
-= Attributes
+= Attributes (by family)
 
-== Authored (committed)
+Every entry carries exactly one identity attribute; its presence selects
+the family.
+
+== Spec
 
 #table(
   columns: (auto, 1fr),
   stroke: 0.4pt + luma(180),
   inset: 3pt,
   table.header[*Attr*][*Description*],
-  [`Id`], [ULID, mandatory],
-  [`Satisfies`], [Upstream parent ID(s)],
-  [`Derived-from`], [External ref + section],
-  [`Labels`], [Comma-separated tags],
+  [`Spec-id`], [Bare ULID, assigned],
+  [`Satisfies`], [Parent spec, complete fulfillment],
+  [`Derived-from`], [Parent spec, V-model decomposition],
+  [`Allocated-to`], [Element(s) responsible],
 )
+
+== Test
+
+#table(
+  columns: (auto, 1fr),
+  stroke: 0.4pt + luma(180),
+  inset: 3pt,
+  [`Test-id`], [Bare ULID, assigned],
+  [`Test-level`], [`unit` / `integration` / `system` / `acceptance`],
+  [`Verifies`], [Spec display ID(s)],
+  [`Tests`], [Element display ID(s)],
+)
+
+== Element
+
+#table(
+  columns: (auto, 1fr),
+  stroke: 0.4pt + luma(180),
+  inset: 3pt,
+  [`Element-id`], [Bare ULID, assigned],
+  [`Element-kind`], [`item` / `artifact` / `dependency` / `unit`],
+  [`Part-of`], [Parent element],
+  [`Realizes`], [Spec display ID(s)],
+  [`Depends-on`], [Element display ID(s)],
+  [`Generated-from`], [Path or element],
+)
+
+== Reference
+
+#table(
+  columns: (auto, 1fr),
+  stroke: 0.4pt + luma(180),
+  inset: 3pt,
+  [`Reference-id`], [URI (URN / DOI / HTTPS), authored],
+  [`Reference-url`], [Navigation link],
+  [`Reference-document`], [Canonical citation],
+)
+
+== Universal
+
+`Labels` · `Status` · `References` · `External-id` · `Supersedes`
 
 == Generated (never in source)
 
-`Verified-by` · `Implemented-by`
+Spec: `Derives`, `Satisfied-by`, `Realized-by`, `Verified-by`\
+Element: `Contains`, `Used-by`, `Allocated`, `Tested-by`\
+Reference: `Cited-by`\
+Universal: `Superseded-by`
 
-== SAD-specific
-
-#table(
-  columns: (auto, 1fr),
-  stroke: 0.4pt + luma(180),
-  inset: 3pt,
-  [`Allocates`], [SRS display ID(s)],
-  [`Component`], [Name or registry ID],
-  [`Constrains`], [Component name(s)],
-)
-
-== ICD-specific
-
-#table(
-  columns: (auto, 1fr),
-  stroke: 0.4pt + luma(180),
-  inset: 3pt,
-  [`Between`], [Two parties, comma-separated],
-  [`Interface`], [RIDL ref `{{ridl.id}}`],
-)
-
-== Derived-from format
+== References format
 
 #code[```text
-Derived-from: ISO-26262-6 §9.4
+References: ISO-26262-6 §9.4
 ```]
 
-ID validated; section locator is free text.
-
-= ATDD example (Kotlin + Gherkin)
-
-#code[```kotlin
-/**
- * [SYS_BRK_0042] Sensor noise filtering
- *
- * Scenario: Reject transient noise
- *   Given a raw sensor input of 512
- *   And a noise spike of 50 lasting 2ms
- *   When the debounce window is 5ms
- *   Then the output shall remain 512
- *
- * Id: SYS_01HGW2P4KFR7\
- * Satisfies: STK_BRK_0001\
- * Labels: ASIL-B
- */
-@Test
-fun `sit_brk_0042 reject transient noise`() {
-    val sensor = SensorDriver(debounceMs = 5)
-    sensor.feed(512, spikeOf(50, durationMs = 2))
-    assertEquals(512, sensor.output())
-}
-```]
+Slug resolved through registry chain; locator is free text.
 
 ]
 

--- a/docs/examples/entry-rendering.md
+++ b/docs/examples/entry-rendering.md
@@ -11,7 +11,7 @@ label pills, and cross-reference links.
   falls below the configurable threshold and the driver has not applied the
   brake pedal.
 
-  Id: STK_01HGW3A2BCD5\
+  Spec-id: 01HGW3A2BCD5VWXYZABCDEFGHJ\
   Labels: ASIL-B, safety-critical
 
 - [SYS_AEB_0012] Object threat assessment from radar tracks
@@ -19,7 +19,7 @@ label pills, and cross-reference links.
   The system shall compute a threat level for each tracked object based on
   time-to-collision, relative velocity, and object classification.
 
-  Id: SYS_01HGW3C4DEF6\
+  Spec-id: 01HGW3C4DEF6VWXYZABCDEFGHJ\
   Satisfies: STK_AEB_0001\
   Labels: ASIL-B
 
@@ -28,7 +28,7 @@ label pills, and cross-reference links.
   The braking ECU shall apply a 5-sample median filter to the raw brake pressure
   sensor input before processing.
 
-  Id: SWE_01HGW2Q8MNP3\
+  Spec-id: 01HGW2Q8MNP3RSTVWXYZABCDEF\
   Satisfies: SYS_AEB_0012\
   Labels: ASIL-B, real-time, performance
 
@@ -44,7 +44,7 @@ alone.
   tracking) from decision (threat assessment, braking command) via a
   publish-subscribe message bus.
 
-  Id: SAD_01HGW4E5GHJ7\
+  Spec-id: 01HGW4E5GHJ7VWXYZABCDEFGHJ\
   Satisfies: STK_AEB_0001
 
 - [ICD_AEB_0010] Radar frame interface
@@ -52,7 +52,7 @@ alone.
   The radar driver shall publish `RadarFrame` messages at 20 Hz containing
   range, velocity, azimuth, and classification for each detected object.
 
-  Id: ICD_01HGW4F6HKL8\
+  Spec-id: 01HGW4F6HKM8VWXYZABCDEFGHJ\
   Satisfies: SAD_AEB_0001\
   Labels: interface
 
@@ -64,7 +64,7 @@ alone.
   positive closing velocity and returns infinity for zero or negative closing
   velocity.
 
-  Id: SWT_01HGW5G7JMN9\
+  Test-id: 01HGW5G7JMN9VWXYZABCDEFGHJ\
   Verifies: SWE_BRK_0107
 
 - [SIT_AEB_0012] Perception-to-decision integration
@@ -72,7 +72,7 @@ alone.
   Verify end-to-end that a radar frame with a stationary object at 40m produces
   a `High` threat level through the full perception–decision pipeline.
 
-  Id: SIT_01HGW5H8KPQ0\
+  Test-id: 01HGW5H8KPQ0VWXYZABCDEFGHJ\
   Verifies: SYS_AEB_0012\
   Labels: integration
 
@@ -85,7 +85,7 @@ Entry with no labels — pill group is not rendered:
   The braking ECU shall reject brake pressure readings outside the valid sensor
   range [0, 250] bar.
 
-  Id: SRS_01HGW6J9LRS1\
+  Spec-id: 01HGW6J9NRS1VWXYZABCDEFGHJ\
   Satisfies: SYS_AEB_0012
 
 Entry with many labels — pill group wraps to the next line:
@@ -95,7 +95,7 @@ Entry with many labels — pill group wraps to the next line:
   The braking ECU shall detect open-circuit, short-circuit, and out-of-range
   faults on all brake pressure sensors within one sample period.
 
-  Id: SRS_01HGW6K0MST2\
+  Spec-id: 01HGW6K0MST2VWXYZABCDEFGHJ\
   Satisfies: SYS_AEB_0012\
   Labels: ASIL-B, safety-critical, real-time, performance, diagnostics, fault-tolerance
 
@@ -106,7 +106,7 @@ Entry with multiple cross-references:
   The braking ECU shall use triple-modular redundancy voting across the three
   brake pressure sensors.
 
-  Id: SRS_01HGW6L1NUV3\
+  Spec-id: 01HGW6N1NVW3VWXYZABCDEFGHJ\
   Satisfies: SYS_AEB_0012\
   Derived-from: STK_AEB_0001\
   Labels: ASIL-B, redundancy

--- a/docs/spec/language/ast.md
+++ b/docs/spec/language/ast.md
@@ -146,7 +146,7 @@ list (unordered, depth 0)
     paragraph
       text "The sensor driver shall debounce..."
     paragraph
-      text "Id: SRS_01HGW2Q8MNP3\"
+      text "Spec-id: 01HGW2Q8MNP3RSTVWXYZABCDEF\"
       softBreak
       text "Satisfies: SYS_BRK_0042\"
       softBreak
@@ -156,7 +156,7 @@ list (unordered, depth 0)
 **Output:**
 
 ```
-msEntry (typed)
+msEntry (spec)
   displayId: "SRS_BRK_0001"
   title
     text "Sensor debouncing"
@@ -164,7 +164,7 @@ msEntry (typed)
     paragraph
       text "The sensor driver shall debounce..."
   attributes
-    { key: "Id", value: "SRS_01HGW2Q8MNP3" }
+    { key: "Spec-id", value: "01HGW2Q8MNP3RSTVWXYZABCDEF" }
     { key: "Satisfies", value: "SYS_BRK_0042" }
     { key: "Labels", value: "ASIL-B" }
 ```
@@ -196,7 +196,7 @@ with identifier `commonmark` exists → skip.
 
     Body text.
 
-    Id: SRS_01HGW2R9QLP4
+    Spec-id: 01HGW2R9QNP4ABCDEFGHJKMNPQ
 ```
 
 The inner `list` has depth > 1 (parent chain includes a `listItem`) → skip.

--- a/docs/spec/site-schema.md
+++ b/docs/spec/site-schema.md
@@ -91,8 +91,8 @@ Authors write entry IDs as usual. Resolution order:
 - [SRS_ABS_0001] Wheel speed sampling rate
 
   Satisfies: SYS_BRK_001\
-  Derived-from: ISO-26262-6 §7.4\
-  Id: SRS_01HGW2Q8MNP3
+  References: ISO-26262-6 §7.4\
+  Spec-id: 01HGW2Q8MNP3RSTVWXYZABCDEF
 ```
 
 `SYS_BRK_001` is not found in the current project, so it is searched in


### PR DESCRIPTION
## What

Dogfood the ADR-002 v2 work: user-facing docs now showcase the new identity attributes (`Spec-id` / `Test-id` / `Element-id`) with bare Crockford ULIDs and family-appropriate relations. Test fixtures stay on the legacy path by design.

## Why

Readers of the README, cheatsheet, and examples should see the current model, not the pre-v2 one. Runs the freshly-built pipeline on real authored content and catches anything the unit tests couldn't.

Refs #215 (first item off the debt ledger)

## How

- **`README.md`** — single "Entry blocks" example updated to `Spec-id: <bare>`
- **`AGENTS.md`** — two test-code snippets migrated to `Spec-id`
- **`docs/examples/entry-rendering.md`** — full showcase (10 entries): STK/SYS/SWE/SAD/ICD/SRS carry `Spec-id`, SWT/SIT carry `Test-id` with `Test-level`
- **`docs/cheatsheet/markspec-cheatsheet.typ`** — entry example updated; attributes section rewritten with per-family tables (spec/test/element/reference) and actual generated-attribute vocabulary; ULID section now specifies the 26-char bare Crockford form; in-code example shows a Test entry with `Test-id` / `Test-level` / `Verifies` / `Tests`
- **`docs/spec/language/ast.md`** — `msAttributeBlock` example switched from `Id:` to `Spec-id:`
- **`docs/spec/site-schema.md`** — §6 references example migrated. §6.3 process/profile examples (PTYPE / FReq / TC / ASIL / Safety-Goal) deliberately left alone: they describe a profile-format mechanism that pre-dates v2 and will be re-specified by a future profile-format ADR

## Validated

```
$ markspec compile docs/examples/entry-rendering.md
10 entries, 10 links from 1 files
```

Zero diagnostics. 384/384 tests still pass.

## Checklist

- [x] `just check` passes locally
- [x] Migrated docs compile cleanly through the CLI
- [x] Test fixtures intentionally preserved on legacy path
