### PR TITLE
feat(cli): add markspec migrate — legacy Id: → Spec-id: rewrite

### DIFF
--- a/packages/markspec/core/migrate/mod.ts
+++ b/packages/markspec/core/migrate/mod.ts
@@ -1,0 +1,94 @@
+/**
+ * @module migrate
+ *
+ * One-shot migration from legacy `Id: TYPE_<26-char>` attributes (ADR-001
+ * two-family model) to the ADR-002 v2 four-family identity attributes
+ * (`Spec-id`, bare Crockford ULID).
+ *
+ * Scope today:
+ * - Only `Id:` on spec entries is rewritten. Reference entries already use
+ *   `URI` / `URL` — no migration needed; the v2 `Reference-id` URI is
+ *   author-provided and can't be derived from the legacy fields.
+ * - Test and Element families have no legacy corpus (they're new), so no
+ *   migration path is needed for them.
+ *
+ * The migration strips the `TYPE_` prefix and emits `Spec-id: <bare-ULID>`.
+ * The Crockford alphabet is checked; values containing I/L/O/U are flagged
+ * (per ADR-002 §Annex B) but still written through, because the validator's
+ * MSL-R004 will surface the problem in the next `markspec validate` run.
+ */
+
+import type { Diagnostic } from "../model/mod.ts";
+
+/** Match a legacy `Id: TYPE_BODY` attribute line (with optional trailing `\`). */
+const LEGACY_ID_LINE_RE = /^(\s*)Id:\s+([A-Z]{2,6})_([0-9A-Z]{26})(\s*\\?)\s*$/;
+
+/** Bare Crockford base32, 26 chars — matches ADR-002 §Annex B. */
+const CROCKFORD_BODY_RE = /^[0-9A-HJKMNP-TV-Z]{26}$/;
+
+/** Options for {@linkcode migrateLegacyIds}. */
+export interface MigrateOptions {
+  /** File path used in diagnostic locations. */
+  readonly file?: string;
+}
+
+/** Result of a migration pass. */
+export interface MigrateResult {
+  /** The rewritten Markdown. */
+  readonly output: string;
+  /** Diagnostics (non-Crockford bodies, skipped entries). */
+  readonly diagnostics: readonly Diagnostic[];
+  /** Number of `Id:` → `Spec-id:` substitutions performed. */
+  readonly migrations: number;
+  /** Whether the output differs from the input. */
+  readonly changed: boolean;
+}
+
+/**
+ * Rewrite legacy `Id: TYPE_BODY` attributes to `Spec-id: BODY`.
+ *
+ * Operates line-by-line on the raw markdown so surrounding formatting
+ * (indentation, trailing backslash continuation, prose) is preserved
+ * exactly. Idempotent: running twice on the same input yields the same
+ * output (the second pass is a no-op because no `Id:` lines remain).
+ *
+ * @param markdown - Source text
+ * @param options - File path for diagnostics
+ */
+export function migrateLegacyIds(
+  markdown: string,
+  options?: MigrateOptions,
+): MigrateResult {
+  const file = options?.file ?? "<unknown>";
+  const lines = markdown.split("\n");
+  const diagnostics: Diagnostic[] = [];
+  let migrations = 0;
+
+  for (let i = 0; i < lines.length; i++) {
+    const match = LEGACY_ID_LINE_RE.exec(lines[i]);
+    if (!match) continue;
+
+    const [, indent, _typePrefix, body, trailing] = match;
+
+    if (!CROCKFORD_BODY_RE.test(body)) {
+      diagnostics.push({
+        code: "MSL-M001",
+        severity: "warning",
+        message:
+          `Id value '${body}' contains Crockford-invalid characters (I/L/O/U); migrated value will fail MSL-R004`,
+        location: { file, line: i + 1, column: 1 },
+      });
+    }
+
+    lines[i] = `${indent}Spec-id: ${body}${trailing ?? ""}`;
+    migrations++;
+  }
+
+  const output = lines.join("\n");
+  return {
+    output,
+    diagnostics,
+    migrations,
+    changed: migrations > 0,
+  };
+}

--- a/packages/markspec/core/migrate/mod_test.ts
+++ b/packages/markspec/core/migrate/mod_test.ts
@@ -1,0 +1,158 @@
+/**
+ * @module migrate/mod_test
+ */
+
+import { assert, assertEquals, assertStringIncludes } from "@std/assert";
+import { migrateLegacyIds } from "./mod.ts";
+
+Deno.test("migrate: Id line becomes Spec-id with TYPE prefix stripped", () => {
+  const md = `# Test
+
+- [SRS_BRK_0001] Title
+
+  Body.
+
+  Id: SRS_00000000000000000000000001\\
+  Labels: ASIL-B
+`;
+  const result = migrateLegacyIds(md);
+  assertEquals(result.migrations, 1);
+  assertEquals(result.changed, true);
+  assertStringIncludes(
+    result.output,
+    "Spec-id: 00000000000000000000000001\\",
+  );
+  assert(!result.output.includes("Id: SRS_"));
+});
+
+Deno.test("migrate: preserves indentation", () => {
+  const md = `# Test
+
+- [SRS_BRK_0001] Title
+
+  Body.
+
+    Id: SRS_00000000000000000000000001
+`;
+  const result = migrateLegacyIds(md);
+  assertStringIncludes(
+    result.output,
+    "    Spec-id: 00000000000000000000000001",
+  );
+});
+
+Deno.test("migrate: preserves trailing backslash continuation", () => {
+  const md = "  Id: SRS_00000000000000000000000001\\\n  Labels: ASIL-B\n";
+  const result = migrateLegacyIds(md);
+  assertStringIncludes(
+    result.output,
+    "  Spec-id: 00000000000000000000000001\\",
+  );
+});
+
+Deno.test("migrate: leaves other attributes untouched", () => {
+  const md = `# Test
+
+- [SRS_BRK_0001] Title
+
+  Body.
+
+  Id: SRS_00000000000000000000000001\\
+  Satisfies: SYS_BRK_0042\\
+  Labels: ASIL-B
+`;
+  const result = migrateLegacyIds(md);
+  assertStringIncludes(result.output, "Satisfies: SYS_BRK_0042\\");
+  assertStringIncludes(result.output, "Labels: ASIL-B");
+});
+
+Deno.test("migrate: idempotent on already-migrated input", () => {
+  const md = `# Test
+
+- [SRS_BRK_0001] Title
+
+  Body.
+
+  Spec-id: 00000000000000000000000001\\
+  Labels: ASIL-B
+`;
+  const result = migrateLegacyIds(md);
+  assertEquals(result.migrations, 0);
+  assertEquals(result.changed, false);
+  assertEquals(result.output, md);
+});
+
+Deno.test("migrate: ignores non-Id attribute lines that start with Id", () => {
+  const md = `# Test
+
+- [SRS_BRK_0001] Title
+
+  Body.
+
+  Identity: something
+  Id-not-really: foo
+  Id: SRS_00000000000000000000000001
+`;
+  const result = migrateLegacyIds(md);
+  assertEquals(result.migrations, 1);
+  assertStringIncludes(result.output, "Identity: something");
+  assertStringIncludes(result.output, "Id-not-really: foo");
+});
+
+Deno.test("migrate: Crockford-invalid body (contains L) emits MSL-M001 warning", () => {
+  // "LLLLLLLLLLLLLLLLLLLLLLLLLL" is 26 chars but violates Crockford alphabet.
+  const md = `  Id: SRS_LLLLLLLLLLLLLLLLLLLLLLLLLL\n`;
+  const result = migrateLegacyIds(md);
+  const warn = result.diagnostics.find((d) => d.code === "MSL-M001");
+  assert(warn !== undefined);
+  assertEquals(warn!.severity, "warning");
+  assertStringIncludes(warn!.message, "Crockford");
+  // Still migrates — the validator catches the alphabet problem.
+  assertStringIncludes(
+    result.output,
+    "Spec-id: LLLLLLLLLLLLLLLLLLLLLLLLLL",
+  );
+});
+
+Deno.test("migrate: multiple entries in one file all rewrite", () => {
+  const md = `# Test
+
+- [SRS_BRK_0001] First
+
+  Body one.
+
+  Id: SRS_00000000000000000000000001
+
+- [SRS_BRK_0002] Second
+
+  Body two.
+
+  Id: SRS_00000000000000000000000002
+`;
+  const result = migrateLegacyIds(md);
+  assertEquals(result.migrations, 2);
+  const specIdCount =
+    result.output.split("\n").filter((l) => l.trim().startsWith("Spec-id:"))
+      .length;
+  assertEquals(specIdCount, 2);
+});
+
+Deno.test("migrate: no changes on a file without any Id: attribute", () => {
+  const md = `# Just prose
+
+No entries here.
+`;
+  const result = migrateLegacyIds(md);
+  assertEquals(result.migrations, 0);
+  assertEquals(result.changed, false);
+  assertEquals(result.output, md);
+});
+
+Deno.test("migrate: legacy Id value with too-short body is NOT migrated", () => {
+  // The regex requires exactly 26 chars — shorter bodies aren't legacy ULIDs
+  // (they're illustrative shorthand used in README-style examples).
+  const md = `  Id: SRS_01HGW2Q8MNP3\n`;
+  const result = migrateLegacyIds(md);
+  assertEquals(result.migrations, 0);
+  assertEquals(result.output, md);
+});

--- a/packages/markspec/core/mod.ts
+++ b/packages/markspec/core/mod.ts
@@ -69,6 +69,10 @@ export type {
 export { format } from "./formatter/mod.ts";
 export type { FormatOptions, FormatResult } from "./formatter/mod.ts";
 
+// Migration (legacy Id: → Spec-id: per ADR-002 v2)
+export { migrateLegacyIds } from "./migrate/mod.ts";
+export type { MigrateOptions, MigrateResult } from "./migrate/mod.ts";
+
 // Validator
 export { validate } from "./validator/mod.ts";
 export type { ValidateResult } from "./validator/mod.ts";

--- a/packages/markspec/main.ts
+++ b/packages/markspec/main.ts
@@ -335,6 +335,66 @@ const cli = new Command()
       Deno.exit(1);
     }
   })
+  .command("migrate [...files:string]")
+  .description(
+    "Rewrite legacy `Id: TYPE_<ULID>` to ADR-002 v2 `Spec-id: <bare-ULID>`",
+  )
+  .option(
+    "--check",
+    "Check mode: report but don't write (exit 1 if changes needed)",
+  )
+  .action(async (options: { check?: boolean }, ...files: string[]) => {
+    if (files.length === 0) {
+      console.error("error: no files specified");
+      console.error("usage: markspec migrate <file...>");
+      Deno.exit(1);
+    }
+
+    const { migrateLegacyIds } = await import("./core/mod.ts");
+
+    let totalMigrated = 0;
+    let totalUnchanged = 0;
+    let totalRewrites = 0;
+    let hasErrors = false;
+
+    for (const filePath of files) {
+      let content: string;
+      try {
+        content = await Deno.readTextFile(filePath);
+      } catch {
+        console.error(`error: ${filePath}: file not found`);
+        hasErrors = true;
+        continue;
+      }
+
+      const result = migrateLegacyIds(content, { file: filePath });
+
+      for (const d of result.diagnostics) {
+        const loc = d.location ? `${d.location.file}:${d.location.line}` : "";
+        console.error(`${d.severity}[${d.code}]: ${loc} ${d.message}`);
+      }
+
+      if (result.changed) {
+        totalMigrated++;
+        totalRewrites += result.migrations;
+        if (!options.check) {
+          await Deno.writeTextFile(filePath, result.output);
+        }
+      } else {
+        totalUnchanged++;
+      }
+    }
+
+    const total = totalMigrated + totalUnchanged;
+    console.error(
+      `${totalMigrated} file(s) migrated (${totalRewrites} attribute${
+        totalRewrites === 1 ? "" : "s"
+      }), ${totalUnchanged} unchanged (${total} total)`,
+    );
+
+    if (hasErrors) Deno.exit(1);
+    if (options.check && totalMigrated > 0) Deno.exit(1);
+  })
   .command("validate [...files:string]")
   .description("Check broken refs, missing Ids, duplicates")
   .option("--strict", "Promote warnings to errors")

--- a/tests/e2e/migrate_test.ts
+++ b/tests/e2e/migrate_test.ts
@@ -1,0 +1,60 @@
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { markspec } from "./helpers.ts";
+
+Deno.test("migrate: rewrites legacy Id: to Spec-id: in place", async () => {
+  const input = `# Test
+
+- [SRS_BRK_0001] Title
+
+  Body.
+
+  Id: SRS_00000000000000000000000001\\
+  Satisfies: SYS_BRK_0042\\
+  Labels: ASIL-B
+`;
+  const { code, stderr } = await markspec(
+    ["migrate", "req.md"],
+    { "req.md": input },
+  );
+  assertEquals(code, 0);
+  assertStringIncludes(stderr, "1 file(s) migrated");
+});
+
+Deno.test("migrate --check: fails when changes would be made", async () => {
+  const input = `# Test
+
+- [SRS_BRK_0001] Title
+
+  Body.
+
+  Id: SRS_00000000000000000000000001
+`;
+  const { code } = await markspec(
+    ["migrate", "--check", "req.md"],
+    { "req.md": input },
+  );
+  assertEquals(code, 1);
+});
+
+Deno.test("migrate --check: succeeds when nothing to change", async () => {
+  const input = `# Test
+
+- [SRS_BRK_0001] Title
+
+  Body.
+
+  Spec-id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+`;
+  const { code, stderr } = await markspec(
+    ["migrate", "--check", "req.md"],
+    { "req.md": input },
+  );
+  assertEquals(code, 0);
+  assertStringIncludes(stderr, "0 file(s) migrated");
+});
+
+Deno.test("migrate: no files → error", async () => {
+  const { code, stderr } = await markspec(["migrate"], {});
+  assertEquals(code, 1);
+  assertStringIncludes(stderr, "no files specified");
+});


### PR DESCRIPTION
## What

New `markspec migrate` subcommand — a standalone one-shot rewrite from the ADR-001 two-family format (`Id: TYPE_<ULID>`) to the ADR-002 v2 format (`Spec-id: <bare-Crockford-ULID>`). Picks off the top item in #215.

## Why

Decision #3 on #198 deliberately kept the formatter idempotent (no silent rewrite of legacy identity attributes). Migration is an opt-in step the user runs when they're ready to cut over. Without this command, retiring the legacy path is blocked on manual edits.

Refs #215

## How

**New module `core/migrate/mod.ts`**:
- `migrateLegacyIds(markdown, options)` operates line-by-line on the raw text so indentation, trailing backslash continuation, and surrounding prose round-trip byte-for-byte
- `LEGACY_ID_LINE_RE` matches `Id: TYPE_<26-char-body>` at any indent
- Strips the `TYPE_` prefix; emits `Spec-id:` with the 26-char body
- Crockford-alphabet check on the body: values containing `I/L/O/U` get an MSL-M001 warning but are still rewritten — the validator's MSL-R004 surfaces the problem on the next `markspec validate`
- Idempotent: running twice is a no-op

**New CLI subcommand**:
```
$ markspec migrate <file...>
$ markspec migrate --check <file...>   # report only, exit 1 if changes needed
```

**Scope**:
- Reference entries need no migration — they always used `URI`/`URL`/`Document`; `Reference-id` is author-provided
- Test and Element families are new in v2 — no legacy corpus
- Only `Id:` → `Spec-id:` is handled today

## Tests

10 unit tests (indent preservation, trailing-backslash preservation, multi-entry, Crockford warning, too-short body not migrated, idempotency, non-`Id` attributes starting with "Id") + 4 e2e tests (happy path, `--check` dirty, `--check` clean, missing args).

**Real-world smoke**:
```
$ markspec migrate req.md
1 file(s) migrated (1 attribute), 0 unchanged (1 total)
```

398/398 total tests pass.

## Checklist

- [x] Tests added (+14: 10 unit, 4 e2e)
- [x] `just check` passes locally
- [x] `core/mod.ts` exports the new function + types
- [x] No documentation PR needed — subcommand is self-documenting via `markspec migrate --help`
