### PR TITLE
docs: ADR-008 profile system + retirement model rewrite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,180 @@
 # Changelog
 
+## [0.2.1] (2026-04-18)
+
+### Bug Fixes
+
+- **ci:** update .githooks for git-std 0.11.1 API ([02cfeea])
+- **ci:** fix deno fmt line length in gen_theme.ts ([dfe26a7])
+- **ci:** update deno fmt excludes and regenerate theme headers after theme/
+  move ([d4b90ae])
+- **ci:** pin git-std to v0.10.2 to fix broken conventional commits check
+  ([72fab14])
+- **ci:** exclude docs/examples/ from dprint markdown formatter ([81205af])
+- **render:** fix single-element Typst array, deferred cross-ref links, label
+  line wrap ([98e25bd])
+- **ci:** add --allow-env --allow-ffi to test step for typst napi addon
+  ([b1b1858])
+
+### Features
+
+- **cli:** add markspec migrate — legacy Id: → Spec-id: rewrite ([c4fbc09]),
+  refs [#215]
+- **core:** phase 6a — end-to-end four-family fixture + citation slug fix
+  ([910282d]), refs [#198]
+- **core:** phase 5b — integrate front matter into parseFile and compile
+  ([7d2ddff]), refs [#198]
+- **core:** phase 5a — compiler extracts new traceability link kinds
+  ([60a5c04]), refs [#198]
+- **core:** phase 4c — front-matter canonical form ([fc232f8]), refs [#198]
+- **core:** phase 4b — multi-line trailer canonicalization ([393fffc]), refs
+  [#198]
+- **core:** phase 4a — formatter identity assignment and canonical orders
+  ([becafec]), refs [#198]
+- **core:** phase 3c — family-aware traceability checks (MSL-T001..T013)
+  ([2137fd8]), refs [#198]
+- **core:** phase 3b — validate enum attribute values (MSL-R014) ([331e2f1]),
+  refs [#198]
+- **core:** phase 3a — validator rules for new identity attributes ([89d83c9]),
+  refs [#198]
+- **core:** phase 2b-iii — collate repeatable attributes into typed map
+  ([cdfacdb]), refs [#198]
+- **core:** phase 2b-ii — identity-attribute family discrimination in parser
+  ([63ec936]), refs [#198]
+- **core:** phase 2a — front-matter parser and additive parser changes
+  ([74fd645]), refs [#198]
+- **core:** add four-family entry model types and attribute catalog ([eb33cd8]),
+  refs [#198]
+- **core:** implement ADR-002 entry model with family discrimination ([23a38b4])
+- **book:** implement markspec book build CLI command ([#182]) ([ad7b7f2]),
+  closes [#182]
+- **book:** implement book/ library module with SUMMARY.md parser and HTML
+  renderer ([b29301d]), closes [#47]
+- **render:** admonition-style entry block rendering ([ca82915]), closes [#175],
+  [#177], [#178], #179. Relates to #176.
+- **render:** add requirement block styling ([#46]) ([6c0be2c])
+- **repo:** commit WASM grammars via Git LFS ([4f361a7])
+- **repo:** fetch grammars during bootstrap ([61aa15f])
+- **render:** add mustache preprocessing ([#172]) ([2901636])
+- **render:** add caption numbering ([#45]) ([#170]) ([4971997])
+- **render:** add include directive processing ([#44]) ([#169]) ([98956f3])
+- **core:** add grammar lockfile and auto-update workflow ([adb7c51])
+- **render:** add render module with Typst PDF compilation ([#42]) ([3f3afb7])
+- **core:** enable Kotlin grammar fetching via GitHub Release ([30e7767])
+- **core:** display ID assignment and source file formatting ([476149a]), closes
+  [#19], [#18], [#10]
+- **core:** extract Verifies/Implements annotations from source doc comments
+  ([#11]) ([7e2efa3])
+
+### Refactoring
+
+- **core:** phase 5c — remove dead standalone-annotation link plumbing
+  ([7aa0bd1]), refs [#198]
+- **core:** phase 2b-i — drop standalone Verifies/Implements annotation path
+  ([0439e6b]), refs [#198]
+- **docs:** consolidate ADRs and reorganize documentation structure ([9845e70])
+- **docs:** restructure spec books, consolidate theme/, move cheatsheet
+  ([9eab514])
+
+### Documentation
+
+- **docs:** migrate user-facing entry examples to four-family model ([e69036e]),
+  refs [#215]
+- **spec:** phase 6b — align §8.3 MSL-T table with implementation, fix ULID
+  examples ([18a9fa3]), refs [#198]
+- **spec:** fix stale front-matter normalization rule (ADR-007) ([5244136])
+- **docs:** make MSL-D008 (non-relative image paths) an error ([5c14e70])
+- **docs:** restructure diagrams by use case, add PNG support ([342c31f])
+- **docs:** tighten diagram conventions (relative paths, preferred formats)
+  ([2c74384])
+- **spec:** align language spec with ADR-007 (front matter) ([ff3ce51])
+- **docs:** add ADR-007 for document structure and front matter ([b1c7013])
+- **spec:** replace warning admonition with a table in entry-block example
+  ([d576f0e])
+- **docs:** add universal attributes, value types, Status, properties
+  ([40d312e])
+- **docs:** rewrite ADR-002 and language spec for four-family model ([2770a47])
+- **docs:** add Test and Element entry families to ADR-002 ([154151c])
+- **docs:** mark old ADR-002 requirement authoring as superseded ([b8cf971])
+- **spec:** update language.md for ADR-002 entry model ([227bf6d])
+- **docs:** document entry rendering, color tokens, and reorder typography spec
+  ([43e05c8])
+
+[0.2.1]: https://github.com/driftsys/markspec/compare/v0.2.0...v0.2.1
+[02cfeea]: https://github.com/driftsys/markspec/commit/02cfeea
+[dfe26a7]: https://github.com/driftsys/markspec/commit/dfe26a7
+[d4b90ae]: https://github.com/driftsys/markspec/commit/d4b90ae
+[72fab14]: https://github.com/driftsys/markspec/commit/72fab14
+[81205af]: https://github.com/driftsys/markspec/commit/81205af
+[98e25bd]: https://github.com/driftsys/markspec/commit/98e25bd
+[b1b1858]: https://github.com/driftsys/markspec/commit/b1b1858
+[c4fbc09]: https://github.com/driftsys/markspec/commit/c4fbc09
+[#215]: https://github.com/driftsys/markspec/issues/215
+[910282d]: https://github.com/driftsys/markspec/commit/910282d
+[#198]: https://github.com/driftsys/markspec/issues/198
+[7d2ddff]: https://github.com/driftsys/markspec/commit/7d2ddff
+[60a5c04]: https://github.com/driftsys/markspec/commit/60a5c04
+[fc232f8]: https://github.com/driftsys/markspec/commit/fc232f8
+[393fffc]: https://github.com/driftsys/markspec/commit/393fffc
+[becafec]: https://github.com/driftsys/markspec/commit/becafec
+[2137fd8]: https://github.com/driftsys/markspec/commit/2137fd8
+[331e2f1]: https://github.com/driftsys/markspec/commit/331e2f1
+[89d83c9]: https://github.com/driftsys/markspec/commit/89d83c9
+[cdfacdb]: https://github.com/driftsys/markspec/commit/cdfacdb
+[63ec936]: https://github.com/driftsys/markspec/commit/63ec936
+[74fd645]: https://github.com/driftsys/markspec/commit/74fd645
+[eb33cd8]: https://github.com/driftsys/markspec/commit/eb33cd8
+[23a38b4]: https://github.com/driftsys/markspec/commit/23a38b4
+[ad7b7f2]: https://github.com/driftsys/markspec/commit/ad7b7f2
+[#182]: https://github.com/driftsys/markspec/issues/182
+[b29301d]: https://github.com/driftsys/markspec/commit/b29301d
+[#47]: https://github.com/driftsys/markspec/issues/47
+[ca82915]: https://github.com/driftsys/markspec/commit/ca82915
+[#175]: https://github.com/driftsys/markspec/issues/175
+[#177]: https://github.com/driftsys/markspec/issues/177
+[#178]: https://github.com/driftsys/markspec/issues/178
+[6c0be2c]: https://github.com/driftsys/markspec/commit/6c0be2c
+[#46]: https://github.com/driftsys/markspec/issues/46
+[4f361a7]: https://github.com/driftsys/markspec/commit/4f361a7
+[61aa15f]: https://github.com/driftsys/markspec/commit/61aa15f
+[2901636]: https://github.com/driftsys/markspec/commit/2901636
+[#172]: https://github.com/driftsys/markspec/issues/172
+[4971997]: https://github.com/driftsys/markspec/commit/4971997
+[#45]: https://github.com/driftsys/markspec/issues/45
+[#170]: https://github.com/driftsys/markspec/issues/170
+[98956f3]: https://github.com/driftsys/markspec/commit/98956f3
+[#44]: https://github.com/driftsys/markspec/issues/44
+[#169]: https://github.com/driftsys/markspec/issues/169
+[adb7c51]: https://github.com/driftsys/markspec/commit/adb7c51
+[3f3afb7]: https://github.com/driftsys/markspec/commit/3f3afb7
+[#42]: https://github.com/driftsys/markspec/issues/42
+[30e7767]: https://github.com/driftsys/markspec/commit/30e7767
+[476149a]: https://github.com/driftsys/markspec/commit/476149a
+[#19]: https://github.com/driftsys/markspec/issues/19
+[#18]: https://github.com/driftsys/markspec/issues/18
+[#10]: https://github.com/driftsys/markspec/issues/10
+[7e2efa3]: https://github.com/driftsys/markspec/commit/7e2efa3
+[#11]: https://github.com/driftsys/markspec/issues/11
+[7aa0bd1]: https://github.com/driftsys/markspec/commit/7aa0bd1
+[0439e6b]: https://github.com/driftsys/markspec/commit/0439e6b
+[9845e70]: https://github.com/driftsys/markspec/commit/9845e70
+[9eab514]: https://github.com/driftsys/markspec/commit/9eab514
+[e69036e]: https://github.com/driftsys/markspec/commit/e69036e
+[18a9fa3]: https://github.com/driftsys/markspec/commit/18a9fa3
+[5244136]: https://github.com/driftsys/markspec/commit/5244136
+[5c14e70]: https://github.com/driftsys/markspec/commit/5c14e70
+[342c31f]: https://github.com/driftsys/markspec/commit/342c31f
+[2c74384]: https://github.com/driftsys/markspec/commit/2c74384
+[ff3ce51]: https://github.com/driftsys/markspec/commit/ff3ce51
+[b1c7013]: https://github.com/driftsys/markspec/commit/b1c7013
+[d576f0e]: https://github.com/driftsys/markspec/commit/d576f0e
+[40d312e]: https://github.com/driftsys/markspec/commit/40d312e
+[2770a47]: https://github.com/driftsys/markspec/commit/2770a47
+[154151c]: https://github.com/driftsys/markspec/commit/154151c
+[b8cf971]: https://github.com/driftsys/markspec/commit/b8cf971
+[227bf6d]: https://github.com/driftsys/markspec/commit/227bf6d
+[43e05c8]: https://github.com/driftsys/markspec/commit/43e05c8
+
 ## [0.2.0] (2026-03-29)
 
 ### Features

--- a/docs/architecture/adr-002-entry-model.md
+++ b/docs/architecture/adr-002-entry-model.md
@@ -134,41 +134,83 @@ Every attribute has an **origin** describing how its value arrives in the model:
 The following attributes apply to every family, with identical semantics and
 value types:
 
-| Attribute         | Type          | Origin    | Description                                                |
-| ----------------- | ------------- | --------- | ---------------------------------------------------------- |
-| **Labels**        | `tag-list`    | authored  | Free-form classification tags                              |
-| **Status**        | `enum`        | authored  | Lifecycle state (see below). Optional, default `approved`. |
-| **References**    | `citation`    | authored  | Citations of external reference entries, with locator      |
-| **External-id**   | `external-id` | authored  | Identifier(s) in an external system                        |
-| **Supersedes**    | `id`          | authored  | Display ID of a same-family entry this one replaces        |
-| **Superseded-by** | `id`          | generated | Inverse of `Supersedes`                                    |
+| Attribute         | Type          | Origin    | Description                                           |
+| ----------------- | ------------- | --------- | ----------------------------------------------------- |
+| **Labels**        | `tag-list`    | authored  | Free-form classification tags                         |
+| **References**    | `citation`    | authored  | Citations of external reference entries, with locator |
+| **External-id**   | `external-id` | authored  | Identifier(s) in an external system                   |
+| **Supersedes**    | `id`          | authored  | Display ID of a same-family entry this one replaces   |
+| **Superseded-by** | `id`          | generated | Inverse of `Supersedes`                               |
+| **Deprecated**    | `string`      | authored  | Retirement reason when no successor exists            |
 
 Identity attributes (`Spec-id`, `Test-id`, `Element-id`, `Reference-id`) are
 structurally universal — every entry carries exactly one — but their name and
 value format depend on the family (see Parts 2–5).
 
-#### Status vocabulary
+#### Retirement semantics
 
-The core `Status` vocabulary is intentionally small:
+Entries can be **retired** — taken out of active use — in one of two
+structurally distinct ways:
 
-| Value        | Meaning                                                          |
-| ------------ | ---------------------------------------------------------------- |
-| `draft`      | Work in progress, not yet accepted                               |
-| `approved`   | Reviewed and accepted (default when `Status` is absent)          |
-| `deprecated` | Still valid, being phased out — new work should not depend on it |
-| `withdrawn`  | No longer valid — references to it should be removed             |
+**Replacement-based retirement** — a successor entry carries
+`Supersedes: <predecessor-id>`. The predecessor automatically gains the
+generated inverse `Superseded-by: <successor-id>`. The presence of
+`Superseded-by:` on an entry is the structural signal that it has been replaced.
 
-Profiles may extend the vocabulary with domain-specific states (`baselined`,
-`verified`, `under-review`, …). Tooling warns when a `Satisfies:` /
-`Derived-from:` / `Verifies:` / `Realizes:` target is `deprecated` or
-`withdrawn`.
+**Non-replacement retirement** — the entry carries
+`Deprecated: "<free-text reason>"`, e.g., "Feature cut from scope in v3.0" or
+"Based on a misunderstanding of FR-BRK-0012; see ADR-042 for context". This
+covers cases where no single successor exists (obsolete, factually wrong, scope
+cut, standard retracted).
+
+An entry is considered **retired** when either signal is present:
+
+- `Superseded-by:` is set (generated), OR
+- `Deprecated:` is authored.
+
+The two are complementary, not mutually exclusive — a replacement may still
+carry a `Deprecated:` reason for additional context. Tooling treats any retired
+entry as a warning target for incoming links.
+
+#### Draft state
+
+The `DRAFT` label is a plain universal tag that marks an entry as "not yet
+authoritative". It does not belong to an exclusive group — it is a free-form
+label that happens to carry a well-known semantic when set:
+
+```text
+Labels: DRAFT
+```
+
+Entries without the `DRAFT` label and without any retirement signal are treated
+as **active and authoritative** (the implicit default). `DRAFT` exists to let
+authors merge work-in-progress entries that should not yet be treated as
+canonical — for example, entries behind a feature flag, or entries in a branch
+pending review that has been merged for visibility but not for adoption.
+
+#### Link-resolution severity
+
+Tooling emits severity-tiered diagnostics when a link attribute (`Satisfies:`,
+`Derived-from:`, `Verifies:`, `Realizes:`, …) targets a non-active entry:
+
+| Target state                                        | Severity |
+| --------------------------------------------------- | -------- |
+| Active (no marker)                                  | OK       |
+| `Labels: DRAFT`                                     | info     |
+| Retired (`Superseded-by:` set OR `Deprecated:` set) | warning  |
+| Unresolved (entry does not exist)                   | error    |
+
+This replaces the legacy MSL-T013 check that targeted
+`Status: deprecated|withdrawn`. There is no separate `DEPRECATED` or `WITHDRAWN`
+label — retirement is expressed structurally through `Supersedes` or
+`Deprecated`.
 
 #### Supersedes semantics
 
-`Supersedes` expresses same-family replacement — a deprecated SRS pointing to
-its successor, a withdrawn reference pointing to the new standard. A test does
-not supersede a spec; the relation is intra-family only. The generated inverse
-`Superseded-by` is computed at build time from the authored `Supersedes` links.
+`Supersedes` expresses same-family replacement. The successor carries
+`Supersedes: <predecessor-id>`; the predecessor gains the generated inverse
+`Superseded-by: <successor-id>`. A test does not supersede a spec; the relation
+is intra-family only. A successor may in turn be superseded, forming a chain.
 
 ### Entry properties (observed)
 
@@ -193,8 +235,8 @@ not define attribute names like `Modified-at` at the entry level.
 If a piece of information is something the author _states_, it belongs in an
 attribute; if it is something the system _witnesses_, it belongs in a property.
 This prevents author-inference conflicts (the author cannot override a git
-commit timestamp, and the system cannot overwrite an authored
-`Status: deprecated`).
+commit timestamp, and the system cannot overwrite an authored `Deprecated:`
+reason).
 
 The full property model — observation contracts, sync connector design, caching
 strategy, build-time provenance — is deferred to
@@ -340,7 +382,9 @@ across the registry chain.
 | **Allocated-to** | `id-list` | authored | Downstream link to element(s) responsible for realizing this spec |
 
 Spec entries also carry the universal attributes from Part 1 (`Labels`,
-`Status`, `References`, `External-id`, `Supersedes`).
+`References`, `External-id`, `Supersedes`, `Deprecated`). Draft state is carried
+by the `DRAFT` label; retirement is expressed through `Supersedes` (replacement)
+or `Deprecated` (non-replacement). See §Retirement semantics.
 
 **Derived-from** expresses the relation by which a spec is produced from a
 parent spec, by decomposition, refinement, or partial realization. It is the
@@ -550,11 +594,13 @@ Unlike specs, tests, and elements, a reference entry's body is optional.
 | **Reference-document** | `text` | authored | Canonical document identifier; falls back to title when absent |
 
 Reference entries also carry the universal attributes from Part 1 (`Labels`,
-`Status`, `External-id`, `Supersedes`). `Supersedes` replaces the previous
-Reference-only `Superseded-by` attribute; the generated inverse is still
-`Superseded-by`. `References` is not applicable to Reference entries (a
-reference entry does not itself cite other references via the `References`
-attribute).
+`External-id`, `Supersedes`, `Deprecated`). Draft state is carried by the
+`DRAFT` label; retirement is expressed through `Supersedes` (replacement by a
+new standard) or `Deprecated` (standard retracted with no successor).
+`Supersedes` replaces the previous Reference-only `Superseded-by` attribute; the
+generated inverse is still `Superseded-by`. `References` is not applicable to
+Reference entries (a reference entry does not itself cite other references via
+the `References` attribute).
 
 ### Section locators in citations
 
@@ -647,7 +693,9 @@ registry chain.
 | **Tests**      | `id-list` | authored | Upstream link to element(s) this test exercises |
 
 Test entries also carry the universal attributes from Part 1 (`Labels`,
-`Status`, `References`, `External-id`, `Supersedes`).
+`References`, `External-id`, `Supersedes`, `Deprecated`). Draft state is carried
+by the `DRAFT` label; retirement is expressed through `Supersedes` (replacement)
+or `Deprecated` (non-replacement). See §Retirement semantics.
 
 Filesystem location (source path of an automated test) is a **property**, not an
 attribute — see Part 1 "Entry properties" and ADR-006.
@@ -924,7 +972,9 @@ system (Codebeamer, DOORS, PLM).
 | **Generated-from** | `path-or-id` | authored | Path or element this element was generated from (repeatable) |
 
 Element entries also carry the universal attributes from Part 1 (`Labels`,
-`Status`, `References`, `External-id`, `Supersedes`).
+`References`, `External-id`, `Supersedes`, `Deprecated`). Draft state is carried
+by the `DRAFT` label; retirement is expressed through `Supersedes` (replacement)
+or `Deprecated` (non-replacement). See §Retirement semantics.
 
 Filesystem location of a code unit is a **property**, not an attribute — see
 Part 1 "Entry properties" and ADR-006.
@@ -1337,14 +1387,14 @@ build time from inverse relations, never committed).
 
 ### Universal attributes (all families)
 
-| Attribute       | Type          | Origin    | Required | Description                               |
-| --------------- | ------------- | --------- | -------- | ----------------------------------------- |
-| `Labels`        | `tag-list`    | authored  | no       | Classification tags                       |
-| `Status`        | `enum`        | authored  | no       | Lifecycle state (default `approved`)      |
-| `References`    | `citation`    | authored  | no       | External reference citations with locator |
-| `External-id`   | `external-id` | authored  | no       | Cross-system identifier(s)                |
-| `Supersedes`    | `id`          | authored  | no       | Same-family entry this one replaces       |
-| `Superseded-by` | `id`          | generated | —        | Inverse of `Supersedes`                   |
+| Attribute       | Type          | Origin    | Required | Description                                   |
+| --------------- | ------------- | --------- | -------- | --------------------------------------------- |
+| `Labels`        | `tag-list`    | authored  | no       | Classification tags (includes `DRAFT` marker) |
+| `References`    | `citation`    | authored  | no       | External reference citations with locator     |
+| `External-id`   | `external-id` | authored  | no       | Cross-system identifier(s)                    |
+| `Supersedes`    | `id`          | authored  | no       | Same-family entry this one replaces           |
+| `Superseded-by` | `id`          | generated | —        | Inverse of `Supersedes`                       |
+| `Deprecated`    | `string`      | authored  | no       | Retirement reason (non-replacement case)      |
 
 ### Spec family
 
@@ -1400,10 +1450,12 @@ expressed via the universal `Supersedes` attribute).
 
 ## Open questions (deferred to later ADRs)
 
-- **Profile document format**: how profiles are authored and distributed.
+- **Profile document format**: how profiles are authored and distributed —
+  specified in [ADR-008 — Profile System](./adr-008-profile-system.md).
 - **Profile-level traceability rules**: validation of `Derived-from`,
   `Allocated-to`, `Verifies`, `Tests` (cardinality, type combinations, ASIL
-  compatibility).
+  compatibility) — mechanism defined in [ADR-008](./adr-008-profile-system.md);
+  automated cross-chain validation remains future work.
 - **Property model**: git observation contracts, sync connectors, property
   namespace, caching, build-time provenance — deferred to
   [ADR-006 — Property Model](./adr-006-property-model.md).

--- a/docs/architecture/adr-006-property-model.md
+++ b/docs/architecture/adr-006-property-model.md
@@ -88,8 +88,9 @@ How external systems (Jira, DOORS, Jama, Codebeamer, PLM) integrate:
 
 - ✅ [ADR-002](./adr-002-entry-model.md) — Entry Model (attributes vs properties
   distinction)
-- 🔗 Related: profile document format ADR (profile-declared properties), in-code
-  entries ADR (file properties for code-authored entries)
+- 🔗 Related: [ADR-008 — Profile System](./adr-008-profile-system.md)
+  (profile-declared attributes populating the property layer), in-code entries
+  ADR (file properties for code-authored entries)
 
 ## Acceptance criteria
 

--- a/docs/architecture/adr-007-document-structure.md
+++ b/docs/architecture/adr-007-document-structure.md
@@ -44,7 +44,6 @@ ecosystem reality.
 ---
 document-id: 01HGW2D0DOCPQ4FGHIJKLMNOPQR
 document-type: requirements
-status: approved
 labels: [requirements, ASIL-B]
 external-id: doors:VHC:SRS-BRK
 ---
@@ -112,8 +111,8 @@ repurposed).
 | --------------- | ------------- | ---------------- | ------------------------------------------------- |
 | `document-id`   | `id`          | core (identity)  | Document ULID; bare 26-char Crockford base32      |
 | `document-type` | `enum`        | core (identity)  | Overrides filename/directive-based type detection |
-| `labels`        | `tag-list`    | core (universal) | Classification tags                               |
-| `status`        | `enum`        | core (universal) | Lifecycle state, default `approved`               |
+| `labels`        | `tag-list`    | core (universal) | Classification tags (includes `DRAFT` marker)     |
+| `deprecated`    | `string`      | core (universal) | Retirement reason (non-replacement case)          |
 | `external-id`   | `external-id` | core (universal) | Cross-system identifier                           |
 | `supersedes`    | `id`          | core (universal) | Replacement link to another document              |
 | `references`    | `citation`    | core (universal) | External reference citations                      |
@@ -122,6 +121,19 @@ repurposed).
 Core keys mirror the universal attribute set from ADR-002 Part 1, plus two
 document-specific identity keys (`document-id`, `document-type`). Attribute
 value types follow the same 14-type system defined in ADR-002.
+
+Document lifecycle follows the same model as entry lifecycle (ADR-002
+§Retirement semantics and §Draft state):
+
+- **Draft state** — set the `DRAFT` label in `labels:` to mark the document as
+  not yet authoritative.
+- **Retirement via replacement** — use `supersedes:` to point at the document
+  that replaces this one; `superseded-by:` is generated on the predecessor.
+- **Retirement without replacement** — set `deprecated:` to a free-text reason
+  (e.g., "archived after platform migration").
+
+There is no separate `status:` front-matter key. There is no `DEPRECATED` /
+`WITHDRAWN` label — retirement is expressed structurally.
 
 ### Profile extensibility
 
@@ -246,7 +258,9 @@ etc.) are errors with auto-fix to remove."
 ## Open questions (deferred)
 
 - **Profile document format** — how profiles declare their front-matter keys,
-  types, and validation rules. Deferred to the profile-format ADR.
+  types, and validation rules — specified in
+  [ADR-008 — Profile System](./adr-008-profile-system.md), specifically the
+  `profile.documents.frontMatter` schema.
 - **TOML support details** — exact normalization behavior, whether TOML is
   first-class input or conversion-only. Leaning YAML-canonical.
 - **Front-matter inline references** — whether `{{document.document-id}}` syntax

--- a/docs/architecture/adr-008-profile-system.md
+++ b/docs/architecture/adr-008-profile-system.md
@@ -1,0 +1,590 @@
+# ADR-008: Profile System — Vocabulary, Rules, and Extension Distribution
+
+Status: Proposed\
+Date: 2026-04-19\
+Scope: MarkSpec\
+Depends on: [ADR-002 — Entry Model](./adr-002-entry-model.md),
+[ADR-006 — Property Model](./adr-006-property-model.md),
+[ADR-007 — Document Structure](./adr-007-document-structure.md)
+
+## Context
+
+ADR-002 separates the **entry format** (four families: Spec, Test, Element,
+Reference) from the **domain vocabulary** (concrete TYPE prefixes, Element
+kinds, status values, traceability rules). It calls this extension layer a
+**profile** and defers the profile format to a future ADR.
+
+Since ADR-002 was drafted, three characteristics of the extension need have
+become clear:
+
+- **Layered authorship.** Public domain profiles (ASPICE, ISO 26262, DO-178C,
+  IEC 62304) form a baseline. Organizations tune that baseline with
+  corporate-wide refinements (mandatory labels, extra attributes, internal
+  status values). Teams refine further (stricter traceability requirements for a
+  safety-critical component). Individual projects may tune again
+  (project-specific TYPEs, overrides). Each layer builds on the one above it.
+- **Compliance-grade review.** Profiles encode the rules auditors and quality
+  engineers care about. They must be reviewable as declarative artifacts, not as
+  executable code. A diff of a profile YAML is the primary review surface.
+- **Heterogeneous distribution.** OSS profiles flow through public git and
+  package registries. Corporate profiles flow through private git and internal
+  npm mirrors, behind the firewall and through audit pipelines. The same
+  mechanism must cover both.
+
+The profile system also anticipates a second extension layer — **hooks** — code
+that extends the parser, language server, and agent integration beyond what a
+declarative profile can express (custom parsing, context-aware completion, MCP
+tools). Hooks are introduced in this ADR as a structural slot but specified in a
+separate ADR (ADR-009, deferred).
+
+## Decision
+
+### 1. Profile as a distributable package
+
+A **profile** is a reusable, versioned, distributable unit that declares
+vocabulary, rules, and (optionally) hook code. It is a directory containing:
+
+```text
+<profile-id>/
+├── markspec.yaml        # manifest + declarative content
+├── hooks/               # optional — JS/TS hooks (deferred to ADR-009)
+│   └── ...
+└── README.md            # recommended
+```
+
+`markspec.yaml` is authoritative. Nothing else in the directory is required by
+the profile system; `hooks/` is loaded only when it exists; everything else is
+documentation.
+
+`package.json` is **not** committed to the profile source tree. When publishing
+to npm, `markspec profile publish` generates a transient `package.json` from the
+`markspec.yaml` manifest, runs `npm publish`, and discards the generated file.
+Authors edit one manifest only.
+
+### 2. Distribution channels
+
+v1 supports three specifier schemes, each addressing a different operational
+reality:
+
+| Scheme | Form                                                      | Use case                                                                |
+| ------ | --------------------------------------------------------- | ----------------------------------------------------------------------- |
+| Local  | `./path/to/profile`                                       | Project-local overrides; monorepo-vendored profiles; development        |
+| Git    | `git+https://<host>/<owner>/<repo>.git[/<subpath>]#<tag>` | OSS baselines; corporate profiles in any git host; zero-infra sharing   |
+| npm    | `npm:@scope/name@<semver-range>`                          | Corporate environments with npm mirrors, audit pipelines, vuln scanning |
+
+The loader resolves each scheme via Deno's native import machinery. No bespoke
+resolver or registry is required. `jsr:` and raw `https:` remain admissible
+extension points but are not v1 requirements.
+
+**Git monorepo support.** Multiple profiles may live in one git repository. The
+subpath between `.git` and the fragment selects which profile; the fragment is a
+per-profile tag using `<profile-id>/v<semver>` convention (matches Lerna / pnpm
+/ Changesets monorepo practice).
+
+```text
+git+https://github.com/driftsys/markspec-profiles.git/aspice-4#aspice-4/v1.2.0
+git+https://github.com/driftsys/markspec-profiles.git/iso-26262#iso-26262/v0.3.0
+```
+
+Single-profile repos may tag with bare `v<semver>` and omit the subpath.
+
+**Git fetch mechanics.** The loader uses shallow + sparse checkout
+(`git clone --depth=1 --branch=<tag> --filter=blob:none --sparse --no-checkout`,
+then `git sparse-checkout set <subpath>`). Bandwidth is minimal (single commit,
+single blob); auth is inherited from the user's git configuration.
+
+**npm vs jsr for profile YAML.** npm is selected over jsr for v1 because:
+
+- Corporate npm mirrors (Nexus, Artifactory, JFrog) are ubiquitous; jsr mirrors
+  are not yet established.
+- jsr requires a TypeScript entry point and static analysis; a pure-YAML profile
+  does not fit. npm accepts data-only packages with a trivial manifest.
+
+Profiles that also carry hook code can be published to jsr later without
+changing the specifier scheme's semantics.
+
+**Vendoring.** `markspec profile add <spec>` resolves the specifier, vendors the
+profile contents into `profiles/<id>/` at the consumer's repo root, and records
+the pinned version in the consumer's `.markspec.yaml`. Vendored profiles are
+committed. This preserves PR-diff reviewability, offline usage, and a single
+source of truth for what the project consumes.
+
+### 3. Consumer binding
+
+A consumer project declares its active profiles in `.markspec.yaml`:
+
+```yaml
+profiles:
+  - npm:@markspec/profile-aspice-4@^1.2
+  - git+https://github.com/acme/markspec-profile-corp.git#v1.0.0
+  - ./profiles/project-overrides
+```
+
+**Multi-profile composition rules:**
+
+- At most **one content-bearing profile chain** per project. The chain is
+  resolved via `extends:` (single parent, see §5). Declaring two independent
+  content-bearing profiles at the consumer level is a configuration error.
+- Any number of **hook-only profiles** may be loaded alongside the content
+  chain. Hook-only profiles carry no `markspec.yaml` content section; they
+  contribute only `hooks/` contents.
+
+Projects wanting to combine two domain standards (e.g., ASPICE + ISO 26262)
+publish a pre-merged profile rather than stacking two in `.markspec.yaml`.
+Merging at the consumer is too error-prone for compliance use.
+
+### 4. Profile schema
+
+`markspec.yaml` has two top-level regions: **manifest fields** (identity,
+distribution) and **content** (the `profile:` subtree that participates in
+`extends:` merging).
+
+```yaml
+# Manifest — identity, versioning, distribution
+id: "@markspec/profile-aspice-4"
+version: 1.2.0
+description: ASPICE 4.0 software engineering profile
+license: MIT
+extends: "npm:@markspec/profile-generic@^1.0"
+
+# Content — participates in the extends-chain merge
+profile:
+
+  # Universal scope — applies to any entry regardless of category
+  required: []
+  attributes: []
+  labels: []
+
+  # Per-category scope
+  spec:
+    required: []
+    attributes: []
+    traceability: {}
+  test:
+    required: []
+    attributes: []
+    levels: []
+    traceability: {}
+  element:
+    required: []
+    attributes: []
+    kinds: []
+    traceability: {}
+  reference:
+    required: []
+    attributes: []
+
+  # Per-TYPE scope (keyed map; TYPE prefix is the key)
+  types:
+    SRS: { category: spec, required: [Derived-from] }
+    SWT: { category: test, level: unit, required: [Tests, Verifies] }
+
+  # Document-level scope (per ADR-007)
+  documents:
+    types: []
+    frontMatter: []
+```
+
+**Terminology mapping.** The YAML uses `category` where ADR-002 uses _family_.
+The two terms refer to the same four values (`spec`, `test`, `element`,
+`reference`). `category` is used in the YAML for clarity of reading; `family`
+remains the normative term in the entry-model ADR. Implementations should accept
+both in parser diagnostics.
+
+**Fixed key set.** Inside `profile:` the recognized keys are:
+
+- Universal content: `required`, `attributes`, `labels`.
+- Category scopes: `spec`, `test`, `element`, `reference`.
+- TYPE scope: `types` (keyed map).
+- Document scope: `documents`.
+
+Any other top-level key under `profile:` is a validation error.
+
+**Note — `kinds:` and `levels:` sugar.** `element.kinds:` and `test.levels:` are
+documented shortcuts for extending the core-defined enum attributes
+`Element-kind` and `Test-level` respectively. Each expands as an implicit
+attribute declaration with enum-union merge (per the standard `attributes:`
+merge semantics):
+
+```yaml
+# Shortcut form
+element:
+  kinds: [ecu, sensor, actuator]
+
+# Equivalent to
+element:
+  attributes:
+    - { name: Element-kind, type: enum, values: [ecu, sensor, actuator] }
+```
+
+Profiles may use either form; tooling treats them identically. The shortcut
+exists because profile authors commonly extend only these two enums.
+
+**Note — TYPE-scoped `level:` semantics.** A TYPE declaration may carry a
+`level:` field (e.g., `SWT: { category: test, level: unit }`). Its semantics
+follow ADR-002 §"Test-level inference from TYPE":
+
+- On `markspec format`, if an entry of the TYPE omits `Test-level:`, the
+  formatter pre-fills it with the TYPE's declared level and commits it to source
+  (so the inferred value is inspectable in diffs).
+- The author's explicit `Test-level:` value always wins. The validator accepts
+  any valid Test-level regardless of the TYPE mapping.
+
+This is default / inference behavior, not enforcement. Profiles that need strict
+TYPE-to-level binding should express it through `rules.required` (not in scope
+for v1).
+
+**Note — default cardinality.** When an attribute declaration omits
+`cardinality:`, the default is inferred from `type:`:
+
+| Type family                                                              | Default cardinality |
+| ------------------------------------------------------------------------ | ------------------- |
+| Singular (`string`, `id`, `enum`, `date`, `url`, `boolean`, `number`, …) | `0..1`              |
+| List (`id-list`, `string-list`, `tag-list`, …)                           | `0..N`              |
+
+Setting `required: true` at the attribute level, or naming the attribute in a
+scope's `required:` list, promotes the lower bound (`0..1` → `1..1`, `0..N` →
+`1..N`).
+
+**Note — link attributes and generated inverses.** Link kinds are not declared
+in a separate schema section. A link is simply an attribute whose `type:` is
+`id` or `id-list`. The attribute declaration may carry an optional `inverse:`
+field describing the auto-generated back-link that markspec produces on the
+target entry:
+
+```yaml
+profile:
+  test:
+    attributes:
+      - name: Verifies
+        type: id-list
+        description: Specs verified by this test
+        inverse:
+          name: Verified-by
+          category: spec # where the generated inverse appears
+      - name: Tests
+        type: id-list
+        inverse:
+          name: Tested-by
+          category: element
+```
+
+Markspec generates the inverse attribute on every target entry matching the
+traceability rule's `target:` matchers. The generated attribute appears in
+compiled output but is not authored in source (per the generated-attribute
+semantics from ADR-002).
+
+**Note — retirement and draft semantics.** The core's retirement and draft
+handling (ADR-002 §Retirement semantics, §Draft state) is structural, not
+label-group based:
+
+- **Draft state** — `Labels: DRAFT` is a plain universal tag; no exclusive
+  group. Profiles treat it like any other label.
+- **Retirement via replacement** — `Supersedes:` on successor; `Superseded-by:`
+  generated on predecessor. Standard attribute machinery (see §Merge semantics
+  and the note on generated inverses).
+- **Retirement without replacement** — `Deprecated:` attribute with a free-text
+  reason string; universal, authored, optional.
+- **No `statuses:` section, no `lifecycle` exclusive label group.** Profiles do
+  not need to declare lifecycle vocabulary beyond what the core already
+  provides; extending retirement semantics is not in scope for v1.
+
+Link-resolution severity on target entries is defined in ADR-002:
+
+| Target state                                        | Severity |
+| --------------------------------------------------- | -------- |
+| Active (no marker)                                  | OK       |
+| `Labels: DRAFT`                                     | info     |
+| Retired (`Superseded-by:` set OR `Deprecated:` set) | warning  |
+| Unresolved                                          | error    |
+
+This replaces the former single-threshold MSL-T013 rule that targeted
+`Status: deprecated|withdrawn`. ADR-002 and ADR-007 are updated accordingly
+(Status attribute and document-level `status:` front-matter key removed;
+`Deprecated:` added as a universal attribute).
+
+**Note — document types and the `contains:` mapping.** Each entry in
+`profile.documents.types:` is structured, not a bare string:
+
+```yaml
+documents:
+  types:
+    - id: requirements
+      contains: [spec]
+      description: Requirement specifications
+    - id: architecture
+      contains: [spec, element]
+    - id: tests
+      contains: [test]
+  frontMatter: []
+```
+
+The `contains:` field declares which entry categories may appear in documents of
+that type. Two uses:
+
+- **Anonymous entry classification** — an entry without an explicit identity
+  attribute (e.g., `[SWT_AUTH_0001]` with no `Test-id:`) is classified into the
+  category listed in the enclosing document's `contains:`. Closes part of the
+  classification heuristic gap from ADR-002.
+- **Scope validation** — placing an entry of a category not listed in
+  `contains:` produces a validation error
+  (`specs don't belong in a tests
+  document`).
+
+Core ships with baked-in `contains:` mappings for the reserved doc types:
+
+| Doc type       | `contains:`       |
+| -------------- | ----------------- |
+| `requirements` | `[spec]`          |
+| `architecture` | `[spec, element]` |
+| `tests`        | `[test]`          |
+| `references`   | `[reference]`     |
+
+**Profiles may add new doc types, but cannot override the core mapping for
+reserved doc types.** Profile-added types must declare `contains:` explicitly.
+
+### 5. `extends:` chain and merge semantics
+
+A profile may specify at most one `extends:` target. That target is itself a
+profile (resolved via any valid specifier). The resolved chain forms a linear
+inheritance path: **public profile → org → team → project**.
+
+**Merge semantics (per-field):**
+
+| Field category                                                              | Merge rule                                                                                                        |
+| --------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| List-like additive (`required`, `attributes`, `labels`, `levels`, `kinds`)  | Union of all tiers. Declaring the same-named attribute in multiple tiers requires compatible definitions.         |
+| Constraint fields (`cardinality`, enum narrowing, `required` flag on attrs) | Child may tighten (narrow). Child may not relax. Relaxation is a validation error at profile load.                |
+| Traceability `target` matchers                                              | Child's target must be a subset of parent's target. Introducing a target not in the parent is a relaxation error. |
+
+**The rule of thumb:** _more specific tiers can add new constraints and tighten
+existing ones; they can never relax._
+
+**Scope precedence within one profile** (unchanged by the chain):
+
+```text
+profile.* (universal)  ⊂  profile.<category>.*  ⊂  profile.types.<PREFIX>.*
+```
+
+Each scope accumulates on `required`, `attributes`, and vocabulary lists; each
+scope may tighten constraints.
+
+### 6. TYPE enforcement
+
+Presence of `profile.types:` determines whether the profile enforces TYPE
+prefixes on entry display IDs:
+
+- **`types:` absent or empty** — anonymous entries permitted; no TYPE
+  vocabulary. Core markspec defaults apply.
+- **`types:` declared with at least one entry** — every entry's display ID must
+  begin with a declared TYPE prefix. Unknown TYPEs are validation errors.
+
+v1 does not support a `'*'` wildcard entry. Profiles wanting "strict on some,
+permissive on others" can be added later without breaking compatibility; the
+two-mode model is easier to teach.
+
+### 7. Traceability rules
+
+Link rules are declared co-located with the **source** of the link — the
+category or TYPE where the link originates. This matches the authoring mental
+model ("when I write an SRS, what are the rules on its outgoing links?").
+
+Each scope may carry a `traceability:` map keyed by link-attribute name. Each
+entry in the map declares:
+
+| Field         | Meaning                                                                                                                                                  |
+| ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `target`      | A list of matchers. Each matcher is a TYPE prefix string, a list of TYPE strings, or an object `{ category: <name> }` matching any member of a category. |
+| `cardinality` | Count bounds (`0..1`, `1..1`, `0..N`, `1..N`). Optional; tightens the attribute's declared cardinality.                                                  |
+| `required`    | Boolean; whether the link attribute must be present. Defaults to false.                                                                                  |
+
+**Example (ASPICE SWE.4 BP5 bidirectional traceability):**
+
+```yaml
+profile:
+  spec:
+    traceability:
+      Derived-from:
+        target: [{ category: spec }] # Specs derive from Specs (default)
+
+  test:
+    traceability:
+      Verifies:
+        target: [{ category: spec }]
+      Tests:
+        target: [{ category: element }]
+
+  types:
+    SRS:
+      category: spec
+      traceability:
+        Derived-from:
+          target: [STK] # narrows: SRS derives only from STK
+          cardinality: 1..N
+          required: true
+
+    SWT:
+      category: test
+      traceability:
+        Verifies:
+          target: [SRS, SWE]
+          cardinality: 1..N
+          required: true
+        Tests:
+          target: [{ category: element }]
+          cardinality: 1..N
+          required: true
+```
+
+**Generated inverses are not declared in profiles.** The downstream half of each
+link (`Verified-by`, `Tested-by`, `Realizes`) is generated by markspec from the
+forward declaration, per ADR-002.
+
+### 8. Identity model — unchanged
+
+This ADR **does not modify** the identity-attribute decisions from ADR-002. Each
+family keeps its dedicated identity attribute:
+
+- `Spec-id` → Spec entries (bare ULID)
+- `Test-id` → Test entries (bare ULID)
+- `Element-id` → Element entries (namespace path / file+symbol)
+- `Reference-id` → Reference entries (slug / Pandoc cite / URI)
+
+Categorized identity attributes remain the discrimination mechanism. Display IDs
+follow the conventions laid out in ADR-002 (human-readable `TYPE_DOMAIN_NUMBER`
+for Spec/Test; symbolic path for Element; slug/cite/URL for Reference). A
+profile's `types:` section declares the TYPE prefixes admitted for Spec and Test
+display IDs; profile authors may further constrain display-ID shapes via
+additional rules in future revisions.
+
+A variant design considered during this ADR's design phase — a single `Id:`
+attribute with family derived by inference — was rejected. Rationale:
+
+- Introduces a multi-input resolution cascade (value shape, discriminator
+  attribute, display-ID TYPE prefix, profile map).
+- Breaks core-only mode (no profile needed to parse entries correctly).
+- Worsens error messages; an explicit `Test-id` says what it is.
+- Would invalidate the PR #217 migration shipped earlier in April 2026.
+- Saves one attribute name per entry — not worth the cost.
+
+### 9. CLI surface
+
+Four commands are in scope for v1. The `profile` subcommand group contains
+author-side and consumer-side operations; `doctor` is top-level and covers
+consumer diagnostics.
+
+```text
+markspec profile new <id>             # author — scaffold a new profile directory
+markspec profile publish [--dry-run]  # author — validate + npm publish
+                                      #          (git users: git tag + git push)
+markspec profile add <spec>           # consumer — resolve, vendor to profiles/<id>/
+markspec doctor                       # consumer — diagnostics: active chain,
+                                      #            resolution errors, version
+                                      #            drift, hook load status
+```
+
+**Deliberately not in v1:**
+
+- `markspec profile lint` — `publish --dry-run` covers the same ground.
+- `markspec profile update` — registry checks are surfaced as hints inside
+  existing commands (e.g., `markspec build` / `markspec validate`) when a newer
+  in-range version is available.
+- `markspec profile show` — replaced by `markspec doctor`, which covers it
+  alongside other diagnostic content.
+
+### 10. Hooks — structural slot
+
+Profiles may contain a `hooks/` directory. When loaded, hooks extend markspec's
+parser, language server, or MCP surface. The interfaces, sandboxing, and
+lifecycle are specified in a separate ADR (ADR-009, deferred) and are not in
+scope here.
+
+This ADR reserves the directory and the loader's awareness of it. Profiles
+without hooks ship pure declarative content; profiles with hooks ship both.
+Hook-only profiles (no `profile:` content section) are valid distribution units.
+
+## Consequences
+
+### What this ADR enables
+
+- A single source of truth for how profiles are authored, distributed, and
+  consumed, closing the deferral in ADR-002.
+- OSS domain profiles (ASPICE, ISO 26262, DO-178C, IEC 62304) can be authored
+  and distributed through git, with organizations layering corporate profiles on
+  top via `extends:`.
+- Corporate environments can route profiles through their existing npm
+  infrastructure without markspec introducing a new distribution channel.
+- Profile changes are reviewed as declarative YAML diffs, keeping compliance
+  audit trails legible.
+- The distinction between declarative profiles and imperative hooks is explicit,
+  preserving the "no code in the compliance artifact" property that regulated
+  industries need.
+
+### What shifts for existing consumers
+
+- Projects using an implicit vocabulary (no profile) continue to work — they run
+  against markspec core defaults. Profile adoption is opt-in.
+- Projects already using the four-family model (post-ADR-002) pick up a profile
+  by running `markspec profile add <spec>`; no source changes required.
+- The `Spec-id` / `Test-id` / `Element-id` / `Reference-id` model survives as
+  the identity mechanism; no additional migration beyond what PR #217 already
+  introduced.
+
+### What is explicitly deferred
+
+- **Hook API and lifecycle** — ADR-009 (separate).
+- **Attribute declaration schema detail** — the full list of value types,
+  per-attribute option flags, and validation helpers is a refinement of this
+  ADR. Skeleton shape is defined here; full detail is a follow-up.
+- **Built-in default profile** — whether markspec ships a `generic` profile that
+  registers the common automotive TYPEs (SRS, SWT, …) is a tooling decision, not
+  an architectural one.
+- **Wildcard `'*'` TYPE fallback** — deferred until a real use case demands
+  "strict on some, permissive on others".
+- **`jsr:` and raw `https:` profile schemes** — admissible extension, not v1
+  scope.
+- **Publish-time cross-profile validation** — checking that a child's `extends:`
+  chain resolves cleanly before publish is a quality-of-life enhancement; v1
+  validates at consumer-side resolution time.
+
+## Dependencies
+
+- ✅ [ADR-002 — Entry Model](./adr-002-entry-model.md) — the four-family model
+  and categorized identity attributes this ADR extends.
+- ✅ [ADR-007 — Document Structure](./adr-007-document-structure.md) — the
+  front-matter mechanism profiles extend via `profile.documents.frontMatter`.
+- 🔗 [ADR-006 — Property Model](./adr-006-property-model.md) — profile-declared
+  generated attributes populate the property layer defined here.
+- 🔗 ADR-009 — Profile Hooks (deferred): API, sandbox, lifecycle.
+
+## Acceptance criteria
+
+- [ ] `markspec.yaml` schema is specified and validated (manifest + content).
+- [ ] Three distribution channels (local, git, npm) resolve end-to-end.
+- [ ] Monorepo subpath + per-profile tag convention supported.
+- [ ] `extends:` chain resolution with additive + tightening merge implemented.
+- [ ] TYPE enforcement (strict vs absent) implemented at validator layer.
+- [ ] `profile.types.<PREFIX>.traceability` merges correctly across the chain
+      and across scope tiers (universal → category → TYPE).
+- [ ] CLI surface (`new`, `publish`, `add`, `doctor`) available with the
+      described behavior.
+- [ ] Vendored profiles are reproducible: running `markspec profile add` against
+      the same pinned version always yields byte-identical output.
+- [ ] ADR-002 §"Out of scope — Profile document format", ADR-006 §Dependencies,
+      and ADR-007 §"Out of scope — Profile document format" updated to reference
+      this ADR.
+
+## Out of scope (future work)
+
+- **Profile hooks** — code that extends parser, LSP, MCP. ADR-009.
+- **Profile registry / discovery** — a markspec-specific registry beyond reusing
+  git and npm.
+- **Profile-level traceability validation** — automated checks across a resolved
+  `extends:` chain (e.g., "this child's Derived-from rule cannot possibly be
+  satisfied given the parent's TYPE vocabulary").
+- **Signing and provenance** — SLSA-style provenance for published profiles;
+  reuses whatever git tag signing / npm signing the ecosystem offers.
+- **Profile composition at the consumer** — merging two content-bearing profiles
+  inside `.markspec.yaml`. Projects use a pre-merged domain profile instead.
+- **`jsr:` and `https:` specifier schemes** for profiles.
+- **Wildcard `'*'` TYPE entry** for permissive-with-fallback mode.

--- a/docs/examples/profiles/aspice-swe-mini/markspec.yaml
+++ b/docs/examples/profiles/aspice-swe-mini/markspec.yaml
@@ -1,0 +1,109 @@
+# Strawman profile used to validate ADR-008 schema shape.
+# Not a complete ASPICE profile — a minimal vertical exercising every
+# section of the profile schema for design review.
+
+id: "@markspec/profile-aspice-swe-mini"
+version: 0.1.0
+description: Minimal ASPICE SWE vertical (design validation)
+license: MIT
+extends: "npm:@markspec/profile-generic@^1.0"
+
+profile:
+
+  # ==========================================================================
+  # Universal — applies to every entry regardless of category
+  # ==========================================================================
+  attributes:
+    - { name: External-id, type: string, cardinality: 0..1 }
+
+  labels:
+    # ASIL — mutually exclusive safety integrity level
+    - { name: QM,     group: asil }
+    - { name: ASIL-A, group: asil }
+    - { name: ASIL-B, group: asil }
+    - { name: ASIL-C, group: asil }
+    - { name: ASIL-D, group: asil }
+    # Ungrouped
+    - { name: security }
+    - { name: automated, applies: [test] }
+    - { name: manual,    applies: [test] }
+
+  # ==========================================================================
+  # Per-category defaults
+  # ==========================================================================
+  spec:
+    attributes:
+      - { name: Derived-from, type: id-list }
+      - { name: Realized-by,  type: id-list }
+    traceability:
+      Derived-from: { target: [{ category: spec }] }
+      Realized-by:  { target: [{ category: element }] }
+
+  test:
+    attributes:
+      - { name: Verifies, type: id-list }
+      - { name: Tests,    type: id-list }
+    levels: [unit, integration, system, acceptance]
+    traceability:
+      Verifies: { target: [{ category: spec }] }
+      Tests:    { target: [{ category: element }] }
+
+  element:
+    required: [Element-kind]
+    kinds: [module, class, function, source]
+
+  reference:
+    attributes:
+      - { name: Reference-url, type: url, cardinality: 0..1 }
+
+  # ==========================================================================
+  # Per-TYPE — tightens rules for each TYPE prefix
+  # ==========================================================================
+  types:
+    STK:
+      category: spec
+      description: Stakeholder requirement (SWE.1 input)
+
+    SRS:
+      category: spec
+      description: Software requirement (SWE.1 output)
+      required: [Derived-from]
+      traceability:
+        Derived-from: { target: [STK], cardinality: 1..N, required: true }
+
+    SWE:
+      category: spec
+      description: Software element spec (SWE.2)
+      required: [Derived-from, Realized-by]
+      traceability:
+        Derived-from: { target: [SRS], cardinality: 1..N, required: true }
+        Realized-by:  { target: [{ category: element }], cardinality: 1..N, required: true }
+
+    SWT:
+      category: test
+      description: Software unit test (SWE.4)
+      level: unit
+      required: [Verifies, Tests]
+      traceability:
+        Verifies: { target: [SRS, SWE], cardinality: 1..N, required: true }
+        Tests:    { target: [{ category: element }], cardinality: 1..N, required: true }
+
+    SIT:
+      category: test
+      description: Software integration test (SWE.5)
+      level: integration
+      required: [Verifies]
+      traceability:
+        Verifies: { target: [SRS, SWE], cardinality: 1..N, required: true }
+
+  # ==========================================================================
+  # Document-level
+  # ==========================================================================
+  documents:
+    # Core doc types (requirements, architecture, tests, references) come
+    # with baked-in contains: mappings — redeclaring them is not permitted.
+    # Add new doc types here if needed, with explicit contains: declarations.
+    types: []
+    frontMatter:
+      - { name: asil, type: enum, values: [QM, A, B, C, D], cardinality: 0..1 }
+      - { name: safety-goal, type: string, cardinality: 0..1 }

--- a/docs/spec/language/ast.md
+++ b/docs/spec/language/ast.md
@@ -384,8 +384,7 @@ interface MsDirectiveEntry {
 ```markdown
 <!--
 markspec:deck
-markspec:deprecated Superseded by braking-v2.md which
-  implements the revised sensor interface.
+markspec:references https://safety.company.io/registry
 -->
 ```
 
@@ -395,7 +394,7 @@ markspec:deprecated Superseded by braking-v2.md which
 msDirective
   directives:
     { name: "deck", payload: "" }
-    { name: "deprecated", payload: "Superseded by braking-v2.md which\n  implements the revised sensor interface." }
+    { name: "references", payload: "https://safety.company.io/registry" }
 ```
 
 Range directives (`markspec:columns`, `markspec:disable`, `markspec:ignore`)

--- a/docs/spec/language/language.md
+++ b/docs/spec/language/language.md
@@ -455,7 +455,6 @@ block at the very top of the file, before the H1.
 ---
 document-id: 01HGW2D0DOCPQ4FGHIJKLMNOPQR
 document-type: requirements
-status: approved
 labels: [requirements, ASIL-B]
 external-id: doors:VHC:SRS-BRK
 ---
@@ -470,8 +469,9 @@ external-id: doors:VHC:SRS-BRK
 Front matter carries:
 
 - **Document identity** (`document-id`, `document-type`).
-- **Universal attributes** (`labels`, `status`, `external-id`, `supersedes`,
+- **Universal attributes** (`labels`, `external-id`, `supersedes`, `deprecated`,
   `references`) — same set and semantics as entry-level universal attributes.
+  Draft state via `DRAFT` label; retirement via `supersedes:` or `deprecated:`.
 - A reserved **`metadata:` map** for org-specific free-form fields.
 - Optional **profile-declared keys** (e.g., automotive `asil:`).
 - Optional **allowlisted ecosystem keys** declared in `.markspec.yaml` (for Hugo
@@ -517,21 +517,33 @@ They come from a profile loaded by the project.
 
 The following attributes apply to every family:
 
-| Attribute       | Type          | Required | Description                               |
-| --------------- | ------------- | -------- | ----------------------------------------- |
-| `Labels`        | `tag-list`    | no       | Classification tags                       |
-| `Status`        | `enum`        | no       | Lifecycle state (default `approved`)      |
-| `References`    | `citation`    | no       | External reference citations with locator |
-| `External-id`   | `external-id` | no       | Cross-system identifier(s)                |
-| `Supersedes`    | `id`          | no       | Same-family entry this one replaces       |
-| `Superseded-by` | `id`          | —        | Generated inverse of `Supersedes`         |
+| Attribute       | Type          | Required | Description                                   |
+| --------------- | ------------- | -------- | --------------------------------------------- |
+| `Labels`        | `tag-list`    | no       | Classification tags (includes `DRAFT` marker) |
+| `References`    | `citation`    | no       | External reference citations with locator     |
+| `External-id`   | `external-id` | no       | Cross-system identifier(s)                    |
+| `Supersedes`    | `id`          | no       | Same-family entry this one replaces           |
+| `Superseded-by` | `id`          | —        | Generated inverse of `Supersedes`             |
+| `Deprecated`    | `string`      | no       | Retirement reason (non-replacement case)      |
 
-`Status` vocabulary: `draft`, `approved` (default), `deprecated`, `withdrawn`.
-Profiles may extend the set.
+**Draft state** is carried by the `DRAFT` label — a plain universal tag with no
+exclusive-group semantics. Authors set `Labels: DRAFT` on entries that are
+merged but not yet authoritative.
 
-`Supersedes` expresses same-family replacement only (a test cannot supersede a
-spec). Tooling warns when a `Satisfies:` / `Derived-from:` / `Verifies:` /
-`Realizes:` target is `deprecated` or `withdrawn`.
+**Retirement** is structural, expressed two ways:
+
+- **Replacement** — successor entry authors `Supersedes: <predecessor-id>`; the
+  predecessor automatically gains the generated `Superseded-by:` inverse.
+- **Non-replacement** — entry authors `Deprecated: "<free-text reason>"` (e.g.,
+  "Feature cut from scope in v3.0").
+
+An entry is **retired** when either signal is present. The two are complementary
+(a replacement may still carry a `Deprecated:` reason for additional context).
+Tooling emits severity-tiered diagnostics when a `Satisfies:` / `Derived-from:`
+/ `Verifies:` / `Realizes:` target is retired or draft: `DRAFT` target → info,
+retired target → warning, unresolved target → error. There is no `DEPRECATED` /
+`WITHDRAWN` label — retirement lives in `Supersedes` and `Deprecated`. See
+ADR-002 §Retirement semantics.
 
 See §2.6 for attribute value types (multi-line repeat vs CSV, canonical form).
 
@@ -719,8 +731,8 @@ display ID, title, and `Reference-id` only.
 | `Reference-document` | `text` | no       | Full formal citation; falls back to title   |
 
 Replacement is expressed via the universal `Supersedes` / `Superseded-by`
-attributes from §2.1. Lifecycle state is expressed via the universal `Status`
-attribute (use `withdrawn` or `deprecated`).
+attributes from §2.1. Retirement without replacement is expressed via the
+universal `Deprecated` attribute (e.g., a withdrawn standard with no successor).
 
 **Example 12 — reference entry:**
 
@@ -821,9 +833,7 @@ the payload.
 ```markdown
 <!--
 markspec:deck
-markspec:deprecated Superseded by braking-v2.md which
-  implements the revised sensor interface defined in
-  SYS_BRK_0050.
+markspec:references https://safety.company.io/registry
 -->
 ```
 
@@ -843,26 +853,28 @@ payload.
 
 Placed in the first HTML comment after the H1 heading.
 
-| Directive             | Payload            | Context |
-| --------------------- | ------------------ | ------- |
-| `markspec:glossary`   | none               | doc     |
-| `markspec:summary`    | none               | doc     |
-| `markspec:deck`       | none               | deck    |
-| `markspec:specs`      | none               | doc     |
-| `markspec:tests`      | none               | doc     |
-| `markspec:elements`   | none               | doc     |
-| `markspec:references` | registry URL       | both    |
-| `markspec:deprecated` | reason (free text) | both    |
-| `markspec:paginate`   | none               | deck    |
+| Directive             | Payload      | Context |
+| --------------------- | ------------ | ------- |
+| `markspec:glossary`   | none         | doc     |
+| `markspec:summary`    | none         | doc     |
+| `markspec:deck`       | none         | deck    |
+| `markspec:specs`      | none         | doc     |
+| `markspec:tests`      | none         | doc     |
+| `markspec:elements`   | none         | doc     |
+| `markspec:references` | registry URL | both    |
+| `markspec:paginate`   | none         | deck    |
 
 Type directives (`glossary`, `summary`, `deck`) are mutually exclusive.
 Family-hint directives (`specs`, `tests`, `elements`, `references` without a
 payload) hint at the predominant entry family in the document — used by
 `markspec format` to classify new entries before they carry an identity
-attribute. `deprecated` and `references` (with a URL payload) can coexist with
-any type directive. `doc` is the default — no directive for it. Multiple
+attribute. `references` (with a URL payload) can coexist with any type
+directive. `doc` is the default — no directive for it. Multiple
 `markspec:references` directives with URL payloads declare multiple upstream
 registries; order matters, with an implicit fallback to RefHub.
+
+Document-level retirement uses the `deprecated:` front-matter key (or
+`supersedes:` for replacement retirement), not a directive. See §6.2.
 
 `glossary` and `summary` are auto-detected from filename (`GLOSSARY.md`,
 `SUMMARY.md`). Family-hint directives are auto-detected from filename:
@@ -891,13 +903,23 @@ markspec:paginate
 **Example 16 — deprecated glossary:**
 
 ```markdown
-# Legacy Terms
+---
+document-type: glossary
+supersedes: 01HGW2D0GLOSPQ4FGHIJKLMNOPQ # platform-glossary.md document-id
+---
 
-<!--
-markspec:glossary
-markspec:deprecated Replaced by platform-glossary.md as of
-  v2.0.0.
--->
+# Legacy Terms
+```
+
+Or for a glossary with no successor:
+
+```markdown
+---
+document-type: glossary
+deprecated: "Archived after platform migration; content no longer maintained."
+---
+
+# Legacy Terms
 ```
 
 **Example 17 — upstream registries:**
@@ -1267,16 +1289,21 @@ Per-file metadata splits into two tiers (mirroring the entry model):
 
 #### Document attributes (authored in front matter)
 
-| Attribute       | Type          | Required | Description                                                                             |
-| --------------- | ------------- | -------- | --------------------------------------------------------------------------------------- |
-| `document-id`   | `id`          | no       | Document ULID — `01H…` 26-char Crockford base32                                         |
-| `document-type` | `enum`        | no       | Overrides filename/directive detection (see §6.3)                                       |
-| `labels`        | `tag-list`    | no       | Classification tags                                                                     |
-| `status`        | `enum`        | no       | Lifecycle state (`draft` / `approved` / `deprecated` / `withdrawn`), default `approved` |
-| `external-id`   | `external-id` | no       | Cross-system identifier (`scheme:value`)                                                |
-| `supersedes`    | `id`          | no       | `document-id` of a document this one replaces                                           |
-| `references`    | `citation`    | no       | External reference citations with optional locator                                      |
-| `metadata`      | map           | no       | Org free-form metadata, never validated                                                 |
+| Attribute       | Type          | Required | Description                                        |
+| --------------- | ------------- | -------- | -------------------------------------------------- |
+| `document-id`   | `id`          | no       | Document ULID — `01H…` 26-char Crockford base32    |
+| `document-type` | `enum`        | no       | Overrides filename/directive detection (see §6.3)  |
+| `labels`        | `tag-list`    | no       | Classification tags (includes `DRAFT` marker)      |
+| `external-id`   | `external-id` | no       | Cross-system identifier (`scheme:value`)           |
+| `supersedes`    | `id`          | no       | `document-id` of a document this one replaces      |
+| `deprecated`    | `string`      | no       | Retirement reason (non-replacement case)           |
+| `references`    | `citation`    | no       | External reference citations with optional locator |
+| `metadata`      | map           | no       | Org free-form metadata, never validated            |
+
+Document lifecycle mirrors entry lifecycle: `DRAFT` label for work in progress;
+`supersedes:` for replacement retirement; `deprecated:` for non-replacement
+retirement. There is no separate `status:` front-matter key. There is no
+`DEPRECATED` / `WITHDRAWN` label.
 
 All attribute value types follow the 14-type system from §2.6. Profiles may
 declare additional keys; projects may allowlist SSG-ecosystem keys in
@@ -1303,9 +1330,9 @@ file. Commits within a branch do not count.
 **authors:** `project.yaml` recommended — Git history is fragile across moves
 and migrations.
 
-**status**: derived from `status:` in front matter if present, otherwise branch
-context (`draft` on branch, `approved` on main) and `markspec:deprecated`
-directive. Front-matter `status:` wins when set.
+**draft / retirement**: structural signals, not derived. Documents carry `DRAFT`
+via `labels:` and/or `deprecated:` via front matter. Replacement is via
+`supersedes:`. No branch-derived lifecycle inference.
 
 ### 6.3 Document types
 
@@ -1436,26 +1463,27 @@ carrying an identity attribute.
 
 ### 8.3 Traceability (MSL-T)
 
-| ID         | Severity | Rule                                                                                                       |
-| ---------- | -------- | ---------------------------------------------------------------------------------------------------------- |
-| `MSL-T001` | error    | `Satisfies:` target must resolve to an existing spec entry.                                                |
-| `MSL-T004` | warning  | `Derived-from:` target must resolve to an existing spec entry.                                             |
-| `MSL-T005` | error    | `References:` slug must resolve to an existing reference entry.                                            |
-| `MSL-T006` | error    | `Allocated-to:` target must resolve to an existing element entry.                                          |
-| `MSL-T007` | error    | `Realizes:` target (on elements) must resolve to an existing spec entry.                                   |
-| `MSL-T008` | error    | `Verifies:` target (on tests) must resolve to an existing spec entry.                                      |
-| `MSL-T009` | error    | `Tests:` target (on tests) must resolve to an existing element entry.                                      |
-| `MSL-T010` | error    | `Part-of:` target must resolve to an existing element entry.                                               |
-| `MSL-T011` | error    | `Depends-on:` target must resolve to an existing element entry.                                            |
-| `MSL-T012` | error    | `Supersedes:` target must resolve to an existing same-family entry.                                        |
-| `MSL-T013` | warning  | `Satisfies:` / `Derived-from:` / `Verifies:` / `Realizes:` target has `Status: deprecated` or `withdrawn`. |
+| ID         | Severity | Rule                                                                                              |
+| ---------- | -------- | ------------------------------------------------------------------------------------------------- |
+| `MSL-T001` | error    | `Satisfies:` target must resolve to an existing spec entry.                                       |
+| `MSL-T004` | warning  | `Derived-from:` target must resolve to an existing spec entry.                                    |
+| `MSL-T005` | error    | `References:` slug must resolve to an existing reference entry.                                   |
+| `MSL-T006` | error    | `Allocated-to:` target must resolve to an existing element entry.                                 |
+| `MSL-T007` | error    | `Realizes:` target (on elements) must resolve to an existing spec entry.                          |
+| `MSL-T008` | error    | `Verifies:` target (on tests) must resolve to an existing spec entry.                             |
+| `MSL-T009` | error    | `Tests:` target (on tests) must resolve to an existing element entry.                             |
+| `MSL-T010` | error    | `Part-of:` target must resolve to an existing element entry.                                      |
+| `MSL-T011` | error    | `Depends-on:` target must resolve to an existing element entry.                                   |
+| `MSL-T012` | error    | `Supersedes:` target must resolve to an existing same-family entry.                               |
+| `MSL-T013` | tiered   | Link target is non-active: `DRAFT` label=info; `Superseded-by:` set or `Deprecated:` set=warning. |
 
 `MSL-T014` is reserved for a future registry-chain check on `References:`
 (warning severity) when reference resolution via upstream registries lands.
 
 MSL-R014 (introduced during the four-family migration) validates enum-type
-attribute values: `Status`, `Test-level`, `Element-kind` must be drawn from the
-vocabulary declared in ADR-002 Annex C.
+attribute values: `Test-level`, `Element-kind` must be drawn from the vocabulary
+declared in ADR-002 Annex C. Lifecycle state is enforced through the label-group
+exclusivity rules rather than enum validation.
 
 Direction and level-crossing rules (e.g., "acceptance tests verify stakeholder
 requirements") are profile concerns, not core concerns.

--- a/project.yaml
+++ b/project.yaml
@@ -1,6 +1,6 @@
 "$schema": https://driftsys.github.io/schemas/project/v1.json
 name: io.driftsys.markspec
-version: 0.0.1
+version: "0.2.1"
 category: [specification, tool]
 description: Markdown flavor and toolchain for traceable industrial documentation
 license: MIT


### PR DESCRIPTION
## What

Introduces ADR-008 — Profile System, and rewrites the entry/document retirement model across ADR-002, ADR-007, and the language spec. Adds a strawman profile under `docs/examples/` that validates the schema shape end to end.

## Why

Closes the profile-document-format deferral flagged in ADR-002, ADR-006, and ADR-007. Provides the concrete design basis for implementing `markspec profile new / publish / add` and the `markspec.yaml` loader. Aligns entry/document lifecycle with structural signals (Supersedes + Deprecated) instead of the former Status enum.

Closes #

## How

**ADR-008 — Profile System** (new)
- Three v1 distribution channels: local path, git (shallow + sparse), npm (monorepo + per-profile-tag convention).
- Single-file `markspec.yaml` manifest; transient `package.json` generated at publish time.
- CLI surface: `markspec profile new / publish / add`, plus top-level `markspec doctor`.
- Schema with universal / per-category / per-TYPE / documents scopes; `extends:` single-parent chain with additive + tightening merge semantics.
- Traceability rules co-located with source scope; `contains:` mapping on doc types; `kinds:` / `levels:` as documented sugar for attribute declarations.

**Retirement model rewrite** (ADR-002, ADR-007, language spec)
- Drops the `Status` attribute and the document-level `status:` front-matter key.
- Retirement is structural: `Supersedes:` for replacement, `Deprecated:` attribute (entry-level) and `deprecated:` front-matter key (document-level) for non-replacement.
- `DRAFT` becomes a plain universal label (no exclusive `lifecycle` group).
- MSL-T013 becomes a tiered rule: DRAFT=info, retired (Superseded-by OR Deprecated)=warning, unresolved=error.
- Drops the `markspec:deprecated` HTML-comment directive (pre-release, no back-compat burden).

**Strawman profile**
- `docs/examples/profiles/aspice-swe-mini/markspec.yaml` exercises every schema section (universal, per-category, per-TYPE, documents, traceability, labels with exclusive groups).

**Cross-references**
- ADR-002, ADR-006, ADR-007 updated to point at ADR-008 where they deferred the profile-document-format decisions.

## Checklist

- [x] Documentation updated (ADRs 002 / 006 / 007 / 008, language spec, ast spec, strawman profile)
- [ ] Tests added or updated — N/A; docs-only PR. Implementation work (parser/validator/formatter Status migration, `markspec.yaml` loader, profile CLI) is tracked separately.
- [x] All checks pass — local `just check` green (398 tests); pre-push hook clean.

## Follow-ups (separate issues/PRs)

- Code migration: Status → lifecycle-label + `Deprecated:` attr handling in parser/validator/formatter + fixture migration (folds into or after #217 migration tool).
- ADR-009 Profile Hooks — design for parser/LSP/MCP extension code.
- `markspec.yaml` profile loader + CLI commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
