### PR TITLE
docs: ADR-009 core/profile boundary + ADR-010/011 follow-ups

### DIFF
--- a/docs/architecture/adr-002-entry-model.md
+++ b/docs/architecture/adr-002-entry-model.md
@@ -1,93 +1,56 @@
-# ADR-002: Entry Model — Spec, Test, Element, and Reference Entries
+# ADR-002: Entry Model — Identified and Referenced Entries
 
 Status: Proposed\
-Date: 2026-04-17\
+Date: 2026-04-17 (revised 2026-04-20 for ADR-009 alignment)\
 Scope: MarkSpec\
-Supersedes: (extends ADR-001)
+Depends on: [ADR-001 — Markdown Format](./adr-001-markdown-format.md),
+[ADR-009 — Core / Profile Boundary](./adr-009-core-profile-boundary.md)
 
 ## Context
 
 ADR-001 introduced entry blocks as MarkSpec's mechanism for authoring traceable
-artifacts alongside prose. It hardcoded an automotive V-model vocabulary (STK,
-SYS, SRS, SAD, ICD, VAL, SIT, SWT) directly into the core specification, which
-ties MarkSpec to a single domain and limits adoption in aerospace, medical,
-railway, and other safety-critical contexts.
+artifacts alongside prose. Its initial formulation hardcoded an automotive
+V-model vocabulary (STK, SYS, SRS, SAD, ICD, VAL, SIT, SWT) directly into the
+core, which would have tied MarkSpec to a single domain.
 
 This ADR separates the **entry format** from the **domain vocabulary**. The core
-defines a universal entry model with four families — **spec entries**, **test
-entries**, **element entries**, and **reference entries** — each with a precise
-format, a dedicated identity attribute, and well-defined validation rules.
-Concrete type vocabularies move out of the core into profiles.
+defines a minimal universal entry model anchored on two semantics-free
+**shapes**:
 
-The four families correspond to four distinct roles in a technical repository:
+- **Identified** — content units the project authors and owns, carrying a stable
+  ULID identity and a human-readable display-ID alias.
+- **Referenced** — citations of external artifacts, identified by a URI and
+  labelled with a slug-style display ID (pandoc/BibTeX cite-key convention).
 
-- **Spec** — a numbered, locally-authoritative declaration the project
-  formulates: a requirement, a design decision, an architecture block, a hazard.
-  The project is the author and carries the editorial authority.
-- **Test** — a verification of declared behavior, either executable (unit,
-  integration, system tests) or procedural (manual acceptance tests). A test is
-  both a specification of what must be verified and, when automated, an
-  executable artifact. Tests are distinct from specs because of this dual nature
-  and their execution lifecycle.
-- **Element** — a canonical declaration of a system object with stable semantic
-  identity: a component, a unit of production code, a file, a piece of hardware,
-  a consumed dependency. The display ID follows a namespace convention that
-  mirrors the naming in the real world.
-- **Reference** — a bibliographic citation of an external published artifact: a
-  standard, a regulation, a paper, an RFC. The slug names an external work; no
-  ULID is needed.
+Concrete type vocabularies — `requirement`, `test`, `unit`, `standard`,
+`dependency`, `hazard`, etc. — move out of the core into profiles per
+[ADR-008 — Profile System](./adr-008-profile-system.md) and
+[ADR-009 — Core / Profile Boundary](./adr-009-core-profile-boundary.md).
 
-### Key design decision: discrimination by identity attribute
+The two-shape model replaces an earlier four-family model (Spec, Test, Element,
+Reference) that baked compliance scaffolding into core. ADR-009 §1–§2 documents
+the rationale; this ADR realizes it in the entry-model specification.
 
-The family of an entry is determined by the **identity attribute** it carries in
-its trailers, not by syntactic markers in the display ID. Each family has its
-own dedicated identity attribute:
+### Key design decision: shape-by-identity-value-format
 
-- `Spec-id` → the entry is a spec
-- `Test-id` → the entry is a test
-- `Element-id` → the entry is an element
-- `Reference-id` → the entry is a reference
+The shape of an entry is determined by the **value format** of its `Id:`
+attribute. A **ULID** (26-char Crockford base32) identifies an identified entry;
+a **URI** (RFC 3986, any scheme — `urn:`, `doi:`, `pkg:`, `https:`, …)
+identifies a referenced entry. The two formats are visually disjoint: a URI must
+carry a scheme followed by `:`, and a ULID is pure base32 with no scheme.
+Discrimination is a one-step format check.
 
-This is a departure from earlier drafts that used syntactic markers (`@` for
-refs, `::` for elements) to signal family. Marker-based discrimination adds
-friction to authoring and creates overlapping regexes that must be kept
-disjoint. Attribute-based discrimination uses the trailer content the entry
-already carries, keeps display IDs clean, and makes family resolution trivial.
-
-Syntactic markers that remain in the format (`@` for Pandoc citation
-compatibility, `::` for element hierarchy) serve different purposes and are no
-longer tied to family recognition.
-
-### Key design decision: Test as a distinct family
-
-Earlier iterations treated tests as elements with a `Role: test` attribute, or
-as specs with a type distinction. Both approaches conflate the dual nature of a
-test. A test is simultaneously:
-
-- A **specification** of expected behavior (what must be true, under what
-  conditions, with what pass/fail criteria).
-- An **executable** (or procedural) artifact with an execution lifecycle (it
-  runs, produces results, can be re-executed, regressed, timed).
-
-Neither specs (purely declarative) nor elements (materially-existing entities)
-capture this duality cleanly. Promoting Test to its own family yields:
-
-- **Clearer semantics** — test-specific attributes (`Verifies`, `Tests`,
-  `Level`) live naturally on Test without polluting other families.
-- **Structural alignment with industry standards** — every safety-critical
-  standard (ISO 26262, DO-178C, IEC 62304, EN 50128) treats test artifacts as
-  distinct work products with dedicated traceability requirements (ASPICE SWE.4
-  BP5, DO-178C §6.4, IEC 62304 §5.5).
-- **Cleaner core** — each family has focused, well-typed attributes instead of
-  shared attributes that only apply in some cases.
+This replaces the earlier four-attribute discrimination (`Spec-id`, `Test-id`,
+`Element-id`, `Reference-id` as separate attributes). The motivation and
+rebuttal of alternatives are in ADR-009 §2 and §12.
 
 ---
 
 ## Part 1 — Entry (Common Base)
 
-All entry families share a common syntactic form and a common set of universal
-properties. `Entry` is an abstract concept — every concrete entry is a spec, a
-test, an element, or a reference.
+Both shapes share a common syntactic form and a common set of universal
+properties. `Entry` is the abstract concept; every concrete entry is either
+identified or referenced.
 
 ### Syntactic form
 
@@ -109,10 +72,10 @@ git-trailers convention.
 
 | Property       | Rule                                                              |
 | -------------- | ----------------------------------------------------------------- |
-| **display_id** | Non-empty string matching the family's display ID format          |
+| **display_id** | Non-empty string; format depends on shape and active profile      |
 | **title**      | Non-empty string on the same line as the `[DISPLAY_ID]` marker    |
-| **body**       | At least one paragraph (reference entries excepted — see Part 3)  |
-| **identity**   | Exactly one of `Spec-id`, `Test-id`, `Element-id`, `Reference-id` |
+| **body**       | At least one paragraph (referenced entries excepted — see Part 3) |
+| **identity**   | Exactly one `Id:` attribute with a well-formed value              |
 
 ### Attribute origin
 
@@ -122,46 +85,70 @@ Every attribute has an **origin** describing how its value arrives in the model:
 - **Inferred** — pre-filled by `markspec format` from a heuristic (source
   context, namespace hierarchy, profile mapping). Committed to the source file,
   author-overridable when the heuristic misfires.
-- **Assigned** — generated fresh by `markspec format` at creation time (identity
-  attributes: `Spec-id`, `Test-id`, `Element-id`). Never derived from other
-  data, never changes after assignment.
+- **Assigned** — generated fresh by `markspec format` at creation time (the ULID
+  inside an identified entry's `Id:`). Never derived from other data, never
+  changes after assignment.
 - **Generated** — computed at build time by inverting other entries' authored
-  relations (`Verified-by`, `Realized-by`, `Cited-by`, …). Never committed to
-  source.
+  relations. Never committed to source.
 
 ### Universal attributes
 
-The following attributes apply to every family, with identical semantics and
+The following attributes apply to every entry, with identical semantics and
 value types:
 
-| Attribute         | Type          | Origin    | Description                                           |
-| ----------------- | ------------- | --------- | ----------------------------------------------------- |
-| **Labels**        | `tag-list`    | authored  | Free-form classification tags                         |
-| **References**    | `citation`    | authored  | Citations of external reference entries, with locator |
-| **External-id**   | `external-id` | authored  | Identifier(s) in an external system                   |
-| **Supersedes**    | `id`          | authored  | Display ID of a same-family entry this one replaces   |
-| **Superseded-by** | `id`          | generated | Inverse of `Supersedes`                               |
-| **Deprecated**    | `string`      | authored  | Retirement reason when no successor exists            |
+| Attribute         | Type               | Origin        | Description                                            |
+| ----------------- | ------------------ | ------------- | ------------------------------------------------------ |
+| **Id**            | `id` (ULID or URI) | see §Identity | Identity attribute, required                           |
+| **Labels**        | `tag-list`         | authored      | Free-form classification tags                          |
+| **References**    | `citation`         | authored      | Citations of referenced entries, with optional locator |
+| **External-id**   | `external-id`      | authored      | Identifier(s) in an external system                    |
+| **Supersedes**    | `id`               | authored      | `Id:` value of a same-shape entry this one replaces    |
+| **Superseded-by** | `id`               | generated     | Inverse of `Supersedes`                                |
+| **Deprecated**    | `string`           | authored      | Retirement reason when no successor exists             |
 
-Identity attributes (`Spec-id`, `Test-id`, `Element-id`, `Reference-id`) are
-structurally universal — every entry carries exactly one — but their name and
-value format depend on the family (see Parts 2–5).
+Profiles may declare additional attributes per shape or per type. They may not
+shadow `Id:`, which is the one core-reserved attribute name (ADR-009 §6).
 
-#### Retirement semantics
+### Identity
+
+Every entry carries exactly one `Id:` attribute. Its value is either:
+
+- a **ULID**: 26 characters of Crockford base32, pattern
+  `^[0-9A-HJKMNP-TV-Z]{26}$`. Identifies an **identified** entry.
+- a **URI**: any valid RFC 3986 URI with a scheme (`urn:`, `doi:`, `pkg:`,
+  `https:`, `isbn:`, etc.). Identifies a **referenced** entry.
+
+```text
+Id: 01HGW2P4KFR7ABCDEFGHJKMNPQ        # ULID → identified
+Id: urn:iso:std:iso:26262:-6:ed-2     # URI → referenced
+Id: pkg:cargo/serde@1.0.0             # URI (purl) → referenced
+Id: doi:10.1109/IEEESTD.2008.4610935  # URI → referenced
+```
+
+A bare slug (no scheme, not a ULID) is rejected as an `Id:` value. Slugs live in
+the display ID for referenced entries; they are not duplicated in `Id:`.
+
+**Assignment.** For identified entries, `markspec format` generates the ULID on
+creation and commits it to source. Once assigned, it never changes.
+
+**For referenced entries**, the URI is author-provided. MarkSpec does not invent
+URIs — it records the canonical external identifier the author knows the
+referenced work by.
+
+### Retirement semantics
 
 Entries can be **retired** — taken out of active use — in one of two
 structurally distinct ways:
 
 **Replacement-based retirement** — a successor entry carries
-`Supersedes: <predecessor-id>`. The predecessor automatically gains the
-generated inverse `Superseded-by: <successor-id>`. The presence of
+`Supersedes: <predecessor-id-value>`. The predecessor automatically gains the
+generated inverse `Superseded-by: <successor-id-value>`. The presence of
 `Superseded-by:` on an entry is the structural signal that it has been replaced.
 
 **Non-replacement retirement** — the entry carries
 `Deprecated: "<free-text reason>"`, e.g., "Feature cut from scope in v3.0" or
-"Based on a misunderstanding of FR-BRK-0012; see ADR-042 for context". This
-covers cases where no single successor exists (obsolete, factually wrong, scope
-cut, standard retracted).
+"Standard retracted; see ADR-042 for context". This covers cases where no single
+successor exists (obsolete, scope cut, standard retracted).
 
 An entry is considered **retired** when either signal is present:
 
@@ -172,26 +159,29 @@ The two are complementary, not mutually exclusive — a replacement may still
 carry a `Deprecated:` reason for additional context. Tooling treats any retired
 entry as a warning target for incoming links.
 
-#### Draft state
+**`Supersedes` operates within a shape**: an identified entry supersedes an
+identified entry; a referenced entry supersedes a referenced entry. The relation
+is intra-shape only. A successor may in turn be superseded, forming a chain.
+
+### Draft state
 
 The `DRAFT` label is a plain universal tag that marks an entry as "not yet
 authoritative". It does not belong to an exclusive group — it is a free-form
-label that happens to carry a well-known semantic when set:
+label that carries a well-known semantic when set:
 
 ```text
 Labels: DRAFT
 ```
 
-Entries without the `DRAFT` label and without any retirement signal are treated
-as **active and authoritative** (the implicit default). `DRAFT` exists to let
+Entries without `DRAFT` and without any retirement signal are treated as
+**active and authoritative** (the implicit default). `DRAFT` exists to let
 authors merge work-in-progress entries that should not yet be treated as
-canonical — for example, entries behind a feature flag, or entries in a branch
-pending review that has been merged for visibility but not for adoption.
+canonical.
 
-#### Link-resolution severity
+### Link-resolution severity
 
-Tooling emits severity-tiered diagnostics when a link attribute (`Satisfies:`,
-`Derived-from:`, `Verifies:`, `Realizes:`, …) targets a non-active entry:
+Tooling emits severity-tiered diagnostics when a link attribute targets a
+non-active entry:
 
 | Target state                                        | Severity |
 | --------------------------------------------------- | -------- |
@@ -200,17 +190,8 @@ Tooling emits severity-tiered diagnostics when a link attribute (`Satisfies:`,
 | Retired (`Superseded-by:` set OR `Deprecated:` set) | warning  |
 | Unresolved (entry does not exist)                   | error    |
 
-This replaces the legacy MSL-T013 check that targeted
-`Status: deprecated|withdrawn`. There is no separate `DEPRECATED` or `WITHDRAWN`
-label — retirement is expressed structurally through `Supersedes` or
-`Deprecated`.
-
-#### Supersedes semantics
-
-`Supersedes` expresses same-family replacement. The successor carries
-`Supersedes: <predecessor-id>`; the predecessor gains the generated inverse
-`Superseded-by: <successor-id>`. A test does not supersede a spec; the relation
-is intra-family only. A successor may in turn be superseded, forming a chain.
+Retirement is expressed structurally through `Supersedes` or `Deprecated`; there
+is no separate `DEPRECATED` / `WITHDRAWN` label.
 
 ### Entry properties (observed)
 
@@ -225,22 +206,18 @@ the tooling from observable sources:
 | `git`    | `git log`, `git blame` | `created_at`, `modified_at`, `contributors`, `revision` |
 | `sync`   | External connectors    | `last_synced_at`, `remote_state`, `external_source`     |
 | `build`  | The compilation step   | `resolution_source`, `registry_origin`                  |
+| `source` | Entry-source adapter   | `type`, `adapter`, `language`, `rule`, `extracted_at`   |
 
 The model exposes properties as a separate namespace alongside attributes —
-`entry.attributes` vs `entry.properties`. Inline references may reach into
-properties via `{{spec.X.modified_at}}` or similar, but the core language does
-not define attribute names like `Modified-at` at the entry level.
+`entry.attributes` vs `entry.properties`. The full property model — observation
+contracts, sync connector design, caching strategy, build-time provenance,
+entry-source provenance — is specified in
+[ADR-006 — Property Model](./adr-006-property-model.md) (as revised alongside
+ADR-009).
 
 **Design rule**: observed facts are properties; declared facts are attributes.
-If a piece of information is something the author _states_, it belongs in an
-attribute; if it is something the system _witnesses_, it belongs in a property.
-This prevents author-inference conflicts (the author cannot override a git
-commit timestamp, and the system cannot overwrite an authored `Deprecated:`
-reason).
-
-The full property model — observation contracts, sync connector design, caching
-strategy, build-time provenance — is deferred to
-[ADR-006 — Property Model](./adr-006-property-model.md).
+Identity lives in attributes; path, line, module name, and adapter metadata live
+in properties (see ADR-009 §4).
 
 ### Attribute value types
 
@@ -249,12 +226,12 @@ parser accepts and which form the formatter produces.
 
 | Type          | Cardinality | Multi-line repeat | CSV on one line | Description                                                 |
 | ------------- | ----------- | ----------------- | --------------- | ----------------------------------------------------------- |
-| `id`          | single      | —                 | —               | Display ID or slug                                          |
+| `id`          | single      | —                 | —               | Identity value (ULID) or URI, used by `Id:` and link attrs  |
 | `id-list`     | repeatable  | ✓                 | ✓               | Multiple identifiers                                        |
-| `uri`         | single      | —                 | —               | URI per RFC 3986 (URN, DOI, HTTPS URL)                      |
+| `uri`         | single      | —                 | —               | URI per RFC 3986 (URN, DOI, HTTPS URL, purl)                |
 | `url`         | single      | —                 | —               | HTTPS navigation link                                       |
 | `path`        | single      | —                 | —               | Filesystem path                                             |
-| `path-or-id`  | single      | —                 | —               | Filesystem path or element display ID                       |
+| `path-or-id`  | single      | —                 | —               | Filesystem path or identity value                           |
 | `enum`        | single      | —                 | —               | One value from a closed vocabulary                          |
 | `tag-list`    | repeatable  | ✓                 | ✓               | Free-form tags                                              |
 | `text`        | single      | —                 | —               | Free-form single-line text                                  |
@@ -271,8 +248,8 @@ For types marked repeatable, authors may use either form.
 **Multi-line repeat** follows the git-trailers convention:
 
 ```text
-Derived-from: SYS_BRK_0042
-Derived-from: SYS_BRK_0043
+Derived-from: 01HGW2R0NPQR4STVWXYZABCDEF
+Derived-from: 01HGW2S1PQRS5TVWXYZABCDEFG
 Labels: ASIL-B
 Labels: safety
 ```
@@ -280,7 +257,7 @@ Labels: safety
 **CSV on one line** is accepted when no value contains a comma:
 
 ```text
-Derived-from: SYS_BRK_0042, SYS_BRK_0043
+Derived-from: 01HGW2R0NPQR4STVWXYZABCDEF, 01HGW2S1PQRS5TVWXYZABCDEFG
 Labels: ASIL-B, safety
 ```
 
@@ -291,7 +268,7 @@ CSV is an accepted input but never a canonical output.
 #### CSV restriction
 
 CSV is forbidden for types whose values may contain commas. The `citation` type
-(used by `References`) permits free-text locators like `§9.4, Table 7`, which
+(used by `References:`) permits free-text locators like `§9.4, Table 7`, which
 would be ambiguous in CSV form. Citations must use multi-line:
 
 ```text
@@ -302,167 +279,104 @@ References: UNECE-R155
 
 #### Future types
 
-The following types are anticipated for profile use or future ADRs but are not
-defined by the core today: `purl` (Package URL, specialized `external-id`),
-`quantity` (number with unit, e.g. `150ms`), `version` (semver), `duration` (ISO
-8601 duration), `email`, `percentage`, `range`. Profiles may introduce these
-types and declare attributes that use them.
+The following types are anticipated for profile use but are not defined by the
+core today: `purl` (Package URL, specialized `external-id` / `uri`), `quantity`
+(number with unit), `version` (semver), `duration`, `email`, `percentage`,
+`range`. Profiles may introduce these types.
 
 ---
 
-## Part 2 — Spec Entries
+## Part 2 — Identified Entries
 
-A spec entry is a numbered, locally-authoritative declaration the project
-formulates: a requirement, an architecture block, a design decision, a hazard,
-an analysis. Anything the project creates, numbers, and treats as a normative or
-design artifact is a spec.
+An identified entry is a content unit the project authors and owns: a
+requirement, a test, a rule, a hazard, a component, a hardware part, a
+configuration key, a glossary term. Its identity is project-local and
+machine-generated (a ULID); its display ID is a human-readable alias chosen by
+the author (subject to profile constraints).
 
-**Tests are not specs** — they have their own family (Part 4).
+### Identity
 
-### Display ID format
-
-```text
-^[A-Z]{2,6}_[A-Z][A-Z0-9]{2,7}(_[A-Z][A-Z0-9]{2,7})?_\d{3,6}$
-```
-
-The display ID has three or four segments separated by underscores:
-
-- **TYPE** — 2 to 6 uppercase letters. Identifies the kind of object. Defined by
-  the loaded profile (e.g., STK, SRS, SAD, ICD in an automotive profile).
-- **DOMAIN** — 3 to 8 characters. Identifies a project subsystem or area (e.g.,
-  BRK for braking).
-- **SUBDOMAIN** — optional, same format as DOMAIN.
-- **NNNN** — 3 to 6 digits, numeric value ≥ 1. Sequence number within the scope.
-
-Examples: `SRS_BRK_0107`, `STK_BRK_0001`, `SAD_BRK_CTRL_0042`, `HAZ_VHC_00001`.
-
-### Numbering rule
-
-Numbering within a scope (`TYPE_DOMAIN` or `TYPE_DOMAIN_SUBDOMAIN`) is
-independent per scope. New entries are assigned the next available number.
-Padding is computed from the current maximum:
+Every identified entry carries `Id:` whose value is a bare ULID:
 
 ```text
-padding = max(3, len(str(N_max_in_scope)))
+Id: 01HGW2P4KFR7ABCDEFGHJKMNPQ
 ```
 
-Mixed padding (3 to 6 digits) is silently accepted within a scope. Existing
-entries are never renumbered. Display IDs are stable.
+The value is 26 characters in Crockford base32, pattern
+`^[0-9A-HJKMNP-TV-Z]{26}$`. The ULID is:
 
-### Subdomain consistency rule
+- **Assigned** by `markspec format` at creation; never hand-authored.
+- **Immutable** — once assigned, never changes.
+- **Unique** — globally unique across the project and its imported registries.
 
-Within a `TYPE_DOMAIN` scope, all entries must either use a subdomain
-consistently or not use one at all. A scope is either flat or subdivided, not
-both.
+The ULID is the stable identity. Display IDs are aliases (see §Display ID).
 
-### Identity attribute
+### Display ID
 
-Every spec entry carries a `Spec-id` attribute containing a bare ULID:
+An identified entry's display ID is a human-readable alias appearing in the
+`[DISPLAY_ID]` bracket. The core accepts any non-empty, project-unique string.
+Profiles may tighten by declaring **display-ID patterns** per type (ADR-009 §5,
+ADR-008 §6):
 
-```text
-Spec-id: 01HGW2P4KFR7ABCDEFGHJKMNPQ
+```yaml
+# Profile declaration
+types:
+  requirement:
+    display-id-pattern: "SPEC-{n:03d}" # SPEC-001, SPEC-042
+  test:
+    display-id-pattern: "TEST-{n:03d}"
+  unit:
+    display-id-pattern-enforcement: off # free-form symbolic IDs
 ```
 
-The value is 26 characters in Crockford base32, with no TYPE prefix. The family
-information is carried by the attribute name, not by a prefix in the value. This
-keeps the value format strictly aligned with the ULID specification and allows
-any standard ULID library to generate and validate it directly.
+Display IDs may be renumbered by tooling without changing the ULID. Refactoring
+a module, moving an entry between files, or renaming the display ID must never
+break a cross-reference — references resolve against the ULID.
 
-**Assignment**: set by `markspec format` on commit, never hand-authored.
-**Immutability**: once assigned, never changed. **Uniqueness**: globally unique
-across the registry chain.
+### Shape-specific universal attributes
 
-### Family-specific attributes
+Identified entries carry the universal attributes from Part 1 (`Id`, `Labels`,
+`References`, `External-id`, `Supersedes`, `Superseded-by`, `Deprecated`).
 
-| Attribute        | Type      | Origin   | Description                                                       |
-| ---------------- | --------- | -------- | ----------------------------------------------------------------- |
-| **Spec-id**      | `id`      | assigned | ULID, required                                                    |
-| **Derived-from** | `id-list` | authored | Upstream link to parent spec(s) via V-model decomposition         |
-| **Satisfies**    | `id-list` | authored | Upstream link to parent spec(s) this spec completely fulfills     |
-| **Allocated-to** | `id-list` | authored | Downstream link to element(s) responsible for realizing this spec |
+### Profile-declared type
 
-Spec entries also carry the universal attributes from Part 1 (`Labels`,
-`References`, `External-id`, `Supersedes`, `Deprecated`). Draft state is carried
-by the `DRAFT` label; retirement is expressed through `Supersedes` (replacement)
-or `Deprecated` (non-replacement). See §Retirement semantics.
+Every identified entry SHOULD carry a `type:` attribute declaring its type-name
+within the active profile's vocabulary. The core does not require `type:`;
+profiles that declare a `types:` vocabulary typically do. The `type:` value is
+validated against the profile's declared types.
 
-**Derived-from** expresses the relation by which a spec is produced from a
-parent spec, by decomposition, refinement, or partial realization. It is the
-**broad** spec-to-spec traceability link in MarkSpec, aligned with the ISO 26262
-vocabulary where requirements are _derived_ from parents in the V-model chain
-(Safety Goal → FSR → TSR → SSR → detailed design).
+Compliance profiles populate the type vocabulary richly:
 
-`Derived-from` covers the common case where a child spec contributes to a parent
-without necessarily fulfilling it on its own. Several children may be derived
-from the same parent, each addressing a different aspect of it.
+- An automotive ASPICE profile declares `type: requirement`,
+  `type: software-requirement`, `type: unit-test`,
+  `type: architectural-element`.
+- A medical-device IEC 62304 profile declares `type: risk`,
+  `type: software-item`, `type: verification-activity`.
+- A generic-document profile declares `type: requirement`, `type: note`,
+  `type: term` (see [ADR-010 — Default Profile](./adr-010-default-profile.md)).
 
-```text
-Derived-from: SYS_BRK_0042
-Derived-from: SYS_BRK_0043
+### Profile-declared attributes
+
+Traceability links, compliance attributes, kind enumerations, and any other
+domain-specific facts are declared by profiles on top of the identified shape.
+The core does not define `Derived-from`, `Verifies`, `Tests`, `Realizes`,
+`Allocated-to`, `Depends-on`, `Element-kind`, `Test-level`, or any similar
+attribute; they belong in the profile layer (ADR-008 §4 and §7).
+
+### Example — with a default-profile type
+
+```markdown
+- [SPEC-107] Sensor input debouncing
+
+  The sensor driver SHALL debounce raw inputs to eliminate electrical noise
+  before processing. The debounce window SHALL be configurable per sensor type.
+
+  Id: 01HGW2Q8MNP3RSTVWXYZABCDEF\
+  type: requirement\
+  Labels: sensor
 ```
 
-**Satisfies** expresses a stronger relation: the child spec **completely
-fulfills** its parent on its own. Where `Derived-from` captures decomposition
-(the child is a piece of the parent), `Satisfies` captures realization (the
-child is a self-sufficient answer to the parent).
-
-```text
-Satisfies: SYS_BRK_0042
-```
-
-The two attributes are **complementary**, not mutually exclusive. A spec may
-carry both when the parent is realized by a single child that is also a
-decomposition element of it.
-
-- Use **`Derived-from`** when several children collectively implement a parent —
-  the default case in V-model decomposition.
-- Use **`Satisfies`** when one child alone is sufficient to fulfill the parent.
-
-Profiles may restrict or refine these semantics.
-
-**Allocated-to** expresses **top-down architectural allocation** — the architect
-declares which Element(s) are responsible for realizing this Spec. The direction
-is opposite to `Realizes` on Element: where `Realizes` is bottom-up (the code
-declares what it implements), `Allocated-to` is top-down (the architect declares
-who must implement).
-
-```text
-Allocated-to: braking::controller
-Allocated-to: braking::controller::debounce_input
-```
-
-The two attributes are **complementary, not redundant**. They support two
-engineering modes that often coexist:
-
-- **Intentional architecture** — the architect allocates Specs to Elements
-  **before** the code exists. `Allocated-to` captures this decision at the
-  moment it is made, in the V-model design phase.
-- **Emergent design** — the developer declares `Realizes` on the code as it is
-  written.
-
-When both are present, tooling verifies consistency: a Spec allocated to Element
-A should be realized by Element A.
-
-`Allocated-to` aligns with the ASPICE 4.0 vocabulary, where **SWE.2 BP2** is
-explicitly named "**Allocate** software requirements".
-
-### Generated attributes
-
-| Attribute        | Description                                                                    |
-| ---------------- | ------------------------------------------------------------------------------ |
-| **Derives**      | Downstream inverse of `Derived-from`. Specs that derive from this one.         |
-| **Satisfied-by** | Downstream inverse of `Satisfies`. Specs that completely fulfill this one.     |
-| **Realized-by**  | Downstream inverse of `Realizes` on elements. Elements that realize this spec. |
-| **Verified-by**  | Downstream inverse of `Verifies` on tests. Tests that verify this spec.        |
-
-Generated attributes are never committed. They are build artifacts produced by
-tooling that walks the repository and collects upstream declarations from
-elements and tests. The traceability matrix is generated by inverting these
-declarations.
-
-### Example
-
-Standard software requirement:
+### Example — with a compliance-profile (ASPICE) type
 
 ```markdown
 - [SRS_BRK_0107] Sensor input debouncing
@@ -473,49 +387,28 @@ Standard software requirement:
   > [!WARNING]
   > Failure to debounce may lead to spurious brake activation.
 
-  Spec-id: 01HGW2Q8MNP3RSTVWXYZABCDEF\
-  Derived-from: SYS_BRK_0042\
+  Id: 01HGW2Q8MNP3RSTVWXYZABCDEF\
+  type: software-requirement\
+  Derived-from: 01HGW2R0NPQR4STVWXYZABCDEF\
   Labels: ASIL-B
 ```
 
-Normative stakeholder requirement mandated by a safety standard:
-
-```markdown
-- [STK_BRK_0042] Structural coverage at unit level
-
-  The project shall measure structural code coverage at the software unit level
-  for all production code, with decision coverage achieved for ASIL-D
-  components.
-
-  Spec-id: 01HGW2R0NPQR4STVWXYZABCDEF\
-  References: ISO-26262-6 §9.4.5\
-  References: ISO-26262-6 Table-12\
-  Labels: ASIL-D, coverage
-```
-
-Architecture block with top-down allocation:
-
-```markdown
-- [SAD_BRK_0003] Sensor filtering component
-
-  The sensor filtering component provides debouncing and range-checking for all
-  pressure sensor inputs to the braking subsystem.
-
-  Spec-id: 01HGW2S1PQRS5TVWXYZABCDEFG\
-  Derived-from: SRS_BRK_0107\
-  Allocated-to: braking_core::controller::sensor_filter\
-  Labels: ASIL-B
-```
+The two examples illustrate the same identified entry viewed under different
+profiles. The core entry model is identical; only the display-ID pattern,
+`type:` vocabulary, and profile-declared attributes (`Derived-from:`) differ.
 
 ---
 
-## Part 3 — Reference Entries
+## Part 3 — Referenced Entries
 
-A reference entry is a bibliographic citation of an external artifact: a
-standard, a regulation, a paper, a specification, a book. It names a work that
-exists outside the project.
+A referenced entry is a bibliographic citation of an external artifact: a
+standard, a regulation, a paper, a specification, a package (dependency), a
+hardware part. It names a work that exists outside the project.
 
-### Slug format
+### Slug (display ID)
+
+The display ID of a referenced entry is a **slug** — a stable project-local
+handle suitable for inline citation, matching pandoc/BibTeX cite-key convention:
 
 ```text
 ^[A-Za-z]([A-Za-z0-9._/-]*[A-Za-z0-9])?$
@@ -528,84 +421,93 @@ This format is a **disciplined subset** of the Pandoc citation key convention.
 MarkSpec excludes the wider range of Pandoc-allowed characters (`:`, `#`, `$`,
 etc.) to keep slugs readable and avoid collisions with other Markdown syntaxes.
 
-**Style recommendation**:
+**Style recommendation:**
 
 - Technical standards: uppercase with hyphens (`ISO-26262-6`, `DO-178C`).
 - Academic citations: lowercase with year suffix (`smith2021`).
 - Standards with hierarchical organization: slash-separated (`ISO/IEC-25010`,
   `ISO/IEC/IEEE-29148`).
+- Dependency packages: language/ecosystem convention (`serde`, `lodash`,
+  `commons-lang3`).
 
-**Pandoc inline citation compatibility** is preserved at the syntactic level:
-MarkSpec recognizes the Pandoc `[@key]` pattern in prose and resolves it through
-its registry chain.
-
-### Pandoc `@` compatibility
-
-Reference entries may be declared with or without a leading `@` in the display
-ID:
+**Pandoc `@` compatibility.** The leading `@` in a bracketed citation key is
+accepted syntactic sugar and stripped at parse time. These declarations are
+equivalent:
 
 ```markdown
 - [@ISO-26262-6] ISO 26262 Part 6
-```
-
-or equivalently:
-
-```markdown
 - [ISO-26262-6] ISO 26262 Part 6
 ```
 
-Both declare a reference with slug `ISO-26262-6`. The `@` is optional syntax,
-stripped during parsing. The canonical slug never contains `@`.
+Inline prose citations `[@key]` resolve to the matching referenced entry.
 
-### Identity attribute
+### Identity
 
-Every reference entry carries a `Reference-id` attribute containing a URI:
+Every referenced entry carries `Id:` whose value is a **URI** (RFC 3986, scheme
+required):
 
 ```text
-Reference-id: urn:iso:std:iso:26262:-6:ed-2
+Id: urn:iso:std:iso:26262:-6:ed-2
+Id: doi:10.1109/IEEESTD.2008.4610935
+Id: https://www.rfc-editor.org/rfc/rfc2119
+Id: pkg:cargo/serde@1.0.0
+Id: isbn:9780132350884
 ```
 
-Unlike specs, tests, and elements, the `Reference-id` is **author-provided**,
-not tooling-generated. It is the canonical identifier of the external work in
-its most stable form:
+Unlike identified entries, the URI is **author-provided**, not
+tooling-generated. It is the canonical identifier of the external work in its
+most stable form.
 
-- **Preferred** — URN: `urn:iso:std:iso:26262:-6:ed-2`, `urn:ietf:rfc:2119`
-- **Preferred** — DOI: `doi:10.1109/IEEESTD.2008.4610935`
-- **Accepted** — HTTPS URL of the authoritative source, when no URN or DOI is
-  available
+Preferred forms, in descending order of stability:
 
-All three forms are valid URIs per RFC 3986.
+- **URN** — `urn:iso:std:iso:26262:-6:ed-2`, `urn:ietf:rfc:2119`
+- **DOI** — `doi:10.1109/IEEESTD.2008.4610935`
+- **purl** (for packages) — `pkg:cargo/serde@1.0.0`
+- **ISBN** — `isbn:9780132350884`
+- **HTTPS URL** — when no authoritative identifier exists
 
-### No ULID for references
+All are valid URIs per RFC 3986.
 
-Reference entries do not carry an ULID. The slug is the canonical local
-identifier, and the `Reference-id` is the canonical external identifier.
+### No ULID for referenced entries
+
+Referenced entries do not carry ULIDs. The slug (display ID) is the
+project-local stable identifier, and the `Id:` URI is the canonical external
+identifier. Attempting to use a ULID as a referenced entry's `Id:` is a
+validation error — format discrimination would classify the entry as identified
+instead.
 
 ### Body is optional
 
-Unlike specs, tests, and elements, a reference entry's body is optional.
+Unlike identified entries, a referenced entry's body is optional. A minimal
+referenced entry contains only a display ID, a title, and the `Id:` URI.
 
-### Family-specific attributes
+### Shape-specific universal attributes
 
-| Attribute              | Type   | Origin   | Description                                                    |
-| ---------------------- | ------ | -------- | -------------------------------------------------------------- |
-| **Reference-id**       | `uri`  | authored | URI, required                                                  |
-| **Reference-url**      | `url`  | authored | HTTPS navigation link when different from `Reference-id`       |
-| **Reference-document** | `text` | authored | Canonical document identifier; falls back to title when absent |
+Referenced entries carry the universal attributes from Part 1 (`Id`, `Labels`,
+`External-id`, `Supersedes`, `Superseded-by`, `Deprecated`). `References:` is
+**not applicable** to referenced entries — a referenced entry does not itself
+cite other referenced entries via the `References:` attribute. (Profiles may
+declare relation attributes that cross between referenced entries if needed, but
+the universal `References:` attribute is for entries citing external works, not
+for external works citing each other.)
 
-Reference entries also carry the universal attributes from Part 1 (`Labels`,
-`External-id`, `Supersedes`, `Deprecated`). Draft state is carried by the
-`DRAFT` label; retirement is expressed through `Supersedes` (replacement by a
-new standard) or `Deprecated` (standard retracted with no successor).
-`Supersedes` replaces the previous Reference-only `Superseded-by` attribute; the
-generated inverse is still `Superseded-by`. `References` is not applicable to
-Reference entries (a reference entry does not itself cite other references via
-the `References` attribute).
+### Navigation and document metadata
+
+Two profile-declaring-friendly attributes are conventionally carried by
+referenced entries:
+
+- `Reference-url:` (optional) — HTTPS navigation link when different from the
+  canonical `Id:` URI. A `urn:` or `doi:` value is authoritative but may not be
+  directly clickable.
+- `Reference-document:` (optional) — canonical document identifier used for
+  display when the title is not enough (e.g., `ISO 26262-6:2018`).
+
+These are not core-reserved; the default profile (ADR-010) declares them.
 
 ### Section locators in citations
 
-When a spec, test, or element cites a reference via the `References` attribute,
-the value may include a free-text locator after the slug:
+When an entry cites a referenced entry via the `References:` attribute, the
+value may include a free-text locator after the slug:
 
 ```text
 References: ISO-26262-6 §9.4.5
@@ -615,13 +517,7 @@ References: IEC-61508-3 Table A.5
 The tooling extracts the leading token as the reference slug; the trailing
 locator is preserved verbatim for display and is not validated.
 
-### Generated attributes
-
-| Attribute    | Description                                                                             |
-| ------------ | --------------------------------------------------------------------------------------- |
-| **Cited-by** | Downstream inverse of `References`. Specs, tests, or elements that cite this reference. |
-
-### Example
+### Example — normative standard
 
 ```markdown
 - [@ISO-26262-6] ISO 26262 Part 6
@@ -630,843 +526,292 @@ locator is preserved verbatim for display and is not validated.
   requirements for software unit design, implementation, and verification across
   ASIL levels A through D.
 
-  Reference-id: urn:iso:std:iso:26262:-6:ed-2\
+  Id: urn:iso:std:iso:26262:-6:ed-2\
   Reference-url: https://www.iso.org/standard/68383.html\
   Reference-document: ISO 26262-6:2018\
   Labels: functional-safety, automotive
 ```
 
----
-
-## Part 4 — Test Entries
-
-A test entry is a verification of declared behavior. Tests are distinct from
-specs because they combine two roles: they **specify** what must be verified
-(under what conditions, with what pass/fail criteria), and they are **executed**
-— either automatically (a `#[test]` function that runs and produces results) or
-manually (a test procedure followed by a human on a vehicle, a HIL bench, or a
-prototype).
-
-This dual nature — specification and executable lifecycle — motivates a
-dedicated family. It also aligns structurally with every safety-critical
-standard, where test artifacts are distinct work products with their own
-traceability requirements (ASPICE SWE.4 BP5, DO-178C §6.4, IEC 62304 §5.5, EN
-50128 §6.5).
-
-### Display ID format
-
-Tests use the same display ID format as specs:
-
-```text
-^[A-Z]{2,6}_[A-Z][A-Z0-9]{2,7}(_[A-Z][A-Z0-9]{2,7})?_\d{3,6}$
-```
-
-The TYPE prefix identifies the kind of test (e.g., `SWT`, `SIT`, `VAL` in common
-automotive conventions, or `UT`, `IT`, `ST`, `AT` in generic usage). **No TYPE
-prefix is prescribed by the core** — profiles define their own conventions, and
-each project may use any TYPE it wishes.
-
-Examples: `SWT_BRK_0107`, `SIT_BRK_0042`, `VAL_VHC_0001`, `UT_BRK_0107`.
-
-### Identity attribute
-
-Every test entry carries a `Test-id` attribute containing a bare ULID:
-
-```text
-Test-id: 01HGW3R9QNP4ABCDEFGHJKMNPQ
-```
-
-Same format as `Spec-id` and `Element-id`: 26 characters in Crockford base32, no
-TYPE prefix.
-
-**Assignment**: set by `markspec format`, never hand-authored. **Immutability**:
-once assigned, never changed. **Uniqueness**: globally unique across the
-registry chain.
-
-### Family-specific attributes
-
-| Attribute      | Type      | Origin   | Description                                     |
-| -------------- | --------- | -------- | ----------------------------------------------- |
-| **Test-id**    | `id`      | assigned | ULID, required                                  |
-| **Test-level** | `enum`    | inferred | Test level in the V-model hierarchy             |
-| **Verifies**   | `id-list` | authored | Upstream link to spec(s) this test verifies     |
-| **Tests**      | `id-list` | authored | Upstream link to element(s) this test exercises |
-
-Test entries also carry the universal attributes from Part 1 (`Labels`,
-`References`, `External-id`, `Supersedes`, `Deprecated`). Draft state is carried
-by the `DRAFT` label; retirement is expressed through `Supersedes` (replacement)
-or `Deprecated` (non-replacement). See §Retirement semantics.
-
-Filesystem location (source path of an automated test) is a **property**, not an
-attribute — see Part 1 "Entry properties" and ADR-006.
-
-### Test-level vocabulary
-
-The core `Test-level` vocabulary follows the universal V-model terminology
-established by ISO/IEC/IEEE 29119 and adopted across every safety-critical
-standard:
-
-| Level         | Description                                                                           |
-| ------------- | ------------------------------------------------------------------------------------- |
-| `unit`        | Verifies a single code unit in isolation against its detailed design or specification |
-| `integration` | Verifies interactions between multiple units or components                            |
-| `system`      | Verifies the integrated system against its system requirements                        |
-| `acceptance`  | Validates the system against stakeholder needs                                        |
-
-`Test-level` is **optional at the core**. A test without `Test-level` is
-structurally valid. Profiles may make it mandatory.
-
-The core vocabulary is **extensible by profile** — a profile may add
-domain-specific levels (e.g., hardware/software integration, penetration test,
-smoke test) or refine distinctions within the base levels.
-
-### Profile mapping examples
-
-The following table illustrates how different industry standards map their test
-activities to the core `Test-level` vocabulary. The activity names are those
-defined by each standard's reference model; **the TYPE prefixes used in display
-IDs are not prescribed by MarkSpec** — each profile or project defines its own
-conventions.
-
-| Core Level    | ASPICE 4.0                                             | DO-178C                             | IEC 62304                         | ISO/IEC/IEEE 29119     |
-| ------------- | ------------------------------------------------------ | ----------------------------------- | --------------------------------- | ---------------------- |
-| `unit`        | SWE.4 Software Unit Verification                       | §6.4.2.1 Low-level testing          | §5.5 Software unit verification   | Unit test level        |
-| `integration` | SWE.5 Software Component Verification and Integration  | §6.4.2.2-3 Integration testing      | §5.6 Software integration testing | Integration test level |
-| `system`      | SWE.6 Software Verification, SYS.5 System Verification | (covered within integration/system) | §5.7 Software system testing      | System test level      |
-| `acceptance`  | VAL.1 Validation                                       | (covered by ARP4754A)               | (covered by IEC 82304-1)          | Acceptance test level  |
-
-### Test-level inference from TYPE
-
-When a profile is loaded, `Test-level` may be **inferred** from the TYPE prefix
-of the display ID. The profile declares the mapping. For example, a profile
-configured with `SWT → unit`, `SIT → integration`, `SQT → system`,
-`VAL → acceptance` allows the tooling to pre-fill `Test-level` during
-`markspec format` based on the display ID's TYPE prefix.
-
-Inferred `Test-level` values are committed to the repository and
-author-overridable when the inference does not fit. Without a profile loaded,
-the TYPE prefix is opaque to the core — the author declares `Test-level`
-explicitly if needed.
-
-### Verifies
-
-`Verifies` expresses the upstream link from a test to the spec(s) it verifies.
-This is the core ASPICE SWE.4 BP5 traceability link between test and
-requirement.
-
-```text
-Verifies: SRS_BRK_0107
-```
-
-`Verifies` is **repeatable**. A test may verify multiple specs (common for
-integration or system tests that cover several requirements).
-
-### Tests
-
-`Tests` expresses the upstream link from a test to the element(s) it exercises.
-This is the other half of ASPICE SWE.4 BP5 — the link between test case and
-software unit.
-
-```text
-Tests: braking_core::controller::debounce_input
-```
-
-`Tests` is **repeatable**. A test may exercise multiple elements (common for
-integration and system tests). The attribute is optional at the core — profiles
-may make it mandatory for specific Levels (e.g., ASPICE imposes `Tests` on
-unit-level tests).
-
-Together, `Verifies` and `Tests` close the bidirectional traceability loop
-required by SWE.4 BP5:
-
-- **Test ↔ requirement** via `Verifies` (and generated `Verified-by`)
-- **Test ↔ unit** via `Tests` (and generated `Tested-by`)
-
-### Two modes: automated and manual
-
-**Automated test** — declared in code as a `#[test]` function (Rust), `@Test`
-method (Java/Kotlin), pytest function (Python), or equivalent. MarkSpec extracts
-the test entry from the code; the source-file path is observable as the `file`
-property (see Part 1 "Entry properties"). The test's behavior is encoded in the
-function body; the MarkSpec entry captures the traceability metadata.
-
-**Manual test** — declared as a standalone Markdown entry, typically in a
-dedicated document. No code, no file property for the test body (only for the
-Markdown location), no inferable attributes.
-
-### Generated attributes
-
-| Attribute       | Lives on | Description                                                           |
-| --------------- | -------- | --------------------------------------------------------------------- |
-| **Verified-by** | Spec     | Downstream inverse of Test.`Verifies`. Tests that verify this spec.   |
-| **Tested-by**   | Element  | Downstream inverse of Test.`Tests`. Tests that exercise this element. |
-
-Tests themselves do not carry generated inverse attributes in the core — a test
-is an endpoint in the traceability graph, not an intermediate node. Profiles may
-add generated attributes (e.g., `Last-result`, `Coverage-summary`) sourced from
-CI test runs.
-
-### Example — automotive unit test (automated, in-code)
-
-Authoring convention using doc comment per ADR-001:
-
-```rust
-/// [SWT_BRK_0107] Debounce unit test
-///
-/// Given a debounce window of 10ms and a stable reading of 500,
-/// when a noise spike of 999 occurs for 5ms (shorter than window),
-/// the output shall remain at 500.
-///
-/// Test-id: 01HGW3R9QNP4ABCDEFGHJKMNPQ
-/// Test-level: unit
-/// Verifies: SRS_BRK_0107
-/// Tests: braking_core::controller::debounce_input
-/// Labels: automated, rust, ASIL-B
-#[test]
-fn swt_brk_0107_debounce_filters_noise() {
-    let window = Duration::from_millis(10);
-    let output = debounce_input_with_history(&[500, 500, 999], window);
-    assert_eq!(output, 500);
-}
-```
-
-The doc comment declares the Test entry; the function body is the executable
-artifact. The file path is observable as the `file.path` property; no attribute
-duplication in the source.
-
-_Note: The TYPE prefix `SWT` is an industrial convention for "Software unit
-Test" common in automotive contexts; it is not prescribed by MarkSpec. ASPICE,
-DO-178C, IEC 62304, and EN 50128 do not define formal abbreviations for test
-types — each profile or project defines its own._
-
-### Example — generic integration test
-
-For projects using a generic profile with neutral TYPE conventions
-(UT/IT/ST/AT):
+### Example — dependency (purl)
 
 ```markdown
-- [IT_BRK_0023] Braking subsystem integration test
+- [serde] serde Rust serialization framework
 
-  Verifies that the sensor filter and brake controller interact correctly across
-  the full pressure range.
-
-  Test-id: 01HGW3T3QRST6VWXYZABCDEFGH\
-  Test-level: integration\
-  Verifies: SRS_BRK_0107\
-  Verifies: SRS_BRK_0108\
-  Tests: braking_core::controller\
-  Tests: braking_core::sensor_filter\
-  Labels: automated, rust
+  Id: pkg:cargo/serde@1.0.0\
+  License: Apache-2.0 OR MIT
 ```
 
-### Example — manual validation test
+A dependency entry is a referenced entry whose `Id:` is a Package URL (purl).
+Compliance profiles (medical device, automotive) can additionally attach SOUP /
+risk / verification attributes to dependency entries; see ADR-011.
+
+### Example — RFC
 
 ```markdown
-- [VAL_VHC_0042] Emergency braking acceptance test
+- [RFC-2119] Key words for use in RFCs
 
-  Procedure:
-
-  1. Drive vehicle at 80 km/h on a dry asphalt track.
-  2. Approach a stationary obstacle positioned 100 m ahead.
-  3. Do not brake manually.
-  4. Observe AEB system activation.
-
-  Pass criteria:
-
-  - AEB detects obstacle within 100 ms of lateral alignment.
-  - Full braking force achieved within 150 ms of detection.
-  - Vehicle stops at least 2 m before the obstacle.
-
-  Test-id: 01HGW3V4RSTW7VWXYZABCDEFGH\
-  Test-level: acceptance\
-  Verifies: STK_BRK_0001\
-  Labels: manual, hil, ASIL-D
+  Id: doi:10.17487/RFC2119\
+  Reference-url: https://www.rfc-editor.org/rfc/rfc2119
 ```
-
-No `Tests` (the procedure exercises the entire vehicle integration, not a
-specific element).
 
 ---
 
-## Part 5 — Element Entries
+## Part 4 — Shape Discrimination
 
-An element entry is a canonical declaration of a system object with stable
-semantic identity: a software component, a code unit, a file, an interface, a
-hardware part, a product, a configuration key. Elements are the nouns of the
-system — entities with material existence, either produced by the project or
-consumed from outside.
+The shape of an entry is determined by the **value format** of its `Id:`
+attribute. An entry has exactly one `Id:`.
 
-### Display ID format
+### Discrimination rule
 
 ```text
-^(::)?[A-Za-z]([A-Za-z0-9._/-]*[A-Za-z0-9])?(::[A-Za-z]([A-Za-z0-9._/-]*[A-Za-z0-9])?)*$
-```
-
-The display ID is composed of one or more **segments** separated by the
-**hierarchy separator** `::`. An optional leading `::` marks the path as
-absolute from the element root.
-
-### Character categories
-
-**Hierarchy separator** — `::`
-
-The only separator that marks a level boundary in the element namespace.
-
-**Technical segment characters** — `.` and `/`
-
-Appear inside a segment, carry technical meaning in the external world:
-
-- `.` — file extensions (`controller.rs`), versions (`aspice-4.0`), dereference
-  (`Class.method`)
-- `/` — filesystem paths (`src/braking/controller.rs`), URL paths
-
-**Semantic segment characters** — `-` and `_`
-
-Readable word connectors inside a segment: `ecu-sensor`, `debounce_input`.
-
-### Segment rules
-
-A segment starts with a letter, ends with an alphanumeric (never with
-punctuation), and contains alphanumerics, `.`, `/`, `_`, `-` in the middle.
-
-### Absolute path convention
-
-The leading `::` marks an absolute path from the element root:
-
-```text
-::braking::debounce_input
-::vehicle::braking::ecu-sensor
-```
-
-Semantically, `::braking::debounce_input` is equivalent to
-`braking::debounce_input`. The canonical form in the model strips the leading
-`::`.
-
-### Identity attribute
-
-Every element entry carries an `Element-id` attribute containing a bare ULID:
-
-```text
-Element-id: 01HGW2R9QNP4ABCDEFGHJKMNPQ
-```
-
-26 characters in Crockford base32, no TYPE prefix.
-
-**Assignment**: set by `markspec format`, never hand-authored. **Immutability**:
-once assigned, never changed. **Uniqueness**: globally unique across the
-registry chain.
-
-The `Element-id` provides the stable internal identity that survives display ID
-renames, whether the rename originates from within MarkSpec or from an external
-system (Codebeamer, DOORS, PLM).
-
-### Family-specific attributes
-
-| Attribute          | Type         | Origin   | Description                                                  |
-| ------------------ | ------------ | -------- | ------------------------------------------------------------ |
-| **Element-id**     | `id`         | assigned | ULID, required                                               |
-| **Element-kind**   | `enum`       | inferred | Element kind from the core vocabulary or a profile           |
-| **Part-of**        | `id`         | inferred | Containment link to a parent element (from namespace)        |
-| **Realizes**       | `id-list`    | authored | Upstream link to spec(s) this element realizes               |
-| **Depends-on**     | `id-list`    | authored | Upstream link to element(s) this element uses                |
-| **Generated-from** | `path-or-id` | authored | Path or element this element was generated from (repeatable) |
-
-Element entries also carry the universal attributes from Part 1 (`Labels`,
-`References`, `External-id`, `Supersedes`, `Deprecated`). Draft state is carried
-by the `DRAFT` label; retirement is expressed through `Supersedes` (replacement)
-or `Deprecated` (non-replacement). See §Retirement semantics.
-
-Filesystem location of a code unit is a **property**, not an attribute — see
-Part 1 "Entry properties" and ADR-006.
-
-Note that Element **no longer carries** `Verifies`, `Tests`, or `Role` — these
-attributes moved to the Test family (`Verifies`, `Tests`) or were dropped
-(`Role`) as part of the four-family refactor.
-
-**Part-of** expresses the containment hierarchy at the semantic level. The
-inference rule strips the last segment from the display ID (`foo::bar::baz` →
-`Part-of: foo::bar`). This is a heuristic: authors frequently override it when a
-code unit belongs to a crate or artifact rather than to its lexical parent
-(e.g., `braking_core::controller::debounce_input` is `Part-of: braking-core`,
-not `Part-of: braking_core::controller`).
-
-**Realizes** — upstream link to one or more specs that this element realizes.
-Used for production code that fulfills requirements:
-
-```text
-Realizes: SRS_BRK_0107
-Realizes: SRS_BRK_0108
-```
-
-`Realizes` applies to any element kind — not only code units. An
-architecture-level element (a component, an artifact) may `Realizes` a spec to
-capture top-down allocation at the architectural level, even before detailed
-code exists.
-
-**Depends-on** — upstream link to one or more elements that this element uses
-(function call, import, library dependency, interface contract). Used for
-explicit dependency declaration, particularly for SoUP (Software of Unknown
-Provenance).
-
-```text
-Depends-on: zlib
-Depends-on: braking::sensors::pressure
-```
-
-`Depends-on` is **author-declared** for significant dependencies (especially
-SoUP). Tooling may suggest values from static analysis, but the attribute is
-authored — not inferred — because dependency declarations have policy
-significance (SoUP acknowledgement, license compliance) that requires explicit
-author intent.
-
-**Generated-from** — upstream link to the source from which this element was
-generated. Important for ISO 26262 Tool Confidence Level analysis.
-
-```text
-Generated-from: schemas/can_messages.dbc
-Generated-from: schemas::can::dbc
-```
-
-### Element-kind vocabulary
-
-| Kind           | Description                               | Typical correspondences                                 |
-| -------------- | ----------------------------------------- | ------------------------------------------------------- |
-| **item**       | Repository or top-level project           | git repo, SVN project root                              |
-| **artifact**   | Unit of build produced by the project     | Rust crate, C/C++ executable or library, jar, package   |
-| **dependency** | External artifact consumed by the project | zlib, OpenSSL, third-party crates, maven dependencies   |
-| **unit**       | Atomic named declaration in source code   | function, method, class, struct, enum, trait, procedure |
-
-The distinction between **`artifact`** and **`dependency`** is structural: an
-`artifact` is something the project **produces** from its own source code; a
-`dependency` is something the project **consumes** from outside.
-`Element-kind: dependency` is the canonical way to declare SoUP usage.
-
-Profiles may extend the `Element-kind` vocabulary with domain-specific values
-(automotive: `ecu`, `sensor`, `actuator`; aerospace: `lrm`, `csci`; medical:
-`software-system`, `software-item`).
-
-**`unit` is uniformly function-level** — the smallest separately executable and
-testable entity, per ASPICE definition. This is independent of language
-conventions: a Rust `mod tests` is a syntactic grouping, not an ASPICE unit.
-Each function is its own testable entity.
-
-### Automatic inference of Element-kind
-
-When `markspec format` parses source code, it infers `Element-kind`:
-
-- Doc comment on a function, method, class, struct, enum → `Element-kind: unit`
-- Doc comment on `Cargo.toml`, `pom.xml`, build descriptor →
-  `Element-kind: artifact`
-- Entry in dependencies section → `Element-kind: dependency`
-- Doc comment on repository root README → `Element-kind: item`
-
-### Generated attributes
-
-| Attribute     | Description                                                                     |
-| ------------- | ------------------------------------------------------------------------------- |
-| **Contains**  | Downstream inverse of `Part-of`. Children of this element.                      |
-| **Used-by**   | Downstream inverse of `Depends-on`. Elements that use this one.                 |
-| **Allocated** | Downstream inverse of `Allocated-to` on specs. Specs allocated to this element. |
-| **Tested-by** | Downstream inverse of `Tests` on tests. Tests that exercise this element.       |
-
-### Examples
-
-**Item** — repository root:
-
-```markdown
-- [github.com/driftsys/braking] DriftSys braking system
-
-  Main repository for the DriftSys open-source braking system.
-
-  Element-id: 01HGW3A0MNPQ4FGHJKMNPQRSTV\
-  Element-kind: item\
-  Labels: automotive, open-source
-```
-
-**Artifact** — a Rust crate:
-
-```markdown
-- [braking-core] Braking core crate
-
-  Core logic for brake pressure calculation and sensor filtering.
-
-  Element-id: 01HGW3B2NPQR5GHJKMNPQRSTVW\
-  Element-kind: artifact\
-  Part-of: github.com/driftsys/braking\
-  Labels: rust, ASIL-B
-```
-
-**Unit** — a production function:
-
-```markdown
-- [braking_core::controller::debounce_input] Debounce function
-
-  Rejects transient noise on raw sensor readings using a configurable window.
-
-  Element-id: 01HGW3D6QRST7JKMNPQRSTVWXY\
-  Element-kind: unit\
-  Part-of: braking-core\
-  Realizes: SRS_BRK_0107\
-  Labels: rust, ASIL-B
-```
-
-The `Realizes: SRS_BRK_0107` declares this unit as the realization of that
-requirement. Tests of this unit are declared as Test entries (Part 4) with
-`Tests: braking_core::controller::debounce_input`.
-
-**Generated unit** — code produced by a build step:
-
-```markdown
-- [braking_core::bindings::can_frames] CAN frame bindings
-
-  Auto-generated Rust bindings for CAN message layouts.
-
-  Element-id: 01HGW3G2VWXY9JKMNPQRSTVWXY\
-  Element-kind: unit\
-  Part-of: braking-core\
-  Generated-from: schemas/can_messages.dbc\
-  Labels: rust
-```
-
-**Dependency** — SoUP third-party library:
-
-```markdown
-- [zlib] zlib compression library
-
-  Third-party compression library. SoUP — not qualified to ASIL standards. Used
-  in non-safety-critical paths only.
-
-  Element-id: 01HGW3M0NPQR5GHJKMNPQRSTVW\
-  Element-kind: dependency\
-  External-id: pkg:generic/zlib@1.2.13\
-  Labels: soup, third-party
-```
-
-**Hardware element** — declared manually:
-
-```markdown
-- [BRK-ECU-SENSOR] Brake ECU pressure sensor
-
-  Front brake pressure sensor connected via CAN to the ECU.
-
-  Element-id: 01HGW2R9QNP4ABCDEFGHJKMNPQ\
-  Labels: hardware, automotive
-```
-
-Hardware elements typically do not carry a core `Element-kind` (the core kinds
-describe code). A profile may add hardware kinds (`ecu`, `sensor`, `actuator`).
-
----
-
-## Part 6 — Family Recognition
-
-The family of an entry is determined by the **identity attribute** it carries in
-its trailers. An entry has exactly one of `Spec-id`, `Test-id`, `Element-id`, or
-`Reference-id`.
-
-### Validation rule
-
-```text
-if entry has Spec-id      → spec
-if entry has Test-id      → test
-if entry has Element-id   → element
-if entry has Reference-id → reference
+if Id matches ULID regex (^[0-9A-HJKMNP-TV-Z]{26}$)  → identified
+if Id is a scheme-qualified URI (RFC 3986)            → referenced
+otherwise                                             → validation error
 ```
 
 Properties:
 
-- **Disjoint**: the four attributes are mutually exclusive. An entry carrying
-  two is invalid.
-- **Complete**: every entry must carry exactly one identity attribute. An entry
-  without any is invalid.
-- **Independent of display ID format**: family is decided by attribute name, not
-  regex matching.
-- **Independent of document context**: family is intrinsic to the entry, not
+- **Disjoint**: ULIDs and URIs do not overlap. A ULID has no scheme; a URI
+  requires a scheme. No value matches both.
+- **Complete**: every well-formed `Id:` value is either a ULID or a URI; the two
+  exhaust the accepted formats.
+- **Independent of display ID**: shape is decided by the `Id:` value, not by the
+  display-ID format.
+- **Independent of document context**: shape is intrinsic to the entry, not
   dependent on which document it appears in.
+- **Independent of profile**: shape resolution completes without consulting any
+  profile. Core-only mode (ADR-009 §10) operates on this rule alone.
 
 ### Classification rule for new entries
 
-When an author writes a new entry without yet specifying an identity attribute,
-`markspec format` uses a classification heuristic:
+When an author writes a new entry without yet specifying `Id:`,
+`markspec format` uses a heuristic to decide whether to mint a ULID or prompt
+for a URI:
 
-1. **If the display ID matches the element format** (contains `::` or `/`) —
-   assign `Element-id` and generate a new ULID.
-2. **Otherwise, if the display ID matches the spec/test format**
-   (TYPE_DOMAIN_NNNN) — consult the document directive (see Part 7) and the
-   loaded profile:
-   - If the profile maps the TYPE to a test → assign `Test-id`.
-   - Otherwise → assign `Spec-id`.
-3. **Otherwise, use the document directive**:
-   - `markspec:references` or filename `references.md` — assign `Reference-id`
-     and prompt for the URI value.
-   - `markspec:tests` or filename `tests.md` — assign `Test-id`.
-   - `markspec:elements` or filename `elements.md` — assign `Element-id`.
-   - Otherwise — the display ID is ambiguous; flag as an error.
+1. If the display ID matches the slug pattern and the enclosing document's
+   `contains:` profile metadata lists only referenced types → prompt for a URI
+   and assign `Id:` once provided.
+2. Otherwise → mint a ULID and assign `Id:` (identified entry by default).
 
-This heuristic is used only for **initial classification**. Once the identity
-attribute is assigned, the family is fixed by the attribute.
+The heuristic is used only for **initial classification**. Once `Id:` is
+assigned, the shape is fixed by the value's format.
 
 ### Post-assignment consistency
 
-After the identity attribute is assigned, the linter verifies:
+After `Id:` is assigned, the linter verifies:
 
-- The display ID matches the format of the assigned family.
-- No other identity attribute is present.
-- The entry satisfies its family's required attributes.
+- The `Id:` value is well-formed (ULID or URI).
+- The display ID matches the shape's format (slug for referenced, free-form for
+  identified unless constrained by profile).
+- The entry satisfies its type's required attributes (if `type:` is declared and
+  the profile makes them required).
 
 ---
 
-## Part 7 — Document Type Directives
+## Part 5 — Document Type Directives
 
 Document directives are **optional hints** used by `markspec format` to classify
-new entries that do not yet have an identity attribute, and by the linter to
-warn about organizational conventions.
+new entries that do not yet have an `Id:` attribute, and by the linter to warn
+about organizational conventions.
 
 ### Directives
 
-- `<!-- markspec:specs -->` — suggests specs (explicit, same as unmarked)
-- `<!-- markspec:tests -->` — suggests tests
-- `<!-- markspec:elements -->` — suggests elements
-- `<!-- markspec:references -->` — suggests references
+Directives are HTML comments at the top of a Markdown file. The core does not
+bake in a fixed directive set; profiles declare which directives map to which
+entry types. Common conventions:
+
+- `<!-- markspec:requirements -->` — suggests identified entries of type
+  `requirement` (or similar normative type in the active profile).
+- `<!-- markspec:tests -->` — suggests identified entries of type `test`.
+- `<!-- markspec:references -->` — suggests referenced entries.
+- `<!-- markspec:glossary -->` — suggests identified entries of type `term`.
 
 ### Filename conventions
 
-Filenames also act as directives:
+Filenames may also act as directives when a profile declares them to do so. The
+default profile (ADR-010) ships these conventions out of the box:
 
-- `tests.md` at any path → equivalent to `markspec:tests`
-- `elements.md` at any path → equivalent to `markspec:elements`
-- `references.md` at any path → equivalent to `markspec:references`
-- Any other filename → equivalent to `markspec:specs`
+- `references.md` at any path → equivalent to `markspec:references`.
+- `glossary.md` at any path → equivalent to `markspec:glossary`.
+- Any other filename → no directive.
 
 An explicit directive overrides the filename convention.
 
 ### Linter warnings
 
-The linter may emit style warnings when entries of a family appear in a document
-whose directive suggests a different family. These are style warnings, not
-errors — the family of an entry is decided by its identity attribute, not by the
+The linter may emit style warnings when entries of a shape or type appear in a
+document whose directive suggests a different type. These are style warnings,
+not errors — the shape of an entry is decided by its `Id:` value, not by the
 document it lives in.
 
 ### Recommended style
 
-Single-family documents are the recommended style. Group references in dedicated
-reference documents, tests in dedicated test documents (or in source code as doc
-comments), elements in dedicated element documents, specs everywhere else.
+Single-shape documents are the recommended style. Group references in dedicated
+reference documents, group authored content by type where practical. A mixed
+document (notes, requirements, references all side by side) is valid but harder
+to navigate.
 
 ---
 
 ## Consequences
 
-### Core stays minimal, families stay focused
+### Core stays minimal; profiles carry vocabulary
 
-Promoting Test to its own family simplifies each family:
+Collapsing the four-family model into two shapes simplifies the core
+specification. The core defines:
 
-- **Spec** is purely declarative — requirements, architecture, decisions,
-  hazards, analyses. No `Verifies`, no `Tests`.
-- **Test** carries its own dedicated attributes — `Level`, `Verifies`, `Tests`,
-  `Source`. No confusion with declarative specs.
-- **Element** is purely material — code, hardware, dependencies. No `Verifies`,
-  no `Tests`, no `Role`.
-- **Reference** unchanged.
+- Entry syntactic form (shared between shapes).
+- Two shapes (identified, referenced) discriminated by `Id:` value format.
+- A single identity attribute (`Id:`) and a short universal attribute set.
+- Retirement semantics, draft state, link-resolution severity.
+- A value-type catalog shared with profiles.
+- Properties (observed facts) as a separate namespace.
 
-Each family has a cohesive set of attributes rather than shared attributes that
-only apply in some cases.
+Everything else — type vocabularies (`requirement`, `test`, `unit`, `standard`,
+`dependency`, …), relation names (`Derived-from`, `Verifies`, `Allocated-to`,
+`Depends-on`, …), traceability rules, display-ID patterns, element kinds, test
+levels — lives in profiles.
 
-### Profiles add domain vocabulary
+### Profiles describe the domain
 
 A profile defines:
 
-- Allowed TYPE prefixes for specs and tests
-- Mapping from test TYPEs to core `Level`
-- Direction and validity rules for `Derived-from` and `Satisfies`
-- Additional attributes — domain-specific traceability links or metadata
-- Additional labels with semantic meaning
-- Extension of `Kind` vocabularies (Element, and optionally Level for Test)
+- Type vocabulary within each shape (`requirement`, `test`, `unit` as identified
+  types; `standard`, `dependency` as referenced types).
+- Per-type attributes and required fields.
+- Display-ID patterns per type (template form, enforced per profile choice).
+- Traceability rules (relation names, target shape/type constraints,
+  cardinality, required flag).
+- Extensions to the attribute value-type catalog.
 
-The same MarkSpec core supports automotive, aerospace, medical, railway, and
-industrial projects without modification.
+The same MarkSpec core supports automotive, aerospace, medical, railway,
+industrial, and pure tech-writing projects without modification, by swapping the
+active profile chain.
 
-### Assisted editing is straightforward
+### Discrimination is a one-step check
 
-- Generating an identity attribute is trivial: a bare ULID from any standard
-  library.
-- Classifying an existing entry is a single attribute lookup.
-- Classifying a new entry uses the heuristic, with profile mapping and document
-  directive as hints.
-- Level inference from TYPE prefix reduces authoring overhead when a profile is
-  loaded.
+Shape resolution does not consult a profile, a document, or a display-ID prefix.
+It inspects `Id:` and decides. This property is what makes core-only mode
+(ADR-009 §10) workable and what keeps error diagnostics precise.
 
-### ASPICE SWE.4 BP5 traceability is covered
+### Migration from pre-ADR-009 format
 
-The bidirectional traceability between test cases, requirements, and units —
-required by ASPICE SWE.4 BP5 — is fully expressible:
+Projects using the pre-ADR-009 family-specific attributes (`Spec-id`, `Test-id`,
+`Element-id`, `Reference-id`) migrate via `markspec migrate`:
 
-- **Test ↔ requirement** via Test.`Verifies` and Spec.`Verified-by`
-- **Test ↔ unit** via Test.`Tests` and Element.`Tested-by`
+- `Spec-id:`, `Test-id:`, `Element-id:` → `Id:` (ULID preserved).
+- `Reference-id: <URI>` → `Id: <URI>` (URI preserved; slug moves to display ID
+  if it was elsewhere).
+- Earlier legacy `Id: <TYPE>_<ULID>` (pre-four-family) → `Id: <ULID>` with
+  `type:` inferred from the prefix.
+
+Display IDs are preserved unchanged. Type values are inferred from the
+historical family or TYPE prefix and written to an explicit `type:` attribute
+when a profile with a matching type is loaded.
 
 ### Pandoc compatibility preserved
 
-The `@` prefix in reference declarations is accepted as optional syntax. Inline
-Pandoc citations `[@ID]` in prose are recognized as references.
-
-### Migration from ADR-001
-
-Projects using ADR-001 format can migrate gradually:
-
-- `Id: <prefixed ULID>` becomes family-specific: `Spec-id`, `Test-id`,
-  `Element-id` depending on content.
-- ADR-001 test entries (SWT, SIT, VAL) declared as requirements move to the Test
-  family with `Test-id` instead of `Spec-id`.
-- `Verifies` attributes declared on code (per ADR-001) move to the Test entries
-  generated from that code.
-
-An automated migration tool can rewrite legacy attributes.
+The `@` prefix in bracketed citation keys is accepted as optional syntax. Inline
+Pandoc citations `[@ID]` in prose are recognized as referenced-entry
+cross-references.
 
 ---
 
-## Annex A — Family Recognition Examples
+## Annex A — Shape Discrimination Examples
 
-| Entry                                                    | Identity attribute | Family                   |
-| -------------------------------------------------------- | ------------------ | ------------------------ |
-| `[SRS_BRK_0107]` with `Spec-id: 01HGW2...`               | Spec-id            | spec                     |
-| `[SWT_BRK_0107]` with `Test-id: 01HGW3...`               | Test-id            | test                     |
-| `[VAL_VHC_0042]` with `Test-id: 01HGW3...`               | Test-id            | test                     |
-| `[ISO-26262-6]` with `Reference-id: urn:iso:...`         | Reference-id       | reference                |
-| `[@ISO-26262-6]` with `Reference-id: urn:iso:...`        | Reference-id       | reference (`@` stripped) |
-| `[BRK-ECU-SENSOR]` with `Element-id: 01HGW2...`          | Element-id         | element                  |
-| `[braking::debounce_input]` with `Element-id: 01HGW2...` | Element-id         | element                  |
+| Entry                                                       | `Id:` value | Shape      |
+| ----------------------------------------------------------- | ----------- | ---------- |
+| `[SPEC-107]` with `Id: 01HGW2P4KFR7ABCDEFGHJKMNPQ`          | ULID        | identified |
+| `[TEST-042]` with `Id: 01HGW3R9QNP4ABCDEFGHJKMNPQ`          | ULID        | identified |
+| `[braking::debounce]` with `Id: 01HGW3D6QRST7JKMNPQRSTVWXY` | ULID        | identified |
+| `[ISO-26262-6]` with `Id: urn:iso:std:iso:26262:-6:ed-2`    | URI (urn)   | referenced |
+| `[@ISO-26262-6]` with `Id: urn:iso:std:iso:26262:-6:ed-2`   | URI (urn)   | referenced |
+| `[serde]` with `Id: pkg:cargo/serde@1.0.0`                  | URI (purl)  | referenced |
+| `[RFC-2119]` with `Id: doi:10.17487/RFC2119`                | URI (doi)   | referenced |
 
-**Invalid entries**:
+**Invalid entries:**
 
-| Entry                                       | Issue                        |
-| ------------------------------------------- | ---------------------------- |
-| `[SRS_BRK_0107]` with no identity attribute | Missing identity             |
-| `[SRS_BRK_0107]` with `Element-id: ...`     | Format/family mismatch       |
-| `[X]` with both `Spec-id` and `Test-id`     | Multiple identity attributes |
+| Entry                                        | Issue                                 |
+| -------------------------------------------- | ------------------------------------- |
+| `[SPEC-107]` with no `Id:` attribute         | Missing identity                      |
+| `[SPEC-107]` with `Id: SPEC-107`             | `Id:` value is neither ULID nor URI   |
+| `[X]` with `Id: 01HGW2...` AND `Id: urn:...` | Multiple identity values              |
+| `[X]` with `Id: foo/bar`                     | Slug-without-scheme in `Id:` rejected |
 
 ---
 
 ## Annex B — Format Regexes
 
-**Spec display ID**:
-
-```text
-^[A-Z]{2,6}_[A-Z][A-Z0-9]{2,7}(_[A-Z][A-Z0-9]{2,7})?_\d{3,6}$
-```
-
-**Test display ID**: same format as Spec.
-
-**Reference slug** (after stripping optional `@` prefix):
-
-```text
-^[A-Za-z]([A-Za-z0-9._/-]*[A-Za-z0-9])?$
-```
-
-**Element display ID** (after stripping optional leading `::`):
-
-```text
-^[A-Za-z]([A-Za-z0-9._/-]*[A-Za-z0-9])?(::[A-Za-z]([A-Za-z0-9._/-]*[A-Za-z0-9])?)*$
-```
-
-**ULID** (value of `Spec-id`, `Test-id`, `Element-id`):
+**ULID** (identified-entry `Id:` value):
 
 ```text
 ^[0-9A-HJKMNP-TV-Z]{26}$
 ```
 
-**URI** (value of `Reference-id`): any valid URI per RFC 3986.
+**URI** (referenced-entry `Id:` value): any valid URI per RFC 3986, must begin
+with a scheme followed by `:`.
+
+**Slug** (referenced-entry display ID, after stripping optional `@`):
+
+```text
+^[A-Za-z]([A-Za-z0-9._/-]*[A-Za-z0-9])?$
+```
+
+**Identified-entry display ID**: free-form non-empty string in the core; pattern
+may be tightened by profile declaration (ADR-009 §5, ADR-008 §6).
 
 ---
 
-## Annex C — Built-in Attributes Recap
+## Annex C — Universal Attributes Recap
 
 Complete catalog of attributes defined by the core. Origin legend: `assigned`
-(tool-generated ULID at creation), `authored` (written by the author),
-`inferred` (pre-filled by tooling, author-overridable), `generated` (computed at
-build time from inverse relations, never committed).
+(tool-generated at creation), `authored` (written by the author), `inferred`
+(pre-filled by tooling, author-overridable), `generated` (computed at build time
+from inverse relations, never committed).
 
-### Universal attributes (all families)
+### Universal attributes (both shapes)
 
-| Attribute       | Type          | Origin    | Required | Description                                   |
-| --------------- | ------------- | --------- | -------- | --------------------------------------------- |
-| `Labels`        | `tag-list`    | authored  | no       | Classification tags (includes `DRAFT` marker) |
-| `References`    | `citation`    | authored  | no       | External reference citations with locator     |
-| `External-id`   | `external-id` | authored  | no       | Cross-system identifier(s)                    |
-| `Supersedes`    | `id`          | authored  | no       | Same-family entry this one replaces           |
-| `Superseded-by` | `id`          | generated | —        | Inverse of `Supersedes`                       |
-| `Deprecated`    | `string`      | authored  | no       | Retirement reason (non-replacement case)      |
+| Attribute       | Type          | Origin        | Required | Description                                   |
+| --------------- | ------------- | ------------- | -------- | --------------------------------------------- |
+| `Id`            | `id`          | see §Identity | yes      | Identity value: ULID or URI                   |
+| `Labels`        | `tag-list`    | authored      | no       | Classification tags (includes `DRAFT` marker) |
+| `References`    | `citation`    | authored      | no       | External reference citations with locator     |
+| `External-id`   | `external-id` | authored      | no       | Cross-system identifier(s)                    |
+| `Supersedes`    | `id`          | authored      | no       | Same-shape entry this one replaces            |
+| `Superseded-by` | `id`          | generated     | —        | Inverse of `Supersedes`                       |
+| `Deprecated`    | `string`      | authored      | no       | Retirement reason (non-replacement case)      |
 
-### Spec family
+Referenced entries do not carry `References:` (a referenced entry does not
+itself cite other referenced entries; the replacement relation is expressed via
+the universal `Supersedes` attribute).
 
-| Attribute      | Type      | Origin    | Required | Description                           |
-| -------------- | --------- | --------- | -------- | ------------------------------------- |
-| `Spec-id`      | `id`      | assigned  | yes      | ULID                                  |
-| `Derived-from` | `id-list` | authored  | no       | Upstream link (V-model decomposition) |
-| `Satisfies`    | `id-list` | authored  | no       | Upstream link (complete fulfillment)  |
-| `Allocated-to` | `id-list` | authored  | no       | Downstream allocation to element(s)   |
-| `Derives`      | `id-list` | generated | —        | Inverse of `Derived-from`             |
-| `Satisfied-by` | `id-list` | generated | —        | Inverse of `Satisfies`                |
-| `Realized-by`  | `id-list` | generated | —        | Inverse of Element.`Realizes`         |
-| `Verified-by`  | `id-list` | generated | —        | Inverse of Test.`Verifies`            |
+### Profile-declared attributes
 
-### Test family
-
-| Attribute    | Type      | Origin   | Required | Description                                      |
-| ------------ | --------- | -------- | -------- | ------------------------------------------------ |
-| `Test-id`    | `id`      | assigned | yes      | ULID                                             |
-| `Test-level` | `enum`    | inferred | no       | `unit` / `integration` / `system` / `acceptance` |
-| `Verifies`   | `id-list` | authored | no       | Upstream link to spec(s) verified                |
-| `Tests`      | `id-list` | authored | no       | Upstream link to element(s) exercised            |
-
-### Element family
-
-| Attribute        | Type         | Origin    | Required | Description                                 |
-| ---------------- | ------------ | --------- | -------- | ------------------------------------------- |
-| `Element-id`     | `id`         | assigned  | yes      | ULID                                        |
-| `Element-kind`   | `enum`       | inferred  | no       | `item` / `artifact` / `dependency` / `unit` |
-| `Part-of`        | `id`         | inferred  | no       | Containment parent (from namespace)         |
-| `Realizes`       | `id-list`    | authored  | no       | Upstream link to spec(s) realized           |
-| `Depends-on`     | `id-list`    | authored  | no       | Upstream link to element(s) used            |
-| `Generated-from` | `path-or-id` | authored  | no       | Source of a tool-generated element          |
-| `Contains`       | `id-list`    | generated | —        | Inverse of `Part-of`                        |
-| `Used-by`        | `id-list`    | generated | —        | Inverse of `Depends-on`                     |
-| `Allocated`      | `id-list`    | generated | —        | Inverse of Spec.`Allocated-to`              |
-| `Tested-by`      | `id-list`    | generated | —        | Inverse of Test.`Tests`                     |
-
-### Reference family
-
-| Attribute            | Type      | Origin    | Required | Description                                  |
-| -------------------- | --------- | --------- | -------- | -------------------------------------------- |
-| `Reference-id`       | `uri`     | authored  | yes      | URI (URN, DOI, or HTTPS URL)                 |
-| `Reference-url`      | `url`     | authored  | no       | Navigation link when different from URI      |
-| `Reference-document` | `text`    | authored  | no       | Canonical citation; falls back to title      |
-| `Cited-by`           | `id-list` | generated | —        | Inverse of `References` on Spec/Test/Element |
-
-Reference entries never carry `References` (a reference entry does not cite
-other references via the `References` attribute; the replacement relation is
-expressed via the universal `Supersedes` attribute).
+All other attributes — `type:`, `Derived-from:`, `Verifies:`, `Tests:`,
+`Realizes:`, `Allocated-to:`, `Depends-on:`, `Element-kind:`, `Test-level:`,
+ASIL / DAL / SIL classifications, etc. — are declared by profiles. See
+[ADR-008 — Profile System](./adr-008-profile-system.md) and
+[ADR-010 — Default Profile](./adr-010-default-profile.md).
 
 ---
 
 ## Open questions (deferred to later ADRs)
 
-- **Profile document format**: how profiles are authored and distributed —
+- **Profile document format** — how profiles are authored and distributed —
   specified in [ADR-008 — Profile System](./adr-008-profile-system.md).
-- **Profile-level traceability rules**: validation of `Derived-from`,
-  `Allocated-to`, `Verifies`, `Tests` (cardinality, type combinations, ASIL
-  compatibility) — mechanism defined in [ADR-008](./adr-008-profile-system.md);
-  automated cross-chain validation remains future work.
-- **Property model**: git observation contracts, sync connectors, property
-  namespace, caching, build-time provenance — deferred to
+- **Core / profile boundary** — the principle that places type vocabulary and
+  compliance rules in the profile layer — specified in
+  [ADR-009 — Core / Profile Boundary](./adr-009-core-profile-boundary.md).
+- **Default profile** — the generic type vocabulary MarkSpec ships with —
+  specified in [ADR-010 — Default Profile](./adr-010-default-profile.md).
+- **Language pack and dependency ingestion** — extracting entries from source
+  code and SBOM output — specified in
+  [ADR-011 — Language Pack and Dependency Ingestion](./adr-011-language-pack-and-dependency-ingestion.md).
+- **Property model** — git observation contracts, sync connectors, property
+  namespace, caching, build-time and extraction provenance — deferred to
   [ADR-006 — Property Model](./adr-006-property-model.md).
-- **In-code entries**: conventions for authoring spec, test, and element entries
-  in doc comments across languages (Rust `///`, Kotlin KDoc, Doxygen, Javadoc,
-  Java JDK 23+).
-- **Inline references in prose**: Mustache `{{spec.X}}`, `{{element.X}}`,
-  `{{test.X}}` syntax, alongside Pandoc `[@ID]` citation syntax.
-- **Test execution attributes**: profile-specific attributes for test results,
-  coverage metrics, execution environment.
-- **Element lifecycle beyond renames**: merge and split operations from external
-  systems.
-- **Tool qualification modeling**: ISO 26262 Part 8 TCL attributes for elements
-  of `Element-kind: dependency` used as development tools.
+- **In-code entries** — conventions for authoring entries in doc comments across
+  languages — deferred to
+  [ADR-011](./adr-011-language-pack-and-dependency-ingestion.md) follow-ups.
+- **Inline references in prose** — Mustache `{{<type>.<slug>}}` /
+  `{{<type>.<display-id>}}` syntax, alongside Pandoc `[@ID]` citation syntax.

--- a/docs/architecture/adr-006-property-model.md
+++ b/docs/architecture/adr-006-property-model.md
@@ -1,25 +1,35 @@
 # ADR-006: Property Model
 
 Status: Proposed\
-Date: 2026-04-17\
+Date: 2026-04-17 (revised 2026-04-20 for ADR-009 alignment)\
 Scope: MarkSpec\
-Depends on: [ADR-002 — Entry Model](./adr-002-entry-model.md)
+Depends on: [ADR-002 — Entry Model](./adr-002-entry-model.md),
+[ADR-009 — Core / Profile Boundary](./adr-009-core-profile-boundary.md)
 
 ## Context
 
 ADR-002 introduces a two-tier model for entries:
 
-- **Attributes** — language-level facts authored in source (`Spec-id`,
-  `Derived-from`, `Status`, …) or generated at build time from inverse relations
-  (`Verified-by`, `Cited-by`, …).
+- **Attributes** — language-level facts authored in source (`Id:`,
+  `Derived-from:`, …) or generated at build time from inverse relations
+  (`Verified-by:`, `Cited-by:`, …).
 - **Properties** — model-level observations about an entry: where it lives in
   the repository, when it was created, who has touched it, how an external
   system tracks it. Properties are never authored in source, never round-trip
   through `markspec format`, and do not appear in git diffs.
 
+ADR-009 §4 formalizes the dual of this distinction on the identity axis:
+**identity** (ULID or URI in the `Id:` attribute, display ID, slug) is stable
+across renames and refactors; **provenance** (path, module, line, commit,
+extraction tool, source-type) is mutable and must never be used as identity. All
+provenance facts are properties; none are attributes.
+
 ADR-002 defines the concept and lists four property categories (`file`, `git`,
 `sync`, `build`) without specifying how they are captured, represented in the
-model, or exposed to downstream consumers.
+model, or exposed to downstream consumers. ADR-009 introduces a fifth
+operational concern — **entry-source provenance** for entries extracted from
+non-Markdown sources (doc comments in source code, SBOM ingestion, ECAD/PLM
+exports) — which this ADR must also specify.
 
 This ADR specifies the property model in detail.
 
@@ -38,6 +48,15 @@ Canonical property names per category:
   `external_source`.
 - **`build.*`** — compilation-time provenance: `resolution_source`,
   `registry_origin`.
+- **`source.*`** — entry-source provenance (per ADR-009 §9 and ADR-011): `type`
+  (one of `markdown`, `code`, `sbom`, `ecad`, `plm`, …), `adapter` (language
+  pack / SBOM tool / custom adapter identifier), `language` (where applicable:
+  `rust`, `kotlin`, `c`, …), `rule` (the extractor rule that matched, for
+  debugging), `extracted_at` (timestamp of last extraction).
+
+The `source.*` category is populated when an entry is produced by an adapter
+other than the Markdown parser. Markdown-authored entries set `source.type` to
+`markdown` and omit adapter-specific fields.
 
 ### 2. Observation contracts
 
@@ -88,9 +107,12 @@ How external systems (Jira, DOORS, Jama, Codebeamer, PLM) integrate:
 
 - ✅ [ADR-002](./adr-002-entry-model.md) — Entry Model (attributes vs properties
   distinction)
+- ✅ [ADR-009 — Core / Profile Boundary](./adr-009-core-profile-boundary.md) —
+  identity vs provenance principle (§4); entry-source abstraction (§9)
 - 🔗 Related: [ADR-008 — Profile System](./adr-008-profile-system.md)
-  (profile-declared attributes populating the property layer), in-code entries
-  ADR (file properties for code-authored entries)
+  (profile-declared attributes populating the property layer),
+  [ADR-011 — Language Pack and Dependency Ingestion](./adr-011-language-pack-and-dependency-ingestion.md)
+  (source-category properties for code-extracted and SBOM-ingested entries)
 
 ## Acceptance criteria
 

--- a/docs/architecture/adr-007-document-structure.md
+++ b/docs/architecture/adr-007-document-structure.md
@@ -1,15 +1,17 @@
 # ADR-007: Document Structure — Front Matter, Title, and Body
 
 Status: Proposed\
-Date: 2026-04-17\
+Date: 2026-04-17 (revised 2026-04-20 for ADR-009 alignment)\
 Scope: MarkSpec\
-Depends on: [ADR-002 — Entry Model](./adr-002-entry-model.md)
+Depends on: [ADR-002 — Entry Model](./adr-002-entry-model.md),
+[ADR-009 — Core / Profile Boundary](./adr-009-core-profile-boundary.md)
 
 ## Context
 
-ADR-002 defines the model for entries inside a document: four families, each
-with identity, attributes, and properties. It does not specify what a
-**document** itself is, how it is identified, or what metadata it carries.
+ADR-002 (as revised alongside ADR-009) defines the model for entries inside a
+document: two shapes (identified, referenced), each with identity, attributes,
+and properties. It does not specify what a **document** itself is, how it is
+identified, or what metadata it carries.
 
 In practice, many organizations need document-level identity and metadata that
 is distinct from the entries the document contains:
@@ -109,7 +111,7 @@ repurposed).
 
 | Key             | Type          | Scope            | Purpose                                           |
 | --------------- | ------------- | ---------------- | ------------------------------------------------- |
-| `document-id`   | `id`          | core (identity)  | Document ULID; bare 26-char Crockford base32      |
+| `document-id`   | `id`          | core (identity)  | Document identity; ULID or URI per ADR-009 §2     |
 | `document-type` | `enum`        | core (identity)  | Overrides filename/directive-based type detection |
 | `labels`        | `tag-list`    | core (universal) | Classification tags (includes `DRAFT` marker)     |
 | `deprecated`    | `string`      | core (universal) | Retirement reason (non-replacement case)          |
@@ -120,7 +122,11 @@ repurposed).
 
 Core keys mirror the universal attribute set from ADR-002 Part 1, plus two
 document-specific identity keys (`document-id`, `document-type`). Attribute
-value types follow the same 14-type system defined in ADR-002.
+value types follow the same 14-type system defined in ADR-002. The `document-id`
+value follows the same ULID-or-URI discrimination rule as the entry-level `Id:`
+attribute (ADR-009 §2); project-authored documents conventionally use a ULID,
+but a document may alternatively carry a URI when it represents a stable
+external artifact.
 
 Document lifecycle follows the same model as entry lifecycle (ADR-002
 §Retirement semantics and §Draft state):
@@ -202,8 +208,8 @@ Front matter keys use **kebab-case** (`document-id`, not `Document-id`). This
 matches YAML-ecosystem convention across Hugo, Jekyll, Docusaurus, Kubernetes,
 Helm, and dozens of other YAML-consuming tools.
 
-Entry attribute trailers continue to use **Title-Case** (`Spec-id:`,
-`Derived-from:`) because they follow git-trailers convention.
+Entry attribute trailers continue to use **Title-Case** (`Id:`, `Derived-from:`)
+because they follow git-trailers convention.
 
 Each syntax follows its own ecosystem's convention; the parser normalizes both
 forms to the same internal key.

--- a/docs/architecture/adr-008-profile-system.md
+++ b/docs/architecture/adr-008-profile-system.md
@@ -1,21 +1,27 @@
 # ADR-008: Profile System — Vocabulary, Rules, and Extension Distribution
 
 Status: Proposed\
-Date: 2026-04-19\
+Date: 2026-04-19 (revised 2026-04-20 for ADR-009 alignment)\
 Scope: MarkSpec\
 Depends on: [ADR-002 — Entry Model](./adr-002-entry-model.md),
 [ADR-006 — Property Model](./adr-006-property-model.md),
-[ADR-007 — Document Structure](./adr-007-document-structure.md)
+[ADR-007 — Document Structure](./adr-007-document-structure.md),
+[ADR-009 — Core / Profile Boundary](./adr-009-core-profile-boundary.md)
 
 ## Context
 
-ADR-002 separates the **entry format** (four families: Spec, Test, Element,
-Reference) from the **domain vocabulary** (concrete TYPE prefixes, Element
-kinds, status values, traceability rules). It calls this extension layer a
-**profile** and defers the profile format to a future ADR.
+ADR-009 establishes the core / profile boundary: the core recognizes two
+semantics-free entry shapes (**identified** and **referenced**) and a single
+`Id:` identity attribute. All type vocabulary, relation names, attribute
+spellings beyond `Id:`, and compliance rules are declared in profiles.
 
-Since ADR-002 was drafted, three characteristics of the extension need have
-become clear:
+This ADR specifies the **profile format, distribution, and extends-chain
+semantics** that realize that boundary. It also covers coding-standard and
+language-pack profiles (rule-profiles and adapter-bearing profiles per ADR-011),
+though the specifics of those live in their own ADRs.
+
+Since ADR-002 was drafted (and amended by ADR-009), three characteristics of the
+extension need have become clear:
 
 - **Layered authorship.** Public domain profiles (ASPICE, ISO 26262, DO-178C,
   IEC 62304) form a baseline. Organizations tune that baseline with
@@ -145,39 +151,43 @@ id: "@markspec/profile-aspice-4"
 version: 1.2.0
 description: ASPICE 4.0 software engineering profile
 license: MIT
-extends: "npm:@markspec/profile-generic@^1.0"
+extends: "npm:@markspec/profile-default@^1.0"
 
 # Content — participates in the extends-chain merge
 profile:
 
-  # Universal scope — applies to any entry regardless of category
+  # Universal scope — applies to any entry regardless of shape or type
   required: []
   attributes: []
   labels: []
 
-  # Per-category scope
-  spec:
+  # Per-shape scope (the two core shapes from ADR-009 §1)
+  identified:
     required: []
     attributes: []
     traceability: {}
-  test:
-    required: []
-    attributes: []
-    levels: []
-    traceability: {}
-  element:
-    required: []
-    attributes: []
-    kinds: []
-    traceability: {}
-  reference:
+  referenced:
     required: []
     attributes: []
 
-  # Per-TYPE scope (keyed map; TYPE prefix is the key)
+  # Per-type scope (keyed map; type-name is the key)
   types:
-    SRS: { category: spec, required: [Derived-from] }
-    SWT: { category: test, level: unit, required: [Tests, Verifies] }
+    requirement:
+      shape: identified
+      display-id-pattern: "SPEC-{n:03d}"
+      required: [Derived-from]
+      traceability: {}
+    test:
+      shape: identified
+      display-id-pattern: "TEST-{n:03d}"
+      required: [Tests, Verifies]
+      traceability: {}
+    standard:
+      shape: referenced
+      attributes: []
+    dependency:
+      shape: referenced
+      attributes: []
 
   # Document-level scope (per ADR-007)
   documents:
@@ -185,54 +195,44 @@ profile:
     frontMatter: []
 ```
 
-**Terminology mapping.** The YAML uses `category` where ADR-002 uses _family_.
-The two terms refer to the same four values (`spec`, `test`, `element`,
-`reference`). `category` is used in the YAML for clarity of reading; `family`
-remains the normative term in the entry-model ADR. Implementations should accept
-both in parser diagnostics.
+**Terminology note.** The schema uses `identified` / `referenced` as the
+per-shape scope keys, matching ADR-009's vocabulary. The earlier four-family
+scope keys (`spec`, `test`, `element`, `reference`) no longer exist: those
+distinctions become profile-declared types within a shape (see `types:` above).
+
+**Type shape requirement.** Every entry under `types:` must declare a `shape:`
+of either `identified` or `referenced`. The shape determines which per-shape
+scope its rules inherit from and which identity-value format its entries must
+carry (ULID or URI, per ADR-009 §2).
 
 **Fixed key set.** Inside `profile:` the recognized keys are:
 
 - Universal content: `required`, `attributes`, `labels`.
-- Category scopes: `spec`, `test`, `element`, `reference`.
-- TYPE scope: `types` (keyed map).
+- Shape scopes: `identified`, `referenced`.
+- Type scope: `types` (keyed map; each type declares `shape:` and optional
+  `display-id-pattern:`, `required:`, `attributes:`, `traceability:`).
 - Document scope: `documents`.
 
 Any other top-level key under `profile:` is a validation error.
 
-**Note — `kinds:` and `levels:` sugar.** `element.kinds:` and `test.levels:` are
-documented shortcuts for extending the core-defined enum attributes
-`Element-kind` and `Test-level` respectively. Each expands as an implicit
-attribute declaration with enum-union merge (per the standard `attributes:`
-merge semantics):
+**Note — per-type attribute shortcuts are profile-specific.** The earlier
+`element.kinds:` and `test.levels:` shortcut syntax no longer exists; kinds and
+levels are no longer core concepts. A profile that wants to declare an
+enum-valued attribute on a type uses the ordinary `attributes:` list:
 
 ```yaml
-# Shortcut form
-element:
-  kinds: [ecu, sensor, actuator]
-
-# Equivalent to
-element:
-  attributes:
-    - { name: Element-kind, type: enum, values: [ecu, sensor, actuator] }
+types:
+  unit:
+    shape: identified
+    attributes:
+      - name: Test-level
+        type: enum
+        values: [unit, integration, system, acceptance]
 ```
 
-Profiles may use either form; tooling treats them identically. The shortcut
-exists because profile authors commonly extend only these two enums.
-
-**Note — TYPE-scoped `level:` semantics.** A TYPE declaration may carry a
-`level:` field (e.g., `SWT: { category: test, level: unit }`). Its semantics
-follow ADR-002 §"Test-level inference from TYPE":
-
-- On `markspec format`, if an entry of the TYPE omits `Test-level:`, the
-  formatter pre-fills it with the TYPE's declared level and commits it to source
-  (so the inferred value is inspectable in diffs).
-- The author's explicit `Test-level:` value always wins. The validator accepts
-  any valid Test-level regardless of the TYPE mapping.
-
-This is default / inference behavior, not enforcement. Profiles that need strict
-TYPE-to-level binding should express it through `rules.required` (not in scope
-for v1).
+Compliance profiles may publish shortcuts of their own (e.g., a "unit-test" type
+declaration with `Test-level` baked in), but these are profile-level
+conveniences, not schema-level shortcuts.
 
 **Note — default cardinality.** When an attribute declaration omits
 `cardinality:`, the default is inferred from `type:`:
@@ -310,38 +310,33 @@ This replaces the former single-threshold MSL-T013 rule that targeted
 documents:
   types:
     - id: requirements
-      contains: [spec]
+      contains: [requirement]
       description: Requirement specifications
-    - id: architecture
-      contains: [spec, element]
     - id: tests
       contains: [test]
+    - id: references
+      contains: [standard, glossary]
   frontMatter: []
 ```
 
-The `contains:` field declares which entry categories may appear in documents of
-that type. Two uses:
+The `contains:` field declares which **entry types** (not shapes) may appear in
+documents of that type. Two uses:
 
-- **Anonymous entry classification** — an entry without an explicit identity
-  attribute (e.g., `[SWT_AUTH_0001]` with no `Test-id:`) is classified into the
-  category listed in the enclosing document's `contains:`. Closes part of the
-  classification heuristic gap from ADR-002.
-- **Scope validation** — placing an entry of a category not listed in
-  `contains:` produces a validation error
-  (`specs don't belong in a tests
-  document`).
+- **Scope validation** — placing an entry of a type not listed in `contains:`
+  produces a validation error ("requirements document does not admit entries of
+  type `test`").
+- **Anonymous entry classification (optional, per profile)** — a profile that
+  declares `contains:` for a doc type may additionally allow an entry with no
+  explicit `type:` attribute to be classified by the enclosing document's
+  `contains:` list, provided the list contains exactly one entry-type. This is
+  purely a convenience and does not make display-ID parsing dependent on
+  document context.
 
-Core ships with baked-in `contains:` mappings for the reserved doc types:
-
-| Doc type       | `contains:`       |
-| -------------- | ----------------- |
-| `requirements` | `[spec]`          |
-| `architecture` | `[spec, element]` |
-| `tests`        | `[test]`          |
-| `references`   | `[reference]`     |
-
-**Profiles may add new doc types, but cannot override the core mapping for
-reserved doc types.** Profile-added types must declare `contains:` explicitly.
+The core does not pre-populate `contains:` for any document type; ADR-009
+removes the four-family baked-in mapping. Each profile declares its own document
+types and their accepted entry types. The default profile (ADR-010) declares
+baseline document types appropriate to its type vocabulary (`requirement`,
+`note`, `term`, `reference`); compliance profiles extend or replace them.
 
 ### 5. `extends:` chain and merge semantics
 
@@ -369,103 +364,110 @@ profile.* (universal)  ⊂  profile.<category>.*  ⊂  profile.types.<PREFIX>.*
 Each scope accumulates on `required`, `attributes`, and vocabulary lists; each
 scope may tighten constraints.
 
-### 6. TYPE enforcement
+### 6. Type enforcement and display-ID patterns
 
-Presence of `profile.types:` determines whether the profile enforces TYPE
-prefixes on entry display IDs:
+Presence of `profile.types:` determines whether the profile enforces typed
+entries:
 
-- **`types:` absent or empty** — anonymous entries permitted; no TYPE
-  vocabulary. Core markspec defaults apply.
-- **`types:` declared with at least one entry** — every entry's display ID must
-  begin with a declared TYPE prefix. Unknown TYPEs are validation errors.
+- **`types:` absent or empty** — type-less entries permitted; profile validates
+  only shape-level rules. Core hygiene (ADR-009 §10) still applies.
+- **`types:` declared with at least one entry** — every entry must carry a
+  `type:` attribute whose value is a declared type-name. Unknown types are
+  validation errors.
 
-v1 does not support a `'*'` wildcard entry. Profiles wanting "strict on some,
+**Display-ID patterns** are declared per type via the `display-id-pattern:`
+template specified in ADR-009 §5 (literal prefix + `{n}` placeholder with
+optional padding). Enforcement modes (`error`, `warn`, `off`) are
+profile-controlled per type:
+
+```yaml
+types:
+  requirement:
+    shape: identified
+    display-id-pattern: "REQ-{n:03d}"
+    display-id-pattern-enforcement: error # strict
+```
+
+Display-ID prefix → type mapping is not baked in; a profile may additionally
+declare a prefix-to-type mapping if it wants automatic classification, but the
+`type:` attribute is always authoritative.
+
+v1 does not support a `'*'` wildcard type. Profiles wanting "strict on some,
 permissive on others" can be added later without breaking compatibility; the
 two-mode model is easier to teach.
 
 ### 7. Traceability rules
 
-Link rules are declared co-located with the **source** of the link — the
-category or TYPE where the link originates. This matches the authoring mental
-model ("when I write an SRS, what are the rules on its outgoing links?").
+Link rules are declared co-located with the **source** of the link — the shape
+or type where the link originates. This matches the authoring mental model
+("when I write a requirement, what are the rules on its outgoing links?").
 
 Each scope may carry a `traceability:` map keyed by link-attribute name. Each
 entry in the map declares:
 
-| Field         | Meaning                                                                                                                                                  |
-| ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `target`      | A list of matchers. Each matcher is a TYPE prefix string, a list of TYPE strings, or an object `{ category: <name> }` matching any member of a category. |
-| `cardinality` | Count bounds (`0..1`, `1..1`, `0..N`, `1..N`). Optional; tightens the attribute's declared cardinality.                                                  |
-| `required`    | Boolean; whether the link attribute must be present. Defaults to false.                                                                                  |
+| Field         | Meaning                                                                                                                                       |
+| ------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `target`      | A list of matchers. Each matcher is a type-name string, a list of type-names, or an object `{ shape: identified }` / `{ shape: referenced }`. |
+| `cardinality` | Count bounds (`0..1`, `1..1`, `0..N`, `1..N`). Optional; tightens the attribute's declared cardinality.                                       |
+| `required`    | Boolean; whether the link attribute must be present. Defaults to false.                                                                       |
 
 **Example (ASPICE SWE.4 BP5 bidirectional traceability):**
 
 ```yaml
 profile:
-  spec:
+  identified:
     traceability:
       Derived-from:
-        target: [{ category: spec }] # Specs derive from Specs (default)
-
-  test:
-    traceability:
-      Verifies:
-        target: [{ category: spec }]
-      Tests:
-        target: [{ category: element }]
+        target: [{ shape: identified }] # default: any identified entry
 
   types:
-    SRS:
-      category: spec
+    requirement:
+      shape: identified
       traceability:
         Derived-from:
-          target: [STK] # narrows: SRS derives only from STK
+          target: [stakeholder-requirement] # narrows by type
           cardinality: 1..N
           required: true
 
-    SWT:
-      category: test
+    test:
+      shape: identified
       traceability:
         Verifies:
-          target: [SRS, SWE]
+          target: [requirement, software-requirement]
           cardinality: 1..N
           required: true
         Tests:
-          target: [{ category: element }]
+          target: [unit, component]
           cardinality: 1..N
           required: true
 ```
 
 **Generated inverses are not declared in profiles.** The downstream half of each
 link (`Verified-by`, `Tested-by`, `Realizes`) is generated by markspec from the
-forward declaration, per ADR-002.
+forward declaration, per ADR-002 (as revised alongside ADR-009).
 
-### 8. Identity model — unchanged
+### 8. Identity model — superseded by ADR-009
 
-This ADR **does not modify** the identity-attribute decisions from ADR-002. Each
-family keeps its dedicated identity attribute:
+This section's earlier content — which retained the four family-specific
+identity attributes (`Spec-id`, `Test-id`, `Element-id`, `Reference-id`) and
+explicitly rejected the single-`Id:` variant — is **superseded by
+[ADR-009 — Core / Profile Boundary](./adr-009-core-profile-boundary.md) §2** and
+its §12 rebuttal of the four rejection reasons.
 
-- `Spec-id` → Spec entries (bare ULID)
-- `Test-id` → Test entries (bare ULID)
-- `Element-id` → Element entries (namespace path / file+symbol)
-- `Reference-id` → Reference entries (slug / Pandoc cite / URI)
+Summary of the new model, for readers who arrive here via `extends:` chains or
+older documentation:
 
-Categorized identity attributes remain the discrimination mechanism. Display IDs
-follow the conventions laid out in ADR-002 (human-readable `TYPE_DOMAIN_NUMBER`
-for Spec/Test; symbolic path for Element; slug/cite/URL for Reference). A
-profile's `types:` section declares the TYPE prefixes admitted for Spec and Test
-display IDs; profile authors may further constrain display-ID shapes via
-additional rules in future revisions.
+- Every entry carries exactly one identity attribute, **`Id:`**.
+- The value is either a **ULID** (26-char Crockford base32 → identified shape)
+  or a **URI** with a scheme (RFC 3986 → referenced shape).
+- Shape is determined by `Id:` value format alone; no discriminator attribute,
+  no display-ID prefix, no profile lookup participates.
+- The former family-specific identity attributes are not accepted by the core
+  parser; `markspec migrate` rewrites them to `Id:`.
 
-A variant design considered during this ADR's design phase — a single `Id:`
-attribute with family derived by inference — was rejected. Rationale:
-
-- Introduces a multi-input resolution cascade (value shape, discriminator
-  attribute, display-ID TYPE prefix, profile map).
-- Breaks core-only mode (no profile needed to parse entries correctly).
-- Worsens error messages; an explicit `Test-id` says what it is.
-- Would invalidate the PR #217 migration shipped earlier in April 2026.
-- Saves one attribute name per entry — not worth the cost.
+Profiles do not redeclare identity — `Id:` is core-reserved. A profile may
+declare its `types:` vocabulary using any naming it wishes; identity is uniform
+across profiles.
 
 ### 9. CLI surface
 
@@ -496,8 +498,9 @@ markspec doctor                       # consumer — diagnostics: active chain,
 
 Profiles may contain a `hooks/` directory. When loaded, hooks extend markspec's
 parser, language server, or MCP surface. The interfaces, sandboxing, and
-lifecycle are specified in a separate ADR (ADR-009, deferred) and are not in
-scope here.
+lifecycle are specified in a separate ADR (ADR-012, deferred; this was
+originally reserved as ADR-009 but that number was reclaimed by the Core /
+Profile Boundary ADR) and are not in scope here.
 
 This ADR reserves the directory and the loader's awareness of it. Profiles
 without hooks ship pure declarative content; profiles with hooks ship both.
@@ -522,24 +525,25 @@ Hook-only profiles (no `profile:` content section) are valid distribution units.
 
 ### What shifts for existing consumers
 
-- Projects using an implicit vocabulary (no profile) continue to work — they run
-  against markspec core defaults. Profile adoption is opt-in.
-- Projects already using the four-family model (post-ADR-002) pick up a profile
-  by running `markspec profile add <spec>`; no source changes required.
-- The `Spec-id` / `Test-id` / `Element-id` / `Reference-id` model survives as
-  the identity mechanism; no additional migration beyond what PR #217 already
-  introduced.
+- Projects using core-only mode (no profile) continue to work — they run against
+  markspec core defaults. The default profile (ADR-010) loads automatically
+  unless explicitly disabled, providing generic types and hygiene rules.
+- Projects already using the pre-ADR-009 four-family identity attributes
+  (`Spec-id` / `Test-id` / `Element-id` / `Reference-id`) run `markspec migrate`
+  to rewrite those attributes to `Id:`; see ADR-009 §12.
+- The identity model is now **single-`Id:`-with-format-discrimination** per
+  ADR-009 §2.
 
 ### What is explicitly deferred
 
-- **Hook API and lifecycle** — ADR-009 (separate).
+- **Hook API and lifecycle** — ADR-012 (separate; originally reserved as
+  ADR-009).
 - **Attribute declaration schema detail** — the full list of value types,
   per-attribute option flags, and validation helpers is a refinement of this
   ADR. Skeleton shape is defined here; full detail is a follow-up.
-- **Built-in default profile** — whether markspec ships a `generic` profile that
-  registers the common automotive TYPEs (SRS, SWT, …) is a tooling decision, not
-  an architectural one.
-- **Wildcard `'*'` TYPE fallback** — deferred until a real use case demands
+- **Built-in default profile** — specified in
+  [ADR-010 — Default Profile](./adr-010-default-profile.md).
+- **Wildcard `'*'` type fallback** — deferred until a real use case demands
   "strict on some, permissive on others".
 - **`jsr:` and raw `https:` profile schemes** — admissible extension, not v1
   scope.
@@ -549,13 +553,22 @@ Hook-only profiles (no `profile:` content section) are valid distribution units.
 
 ## Dependencies
 
-- ✅ [ADR-002 — Entry Model](./adr-002-entry-model.md) — the four-family model
-  and categorized identity attributes this ADR extends.
+- ✅ [ADR-002 — Entry Model](./adr-002-entry-model.md) (as revised alongside
+  ADR-009) — entry model this ADR extends.
 - ✅ [ADR-007 — Document Structure](./adr-007-document-structure.md) — the
   front-matter mechanism profiles extend via `profile.documents.frontMatter`.
+- ✅ [ADR-009 — Core / Profile Boundary](./adr-009-core-profile-boundary.md) —
+  core / profile split, two-shape model, identity contract. Supersedes the
+  previous ADR-008 §8.
 - 🔗 [ADR-006 — Property Model](./adr-006-property-model.md) — profile-declared
   generated attributes populate the property layer defined here.
-- 🔗 ADR-009 — Profile Hooks (deferred): API, sandbox, lifecycle.
+- 🔗 [ADR-010 — Default Profile](./adr-010-default-profile.md) — the bundled
+  profile that loads by default, using the schema specified here.
+- 🔗
+  [ADR-011 — Language Pack and Dependency Ingestion](./adr-011-language-pack-and-dependency-ingestion.md)
+  — language packs and rule-profiles as instances of this schema.
+- 🔗 ADR-012 — Profile Hooks (deferred; originally reserved as ADR-009): API,
+  sandbox, lifecycle.
 
 ## Acceptance criteria
 
@@ -563,9 +576,9 @@ Hook-only profiles (no `profile:` content section) are valid distribution units.
 - [ ] Three distribution channels (local, git, npm) resolve end-to-end.
 - [ ] Monorepo subpath + per-profile tag convention supported.
 - [ ] `extends:` chain resolution with additive + tightening merge implemented.
-- [ ] TYPE enforcement (strict vs absent) implemented at validator layer.
-- [ ] `profile.types.<PREFIX>.traceability` merges correctly across the chain
-      and across scope tiers (universal → category → TYPE).
+- [ ] Type enforcement (strict vs absent) implemented at validator layer.
+- [ ] `profile.types.<name>.traceability` merges correctly across the chain and
+      across scope tiers (universal → shape → type).
 - [ ] CLI surface (`new`, `publish`, `add`, `doctor`) available with the
       described behavior.
 - [ ] Vendored profiles are reproducible: running `markspec profile add` against
@@ -573,18 +586,20 @@ Hook-only profiles (no `profile:` content section) are valid distribution units.
 - [ ] ADR-002 §"Out of scope — Profile document format", ADR-006 §Dependencies,
       and ADR-007 §"Out of scope — Profile document format" updated to reference
       this ADR.
+- [ ] Identity contract conforms to ADR-009 §2: `Id:` with ULID-or-URI
+      discrimination; no family-specific identity attributes accepted.
 
 ## Out of scope (future work)
 
-- **Profile hooks** — code that extends parser, LSP, MCP. ADR-009.
+- **Profile hooks** — code that extends parser, LSP, MCP. ADR-012.
 - **Profile registry / discovery** — a markspec-specific registry beyond reusing
   git and npm.
 - **Profile-level traceability validation** — automated checks across a resolved
   `extends:` chain (e.g., "this child's Derived-from rule cannot possibly be
-  satisfied given the parent's TYPE vocabulary").
+  satisfied given the parent's type vocabulary").
 - **Signing and provenance** — SLSA-style provenance for published profiles;
   reuses whatever git tag signing / npm signing the ecosystem offers.
 - **Profile composition at the consumer** — merging two content-bearing profiles
   inside `.markspec.yaml`. Projects use a pre-merged domain profile instead.
 - **`jsr:` and `https:` specifier schemes** for profiles.
-- **Wildcard `'*'` TYPE entry** for permissive-with-fallback mode.
+- **Wildcard `'*'` type entry** for permissive-with-fallback mode.

--- a/docs/architecture/adr-009-core-profile-boundary.md
+++ b/docs/architecture/adr-009-core-profile-boundary.md
@@ -1,0 +1,395 @@
+# ADR-009: Core / Profile Boundary
+
+Status: Proposed\
+Date: 2026-04-20\
+Scope: MarkSpec\
+Supersedes: ADR-002 §Part 6 (Family Recognition), ADR-008 §8 (Identity model —
+unchanged)\
+Updates: [ADR-002 — Entry Model](./adr-002-entry-model.md),
+[ADR-006 — Property Model](./adr-006-property-model.md),
+[ADR-007 — Document Structure](./adr-007-document-structure.md),
+[ADR-008 — Profile System](./adr-008-profile-system.md)
+
+## Context
+
+ADR-001 through ADR-008 gradually built a data model centered on four entry
+**families** — Spec, Test, Element, Reference — with four dedicated identity
+attributes (`Spec-id`, `Test-id`, `Element-id`, `Reference-id`), a rich
+per-family attribute catalog, and traceability rules baked into the core
+specification.
+
+That shape made sense when MarkSpec's identity was "the spec authoring tool for
+ASPICE and ISO 26262". Two observations recorded after ADR-008 landed changed
+the frame:
+
+- **Two personas, not one.** MarkSpec serves a **technical-writing persona**
+  (ergonomic authoring, high-quality PDF/book/deck output, stable
+  cross-references) _and_ a **process-enforcement persona** (ASPICE/ISO
+  traceability, validation, audit trails). The two share a core model but
+  diverge sharply in surface, docs, and success criteria.
+- **The four families encode compliance scaffolding, not a universal taxonomy.**
+  Outside compliance-heavy contexts, the split between spec/test and
+  element/reference is not obvious. The universal distinction — the one a
+  tech-writer tool also needs — is **referenced vs. identified**: citation
+  pointers outward vs. content units carrying a stable local identity.
+
+MarkSpec has not shipped. The ADR trail _is_ the baseline, not history. Rather
+than layer a superseding decision on top of ADR-002/008, this ADR revises the
+baseline in place: it names the core/profile boundary, defines the two core
+shapes, and documents what moves out of the core into the profile layer. Later
+revisions to ADR-002/006/007/008 bring those documents into line.
+
+### Guiding principle
+
+**Mechanism in core; policy in profile.** The core ships generic machinery
+(identity, graph, attribute schema, rule evaluator, entry-source pipeline). The
+profile layer declares concrete vocabulary, types, relation names, and rules
+evaluated by that machinery. Without a profile loaded, the machinery is dormant
+but the core still produces a well-formed model.
+
+A single rule settles every "does this belong in core?" question: if a feature
+serves only compliance/enforcement, it belongs in a profile; if it is universal
+to any structured authoring, it belongs in core.
+
+## Decision
+
+### 1. Two core entry shapes
+
+The core recognizes **two** entry shapes, both semantics-free. The profile layer
+declares types within each shape (spec, test, requirement, rule, standard,
+glossary term, SOUP package, hardware part, …).
+
+| Shape          | Intent                                    | Identity                  | Display-ID role                     |
+| -------------- | ----------------------------------------- | ------------------------- | ----------------------------------- |
+| **Identified** | Content unit the project authors and owns | ULID, project-unique      | Human-readable alias                |
+| **Referenced** | Citation pointing to an external artifact | URI (any RFC 3986 scheme) | Slug (pandoc/BibTeX-style cite-key) |
+
+The four families from ADR-002 (Spec, Test, Element, Reference) collapse as
+follows:
+
+- **Spec**, **Test**, **Element** (when the element is a project-authored
+  artifact or unit) → **identified** entries with a profile-declared `type:`
+  value (`type: spec`, `type: test`, `type: unit`, …).
+- **Element** (when it names a third-party dependency), **Reference** →
+  **referenced** entries with a profile-declared `type:` value
+  (`type: standard`, `type: glossary`, `type: dependency`, …).
+
+The same external thing (e.g., `zlib`) may be modeled as either shape depending
+on intent: if it is cited bibliographically, it is referenced; if it is tracked
+as a project graph participant (SOUP, traced component, allocated unit), it is
+identified. The author picks.
+
+### 2. Single `Id:` identity attribute with format discrimination
+
+Every entry carries exactly one identity attribute named `Id:`. The **value
+format** discriminates the shape:
+
+```text
+Id: 01HGW2P4KFR7ABCDEFGHJKMNPQ       # ULID → identified
+Id: urn:iso:std:iso:26262:-6:ed-2    # URI → referenced
+Id: doi:10.1109/IEEESTD.2008.4610935 # URI → referenced
+Id: pkg:cargo/serde@1.0.0            # URI (purl scheme) → referenced
+Id: https://www.rfc-editor.org/rfc/rfc2119 # URI → referenced
+```
+
+**Discrimination is bulletproof.** The two value shapes are visually and
+grammatically disjoint:
+
+- ULID: `^[0-9A-HJKMNP-TV-Z]{26}$` — 26 characters of Crockford base32, no
+  scheme, no colon, no slash.
+- URI (RFC 3986): MUST begin with a scheme followed by `:`. A bare slug (no
+  scheme) is rejected as an `Id:` value — the slug lives in the display ID, not
+  in `Id:`.
+
+The one-step rule replaces the four-attribute discrimination of ADR-002 and
+dissolves the multi-input cascade ADR-008 §8 was rejecting (see §9 — Rebuttal of
+ADR-008 §8).
+
+**Identity is the only thing `Id:` encodes.** Type, category, kind, and any
+other classification move to profile-declared `type:` (or equivalent)
+attributes. The identity attribute is spelling-stable across profiles; only
+values and type attributes vary.
+
+### 3. Display ID and slug
+
+The display ID in an entry's bracket header (`- [DISPLAY_ID] Title`) plays two
+roles depending on shape:
+
+- **Identified entry** — display ID is a human-readable alias. Stable within a
+  project, can be renumbered via tooling. The ULID underneath preserves identity
+  across renames. Format is profile-constrained (see §5).
+- **Referenced entry** — display ID _is_ the slug. Matches pandoc/BibTeX
+  convention (`[@ISO-26262-6]` or `[ISO-26262-6]` are equivalent). The slug is
+  the stable project-local handle; no separate `Slug:` attribute is needed.
+
+The leading `@` in a referenced entry's display ID is accepted syntactic sugar
+for pandoc compatibility and is stripped at parse time.
+
+### 4. Identity vs. provenance
+
+Identity is what a cross-reference resolves against. **Provenance** — where an
+entry's bytes came from — is separate and never identity.
+
+| Kind                                                               | Stable across                                 | Captured as                 |
+| ------------------------------------------------------------------ | --------------------------------------------- | --------------------------- |
+| Identity (ULID, slug)                                              | Renames, file moves, refactors, profile swaps | `Id:` attribute, display ID |
+| Provenance (path, module, line, commit, extracted-at, source-type) | Change with authoring                         | Properties (per ADR-006)    |
+
+Refactoring a module, renaming a file, or moving an entry between files must
+never break a cross-reference. Provenance updates; identity does not. File path
+and module name are observable properties, not authored attributes.
+
+### 5. Display-ID patterns are profile-declared
+
+The core accepts any non-empty, project-unique display ID string. It does not
+constrain format, does not enforce prefixes, and does not derive type from
+prefix.
+
+Profiles may tighten this by declaring **display-ID patterns** per type, in
+template form (not regex), so the same declaration can both **recognize** an
+existing display ID and **mint** a new one:
+
+```yaml
+profile:
+  types:
+    requirement:
+      display-id-pattern: "SPEC-{n:03d}" # SPEC-001, SPEC-042, SPEC-107
+    test:
+      display-id-pattern: "TEST-{n:03d}"
+```
+
+Minimum pattern grammar: literal prefix + one numeric placeholder `{n}` with
+optional zero-padding (`{n:03d}`). Later extensions (slug placeholders, per-type
+scope counters, domain sub-scoping) are additive refinements.
+
+Templates are compiled internally to a recognizer regex for parsing and used
+directly for minting. Regex-only declarations are not supported because they
+cannot be inverted to generate the next available ID.
+
+### 6. Attribute machinery: generic core, profile vocabulary
+
+The core defines a single attribute system:
+
+- Every entry carries a bag of `Key: Value` trailers following git-trailers
+  convention (carried unchanged from ADR-001).
+- Every attribute has a **name** (bare key), a **value type**, a **cardinality
+  bound**, and an **origin** (`authored`, `inferred`, `assigned`, `generated`).
+- Value types, cardinality, and origin semantics are core concepts (reused from
+  ADR-002 Part 1).
+
+Core reserves exactly one attribute name: **`Id:`**. Every other attribute
+spelling is profile-declared. Profile schemas populate the attribute-name
+namespace with their own vocabulary (`Derived-from`, `Verifies`, `Allocated-to`,
+`Risk-class`, `License`, …) and their own value-type catalog extensions.
+
+Profiles may not shadow the core `Id:` spelling. A profile can define an alias
+if it desires (e.g., for migration), but the canonical slot name is `Id:`.
+
+### 7. Typed edges (relations)
+
+The core graph carries typed edges: every cross-reference is labelled with a
+**relation name** (from the enclosing attribute's name). The core evaluator
+treats edges generically — it resolves source→target, validates that targets
+exist, and surfaces edges to rule evaluation. It has no built-in knowledge of
+what a specific relation means.
+
+Relation names (`Derived-from`, `Verifies`, `Allocated-to`, `Depends-on`,
+`Mitigates`, `Supersedes`, …) and their semantics — direction, target matchers,
+cardinality, inverse generation — are **profile-declared** via the traceability
+machinery specified in ADR-008 §7.
+
+The core has one baked-in relation: `Supersedes:` (universal retirement
+semantic, carried from ADR-002 §Retirement semantics). All other relations live
+in profiles.
+
+### 8. Rule evaluator — dormant without profile
+
+The core ships a generic rule evaluator: a small predicate runner over the entry
+graph that exposes queries like "every identified entry with `type: X` must have
+at least one outgoing edge labelled `R`" or "every target of `R` must be of
+`type: Y`".
+
+The evaluator carries **no rules of its own**. Rules are profile-declared
+(ADR-008). With no profile loaded, the evaluator observes the graph and reports
+nothing. Core-only mode is valid: the tool still parses, renders, and exposes
+the model; it just enforces no domain constraints beyond core hygiene (unique
+IDs, resolvable cross-references, well-formed `Id:` values).
+
+### 9. Entry-source pipeline
+
+The core defines an **entry-source abstraction**: an interface over places
+entries come from. The Markdown parser is one implementation. Other adapters
+(tree-sitter-backed doc-comment extractors for Rust/Kotlin/C/C++/Java/etc., SBOM
+ingesters, ECAD/PLM connectors) plug in via the same interface.
+
+Once extracted, an entry is shape-indistinguishable from a Markdown-authored
+one. Provenance captures the source ("extracted from `src/foo.rs:42`", "ingested
+from `syft` CycloneDX output"). No entry type is privileged by its source.
+
+Adapters ship as **bundled extensions** (default language pack) or as separate
+packs. The tree-sitter runtime itself lives in core (also used for code-block
+syntax highlighting in rendering); specific grammars and extraction rules are
+profile/extension territory.
+
+Specification of the default language pack, SBOM delegation, and the adapter API
+is deferred to **ADR-011** (Language pack + dependency ingestion).
+
+### 10. Core-only mode
+
+Without any profile loaded, the core provides:
+
+- Parsing of Markdown + GFM subset (per ADR-001).
+- Entry recognition: both shapes discriminated by `Id:` value format.
+- Display-ID uniqueness and cross-reference resolution as hygiene checks.
+- `Supersedes:` / `Superseded-by:` retirement (the one baked-in relation).
+- Typography, rendering, deck/book output.
+- Tree-sitter runtime for syntax highlighting in code blocks.
+
+Core-only mode is a legitimate use case — a tech-writer persona who wants stable
+IDs, cross-references, and high-quality print output without compliance
+vocabulary. A small **default profile** layered on top (specified in ADR-010)
+adds generic types (`requirement`, `note`, `section`, `reference`) and universal
+hygiene rules grounded in RFC 2119 / BCP 14 normative language conventions —
+without introducing ASPICE/ISO scaffolding.
+
+### 11. Default and compliance profiles — stacking
+
+The intended layering is:
+
+```text
+core (mechanism)
+  │
+  └─ default profile (generic types, RFC 2119 hygiene)    ← ADR-010
+       │
+       └─ compliance profile (ASPICE, ISO 26262, IEC 62304, …)
+            │
+            └─ organization / team / project profile    ← ADR-008 extends:
+```
+
+`extends:` chain semantics (ADR-008 §5) apply at every layer: additive for
+vocabulary, tightening for constraints, never relaxing. Core-only mode is
+equivalent to "no profile"; default-profile mode is equivalent to "default only,
+no compliance stack".
+
+### 12. Rebuttal of ADR-008 §8
+
+ADR-008 §8 rejected a single-`Id:`-with-inference variant for four reasons. Each
+is addressed by the model above:
+
+1. **"Introduces a multi-input resolution cascade (value shape, discriminator
+   attribute, display-ID TYPE prefix, profile map)."** The cascade collapses to
+   a single input: the `Id:` value. ULID regex and URI-with-scheme regex are
+   disjoint. No display-ID prefix, no profile map, no discriminator attribute
+   participates in shape resolution.
+2. **"Breaks core-only mode (no profile needed to parse entries correctly)."**
+   Core-only mode is preserved: `Id:` is core-reserved, its two value formats
+   are core-defined, and shape resolution completes without consulting any
+   profile.
+3. **"Worsens error messages; an explicit `Test-id` says what it is."** Under
+   the new model, "missing `Id:`" is a single-source diagnostic. "Malformed
+   `Id:` — expected ULID or URI" is concrete. Type-level diagnostics
+   (`missing
+   \`type: test\`` on an identified entry) are separate from
+   identity diagnostics and come from profile rules.
+4. **"Would invalidate the PR #217 migration shipped earlier in April 2026."**
+   MarkSpec has not shipped. The migration is pre-release and explicitly
+   revisable; the revision to ADR-002 accompanying this ADR reverses it and
+   `markspec migrate` gains a follow-up legacy-`Spec-id:`/`Test-id:`/etc. →
+   `Id:` rewrite.
+
+ADR-008 §8 is superseded by this section.
+
+## Consequences
+
+### What this ADR enables
+
+- A core model that is both tech-writer-friendly (no compliance vocabulary
+  required) and compliance-ready (all the scaffolding is available the moment a
+  compliance profile is loaded).
+- A single, sharp rule for scope decisions: mechanism vs. policy. Every "does
+  this belong in core?" question reduces to "is this universal machinery or
+  domain-specific vocabulary?".
+- A stable core-contract surface (`Id:`, two shapes, typed edges, generic
+  attribute schema) that profiles extend without the core chasing domain
+  specificity.
+- A credible path to shipping MarkSpec as either an authoring tool with optional
+  enforcement, or a full compliance tool — without forking the codebase or
+  positioning around a single persona.
+
+### What shifts for the code (not yet implemented)
+
+- Entry-parser: drops four-attribute family recognition (`Spec-id` / `Test-id` /
+  `Element-id` / `Reference-id` → family lookup) in favor of one-attribute
+  format discrimination (`Id:` value → ULID vs URI).
+- Entry model: one shape field (`identified | referenced`) replaces the
+  four-family enum.
+- Attribute catalog in core: reduces to the short universal set (`Id`, `Labels`,
+  `References`, `External-id`, `Supersedes`, `Superseded-by`, `Deprecated`) plus
+  the built-in `Supersedes:` relation. Everything else moves to the default
+  profile (ADR-010) or to compliance profiles.
+- Tooling: `markspec migrate` adds a legacy-Id rewrite step covering both
+  ADR-001 `Id:` (already handled, pre-family) and ADR-002 family-specific
+  attributes.
+
+### What does _not_ change
+
+- Markdown format (ADR-001) — unchanged.
+- Document structure (ADR-007) — front matter remains the document-metadata
+  carrier; `document-id` and `document-type` keep their current shape. The
+  `document-id` value follows the same ULID-or-URI rule as entry `Id:`.
+- Book structure (ADR-004) — unchanged; the four book parts (Product /
+  Architecture / Guide / Verification) are an authoring convention, not a core
+  concept.
+- CLI architecture (ADR-005) — unchanged.
+- Profile distribution mechanics (ADR-008 §§1–7, §§9–10) — distribution
+  channels, `extends:` chain, vendoring, CLI surface, and hook-slot decisions
+  are preserved.
+
+## Dependencies
+
+- ✅ [ADR-001 — Markdown Format](./adr-001-markdown-format.md) — trailer syntax,
+  entry block form.
+- ✅ [ADR-002 — Entry Model](./adr-002-entry-model.md) — attribute-origin
+  taxonomy, value types, retirement semantics (reused; family-specific sections
+  revised).
+- ✅ [ADR-008 — Profile System](./adr-008-profile-system.md) — distribution and
+  extends-chain mechanics (reused; §8 superseded, vocabulary expanded for
+  type-declaration duty).
+- 🔗 ADR-010 — Default Profile (follow-up): the generic type set and RFC 2119
+  hygiene rules shipped with MarkSpec out of the box.
+- 🔗 ADR-011 — Language Pack and Dependency Ingestion (follow-up): the bundled
+  tree-sitter language pack, the SBOM-tool delegation for manifest parsing, and
+  the entry-source adapter API.
+
+## Acceptance criteria
+
+- [ ] Core parser recognizes entries via single `Id:` attribute with ULID-or-URI
+      format discrimination.
+- [ ] Core model carries a two-value shape field (`identified | referenced`) and
+      no four-family enum.
+- [ ] Core attribute catalog reduced to the universal set; all family-specific
+      attributes relocated to a profile.
+- [ ] Cross-reference resolution operates on identity values without consulting
+      profile vocabulary.
+- [ ] Core-only mode (no profile loaded) produces a well-formed model with only
+      hygiene diagnostics.
+- [ ] `markspec migrate` rewrites legacy family-specific identity attributes
+      (`Spec-id` / `Test-id` / `Element-id` / `Reference-id`) to `Id:`.
+- [ ] Revisions to ADR-002, ADR-006, ADR-007, ADR-008 land alongside this ADR,
+      with cross-references updated.
+
+## Out of scope (future ADRs)
+
+- **Default profile specification** — the generic type set (`requirement`,
+  `note`, `section`, `reference`), hygiene rules, RFC 2119 anchoring, and
+  display-ID patterns for the out-of-box experience. **ADR-010**.
+- **Language pack and dependency ingestion** — bundled tree-sitter grammars,
+  per-language doc-comment conventions, SBOM-tool delegation (Syft / cdxgen),
+  `pkg:` identity for dependencies, hardware BOM ingestion. **ADR-011**.
+- **Profile hooks** — code extension points for parser, LSP, MCP. **ADR-012**
+  (renumbered from ADR-009 slot previously reserved by ADR-008).
+- **Migration tooling for legacy `Spec-id:`/`Test-id:`/`Element-id:`
+  /`Reference-id:` attributes** — implementation-level; `markspec migrate`
+  follow-up.
+- **Display-ID pattern grammar extensions** — slug placeholders, per-type scope
+  counters, domain sub-scoping beyond the minimum `{n:03d}` form.

--- a/docs/architecture/adr-010-default-profile.md
+++ b/docs/architecture/adr-010-default-profile.md
@@ -1,0 +1,298 @@
+# ADR-010: Default Profile — RFC 2119 Hygiene and Generic Types
+
+Status: Proposed\
+Date: 2026-04-20\
+Scope: MarkSpec\
+Depends on: [ADR-008 — Profile System](./adr-008-profile-system.md),
+[ADR-009 — Core / Profile Boundary](./adr-009-core-profile-boundary.md)
+
+## Context
+
+ADR-009 moves the four-family taxonomy out of the core into the profile layer
+and reduces the core to two semantics-free shapes (identified, referenced). The
+core itself enforces only hygiene (unique `Id:` values, resolvable
+cross-references, well-formed value shapes); it carries no type vocabulary.
+
+A core-only MarkSpec is usable — a tech-writing persona can author Markdown, get
+stable IDs, render PDF/book/deck — but the experience is under-powered for the
+authors MarkSpec was first built to serve. Spec authors expect to write numbered
+requirements, cite external standards, define glossary terms, and have the tool
+notice the difference. Loading a full ASPICE or ISO 26262 profile to get that
+baseline is a disproportionate first-run cost.
+
+This ADR specifies the **default profile**: a small, opinion-light profile that
+ships bundled with MarkSpec, loads by default, provides a generic type
+vocabulary grounded in community standards rather than any compliance framework,
+and gets out of the way when a compliance profile is loaded on top.
+
+The default profile's reference point is **RFC 2119 / BCP 14** — the
+MUST/SHALL/SHOULD/MAY vocabulary used by every IETF, W3C, and OASIS
+specification. It is the closest thing the general tech-writing world has to a
+universal normative-language standard, it is compact, it is compliance-neutral,
+and most authors recognize it.
+
+## Decision
+
+### 1. The default profile is a profile
+
+The default profile is an ordinary profile (per ADR-008): a `markspec.yaml`
+manifest plus optional hooks, distributable via the same mechanisms. It happens
+to be bundled with the MarkSpec binary rather than fetched, and it loads
+automatically unless the consumer opts out.
+
+**Bundling.** The default profile ships as a bundled package inside the MarkSpec
+binary (e.g., `packages/markspec-profile-default/markspec.yaml`). On startup it
+is registered in the loader as if the consumer had declared it at the bottom of
+their `profiles:` chain.
+
+**Opt-out.** A consumer may disable the default profile by setting
+`default-profile: false` in `.markspec.yaml`:
+
+```yaml
+default-profile: false
+profiles:
+  - npm:@markspec/profile-aspice-4@^1.2
+```
+
+Opting out yields core-only mode plus whatever compliance profiles are declared.
+Opting out is appropriate when a compliance profile supplies its own baseline
+types (most do); the default profile exists for users who do not load a
+compliance profile.
+
+**Compatibility with compliance profiles.** When a compliance profile is
+declared, it normally extends the default profile via ADR-008 `extends:`.
+Compliance profiles that already cover the generic vocabulary may shadow or
+replace the default profile's types; the `extends:` merge rules (additive for
+vocabulary, tightening for constraints, see ADR-008 §5) apply.
+
+### 2. Type vocabulary — minimal and generic
+
+The default profile declares four types across the two core shapes. The
+vocabulary covers what every structured technical document needs and nothing
+more.
+
+**Identified entries:**
+
+| Type          | Purpose                                       | Typical authoring pattern                              |
+| ------------- | --------------------------------------------- | ------------------------------------------------------ |
+| `requirement` | A normative statement using RFC 2119 keywords | "The system MUST …" / "The agent SHALL …"              |
+| `note`        | Informational callout that needs a stable ID  | Warnings, rationales, implementation notes             |
+| `term`        | Glossary term definition                      | A term and its definition, cross-referenced from prose |
+
+**Referenced entries:**
+
+| Type        | Purpose                                        | Typical identity             |
+| ----------- | ---------------------------------------------- | ---------------------------- |
+| `reference` | External citation (standard, paper, RFC, book) | URN / DOI / HTTPS URL / ISBN |
+
+The `type:` attribute value is `requirement`, `note`, `term`, or `reference`.
+Profiles may extend the type catalog but may not shadow these names.
+
+**Intentionally excluded from the default profile:**
+
+- Test, element, dependency, SOUP, risk, hazard — all compliance-flavored; they
+  belong in compliance profiles, not the default baseline.
+- Section, subsection, appendix — Markdown headings already carry structure;
+  promoting them to typed entries is duplication.
+- Title, description, author — document-level metadata covered by front matter
+  (ADR-007).
+
+### 3. Normative language — RFC 2119 / BCP 14
+
+The default profile names RFC 2119 / BCP 14 as the recommended normative
+vocabulary for `requirement` entries. It is a recommendation, not an
+enforcement:
+
+```yaml
+profile:
+  types:
+    requirement:
+      normative-language: rfc2119
+```
+
+The `normative-language:` hint is carried by the profile and available to
+tooling. The default profile's linter raises an **informational** diagnostic
+(not a warning, not an error) when a `requirement` entry's body contains no RFC
+2119 keyword. Authors override the convention by setting
+`normative-language: none` on the type in their own profile, or by ignoring the
+diagnostic.
+
+The canonical keywords (per RFC 2119 and RFC 8174 clarification):
+
+```text
+MUST, MUST NOT, REQUIRED, SHALL, SHALL NOT,
+SHOULD, SHOULD NOT, RECOMMENDED, NOT RECOMMENDED,
+MAY, OPTIONAL
+```
+
+Case sensitivity follows RFC 8174: uppercase is normative, lowercase is not.
+Tooling recognizes both but only uppercase triggers the informational diagnostic
+as "present".
+
+### 4. Hygiene rules
+
+The default profile ships the universal rules that any structured document set
+benefits from, regardless of domain:
+
+| Rule                                             | Scope                  | Severity |
+| ------------------------------------------------ | ---------------------- | -------- |
+| Unique identity values                           | All entries            | error    |
+| Unique display IDs                               | All entries            | error    |
+| All cross-references resolve                     | All typed edges        | error    |
+| Referenced-entry `Id:` is a scheme-qualified URI | Referenced entries     | error    |
+| Identified-entry `Id:` is a well-formed ULID     | Identified entries     | error    |
+| `requirement` body contains an RFC 2119 keyword  | `type: requirement`    | info     |
+| `term` entries referenced from prose are defined | Prose mentions         | warning  |
+| Display ID matches type's declared pattern       | Entries with a `type:` | warning  |
+
+The first five are core hygiene restated at the profile layer so the default
+profile can surface them as user-facing diagnostics with explanatory messages.
+They are not duplicated enforcement — core enforces them structurally; the
+default profile names them for the diagnostic surface.
+
+### 5. Display-ID patterns — permissive by default
+
+The default profile declares templates that are **recognized** but not
+**enforced**. A display ID matching the template is understood; a display ID not
+matching is accepted with a warning (not an error) because the default profile
+is opinion-light:
+
+```yaml
+profile:
+  types:
+    requirement:
+      display-id-pattern: "REQ-{n:03d}" # suggested, not enforced
+      display-id-pattern-enforcement: warn
+    note:
+      display-id-pattern: "NOTE-{n:03d}"
+      display-id-pattern-enforcement: warn
+    term:
+      display-id-pattern-enforcement: off # free-form slugs
+    reference:
+      display-id-pattern-enforcement: off # free-form slugs
+```
+
+Enforcement modes:
+
+- `error` — non-matching display ID is a validation error. Compliance profiles
+  typically pick this.
+- `warn` — non-matching display ID raises a warning; the entry still validates.
+  The default profile picks this for typed identified entries.
+- `off` — no check; any valid core display ID is accepted. The default profile
+  picks this for slug-based referenced entries and for glossary terms.
+
+The pattern template grammar is defined in ADR-009 §5 (literal prefix + `{n}`
+placeholder with optional padding).
+
+### 6. Glossary support
+
+`term` entries form a lightweight glossary. The default profile declares:
+
+- `type: term` entries have a free-form slug display ID and no required external
+  `Id:` (they are identified entries with a ULID).
+- A prose mention of a term (via `{{term.<slug>}}` inline reference or a
+  `[[term-slug]]` wiki-link, subject to ADR-001 reference syntax) resolves to
+  the defining entry.
+- A prose mention of a term not defined anywhere raises a warning.
+
+Glossary entries do not carry compliance attributes. Profiles that need a richer
+glossary model (acronyms, cross-lingual terms, see-also relationships) extend
+`term` or replace it.
+
+### 7. Front-matter additions
+
+The default profile does not add required front-matter keys. It declares two
+optional keys for consumer convenience:
+
+```yaml
+profile:
+  documents:
+    frontMatter:
+      - name: normative-language
+        type: enum
+        values: [rfc2119, none]
+        description: |
+          Overrides the default RFC 2119 normative-language hint for all
+          requirement entries in this document.
+      - name: glossary-scope
+        type: enum
+        values: [local, project]
+        description: |
+          Whether term entries defined in this document scope to the
+          document only or to the whole project.
+```
+
+Neither is required. Both are absent from documents by default.
+
+### 8. No hooks
+
+The default profile is pure declarative YAML. It ships no `hooks/` directory.
+Profile hooks (when specified by the future ADR-012) remain an extension point
+available to other profiles, not a mechanism the default uses.
+
+## Consequences
+
+### What this ADR enables
+
+- MarkSpec ships with a usable out-of-box experience for a tech-writer persona
+  without dragging in compliance vocabulary.
+- A single, well-known reference point (RFC 2119 / BCP 14) anchors the default's
+  normative semantics. Authors across industries recognize it.
+- Compliance profiles stack cleanly on top via `extends:`, treating the default
+  as the generic baseline they tighten.
+- The opt-out mechanism keeps core-only mode reachable for users who want it.
+
+### What shifts for existing assumptions
+
+- The current core-attribute catalog — with family-specific attributes — loses
+  its family-specific members to the compliance-profile layer and retains only
+  the universal subset. The default profile picks up the generic types
+  (`requirement`, `note`, `term`, `reference`) but does not introduce compliance
+  vocabulary (`Derived-from`, `Verifies`, `Allocated-to`, etc.), which move to
+  compliance profiles.
+- Documents written under a compliance profile (ASPICE, ISO 26262, …) are
+  unaffected — the compliance profile supplies its own richer types that extend
+  or replace the defaults.
+- Documents written without any profile (core-only mode) remain valid; they
+  simply do not get type-level diagnostics.
+
+## Dependencies
+
+- ✅ [ADR-008 — Profile System](./adr-008-profile-system.md) — manifest format,
+  distribution, extends-chain, CLI surface.
+- ✅ [ADR-009 — Core / Profile Boundary](./adr-009-core-profile-boundary.md) —
+  two-shape core, single `Id:` attribute, generic attribute machinery.
+- 🔗 ADR-011 — Language Pack and Dependency Ingestion (follow-up): the default
+  profile composes with the default language pack when source-code extraction is
+  active.
+- 🔗 ADR-012 — Profile Hooks (future): hook extension points; not used by the
+  default profile.
+
+## Acceptance criteria
+
+- [ ] Default profile is bundled into the MarkSpec binary and loaded
+      automatically.
+- [ ] `default-profile: false` in `.markspec.yaml` disables it without error.
+- [ ] Four types (`requirement`, `note`, `term`, `reference`) are declared with
+      their specified shapes and display-ID rules.
+- [ ] RFC 2119 / 8174 keyword detection runs on `type: requirement` entries and
+      emits an informational diagnostic when none is present.
+- [ ] The eight hygiene rules from §4 emit diagnostics with the specified
+      severities and explanatory messages.
+- [ ] Display-ID pattern enforcement honors the three-mode configuration
+      (`error`, `warn`, `off`).
+- [ ] `term` cross-resolution works via `{{term.<slug>}}` inline references.
+- [ ] A compliance profile extending the default via `extends:` merges correctly
+      per ADR-008 §5 merge rules.
+
+## Out of scope (future work)
+
+- **Domain-specific default types** — test, element, dependency. These belong in
+  compliance profiles, not the generic default.
+- **Rich glossary semantics** — acronym expansion, see-also relationships,
+  cross-lingual variants. Profile extensions or a dedicated glossary profile.
+- **Natural-language heuristics beyond RFC 2119** — tone, voice, readability
+  scoring. Not a core or default-profile concern.
+- **Default-profile localization** — diagnostic messages and RFC 2119
+  equivalents in other languages. Deferred until an internationalization story
+  is scoped for MarkSpec as a whole.

--- a/docs/architecture/adr-011-language-pack-and-dependency-ingestion.md
+++ b/docs/architecture/adr-011-language-pack-and-dependency-ingestion.md
@@ -1,0 +1,327 @@
+# ADR-011: Language Pack and Dependency Ingestion
+
+Status: Proposed\
+Date: 2026-04-20\
+Scope: MarkSpec\
+Depends on: [ADR-008 — Profile System](./adr-008-profile-system.md),
+[ADR-009 — Core / Profile Boundary](./adr-009-core-profile-boundary.md),
+[ADR-010 — Default Profile](./adr-010-default-profile.md)
+
+## Context
+
+ADR-009 introduces an **entry-source abstraction**: entries in the MarkSpec
+model may come from anywhere — Markdown files, source code doc comments,
+dependency manifests, SBOM reports, ECAD/PLM exports — through a uniform
+pipeline. Markdown is the canonical source; everything else is an adapter.
+
+Two practical questions follow: which languages does MarkSpec parse out of the
+box, and how does it learn about a project's third-party dependencies without
+re-implementing every ecosystem's package-manager manifests? This ADR answers
+both.
+
+The decisions rest on three observations:
+
+- **Syntax highlighting is table stakes.** The tree-sitter runtime is useful
+  independent of entry extraction — every code block in rendered output wants
+  grammar-based highlighting. The runtime has to live in the core for that
+  reason alone. Language adapters for doc-comment extraction piggyback on the
+  same infrastructure.
+- **Dependency parsing is a solved problem.** Syft, cdxgen, and the wider SBOM
+  ecosystem already parse every mainstream manifest format into CycloneDX / SPDX
+  JSON. MarkSpec should consume that output rather than maintain a parser per
+  ecosystem. CycloneDX also covers hardware BOMs, so the same path extends to
+  parts and HBOM use cases.
+- **Coding standards are rules, not languages.** MISRA-C, AUTOSAR C++, CERT,
+  HIC++ are rule sets evaluated against an existing C / C++ parse tree. They fit
+  the profile-with-rules shape defined in ADR-008 and do not justify new
+  language adapters.
+
+## Decision
+
+### 1. Tree-sitter runtime in core
+
+The tree-sitter runtime — grammar loading, tree walking, queries — is part of
+the MarkSpec core. It is exposed as a generic service to:
+
+- Markdown code-block syntax highlighting in the rendering pipeline (runs
+  unconditionally).
+- Language adapters that extract entries from source code.
+- Profile hooks (future ADR-012) that want to inspect parse trees.
+
+Grammars themselves do **not** live in core. Grammars ship with language packs
+or are installed by consumers. The core runtime has no built-in language
+knowledge.
+
+### 2. Default language pack — bundled, opt-out
+
+The **default language pack** is a bundled extension: a package built into the
+MarkSpec binary, registered at startup as if the consumer had installed it. It
+supplies tree-sitter grammars and per-language doc-comment extraction rules for
+a curated set of languages.
+
+**Languages in v1:**
+
+| Language   | Grammar source         | Doc-comment convention             | Manifests (via SBOM, §5)         |
+| ---------- | ---------------------- | ---------------------------------- | -------------------------------- |
+| Rust       | tree-sitter-rust       | `///`, `//!`, `/** */`             | Cargo.toml, Cargo.lock           |
+| Kotlin     | tree-sitter-kotlin     | KDoc `/** */`                      | build.gradle(.kts)               |
+| C          | tree-sitter-c          | `/** */`, `///`, Doxygen           | (ecosystem-dependent)            |
+| C++        | tree-sitter-cpp        | `/** */`, `///`, Doxygen           | (ecosystem-dependent)            |
+| Java       | tree-sitter-java       | Javadoc `/** */`                   | pom.xml, build.gradle            |
+| TypeScript | tree-sitter-typescript | TSDoc `/** */`                     | package.json                     |
+| JavaScript | tree-sitter-javascript | JSDoc `/** */`                     | package.json                     |
+| Python     | tree-sitter-python     | docstrings (module/class/function) | pyproject.toml, requirements.txt |
+| C#         | tree-sitter-c-sharp    | XML doc comments `///`             | .csproj, packages.lock.json      |
+
+Go is **deferred**. Cloud-native tooling has weaker overlap with MarkSpec's
+authoring and enforcement personas; Go support can be added as an opt-in pack if
+demand emerges.
+
+**Opt-out.** A consumer disables the default language pack with
+`default-language-pack: false` in `.markspec.yaml`. Useful for minimal
+tech-writing projects that do not want the binary size or the extractor
+overhead.
+
+**Custom packs.** Consumers install additional or alternative language packs
+through the ordinary profile-distribution channels (local path, git, npm). A
+pack is a profile (per ADR-008) that declares grammars and extractors in its
+manifest and optionally ships them in its bundle. Rule-profiles (§6) compose
+with whatever adapters are active — default pack, custom pack, or both.
+
+### 3. Entry-source adapter API
+
+Each language adapter in a pack implements the entry-source interface specified
+(in detail) by a follow-up ADR. At the architectural level the contract is:
+
+```text
+adapter.detect(path) -> yields (entry-shape, identity, attributes, provenance)
+```
+
+- Given a path to a file the adapter recognizes, it walks the tree-sitter parse
+  tree and yields MarkSpec entries.
+- Each yielded entry carries its **provenance** (source path, line, column,
+  language, extraction rule) as properties, not as authored attributes (per
+  ADR-009 §4).
+- Each yielded entry carries a **shape** (identified or referenced) and a
+  `type:` value that the active profile recognizes.
+
+Default-pack extractors follow a consistent pattern: a doc-comment attached to a
+code declaration yields an **identified** entry with a type drawn from the
+language pack's convention (`type: unit` for a function or method,
+`type: module` for a package-level declaration). An `import` / `use` / `require`
+/ `#include` statement optionally yields a **referenced** entry whose identity
+is a purl (§5) or language-specific URI.
+
+### 4. Language-pack extraction scope
+
+The default pack's extractors are conservative by default. They emit entries
+for:
+
+- Declarations that carry a doc comment (identified, `type: unit` or
+  equivalent).
+- Imports / external references at the module level (referenced, identity = purl
+  when resolvable).
+
+Extractors do **not** attempt to emit entries for every declaration. Authors opt
+into extraction by writing a doc comment; silent walls of auto-generated entries
+would pollute the model and flood cross-reference resolution.
+
+**Compliance profiles may tighten this.** An ASPICE profile can declare that
+every function in a subsystem requires a doc-comment-backed identified entry or
+a `Realizes:` link (ADR-008 traceability rules). The default pack supplies the
+extraction; the compliance profile supplies the requirement.
+
+### 5. Dependency ingestion — SBOM delegation
+
+MarkSpec does not parse ecosystem manifest formats (Cargo.toml, package.json,
+pom.xml, pyproject.toml, .csproj, …) natively. Instead, it delegates to external
+SBOM generators that already handle every mainstream ecosystem.
+
+**Tooling.** The supported SBOM producers in v1 are:
+
+- **[Syft](https://github.com/anchore/syft)** — language- and ecosystem-agnostic
+  SBOM generator, produces CycloneDX and SPDX.
+- **[cdxgen](https://github.com/CycloneDX/cdxgen)** — OWASP CycloneDX's
+  generator with broad ecosystem coverage.
+
+Either tool satisfies the dependency-ingestion input contract: CycloneDX or SPDX
+JSON. Both tools are distributable, scriptable, and ubiquitously deployed in
+security-scanning pipelines.
+
+**Invocation.** `markspec deps ingest` runs the configured SBOM producer against
+the project, parses the resulting CycloneDX / SPDX JSON, and emits one
+**referenced** entry per package component plus typed **`depends-on`** edges
+between them. Caching behavior, retry semantics, and CLI flags are
+implementation detail to be specified with the other entry-source APIs.
+
+**Identity — purl.** Dependency entries use Package URL (**purl**, per the
+purl-spec) as the `Id:` value:
+
+```text
+Id: pkg:cargo/serde@1.0.0
+Id: pkg:npm/lodash@4.17.21
+Id: pkg:pypi/requests@2.31.0
+Id: pkg:maven/org.apache.commons/commons-lang3@3.14.0
+Id: pkg:nuget/Newtonsoft.Json@13.0.3
+```
+
+purl values are valid RFC 3986 URIs (scheme `pkg:`), so they fit the ADR-009 §2
+identity contract unchanged. Discrimination via the URI scheme classifies them
+as referenced entries.
+
+**Relation — `Depends-on`.** The core recognizes `Depends-on:` as a relation
+name when a profile declares it. The default profile does **not** declare it
+(dependency relationships are domain vocabulary). Compliance profiles (ASPICE,
+ISO 26262, IEC 62304 SOUP) declare `Depends-on:` with their specific semantics.
+The SBOM ingester emits the edges; the active profile decides what rules apply
+to them.
+
+**Attributes from SBOM.** The ingester populates:
+
+- `Id:` — purl, as above.
+- `Licenses:` — from CycloneDX/SPDX license fields (list of SPDX license IDs).
+- `Description:` — package description when present.
+- Provenance properties: source manifest path, SBOM tool, SBOM generation
+  timestamp.
+
+Compliance attributes (SOUP class, risk rating, verification evidence, safety
+impact) are **not** populated by the ingester. They are authored — or populated
+by a compliance profile hook — on top of the ingested referenced entries.
+
+### 6. Rule-profiles — standards on top of adapters
+
+Coding standards that constrain what is acceptable in a given language (MISRA-C,
+MISRA-C++, AUTOSAR C++, CERT C/C++, HIC++, SEI coding rules, …) are profiles,
+not language adapters. They ship rules evaluated by the core rule evaluator
+(ADR-009 §8) against the parse tree produced by the active C / C++ adapter.
+
+A rule-profile manifest looks structurally identical to any other profile
+(ADR-008) but populates `rules:` with AST-shaped conditions rather than relation
+constraints:
+
+```yaml
+# hypothetical — rule grammar specified by a follow-up ADR
+profile:
+  rules:
+    - id: misra-c-15.1
+      source: c
+      pattern: goto_statement
+      severity: warning
+      description: The goto statement should not be used (MISRA-C 15.1)
+```
+
+Rule-profiles compose freely with compliance profiles. An ASPICE profile that
+extends a MISRA-C rule-profile gets both traceability rules and static-code
+rules from one `extends:` chain.
+
+The rule grammar, AST query language, and diagnostic surface for code-shaped
+rules are deferred to a follow-up ADR. This ADR reserves the pattern.
+
+### 7. Hardware BOM and ECAD sources
+
+The same ingestion pipeline extends to hardware:
+
+- **CycloneDX hardware components** and **SPDX 3.0 hardware profile** are
+  consumed by the same `markspec deps ingest` entry point.
+- **Parts** (catalog components) are emitted as referenced entries with a
+  purl-like identity scheme (`pkg:hardware/...`, supplier catalog URIs, or
+  profile-declared part-ID schemes).
+- **Internally-specified parts** (assemblies, components declared by the
+  project) are authored as identified entries with ULIDs, or extracted from
+  ECAD/PLM exports via a profile-provided adapter.
+- Relations specific to parts (`part-of`, `composes`, `substitutes`,
+  `supplied-by`) are profile-declared.
+
+Compliance profiles for hardware-involving domains (IEC 62304 medical device
+software, ISO 26262 automotive) declare the dependency/parts relations and the
+SOUP/component classification attributes they need. The core and default pack
+provide the ingestion; the compliance profile provides the semantics.
+
+## Consequences
+
+### What this ADR enables
+
+- Out-of-box language coverage for nine languages that between them account for
+  most industry software work relevant to MarkSpec's personas.
+- A first-class dependency story without MarkSpec maintaining N ecosystem
+  parsers — the SBOM ecosystem carries that weight.
+- A clean separation between parsing (core + pack) and rules (profile) that
+  makes coding-standard support mechanical to add: one profile per standard, all
+  running on the same adapter trees.
+- A uniform pipeline for software and hardware BOMs, so compliance profiles in
+  domains like medical devices and automotive can cover both without the tool
+  chasing domain specificity.
+
+### What shifts for existing code (not yet implemented)
+
+- The existing language-grammar registration code relocates behind the
+  entry-source adapter API.
+- A new `markspec deps ingest` command is introduced; `markspec deps` is
+  reserved as the subcommand group for future dependency operations.
+- SBOM-tool invocation is an external-process call; tests and CI pipelines need
+  at least one producer installed. A consumer-friendly error path is required
+  when neither tool is available.
+
+### Trade-offs accepted
+
+- **Default pack size.** Nine tree-sitter grammars add measurable weight to the
+  binary. The opt-out mechanism is the escape hatch for weight-sensitive users.
+  Expected binary growth is acceptable given the ubiquity of each language in
+  MarkSpec's target audiences.
+- **External tool dependency.** `markspec deps ingest` relies on Syft or cdxgen.
+  This trades a runtime dependency for the avoidance of N maintainer-years of
+  manifest-parser code. The trade is justified because the SBOM tools are
+  mature, widely deployed, and standardized on CycloneDX / SPDX.
+
+## Dependencies
+
+- ✅ [ADR-008 — Profile System](./adr-008-profile-system.md) — distribution,
+  manifest schema, extends-chain; language packs and rule-profiles compose via
+  the profile layer.
+- ✅ [ADR-009 — Core / Profile Boundary](./adr-009-core-profile-boundary.md) —
+  two-shape model, entry-source abstraction, identity via ULID or URI, typed
+  edges.
+- ✅ [ADR-010 — Default Profile](./adr-010-default-profile.md) — out-of-box type
+  vocabulary composed with the default language pack's extraction.
+- 🔗 ADR-012 — Profile Hooks (future): code extension points; language packs
+  with custom extraction logic use this surface.
+- 🔗 Follow-up ADR — Entry-source adapter API: the formal interface contract
+  referenced in §3.
+- 🔗 Follow-up ADR — Code-rule grammar: AST query language referenced in §6.
+
+## Acceptance criteria
+
+- [ ] Tree-sitter runtime is part of the core and usable for code-block syntax
+      highlighting in the rendering pipeline.
+- [ ] Default language pack ships with the nine v1 languages and is loaded at
+      startup unless disabled.
+- [ ] `default-language-pack: false` in `.markspec.yaml` disables it cleanly.
+- [ ] Each adapter yields identified entries for doc-commented declarations and
+      referenced entries for imports.
+- [ ] `markspec deps ingest` invokes a configured SBOM producer (Syft or
+      cdxgen), ingests CycloneDX / SPDX JSON, emits purl-identified referenced
+      entries, and emits `depends-on` edges.
+- [ ] Dependency entries carry SBOM-sourced attributes (licenses, description)
+      and provenance properties (manifest path, tool name, timestamp).
+- [ ] Hardware-BOM ingestion reuses the same CycloneDX / SPDX pipeline for
+      hardware components.
+- [ ] At least one rule-profile (`markspec-rules-misra-c`, as a
+      proof-of-concept, if scope permits) demonstrates code-rule evaluation on a
+      C adapter's parse tree.
+
+## Out of scope (future work)
+
+- **Entry-source adapter API specification** — interface, error handling,
+  caching, incremental extraction. Follow-up ADR.
+- **Code-rule grammar** — the AST query language used by rule-profiles (§6).
+  Follow-up ADR.
+- **Go language support** — deferred, addable as an opt-in pack.
+- **Ada / MISRA-Ada, SPARK, VHDL / Verilog, MATLAB / Simulink, Solidity** —
+  domain-specific languages; third-party packs.
+- **Native manifest parsers** — only considered as a fallback if an ecosystem
+  lacks Syft / cdxgen support. Not v1.
+- **Source-to-source derivation tracking beyond doc comments** — capturing
+  symbol graphs, call graphs, and data-flow relations from tree-sitter output.
+  Deferred until a concrete compliance use case demands it.
+- **Rule-profile ADRs per standard** — MISRA-C, MISRA-C++, AUTOSAR C++, CERT,
+  HIC++ as individual profile specifications. Each is a separate follow-up.

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,0 +1,161 @@
+# MarkSpec Architecture Overview
+
+This document gives the narrative tour of MarkSpec's architecture. For the
+decisions behind it, see the [ADRs](./) in this directory.
+
+## Who MarkSpec is for
+
+MarkSpec serves two distinct personas that share a common core:
+
+- **Technical writers** — authors who want ergonomic Markdown authoring, stable
+  cross-references, good typography, and high-quality PDF / book / deck output.
+  They care about writing speed, rendering fidelity, and being able to cite
+  external sources cleanly.
+- **Process / compliance owners** — quality engineers, safety assessors, and
+  audit-facing roles who need ASPICE, ISO 26262, DO-178C, IEC 62304
+  traceability, coverage checks, and rule enforcement. They care about what the
+  tool can _prove_ about a document set.
+
+The two personas diverge sharply in what they want on the surface. They converge
+on a shared substrate: Markdown with stable IDs and typed cross-references.
+MarkSpec is organized around that convergence — one codebase, one binary,
+layered behavior depending on which profile(s) are loaded.
+
+## The three layers
+
+```text
+compliance profile  ·  ASPICE / ISO 26262 / DO-178C / IEC 62304 / MISRA / …
+                       Type vocabulary, relation names, traceability rules,
+                       safety classifications.
+
+default profile     ·  Generic types (requirement, note, term, reference),
+                       RFC 2119 hygiene, universal validation rules.
+
+core                ·  Two entry shapes (identified, referenced), single `Id:`
+                       with ULID-or-URI format discrimination, typed-edge
+                       graph, attribute schema, rule evaluator, entry-source
+                       pipeline, tree-sitter runtime, typography pipeline.
+```
+
+Each layer is optional relative to the one above it. Core runs standalone.
+Default profile loads on top unless opted out. Compliance profiles stack on top
+of the default (or replace it) via the `extends:` chain. Organization, team, and
+project profiles tune further.
+
+See [ADR-009](./adr-009-core-profile-boundary.md) for the principle,
+[ADR-010](./adr-010-default-profile.md) for the default profile, and
+[ADR-008](./adr-008-profile-system.md) for the distribution and stacking
+mechanics.
+
+## What's in the core
+
+The core is deliberately small and semantics-free. It ships:
+
+- **Markdown authoring** — CommonMark + GFM subset
+  ([ADR-001](./adr-001-markdown-format.md)).
+- **Two entry shapes** — identified (ULID + display ID) and referenced (URI +
+  slug) ([ADR-002](./adr-002-entry-model.md),
+  [ADR-009](./adr-009-core-profile-boundary.md)).
+- **Typed-edge graph** — cross-references are labelled with relation names
+  declared by the active profile; the core resolves and validates them.
+- **Attribute-schema machinery** — generic `Key: Value` trailers with value
+  types, origin, cardinality; profiles populate the vocabulary.
+- **Generic rule evaluator** — predicates over the graph; dormant without
+  profile rules.
+- **Entry-source pipeline** — adapters for Markdown, code (tree-sitter), SBOM
+  tools, etc. ([ADR-011](./adr-011-language-pack-and-dependency-ingestion.md)).
+- **Tree-sitter runtime** — for code-block syntax highlighting and for language
+  adapters.
+- **Typography / rendering** — PDF, book, deck output; same rendering engine
+  across output formats ([ADR-004](./adr-004-book-structure.md)).
+- **Property namespace** — observed facts (path, git history, extraction
+  provenance) separate from authored attributes
+  ([ADR-006](./adr-006-property-model.md)).
+- **Document structure** — front matter, document identity, reserved keys
+  ([ADR-007](./adr-007-document-structure.md)).
+- **CLI** — `markspec format`, `validate`, `migrate`, `profile`, `deps`,
+  `render`, etc. ([ADR-005](./adr-005-cli-architecture.md)).
+
+The core does **not** ship: type vocabulary, compliance attributes, traceability
+rules, in-code doc-comment conventions, dependency manifest parsers, specific
+language grammars.
+
+## What the default profile adds
+
+The default profile (loaded automatically unless `default-profile: false`) adds
+the minimum vocabulary any structured doc set needs, grounded in RFC 2119 / BCP
+14:
+
+- **Types**: `requirement`, `note`, `term`, `reference`.
+- **Hygiene rules**: unique IDs, resolvable cross-references, RFC 2119 keyword
+  hinting on requirements, glossary-term resolution.
+- **Display-ID patterns**: `REQ-{n:03d}`, `NOTE-{n:03d}` (warn-only, not
+  enforced).
+- **Glossary support**: `type: term` entries with prose resolution via
+  `{{term.<slug>}}`.
+
+See [ADR-010](./adr-010-default-profile.md).
+
+## What compliance profiles layer on
+
+A compliance profile expresses the vocabulary and rules of a standard:
+
+- **Type vocabulary** — `software-requirement`, `unit-test`, `integration-test`,
+  `safety-goal`, `hazard`, `soup-package`, …
+- **Relation names** — `Derived-from`, `Verifies`, `Tests`, `Allocated-to`,
+  `Mitigates`, `Implements`, …
+- **Required attributes per type** — `ASIL`, `DAL`, `SIL`, `Risk-class`,
+  `Verification-evidence`, …
+- **Traceability rules** — cardinality, target-type matchers, required
+  bidirectional links.
+
+Examples that typically ship as separate profile packages:
+`@markspec/profile-aspice-4`, `@markspec/profile-iso-26262`,
+`@markspec/profile-do-178c`, `@markspec/profile-iec-62304`,
+`@markspec/profile-misra-c`.
+
+See [ADR-008](./adr-008-profile-system.md) for distribution and
+[ADR-011 §6](./adr-011-language-pack-and-dependency-ingestion.md) for the
+coding-standard rule-profile pattern.
+
+## What the language pack adds
+
+The default language pack ships with the binary (opt out via
+`default-language-pack: false`) and covers nine languages: Rust, Kotlin, C, C++,
+Java, TypeScript, JavaScript, Python, C#.
+
+Each adapter:
+
+- Extracts identified entries from doc-commented declarations.
+- Emits referenced entries for imports / dependencies (purl-identified when
+  resolvable).
+- Provides a tree-sitter grammar the rendering pipeline uses for code-block
+  syntax highlighting.
+
+Dependency ingestion delegates to SBOM tooling (Syft, cdxgen) — MarkSpec does
+not re-implement manifest parsers. See
+[ADR-011](./adr-011-language-pack-and-dependency-ingestion.md) for the full
+design.
+
+## Reading order for new contributors
+
+If you are new to MarkSpec and want the full picture:
+
+1. [ADR-001 — Markdown Format](./adr-001-markdown-format.md) — what MarkSpec
+   considers valid input.
+2. [ADR-009 — Core / Profile Boundary](./adr-009-core-profile-boundary.md) — the
+   principle that organizes everything else.
+3. [ADR-002 — Entry Model](./adr-002-entry-model.md) — the two-shape entry model
+   the core implements.
+4. [ADR-008 — Profile System](./adr-008-profile-system.md) — how vocabulary and
+   rules live outside the core.
+5. [ADR-010 — Default Profile](./adr-010-default-profile.md) — the out-of-box
+   experience.
+6. [ADR-011 — Language Pack and Dependency Ingestion](./adr-011-language-pack-and-dependency-ingestion.md)
+   — how code and dependencies enter the model.
+
+For document-level structure and rendering, see
+[ADR-004](./adr-004-book-structure.md) (book),
+[ADR-007](./adr-007-document-structure.md) (front matter),
+[ADR-003](./adr-003-diagram-authoring.md) (diagrams),
+[ADR-005](./adr-005-cli-architecture.md) (CLI).


### PR DESCRIPTION
## What

Lands the **core/profile boundary** as MarkSpec's anchoring architectural
principle. Introduces ADR-009/010/011, rewrites ADR-002 around the two-shape
model, and revises ADR-006/007/008 in place to match — pre-ship, so the ADR
trail stays the canonical baseline.

## Why

ADR-001 through ADR-008 converged on a core that baked ASPICE/ISO compliance
scaffolding into the entry model (four families: Spec/Test/Element/Reference).
That scope worked when MarkSpec's identity was "spec authoring for automotive
safety", but two observations shifted the frame:

- MarkSpec serves **two personas** — technical-writer and
  process-enforcement — sharing a core but with divergent surfaces.
- The four-family split is compliance scaffolding, not a universal taxonomy.
  The universal distinction is **referenced vs. identified**: citations out
  vs. content-units-with-stable-local-identity.

Leaving the model as-is would have forced every core change to chase
compliance semantics, and would have blocked entry-model-v2 implementation
from starting against a soon-to-be-revised baseline.

## How

- **ADR-009** (new) — the anchoring principle: mechanism in core, policy in
  profile; two shapes; single `Id:` with ULID-or-URI format discrimination;
  identity vs. provenance; display-ID patterns as profile-declared templates;
  dormant rule engine; entry-source pipeline. Includes explicit rebuttal of
  ADR-008 §8's earlier rejection of single-`Id:`.
- **ADR-010** (new) — the default profile shipped bundled: 4 generic types
  (`requirement`, `note`, `term`, `reference`), RFC 2119 hygiene, opt-out
  mechanism.
- **ADR-011** (new) — the default language pack (9 languages: Rust, Kotlin,
  C, C++, Java, TypeScript, JavaScript, Python, C#; Go deferred) and the
  SBOM-delegation path (Syft/cdxgen) for dependency ingestion. Rule-profiles
  pattern for MISRA-C / AUTOSAR / CERT as profiles on top of existing
  adapters.
- **ADR-002** (rewritten) — replaces Spec/Test/Element/Reference Parts with
  Identified/Referenced Parts. Preserves universal content (syntactic form,
  value types, origin taxonomy, retirement semantics, properties).
- **ADR-008** (revised in place) — schema shifted from category-based
  (`spec:`/`test:`/`element:`/`reference:` scopes) to shape+type
  (`identified:`/`referenced:` scopes + per-type declarations with explicit
  `shape:`). §8 superseded; hooks ADR renumbered from ADR-009 to ADR-012.
- **ADR-006, ADR-007** — light touches: ADR-009 added as dependency;
  `source.*` property category added; `document-id` follows ULID-or-URI rule;
  trailer examples updated.
- **overview.md** (new) — narrative architecture tour and ADR reading order
  for new contributors.
- **ADR-003, ADR-001, ADR-004, ADR-005** — confirmed unchanged (no references
  to the family model).

## Checklist

- [ ] Tests added or updated (N/A — docs-only change; pre-push hook ran all
      398 tests, all passing)
- [x] Documentation updated (this IS the documentation update)
- [x] All checks pass (pre-commit `deno fmt` + `deno lint` + type-check;
      pre-push full test suite)

## Follow-up work (tracked in `project_roadmap.md` memory)

Entry-model-v2 implementation is blocked on this ADR pass landing, then
proceeds against the two-shape model directly (no four-family intermediate).
Default profile and default language pack are implemented alongside. Compliance
profile packages (ASPICE, ISO 26262, MISRA-C, …) are follow-up work after the
core/default layer is stable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
