### PR TITLE
fix(render): resolve relative image paths against source doc

### DIFF
--- a/packages/markspec/main.ts
+++ b/packages/markspec/main.ts
@@ -96,10 +96,12 @@ const docCmd = new Command()
       "../markspec-typst/",
       import.meta.url,
     ).pathname;
+    const sourceFilePath = new URL(file, `file://${Deno.cwd()}/`).pathname;
     const result = renderPdf(markdown, {
       compiled,
       config,
       typstPackagePath,
+      sourceFilePath,
     });
 
     for (const d of result.diagnostics) {

--- a/packages/markspec/render/mod.ts
+++ b/packages/markspec/render/mod.ts
@@ -16,7 +16,7 @@ import { generateTypstDocument } from "./typst/template.ts";
 import type { DocumentMetadata } from "./typst/template.ts";
 import { compileTypst } from "./typst/mod.ts";
 import type { TypstDiagnostic } from "./typst/mod.ts";
-import { join } from "@std/path";
+import { dirname, isAbsolute, join, relative, resolve } from "@std/path";
 
 /** Options for rendering a Markdown document. */
 export interface RenderOptions {
@@ -29,6 +29,15 @@ export interface RenderOptions {
    * Contains lib.typ, fonts/, and vendor/cmarker/.
    */
   readonly typstPackagePath: string;
+  /**
+   * Absolute path to the source Markdown file on disk.
+   *
+   * The Typst compiler resolves relative paths in the source
+   * (`![image](./asset.svg)`, etc.) against this file's directory.
+   * When omitted, relative paths resolve against `typstPackagePath`
+   * and image references outside the package will not load.
+   */
+  readonly sourceFilePath?: string;
 }
 
 /** Result of a render operation. */
@@ -42,9 +51,10 @@ export interface RenderResult {
 /**
  * Render a Markdown document to PDF.
  *
- * Generates a Typst document from the Markdown content using
- * the markspec-doc template and cmarker, then compiles it to PDF
- * via the Typst compiler.
+ * Generates a Typst document from the Markdown content using the
+ * markspec-doc template and cmarker, then compiles it to PDF via the
+ * Typst compiler. When `sourceFilePath` is provided, image references
+ * relative to the source Markdown resolve correctly.
  *
  * @param markdown - Preprocessed Markdown content
  * @param options - Render options with compiled model and config
@@ -54,12 +64,58 @@ export function renderPdf(
   markdown: string,
   options: RenderOptions,
 ): RenderResult {
-  const typstSource = renderTypst(markdown, options);
-  const fontPath = join(options.typstPackagePath, "fonts");
+  const typstPackagePath = ensureTrailingSlash(
+    resolve(options.typstPackagePath),
+  );
+  const sourceAbsPath = options.sourceFilePath
+    ? resolve(options.sourceFilePath)
+    : undefined;
 
+  // Workspace must contain both the markspec-typst package (for
+  // lib.typ, vendor/cmarker, themes) and the source Markdown (for
+  // relative image references). Use the longest common ancestor.
+  const workspace = sourceAbsPath
+    ? longestCommonDirectory(typstPackagePath, sourceAbsPath)
+    : typstPackagePath;
+
+  // Build the Typst package import prefix as a workspace-absolute path
+  // (Typst recognizes a leading `/` as "from workspace root").
+  const typstPackageImportPrefix = "/" +
+    ensureTrailingSlash(
+      relative(workspace, typstPackagePath).replaceAll("\\", "/"),
+    );
+
+  // Build the image-path base prefix: a workspace-absolute path to the
+  // source document's directory. cmarker's `image()` calls are written
+  // inside its own `lib.typ`, so relative image paths otherwise resolve
+  // against cmarker rather than the source doc; prefixing with this path
+  // (in a scope-provided wrapper) fixes that.
+  const imageBasePrefix = sourceAbsPath
+    ? "/" +
+      ensureTrailingSlash(
+        relative(workspace, dirname(sourceAbsPath)).replaceAll("\\", "/"),
+      )
+    : "";
+
+  const typstSource = renderTypst(
+    markdown,
+    options,
+    typstPackageImportPrefix,
+    imageBasePrefix,
+  );
+
+  // When compiling from a source file on disk, register the generated
+  // Typst source as a shadow file next to the Markdown so Typst
+  // resolves relative paths against the source directory.
+  const mainFilePath = sourceAbsPath
+    ? join(dirname(sourceAbsPath), "__markspec_render__.typ")
+    : undefined;
+
+  const fontPath = join(typstPackagePath, "fonts");
   const result = compileTypst(typstSource, {
-    workspace: options.typstPackagePath,
+    workspace,
     fontPaths: [fontPath],
+    mainFilePath,
   });
 
   const diagnostics: Diagnostic[] = result.diagnostics.map(
@@ -75,16 +131,22 @@ export function renderPdf(
 /**
  * Render a Markdown document to Typst source.
  *
- * Generates the Typst document without compiling to PDF.
- * Useful for debugging and inspection.
+ * Generates the Typst document without compiling to PDF. Useful for
+ * debugging and inspection.
  *
  * @param markdown - Preprocessed Markdown content
  * @param options - Render options with compiled model and config
+ * @param typstPackageImportPrefix - Optional workspace-absolute prefix
+ *   to use for the markspec-typst package imports (e.g. `"/"` or
+ *   `"/path/to/markspec-typst/"`). Defaults to empty (imports
+ *   resolved relative to workspace root).
  * @returns Typst source string
  */
 export function renderTypst(
   markdown: string,
   options: RenderOptions,
+  typstPackageImportPrefix: string = "",
+  imageBasePrefix: string = "",
 ): string {
   const metadata: DocumentMetadata = {
     project: options.config.name,
@@ -94,7 +156,13 @@ export function renderTypst(
   // Parse entries from the markdown for structured rendering
   const entries = parse(markdown);
 
-  return generateTypstDocument(markdown, metadata, entries);
+  return generateTypstDocument(
+    markdown,
+    metadata,
+    entries,
+    typstPackageImportPrefix,
+    imageBasePrefix,
+  );
 }
 
 /** Convert a Typst diagnostic to a MarkSpec diagnostic. */
@@ -105,4 +173,33 @@ function typstToDiagnostic(d: TypstDiagnostic): Diagnostic {
     message: `typst: ${d.message}`,
     location: undefined,
   };
+}
+
+/**
+ * Longest-common-directory of two absolute paths. Used to compute a
+ * Typst workspace that includes both the markspec-typst package and
+ * an arbitrary source document's directory.
+ */
+function longestCommonDirectory(a: string, b: string): string {
+  if (!isAbsolute(a) || !isAbsolute(b)) {
+    throw new Error("longestCommonDirectory requires absolute paths");
+  }
+  const aParts = a.replace(/\/+$/, "").split("/");
+  const bParts = b.replace(/\/+$/, "").split("/");
+  const shared: string[] = [];
+  const len = Math.min(aParts.length, bParts.length);
+  for (let i = 0; i < len; i++) {
+    if (aParts[i] === bParts[i]) {
+      shared.push(aParts[i]);
+    } else {
+      break;
+    }
+  }
+  const result = shared.join("/");
+  return result === "" ? "/" : result;
+}
+
+/** Ensure a directory path ends with a single `/`. */
+function ensureTrailingSlash(p: string): string {
+  return p.endsWith("/") ? p : `${p}/`;
 }

--- a/packages/markspec/render/typst/mod.ts
+++ b/packages/markspec/render/typst/mod.ts
@@ -5,6 +5,7 @@
  * and compiles Typst source to PDF.
  */
 
+import { Buffer } from "node:buffer";
 import { NodeCompiler } from "typst-ts-node-compiler";
 
 /** Result of a Typst compilation. */
@@ -23,17 +24,32 @@ export interface TypstDiagnostic {
 
 /** Options for Typst compilation. */
 export interface CompileTypstOptions {
-  /** Absolute path to the workspace root (where lib.typ lives). */
+  /** Absolute path to the workspace root. */
   readonly workspace: string;
   /** Absolute paths to directories containing font files. */
   readonly fontPaths: readonly string[];
+  /**
+   * Absolute path to use as the main file's virtual location.
+   *
+   * When set, the Typst source is registered as a shadow file at this path
+   * and compiled via `mainFilePath`. Typst then resolves relative paths in
+   * the source (most importantly image paths) against this file's
+   * directory. When unset, the source is passed as `mainFileContent` and
+   * relative paths resolve against the workspace root.
+   */
+  readonly mainFilePath?: string;
 }
 
 /**
  * Compile a Typst source string to PDF bytes.
  *
- * Creates a NodeCompiler configured with the given workspace and
- * font paths, compiles the source, and returns the PDF bytes.
+ * Creates a NodeCompiler configured with the given workspace and font
+ * paths, compiles the source, and returns the PDF bytes.
+ *
+ * If `mainFilePath` is provided, the source is mounted as a shadow file
+ * at that path so Typst can resolve relative-to-source paths (e.g. image
+ * references in the user's Markdown). The path must be inside
+ * `workspace`.
  */
 export function compileTypst(
   source: string,
@@ -47,7 +63,18 @@ export function compileTypst(
   });
 
   try {
-    const result = compiler.compile({ mainFileContent: source });
+    let result;
+    if (options.mainFilePath) {
+      compiler.mapShadow(options.mainFilePath, Buffer.from(source, "utf-8"));
+      try {
+        result = compiler.compile({ mainFilePath: options.mainFilePath });
+      } finally {
+        compiler.unmapShadow(options.mainFilePath);
+      }
+    } else {
+      result = compiler.compile({ mainFileContent: source });
+    }
+
     const diagnostics: TypstDiagnostic[] = [];
 
     if (result.hasError()) {

--- a/packages/markspec/render/typst/mod_test.ts
+++ b/packages/markspec/render/typst/mod_test.ts
@@ -84,3 +84,33 @@ Deno.test("compileTypst: reports error for invalid Typst", () => {
   assert(result.diagnostics.length > 0, "expected diagnostics");
   assertEquals(result.pdf, undefined);
 });
+
+Deno.test("compileTypst: mainFilePath lets relative paths resolve from source dir", async () => {
+  // Create a temp SVG in a scratch directory, then compile a Typst source
+  // that references it relatively. Without `mainFilePath`, the path would
+  // resolve from the workspace root and fail; with `mainFilePath` pointing
+  // at a shadow file next to the SVG, it resolves correctly.
+  const tempDir = await Deno.makeTempDir();
+  const svg =
+    `<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10"><rect width="10" height="10"/></svg>`;
+  await Deno.writeTextFile(`${tempDir}/chart.svg`, svg);
+
+  try {
+    const source = `#image("chart.svg", width: 10pt)`;
+    const result = compileTypst(source, {
+      workspace: tempDir,
+      fontPaths: [FONT_PATH],
+      mainFilePath: `${tempDir}/main.typ`,
+    });
+
+    assertEquals(
+      result.diagnostics.map((d) => d.message),
+      [],
+      "expected no diagnostics when relative SVG resolves from source dir",
+    );
+    assert(result.pdf !== undefined, "expected PDF output");
+    assert(result.pdf.length > 100, "expected non-trivial PDF");
+  } finally {
+    await Deno.remove(tempDir, { recursive: true });
+  }
+});

--- a/packages/markspec/render/typst/template.ts
+++ b/packages/markspec/render/typst/template.ts
@@ -34,29 +34,50 @@ export function generateTypstDocument(
   markdown: string,
   metadata: DocumentMetadata = {},
   entries: readonly Entry[] = [],
+  typstPackageImportPrefix: string = "",
+  imageBasePrefix: string = "",
 ): string {
   const metaArgs = buildMetaArgs(metadata);
-  const imports = `#import "lib.typ": markspec-doc, req-block, entry-category
-#import "vendor/cmarker/lib.typ": render
-#import "themes/light.typ" as theme`;
+  const prefix = typstPackageImportPrefix;
+  const imports =
+    `#import "${prefix}lib.typ": markspec-doc, req-block, entry-category
+#import "${prefix}vendor/cmarker/lib.typ": render
+#import "${prefix}themes/light.typ" as theme`;
 
   const showRule = `#show: markspec-doc.with(${metaArgs})`;
 
+  // When `imageBasePrefix` is set, pass a scope-level `image` function
+  // to cmarker so that relative image paths in the user's Markdown
+  // resolve against the source-document directory instead of cmarker's
+  // own location.
+  const imageBinding = imageBasePrefix
+    ? `#let ms-image(src, alt: none, ..args) = {
+  let prefixed = if src.starts-with("/") or src.contains("://") {
+    src
+  } else {
+    "${escapeTypstString(imageBasePrefix)}" + src
+  }
+  image(prefixed, alt: alt, ..args)
+}`
+    : "";
+  const renderCall = imageBasePrefix ? "render" : "render";
+  const scopeArg = imageBasePrefix ? `, scope: (image: ms-image)` : "";
+
   if (entries.length === 0) {
     const escaped = escapeTypstString(markdown);
-    return `${imports}\n\n${showRule}\n\n#render("${escaped}")\n`;
+    return `${imports}\n\n${imageBinding}\n\n${showRule}\n\n#${renderCall}("${escaped}"${scopeArg})\n`;
   }
 
   const segments = spliceEntries(markdown, entries);
   const body = segments.map((seg) => {
     if (seg.kind === "prose") {
       if (seg.content.trim() === "") return "";
-      return `#render("${escapeTypstString(seg.content)}")`;
+      return `#${renderCall}("${escapeTypstString(seg.content)}"${scopeArg})`;
     }
-    return renderEntryTypst(seg.entry);
+    return renderEntryTypst(seg.entry, scopeArg);
   }).filter((s) => s !== "").join("\n\n");
 
-  return `${imports}\n\n${showRule}\n\n${body}\n`;
+  return `${imports}\n\n${imageBinding}\n\n${showRule}\n\n${body}\n`;
 }
 
 /** A segment of the document: either prose or an entry block. */
@@ -179,7 +200,7 @@ function displayIdCategory(displayId: string, shape: string): string {
 }
 
 /** Render a single entry as a Typst `req-block` call. */
-function renderEntryTypst(entry: Entry): string {
+function renderEntryTypst(entry: Entry, scopeArg: string = ""): string {
   const category = displayIdCategory(entry.displayId, entry.shape);
 
   // Extract labels from attributes
@@ -213,7 +234,7 @@ function renderEntryTypst(entry: Entry): string {
   type: "${category}",
   display-id: "${escapeTypstString(entry.displayId)}",
   title: "${escapeTypstString(entry.title)}",
-  body: render("${bodyEscaped}"),
+  body: render("${bodyEscaped}"${scopeArg}),
   attrs: ${attrsStr},
   labels: ${labelsStr},
   theme: theme,

--- a/packages/markspec/render/typst/template_test.ts
+++ b/packages/markspec/render/typst/template_test.ts
@@ -59,3 +59,52 @@ Deno.test("generateTypstDocument: handles multiline markdown", () => {
   assertStringIncludes(result, "# Title");
   assertStringIncludes(result, "## Section");
 });
+
+// ---------------------------------------------------------------------------
+// Import prefix + image base prefix (relative-image support)
+// ---------------------------------------------------------------------------
+
+Deno.test("generateTypstDocument: applies typstPackageImportPrefix to imports", () => {
+  const result = generateTypstDocument(
+    "content",
+    {},
+    [],
+    "/driftsys/markspec/packages/markspec-typst/",
+  );
+  assertStringIncludes(
+    result,
+    '#import "/driftsys/markspec/packages/markspec-typst/lib.typ":',
+  );
+  assertStringIncludes(
+    result,
+    '#import "/driftsys/markspec/packages/markspec-typst/vendor/cmarker/lib.typ":',
+  );
+});
+
+Deno.test("generateTypstDocument: emits ms-image scope binding when imageBasePrefix set", () => {
+  const result = generateTypstDocument(
+    "![alt](asset.svg)",
+    {},
+    [],
+    "",
+    "/asdk/project/docs/",
+  );
+  // ms-image wrapper is defined
+  assertStringIncludes(result, "#let ms-image(src, alt: none, ..args)");
+  // The base prefix is embedded
+  assertStringIncludes(result, '"/asdk/project/docs/" + src');
+  // render() is called with the scope override
+  assertStringIncludes(result, "scope: (image: ms-image)");
+});
+
+Deno.test("generateTypstDocument: no ms-image binding when imageBasePrefix empty", () => {
+  const result = generateTypstDocument("![alt](asset.svg)", {}, [], "", "");
+  if (result.includes("ms-image")) {
+    throw new Error("ms-image should not appear when imageBasePrefix is empty");
+  }
+  if (result.includes("scope: (image:")) {
+    throw new Error(
+      "render() should not carry a scope override when no imageBasePrefix",
+    );
+  }
+});


### PR DESCRIPTION
## What

`markspec doc build <file>` can now render documents that reference
images with relative paths (e.g. `![diagram](./chart.svg)`). The SVG
was previously looked up next to `packages/markspec-typst/vendor/cmarker/`
instead of next to the source document, so rendering failed with
"file not found".

## Why

Reported against `vibe-spec/seed/examples/markdown-rendering/README.md`,
which embeds a PlantUML-rendered SVG (`seq-welcome.svg`) and a
hand-authored SVG (`state-hsm.svg`) inside entry bodies. Rendering the
README produced:

```
error[R001]: typst: file not found (searched at
  /Users/.../driftsys/markspec/packages/markspec-typst/vendor/cmarker/seq-welcome.svg)
```

Root cause: Typst was configured with its workspace fixed at the
markspec-typst package path and the source passed as
`mainFileContent` (no file location), so cmarker's eval-generated
`#image(path)` calls resolved relative paths against cmarker's own
directory.

## How

- **Workspace = longest common ancestor** of the markspec-typst package
  path and the source document's absolute path.
- **Shadow-mount the generated Typst** next to the source doc via
  `mapShadow` + `mainFilePath`, so any `#image(path)` that Typst
  resolves from "main file directory" lands in the source doc's
  directory.
- **Rewrite markspec-typst `#import`s** to use workspace-absolute paths
  (prefixed with `/...`).
- **Inject a `ms-image` wrapper** into cmarker's
  `scope: (image: ms-image)` so that paths inside cmarker's eval get
  prefixed with the source directory's workspace-absolute path before
  hitting Typst's built-in `image()`. Entry bodies inside `#req-block`
  now also pass the scope override.

## Checklist

- [x] Tests added: 3 new template tests + 1 new compile test covering
      `mainFilePath` relative-path resolution
- [x] Full suite: 287 / 0
- [x] Verified end-to-end on the vibe-spec README: 5-page PDF rendered

🤖 Generated with [Claude Code](https://claude.com/claude-code)
