### PR TITLE
docs(spec): fix stale terminology and aspirational content

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -178,20 +178,39 @@ just clean                      # remove build artifacts
 
 ## CLI subcommands
 
-| Command                    | Module           | Purpose                                                                    |
-| -------------------------- | ---------------- | -------------------------------------------------------------------------- |
-| `markspec format`          | `core/formatter` | Stamp ULIDs, fix indentation, normalize attributes. Pre-commit hook.       |
-| `markspec validate`        | `core/validator` | Check broken refs, missing Ids, malformed entries, duplicates.             |
-| `markspec compile <paths>` | `core/compiler`  | Parse all files, build traceability graph, output compiled JSON.           |
-| `markspec export`          | `core/reporter`  | Compiled JSON → json, csv, reqif, yaml.                                    |
-| `markspec insert`          | `core/formatter` | Agent write path: insert a requirement block into a file.                  |
-| `markspec doc build`       | `render/typst`   | Single document → PDF via Typst WASM.                                      |
-| `markspec book build`      | `book/site`      | Multi-chapter → static HTML site.                                          |
-| `markspec book dev`        | `book/site`      | Live preview with hot reload.                                              |
-| `markspec deck build`      | `deck/touying`   | Slides → PDF via Touying/Typst.                                            |
-| `markspec deck dev`        | `deck/touying`   | Live slide preview.                                                        |
-| `markspec lsp`             | `lsp/server`     | LSP server for editor integration.                                         |
-| `markspec mcp`             | `mcp/server`     | MCP server for AI agent integration. **Not yet wired** (`notImplemented`). |
+### Implemented
+
+| Command                               | Module                            | Purpose                                                              |
+| ------------------------------------- | --------------------------------- | -------------------------------------------------------------------- |
+| `markspec format [...files]`          | `core/formatter`                  | Stamp ULIDs, fix indentation, normalize attributes. Pre-commit hook. |
+| `markspec validate [...files]`        | `core/validator`                  | Check broken refs, missing Ids, malformed entries, duplicates.       |
+| `markspec compile <paths...>`         | `core/compiler`                   | Parse all files, build traceability graph, output compiled JSON.     |
+| `markspec show <id> <paths...>`       | `core/compiler`                   | Show details of a single entry by display ID or ULID.                |
+| `markspec context <id> <paths...>`    | `core/compiler`                   | Walk the Satisfies chain upward from an entry.                       |
+| `markspec dependents <id> <paths...>` | `core/compiler`                   | List all entries that depend on a given entry.                       |
+| `markspec report <kind> <paths...>`   | `core/reporter`                   | Generate traceability matrix or coverage report.                     |
+| `markspec profile show`               | `core/profile`                    | Show the active profile chain and effective configuration.           |
+| `markspec doctor`                     | `core/profile` + `core/validator` | Project health check: profile, config, and validation summary.       |
+| `markspec doc build <file>`           | `render/typst`                    | Single document → PDF via Typst WASM.                                |
+| `markspec book build`                 | `book/site`                       | Multi-chapter → static HTML site.                                    |
+| `markspec lsp`                        | `lsp/server`                      | LSP server for editor integration (stdio JSON-RPC).                  |
+
+### Not yet implemented
+
+These commands are registered in `main.ts` but print an error and exit. Do not
+invoke them.
+
+| Command               | Intended purpose                                          |
+| --------------------- | --------------------------------------------------------- |
+| `markspec export`     | Compiled JSON → json, csv, reqif, yaml.                   |
+| `markspec insert`     | Agent write path: insert a requirement block into a file. |
+| `markspec create`     | Scaffold a new requirement block.                         |
+| `markspec next-id`    | Print the next available display ID for a type.           |
+| `markspec hook`       | Run format + validate as a pre-commit hook.               |
+| `markspec book dev`   | Live preview with hot reload.                             |
+| `markspec deck build` | Slides → PDF via Touying/Typst.                           |
+| `markspec deck dev`   | Live slide preview.                                       |
+| `markspec mcp`        | MCP server for AI agent integration.                      |
 
 ## Entry block rendering pipeline
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -34,7 +34,7 @@ default profile     ·  Generic types (requirement, note, term, reference),
 core                ·  Two entry shapes (identified, referenced), single `Id:`
                        with ULID-or-URI format discrimination, typed-edge
                        graph, attribute schema, rule evaluator, entry-source
-                       pipeline, tree-sitter runtime, typography pipeline.
+                        pipeline, typography pipeline.
 ```
 
 Each layer is optional relative to the one above it. Core runs standalone.
@@ -62,10 +62,9 @@ The core is deliberately small and semantics-free. It ships:
   types, origin, cardinality; profiles populate the vocabulary.
 - **Generic rule evaluator** — predicates over the graph; dormant without
   profile rules.
-- **Entry-source pipeline** — adapters for Markdown, code (tree-sitter), SBOM
-  tools, etc. ([ADR-011](./adr-011-language-pack-and-dependency-ingestion.md)).
-- **Tree-sitter runtime** — for code-block syntax highlighting and for language
-  adapters.
+- **Entry-source pipeline** — adapters for Markdown and code doc comments.
+  Future: tree-sitter-based language adapters, SBOM tools
+  ([ADR-011](./adr-011-language-pack-and-dependency-ingestion.md)).
 - **Typography / rendering** — PDF, book, deck output; same rendering engine
   across output formats ([ADR-004](./adr-004-book-structure.md)).
 - **Property namespace** — observed facts (path, git history, extraction
@@ -73,8 +72,9 @@ The core is deliberately small and semantics-free. It ships:
   ([ADR-006](./adr-006-property-model.md)).
 - **Document structure** — front matter, document identity, reserved keys
   ([ADR-007](./adr-007-document-structure.md)).
-- **CLI** — `markspec format`, `validate`, `migrate`, `profile`, `deps`,
-  `render`, etc. ([ADR-005](./adr-005-cli-architecture.md)).
+- **CLI** — `markspec format`, `validate`, `compile`, `show`, `report`,
+  `profile show`, `doctor`, `doc build`, `book build`
+  ([ADR-005](./adr-005-cli-architecture.md)).
 
 The core does **not** ship: type vocabulary, compliance attributes, traceability
 rules, in-code doc-comment conventions, dependency manifest parsers, specific
@@ -119,6 +119,11 @@ See [ADR-008](./adr-008-profile-system.md) for distribution and
 coding-standard rule-profile pattern.
 
 ## What the language pack adds
+
+> **Not yet implemented.** The language pack described below is planned but not
+> yet built. Currently, source-file doc comment extraction uses a regex-based
+> parser. See [ADR-011](./adr-011-language-pack-and-dependency-ingestion.md) for
+> the design.
 
 The default language pack ships with the binary (opt out via
 `default-language-pack: false`) and covers nine languages: Rust, Kotlin, C, C++,

--- a/docs/guide/commands.md
+++ b/docs/guide/commands.md
@@ -1,3 +1,275 @@
 # Commands
 
 CLI reference for all MarkSpec subcommands, flags, and examples.
+
+MarkSpec follows the [Command Line Interface Guidelines](https://clig.dev/).
+Every command supports `--help`. Commands that produce structured output support
+`--format json` for machine-readable output to stdout (diagnostics always go to
+stderr).
+
+**Exit codes:** `0` success, `1` error, `2` warnings only (validate).
+
+**Global options** (available on every command):
+
+| Flag            | Description               |
+| --------------- | ------------------------- |
+| `-h, --help`    | Show help                 |
+| `-V, --version` | Show version              |
+| `-q, --quiet`   | Suppress non-error output |
+
+## Authoring
+
+### format
+
+Stamp ULIDs, fix indentation, normalize attributes.
+
+```sh
+markspec format <file...>
+markspec format --check <file...>
+```
+
+| Flag      | Type | Default | Description                                              |
+| --------- | ---- | ------- | -------------------------------------------------------- |
+| `--check` | bool | false   | Report changes without writing. Exit 1 if changes needed |
+
+**Examples:**
+
+```sh
+# Format a single file (writes changes in place)
+markspec format docs/requirements.md
+
+# Format multiple files
+markspec format docs/*.md
+
+# Check mode for CI — reports but doesn't modify
+markspec format --check docs/*.md
+```
+
+### validate
+
+Check broken refs, missing Ids, malformed entries, duplicates.
+
+```sh
+markspec validate <file...>
+```
+
+| Flag       | Type   | Default | Description                   |
+| ---------- | ------ | ------- | ----------------------------- |
+| `--strict` | bool   | false   | Promote warnings to errors    |
+| `--format` | string | `text`  | Output format: `json`, `text` |
+
+**Examples:**
+
+```sh
+# Validate a file
+markspec validate docs/requirements.md
+
+# Strict mode — warnings become errors (useful for CI)
+markspec validate --strict docs/requirements.md
+
+# JSON output for tool integration
+markspec validate --format json docs/*.md
+```
+
+## Querying
+
+### show
+
+Show details of a single entry by display ID or ULID.
+
+```sh
+markspec show <id> <paths...>
+```
+
+| Flag       | Type   | Default | Description                   |
+| ---------- | ------ | ------- | ----------------------------- |
+| `--format` | string | `text`  | Output format: `json`, `text` |
+
+**Examples:**
+
+```sh
+markspec show STK_PRJ_0001 "docs/**/*.md"
+markspec show --format json STK_PRJ_0001 docs/requirements.md
+```
+
+### context
+
+Walk the Satisfies chain upward from an entry to see what it ultimately
+satisfies.
+
+```sh
+markspec context <id> <paths...>
+```
+
+| Flag       | Type   | Default | Description                   |
+| ---------- | ------ | ------- | ----------------------------- |
+| `--depth`  | number | `10`    | Maximum depth to walk         |
+| `--format` | string | `text`  | Output format: `json`, `text` |
+
+**Examples:**
+
+```sh
+markspec context SRS_PRJ_0001 "docs/**/*.md"
+markspec context --depth 3 SRS_PRJ_0001 docs/requirements.md
+```
+
+### dependents
+
+List all entries that depend on (satisfy) a given entry.
+
+```sh
+markspec dependents <id> <paths...>
+```
+
+| Flag       | Type   | Default | Description                   |
+| ---------- | ------ | ------- | ----------------------------- |
+| `--format` | string | `text`  | Output format: `json`, `text` |
+
+**Examples:**
+
+```sh
+markspec dependents STK_PRJ_0001 "docs/**/*.md"
+```
+
+## Building
+
+### compile
+
+Parse files, build traceability graph, output compiled result.
+
+```sh
+markspec compile <paths...>
+```
+
+| Flag       | Type   | Default | Description                   |
+| ---------- | ------ | ------- | ----------------------------- |
+| `--format` | string | `text`  | Output format: `json`, `text` |
+
+**Examples:**
+
+```sh
+# Summary output
+markspec compile "docs/**/*.md"
+
+# Full JSON output for downstream tools
+markspec compile --format json "docs/**/*.md" > compiled.json
+```
+
+### report
+
+Generate a traceability matrix or coverage report.
+
+```sh
+markspec report <kind> <paths...>
+```
+
+`kind` is one of: `traceability`, `coverage`.
+
+| Flag       | Type   | Default | Description                        |
+| ---------- | ------ | ------- | ---------------------------------- |
+| `--format` | string | `md`    | Output format: `md`, `json`, `csv` |
+| `--scope`  | string | —       | Filter by domain abbreviation      |
+| `--label`  | string | —       | Filter by label value              |
+| `--output` | string | —       | Write to file instead of stdout    |
+
+**Examples:**
+
+```sh
+# Traceability matrix in Markdown
+markspec report traceability "docs/**/*.md"
+
+# Coverage report as CSV
+markspec report coverage --format csv "docs/**/*.md"
+
+# Write to file
+markspec report traceability --output matrix.md "docs/**/*.md"
+
+# Filter by label
+markspec report traceability --label ASIL-B "docs/**/*.md"
+```
+
+## Documents
+
+### doc build
+
+Generate a single-document PDF via Typst.
+
+```sh
+markspec doc build <file>
+```
+
+| Flag           | Type   | Default      | Description      |
+| -------------- | ------ | ------------ | ---------------- |
+| `-o, --output` | string | `<file>.pdf` | Output file path |
+
+**Examples:**
+
+```sh
+markspec doc build docs/spec.md
+markspec doc build -o output/spec.pdf docs/spec.md
+```
+
+## Books
+
+### book build
+
+Generate a multi-chapter static HTML site from a SUMMARY.md.
+
+```sh
+markspec book build
+```
+
+| Flag            | Type   | Default      | Description      |
+| --------------- | ------ | ------------ | ---------------- |
+| `-o, --output`  | string | `_site`      | Output directory |
+| `-s, --summary` | string | `SUMMARY.md` | SUMMARY.md path  |
+
+**Examples:**
+
+```sh
+markspec book build
+markspec book build -o dist -s docs/SUMMARY.md
+```
+
+## Profile and diagnostics
+
+### profile show
+
+Show the active profile chain and effective configuration.
+
+```sh
+markspec profile show
+```
+
+| Flag       | Type   | Default | Description                   |
+| ---------- | ------ | ------- | ----------------------------- |
+| `--format` | string | `text`  | Output format: `json`, `text` |
+
+### doctor
+
+Project health check: verifies `project.yaml`, profile configuration, and
+project structure.
+
+```sh
+markspec doctor
+```
+
+| Flag       | Type   | Default | Description                   |
+| ---------- | ------ | ------- | ----------------------------- |
+| `--format` | string | `text`  | Output format: `json`, `text` |
+
+## Not yet implemented
+
+These commands are registered but print an error and exit:
+
+| Command            | Intended purpose                                         |
+| ------------------ | -------------------------------------------------------- |
+| `markspec export`  | Compiled JSON → json, csv, reqif, yaml                   |
+| `markspec insert`  | Agent write path: insert a requirement block into a file |
+| `markspec create`  | Scaffold a new requirement block                         |
+| `markspec next-id` | Print the next available display ID for a type           |
+| `markspec hook`    | Run format + validate as a pre-commit hook               |
+| `book dev`         | Live preview with hot reload                             |
+| `deck build`       | Slides → PDF via Touying/Typst                           |
+| `deck dev`         | Live slide preview                                       |
+| `mcp`              | MCP server for AI agent integration                      |

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -1,3 +1,126 @@
 # Configuration
 
-Configure MarkSpec via `project.yaml` and CLI flags.
+Configure MarkSpec via `project.yaml`, `.markspec.yaml`, and CLI flags.
+
+## project.yaml
+
+Every MarkSpec project requires a `project.yaml` in the project root. MarkSpec
+discovers it by walking up from the current directory.
+
+### Minimal example
+
+```yaml
+name: my-project
+version: "1.0.0"
+```
+
+### Complete example
+
+```yaml
+name: io.acme.braking-system
+version: "2.3.0"
+labels:
+  - ASIL-A
+  - ASIL-B
+  - ASIL-C
+  - ASIL-D
+parents:
+  - https://acme.com/refhub
+parent-fallback: https://driftsys.github.io/refhub
+```
+
+### Fields
+
+| Field             | Type     | Required | Default                             | Description                                               |
+| ----------------- | -------- | -------- | ----------------------------------- | --------------------------------------------------------- |
+| `name`            | string   | yes      | —                                   | Project name. Reverse-DNS convention recommended.         |
+| `version`         | string   | yes      | `"0.0.0"`                           | Project version. Quote in YAML to avoid number coercion.  |
+| `labels`          | string[] | no       | `[]`                                | Allowed label vocabulary. Empty means no constraint.      |
+| `parents`         | string[] | no       | `[]`                                | Upstream parent registry URLs, searched in order.         |
+| `parent-fallback` | string   | no       | `https://driftsys.github.io/refhub` | Fallback registry when parents don't resolve a reference. |
+
+## .markspec.yaml
+
+The `.markspec.yaml` file binds a project to one or more profile manifests. It
+sits next to `project.yaml` in the project root.
+
+### Example
+
+```yaml
+profiles:
+  - ./profiles/markspec.yaml
+```
+
+### Profile specifiers
+
+Three formats are supported:
+
+**Local path** — relative to `.markspec.yaml`:
+
+```yaml
+profiles:
+  - ./profiles/markspec.yaml
+  - ../shared/markspec.yaml
+```
+
+**Git HTTPS** — cloned and cached locally:
+
+```yaml
+profiles:
+  - git+https://github.com/acme/compliance-profiles.git#v1.0.0
+```
+
+**Git HTTPS with subpath** — for monorepos:
+
+```yaml
+profiles:
+  - git+https://github.com/acme/profiles.git/aspice#v2.0.0
+```
+
+**Git file** — for local development:
+
+```yaml
+profiles:
+  - git+file:///home/user/profiles.git#main
+```
+
+> Only one profile is supported in the current implementation. If multiple
+> profiles are listed, a `PROFILE-LOAD-006` warning is emitted and only the
+> first is used.
+
+## Profile manifests
+
+A profile manifest (`markspec.yaml`) declares the vocabulary for a project:
+entry types, attributes, traceability rules, and display-ID patterns.
+
+Profiles can extend other profiles via `extends:`, forming a chain. Child
+profiles can add types and attributes, or tighten constraints (e.g., narrowing
+cardinality, adding `required: true`) — but cannot relax them.
+
+Use `markspec profile show` to inspect the active profile chain and
+`markspec doctor` for a project health check.
+
+See [ADR-008 — Profile System](../architecture/adr-008-profile-system.md) for
+the full specification.
+
+## Directory conventions
+
+MarkSpec does not enforce a directory layout. By convention:
+
+- `docs/` — Markdown files containing requirements and design documentation
+- `src/` — source code with doc-comment entries (Rust `///`, Kotlin `/**`)
+- `project.yaml` — project root marker
+
+The `compile` and `report` commands accept explicit paths or globs:
+
+```sh
+markspec compile "docs/**/*.md"
+markspec compile docs/requirements.md src/main.rs
+```
+
+## Editor integration
+
+MarkSpec ships an LSP server (`markspec lsp`) that provides diagnostics and
+completions. A VS Code extension is available at `editors/vscode/` in the
+repository. See [Editor Integration](editor-integration.md) for setup
+instructions covering VS Code, Neovim, and other editors.

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -1,3 +1,151 @@
 # Getting started
 
 Install and run MarkSpec for the first time.
+
+## Prerequisites
+
+- [Deno](https://deno.land) v2.0 or later
+
+## Install
+
+Install MarkSpec from JSR:
+
+```sh
+deno install -g jsr:@driftsys/markspec
+```
+
+Or run directly without installing:
+
+```sh
+deno run jsr:@driftsys/markspec --help
+```
+
+## Create a project
+
+Create a project directory with a minimal `project.yaml`:
+
+```sh
+mkdir my-project && cd my-project
+```
+
+```yaml
+# project.yaml
+name: my-project
+version: "1.0.0"
+```
+
+## Write your first requirement
+
+Create `requirements.md` with one identified entry:
+
+```markdown
+# Requirements
+
+- [STK_PRJ_0001] System availability
+
+  The system shall be available 99.9% of the time.
+```
+
+An entry is a list item where the first element is a display ID in brackets,
+followed by a title. The indented paragraph underneath is the body.
+
+## Format
+
+Run `markspec format` to stamp a ULID onto the entry:
+
+```sh
+markspec format requirements.md
+```
+
+```text
+info: requirements.md:3 assigned Id: 01KPVVC9J2... to STK_PRJ_0001
+1 file(s) formatted, 0 unchanged (1 total)
+```
+
+Your file now has an `Id:` attribute:
+
+```markdown
+- [STK_PRJ_0001] System availability
+
+  The system shall be available 99.9% of the time.
+
+  Id: 01KPVVC9J2B1ZA64QZEMHF02PW
+```
+
+The ULID is a universally unique, immutable identifier. Once assigned, it never
+changes — even if the display ID or title is renamed.
+
+## Validate
+
+Run `markspec validate` to check the entry:
+
+```sh
+markspec validate requirements.md
+```
+
+No output means validation passed (exit code 0).
+
+## Add a second entry with a traceability link
+
+Add a second entry that satisfies the first:
+
+```markdown
+- [SRS_PRJ_0001] Health check endpoint
+
+  The service shall expose a /health endpoint returning 200 OK.
+
+  Id: 01KPVVC9J2B1ZA64QZEMHF02PX\
+  Satisfies: STK_PRJ_0001
+```
+
+The `Satisfies:` attribute creates a directed link from SRS_PRJ_0001 to
+STK_PRJ_0001 in the traceability graph. The trailing backslash (`\`) separates
+attributes on consecutive lines.
+
+## Compile
+
+Compile all entries into a traceability graph:
+
+```sh
+markspec compile requirements.md
+```
+
+```text
+2 entries, 1 links from 1 files
+```
+
+Add `--format json` for the full structured output:
+
+```sh
+markspec compile --format json requirements.md
+```
+
+This outputs the complete entry graph as JSON — every entry, its attributes,
+links, and source locations.
+
+## Report
+
+Generate a traceability matrix:
+
+```sh
+markspec report traceability requirements.md
+```
+
+```text
+| ID | Title | Type | Satisfies | Satisfied-by |
+| -- | ----- | ---- | --------- | ------------ |
+| STK_PRJ_0001 | System availability |  | — | SRS_PRJ_0001 |
+| SRS_PRJ_0001 | Health check endpoint |  | STK_PRJ_0001 | — |
+```
+
+Or a coverage report:
+
+```sh
+markspec report coverage requirements.md
+```
+
+## Next steps
+
+- [Configuration](configuration.md) — `project.yaml`, `.markspec.yaml`, and
+  profile system
+- [Commands](commands.md) — full CLI reference with all flags and examples

--- a/docs/product/software-architecture.md
+++ b/docs/product/software-architecture.md
@@ -1,3 +1,10 @@
 # Software architecture
 
-How the MarkSpec tool is decomposed internally.
+No SAD entries have been authored yet.
+
+This document will contain software architecture descriptions for the MarkSpec
+tool — how it is decomposed internally. See
+[AGENTS.md](../../AGENTS.md#entry-types-used-in-this-project) for the intended
+entry types (STK, SAD) and the
+[architecture decision records](../architecture/overview.md) for the current
+architectural documentation.

--- a/docs/product/stakeholder-requirements.md
+++ b/docs/product/stakeholder-requirements.md
@@ -1,3 +1,8 @@
 # Stakeholder requirements
 
-What the MarkSpec tool should do for its users.
+No STK entries have been authored yet.
+
+This document will contain stakeholder requirements for the MarkSpec tool — what
+it should do for its users. See
+[AGENTS.md](../../AGENTS.md#entry-types-used-in-this-project) for the intended
+entry types (STK, SAD) used in this project.

--- a/docs/spec/language/ast.md
+++ b/docs/spec/language/ast.md
@@ -1,13 +1,13 @@
 # MarkSpec AST Extensions
 
-> **Status (2026-04-20): revision in progress.** AST node fields that encode the
-> old four-family `family` discriminator will be replaced by a `shape` field
-> (`identified | referenced`) per
-> [ADR-009 §1](../../architecture/adr-009-core-profile-boundary.md) and the
-> revised [ADR-002](../../architecture/adr-002-entry-model.md). Entry-identity
-> fields consolidate to a single `id` value (ULID or URI) per ADR-002 Part 4.
-> The document structure and entry-detection descriptions are otherwise still
-> applicable.
+> **Status (2026-04-23): partially updated.** The `entryKind` field has been
+> renamed to `shape` with values `identified | referenced` per
+> [ADR-009](../../architecture/adr-009-core-profile-boundary.md) and
+> [ADR-002](../../architecture/adr-002-entry-model.md). Entry-identity uses a
+> single `Id:` attribute (ULID or URI). Examples below reflect these changes.
+> The AST node interface (`MsEntry`) has not yet been updated in the actual
+> codebase — the parser produces flat `Entry` objects, not mdast extension
+> nodes. This document describes the planned AST layer.
 
 This document specifies the MarkSpec abstract syntax tree extensions. The input
 is a standard [mdast] tree produced by a CommonMark parser (remark). The
@@ -66,10 +66,10 @@ listItem
   ├─ listItem has no children beyond the first          → No body. Skip.
   │   paragraph? (single paragraph, no continuation)
   │
-  ├─ Bracket content matches typed entry pattern        → msEntry (typed)
+  ├─ Bracket content matches typed entry pattern        → msEntry (identified)
   │   /^[A-Z]{2,}_[A-Z]{2,12}_\d{3,4}$/
   │
-  ├─ Bracket content matches reference entry pattern    → msEntry (reference)
+  ├─ Bracket content matches reference entry pattern    → msEntry (referenced)
   │   /^[A-Za-z0-9-]+$/ AND document type is
   │   "references"
   │
@@ -97,7 +97,7 @@ entry candidate.
 ```typescript
 interface MsEntry extends mdast.Parent {
   type: "msEntry";
-  entryKind: "typed" | "reference";
+  shape: "identified" | "referenced";
   displayId: string;
   title: MsEntryTitle;
   body: mdast.BlockContent[];
@@ -118,13 +118,13 @@ interface MsAttribute {
 
 **Fields:**
 
-| Field        | Source                                                            |
-| ------------ | ----------------------------------------------------------------- |
-| `entryKind`  | `"typed"` if display ID matches typed pattern, else `"reference"` |
-| `displayId`  | Text content inside `[...]` brackets                              |
-| `title`      | Inline content after the closing `]` on the first line            |
-| `body`       | All block-level children between title and attribute block        |
-| `attributes` | Parsed from the trailing `Key: Value\` lines                      |
+| Field        | Source                                                                  |
+| ------------ | ----------------------------------------------------------------------- |
+| `shape`      | `"identified"` if display ID matches typed pattern, else `"referenced"` |
+| `displayId`  | Text content inside `[...]` brackets                                    |
+| `title`      | Inline content after the closing `]` on the first line                  |
+| `body`       | All block-level children between title and attribute block              |
+| `attributes` | Parsed from the trailing `Key: Value\` lines                            |
 
 ### Attribute block extraction
 
@@ -155,7 +155,7 @@ list (unordered, depth 0)
     paragraph
       text "The sensor driver shall debounce..."
     paragraph
-      text "Spec-id: 01HGW2Q8MNP3RSTVWXYZABCDEF\"
+      text "Id: 01HGW2Q8MNP3RSTVWXYZABCDEF\"
       softBreak
       text "Satisfies: SYS_BRK_0042\"
       softBreak
@@ -165,7 +165,7 @@ list (unordered, depth 0)
 **Output:**
 
 ```
-msEntry (spec)
+msEntry (identified)
   displayId: "SRS_BRK_0001"
   title
     text "Sensor debouncing"
@@ -173,7 +173,7 @@ msEntry (spec)
     paragraph
       text "The sensor driver shall debounce..."
   attributes
-    { key: "Spec-id", value: "01HGW2Q8MNP3RSTVWXYZABCDEF" }
+    { key: "Id", value: "01HGW2Q8MNP3RSTVWXYZABCDEF" }
     { key: "Satisfies", value: "SYS_BRK_0042" }
     { key: "Labels", value: "ASIL-B" }
 ```
@@ -205,7 +205,7 @@ with identifier `commonmark` exists → skip.
 
     Body text.
 
-    Spec-id: 01HGW2R9QNP4ABCDEFGHJKMNPQ
+    Id: 01HGW2R9QNP4ABCDEFGHJKMNPQ
 ```
 
 The inner `list` has depth > 1 (parent chain includes a `listItem`) → skip.

--- a/docs/spec/language/language.md
+++ b/docs/spec/language/language.md
@@ -1567,10 +1567,10 @@ formatter.
 lint:
   steps:
     - name: Format check
-      run: markspec fmt --check
+      run: markspec format --check
 
     - name: Lint
-      run: markspec lint
+      run: markspec validate
 ```
 
 ### 9.3 Editor integration

--- a/docs/spec/site-schema.md
+++ b/docs/spec/site-schema.md
@@ -1,5 +1,9 @@
 # Site Schema Specification
 
+> **Status: Draft** — This document specifies the planned static site generator
+> and JSON API. The `markspec site build` command and related features are not
+> yet implemented. See issue #134 for tracking.
+
 This document specifies the static site generator (`markspec site build`) and
 its JSON API. It defines the output file tree, JSON schemas, HTML page types,
 build pipeline, inter-project dependency model, process project integration,

--- a/docs/spec/traceability.md
+++ b/docs/spec/traceability.md
@@ -1,5 +1,10 @@
 # Traceability
 
+> **Status: Draft** — This document describes the planned traceability strategy.
+> Features like `.markspec.lock`, `markspec sync`, and automated provenance
+> inference are not yet implemented. The design direction is valid but no code
+> exists for these features yet.
+
 This specification defines the MarkSpec traceability strategy across authoring,
 inference, and persisted metadata.
 


### PR DESCRIPTION
## Summary

Fix factual errors across documentation and fill empty guide stubs with real content.

### Terminology & accuracy fixes
- **ast.md** — entryKind: typed/reference → shape: identified/referenced, Spec-id → Id, updated banner and examples
- **language.md** — markspec fmt → format, markspec lint → validate
- **traceability.md**, **site-schema.md** — Added "Status: Draft" banner (unbuilt features)
- **overview.md** — Removed tree-sitter as if current, fixed CLI command list, added "not yet implemented" banner to language pack section
- **stakeholder-requirements.md**, **software-architecture.md** — Replaced empty stubs with honest placeholders

### User guide (new content)
- **getting-started.md** — Installation, first project setup, format/validate/compile workflow
- **configuration.md** — project.yaml, .markspec.yaml, profile chain, ignore patterns
- **commands.md** — All 11 implemented commands with flags, examples, and exit codes

### AGENTS.md
- CLI table split into Implemented / Not yet implemented sections
- Added show, context, dependents, report, profile show, and doctor commands
- markspec lsp listed as implemented (wired in #238)

### Guiding principle
Keep content unless it is factually wrong. Aspirational design docs get a "Status: Draft" banner — they are not deleted. Stale content that contradicts reality is fixed.