### PR TITLE
feat(lsp): wire markspec lsp subcommand, add VSCode extension and editor integration guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,9 +65,20 @@ markspec/
 │       ├── cli/
 │       │   └── commands/            ← one file per subcommand
 │       ├── lsp/
-│       │   └── server.ts            ← LSP protocol adapter
+│       │   ├── server.ts            ← LSP server entry point (stdio JSON-RPC,
+│       │   │                          diagnostics + completions)
+│       │   ├── workspace.ts         ← in-memory entry index, incremental updates
+│       │   ├── diagnostics.ts       ← core Diagnostic → LSP Diagnostic bridge
+│       │   ├── completions.ts       ← block scaffold + ID reference completion
+│       │   ├── context.ts           ← doc comment context guard (source files)
+│       │   └── util.ts              ← URI↔path conversion, debounce
 │       └── mcp/
 │           └── server.ts            ← MCP protocol adapter
+├── editors/
+│   └── vscode/                      ← markspec-ide VSCode extension
+│       ├── package.json
+│       ├── src/extension.ts         ← spawns `markspec lsp`, connects to VSCode
+│       └── tsconfig.json
 ├── theme/
 │   └── tokens.yaml                  ← canonical design tokens SSOT (run `just tokens`)
 ├── docs/
@@ -90,28 +101,35 @@ markspec/
     └── fixtures/                    ← sample .md and source files for testing
 ```
 
+**Read these files for current LSP implementation — do not rely on prose
+alone:**
+
+@packages/markspec/lsp/server.ts @packages/markspec/lsp/workspace.ts
+@packages/markspec/lsp/completions.ts @packages/markspec/lsp/context.ts
+@packages/markspec/lsp/diagnostics.ts @packages/markspec/lsp/util.ts
+@packages/markspec/main.ts
+
 ## Key rules
 
 **Single binary, lazy loading.** `main.ts` dispatches subcommands. Each
 subcommand dynamically imports only the modules it needs. `markspec validate`
 never loads Typst WASM. `markspec book build` never loads ReqIF.
 
-**Three compile targets from the same source:**
+**One compile target — one binary:**
 
 ```bash
 deno compile packages/markspec/main.ts            # → markspec
-deno compile packages/markspec/lsp/server.ts      # → markspec-lsp
-deno compile packages/markspec/mcp/server.ts      # → markspec-mcp
 ```
+
+All subcommands — including `lsp` and `mcp` — are dispatched from the single
+`markspec` binary. There is no separate `markspec-lsp` or `markspec-mcp` binary.
+The `lsp/server.ts` and `mcp/server.ts` modules are dynamically imported by
+`main.ts` when the corresponding subcommand is invoked.
 
 **`core/mod.ts` is the library boundary.** Everything outside `core/` imports
 from `core/mod.ts`, never from internal paths like `core/parser/markdown.ts`.
 This is enforced by convention. When an external consumer needs the library, we
 add a `deno.json` to `core/` and publish to JSR — nothing else changes.
-
-**`markspec-ide` is the only external extension.** It lives in a separate repo
-and dispatches via PATH lookup (`markspec ide` → finds `markspec-ide` binary).
-PDF, book, and deck are subcommands of the main binary, not extensions.
 
 **Dependency flow is strictly one-directional:**
 
@@ -160,20 +178,20 @@ just clean                      # remove build artifacts
 
 ## CLI subcommands
 
-| Command                    | Module                       | Purpose                                                              |
-| -------------------------- | ---------------------------- | -------------------------------------------------------------------- |
-| `markspec format`          | `core/formatter`             | Stamp ULIDs, fix indentation, normalize attributes. Pre-commit hook. |
-| `markspec validate`        | `core/validator`             | Check broken refs, missing Ids, malformed entries, duplicates.       |
-| `markspec compile <paths>` | `core/compiler`              | Parse all files, build traceability graph, output compiled JSON.     |
-| `markspec export`          | `core/reporter`              | Compiled JSON → json, csv, reqif, yaml.                              |
-| `markspec insert`          | `core/formatter`             | Agent write path: insert a requirement block into a file.            |
-| `markspec doc build`       | `render/typst`               | Single document → PDF via Typst WASM.                                |
-| `markspec book build`      | `book/site`                  | Multi-chapter → static HTML site.                                    |
-| `markspec book dev`        | `book/site`                  | Live preview with hot reload.                                        |
-| `markspec deck build`      | `deck/touying`               | Slides → PDF via Touying/Typst.                                      |
-| `markspec deck dev`        | `deck/touying`               | Live slide preview.                                                  |
-| `markspec lsp`             | dispatches to `markspec-lsp` | LSP server for editor integration.                                   |
-| `markspec mcp`             | dispatches to `markspec-mcp` | MCP server for AI agent integration.                                 |
+| Command                    | Module           | Purpose                                                                    |
+| -------------------------- | ---------------- | -------------------------------------------------------------------------- |
+| `markspec format`          | `core/formatter` | Stamp ULIDs, fix indentation, normalize attributes. Pre-commit hook.       |
+| `markspec validate`        | `core/validator` | Check broken refs, missing Ids, malformed entries, duplicates.             |
+| `markspec compile <paths>` | `core/compiler`  | Parse all files, build traceability graph, output compiled JSON.           |
+| `markspec export`          | `core/reporter`  | Compiled JSON → json, csv, reqif, yaml.                                    |
+| `markspec insert`          | `core/formatter` | Agent write path: insert a requirement block into a file.                  |
+| `markspec doc build`       | `render/typst`   | Single document → PDF via Typst WASM.                                      |
+| `markspec book build`      | `book/site`      | Multi-chapter → static HTML site.                                          |
+| `markspec book dev`        | `book/site`      | Live preview with hot reload.                                              |
+| `markspec deck build`      | `deck/touying`   | Slides → PDF via Touying/Typst.                                            |
+| `markspec deck dev`        | `deck/touying`   | Live slide preview.                                                        |
+| `markspec lsp`             | `lsp/server`     | LSP server for editor integration.                                         |
+| `markspec mcp`             | `mcp/server`     | MCP server for AI agent integration. **Not yet wired** (`notImplemented`). |
 
 ## Entry block rendering pipeline
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,5 +3,4 @@
 This file provides guidance to Claude Code (claude.ai/code) when working with
 code in this repository.
 
-See [AGENTS.md](AGENTS.md) for project details, build commands, architecture,
-and conventions.
+@AGENTS.md

--- a/docs/guide/SUMMARY.md
+++ b/docs/guide/SUMMARY.md
@@ -3,3 +3,4 @@
 - [Getting started](getting-started.md)
 - [Configuration](configuration.md)
 - [Commands](commands.md)
+- [Editor integration](editor-integration.md)

--- a/docs/guide/editor-integration.md
+++ b/docs/guide/editor-integration.md
@@ -1,0 +1,126 @@
+# Editor integration
+
+MarkSpec ships a built-in Language Server Protocol (LSP) server. Run it with:
+
+```bash
+markspec lsp
+```
+
+The server communicates over **stdio JSON-RPC** — the standard transport that
+every LSP-capable editor supports.
+
+## Features
+
+**Diagnostics** — broken references, missing IDs, duplicate display IDs, and
+malformed entries appear as inline errors and warnings as you type. File-local
+checks run immediately; cross-file validation runs on save.
+
+**Entry block completion** — type `- [` at the start of a line to get a
+pre-filled entry block scaffold with the next available display ID for each type
+defined in your profile.
+
+**ID reference completion** — after a trace attribute keyword (`Satisfies:`,
+`Derived-from:`, `Verified-by:`, etc.) the server suggests all known display IDs
+in the project.
+
+**Source file context guard** — in source files (Rust, Kotlin, Java, C, C++),
+completions only activate near entry markers or trace keywords. The server won't
+interfere with your language's native LSP (rust-analyzer, kotlin-lsp, etc.).
+
+## VS Code
+
+Install the **MarkSpec** extension from the `editors/vscode/` directory in this
+repository.
+
+### From source
+
+```bash
+cd editors/vscode
+npm install
+npm run compile
+```
+
+Then in VS Code: `Extensions → ⋯ → Install from VSIX` or press `Ctrl+Shift+P` →
+`Extensions: Install from VSIX…` and select the `.vsix` file, or use the
+development host:
+
+```bash
+code --extensionDevelopmentPath=editors/vscode
+```
+
+### Configuration
+
+| Setting                 | Default      | Description                                   |
+| ----------------------- | ------------ | --------------------------------------------- |
+| `markspec.server.path`  | `"markspec"` | Path to the `markspec` binary.                |
+| `markspec.server.args`  | `["lsp"]`    | Arguments passed to start the LSP server.     |
+| `markspec.trace.server` | `"off"`      | Trace level: `off`, `messages`, or `verbose`. |
+
+If `markspec` is not on your PATH, set the full path:
+
+```json
+{
+  "markspec.server.path": "/home/you/.local/bin/markspec"
+}
+```
+
+## Neovim
+
+Neovim's built-in LSP client works out of the box. Add this to your `init.lua`:
+
+```lua
+vim.api.nvim_create_autocmd("FileType", {
+  pattern = { "markdown" },
+  callback = function()
+    vim.lsp.start({
+      name = "markspec",
+      cmd = { "markspec", "lsp" },
+      root_dir = vim.fs.root(0, { "project.yaml", ".git" }),
+    })
+  end,
+})
+```
+
+For source files (Rust, Kotlin, etc.) where MarkSpec entry blocks appear in doc
+comments, add the relevant file types to the `pattern` list:
+
+```lua
+pattern = { "markdown", "rust", "kotlin", "java", "c", "cpp" },
+```
+
+The server's context guard ensures it only activates near MarkSpec entry
+markers, so it won't conflict with rust-analyzer or other language servers
+running on the same buffer.
+
+### With nvim-lspconfig
+
+If you use [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig), add a
+custom server definition:
+
+```lua
+local lspconfig = require("lspconfig")
+local configs = require("lspconfig.configs")
+
+if not configs.markspec then
+  configs.markspec = {
+    default_config = {
+      cmd = { "markspec", "lsp" },
+      filetypes = { "markdown", "rust", "kotlin", "java", "c", "cpp" },
+      root_dir = lspconfig.util.root_pattern("project.yaml", ".git"),
+    },
+  }
+end
+
+lspconfig.markspec.setup({})
+```
+
+## Other editors
+
+Any editor with LSP support can use `markspec lsp`. The server expects:
+
+- **Transport:** stdio (stdin/stdout JSON-RPC)
+- **Trigger characters:** `[` (block scaffold) and `:` (ID reference)
+- **Document sync:** full text on each change
+
+Point your editor's LSP client at `markspec lsp` and it should work. If your
+editor needs a specific configuration example, please open an issue.

--- a/editors/vscode/.gitignore
+++ b/editors/vscode/.gitignore
@@ -1,0 +1,3 @@
+out/
+node_modules/
+*.vsix

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -1,0 +1,70 @@
+{
+  "name": "markspec-ide",
+  "displayName": "MarkSpec",
+  "description": "MarkSpec language support — diagnostics, completions, and entry block scaffolding for traceable industrial documentation.",
+  "version": "0.0.1",
+  "publisher": "driftsys",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/driftsys/markspec",
+    "directory": "editors/vscode"
+  },
+  "engines": {
+    "vscode": "^1.82.0"
+  },
+  "categories": [
+    "Programming Languages",
+    "Linters"
+  ],
+  "keywords": [
+    "markspec",
+    "requirements",
+    "traceability",
+    "iso26262",
+    "aspice"
+  ],
+  "activationEvents": [
+    "onLanguage:markdown",
+    "workspaceContains:**/*.md"
+  ],
+  "main": "./out/extension.js",
+  "contributes": {
+    "configuration": {
+      "title": "MarkSpec",
+      "properties": {
+        "markspec.server.path": {
+          "type": "string",
+          "default": "markspec",
+          "description": "Path to the markspec binary. Defaults to 'markspec' on PATH."
+        },
+        "markspec.server.args": {
+          "type": "array",
+          "items": { "type": "string" },
+          "default": ["lsp"],
+          "description": "Arguments passed to the markspec binary to start the LSP server."
+        },
+        "markspec.trace.server": {
+          "type": "string",
+          "enum": ["off", "messages", "verbose"],
+          "default": "off",
+          "description": "Trace communication between VS Code and the MarkSpec LSP server."
+        }
+      }
+    }
+  },
+  "scripts": {
+    "compile": "tsc -p tsconfig.json",
+    "watch": "tsc -watch -p tsconfig.json",
+    "package": "vsce package --no-dependencies",
+    "lint": "eslint src"
+  },
+  "dependencies": {
+    "vscode-languageclient": "^9.0.1"
+  },
+  "devDependencies": {
+    "@types/vscode": "^1.82.0",
+    "@vscode/vsce": "^3.0.0",
+    "typescript": "^5.5.0"
+  }
+}

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -1,0 +1,67 @@
+/**
+ * MarkSpec VSCode Extension
+ *
+ * Thin LSP client that spawns `markspec lsp` and connects it to VS Code.
+ * All language intelligence (diagnostics, completions) lives in the server;
+ * this extension just manages the lifecycle.
+ */
+
+import { type ExtensionContext, window, workspace } from "vscode";
+
+import {
+  LanguageClient,
+  type LanguageClientOptions,
+  type ServerOptions,
+  TransportKind,
+} from "vscode-languageclient/node";
+
+let client: LanguageClient | undefined;
+
+export function activate(context: ExtensionContext): void {
+  const config = workspace.getConfiguration("markspec");
+  const serverPath = config.get<string>("server.path", "markspec");
+  const serverArgs = config.get<string[]>("server.args", ["lsp"]);
+  const traceLevel = config.get<string>("trace.server", "off");
+
+  const serverOptions: ServerOptions = {
+    command: serverPath,
+    args: serverArgs,
+    transport: TransportKind.stdio,
+  };
+
+  const clientOptions: LanguageClientOptions = {
+    documentSelector: [
+      { scheme: "file", language: "markdown" },
+      { scheme: "file", language: "rust" },
+      { scheme: "file", language: "kotlin" },
+      { scheme: "file", language: "java" },
+      { scheme: "file", language: "c" },
+      { scheme: "file", language: "cpp" },
+    ],
+    synchronize: {
+      fileEvents: workspace.createFileSystemWatcher("**/*.md"),
+    },
+    traceOutputChannel: traceLevel !== "off"
+      ? window.createOutputChannel("MarkSpec LSP")
+      : undefined,
+  };
+
+  client = new LanguageClient(
+    "markspec",
+    "MarkSpec",
+    serverOptions,
+    clientOptions,
+  );
+
+  client.start();
+
+  context.subscriptions.push({
+    dispose: () => {
+      client?.stop();
+    },
+  });
+}
+
+export function deactivate(): Thenable<void> | undefined {
+  return client?.stop();
+}

--- a/editors/vscode/tsconfig.json
+++ b/editors/vscode/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "lib": ["ES2022"],
+    "outDir": "out",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "sourceMap": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "out"]
+}

--- a/packages/markspec/main.ts
+++ b/packages/markspec/main.ts
@@ -774,8 +774,10 @@ const cli = new Command()
   .command("deck", deckCmd)
   // Server commands
   .command("lsp")
-  .description("Start LSP server")
-  .action(notImplemented("lsp"))
+  .description("Start LSP server (stdio JSON-RPC)")
+  .action(async () => {
+    await import("./lsp/server.ts");
+  })
   .command("mcp")
   .description("Start MCP server")
   .action(notImplemented("mcp"))


### PR DESCRIPTION
## Summary

- **Wire `markspec lsp`** — replace `notImplemented("lsp")` in `main.ts` with dynamic import of `lsp/server.ts` so the subcommand actually starts the stdio JSON-RPC server
- **Add VSCode extension** (`editors/vscode/`) — minimal `vscode-languageclient` wrapper that spawns `markspec lsp`, with configurable `markspec.server.path`, `markspec.server.args`, and `markspec.trace.server` settings
- **Add editor integration guide** (`docs/guide/editor-integration.md`) — covers LSP features, VS Code setup, Neovim setup (native + nvim-lspconfig), and generic LSP client instructions
- **Fix AGENTS.md** — correct LSP module tree, remove "three compile targets" fiction, remove nonexistent `markspec-ide` external repo, fix CLI table, add `editors/vscode/` to repo layout
- **Fix CLAUDE.md** — switch from markdown link to `@AGENTS.md` include so Claude Code reads it

## Context

The LSP server was fully implemented in #237 but `markspec lsp` still called `notImplemented()`. This PR wires it up and adds the editor tooling needed to actually use it.

## Changed files

| File | Change |
|------|--------|
| `packages/markspec/main.ts` | Replace `notImplemented("lsp")` with `await import("./lsp/server.ts")` |
| `editors/vscode/package.json` | VSCode extension manifest (activates on markdown) |
| `editors/vscode/src/extension.ts` | LSP client (~65 lines) |
| `editors/vscode/tsconfig.json` | TypeScript config for the extension |
| `editors/vscode/.gitignore` | Ignores out/, node_modules/, *.vsix |
| `docs/guide/editor-integration.md` | Editor integration guide |
| `docs/guide/SUMMARY.md` | Add editor-integration.md to book |
| `AGENTS.md` | Fix LSP tree, compile targets, CLI table, repo layout |
| `CLAUDE.md` | `@AGENTS.md` include |