### PR TITLE
chore(ci): set dependabot commit prefix to chore

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,8 @@ updates:
       actions:
         patterns:
           - "*"
+    commit-message:
+      prefix: "chore"
     open-pull-requests-limit: 5
     labels:
       - "dependencies"


### PR DESCRIPTION
Adds `commit-message.prefix: chore` to the GitHub Actions dependabot entry so future PRs open with `chore(deps):` instead of `build(deps):`.