### PR TITLE
fix(ci): allow deps scope for Dependabot and isolate git env in e2e tests

### DIFF
--- a/.git-std.toml
+++ b/.git-std.toml
@@ -1,6 +1,6 @@
 scheme = "semver"
 strict = true
-scopes = ["auto", "repo", "ci", "spec", "core", "cli", "lsp", "mcp", "render", "book", "deck", "docs"]
+scopes = ["auto", "repo", "ci", "spec", "core", "cli", "lsp", "mcp", "render", "book", "deck", "docs", "deps"]
 
 [versioning]
 tag_prefix = "v"

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -51,6 +51,17 @@ export async function markspec(
       "--allow-write",
       ...(opts.permissions ?? []),
     ];
+    // Strip GIT_* variables so that git commands spawned by the CLI (e.g.
+    // `git clone` in the profile resolver) are not polluted by the hook
+    // environment (GIT_DIR, GIT_WORK_TREE, etc.) when tests run inside a
+    // git pre-push hook from a bare-with-worktree repository.
+    const parentEnv = Deno.env.toObject();
+    const safeEnv: Record<string, string> = {};
+    for (const [k, v] of Object.entries(parentEnv)) {
+      if (!k.startsWith("GIT_")) {
+        safeEnv[k] = v;
+      }
+    }
     const cmd = new Deno.Command("deno", {
       args: [
         "run",
@@ -61,6 +72,8 @@ export async function markspec(
       cwd,
       stdout: "piped",
       stderr: "piped",
+      clearEnv: true,
+      env: safeEnv,
     });
     const result = await cmd.output();
     return {

--- a/tests/e2e/helpers_git.ts
+++ b/tests/e2e/helpers_git.ts
@@ -92,10 +92,24 @@ export async function setupGitFixture(
 
 async function runOrThrow(args: string[]): Promise<void> {
   const [bin, ...rest] = args;
+  // Deno.Command env merges with the parent process environment. When this
+  // function runs inside a git hook (e.g. pre-push), git has already set
+  // GIT_DIR and GIT_WORK_TREE, which causes `git init --bare` to fail with
+  //   "GIT_WORK_TREE not allowed without specifying GIT_DIR"
+  // Use clearEnv + an explicit allowlist to guarantee a clean git environment.
+  const parentEnv = Deno.env.toObject();
+  const safeEnv: Record<string, string> = {};
+  for (const [k, v] of Object.entries(parentEnv)) {
+    if (!k.startsWith("GIT_")) {
+      safeEnv[k] = v;
+    }
+  }
   const cmd = new Deno.Command(bin, {
     args: rest,
     stdout: "piped",
     stderr: "piped",
+    clearEnv: true,
+    env: safeEnv,
   });
   const { code, stderr } = await cmd.output();
   if (code !== 0) {


### PR DESCRIPTION
## Summary

- Adds `deps` to the allowed scopes in `.git-std.toml` so Dependabot's auto-generated `chore(deps): ...` commit messages pass the `Conventional commits` CI check.
- Isolates `GIT_*` environment variables (`GIT_DIR`, `GIT_WORK_TREE`, etc.) from `Deno.Command` subprocesses in both e2e test helpers (`helpers.ts` and `helpers_git.ts`) so tests pass inside the git pre-push hook on a bare-with-worktree repository.

## Root cause

GitHub sets `prefix: "chore"` in Dependabot config, which causes Dependabot to append `(deps)` as a scope. The `deps` scope was not in the `.git-std.toml` allowlist, causing the `Conventional commits` check to fail on every Dependabot PR.

The test isolation fix was needed because the pre-push hook runs inside a bare-with-worktree git repo, where git sets `GIT_DIR` and `GIT_WORK_TREE` in the environment. Those variables leaked into `git init --bare` and `git clone` subprocesses spawned by the tests, causing spurious failures.

## Files changed

- `.git-std.toml` — added `deps` to `scopes`
- `tests/e2e/helpers_git.ts` — `runOrThrow()` now uses `clearEnv: true` + strips all `GIT_*` vars
- `tests/e2e/helpers.ts` — CLI subprocess also strips `GIT_*` vars so internal `git clone` calls in the profile resolver are not polluted by the hook environment

## Testing

`just check` passes locally (631 tests, 0 failures). Once this merges, re-running CI on Dependabot PR #240 will pick up the updated `.git-std.toml` and the `Conventional commits` check will pass.