### PR TITLE
feat: profile system completion — CLI commands, retirement model, strawman validation

### DIFF
--- a/docs/examples/profiles/aspice-swe-mini/markspec.yaml
+++ b/docs/examples/profiles/aspice-swe-mini/markspec.yaml
@@ -14,19 +14,19 @@ profile:
   # Universal — applies to every entry regardless of shape or type
   # ==========================================================================
   attributes:
-    - { name: External-id, type: string, cardinality: 0..1 }
+    - { name: External-id, type: external-id, cardinality: 0..1 }
 
   labels:
     # ASIL — mutually exclusive safety integrity level
-    - { name: QM,     group: asil }
-    - { name: ASIL-A, group: asil }
-    - { name: ASIL-B, group: asil }
-    - { name: ASIL-C, group: asil }
-    - { name: ASIL-D, group: asil }
+    - QM
+    - ASIL-A
+    - ASIL-B
+    - ASIL-C
+    - ASIL-D
     # Ungrouped
-    - { name: security }
-    - { name: automated, applies: [unit-test, integration-test] }
-    - { name: manual,    applies: [unit-test, integration-test] }
+    - security
+    - automated
+    - manual
 
   # ==========================================================================
   # Per-shape defaults (the two core shapes from ADR-009 §1)
@@ -134,4 +134,4 @@ profile:
         contains: [standard]
     frontMatter:
       - { name: asil, type: enum, values: [QM, A, B, C, D], cardinality: 0..1 }
-      - { name: safety-goal, type: string, cardinality: 0..1 }
+      - { name: safety-goal, type: text, cardinality: 0..1 }

--- a/docs/examples/profiles/default/markspec.yaml
+++ b/docs/examples/profiles/default/markspec.yaml
@@ -1,0 +1,22 @@
+# Baseline default profile — minimal identity, no rules.
+# Used as the root of extends: chains in examples and tests.
+
+id: "@markspec/profile-default"
+version: 1.0.0
+description: Baseline MarkSpec profile
+license: MIT
+
+profile:
+  attributes: []
+  labels: []
+
+  identified:
+    attributes: []
+  referenced:
+    attributes: []
+
+  types: {}
+
+  documents:
+    types: []
+    frontMatter: []

--- a/packages/markspec/core/compiler/link_target.ts
+++ b/packages/markspec/core/compiler/link_target.ts
@@ -1,0 +1,76 @@
+/**
+ * @module core/compiler/link_target
+ *
+ * MSL-T013: Tiered link-target severity. After links are extracted and
+ * inverses generated, check the state of each link target:
+ *
+ * | Target state | Severity |
+ * |---|---|
+ * | Active | OK (no diagnostic) |
+ * | Draft (Labels: DRAFT) | info |
+ * | Retired (Superseded-by: set OR Deprecated: set) | warning |
+ */
+
+import type { Diagnostic, DisplayId, Entry, Link } from "../model/mod.ts";
+
+/**
+ * Check all link targets for retirement/draft state.
+ * Run after inverse generation so `Superseded-by:` is available.
+ */
+export function checkLinkTargets(
+  entries: ReadonlyMap<DisplayId, Entry>,
+  links: readonly Link[],
+): Diagnostic[] {
+  const diagnostics: Diagnostic[] = [];
+
+  for (const link of links) {
+    const target = entries.get(link.to);
+    if (!target) continue; // Unresolved — handled by MSL-T005/MSL-T012
+
+    const state = classifyTargetState(target);
+    if (state === "active") continue;
+
+    if (state === "draft") {
+      diagnostics.push({
+        code: "MSL-T013",
+        severity: "info",
+        message: `${link.from}: link target '${link.to}' is marked DRAFT`,
+        location: link.location,
+      });
+    } else {
+      diagnostics.push({
+        code: "MSL-T013",
+        severity: "warning",
+        message: `${link.from}: link target '${link.to}' is retired`,
+        location: link.location,
+      });
+    }
+  }
+
+  return diagnostics;
+}
+
+type TargetState = "active" | "draft" | "retired";
+
+function classifyTargetState(entry: Entry): TargetState {
+  // Check for retirement markers
+  const hasDeprecated = entry.attributes.some((a) => a.key === "Deprecated");
+  if (hasDeprecated) return "retired";
+
+  const supersededBy = entry.typedAttributes?.get("Superseded-by");
+  if (supersededBy && supersededBy.length > 0) return "retired";
+
+  // Check for DRAFT label via typedAttributes
+  const labels = entry.typedAttributes?.get("Labels");
+  if (labels && labels.includes("DRAFT")) return "draft";
+
+  // Also check raw attributes for Labels containing DRAFT
+  for (const attr of entry.attributes) {
+    if (attr.key === "Labels") {
+      const values = attr.value.split(",").map((s) => s.trim());
+      if (values.includes("DRAFT")) return "draft";
+    }
+  }
+
+  return "active";
+}

--- a/packages/markspec/core/compiler/link_target_test.ts
+++ b/packages/markspec/core/compiler/link_target_test.ts
@@ -1,0 +1,98 @@
+import { assertEquals } from "@std/assert";
+import { checkLinkTargets } from "./link_target.ts";
+import type { DisplayId, Entry, Link, SourceLocation } from "../model/mod.ts";
+
+const LOC: SourceLocation = { file: "test.md", line: 1, column: 1 };
+
+function makeEntry(
+  displayId: string,
+  opts: {
+    attributes?: Array<{ key: string; value: string }>;
+    typedAttributes?: ReadonlyMap<string, readonly string[]>;
+  } = {},
+): Entry {
+  return {
+    displayId,
+    title: displayId,
+    body: "",
+    attributes: opts.attributes ?? [],
+    typedAttributes: opts.typedAttributes,
+    shape: "identified",
+    location: LOC,
+    source: "markdown",
+  };
+}
+
+function makeLink(from: string, to: string): Link {
+  return { from, to, kind: "satisfies", location: LOC };
+}
+
+Deno.test("checkLinkTargets: active target produces no diagnostic", () => {
+  const entries = new Map<DisplayId, Entry>([
+    ["REQ-001", makeEntry("REQ-001")],
+    ["REQ-002", makeEntry("REQ-002")],
+  ]);
+  const links = [makeLink("REQ-002", "REQ-001")];
+  const diagnostics = checkLinkTargets(entries, links);
+  assertEquals(diagnostics.length, 0);
+});
+
+Deno.test("checkLinkTargets: DRAFT target produces info", () => {
+  const entries = new Map<DisplayId, Entry>([
+    [
+      "REQ-001",
+      makeEntry("REQ-001", {
+        typedAttributes: new Map([["Labels", ["DRAFT"]]]),
+      }),
+    ],
+    ["REQ-002", makeEntry("REQ-002")],
+  ]);
+  const links = [makeLink("REQ-002", "REQ-001")];
+  const diagnostics = checkLinkTargets(entries, links);
+  assertEquals(diagnostics.length, 1);
+  assertEquals(diagnostics[0].code, "MSL-T013");
+  assertEquals(diagnostics[0].severity, "info");
+});
+
+Deno.test("checkLinkTargets: Deprecated target produces warning", () => {
+  const entries = new Map<DisplayId, Entry>([
+    [
+      "REQ-001",
+      makeEntry("REQ-001", {
+        attributes: [{ key: "Deprecated", value: "replaced by REQ-003" }],
+      }),
+    ],
+    ["REQ-002", makeEntry("REQ-002")],
+  ]);
+  const links = [makeLink("REQ-002", "REQ-001")];
+  const diagnostics = checkLinkTargets(entries, links);
+  assertEquals(diagnostics.length, 1);
+  assertEquals(diagnostics[0].code, "MSL-T013");
+  assertEquals(diagnostics[0].severity, "warning");
+});
+
+Deno.test("checkLinkTargets: Superseded-by target produces warning", () => {
+  const entries = new Map<DisplayId, Entry>([
+    [
+      "REQ-001",
+      makeEntry("REQ-001", {
+        typedAttributes: new Map([["Superseded-by", ["REQ-003"]]]),
+      }),
+    ],
+    ["REQ-002", makeEntry("REQ-002")],
+  ]);
+  const links = [makeLink("REQ-002", "REQ-001")];
+  const diagnostics = checkLinkTargets(entries, links);
+  assertEquals(diagnostics.length, 1);
+  assertEquals(diagnostics[0].code, "MSL-T013");
+  assertEquals(diagnostics[0].severity, "warning");
+});
+
+Deno.test("checkLinkTargets: unresolved target is skipped (handled by MSL-T005)", () => {
+  const entries = new Map<DisplayId, Entry>([
+    ["REQ-002", makeEntry("REQ-002")],
+  ]);
+  const links = [makeLink("REQ-002", "NONEXISTENT")];
+  const diagnostics = checkLinkTargets(entries, links);
+  assertEquals(diagnostics.length, 0);
+});

--- a/packages/markspec/core/compiler/mod.ts
+++ b/packages/markspec/core/compiler/mod.ts
@@ -18,6 +18,7 @@ import type {
 import { parseFile } from "../parser/mod.ts";
 import { classifyEntriesStage, validate } from "../validator/mod.ts";
 import { generateInverses } from "./inverses.ts";
+import { checkLinkTargets } from "./link_target.ts";
 
 /** Options for {@linkcode compile}. */
 export interface CompileOptions {
@@ -120,12 +121,17 @@ export async function compile(
   }
 
   const links = extractLinks([...entries.values()]);
+
+  // MSL-T013: check link targets for draft/retired state.
+  const linkTargetDiags = checkLinkTargets(entries, links);
+
   const forward = buildAdjacency(links, (l) => l.from);
   const reverse = buildAdjacency(links, (l) => l.to);
 
   const diagnostics = [
     ...parseDiagnostics,
     ...validationResult.diagnostics,
+    ...linkTargetDiags,
   ];
 
   return { entries, links, forward, reverse, documents, diagnostics };

--- a/packages/markspec/core/config/markspec.ts
+++ b/packages/markspec/core/config/markspec.ts
@@ -179,11 +179,39 @@ function parseProfileSpecifier(
     const subpath = rawSubpath ? rawSubpath.slice(1) : undefined;
     return { kind: "git", repo, subpath, tag };
   }
+  if (raw.startsWith("npm:")) {
+    // npm:@scope/name@range or npm:name@range
+    const body = raw.slice(4); // strip "npm:"
+    const scopedMatch = /^(@[a-z0-9-]+\/[a-z0-9-]+)@(.+)$/.exec(body);
+    if (scopedMatch) {
+      const [, fullName, range] = scopedMatch;
+      const slashIdx = fullName.indexOf("/");
+      return {
+        kind: "npm",
+        scope: fullName.slice(0, slashIdx),
+        name: fullName.slice(slashIdx + 1),
+        range,
+      };
+    }
+    const unscopedMatch = /^([a-z0-9-]+)@(.+)$/.exec(body);
+    if (unscopedMatch) {
+      const [, name, range] = unscopedMatch;
+      return { kind: "npm", name, range };
+    }
+    diagnostics.push({
+      code: "MARKSPEC-YAML-003",
+      severity: "error",
+      message:
+        `${context}: npm specifier malformed; expected npm:[@scope/]name@<version-range>`,
+      location: { file: sourcePath, line: 1, column: 1 },
+    });
+    return undefined;
+  }
   diagnostics.push({
     code: "MARKSPEC-YAML-003",
     severity: "error",
     message:
-      `${context}: unsupported specifier scheme (use './path' or 'git+<https|file>://…#<tag>')`,
+      `${context}: unsupported specifier scheme (use './path', 'git+<https|file>://…#<tag>', or 'npm:[@scope/]name@<range>')`,
     location: { file: sourcePath, line: 1, column: 1 },
   });
   return undefined;

--- a/packages/markspec/core/config/markspec.ts
+++ b/packages/markspec/core/config/markspec.ts
@@ -216,3 +216,71 @@ function parseProfileSpecifier(
   });
   return undefined;
 }
+
+/** Injectable file writer for addProfileSpecifier. */
+export type WriteFile = (path: string, content: string) => Promise<void>;
+
+/**
+ * Append a profile specifier to `.markspec.yaml`.
+ *
+ * - File absent: creates with `profiles:\n  - <specifier>\n`.
+ * - File exists with `profiles:` key: appends after the last list entry.
+ * - File exists without `profiles:` key: appends the block at end of file.
+ *
+ * Uses raw string manipulation to preserve user comments and formatting.
+ */
+export async function addProfileSpecifier(
+  specifier: string,
+  readFileFn: ReadFile,
+  writeFileFn: WriteFile,
+  projectRoot: string,
+): Promise<void> {
+  const filePath = join(projectRoot, MARKSPEC_YAML_FILENAME);
+  const existing = await readFileFn(filePath);
+
+  if (existing === undefined) {
+    await writeFileFn(filePath, `profiles:\n  - "${specifier}"\n`);
+    return;
+  }
+
+  const profilesIdx = existing.indexOf("profiles:");
+  if (profilesIdx === -1) {
+    const trailing = existing.endsWith("\n") ? "" : "\n";
+    await writeFileFn(
+      filePath,
+      existing + trailing + `\nprofiles:\n  - "${specifier}"\n`,
+    );
+    return;
+  }
+
+  const lines = existing.split("\n");
+  let lastEntryLine = -1;
+  let inProfiles = false;
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].trimStart().startsWith("profiles:")) {
+      inProfiles = true;
+      continue;
+    }
+    if (inProfiles) {
+      if (/^\s+-\s/.test(lines[i])) {
+        lastEntryLine = i;
+      } else if (
+        lines[i].trim().length > 0 && !lines[i].startsWith(" ") &&
+        !lines[i].startsWith("#")
+      ) {
+        break;
+      }
+    }
+  }
+
+  if (lastEntryLine >= 0) {
+    lines.splice(lastEntryLine + 1, 0, `  - "${specifier}"`);
+  } else {
+    const profilesLine = lines.findIndex((l) =>
+      l.trimStart().startsWith("profiles:")
+    );
+    lines.splice(profilesLine + 1, 0, `  - "${specifier}"`);
+  }
+
+  await writeFileFn(filePath, lines.join("\n"));
+}

--- a/packages/markspec/core/config/markspec_test.ts
+++ b/packages/markspec/core/config/markspec_test.ts
@@ -4,7 +4,7 @@
  * Unit tests for .markspec.yaml loading.
  */
 
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertExists } from "@std/assert";
 import {
   MARKSPEC_YAML_FILENAME,
   parseMarkspecYaml,
@@ -150,4 +150,48 @@ Deno.test("parseMarkspecYaml: git+file:// with subpath parsed", () => {
     subpath: "sub",
     tag: "v1.0",
   });
+});
+
+Deno.test("parseMarkspecYaml: npm scoped specifier parsed", () => {
+  const result = parseMarkspecYaml(
+    'profiles:\n  - "npm:@markspec/profile-default@^1.0"',
+    "/project/.markspec.yaml",
+  );
+  assertEquals(result.diagnostics.length, 0);
+  assertExists(result.config);
+  assertEquals(result.config.profiles.length, 1);
+  const spec = result.config.profiles[0];
+  assertEquals(spec.kind, "npm");
+  if (spec.kind === "npm") {
+    assertEquals(spec.scope, "@markspec");
+    assertEquals(spec.name, "profile-default");
+    assertEquals(spec.range, "^1.0");
+  }
+});
+
+Deno.test("parseMarkspecYaml: npm unscoped specifier parsed", () => {
+  const result = parseMarkspecYaml(
+    'profiles:\n  - "npm:my-profile@1.2.3"',
+    "/project/.markspec.yaml",
+  );
+  assertEquals(result.diagnostics.length, 0);
+  assertExists(result.config);
+  assertEquals(result.config.profiles.length, 1);
+  const spec = result.config.profiles[0];
+  assertEquals(spec.kind, "npm");
+  if (spec.kind === "npm") {
+    assertEquals(spec.scope, undefined);
+    assertEquals(spec.name, "my-profile");
+    assertEquals(spec.range, "1.2.3");
+  }
+});
+
+Deno.test("parseMarkspecYaml: npm specifier missing version range errors", () => {
+  const result = parseMarkspecYaml(
+    'profiles:\n  - "npm:@markspec/profile-default"',
+    "/project/.markspec.yaml",
+  );
+  assertEquals(result.config, null);
+  assertEquals(result.diagnostics.length, 1);
+  assertEquals(result.diagnostics[0].code, "MARKSPEC-YAML-003");
 });

--- a/packages/markspec/core/config/markspec_test.ts
+++ b/packages/markspec/core/config/markspec_test.ts
@@ -4,8 +4,9 @@
  * Unit tests for .markspec.yaml loading.
  */
 
-import { assertEquals, assertExists } from "@std/assert";
+import { assertEquals, assertExists, assertStringIncludes } from "@std/assert";
 import {
+  addProfileSpecifier,
   MARKSPEC_YAML_FILENAME,
   parseMarkspecYaml,
   readMarkspecYaml,
@@ -194,4 +195,58 @@ Deno.test("parseMarkspecYaml: npm specifier missing version range errors", () =>
   assertEquals(result.config, null);
   assertEquals(result.diagnostics.length, 1);
   assertEquals(result.diagnostics[0].code, "MARKSPEC-YAML-003");
+});
+
+Deno.test("addProfileSpecifier: creates file when absent", async () => {
+  const writes: Record<string, string> = {};
+  await addProfileSpecifier(
+    "npm:@markspec/profile-default@^1.0",
+    () => Promise.resolve(undefined),
+    (path, content) => {
+      writes[path] = content;
+      return Promise.resolve();
+    },
+    "/project",
+  );
+  const written = writes["/project/.markspec.yaml"];
+  assertExists(written);
+  assertStringIncludes(written, "profiles:");
+  assertStringIncludes(written, "npm:@markspec/profile-default@^1.0");
+});
+
+Deno.test("addProfileSpecifier: appends to existing profiles list", async () => {
+  const existing = 'profiles:\n  - "./local-profile"\n';
+  const writes: Record<string, string> = {};
+  await addProfileSpecifier(
+    "npm:@markspec/profile-default@^1.0",
+    () => Promise.resolve(existing),
+    (path, content) => {
+      writes[path] = content;
+      return Promise.resolve();
+    },
+    "/project",
+  );
+  const written = writes["/project/.markspec.yaml"];
+  assertExists(written);
+  assertStringIncludes(written, "./local-profile");
+  assertStringIncludes(written, "npm:@markspec/profile-default@^1.0");
+});
+
+Deno.test("addProfileSpecifier: adds profiles key when missing", async () => {
+  const existing = "# some comment\n";
+  const writes: Record<string, string> = {};
+  await addProfileSpecifier(
+    "./my-profile",
+    () => Promise.resolve(existing),
+    (path, content) => {
+      writes[path] = content;
+      return Promise.resolve();
+    },
+    "/project",
+  );
+  const written = writes["/project/.markspec.yaml"];
+  assertExists(written);
+  assertStringIncludes(written, "# some comment");
+  assertStringIncludes(written, "profiles:");
+  assertStringIncludes(written, "./my-profile");
 });

--- a/packages/markspec/core/formatter/mod.ts
+++ b/packages/markspec/core/formatter/mod.ts
@@ -39,7 +39,7 @@ const FRONT_MATTER_CORE_ORDER: readonly string[] = [
   "document-id",
   "document-type",
   "labels",
-  "status",
+  "deprecated",
   "external-id",
   "supersedes",
   "references",

--- a/packages/markspec/core/model/mod.ts
+++ b/packages/markspec/core/model/mod.ts
@@ -461,8 +461,8 @@ export interface DocumentAttributes {
   readonly "document-type"?: string;
   /** Classification tags (`tag-list`). */
   readonly labels?: readonly string[];
-  /** Lifecycle state (`draft` / `approved` / `deprecated` / `withdrawn`). */
-  readonly status?: string;
+  /** Retirement reason (free-text). Presence marks the document as retired. */
+  readonly deprecated?: string;
   /** Cross-system identifier(s) (`external-id`). */
   readonly "external-id"?: readonly string[];
   /** `document-id` of a document this one replaces. */

--- a/packages/markspec/core/model/profile.ts
+++ b/packages/markspec/core/model/profile.ts
@@ -121,6 +121,12 @@ export type ProfileSpecifier =
     readonly repo: string;
     readonly subpath?: string;
     readonly tag: string;
+  }
+  | {
+    readonly kind: "npm";
+    readonly scope?: string;
+    readonly name: string;
+    readonly range: string;
   };
 
 /** Parsed `markspec.yaml` content — the manifest authored in a profile. */

--- a/packages/markspec/core/parser/frontmatter.ts
+++ b/packages/markspec/core/parser/frontmatter.ts
@@ -29,7 +29,7 @@ const CORE_KEYS: ReadonlySet<string> = new Set([
   "document-id",
   "document-type",
   "labels",
-  "status",
+  "deprecated",
   "external-id",
   "supersedes",
   "references",
@@ -190,6 +190,18 @@ export function extractFrontMatter(
         continue;
       }
       metadata = value as Record<string, unknown>;
+      continue;
+    }
+
+    // Transitional: status: was removed in favor of Labels: DRAFT / deprecated:
+    if (key === "status") {
+      diagnostics.push({
+        code: "MSL-D002",
+        severity: "warning",
+        message: `front-matter key 'status' is no longer recognized; ` +
+          `use 'Labels: DRAFT' for draft state or 'deprecated: "<reason>"' for retirement`,
+        location: { file, line: 1, column: 1 },
+      });
       continue;
     }
 

--- a/packages/markspec/core/parser/frontmatter_test.ts
+++ b/packages/markspec/core/parser/frontmatter_test.ts
@@ -2,7 +2,7 @@
  * @module parser/frontmatter_test
  */
 
-import { assert, assertEquals } from "@std/assert";
+import { assert, assertEquals, assertExists } from "@std/assert";
 import { extractFrontMatter } from "./frontmatter.ts";
 
 Deno.test("extractFrontMatter: no front matter returns input unchanged", () => {
@@ -18,7 +18,7 @@ Deno.test("extractFrontMatter: extracts core keys", () => {
   const md = `---
 document-id: 01HGW2D0DOCPQ4FGHIJKLMNOPQR
 document-type: requirements
-status: approved
+deprecated: "Replaced by v2"
 ---
 
 # Title
@@ -30,7 +30,7 @@ status: approved
     "01HGW2D0DOCPQ4FGHIJKLMNOPQR",
   );
   assertEquals(result.attributes["document-type"], "requirements");
-  assertEquals(result.attributes.status, "approved");
+  assertEquals(result.attributes.deprecated, "Replaced by v2");
   assertEquals(result.markdown, "# Title\n");
 });
 
@@ -161,4 +161,36 @@ Deno.test("extractFrontMatter: empty front matter is valid", () => {
   assert(result.hadFrontMatter);
   assertEquals(result.attributes, {});
   assertEquals(result.diagnostics.length, 0);
+});
+
+Deno.test("extractFrontMatter: deprecated key accepted", () => {
+  const md = `---
+document-id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+deprecated: "Replaced by v2 architecture document"
+---
+
+# My Document
+`;
+  const result = extractFrontMatter(md);
+  assertEquals(result.diagnostics.length, 0);
+  assertEquals(
+    result.attributes.deprecated,
+    "Replaced by v2 architecture document",
+  );
+});
+
+Deno.test("extractFrontMatter: status key emits MSL-D002 warning", () => {
+  const md = `---
+document-id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+status: draft
+---
+
+# My Document
+`;
+  const result = extractFrontMatter(md);
+  const d002 = result.diagnostics.find((d) => d.code === "MSL-D002");
+  assertExists(d002);
+  assertEquals(d002.severity, "warning");
+  assert(d002.message.includes("status"));
+  assert(d002.message.includes("Labels: DRAFT"));
 });

--- a/packages/markspec/core/profile/cache.ts
+++ b/packages/markspec/core/profile/cache.ts
@@ -1,0 +1,65 @@
+/**
+ * @module core/profile/cache
+ *
+ * XDG-compliant cache directory resolution for profile storage.
+ * Profiles fetched from git or npm are cached globally so they can
+ * be shared across projects.
+ */
+
+import { join } from "@std/path";
+
+/**
+ * Environment variables consulted for cache directory resolution.
+ * Injectable for testing — production code passes `Deno.env.toObject()`.
+ */
+export interface CacheEnv {
+  readonly XDG_CACHE_HOME?: string;
+  readonly HOME?: string;
+  readonly LOCALAPPDATA?: string;
+}
+
+/**
+ * Resolve the global markspec cache directory (XDG-compliant).
+ *
+ * - `$XDG_CACHE_HOME/markspec` if set (any platform)
+ * - macOS: `~/Library/Caches/markspec`
+ * - Windows: `%LOCALAPPDATA%/markspec/cache`
+ * - Linux/other: `~/.cache/markspec`
+ *
+ * @param env - Environment variables (injectable for tests)
+ * @param platform - OS platform string (injectable for tests; defaults to `Deno.build.os`)
+ */
+export function cacheDir(
+  env?: CacheEnv,
+  platform?: string,
+): string {
+  const e = env ?? envFromDeno();
+  const os = platform ?? Deno.build.os;
+
+  if (e.XDG_CACHE_HOME) {
+    return join(e.XDG_CACHE_HOME, "markspec");
+  }
+
+  if (os === "darwin") {
+    const home = e.HOME ?? "/tmp";
+    return join(home, "Library", "Caches", "markspec");
+  }
+
+  if (os === "windows") {
+    const localAppData = e.LOCALAPPDATA ??
+      join(e.HOME ?? "C:\\Users\\default", "AppData", "Local");
+    return join(localAppData, "markspec", "cache");
+  }
+
+  // Linux and others — XDG default
+  const home = e.HOME ?? "/tmp";
+  return join(home, ".cache", "markspec");
+}
+
+function envFromDeno(): CacheEnv {
+  return {
+    XDG_CACHE_HOME: Deno.env.get("XDG_CACHE_HOME"),
+    HOME: Deno.env.get("HOME"),
+    LOCALAPPDATA: Deno.env.get("LOCALAPPDATA"),
+  };
+}

--- a/packages/markspec/core/profile/cache_test.ts
+++ b/packages/markspec/core/profile/cache_test.ts
@@ -1,0 +1,23 @@
+import { assertEquals } from "@std/assert";
+import { cacheDir } from "./cache.ts";
+
+Deno.test("cacheDir: uses XDG_CACHE_HOME when set", () => {
+  const dir = cacheDir({ XDG_CACHE_HOME: "/custom/cache" });
+  assertEquals(dir, "/custom/cache/markspec");
+});
+
+Deno.test("cacheDir: falls back to platform default when XDG_CACHE_HOME unset", () => {
+  const dir = cacheDir(
+    { XDG_CACHE_HOME: undefined, HOME: "/Users/test" },
+    "darwin",
+  );
+  assertEquals(dir, "/Users/test/Library/Caches/markspec");
+});
+
+Deno.test("cacheDir: uses ~/.cache/markspec on linux without XDG", () => {
+  const dir = cacheDir(
+    { XDG_CACHE_HOME: undefined, HOME: "/home/user" },
+    "linux",
+  );
+  assertEquals(dir, "/home/user/.cache/markspec");
+});

--- a/packages/markspec/core/profile/chain.ts
+++ b/packages/markspec/core/profile/chain.ts
@@ -24,7 +24,11 @@ import type {
 import type { AppendFile, RunGit } from "./git-cache.ts";
 import { parseManifest } from "./manifest.ts";
 import { mergeChain } from "./merge.ts";
-import { resolveGitSpecifier, resolveLocalSpecifier } from "./resolver.ts";
+import {
+  type ResolvedProfileSource,
+  resolveGitSpecifier,
+  resolveLocalSpecifier,
+} from "./resolver.ts";
 
 /** Maximum number of tiers allowed in an `extends:` chain. */
 const MAX_CHAIN_DEPTH = 20;
@@ -96,20 +100,34 @@ export async function loadChain(
       return { chain: null, diagnostics };
     }
 
-    const resolved = cursorSpec.kind === "git"
-      ? await resolveGitSpecifier(
+    let resolved: ResolvedProfileSource | null;
+    if (cursorSpec.kind === "git") {
+      resolved = await resolveGitSpecifier(
         cursorSpec,
         projectRoot,
         readFile,
         diagnostics,
         { runGit: opts.runGit, appendFile: opts.appendFile },
-      )
-      : await resolveLocalSpecifier(
+      );
+    } else if (cursorSpec.kind === "npm") {
+      // npm resolution wired in Task 4
+      diagnostics.push({
+        code: "PROFILE-LOAD-001",
+        severity: "error",
+        message: `npm specifier '${
+          stringifySpec(cursorSpec)
+        }' not yet supported in chain resolution`,
+        location: { file: "<specifier>", line: 1, column: 1 },
+      });
+      resolved = null;
+    } else {
+      resolved = await resolveLocalSpecifier(
         cursorSpec,
         cursorDir,
         readFile,
         diagnostics,
       );
+    }
     if (!resolved) {
       return { chain: null, diagnostics };
     }
@@ -183,7 +201,15 @@ function specifierKey(
   if (spec.kind === "local") {
     return `local:${resolvePath(contextDir, spec.path)}`;
   }
-  return `git:${spec.repo}#${spec.tag}|${spec.subpath ?? ""}`;
+  if (spec.kind === "git") {
+    return `git:${spec.repo}#${spec.tag}|${spec.subpath ?? ""}`;
+  }
+  if (spec.kind === "npm") {
+    const pkg = spec.scope ? `${spec.scope}/${spec.name}` : spec.name;
+    return `npm:${pkg}@${spec.range}`;
+  }
+  const _exhaustive: never = spec;
+  throw new Error(`Unknown specifier kind`);
 }
 
 /** Human-readable one-liner for a specifier (used in diagnostic messages). */
@@ -191,7 +217,15 @@ function stringifySpec(spec: ProfileSpecifier): string {
   if (spec.kind === "local") {
     return spec.path;
   }
-  return `git+${spec.repo}#${spec.tag}`;
+  if (spec.kind === "git") {
+    return `git+${spec.repo}#${spec.tag}`;
+  }
+  if (spec.kind === "npm") {
+    const pkg = spec.scope ? `${spec.scope}/${spec.name}` : spec.name;
+    return `npm:${pkg}@${spec.range}`;
+  }
+  const _exhaustive: never = spec;
+  throw new Error(`Unknown specifier kind`);
 }
 
 /**

--- a/packages/markspec/core/profile/chain.ts
+++ b/packages/markspec/core/profile/chain.ts
@@ -110,16 +110,16 @@ export async function loadChain(
         { runGit: opts.runGit, appendFile: opts.appendFile },
       );
     } else if (cursorSpec.kind === "npm") {
-      // npm resolution wired in Task 4
-      diagnostics.push({
-        code: "PROFILE-LOAD-001",
-        severity: "error",
-        message: `npm specifier '${
-          stringifySpec(cursorSpec)
-        }' not yet supported in chain resolution`,
-        location: { file: "<specifier>", line: 1, column: 1 },
-      });
-      resolved = null;
+      const { resolveNpmSpecifier } = await import("./npm.ts");
+      const { cacheDir: cacheDirFn } = await import("./cache.ts");
+      resolved = await resolveNpmSpecifier(
+        cursorSpec,
+        diagnostics,
+        {
+          cacheRoot: cacheDirFn(),
+          readFile,
+        },
+      );
     } else {
       resolved = await resolveLocalSpecifier(
         cursorSpec,

--- a/packages/markspec/core/profile/manifest.ts
+++ b/packages/markspec/core/profile/manifest.ts
@@ -53,6 +53,7 @@ const ALLOWED_REFERENCED_KEYS = new Set(["required", "attributes"]);
 
 const ALLOWED_TYPE_KEYS = new Set([
   "shape",
+  "description",
   "display-id-pattern",
   "display-id-pattern-enforcement",
   "required",
@@ -168,11 +169,38 @@ function parseSpecifier(
     const subpath = rawSubpath ? rawSubpath.slice(1) : undefined;
     return { kind: "git", repo, subpath, tag };
   }
+  if (raw.startsWith("npm:")) {
+    const body = raw.slice(4);
+    const scopedMatch = /^(@[a-z0-9-]+\/[a-z0-9-]+)@(.+)$/.exec(body);
+    if (scopedMatch) {
+      const [, fullName, range] = scopedMatch;
+      const slashIdx = fullName.indexOf("/");
+      return {
+        kind: "npm",
+        scope: fullName.slice(0, slashIdx),
+        name: fullName.slice(slashIdx + 1),
+        range,
+      };
+    }
+    const unscopedMatch = /^([a-z0-9-]+)@(.+)$/.exec(body);
+    if (unscopedMatch) {
+      const [, name, range] = unscopedMatch;
+      return { kind: "npm", scope: undefined, name, range };
+    }
+    diagnostics.push({
+      code: "PROFILE-LOAD-003",
+      severity: "error",
+      message:
+        `'extends' npm specifier malformed; expected npm:[@scope/]name@<version-range>`,
+      location: { file: sourcePath, line: 1, column: 1 },
+    });
+    return undefined;
+  }
   diagnostics.push({
     code: "PROFILE-LOAD-003",
     severity: "error",
     message:
-      `'extends' specifier scheme not supported in v1 (use local './path' or 'git+<https|file>://…#<tag>')`,
+      `'extends' specifier scheme not supported (use './path', 'git+<https|file>://…#<tag>', or 'npm:[@scope/]name@<range>')`,
     location: { file: sourcePath, line: 1, column: 1 },
   });
   return undefined;

--- a/packages/markspec/core/profile/manifest_test.ts
+++ b/packages/markspec/core/profile/manifest_test.ts
@@ -4,7 +4,7 @@
  * Unit tests for markspec.yaml manifest parsing.
  */
 
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertExists } from "@std/assert";
 import { fromFileUrl } from "@std/path";
 import { parseManifest } from "./manifest.ts";
 
@@ -371,7 +371,34 @@ Deno.test("parseManifest: extends unrecognized scheme errors", () => {
   const result = parseManifest(`
 id: "@acme/x"
 version: 1.0.0
+extends: "s3://bucket/profile"
+`);
+  assertEquals(result.manifest, null);
+  assertEquals(result.diagnostics[0].code, "PROFILE-LOAD-003");
+});
+
+Deno.test("parseManifest: extends npm scoped specifier parsed", () => {
+  const result = parseManifest(`
+id: "@acme/x"
+version: 1.0.0
 extends: "npm:@acme/profile@1.0"
+`);
+  assertEquals(result.diagnostics.length, 0);
+  assertExists(result.manifest);
+  assertExists(result.manifest.extends);
+  assertEquals(result.manifest.extends.kind, "npm");
+  if (result.manifest.extends.kind === "npm") {
+    assertEquals(result.manifest.extends.scope, "@acme");
+    assertEquals(result.manifest.extends.name, "profile");
+    assertEquals(result.manifest.extends.range, "1.0");
+  }
+});
+
+Deno.test("parseManifest: extends npm malformed specifier errors", () => {
+  const result = parseManifest(`
+id: "@acme/x"
+version: 1.0.0
+extends: "npm:@acme/profile"
 `);
   assertEquals(result.manifest, null);
   assertEquals(result.diagnostics[0].code, "PROFILE-LOAD-003");

--- a/packages/markspec/core/profile/mod.ts
+++ b/packages/markspec/core/profile/mod.ts
@@ -34,3 +34,6 @@ export type { LoadProfileForCommandResult } from "./load.ts";
 
 export { mergeChain } from "./merge.ts";
 export type { MergeResult } from "./merge.ts";
+
+export { cacheDir } from "./cache.ts";
+export type { CacheEnv } from "./cache.ts";

--- a/packages/markspec/core/profile/mod.ts
+++ b/packages/markspec/core/profile/mod.ts
@@ -37,3 +37,6 @@ export type { MergeResult } from "./merge.ts";
 
 export { cacheDir } from "./cache.ts";
 export type { CacheEnv } from "./cache.ts";
+
+export { defaultRunNpm, resolveNpmSpecifier } from "./npm.ts";
+export type { ResolveNpmOptions, RunNpm } from "./npm.ts";

--- a/packages/markspec/core/profile/npm.ts
+++ b/packages/markspec/core/profile/npm.ts
@@ -1,0 +1,247 @@
+/**
+ * @module core/profile/npm
+ *
+ * Resolve an npm profile specifier by downloading the package tarball
+ * via `npm pack` and extracting `markspec.yaml` from it. Results are
+ * cached under the global XDG cache directory.
+ */
+
+import { join } from "@std/path";
+import type { Diagnostic, ProfileSpecifier } from "../model/mod.ts";
+import type { ResolvedProfileSource } from "./resolver.ts";
+
+/** Result of running an npm command. Same shape as {@linkcode RunGit}. */
+export type RunNpm = (
+  args: readonly string[],
+  cwd?: string,
+) => Promise<{ code: number; stdout: string; stderr: string }>;
+
+/** Options for {@linkcode resolveNpmSpecifier}. */
+export interface ResolveNpmOptions {
+  /** Injectable npm runner — defaults to {@linkcode defaultRunNpm}. */
+  readonly runNpm?: RunNpm;
+  /** Global cache root (from {@linkcode cacheDir}). */
+  readonly cacheRoot: string;
+  /** File reader — returns contents or undefined if missing. */
+  readonly readFile: (path: string) => Promise<string | undefined>;
+  /** Pre-resolved version for cache lookup (testing only). */
+  readonly resolvedVersion?: string;
+  /** Injectable temp dir creator — defaults to `Deno.makeTempDir`. */
+  readonly makeTempDir?: () => Promise<string>;
+  /** Injectable temp dir remover — defaults to `Deno.remove`. */
+  readonly removeTempDir?: (path: string) => Promise<void>;
+}
+
+/** Default npm runner using `Deno.Command`. */
+export async function defaultRunNpm(
+  args: readonly string[],
+  cwd?: string,
+): Promise<{ code: number; stdout: string; stderr: string }> {
+  const cmd = new Deno.Command("npm", {
+    args: [...args],
+    cwd,
+    stdout: "piped",
+    stderr: "piped",
+  });
+  const result = await cmd.output();
+  return {
+    code: result.code,
+    stdout: new TextDecoder().decode(result.stdout),
+    stderr: new TextDecoder().decode(result.stderr),
+  };
+}
+
+/**
+ * Build the cache directory path for an npm package.
+ * Layout: `<cacheRoot>/npm/@scope/name/<version>/` or `<cacheRoot>/npm/name/<version>/`
+ */
+function npmCacheDir(
+  cacheRoot: string,
+  spec: Extract<ProfileSpecifier, { kind: "npm" }>,
+  version: string,
+): string {
+  return spec.scope
+    ? join(cacheRoot, "npm", spec.scope, spec.name, version)
+    : join(cacheRoot, "npm", spec.name, version);
+}
+
+/** Extract semver from a tarball filename like `profile-default-1.0.0.tgz`. */
+export function extractVersionFromTarball(filename: string): string | null {
+  const match = filename.match(
+    /(\d+\.\d+\.\d+(?:-[\w.]+)?(?:\+[\w.]+)?)\.tgz$/,
+  );
+  return match ? match[1] : null;
+}
+
+/**
+ * Resolve an npm specifier into a {@linkcode ResolvedProfileSource}.
+ *
+ * 1. Check the cache for an existing resolution
+ * 2. On miss, run `npm pack <pkg>@<range> --pack-destination <tmpdir>`
+ * 3. Extract `markspec.yaml` from the tarball
+ * 4. Cache to `<cacheRoot>/npm/<pkg>/<version>/`
+ * 5. Return the resolved source
+ */
+export async function resolveNpmSpecifier(
+  specifier: Extract<ProfileSpecifier, { kind: "npm" }>,
+  diagnostics: Diagnostic[],
+  opts: ResolveNpmOptions,
+): Promise<ResolvedProfileSource | null> {
+  const runNpm = opts.runNpm ?? defaultRunNpm;
+  const pkgName = specifier.scope
+    ? `${specifier.scope}/${specifier.name}`
+    : specifier.name;
+  const pkgWithRange = `${pkgName}@${specifier.range}`;
+
+  // Cache hit — if we know the version, check for cached manifest.
+  if (opts.resolvedVersion) {
+    const cachedDir = npmCacheDir(
+      opts.cacheRoot,
+      specifier,
+      opts.resolvedVersion,
+    );
+    const cachedManifest = join(cachedDir, "markspec.yaml");
+    const cached = await opts.readFile(cachedManifest);
+    if (cached !== undefined) {
+      return {
+        rawYaml: cached,
+        sourcePath: cachedManifest,
+        baseDir: cachedDir,
+      };
+    }
+  }
+
+  // Run npm pack to download the tarball.
+  let tmpDir: string | undefined;
+  const mkTmp = opts.makeTempDir ??
+    (() => Deno.makeTempDir({ prefix: "markspec-npm-" }));
+  const rmTmp = opts.removeTempDir ??
+    ((p: string) => Deno.remove(p, { recursive: true }));
+  try {
+    tmpDir = await mkTmp();
+    const packResult = await runNpm([
+      "pack",
+      pkgWithRange,
+      "--pack-destination",
+      tmpDir,
+    ]);
+
+    if (packResult.code !== 0) {
+      // Distinguish npm-not-found from package-not-found.
+      const stderr = packResult.stderr.toLowerCase();
+      if (
+        packResult.code === 127 ||
+        stderr.includes("command not found") ||
+        stderr.includes("not recognized")
+      ) {
+        diagnostics.push({
+          code: "PROFILE-ADD-004",
+          severity: "error",
+          message:
+            `npm is not installed or not in PATH; cannot resolve '${pkgWithRange}'`,
+          location: { file: "<specifier>", line: 1, column: 1 },
+        });
+      } else {
+        diagnostics.push({
+          code: "PROFILE-LOAD-001",
+          severity: "error",
+          message:
+            `npm pack failed for '${pkgWithRange}': ${packResult.stderr.trim()}`,
+          location: { file: "<specifier>", line: 1, column: 1 },
+        });
+      }
+      return null;
+    }
+
+    // Find the tarball in tmpDir.
+    const stdout = packResult.stdout.trim();
+    const tarballName = stdout.split("\n").pop()?.trim();
+    if (!tarballName) {
+      diagnostics.push({
+        code: "PROFILE-LOAD-001",
+        severity: "error",
+        message: `npm pack for '${pkgWithRange}' produced no output`,
+        location: { file: "<specifier>", line: 1, column: 1 },
+      });
+      return null;
+    }
+
+    const version = extractVersionFromTarball(tarballName);
+    if (!version) {
+      diagnostics.push({
+        code: "PROFILE-LOAD-001",
+        severity: "error",
+        message: `cannot extract version from tarball '${tarballName}'`,
+        location: { file: "<specifier>", line: 1, column: 1 },
+      });
+      return null;
+    }
+
+    // Check cache again with the resolved version.
+    const cacheTargetDir = npmCacheDir(opts.cacheRoot, specifier, version);
+    const cacheManifestPath = join(cacheTargetDir, "markspec.yaml");
+    const existingCached = await opts.readFile(cacheManifestPath);
+    if (existingCached !== undefined) {
+      return {
+        rawYaml: existingCached,
+        sourcePath: cacheManifestPath,
+        baseDir: cacheTargetDir,
+      };
+    }
+
+    // Extract tarball into cache directory.
+    await Deno.mkdir(cacheTargetDir, { recursive: true });
+    const tgzPath = join(tmpDir, tarballName);
+    const tarResult = await runTar(tgzPath, cacheTargetDir);
+    if (tarResult.code !== 0) {
+      diagnostics.push({
+        code: "PROFILE-LOAD-001",
+        severity: "error",
+        message:
+          `tar extraction failed for '${tarballName}': ${tarResult.stderr.trim()}`,
+        location: { file: tgzPath, line: 1, column: 1 },
+      });
+      return null;
+    }
+
+    // Read the manifest from extracted contents.
+    const rawYaml = await opts.readFile(cacheManifestPath);
+    if (rawYaml === undefined) {
+      diagnostics.push({
+        code: "PROFILE-LOAD-001",
+        severity: "error",
+        message: `npm package '${pkgWithRange}' does not contain markspec.yaml`,
+        location: { file: cacheManifestPath, line: 1, column: 1 },
+      });
+      return null;
+    }
+
+    return { rawYaml, sourcePath: cacheManifestPath, baseDir: cacheTargetDir };
+  } finally {
+    if (tmpDir) {
+      try {
+        await rmTmp(tmpDir);
+      } catch {
+        // Best-effort cleanup.
+      }
+    }
+  }
+}
+
+/** Extract a .tgz tarball, stripping the top-level `package/` directory. */
+async function runTar(
+  tgzPath: string,
+  targetDir: string,
+): Promise<{ code: number; stdout: string; stderr: string }> {
+  const cmd = new Deno.Command("tar", {
+    args: ["xzf", tgzPath, "--strip-components=1", "-C", targetDir],
+    stdout: "piped",
+    stderr: "piped",
+  });
+  const result = await cmd.output();
+  return {
+    code: result.code,
+    stdout: new TextDecoder().decode(result.stdout),
+    stderr: new TextDecoder().decode(result.stderr),
+  };
+}

--- a/packages/markspec/core/profile/npm_test.ts
+++ b/packages/markspec/core/profile/npm_test.ts
@@ -1,0 +1,92 @@
+import { assertEquals, assertExists } from "@std/assert";
+import { resolveNpmSpecifier } from "./npm.ts";
+import type { Diagnostic, ProfileSpecifier } from "../model/mod.ts";
+
+const npmSpec: Extract<ProfileSpecifier, { kind: "npm" }> = {
+  kind: "npm",
+  scope: "@markspec",
+  name: "profile-default",
+  range: "^1.0",
+};
+
+const fakeTmpOpts = {
+  makeTempDir: () => Promise.resolve("/tmp/fake-markspec-npm"),
+  removeTempDir: (_p: string) => Promise.resolve(),
+};
+
+Deno.test("resolveNpmSpecifier: npm not found emits PROFILE-ADD-004", async () => {
+  const diagnostics: Diagnostic[] = [];
+  const failNpm = () =>
+    Promise.resolve({
+      code: 127,
+      stdout: "",
+      stderr: "npm: command not found",
+    });
+  const result = await resolveNpmSpecifier(
+    npmSpec,
+    diagnostics,
+    {
+      runNpm: failNpm,
+      cacheRoot: "/tmp/test-cache",
+      readFile: () => Promise.resolve(undefined),
+      ...fakeTmpOpts,
+    },
+  );
+  assertEquals(result, null);
+  assertEquals(diagnostics.length, 1);
+  assertEquals(diagnostics[0].code, "PROFILE-ADD-004");
+});
+
+Deno.test("resolveNpmSpecifier: package not found emits PROFILE-LOAD-001", async () => {
+  const diagnostics: Diagnostic[] = [];
+  const failPack = () =>
+    Promise.resolve({
+      code: 1,
+      stdout: "",
+      stderr: "npm ERR! 404 Not Found",
+    });
+  const result = await resolveNpmSpecifier(
+    npmSpec,
+    diagnostics,
+    {
+      runNpm: failPack,
+      cacheRoot: "/tmp/test-cache",
+      readFile: () => Promise.resolve(undefined),
+      ...fakeTmpOpts,
+    },
+  );
+  assertEquals(result, null);
+  assertEquals(diagnostics.length, 1);
+  assertEquals(diagnostics[0].code, "PROFILE-LOAD-001");
+});
+
+Deno.test("resolveNpmSpecifier: cache hit skips npm pack", async () => {
+  const diagnostics: Diagnostic[] = [];
+  let npmCalled = false;
+  const spyNpm = () => {
+    npmCalled = true;
+    return Promise.resolve({ code: 0, stdout: "", stderr: "" });
+  };
+  const manifestContent =
+    `id: "@markspec/profile-default"\nversion: 1.0.0\nprofile:\n  types: {}\n`;
+
+  const result = await resolveNpmSpecifier(
+    npmSpec,
+    diagnostics,
+    {
+      runNpm: spyNpm,
+      cacheRoot: "/tmp/test-cache",
+      readFile: (path: string) => {
+        if (path.includes("@markspec") && path.endsWith("markspec.yaml")) {
+          return Promise.resolve(manifestContent);
+        }
+        return Promise.resolve(undefined);
+      },
+      resolvedVersion: "1.0.0",
+    },
+  );
+  assertEquals(npmCalled, false, "npm should not be called on cache hit");
+  assertExists(result);
+  assertEquals(result.rawYaml, manifestContent);
+  assertEquals(diagnostics.length, 0);
+});

--- a/packages/markspec/core/profile/strawman_test.ts
+++ b/packages/markspec/core/profile/strawman_test.ts
@@ -1,0 +1,123 @@
+/**
+ * End-to-end validation of the aspice-swe-mini strawman profile.
+ *
+ * Loads the strawman through the full chain → merge → classify → validate
+ * pipeline to exercise every profile schema section against a real profile.
+ */
+
+import { assertEquals, assertExists } from "@std/assert";
+import { loadChain } from "./chain.ts";
+import type { ProfileChain, ProfileSpecifier } from "../model/mod.ts";
+import { resolve } from "@std/path";
+
+const readFile = async (path: string): Promise<string | undefined> => {
+  try {
+    return await Deno.readTextFile(path);
+  } catch {
+    return undefined;
+  }
+};
+
+/** Absolute path to the examples/profiles directory. */
+const PROFILES_DIR = resolve(
+  new URL(".", import.meta.url).pathname,
+  "../../../../docs/examples/profiles",
+);
+
+/**
+ * The strawman uses `extends: npm:@markspec/profile-default@^1.0`.
+ * For testing, we create a modified version that extends the local default.
+ */
+async function loadStrawmanChain(): Promise<{
+  chain: ProfileChain | null;
+  diagnostics: readonly { severity: string; code: string; message: string }[];
+}> {
+  const originalPath = resolve(PROFILES_DIR, "aspice-swe-mini/markspec.yaml");
+  const original = await Deno.readTextFile(originalPath);
+  const rewritten = original.replace(
+    /extends:.*$/m,
+    'extends: "../default"',
+  );
+
+  const tmpDir = await Deno.makeTempDir({ prefix: "markspec-strawman-" });
+  const profileDir = `${tmpDir}/aspice-swe-mini`;
+  const defaultDir = `${tmpDir}/default`;
+
+  await Deno.mkdir(profileDir, { recursive: true });
+  await Deno.mkdir(defaultDir, { recursive: true });
+
+  await Deno.writeTextFile(`${profileDir}/markspec.yaml`, rewritten);
+
+  const defaultManifest = await Deno.readTextFile(
+    resolve(PROFILES_DIR, "default/markspec.yaml"),
+  );
+  await Deno.writeTextFile(`${defaultDir}/markspec.yaml`, defaultManifest);
+
+  const specifier: ProfileSpecifier = {
+    kind: "local",
+    path: "./aspice-swe-mini",
+  };
+
+  try {
+    return await loadChain(specifier, tmpDir, tmpDir, readFile);
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true }).catch(() => {});
+  }
+}
+
+Deno.test("strawman: chain resolves with 2 tiers", async () => {
+  const result = await loadStrawmanChain();
+  assertEquals(
+    result.diagnostics.filter((d) => d.severity === "error").length,
+    0,
+    `unexpected errors: ${JSON.stringify(result.diagnostics)}`,
+  );
+  assertExists(result.chain);
+  assertEquals(result.chain.tiers.length, 2);
+  assertEquals(result.chain.tiers[0].id, "@markspec/profile-default");
+  assertEquals(result.chain.tiers[1].id, "@markspec/profile-aspice-swe-mini");
+});
+
+Deno.test("strawman: effective profile has all 7 types", async () => {
+  const result = await loadStrawmanChain();
+  assertExists(result.chain);
+  const types = result.chain.effective.types;
+  const typeNames = [...types.keys()].sort();
+  assertEquals(typeNames, [
+    "integration-test",
+    "software-element",
+    "software-requirement",
+    "stakeholder-requirement",
+    "standard",
+    "unit",
+    "unit-test",
+  ]);
+});
+
+Deno.test("strawman: effective profile has ASIL labels", async () => {
+  const result = await loadStrawmanChain();
+  assertExists(result.chain);
+  const labels = result.chain.effective.labels.value;
+  const asilLabels = labels.filter((l: string) =>
+    l === "QM" || l.startsWith("ASIL-")
+  );
+  assertEquals(asilLabels.length, 5); // QM, ASIL-A, ASIL-B, ASIL-C, ASIL-D
+});
+
+Deno.test("strawman: software-requirement has Derived-from traceability rule", async () => {
+  const result = await loadStrawmanChain();
+  assertExists(result.chain);
+  const srs = result.chain.effective.types.get("software-requirement");
+  assertExists(srs);
+  const derivedFrom = srs.value.traceability.get("Derived-from");
+  assertExists(derivedFrom);
+  assertEquals(derivedFrom.value.required, true);
+});
+
+Deno.test("strawman: standard type has referenced shape", async () => {
+  const result = await loadStrawmanChain();
+  assertExists(result.chain);
+  const standard = result.chain.effective.types.get("standard");
+  assertExists(standard);
+  assertEquals(standard.value.shape, "referenced");
+});

--- a/packages/markspec/main.ts
+++ b/packages/markspec/main.ts
@@ -320,7 +320,11 @@ const profileCmd = new Command()
         for (const tier of chain.tiers) {
           const spec = tier.specifier.kind === "local"
             ? tier.specifier.path
-            : `${tier.specifier.repo}@${tier.specifier.tag}`;
+            : tier.specifier.kind === "git"
+            ? `${tier.specifier.repo}@${tier.specifier.tag}`
+            : `npm:${
+              tier.specifier.scope ? `${tier.specifier.scope}/` : ""
+            }${tier.specifier.name}@${tier.specifier.range}`;
           console.error(`  ${tier.id}@${tier.version}  (${spec})`);
           console.error(`    source: ${tier.sourcePath}`);
         }

--- a/packages/markspec/main.ts
+++ b/packages/markspec/main.ts
@@ -330,6 +330,199 @@ const profileCmd = new Command()
         }
       }
     }
+  })
+  .command("new <id:string>")
+  .description("Scaffold a new profile directory")
+  .option("--dir <dir:string>", "Override output directory")
+  .action(async (options: { dir?: string }, id: string) => {
+    const PROFILE_ID_RE = /^(@[a-z0-9-]+\/)?[a-z0-9][a-z0-9-]*$/;
+    if (!PROFILE_ID_RE.test(id)) {
+      console.error(
+        `error: invalid profile id '${id}'\n` +
+          "  expected: lowercase alphanumeric with hyphens, optional @scope/ prefix\n" +
+          "  examples: my-profile, @org/my-profile",
+      );
+      Deno.exit(1);
+    }
+
+    const dirName = id.includes("/") ? id.split("/")[1] : id;
+    const targetDir = options.dir ?? `./${dirName}`;
+
+    try {
+      await Deno.stat(targetDir);
+      console.error(`error: directory '${targetDir}' already exists`);
+      Deno.exit(1);
+    } catch (err) {
+      if (!(err instanceof Deno.errors.NotFound)) throw err;
+    }
+
+    await Deno.mkdir(targetDir, { recursive: true });
+
+    const manifest = `id: "${id}"
+version: 0.1.0
+description: ""
+# license: MIT
+# extends: "./path/to/parent"
+
+profile:
+  # Universal scope
+  attributes: []
+  labels: []
+
+  # Per-shape scope
+  identified:
+    attributes: []
+  referenced:
+    attributes: []
+
+  # Per-type scope
+  types: {}
+
+  # Document scope
+  documents:
+    types: []
+    frontMatter: []
+`;
+
+    const readme = `# ${id}\n\nA MarkSpec profile.\n`;
+
+    await Deno.writeTextFile(`${targetDir}/markspec.yaml`, manifest);
+    await Deno.writeTextFile(`${targetDir}/README.md`, readme);
+
+    console.error(`created profile at ${targetDir}/`);
+  })
+  .command("publish")
+  .description("Validate a profile manifest for publishability")
+  .option("--dry-run", "Validate only (default)", { default: true })
+  .option("--dir <dir:string>", "Profile directory", { default: "." })
+  .option("--format <format:string>", "Output format (json|text)", {
+    default: "text",
+  })
+  .action(
+    async (options: { dryRun?: boolean; dir?: string; format?: string }) => {
+      const { parseManifest } = await import("./core/mod.ts");
+      const dir = options.dir ?? ".";
+      const manifestPath = `${dir}/markspec.yaml`;
+
+      let rawYaml: string;
+      try {
+        rawYaml = await Deno.readTextFile(manifestPath);
+      } catch {
+        console.error(`error: no markspec.yaml found at ${manifestPath}`);
+        Deno.exit(1);
+      }
+
+      const result = parseManifest(rawYaml, manifestPath);
+      const diagnostics = [...result.diagnostics];
+
+      if (result.manifest) {
+        if (!result.manifest.description) {
+          diagnostics.push({
+            code: "PROFILE-PUB-001",
+            severity: "warning",
+            message:
+              "profile is missing 'description' (recommended for publishing)",
+            location: { file: manifestPath, line: 1, column: 1 },
+          });
+        }
+        if (!result.manifest.license) {
+          diagnostics.push({
+            code: "PROFILE-PUB-002",
+            severity: "warning",
+            message:
+              "profile is missing 'license' (recommended for publishing)",
+            location: { file: manifestPath, line: 1, column: 1 },
+          });
+        }
+      }
+
+      const hasErrors = diagnostics.some((d) => d.severity === "error");
+
+      if (options.format === "json") {
+        const output = {
+          valid: !hasErrors,
+          profile: result.manifest
+            ? { id: result.manifest.id, version: result.manifest.version }
+            : null,
+          diagnostics: diagnostics.map((d) => ({
+            severity: d.severity,
+            code: d.code,
+            message: d.message,
+          })),
+        };
+        console.log(JSON.stringify(output, null, 2));
+      } else {
+        for (const diag of diagnostics) {
+          console.error(`${diag.severity}[${diag.code}]: ${diag.message}`);
+        }
+        if (!hasErrors) {
+          console.error(
+            result.manifest
+              ? `✓ ${result.manifest.id}@${result.manifest.version} is valid for publishing`
+              : "✓ profile is valid",
+          );
+        }
+      }
+
+      Deno.exit(hasErrors ? 1 : 0);
+    },
+  )
+  .command("add <spec:string>")
+  .description("Add a profile to the project")
+  .option("--format <format:string>", "Output format (json|text)", {
+    default: "text",
+  })
+  .action(async (options: { format?: string }, spec: string) => {
+    const { config: _config, projectRoot } = await requireProjectConfig();
+
+    // Parse the specifier string to validate format.
+    const { parseMarkspecYaml } = await import("./core/config/markspec.ts");
+    const testYaml = `profiles:\n  - "${spec}"\n`;
+    const parseResult = parseMarkspecYaml(testYaml, "<cli>");
+
+    if (!parseResult.config || parseResult.config.profiles.length === 0) {
+      for (const diag of parseResult.diagnostics) {
+        console.error(`${diag.severity}[${diag.code}]: ${diag.message}`);
+      }
+      Deno.exit(1);
+    }
+
+    const specifier = parseResult.config.profiles[0];
+
+    // For local specifiers, validate the profile exists by attempting load.
+    if (specifier.kind === "local") {
+      const { loadChain } = await import("./core/mod.ts");
+      const chainResult = await loadChain(
+        specifier,
+        projectRoot,
+        projectRoot,
+        readFile,
+      );
+
+      let sawError = false;
+      for (const diag of chainResult.diagnostics) {
+        console.error(`${diag.severity}[${diag.code}]: ${diag.message}`);
+        if (diag.severity === "error") sawError = true;
+      }
+      if (sawError || !chainResult.chain) {
+        Deno.exit(1);
+      }
+    }
+
+    // Record the specifier in .markspec.yaml.
+    const { addProfileSpecifier } = await import("./core/config/markspec.ts");
+    await addProfileSpecifier(
+      spec,
+      readFile,
+      (path: string, content: string) => Deno.writeTextFile(path, content),
+      projectRoot,
+    );
+
+    if (options.format === "json") {
+      console.log(JSON.stringify({ added: spec }));
+    } else {
+      console.error(`added profile: ${spec}`);
+    }
   });
 
 const deckCmd = new Command()

--- a/tests/e2e/helpers_git.ts
+++ b/tests/e2e/helpers_git.ts
@@ -40,15 +40,18 @@ export async function setupGitFixture(
   const workDir = `${opts.workspaceDir}/_gitwork/${opts.name}`;
 
   await Deno.mkdir(bareDir, { recursive: true });
+  // Ensure workDir is truly fresh — uncaught errors from other test files
+  // (render/typst WASM NAPI) can corrupt Deno runner state, leaving ghost
+  // artifacts. Deleting first guarantees a clean git init.
+  await Deno.remove(workDir, { recursive: true }).catch(() => {});
   await Deno.mkdir(workDir, { recursive: true });
 
   await runOrThrow(["git", "init", "--bare", bareDir]);
 
-  await runOrThrow(["git", "init", workDir]);
+  await runOrThrow(["git", "init", "-b", "main", workDir]);
   await runOrThrow(["git", "-C", workDir, "config", "user.email", "t@t.test"]);
   await runOrThrow(["git", "-C", workDir, "config", "user.name", "Test"]);
   await runOrThrow(["git", "-C", workDir, "config", "commit.gpgsign", "false"]);
-  await runOrThrow(["git", "-C", workDir, "checkout", "-b", "main"]);
 
   for (const [relPath, content] of Object.entries(opts.files)) {
     const abs = `${workDir}/${relPath}`;

--- a/tests/e2e/profile_test.ts
+++ b/tests/e2e/profile_test.ts
@@ -1,0 +1,80 @@
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { markspec } from "./helpers.ts";
+
+// ── profile new ──────────────────────────────────────────────────────
+
+Deno.test("profile new: scaffolds profile directory", async () => {
+  const { code, stderr } = await markspec(["profile", "new", "my-profile"]);
+  assertEquals(code, 0);
+  assertStringIncludes(stderr, "my-profile");
+});
+
+Deno.test("profile new: accepts scoped id", async () => {
+  const { code, stderr } = await markspec([
+    "profile",
+    "new",
+    "@org/my-profile",
+  ]);
+  assertEquals(code, 0);
+  assertStringIncludes(stderr, "my-profile");
+});
+
+Deno.test("profile new: rejects invalid id", async () => {
+  const { code, stderr } = await markspec(["profile", "new", "INVALID_ID"]);
+  assertEquals(code, 1);
+  assertStringIncludes(stderr, "invalid profile id");
+});
+
+// ── profile publish ──────────────────────────────────────────────────
+
+Deno.test("profile publish: validates a well-formed profile", async () => {
+  const { code } = await markspec(["profile", "publish", "--dir", "."], {
+    "markspec.yaml":
+      `id: "@test/my-profile"\nversion: 1.0.0\ndescription: test\nlicense: MIT\nprofile:\n  types: {}\n`,
+  });
+  assertEquals(code, 0);
+});
+
+Deno.test("profile publish: fails on invalid manifest", async () => {
+  const { code } = await markspec(["profile", "publish", "--dir", "."], {
+    "markspec.yaml": "not: valid\n",
+  });
+  assertEquals(code, 1);
+});
+
+Deno.test("profile publish: warns on missing description", async () => {
+  const { code, stderr } = await markspec(
+    ["profile", "publish", "--dir", "."],
+    {
+      "markspec.yaml":
+        `id: "@test/my-profile"\nversion: 1.0.0\nlicense: MIT\nprofile:\n  types: {}\n`,
+    },
+  );
+  assertEquals(code, 0);
+  assertStringIncludes(stderr, "description");
+});
+
+// ── profile add ──────────────────────────────────────────────────────
+
+Deno.test("profile add: adds local specifier to .markspec.yaml", async () => {
+  const { code, stderr } = await markspec(
+    ["profile", "add", "./profiles/my-profile"],
+    {
+      "project.yaml": "name: test\nversion: 0.1.0\n",
+      "profiles/my-profile/markspec.yaml":
+        `id: "my-profile"\nversion: 0.1.0\nprofile:\n  types: {}\n`,
+    },
+  );
+  assertEquals(code, 0);
+  assertStringIncludes(stderr, "added");
+});
+
+Deno.test("profile add: fails on unresolvable specifier", async () => {
+  const { code } = await markspec(
+    ["profile", "add", "./nonexistent"],
+    {
+      "project.yaml": "name: test\nversion: 0.1.0\n",
+    },
+  );
+  assertEquals(code, 1);
+});


### PR DESCRIPTION
## Summary

Completes the profile system epic (#221) with three phases:

**Phase A: CLI Commands**
- `profile new <id>` — scaffold a new profile (markspec.yaml + README.md)
- `profile publish` — validate manifest for publishing (dry-run only)
- `profile add <spec>` — record a specifier in `.markspec.yaml`
- npm specifier parsing and resolution (`npm:@scope/name@range`)
- XDG cache directory helper for profile storage

**Phase B: Retirement Model Cleanup**
- Add `deprecated:` front-matter key (replaces `status:`)
- MSL-D002 transitional diagnostic for `status:` key usage
- MSL-T013 tiered link-target severity (draft → info, retired → warning)
- Formatter core-order updated (`status` → `deprecated`)

**Phase C: Strawman Validation**
- `aspice-swe-mini` profile updated to valid parser schema
- Local default profile for testing
- End-to-end test: 2-tier chain resolution, 7 types, ASIL labels, traceability rules, referenced shape

## Test Plan

- 659 tests pass (2 pre-existing render/typst WASM NAPI failures unrelated to this PR)
- New unit tests: npm parsing (3), XDG cache (3), npm resolver (3), addProfileSpecifier (3), link-target severity (5), strawman (5), frontmatter deprecated (2)
- New E2E tests: profile CLI commands (profile_test.ts), git specifier resilience fix

## Notes

- The render/typst test failures are pre-existing (WASM NAPI module requires --allow-env which the test runner does not grant) and unrelated to this PR
- `profile publish` is validate-only (dry-run) — actual npm publishing deferred
- `profile add` records specifier but resolves from global XDG cache, no vendoring