### PR TITLE
refactor(core): entry model type-safety cleanup

### DIFF
--- a/docs/superpowers/plans/2026-05-02-entry-model-type-safety.md
+++ b/docs/superpowers/plans/2026-05-02-entry-model-type-safety.md
@@ -1,0 +1,424 @@
+# Entry Model Type-Safety Cleanup Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove transitional optionals and clarify the dual-view relationship
+in the Entry model.
+
+**Architecture:** Three independent type-level changes to `Entry` and
+`CompileResult`. No behavioral changes — purely mechanical rename and optional
+removal. `deno check` guides all changes (compiler errors show exactly what to
+fix).
+
+**Tech Stack:** Deno/TypeScript, no new dependencies.
+
+**Worktree:** `/Users/sebastientasson/Workspace/driftsys/markspec-entry-model`
+**Branch:** `refactor/entry-model-type-safety` **Base SHA:** `b6cb772` (main)
+
+---
+
+### Task 1: Make `typedAttributes` required
+
+**Files:**
+
+- Modify: `packages/markspec/core/model/mod.ts` (line ~253)
+- Modify: `packages/markspec/core/validator/attributes.ts` (line ~142)
+- Modify: `packages/markspec/core/validator/traceability.ts` (line ~101)
+- Modify: `packages/markspec/core/validator/normalize.ts` (lines ~29, ~35)
+- Modify: `packages/markspec/core/compiler/inverses.ts` (lines ~69, ~77, ~111,
+  ~117)
+
+- [ ] **Step 1: Change the type in model/mod.ts**
+
+In `packages/markspec/core/model/mod.ts`, change the `typedAttributes` field
+from optional to required:
+
+```typescript
+// Before
+readonly typedAttributes?: TypedAttributes;
+
+// After
+readonly typedAttributes: TypedAttributes;
+```
+
+- [ ] **Step 2: Run `deno check` to find all errors**
+
+Run:
+`deno check packages/markspec/main.ts packages/markspec/core/mod.ts packages/markspec/lsp/server.ts packages/markspec/mcp/server.ts`
+
+Expected: Compile errors at sites using `?? new Map()` on `typedAttributes`
+(since TypeScript now knows it's always defined, the fallback is unnecessary but
+not an error) and possibly at test files constructing Entry objects without the
+field. The actual errors will be in test files that construct partial Entry
+literals without `typedAttributes`.
+
+- [ ] **Step 3: Fix validator/attributes.ts**
+
+In `packages/markspec/core/validator/attributes.ts`, find:
+
+```typescript
+const typed = entry.typedAttributes ?? new Map();
+```
+
+Replace with:
+
+```typescript
+const typed = entry.typedAttributes;
+```
+
+- [ ] **Step 4: Fix validator/traceability.ts**
+
+In `packages/markspec/core/validator/traceability.ts`, find:
+
+```typescript
+const typed = entry.typedAttributes ?? new Map();
+```
+
+Replace with:
+
+```typescript
+const typed = entry.typedAttributes;
+```
+
+- [ ] **Step 5: Fix validator/normalize.ts**
+
+In `packages/markspec/core/validator/normalize.ts`, find any `?? new Map()`
+guard on `typedAttributes` and remove the fallback. Also remove any
+`if (entry.typedAttributes === undefined)` early return — instead, check
+`.size === 0` if the guard is needed.
+
+- [ ] **Step 6: Fix compiler/inverses.ts**
+
+In `packages/markspec/core/compiler/inverses.ts`, find all
+`entry.typedAttributes ?? new Map()` or optional chaining on `typedAttributes`
+and simplify to direct access.
+
+- [ ] **Step 7: Fix test Entry literals**
+
+Search all test files for Entry literal objects that omit `typedAttributes`. Add
+`typedAttributes: new Map()` to each. Use `deno check` output to find them.
+
+Common locations:
+
+- `packages/markspec/core/validator/mod_test.ts`
+- `packages/markspec/core/validator/attributes_test.ts`
+- `packages/markspec/core/validator/traceability_test.ts`
+- `packages/markspec/core/validator/normalize_test.ts`
+- `packages/markspec/core/compiler/inverses_test.ts` (if exists)
+- `packages/markspec/lsp/workspace_test.ts`
+
+- [ ] **Step 8: Run `deno check` — verify no type errors**
+
+Run:
+`deno check packages/markspec/main.ts packages/markspec/core/mod.ts packages/markspec/lsp/server.ts packages/markspec/mcp/server.ts`
+
+Expected: Clean (0 errors).
+
+- [ ] **Step 9: Run tests**
+
+Run: `deno test --allow-read --allow-write --allow-run`
+
+Expected: 659+ pass, only 2 pre-existing render/typst failures.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add -A
+git commit -m "refactor(core): make Entry.typedAttributes required"
+```
+
+Commit scope: `core`. Message explains that the parser always populates it and
+the optional was a transitional artifact.
+
+---
+
+### Task 2: Make `CompileResult.documents` required
+
+**Files:**
+
+- Modify: `packages/markspec/core/compiler/mod.ts` (line ~44)
+- Modify: `packages/markspec/core/mod_test.ts` (lines ~148, ~160)
+- Modify: `packages/markspec/core/compiler/schema_test.ts` (lines ~37, ~64, ~91,
+  ~109)
+- Modify: `packages/markspec/render/styles/mod_test.ts` (line ~26)
+- Modify: `packages/markspec/render/includes/mod_test.ts` (line ~30)
+- Modify: `packages/markspec/render/mustache/mod_test.ts` (line ~46)
+- Modify: `packages/markspec/render/mod_test.ts` (line ~6)
+
+- [ ] **Step 1: Change the type in compiler/mod.ts**
+
+In `packages/markspec/core/compiler/mod.ts`, find the `CompileResult` interface.
+Change `documents` from optional to required:
+
+```typescript
+// Before
+readonly documents?: ReadonlyMap<string, Document>;
+
+// After
+readonly documents: ReadonlyMap<string, Document>;
+```
+
+Also remove any "Optional during the v2 migration" comment.
+
+- [ ] **Step 2: Run `deno check` to find all errors**
+
+Run:
+`deno check packages/markspec/main.ts packages/markspec/core/mod.ts packages/markspec/lsp/server.ts packages/markspec/mcp/server.ts`
+
+Expected: Errors in test files constructing `CompileResult` literals without
+`documents`.
+
+- [ ] **Step 3: Fix all test literals**
+
+Add `documents: new Map()` to every `CompileResult` literal that omits it. Use
+the `deno check` error output as the authoritative list. Expected ~9 sites
+across 6 test files.
+
+Example fix:
+
+```typescript
+// Before
+const result: CompileResult = {
+  entries: new Map(),
+  links: [],
+  forward: new Map(),
+  reverse: new Map(),
+  diagnostics: [],
+};
+
+// After
+const result: CompileResult = {
+  entries: new Map(),
+  links: [],
+  forward: new Map(),
+  reverse: new Map(),
+  documents: new Map(),
+  diagnostics: [],
+};
+```
+
+- [ ] **Step 4: Also fix any consumer that guards with `?.` or `?? new Map()`**
+
+Search for `result.documents?.` or `result.documents ??` in the codebase and
+simplify to direct access.
+
+- [ ] **Step 5: Run `deno check` — verify no type errors**
+
+Run:
+`deno check packages/markspec/main.ts packages/markspec/core/mod.ts packages/markspec/lsp/server.ts packages/markspec/mcp/server.ts`
+
+Expected: Clean (0 errors).
+
+- [ ] **Step 6: Run tests**
+
+Run: `deno test --allow-read --allow-write --allow-run`
+
+Expected: Same pass/fail count as Task 1.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add -A
+git commit -m "refactor(core): make CompileResult.documents required"
+```
+
+---
+
+### Task 3: Rename `attributes` → `rawAttributes`
+
+**Files:**
+
+- Modify: `packages/markspec/core/model/mod.ts` (Entry interface, line ~244)
+- Modify: `packages/markspec/core/parser/markdown.ts` (entry construction,
+  ~line 248)
+- Modify: `packages/markspec/core/parser/source.ts` (entry construction)
+- Modify: `packages/markspec/core/validator/mod.ts` (~4 sites)
+- Modify: `packages/markspec/core/compiler/mod.ts` (~1 site)
+- Modify: `packages/markspec/core/formatter/mod.ts` (~1 site)
+- Modify: `packages/markspec/render/typst/template.ts` (~2 sites)
+- Modify: `packages/markspec/render/includes/mod.ts` (~1 site)
+- Modify: `packages/markspec/book/site/mod.ts` (~2 sites)
+- Modify: `packages/markspec/main.ts` (~1 site)
+- Modify: All test files constructing Entry objects (~15-20 files)
+
+- [ ] **Step 1: Rename in model/mod.ts with doc comment**
+
+In `packages/markspec/core/model/mod.ts`, find the `attributes` field in the
+`Entry` interface:
+
+```typescript
+// Before
+readonly attributes: readonly Attribute[];
+
+// After
+/**
+ * Source-order raw attribute array. Used by the formatter for round-trip
+ * fidelity (preserving key casing, line order, and trailing backslashes).
+ * For lookup-oriented access, use `typedAttributes` — the collated,
+ * CSV-split Map view of the same data.
+ */
+readonly rawAttributes: readonly Attribute[];
+```
+
+- [ ] **Step 2: Run `deno check` to get the full error list**
+
+Run:
+`deno check packages/markspec/main.ts packages/markspec/core/mod.ts packages/markspec/lsp/server.ts packages/markspec/mcp/server.ts`
+
+Expected: Many errors — every `.attributes` access on an Entry object will fail.
+Use this output as the exhaustive TODO list.
+
+- [ ] **Step 3: Fix parser/markdown.ts**
+
+In the entry construction literal (around line 248), rename:
+
+```typescript
+// Before
+attributes,
+
+// After
+rawAttributes: attributes,
+```
+
+(The local variable `attributes` can keep its name — it's the field name on
+Entry that changes.)
+
+- [ ] **Step 4: Fix parser/source.ts**
+
+Same pattern as Step 3 — find the entry construction literal and rename the
+field.
+
+- [ ] **Step 5: Fix core/validator/mod.ts**
+
+Find all `entry.attributes` references (expect ~4 sites) and rename to
+`entry.rawAttributes`. For example:
+
+```typescript
+// Before
+const idAttrs = entry.attributes.filter((a) => a.key === IDENTITY_KEY);
+
+// After
+const idAttrs = entry.rawAttributes.filter((a) => a.key === IDENTITY_KEY);
+```
+
+- [ ] **Step 6: Fix core/compiler/mod.ts**
+
+Find `entry.attributes` in `extractLinks()` or similar and rename to
+`entry.rawAttributes`.
+
+- [ ] **Step 7: Fix core/formatter/mod.ts**
+
+Find the spread `[...entry.attributes]` and rename to
+`[...entry.rawAttributes]`.
+
+- [ ] **Step 8: Fix render/ consumers**
+
+- `render/typst/template.ts`: ~2 sites (`.find()` and `.filter()` for Labels)
+- `render/includes/mod.ts`: ~1 site (serialization)
+
+Rename all `.attributes` → `.rawAttributes`.
+
+- [ ] **Step 9: Fix book/site/mod.ts**
+
+~2 sites — `.find()` and `.filter()` patterns. Rename to `.rawAttributes`.
+
+- [ ] **Step 10: Fix main.ts**
+
+~1 site in the `show` command output loop. Rename to `.rawAttributes`.
+
+- [ ] **Step 11: Fix ALL test files**
+
+Use `deno check` output to find every remaining error. These will be Entry
+literal constructions in test files. Replace `attributes:` with `rawAttributes:`
+in each.
+
+Expected files (non-exhaustive — use `deno check` as authoritative):
+
+- `packages/markspec/core/parser/markdown_test.ts`
+- `packages/markspec/core/parser/attributes_test.ts`
+- `packages/markspec/core/parser/source_test.ts`
+- `packages/markspec/core/validator/mod_test.ts`
+- `packages/markspec/core/validator/attributes_test.ts`
+- `packages/markspec/core/validator/traceability_test.ts`
+- `packages/markspec/core/validator/normalize_test.ts`
+- `packages/markspec/core/validator/types_test.ts`
+- `packages/markspec/core/compiler/mod_test.ts`
+- `packages/markspec/core/compiler/inverses_test.ts`
+- `packages/markspec/core/compiler/link_target_test.ts`
+- `packages/markspec/core/mod_test.ts`
+- `packages/markspec/render/styles/mod_test.ts`
+- `packages/markspec/render/includes/mod_test.ts`
+- `packages/markspec/render/mustache/mod_test.ts`
+- `packages/markspec/render/mod_test.ts`
+- `packages/markspec/lsp/workspace_test.ts`
+- `tests/e2e/` files (if they construct Entry objects — unlikely since E2E tests
+  are blackbox)
+
+- [ ] **Step 12: Run `deno check` — verify zero type errors**
+
+Run:
+`deno check packages/markspec/main.ts packages/markspec/core/mod.ts packages/markspec/lsp/server.ts packages/markspec/mcp/server.ts`
+
+Expected: Clean (0 errors).
+
+- [ ] **Step 13: Run `deno lint`**
+
+Run: `deno lint`
+
+Expected: Clean (0 warnings).
+
+- [ ] **Step 14: Run tests**
+
+Run: `deno test --allow-read --allow-write --allow-run`
+
+Expected: Same pass/fail count as before. Zero assertion failures — only field
+names changed, not values.
+
+- [ ] **Step 15: Commit**
+
+```bash
+git add -A
+git commit -m "refactor(core): rename Entry.attributes to rawAttributes
+
+Clarifies that rawAttributes is the source-order array used by the formatter
+for round-trip fidelity, while typedAttributes is the collated Map for
+lookup-oriented access. Both are views of the same data."
+```
+
+---
+
+### Task 4: Final verification
+
+- [ ] **Step 1: Run full check + test + lint**
+
+```bash
+just build
+```
+
+Or if `just` is not available:
+
+```bash
+deno check packages/markspec/main.ts packages/markspec/core/mod.ts packages/markspec/lsp/server.ts packages/markspec/mcp/server.ts && deno lint && deno test --allow-read --allow-write --allow-run
+```
+
+Expected: type-check clean, lint clean, 659+ tests pass (only 2 pre-existing
+render/typst failures).
+
+- [ ] **Step 2: Review git log**
+
+```bash
+git log --oneline main..HEAD
+```
+
+Expected 3 commits:
+
+```
+<sha> refactor(core): rename Entry.attributes to rawAttributes
+<sha> refactor(core): make CompileResult.documents required
+<sha> refactor(core): make Entry.typedAttributes required
+```
+
+(Plus the spec commit at the bottom.)

--- a/docs/superpowers/specs/2026-05-02-entry-model-type-safety-design.md
+++ b/docs/superpowers/specs/2026-05-02-entry-model-type-safety-design.md
@@ -1,7 +1,6 @@
 # Entry Model Type-Safety Cleanup
 
-**Date:** 2026-05-02
-**Issue:** #215 (partial — type-safety / API hygiene items)
+**Date:** 2026-05-02 **Issue:** #215 (partial — type-safety / API hygiene items)
 **Scope:** Three mechanical changes to remove transitional optionals and clarify
 the Entry model.
 
@@ -56,15 +55,15 @@ readonly rawAttributes: readonly Attribute[];
 
 **Consumer impact:** rename `.attributes` → `.rawAttributes` in:
 
-| File | Sites |
-|------|-------|
-| `core/validator/mod.ts` | 4 |
-| `core/compiler/mod.ts` | 1 |
-| `core/formatter/mod.ts` | 1 |
-| `render/typst/template.ts` | 2 |
-| `render/includes/mod.ts` | 1 |
-| `book/site/mod.ts` | 2 |
-| `main.ts` | 1 |
+| File                                   | Sites  |
+| -------------------------------------- | ------ |
+| `core/validator/mod.ts`                | 4      |
+| `core/compiler/mod.ts`                 | 1      |
+| `core/formatter/mod.ts`                | 1      |
+| `render/typst/template.ts`             | 2      |
+| `render/includes/mod.ts`               | 1      |
+| `book/site/mod.ts`                     | 2      |
+| `main.ts`                              | 1      |
 | Test files constructing Entry literals | ~15-20 |
 
 ### 3. Make `CompileResult.documents` required
@@ -91,8 +90,8 @@ readonly documents: ReadonlyMap<string, Document>;
 ## Verification
 
 - `deno check` passes (type errors → compile errors guide the rename)
-- `deno test --allow-read --allow-write --allow-run` passes with same results
-  as before (659 pass, 2 pre-existing render/typst failures)
+- `deno test --allow-read --allow-write --allow-run` passes with same results as
+  before (659 pass, 2 pre-existing render/typst failures)
 - `deno lint` clean
 
 ## Estimated size

--- a/docs/superpowers/specs/2026-05-02-entry-model-type-safety-design.md
+++ b/docs/superpowers/specs/2026-05-02-entry-model-type-safety-design.md
@@ -1,0 +1,100 @@
+# Entry Model Type-Safety Cleanup
+
+**Date:** 2026-05-02
+**Issue:** #215 (partial — type-safety / API hygiene items)
+**Scope:** Three mechanical changes to remove transitional optionals and clarify
+the Entry model.
+
+## Context
+
+After the ADR-002 v2 rewrite (#198) and the profile system completion (#243),
+the Entry model carries two transitional artifacts:
+
+1. `typedAttributes` is marked optional (`?`) even though the parser always
+   populates it. Consumers defensively guard with `?? new Map()`.
+2. `attributes` and `typedAttributes` are a dual-view of the same data but the
+   relationship is undocumented and the naming is ambiguous.
+3. `CompileResult.documents` is optional with a comment "Optional during the v2
+   migration" — the migration is done.
+
+## Changes
+
+### 1. Make `typedAttributes` required
+
+```typescript
+// model/mod.ts — Entry interface
+// Before
+readonly typedAttributes?: TypedAttributes;
+
+// After
+readonly typedAttributes: TypedAttributes;
+```
+
+**Consumer impact:** ~4 sites drop `?? new Map()` fallbacks:
+
+- `core/validator/attributes.ts`
+- `core/validator/traceability.ts`
+- `core/validator/normalize.ts`
+- `core/compiler/inverses.ts`
+
+### 2. Rename `attributes` → `rawAttributes`
+
+```typescript
+// model/mod.ts — Entry interface
+// Before
+readonly attributes: readonly Attribute[];
+
+// After
+/**
+ * Source-order raw attribute array. Used by the formatter for round-trip
+ * fidelity (preserving key casing, line order, and trailing backslashes).
+ * For lookup-oriented access, use `typedAttributes` — the collated,
+ * CSV-split Map view of the same data.
+ */
+readonly rawAttributes: readonly Attribute[];
+```
+
+**Consumer impact:** rename `.attributes` → `.rawAttributes` in:
+
+| File | Sites |
+|------|-------|
+| `core/validator/mod.ts` | 4 |
+| `core/compiler/mod.ts` | 1 |
+| `core/formatter/mod.ts` | 1 |
+| `render/typst/template.ts` | 2 |
+| `render/includes/mod.ts` | 1 |
+| `book/site/mod.ts` | 2 |
+| `main.ts` | 1 |
+| Test files constructing Entry literals | ~15-20 |
+
+### 3. Make `CompileResult.documents` required
+
+```typescript
+// compiler/mod.ts — CompileResult interface
+// Before
+readonly documents?: ReadonlyMap<string, Document>;
+
+// After
+readonly documents: ReadonlyMap<string, Document>;
+```
+
+**Consumer impact:** ~9 test literals add `documents: new Map()`.
+
+## Out of scope
+
+- **Split `Entry.id` into typed fields** — YAGNI. Nobody discriminates ULID vs
+  URI on `.id` directly; they use `.shape`. The raw string + shape enum is
+  already clean.
+- **Behavioral changes** — This PR is purely type-level. No assertion changes,
+  no new diagnostics, no runtime behavior differences.
+
+## Verification
+
+- `deno check` passes (type errors → compile errors guide the rename)
+- `deno test --allow-read --allow-write --allow-run` passes with same results
+  as before (659 pass, 2 pre-existing render/typst failures)
+- `deno lint` clean
+
+## Estimated size
+
+~150-200 LOC diff across ~25 files. Mechanical rename + optional removal.

--- a/packages/markspec/book/site/mod.ts
+++ b/packages/markspec/book/site/mod.ts
@@ -264,12 +264,12 @@ function _entryCategory(displayId: string, shape: string): string {
 function _entryToHtml(entry: Entry): string {
   const category = _entryCategory(entry.displayId, entry.shape);
 
-  const labelsAttr = entry.attributes.find((a) => a.key === "Labels");
+  const labelsAttr = entry.rawAttributes.find((a) => a.key === "Labels");
   const labels = labelsAttr
     ? labelsAttr.value.split(",").map((s) => s.trim()).filter(Boolean)
     : [];
 
-  const metaAttrs = entry.attributes.filter((a) => a.key !== "Labels");
+  const metaAttrs = entry.rawAttributes.filter((a) => a.key !== "Labels");
 
   const pillsHtml = labels.length > 0
     ? `<span class="pill-group">${

--- a/packages/markspec/core/compiler/inverses.ts
+++ b/packages/markspec/core/compiler/inverses.ts
@@ -66,7 +66,6 @@ export function generateInverses(
 
   for (const source of entries) {
     if (source.shape !== "identified" || source.id === undefined) continue;
-    if (!source.typedAttributes) continue;
 
     const applicableSpecs = resolveApplicableSpecs(
       inverseSpecs,
@@ -108,13 +107,13 @@ export function generateInverses(
     }
 
     const newAttrs = new Map<string, readonly string[]>(
-      e.typedAttributes ?? [],
+      e.typedAttributes,
     );
     let changed = false;
 
     for (const [inverseName, generatedIds] of targetInverses) {
       const generatedArr = [...generatedIds];
-      const authored = e.typedAttributes?.get(inverseName);
+      const authored = e.typedAttributes.get(inverseName);
 
       if (authored && authored.length > 0) {
         const authoredSet = new Set(authored);

--- a/packages/markspec/core/compiler/inverses_test.ts
+++ b/packages/markspec/core/compiler/inverses_test.ts
@@ -22,7 +22,7 @@ function entry(
   return {
     title: "",
     body: "",
-    attributes: [],
+    rawAttributes: [],
     shape: "identified",
     location: LOC,
     source: "markdown",
@@ -129,7 +129,7 @@ Deno.test("generateInverses: basic inverse — Verifies → Verified-by", () => 
   assertEquals(result.diagnostics.length, 0);
   const updatedReq = result.entries.find((e) => e.displayId === "REQ_001")!;
   assertEquals(
-    updatedReq.typedAttributes?.get("Verified-by"),
+    updatedReq.typedAttributes.get("Verified-by"),
     ["01BBBBBBBBBBBBBBBBBBBBBBBBB"],
   );
 });
@@ -165,7 +165,7 @@ Deno.test("generateInverses: category filter — skips non-matching target type"
   assertEquals(result.diagnostics.length, 0);
   const updatedSpec = result.entries.find((e) => e.displayId === "SPEC_001")!;
   // Inverse should NOT be added — category mismatch
-  assertEquals(updatedSpec.typedAttributes?.has("Verified-by"), false);
+  assertEquals(updatedSpec.typedAttributes.has("Verified-by"), false);
 });
 
 Deno.test("generateInverses: multiple sources aggregate into id-list", () => {
@@ -206,7 +206,7 @@ Deno.test("generateInverses: multiple sources aggregate into id-list", () => {
   const result = generateInverses([req, tst1, tst2], profile);
   assertEquals(result.diagnostics.length, 0);
   const updatedReq = result.entries.find((e) => e.displayId === "REQ_002")!;
-  const verifiedBy = updatedReq.typedAttributes?.get("Verified-by");
+  const verifiedBy = updatedReq.typedAttributes.get("Verified-by");
   assertEquals(verifiedBy?.length, 2);
   assertEquals(verifiedBy?.includes("01FFFFFFFFFFFFFFFFFFFFFFFFFF"), true);
   assertEquals(verifiedBy?.includes("01GGGGGGGGGGGGGGGGGGGGGGGG1"), true);
@@ -262,7 +262,7 @@ Deno.test("generateInverses: referenced entries are skipped as sources", () => {
   const result = generateInverses([req, ref], profile);
   assertEquals(result.diagnostics.length, 0);
   const updatedReq = result.entries.find((e) => e.displayId === "REQ_004")!;
-  assertEquals(updatedReq.typedAttributes?.has("Verified-by"), false);
+  assertEquals(updatedReq.typedAttributes.has("Verified-by"), false);
 });
 
 Deno.test("generateInverses: clean run produces empty diagnostics", () => {
@@ -309,7 +309,7 @@ Deno.test("generateInverses: MSL-L005 when authored inverse disagrees with gener
 
   // Union: both authored and generated values present
   const updatedReq = result.entries.find((e) => e.displayId === "REQ_005")!;
-  const verifiedBy = updatedReq.typedAttributes?.get("Verified-by")!;
+  const verifiedBy = updatedReq.typedAttributes.get("Verified-by")!;
   assertEquals(verifiedBy.length, 2);
   assertEquals(verifiedBy.includes("01ZZZZZZZZZZZZZZZZZZZZZZZZ1"), true);
   assertEquals(verifiedBy.includes("01LLLLLLLLLLLLLLLLLLLLLLLL1"), true);
@@ -379,7 +379,7 @@ Deno.test("generateInverses: inverse from universal-scope attribute", () => {
   assertEquals(result.diagnostics.length, 0);
   const updatedParent = result.entries.find((e) => e.displayId === "REQ_P")!;
   assertEquals(
-    updatedParent.typedAttributes?.get("Satisfied-by"),
+    updatedParent.typedAttributes.get("Satisfied-by"),
     ["01QQQQQQQQQQQQQQQQQQQQQQQQ1"],
   );
 });
@@ -416,7 +416,7 @@ Deno.test("generateInverses: inverse from identified-shape-scope attribute", () 
   assertEquals(result.diagnostics.length, 0);
   const updatedParent = result.entries.find((e) => e.displayId === "REQ_IS1")!;
   assertEquals(
-    updatedParent.typedAttributes?.get("Satisfied-by"),
+    updatedParent.typedAttributes.get("Satisfied-by"),
     ["01SSSSSSSSSSSSSSSSSSSSSSSS1"],
   );
 });

--- a/packages/markspec/core/compiler/inverses_test.ts
+++ b/packages/markspec/core/compiler/inverses_test.ts
@@ -26,6 +26,7 @@ function entry(
     shape: "identified",
     location: LOC,
     source: "markdown",
+    typedAttributes: new Map(),
     ...overrides,
   };
 }

--- a/packages/markspec/core/compiler/link_target.ts
+++ b/packages/markspec/core/compiler/link_target.ts
@@ -54,18 +54,18 @@ type TargetState = "active" | "draft" | "retired";
 
 function classifyTargetState(entry: Entry): TargetState {
   // Check for retirement markers
-  const hasDeprecated = entry.attributes.some((a) => a.key === "Deprecated");
+  const hasDeprecated = entry.rawAttributes.some((a) => a.key === "Deprecated");
   if (hasDeprecated) return "retired";
 
-  const supersededBy = entry.typedAttributes?.get("Superseded-by");
+  const supersededBy = entry.typedAttributes.get("Superseded-by");
   if (supersededBy && supersededBy.length > 0) return "retired";
 
   // Check for DRAFT label via typedAttributes
-  const labels = entry.typedAttributes?.get("Labels");
+  const labels = entry.typedAttributes.get("Labels");
   if (labels && labels.includes("DRAFT")) return "draft";
 
   // Also check raw attributes for Labels containing DRAFT
-  for (const attr of entry.attributes) {
+  for (const attr of entry.rawAttributes) {
     if (attr.key === "Labels") {
       const values = attr.value.split(",").map((s) => s.trim());
       if (values.includes("DRAFT")) return "draft";

--- a/packages/markspec/core/compiler/link_target_test.ts
+++ b/packages/markspec/core/compiler/link_target_test.ts
@@ -7,7 +7,7 @@ const LOC: SourceLocation = { file: "test.md", line: 1, column: 1 };
 function makeEntry(
   displayId: string,
   opts: {
-    attributes?: Array<{ key: string; value: string }>;
+    rawAttributes?: Array<{ key: string; value: string }>;
     typedAttributes?: ReadonlyMap<string, readonly string[]>;
   } = {},
 ): Entry {
@@ -15,7 +15,7 @@ function makeEntry(
     displayId,
     title: displayId,
     body: "",
-    attributes: opts.attributes ?? [],
+    rawAttributes: opts.rawAttributes ?? [],
     typedAttributes: opts.typedAttributes ?? new Map(),
     shape: "identified",
     location: LOC,
@@ -59,7 +59,7 @@ Deno.test("checkLinkTargets: Deprecated target produces warning", () => {
     [
       "REQ-001",
       makeEntry("REQ-001", {
-        attributes: [{ key: "Deprecated", value: "replaced by REQ-003" }],
+        rawAttributes: [{ key: "Deprecated", value: "replaced by REQ-003" }],
       }),
     ],
     ["REQ-002", makeEntry("REQ-002")],

--- a/packages/markspec/core/compiler/link_target_test.ts
+++ b/packages/markspec/core/compiler/link_target_test.ts
@@ -16,7 +16,7 @@ function makeEntry(
     title: displayId,
     body: "",
     attributes: opts.attributes ?? [],
-    typedAttributes: opts.typedAttributes,
+    typedAttributes: opts.typedAttributes ?? new Map(),
     shape: "identified",
     location: LOC,
     source: "markdown",

--- a/packages/markspec/core/compiler/mod.ts
+++ b/packages/markspec/core/compiler/mod.ts
@@ -38,12 +38,8 @@ export interface CompileResult {
   readonly forward: ReadonlyMap<DisplayId, readonly Link[]>;
   /** Incoming links per entry (entry → sources pointing to it). */
   readonly reverse: ReadonlyMap<DisplayId, readonly Link[]>;
-  /**
-   * Documents keyed by file path. A file appears here only when it carried
-   * YAML front matter per ADR-007. Optional during the v2 migration;
-   * consumers should treat absence as an empty map.
-   */
-  readonly documents?: ReadonlyMap<string, Document>;
+  /** Documents keyed by file path. A file appears here only when it carried YAML front matter per ADR-007. */
+  readonly documents: ReadonlyMap<string, Document>;
   /** Diagnostics from parsing and validation. */
   readonly diagnostics: readonly Diagnostic[];
 }

--- a/packages/markspec/core/compiler/mod.ts
+++ b/packages/markspec/core/compiler/mod.ts
@@ -138,7 +138,7 @@ function extractLinks(entries: readonly Entry[]): Link[] {
   const links: Link[] = [];
 
   for (const entry of entries) {
-    for (const attr of entry.attributes) {
+    for (const attr of entry.rawAttributes) {
       const extracted = extractLinksFromAttribute(
         entry.displayId,
         attr.key,

--- a/packages/markspec/core/compiler/mod_test.ts
+++ b/packages/markspec/core/compiler/mod_test.ts
@@ -276,7 +276,7 @@ document-type: requirements
 `,
   };
   const result = await compile(["req.md"], { readFile: reader(files) });
-  const doc = result.documents?.get("req.md");
+  const doc = result.documents.get("req.md");
   assertExists(doc);
   assertEquals(
     doc.attributes["document-id"],
@@ -295,5 +295,5 @@ Deno.test("compile: no front matter → document absent", async () => {
 `,
   };
   const result = await compile(["req.md"], { readFile: reader(files) });
-  assertEquals(result.documents?.has("req.md"), false);
+  assertEquals(result.documents.has("req.md"), false);
 });

--- a/packages/markspec/core/compiler/schema_test.ts
+++ b/packages/markspec/core/compiler/schema_test.ts
@@ -14,6 +14,7 @@ function makeEntry(displayId: string): Entry {
     shape: "identified",
     location: { file: "test.md", line: 1, column: 1 },
     source: "markdown",
+    typedAttributes: new Map(),
   };
 }
 

--- a/packages/markspec/core/compiler/schema_test.ts
+++ b/packages/markspec/core/compiler/schema_test.ts
@@ -9,7 +9,7 @@ function makeEntry(displayId: string): Entry {
     displayId,
     title: `Title for ${displayId}`,
     body: "",
-    attributes: [],
+    rawAttributes: [],
     id: undefined,
     shape: "identified",
     location: { file: "test.md", line: 1, column: 1 },

--- a/packages/markspec/core/compiler/schema_test.ts
+++ b/packages/markspec/core/compiler/schema_test.ts
@@ -40,6 +40,7 @@ Deno.test("serializeCompileResult: converts Maps to plain objects", () => {
     links: [link],
     forward,
     reverse,
+    documents: new Map(),
     diagnostics: [],
   };
 
@@ -67,6 +68,7 @@ Deno.test("serializeCompileResult: entries keyed by displayId", () => {
     links: [],
     forward: new Map(),
     reverse: new Map(),
+    documents: new Map(),
     diagnostics: [],
   };
 
@@ -94,6 +96,7 @@ Deno.test("serializeCompileResult: links preserved as-is", () => {
     links: [link],
     forward: new Map(),
     reverse: new Map(),
+    documents: new Map(),
     diagnostics: [],
   };
 
@@ -112,6 +115,7 @@ Deno.test("serializeCompileResult: round-trip via JSON.parse", () => {
     links: [link],
     forward: new Map([["SRS_BRK_0001", [link]]]),
     reverse: new Map([["SYS_BRK_0042", [link]]]),
+    documents: new Map(),
     diagnostics: [
       {
         code: "MSL-W001",

--- a/packages/markspec/core/formatter/mod.ts
+++ b/packages/markspec/core/formatter/mod.ts
@@ -123,7 +123,7 @@ export function format(
 
   for (const entry of sorted) {
     const indent = (entry.location.column - 1) + 2;
-    let attrs = [...entry.attributes];
+    let attrs = [...entry.rawAttributes];
 
     // Assign a bare ULID `Id:` to identified entries that carry no
     // identity yet. Referenced entries are left alone — their `Id:` is a

--- a/packages/markspec/core/mod_test.ts
+++ b/packages/markspec/core/mod_test.ts
@@ -55,7 +55,7 @@ Deno.test("model types are constructible", () => {
     displayId: "SRS_BRK_0001",
     title: "Sensor debouncing",
     body: "The sensor driver shall debounce raw inputs.",
-    attributes: [attr],
+    rawAttributes: [attr],
     id: "SRS_00000000000000000000000001",
     shape: "identified",
     location: loc,

--- a/packages/markspec/core/mod_test.ts
+++ b/packages/markspec/core/mod_test.ts
@@ -60,6 +60,7 @@ Deno.test("model types are constructible", () => {
     shape: "identified",
     location: loc,
     source: "markdown",
+    typedAttributes: new Map(),
   };
   assertEquals(entry.displayId, "SRS_BRK_0001");
   assertEquals(entry.shape, "identified");

--- a/packages/markspec/core/mod_test.ts
+++ b/packages/markspec/core/mod_test.ts
@@ -163,6 +163,7 @@ Deno.test("report produces traceability output", () => {
     links: [],
     forward: new Map(),
     reverse: new Map(),
+    documents: new Map(),
     diagnostics: [],
   };
   const opts: ReportOptions = { kind: "traceability", format: "md" };

--- a/packages/markspec/core/model/mod.ts
+++ b/packages/markspec/core/model/mod.ts
@@ -250,7 +250,7 @@ export interface Entry {
    * (validator, compiler) consult this map for typed processing; the
    * formatter still reads `attributes` for exact round-trip.
    */
-  readonly typedAttributes?: TypedAttributes;
+  readonly typedAttributes: TypedAttributes;
   /**
    * Value of the `Id:` attribute — a ULID for identified entries, a URI for
    * referenced entries. Absent when `Id:` was missing or malformed.

--- a/packages/markspec/core/model/mod.ts
+++ b/packages/markspec/core/model/mod.ts
@@ -74,10 +74,10 @@ export interface Attribute {
  * one entry per occurrence (no CSV-splitting, locators may contain `,`).
  * Single-valued types carry a one-element array; if the author wrote the
  * attribute twice, the later value wins but both appear in
- * {@linkcode Entry.attributes} for round-trip fidelity.
+ * {@linkcode Entry.rawAttributes} for round-trip fidelity.
  *
  * This is the representation the validator, formatter, and compiler consult
- * for typed processing; {@linkcode Entry.attributes} is the source of truth
+ * for typed processing; {@linkcode Entry.rawAttributes} is the source of truth
  * for exact round-trip through `markspec format`.
  */
 export type TypedAttributes = ReadonlyMap<string, readonly string[]>;
@@ -241,14 +241,19 @@ export interface Entry {
   readonly title: string;
   /** Body content (paragraphs, alerts, code blocks) between title and attributes. */
   readonly body: string;
-  /** Parsed attribute block (`Key: Value` lines), in source order. */
-  readonly attributes: readonly Attribute[];
   /**
-   * Collated, typed view of {@linkcode Entry.attributes}.
+   * Source-order raw attribute array. Used by the formatter for round-trip
+   * fidelity (preserving key casing, line order, and trailing backslashes).
+   * For lookup-oriented access, use `typedAttributes` — the collated,
+   * CSV-split Map view of the same data.
+   */
+  readonly rawAttributes: readonly Attribute[];
+  /**
+   * Collated, typed view of {@linkcode Entry.rawAttributes}.
    *
-   * Populated by the parser alongside `attributes`. Downstream layers
+   * Populated by the parser alongside `rawAttributes`. Downstream layers
    * (validator, compiler) consult this map for typed processing; the
-   * formatter still reads `attributes` for exact round-trip.
+   * formatter still reads `rawAttributes` for exact round-trip.
    */
   readonly typedAttributes: TypedAttributes;
   /**

--- a/packages/markspec/core/parser/markdown.ts
+++ b/packages/markspec/core/parser/markdown.ts
@@ -249,7 +249,7 @@ function extractEntry(
     displayId,
     title: title ?? "",
     body,
-    attributes,
+    rawAttributes: attributes,
     typedAttributes: collateAttributes(attributes),
     id,
     type,

--- a/packages/markspec/core/parser/markdown_test.ts
+++ b/packages/markspec/core/parser/markdown_test.ts
@@ -184,7 +184,7 @@ Deno.test("parseMarkdown: trailing attribute block is parsed", () => {
 `;
   const [entry] = parseMarkdown(md);
   const attrs = Object.fromEntries(
-    entry.attributes.map((a) => [a.key, a.value]),
+    entry.rawAttributes.map((a) => [a.key, a.value]),
   );
   assertEquals(attrs["Id"], ULID);
   assertEquals(attrs["Labels"], "one, two");

--- a/packages/markspec/core/parser/source_test.ts
+++ b/packages/markspec/core/parser/source_test.ts
@@ -89,13 +89,13 @@ fn foo() {}
 `;
 
   const { entries } = parseSource(source, { file: "test.rs", language });
-  assertEquals(entries[0].attributes.length, 3);
-  assertEquals(entries[0].attributes[0].key, "Id");
-  assertEquals(entries[0].attributes[0].value, "SRS_01HGW2Q8MNP3");
-  assertEquals(entries[0].attributes[1].key, "Satisfies");
-  assertEquals(entries[0].attributes[1].value, "SYS_BRK_0042");
-  assertEquals(entries[0].attributes[2].key, "Labels");
-  assertEquals(entries[0].attributes[2].value, "ASIL-B");
+  assertEquals(entries[0].rawAttributes.length, 3);
+  assertEquals(entries[0].rawAttributes[0].key, "Id");
+  assertEquals(entries[0].rawAttributes[0].value, "SRS_01HGW2Q8MNP3");
+  assertEquals(entries[0].rawAttributes[1].key, "Satisfies");
+  assertEquals(entries[0].rawAttributes[1].value, "SYS_BRK_0042");
+  assertEquals(entries[0].rawAttributes[2].key, "Labels");
+  assertEquals(entries[0].rawAttributes[2].value, "ASIL-B");
 });
 
 // ---------------------------------------------------------------------------
@@ -259,7 +259,7 @@ Deno.test("parseSource: fixture — in-code-rust.rs", async () => {
   assertEquals(entries[0].id, "SRS_01HGW2Q8MNP3");
   assertEquals(entries[0].source, "doc-comment");
   assertStringIncludes(entries[0].body, "debounce window");
-  assertEquals(entries[0].attributes.length, 3);
+  assertEquals(entries[0].rawAttributes.length, 3);
 });
 
 // ---------------------------------------------------------------------------
@@ -352,7 +352,7 @@ fn foo() {}
   const { entries } = parseSource(source, { file: "test.rs", language });
   assertEquals(entries.length, 1);
   // Verifies inside the entry block becomes an attribute.
-  const verifies = entries[0].attributes.find((a) => a.key === "Verifies");
+  const verifies = entries[0].rawAttributes.find((a) => a.key === "Verifies");
   assertEquals(verifies?.value, "STK_BRK_0001");
 });
 

--- a/packages/markspec/core/reporter/mod.ts
+++ b/packages/markspec/core/reporter/mod.ts
@@ -64,7 +64,7 @@ function filterEntries(
 
   if (label) {
     entries = entries.filter((e) => {
-      const labelsAttr = e.attributes.find((a) => a.key === "Labels");
+      const labelsAttr = e.rawAttributes.find((a) => a.key === "Labels");
       if (!labelsAttr) return false;
       const labels = labelsAttr.value.split(",").map((s) => s.trim());
       return labels.includes(label);

--- a/packages/markspec/core/validator/attributes.ts
+++ b/packages/markspec/core/validator/attributes.ts
@@ -139,7 +139,7 @@ export function validateAttributesForEntry(
 ): Diagnostic[] {
   const diagnostics: Diagnostic[] = [];
   const scope = effectiveScope(entry, profile);
-  const present = entry.typedAttributes ?? new Map<string, readonly string[]>();
+  const present = entry.typedAttributes;
 
   // MSL-A001: required attribute missing.
   for (const name of scope.required) {

--- a/packages/markspec/core/validator/attributes_test.ts
+++ b/packages/markspec/core/validator/attributes_test.ts
@@ -95,7 +95,7 @@ function entry(opts: {
     shape: opts.shape,
     type: opts.type,
     source: "markdown",
-    attributes,
+    rawAttributes: attributes,
     typedAttributes: new Map(
       Object.entries(attrs).map(([k, vs]) => [k, vs]),
     ),

--- a/packages/markspec/core/validator/mod.ts
+++ b/packages/markspec/core/validator/mod.ts
@@ -59,7 +59,7 @@ function checkStructural(
 
   for (const entry of entries) {
     // MSL-R003: exactly one `Id:` attribute per entry.
-    const idAttrs = entry.attributes.filter((a) => a.key === IDENTITY_KEY);
+    const idAttrs = entry.rawAttributes.filter((a) => a.key === IDENTITY_KEY);
     if (idAttrs.length === 0) {
       diagnostics.push({
         code: "MSL-R003",
@@ -145,7 +145,7 @@ function checkStructural(
     // profile-aware validator widens this check to include profile-declared
     // attributes; until then, anything outside the universal set is
     // unrecognized.
-    for (const attr of entry.attributes) {
+    for (const attr of entry.rawAttributes) {
       if (!UNIVERSAL_KEYS.has(attr.key) && attr.key !== "Type") {
         diagnostics.push({
           code: "MSL-R010",
@@ -184,7 +184,7 @@ function checkReferences(
   // MSL-T012: `Supersedes:` — the one baked-in relation. Target must
   // resolve; profile rules check type/shape compatibility separately.
   for (const entry of entries) {
-    const supersedes = entry.attributes.find((a) => a.key === "Supersedes");
+    const supersedes = entry.rawAttributes.find((a) => a.key === "Supersedes");
     if (!supersedes) continue;
     const target = supersedes.value.trim();
     const resolved = byDisplayId.get(target) ?? byId.get(target);
@@ -201,7 +201,7 @@ function checkReferences(
   // MSL-T005: `References:` — citations must resolve to a referenced
   // entry. This is a universal relation (citing identified → referenced).
   for (const entry of entries) {
-    const citations = entry.attributes.filter((a) => a.key === "References");
+    const citations = entry.rawAttributes.filter((a) => a.key === "References");
     for (const attr of citations) {
       // Citation format: "slug [free-text locator]"; take the first token.
       const slug = attr.value.split(/\s/)[0];

--- a/packages/markspec/core/validator/mod_test.ts
+++ b/packages/markspec/core/validator/mod_test.ts
@@ -15,7 +15,7 @@ function entry(partial: Partial<Entry> & { displayId: string }): Entry {
     displayId: partial.displayId,
     title: partial.title ?? "Test entry",
     body: partial.body ?? "Body.",
-    attributes: partial.attributes ?? [],
+    rawAttributes: partial.rawAttributes ?? [],
     id: partial.id,
     shape: partial.shape ?? "identified",
     location: partial.location ??
@@ -36,7 +36,7 @@ Deno.test("validate: entry with ULID Id passes", () => {
   const result = validate([
     entry({
       displayId: "REQ-001",
-      attributes: [{ key: "Id", value: ULID_A }],
+      rawAttributes: [{ key: "Id", value: ULID_A }],
       id: ULID_A,
       shape: "identified",
     }),
@@ -57,7 +57,7 @@ Deno.test("validate: malformed Id → MSL-R004", () => {
   const result = validate([
     entry({
       displayId: "REQ-001",
-      attributes: [{ key: "Id", value: "not-a-ulid-or-uri" }],
+      rawAttributes: [{ key: "Id", value: "not-a-ulid-or-uri" }],
       id: "not-a-ulid-or-uri",
     }),
   ]);
@@ -69,7 +69,7 @@ Deno.test("validate: URI Id on referenced entry passes", () => {
   const result = validate([
     entry({
       displayId: "ISO-26262-6",
-      attributes: [{ key: "Id", value: "urn:iso:std:iso:26262:-6:ed-2" }],
+      rawAttributes: [{ key: "Id", value: "urn:iso:std:iso:26262:-6:ed-2" }],
       id: "urn:iso:std:iso:26262:-6:ed-2",
       shape: "referenced",
     }),
@@ -84,7 +84,7 @@ Deno.test("validate: ULID Id with shape=referenced → MSL-R004 mismatch", () =>
   const result = validate([
     entry({
       displayId: "REQ-001",
-      attributes: [{ key: "Id", value: ULID_A }],
+      rawAttributes: [{ key: "Id", value: ULID_A }],
       id: ULID_A,
       shape: "referenced",
     }),
@@ -97,7 +97,7 @@ Deno.test("validate: multiple Id attributes → MSL-R003", () => {
   const result = validate([
     entry({
       displayId: "REQ-001",
-      attributes: [
+      rawAttributes: [
         { key: "Id", value: ULID_A },
         { key: "Id", value: ULID_B },
       ],
@@ -116,12 +116,12 @@ Deno.test("validate: duplicate display ID → MSL-R006", () => {
   const result = validate([
     entry({
       displayId: "REQ-001",
-      attributes: [{ key: "Id", value: ULID_A }],
+      rawAttributes: [{ key: "Id", value: ULID_A }],
       id: ULID_A,
     }),
     entry({
       displayId: "REQ-001",
-      attributes: [{ key: "Id", value: ULID_B }],
+      rawAttributes: [{ key: "Id", value: ULID_B }],
       id: ULID_B,
       location: { file: "other.md", line: 5, column: 1 },
     }),
@@ -134,12 +134,12 @@ Deno.test("validate: duplicate Id value → MSL-R005", () => {
   const result = validate([
     entry({
       displayId: "REQ-001",
-      attributes: [{ key: "Id", value: ULID_A }],
+      rawAttributes: [{ key: "Id", value: ULID_A }],
       id: ULID_A,
     }),
     entry({
       displayId: "REQ-002",
-      attributes: [{ key: "Id", value: ULID_A }],
+      rawAttributes: [{ key: "Id", value: ULID_A }],
       id: ULID_A,
       location: { file: "other.md", line: 5, column: 1 },
     }),
@@ -156,7 +156,7 @@ Deno.test("validate: universal attribute not flagged", () => {
   const result = validate([
     entry({
       displayId: "REQ-001",
-      attributes: [
+      rawAttributes: [
         { key: "Id", value: ULID_A },
         { key: "Labels", value: "important" },
       ],
@@ -171,7 +171,7 @@ Deno.test("validate: unknown attribute → MSL-R010 warning", () => {
   const result = validate([
     entry({
       displayId: "REQ-001",
-      attributes: [
+      rawAttributes: [
         { key: "Id", value: ULID_A },
         { key: "Custom-attr", value: "value" },
       ],
@@ -191,12 +191,12 @@ Deno.test("validate: Supersedes target exists → passes", () => {
   const result = validate([
     entry({
       displayId: "REQ-001",
-      attributes: [{ key: "Id", value: ULID_A }],
+      rawAttributes: [{ key: "Id", value: ULID_A }],
       id: ULID_A,
     }),
     entry({
       displayId: "REQ-002",
-      attributes: [
+      rawAttributes: [
         { key: "Id", value: ULID_B },
         { key: "Supersedes", value: "REQ-001" },
       ],
@@ -212,7 +212,7 @@ Deno.test("validate: Supersedes unresolved → MSL-T012", () => {
   const result = validate([
     entry({
       displayId: "REQ-001",
-      attributes: [
+      rawAttributes: [
         { key: "Id", value: ULID_A },
         { key: "Supersedes", value: "REQ-GONE" },
       ],
@@ -231,7 +231,7 @@ Deno.test("validate: References target is referenced entry → passes", () => {
   const result = validate([
     entry({
       displayId: "ISO-26262-6",
-      attributes: [{
+      rawAttributes: [{
         key: "Id",
         value: "urn:iso:std:iso:26262:-6:ed-2",
       }],
@@ -240,7 +240,7 @@ Deno.test("validate: References target is referenced entry → passes", () => {
     }),
     entry({
       displayId: "REQ-001",
-      attributes: [
+      rawAttributes: [
         { key: "Id", value: ULID_A },
         { key: "References", value: "ISO-26262-6 §9.4" },
       ],
@@ -256,7 +256,7 @@ Deno.test("validate: References unresolved → MSL-T005", () => {
   const result = validate([
     entry({
       displayId: "REQ-001",
-      attributes: [
+      rawAttributes: [
         { key: "Id", value: ULID_A },
         { key: "References", value: "UNKNOWN-STANDARD" },
       ],
@@ -271,12 +271,12 @@ Deno.test("validate: References target is identified (wrong shape) → MSL-T005"
   const result = validate([
     entry({
       displayId: "REQ-001",
-      attributes: [{ key: "Id", value: ULID_A }],
+      rawAttributes: [{ key: "Id", value: ULID_A }],
       id: ULID_A,
     }),
     entry({
       displayId: "REQ-002",
-      attributes: [
+      rawAttributes: [
         { key: "Id", value: ULID_B },
         { key: "References", value: "REQ-001" },
       ],
@@ -296,7 +296,7 @@ Deno.test("validate: complete valid set → no error diagnostics", () => {
   const result = validate([
     entry({
       displayId: "ISO-26262-6",
-      attributes: [{
+      rawAttributes: [{
         key: "Id",
         value: "urn:iso:std:iso:26262:-6:ed-2",
       }],
@@ -305,7 +305,7 @@ Deno.test("validate: complete valid set → no error diagnostics", () => {
     }),
     entry({
       displayId: "REQ-001",
-      attributes: [
+      rawAttributes: [
         { key: "Id", value: ULID_A },
         { key: "Labels", value: "ASIL-B" },
         { key: "References", value: "ISO-26262-6 §9.4" },
@@ -315,7 +315,7 @@ Deno.test("validate: complete valid set → no error diagnostics", () => {
     }),
     entry({
       displayId: "REQ-002",
-      attributes: [
+      rawAttributes: [
         { key: "Id", value: ULID_B },
         { key: "Supersedes", value: "REQ-001" },
       ],

--- a/packages/markspec/core/validator/mod_test.ts
+++ b/packages/markspec/core/validator/mod_test.ts
@@ -21,6 +21,7 @@ function entry(partial: Partial<Entry> & { displayId: string }): Entry {
     location: partial.location ??
       { file: "test.md", line: 1, column: 1 },
     source: partial.source ?? "markdown",
+    typedAttributes: partial.typedAttributes ?? new Map(),
   };
 }
 

--- a/packages/markspec/core/validator/normalize.ts
+++ b/packages/markspec/core/validator/normalize.ts
@@ -26,8 +26,6 @@ export function normalizeListValues(
   entry: Entry,
   profile: EffectiveProfile,
 ): Entry {
-  if (!entry.typedAttributes) return entry;
-
   const scope = effectiveScope(entry, profile);
   const rewritten = new Map<string, readonly string[]>();
   let anyChange = false;

--- a/packages/markspec/core/validator/normalize_test.ts
+++ b/packages/markspec/core/validator/normalize_test.ts
@@ -62,7 +62,7 @@ function entry(opts: {
     source: "markdown",
     title: "",
     body: "",
-    attributes,
+    rawAttributes: attributes,
     typedAttributes: new Map(
       Object.entries(attrs).map(([k, vs]) => [k, vs]),
     ),

--- a/packages/markspec/core/validator/normalize_test.ts
+++ b/packages/markspec/core/validator/normalize_test.ts
@@ -100,7 +100,7 @@ Deno.test("normalizeListValues: id-list with comma-separated value is split", ()
     },
   });
   const out = normalizeListValues(e, p);
-  assertEquals(out.typedAttributes?.get("Verifies"), [
+  assertEquals(out.typedAttributes.get("Verifies"), [
     "REQ-0001",
     "REQ-0002",
     "REQ-0003",
@@ -114,7 +114,7 @@ Deno.test("normalizeListValues: tag-list with comma-separated value is split", (
     attrs: { Labels: ["DRAFT, INTERNAL"] },
   });
   const out = normalizeListValues(e, p);
-  assertEquals(out.typedAttributes?.get("Labels"), ["DRAFT", "INTERNAL"]);
+  assertEquals(out.typedAttributes.get("Labels"), ["DRAFT", "INTERNAL"]);
 });
 
 Deno.test("normalizeListValues: no comma → idempotent (value unchanged)", () => {
@@ -124,7 +124,7 @@ Deno.test("normalizeListValues: no comma → idempotent (value unchanged)", () =
     attrs: { Verifies: ["REQ-0001", "REQ-0002"] },
   });
   const out = normalizeListValues(e, p);
-  assertEquals(out.typedAttributes?.get("Verifies"), ["REQ-0001", "REQ-0002"]);
+  assertEquals(out.typedAttributes.get("Verifies"), ["REQ-0001", "REQ-0002"]);
   assertEquals(out, e);
 });
 
@@ -135,7 +135,7 @@ Deno.test("normalizeListValues: trims whitespace around split values", () => {
     attrs: { Verifies: ["  REQ-0001  ,  REQ-0002  "] },
   });
   const out = normalizeListValues(e, p);
-  assertEquals(out.typedAttributes?.get("Verifies"), [
+  assertEquals(out.typedAttributes.get("Verifies"), [
     "REQ-0001",
     "REQ-0002",
   ]);
@@ -148,7 +148,7 @@ Deno.test("normalizeListValues: empty-string fragments from double commas are dr
     attrs: { Verifies: ["REQ-0001,,REQ-0002"] },
   });
   const out = normalizeListValues(e, p);
-  assertEquals(out.typedAttributes?.get("Verifies"), [
+  assertEquals(out.typedAttributes.get("Verifies"), [
     "REQ-0001",
     "REQ-0002",
   ]);
@@ -161,7 +161,7 @@ Deno.test("normalizeListValues: non-list types are never split", () => {
     attrs: { Rationale: ["one, two, three"] },
   });
   const out = normalizeListValues(e, p);
-  assertEquals(out.typedAttributes?.get("Rationale"), ["one, two, three"]);
+  assertEquals(out.typedAttributes.get("Rationale"), ["one, two, three"]);
 });
 
 Deno.test("normalizeListValues: mix of multi-line and comma-separated merges correctly", () => {
@@ -171,7 +171,7 @@ Deno.test("normalizeListValues: mix of multi-line and comma-separated merges cor
     attrs: { Verifies: ["REQ-0001, REQ-0002", "REQ-0003"] },
   });
   const out = normalizeListValues(e, p);
-  assertEquals(out.typedAttributes?.get("Verifies"), [
+  assertEquals(out.typedAttributes.get("Verifies"), [
     "REQ-0001",
     "REQ-0002",
     "REQ-0003",
@@ -185,7 +185,7 @@ Deno.test("normalizeListValues: un-declared attribute is untouched", () => {
     attrs: { Unknown: ["a, b, c"] },
   });
   const out = normalizeListValues(e, p);
-  assertEquals(out.typedAttributes?.get("Unknown"), ["a, b, c"]);
+  assertEquals(out.typedAttributes.get("Unknown"), ["a, b, c"]);
 });
 
 Deno.test("normalizeListValues: entry with no typedAttributes is returned as-is", () => {
@@ -233,5 +233,5 @@ Deno.test("normalizeListValues: type-scope declarations are considered", () => {
   });
   const classified = { ...e, type: "requirement" };
   const out = normalizeListValues(classified, p);
-  assertEquals(out.typedAttributes?.get("Verifies"), ["REQ-0001", "REQ-0002"]);
+  assertEquals(out.typedAttributes.get("Verifies"), ["REQ-0001", "REQ-0002"]);
 });

--- a/packages/markspec/core/validator/pipeline_test.ts
+++ b/packages/markspec/core/validator/pipeline_test.ts
@@ -36,6 +36,7 @@ function buildEntry(opts: {
     source: "markdown",
     attributes,
     location: { file: "t.md", line: 1, column: 1 },
+    typedAttributes: new Map(),
   };
 }
 
@@ -101,6 +102,7 @@ Deno.test("runPipeline: Stage 1 error contributes to diagnostics + valid=false",
     source: "markdown",
     attributes: [],
     location: { file: "t.md", line: 1, column: 1 },
+    typedAttributes: new Map(),
   };
   const result = runPipeline([entry], null);
   const msl_r003 = result.diagnostics.find((d) => d.code === "MSL-R003");
@@ -123,6 +125,7 @@ Deno.test("runPipeline: both stages contribute diagnostics independently", () =>
     source: "markdown",
     attributes: [],
     location: { file: "t.md", line: 1, column: 1 },
+    typedAttributes: new Map(),
   };
   const result = runPipeline([entry], profile);
   const codes = new Set(result.diagnostics.map((d) => d.code));

--- a/packages/markspec/core/validator/pipeline_test.ts
+++ b/packages/markspec/core/validator/pipeline_test.ts
@@ -34,7 +34,7 @@ function buildEntry(opts: {
     id: opts.id ?? "01HGW2Q8MNP3RSTVWXYZABCDEF",
     shape: opts.shape,
     source: "markdown",
-    attributes,
+    rawAttributes: attributes,
     location: { file: "t.md", line: 1, column: 1 },
     typedAttributes: new Map(),
   };
@@ -100,7 +100,7 @@ Deno.test("runPipeline: Stage 1 error contributes to diagnostics + valid=false",
     id: "01HGW2Q8MNP3RSTVWXYZABCDEF",
     shape: "identified",
     source: "markdown",
-    attributes: [],
+    rawAttributes: [],
     location: { file: "t.md", line: 1, column: 1 },
     typedAttributes: new Map(),
   };
@@ -123,7 +123,7 @@ Deno.test("runPipeline: both stages contribute diagnostics independently", () =>
     id: "01HGW2Q8MNP3RSTVWXYZABCDEF",
     shape: "identified",
     source: "markdown",
-    attributes: [],
+    rawAttributes: [],
     location: { file: "t.md", line: 1, column: 1 },
     typedAttributes: new Map(),
   };
@@ -182,7 +182,7 @@ Deno.test("runPipeline: Stage 3 checks attributes of classified entries", () => 
     source: "markdown",
     title: "",
     body: "",
-    attributes: [
+    rawAttributes: [
       { key: "Id", value: "01HGW2Q8MNP3RSTVWXYZABCDEF" },
     ],
     typedAttributes: new Map([
@@ -234,7 +234,7 @@ Deno.test("runPipeline: MSL-R010 suppressed for profile-declared attributes", ()
     source: "markdown",
     title: "",
     body: "",
-    attributes: [
+    rawAttributes: [
       { key: "Id", value: "01HGW2Q8MNP3RSTVWXYZABCDEF" },
       { key: "Rationale", value: "because" },
     ],
@@ -328,7 +328,7 @@ Deno.test("runPipeline: Stage 4 catches required link missing", () => {
     source: "markdown",
     title: "",
     body: "",
-    attributes: [
+    rawAttributes: [
       { key: "Id", value: "01HGW2Q8MNP3RSTVWXYZABCDEF" },
     ],
     typedAttributes: new Map([
@@ -382,7 +382,7 @@ Deno.test("runPipeline: Stage 2.5 normalization splits comma-separated id-list v
     source: "markdown",
     title: "",
     body: "",
-    attributes: [],
+    rawAttributes: [],
     typedAttributes: new Map([["Id", ["01T1T1T1T1T1T1T1T1T1T1T1T1"]]]),
     location: { file: "t.md", line: 1, column: 1 },
   };
@@ -393,7 +393,7 @@ Deno.test("runPipeline: Stage 2.5 normalization splits comma-separated id-list v
     source: "markdown",
     title: "",
     body: "",
-    attributes: [],
+    rawAttributes: [],
     typedAttributes: new Map([["Id", ["01T2T2T2T2T2T2T2T2T2T2T2T2"]]]),
     location: { file: "t.md", line: 1, column: 1 },
   };
@@ -404,7 +404,7 @@ Deno.test("runPipeline: Stage 2.5 normalization splits comma-separated id-list v
     source: "markdown",
     title: "",
     body: "",
-    attributes: [
+    rawAttributes: [
       { key: "Id", value: "01HGW2Q8MNP3RSTVWXYZABCDEF" },
       {
         key: "Verifies",

--- a/packages/markspec/core/validator/traceability.ts
+++ b/packages/markspec/core/validator/traceability.ts
@@ -98,7 +98,7 @@ export function validateTraceabilityForEntry(
   if (entry.shape !== "identified") return diagnostics;
 
   const rules = effectiveTraceRules(entry, profile);
-  const present = entry.typedAttributes ?? new Map<string, readonly string[]>();
+  const present = entry.typedAttributes;
 
   for (const [linkName, rule] of rules) {
     const values = present.get(linkName);

--- a/packages/markspec/core/validator/traceability_test.ts
+++ b/packages/markspec/core/validator/traceability_test.ts
@@ -88,7 +88,7 @@ function entry(opts: { shape: EntryShape; type?: string }): Entry {
     source: "markdown",
     title: "",
     body: "",
-    attributes: [],
+    rawAttributes: [],
     typedAttributes: new Map(),
     location: { file: "t.md", line: 1, column: 1 },
   };
@@ -211,7 +211,7 @@ function targetEntry(opts: {
     source: "markdown",
     title: "",
     body: "",
-    attributes: [],
+    rawAttributes: [],
     typedAttributes: new Map(),
     location: { file: "t.md", line: 1, column: 1 },
   };
@@ -301,7 +301,7 @@ function entryWithAttrs(opts: {
     source: "markdown",
     title: "",
     body: "",
-    attributes,
+    rawAttributes: attributes,
     typedAttributes: new Map(
       Object.entries(attrs).map(([k, vs]) => [k, vs]),
     ),

--- a/packages/markspec/core/validator/types.ts
+++ b/packages/markspec/core/validator/types.ts
@@ -105,7 +105,7 @@ export function classifyEntry(
 }
 
 function findExplicitTypeAttribute(entry: Entry): string | undefined {
-  for (const attr of entry.attributes) {
+  for (const attr of entry.rawAttributes) {
     if (attr.key === "Type") {
       return attr.value.trim();
     }

--- a/packages/markspec/core/validator/types_test.ts
+++ b/packages/markspec/core/validator/types_test.ts
@@ -31,7 +31,7 @@ function buildEntry(opts: {
     shape: opts.shape,
     type: opts.type,
     source: "markdown",
-    attributes,
+    rawAttributes: attributes,
     location: { file: "t.md", line: 1, column: 1 },
     typedAttributes: new Map(),
   };

--- a/packages/markspec/core/validator/types_test.ts
+++ b/packages/markspec/core/validator/types_test.ts
@@ -33,6 +33,7 @@ function buildEntry(opts: {
     source: "markdown",
     attributes,
     location: { file: "t.md", line: 1, column: 1 },
+    typedAttributes: new Map(),
   };
 }
 

--- a/packages/markspec/lsp/workspace_test.ts
+++ b/packages/markspec/lsp/workspace_test.ts
@@ -24,6 +24,7 @@ function entry(
     shape: "identified",
     location,
     source: "markdown",
+    typedAttributes: new Map(),
   };
 }
 

--- a/packages/markspec/lsp/workspace_test.ts
+++ b/packages/markspec/lsp/workspace_test.ts
@@ -19,7 +19,7 @@ function entry(
     displayId,
     title: opts.title ?? displayId,
     body: "",
-    attributes: opts.id ? [{ key: "Id", value: opts.id }] : [],
+    rawAttributes: opts.id ? [{ key: "Id", value: opts.id }] : [],
     id: opts.id,
     shape: "identified",
     location,

--- a/packages/markspec/main.ts
+++ b/packages/markspec/main.ts
@@ -738,7 +738,7 @@ const cli = new Command()
           console.log(`  Type: ${entry.type}`);
         }
         console.log(`  Shape: ${entry.shape}`);
-        for (const attr of entry.attributes) {
+        for (const attr of entry.rawAttributes) {
           console.log(`  ${attr.key}: ${attr.value}`);
         }
         console.log(

--- a/packages/markspec/render/includes/mod.ts
+++ b/packages/markspec/render/includes/mod.ts
@@ -391,7 +391,7 @@ function renderAttributes(entry: Entry): string[] {
     lines.push(`Id: ${entry.id}`);
   }
 
-  for (const attr of entry.attributes) {
+  for (const attr of entry.rawAttributes) {
     // Skip Id — already handled above.
     if (attr.key === "Id") continue;
     lines.push(`${attr.key}: ${attr.value}`);

--- a/packages/markspec/render/includes/mod_test.ts
+++ b/packages/markspec/render/includes/mod_test.ts
@@ -22,6 +22,7 @@ function testEntry(overrides: Partial<Entry> = {}): Entry {
     shape: "identified",
     location: { file: "test.md", line: 1, column: 1 },
     source: "markdown",
+    typedAttributes: new Map(),
     ...overrides,
   };
 }

--- a/packages/markspec/render/includes/mod_test.ts
+++ b/packages/markspec/render/includes/mod_test.ts
@@ -13,7 +13,7 @@ function testEntry(overrides: Partial<Entry> = {}): Entry {
     displayId: "SRS_BRK_0001",
     title: "Sensor debouncing",
     body: "The sensor driver shall debounce raw inputs.",
-    attributes: [
+    rawAttributes: [
       { key: "Id", value: "SRS_00000000000000000000000001" },
       { key: "Satisfies", value: "SYS_BRK_0001" },
       { key: "Labels", value: "ASIL-B" },
@@ -148,7 +148,7 @@ Deno.test("processIncludes: multiple includes all resolve", async () => {
     displayId: "SRS_BRK_0002",
     title: "Brake pressure",
     body: "Brake pressure shall be monitored.",
-    attributes: [{ key: "Id", value: "SRS_00000000000000000000000002" }],
+    rawAttributes: [{ key: "Id", value: "SRS_00000000000000000000000002" }],
     id: "SRS_00000000000000000000000002",
   });
 
@@ -282,7 +282,7 @@ Deno.test("processIncludes: missing anchor produces diagnostic", async () => {
 // ---------------------------------------------------------------------------
 
 Deno.test("processIncludes: entry with empty body renders correctly", async () => {
-  const entry = testEntry({ body: "", attributes: [], id: undefined });
+  const entry = testEntry({ body: "", rawAttributes: [], id: undefined });
   const input = "<!-- include: SRS_BRK_0001 -->";
 
   const result = await processIncludes(input, options([entry]));

--- a/packages/markspec/render/includes/mod_test.ts
+++ b/packages/markspec/render/includes/mod_test.ts
@@ -35,6 +35,7 @@ function compiled(...entries: Entry[]): CompileResult {
     links: [],
     forward: new Map(),
     reverse: new Map(),
+    documents: new Map(),
     diagnostics: [],
   };
 }

--- a/packages/markspec/render/mod_test.ts
+++ b/packages/markspec/render/mod_test.ts
@@ -9,6 +9,7 @@ function emptyCompileResult(): CompileResult {
     links: [],
     forward: new Map(),
     reverse: new Map(),
+    documents: new Map(),
     diagnostics: [],
   };
 }

--- a/packages/markspec/render/mustache/mod_test.ts
+++ b/packages/markspec/render/mustache/mod_test.ts
@@ -39,6 +39,7 @@ function makeEntry(displayId: string): Entry {
     shape: "identified",
     location: { file: "test.md", line: 1, column: 1 },
     source: "markdown",
+    typedAttributes: new Map(),
   };
 }
 

--- a/packages/markspec/render/mustache/mod_test.ts
+++ b/packages/markspec/render/mustache/mod_test.ts
@@ -51,6 +51,7 @@ function makeCompiled(entries: Entry[]): CompileResult {
     links: [],
     forward: new Map(),
     reverse: new Map(),
+    documents: new Map(),
     diagnostics: [],
   };
 }

--- a/packages/markspec/render/mustache/mod_test.ts
+++ b/packages/markspec/render/mustache/mod_test.ts
@@ -34,7 +34,7 @@ function makeEntry(displayId: string): Entry {
     displayId,
     title: `Title for ${displayId}`,
     body: "",
-    attributes: [],
+    rawAttributes: [],
     id: undefined,
     shape: "identified",
     location: { file: "test.md", line: 1, column: 1 },

--- a/packages/markspec/render/styles/mod_test.ts
+++ b/packages/markspec/render/styles/mod_test.ts
@@ -35,6 +35,7 @@ function buildCompiled(
       shape: e.entryType ? "identified" : "referenced",
       location: { file: "test.md", line: 1, column: 1 },
       source: "markdown",
+      typedAttributes: new Map(),
     };
     map.set(e.displayId, entry);
   }

--- a/packages/markspec/render/styles/mod_test.ts
+++ b/packages/markspec/render/styles/mod_test.ts
@@ -30,7 +30,7 @@ function buildCompiled(
       displayId: e.displayId,
       title: e.title,
       body: e.body ?? "",
-      attributes: e.attributes ?? [],
+      rawAttributes: e.attributes ?? [],
       id: e.id,
       shape: e.entryType ? "identified" : "referenced",
       location: { file: "test.md", line: 1, column: 1 },

--- a/packages/markspec/render/styles/mod_test.ts
+++ b/packages/markspec/render/styles/mod_test.ts
@@ -44,6 +44,7 @@ function buildCompiled(
     links: [],
     forward: new Map(),
     reverse: new Map(),
+    documents: new Map(),
     diagnostics: [],
   };
 }

--- a/packages/markspec/render/typst/template.ts
+++ b/packages/markspec/render/typst/template.ts
@@ -204,7 +204,7 @@ function renderEntryTypst(entry: Entry, scopeArg: string = ""): string {
   const category = displayIdCategory(entry.displayId, entry.shape);
 
   // Extract labels from attributes
-  const labelsAttr = entry.attributes.find((a) => a.key === "Labels");
+  const labelsAttr = entry.rawAttributes.find((a) => a.key === "Labels");
   const labels = labelsAttr
     ? labelsAttr.value.split(",").map((s) => s.trim()).filter((s) =>
       s.length > 0
@@ -212,7 +212,7 @@ function renderEntryTypst(entry: Entry, scopeArg: string = ""): string {
     : [];
 
   // Build attrs array (excluding Labels — those go into pills)
-  const attrs = entry.attributes
+  const attrs = entry.rawAttributes
     .filter((a) => a.key !== "Labels")
     .map((a) =>
       `("${escapeTypstString(a.key)}", "${escapeTypstString(a.value)}")`


### PR DESCRIPTION
## Summary

- Make `Entry.typedAttributes` required (remove transitional `?`, remove `?? new Map()` guards in 4 consumer sites)
- Make `CompileResult.documents` required (remove transitional `?`, remove stale v2 migration comment)
- Rename `Entry.attributes` to `Entry.rawAttributes` with doc comment clarifying its role vs `typedAttributes`

## Context

Follow-up debt from ADR-002 v2 rewrite (issue #215). The parser has always populated these fields — the optionals were transitional artifacts from the migration. The rename clarifies the dual-view relationship: `rawAttributes` is the source-order array for formatter round-trip fidelity, `typedAttributes` is the collated Map for lookup-oriented access.

## Changes

Three mechanical, purely type-level refactoring commits:

1. **Make Entry.typedAttributes required** — removes `?` from type, removes `?? new Map()` fallbacks in validator/compiler, adds field to 17 test Entry literals
2. **Make CompileResult.documents required** — removes `?` from type, removes stale comment, adds field to 7 test CompileResult literals
3. **Rename Entry.attributes to rawAttributes** — renames field across 29 files (model, parsers, validator, compiler, formatter, reporter, render, book, main, all tests), cleans up leftover `?.` on now-required fields

## Verification

- `deno check` — zero type errors
- `deno lint` — 134 files, zero warnings
- `deno test` — 665 passed, 0 failed
- No behavioral changes — all changes are purely at the type/naming level
