### PR TITLE
fix(lsp): bind stdio transport explicitly and accept --stdio flag

### DIFF
--- a/packages/markspec/lsp/server.ts
+++ b/packages/markspec/lsp/server.ts
@@ -20,10 +20,13 @@ import {
   type InitializeResult,
   InsertTextFormat,
   ProposedFeatures,
+  StreamMessageReader,
+  StreamMessageWriter,
   TextDocuments,
   TextDocumentSyncKind,
 } from "vscode-languageserver/node";
 import { TextDocument } from "vscode-languageserver-textdocument";
+import process from "node:process";
 import {
   DEFAULT_PROJECT_CONFIG,
   type Diagnostic as CoreDiagnostic,
@@ -55,7 +58,11 @@ export const VERSION = "0.0.1";
 // Connection and document manager
 // ---------------------------------------------------------------------------
 
-const connection = createConnection(ProposedFeatures.all);
+const connection = createConnection(
+  ProposedFeatures.all,
+  new StreamMessageReader(process.stdin),
+  new StreamMessageWriter(process.stdout),
+);
 const documents = new TextDocuments(TextDocument);
 
 // ---------------------------------------------------------------------------

--- a/packages/markspec/main.ts
+++ b/packages/markspec/main.ts
@@ -972,6 +972,14 @@ const cli = new Command()
   // Server commands
   .command("lsp")
   .description("Start LSP server (stdio JSON-RPC)")
+  // LSP clients (e.g. vscode-languageclient) append a transport flag to args.
+  // We always use stdio, so accept and ignore these.
+  .option("--stdio", "Transport flag (no-op; stdio is always used)")
+  .option("--node-ipc", "Transport flag (no-op; stdio is always used)")
+  .option(
+    "--socket=<port:number>",
+    "Transport flag (no-op; stdio is always used)",
+  )
   .action(async () => {
     await import("./lsp/server.ts");
   })


### PR DESCRIPTION
## Summary

Two surgical fixes that should have landed alongside #245 but were missed (they predated the formal plan and were applied locally during the 2026-05-02 hot-debugging session, never committed). Without these, the bundled binary built from `main` does not work — the LSP server crashes on spawn (bug 1) or is rejected by Cliffy (bug 4).

The PR description for #245 claimed bugs 1-5 were addressed; that was incorrect for bugs 1 and 4. This PR closes the gap.

## Bug 1 — `createConnection(features)` with no transport

Fixed in `packages/markspec/lsp/server.ts` by passing explicit `StreamMessageReader(process.stdin)` and `StreamMessageWriter(process.stdout)`.

Without this, vscode-languageserver's `createConnection(features)` overload parses `process.argv` for `--stdio` / `--node-ipc` / `--socket={number}`. Since the `markspec lsp` subcommand consumes its own argv via Cliffy, the transport flag never reaches `createConnection`, and the server throws `Connection input stream is not set` immediately on startup.

## Bug 4 — Cliffy rejects `--stdio`

Fixed in `packages/markspec/main.ts` lsp subcommand by registering `--stdio`, `--node-ipc`, `--socket=<port:number>` as no-op options.

vscode-languageclient appends `--stdio` to the spawn args when `transport: TransportKind.stdio` is set in `ServerOptions`. Cliffy rejects unknown flags and exits 2, killing the server before it can bind transport.

## What changed

- `packages/markspec/lsp/server.ts` (+8/-1): import `StreamMessageReader` and `StreamMessageWriter`, import `node:process`, pass them to `createConnection`.
- `packages/markspec/main.ts` (+8): three no-op options on the lsp subcommand for the standard LSP transport flags.

17 line addition total. Type-check (`deno check`) passes.

## Test plan

- [x] `deno check packages/markspec/main.ts packages/markspec/lsp/server.ts` — exits 0.
- [x] Manual: build binary (`just compile`), spawn `dist/markspec lsp --stdio`, send LSP initialize over stdio, confirm a valid initialize response. Tested locally.
- [ ] Reviewer-side: pull, run `just compile`, send a framed `initialize` request to `./dist/markspec lsp --stdio` — should produce a JSON-RPC initialize response, not crash.

## Follow-up

Phase 2 of the broader plan (test layers) will add a CI smoke test against the compiled binary so regressions of bugs 1 and 4 fail at PR time. That work is queued in [docs/superpowers/plans/2026-05-03-lsp-install-and-diagnostics.md](https://github.com/driftsys/markspec/blob/main/docs/superpowers/plans/2026-05-03-lsp-install-and-diagnostics.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
