### PR TITLE
feat(lsp): Phase 3 — diagnostic layers (debug log, indexed notification, status bar)

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -30,6 +30,13 @@
   ],
   "main": "./out/extension.js",
   "contributes": {
+    "commands": [
+      {
+        "command": "markspec.showOutput",
+        "title": "MarkSpec: Show Output",
+        "category": "MarkSpec"
+      }
+    ],
     "configuration": {
       "title": "MarkSpec",
       "properties": {

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -5,19 +5,30 @@
  * or a configured deno + source path for dev mode) and connects it to VS Code.
  */
 
-import { type ExtensionContext, window, workspace } from "vscode";
+import {
+  commands,
+  type ExtensionContext,
+  type OutputChannel,
+  window,
+  workspace,
+} from "vscode";
 import process from "node:process";
 import {
   LanguageClient,
   type LanguageClientOptions,
 } from "vscode-languageclient/node";
 import { resolveServerOptions } from "./serverOptions";
+import { createStatusBar } from "./statusBar";
 
 let client: LanguageClient | undefined;
+let outputChannel: OutputChannel | undefined;
 
 export function activate(context: ExtensionContext): void {
   const config = workspace.getConfiguration("markspec");
   const traceLevel = config.get<string>("trace.server", "off");
+
+  outputChannel = window.createOutputChannel("MarkSpec");
+  context.subscriptions.push(outputChannel);
 
   const workspaceFolder = workspace.workspaceFolders?.[0]?.uri.fsPath;
 
@@ -42,6 +53,7 @@ export function activate(context: ExtensionContext): void {
     synchronize: {
       fileEvents: workspace.createFileSystemWatcher("**/*.md"),
     },
+    outputChannel,
     traceOutputChannel: traceLevel !== "off"
       ? window.createOutputChannel("MarkSpec LSP")
       : undefined,
@@ -54,7 +66,15 @@ export function activate(context: ExtensionContext): void {
     clientOptions,
   );
 
+  context.subscriptions.push(
+    commands.registerCommand("markspec.showOutput", () => {
+      outputChannel?.show();
+    }),
+  );
+
   client.start();
+
+  createStatusBar(context, client);
 
   context.subscriptions.push({
     dispose: () => {

--- a/editors/vscode/src/statusBar.ts
+++ b/editors/vscode/src/statusBar.ts
@@ -1,0 +1,85 @@
+/**
+ * @module statusBar
+ *
+ * Status bar item showing the LSP health. Driven by LanguageClient state
+ * transitions plus the server's custom `markspec/indexed` notification.
+ *
+ *   ⟳  starting / restarting / indexing
+ *   ✓  ready (initial indexing complete)
+ *   ✗  failed / stopped unexpectedly
+ *
+ * Click action opens the MarkSpec output channel.
+ */
+
+import {
+  type ExtensionContext,
+  MarkdownString,
+  StatusBarAlignment,
+  type StatusBarItem,
+  ThemeColor,
+  window,
+} from "vscode";
+import { type LanguageClient, State } from "vscode-languageclient/node";
+
+const COMMAND_SHOW_OUTPUT = "markspec.showOutput";
+
+export function createStatusBar(
+  context: ExtensionContext,
+  client: LanguageClient,
+): StatusBarItem {
+  const item = window.createStatusBarItem(StatusBarAlignment.Right, 100);
+  item.command = COMMAND_SHOW_OUTPUT;
+
+  setStarting(item);
+  item.show();
+
+  client.onDidChangeState((event) => {
+    if (event.newState === State.Starting) setStarting(item);
+    else if (event.newState === State.Stopped) setFailed(item);
+    // State.Running alone doesn't mean indexing complete — wait for
+    // markspec/indexed notification.
+  });
+
+  client.onNotification("markspec/indexed", (params) => {
+    setReady(
+      item,
+      (params as { files: number; entries: number } | undefined) ??
+        { files: 0, entries: 0 },
+    );
+  });
+
+  context.subscriptions.push(
+    item,
+    {
+      dispose: () => item.dispose(),
+    },
+  );
+
+  return item;
+}
+
+function setStarting(item: StatusBarItem): void {
+  item.text = "$(sync~spin) MarkSpec";
+  item.tooltip = "MarkSpec LSP starting…";
+  item.backgroundColor = undefined;
+}
+
+function setReady(
+  item: StatusBarItem,
+  params: { files: number; entries: number },
+): void {
+  item.text = "$(check) MarkSpec";
+  const tooltip = new MarkdownString();
+  tooltip.appendMarkdown("**MarkSpec LSP** ready\n\n");
+  tooltip.appendMarkdown(
+    `Indexed ${params.files} files, ${params.entries} entries.`,
+  );
+  item.tooltip = tooltip;
+  item.backgroundColor = undefined;
+}
+
+function setFailed(item: StatusBarItem): void {
+  item.text = "$(error) MarkSpec";
+  item.tooltip = "MarkSpec LSP not running. Click to view output.";
+  item.backgroundColor = new ThemeColor("statusBarItem.errorBackground");
+}

--- a/packages/markspec/lsp/debug_log.ts
+++ b/packages/markspec/lsp/debug_log.ts
@@ -1,0 +1,52 @@
+/**
+ * @module lsp/debug_log
+ *
+ * Append-only debug log for LSP lifecycle events. Activated by the
+ * MARKSPEC_LSP_DEBUG_LOG environment variable; otherwise a no-op.
+ *
+ * Stderr is intercepted by the LSP framework, and the framework's own error
+ * handlers swallow exceptions silently. This module lets us recover crash
+ * information after the fact by writing to a file we control.
+ */
+
+const ENV_KEY = "MARKSPEC_LSP_DEBUG_LOG";
+
+let logPath: string | undefined;
+let initialized = false;
+
+function lazyInit(): void {
+  if (initialized) return;
+  initialized = true;
+  const value = Deno.env.get(ENV_KEY);
+  if (value && value.length > 0) {
+    logPath = value;
+  }
+}
+
+/** Append a timestamped event to the debug log. No-op if env var is unset. */
+export function debugLog(event: string): void {
+  lazyInit();
+  if (!logPath) return;
+  try {
+    Deno.writeTextFileSync(
+      logPath,
+      `[${new Date().toISOString()}] ${event}\n`,
+      { append: true },
+    );
+  } catch {
+    // Cannot write the log — there's no fallback (stderr is intercepted).
+    // Drop the event silently rather than crash the server.
+  }
+}
+
+/** Returns the configured log path, or undefined. For testing. */
+export function getDebugLogPath(): string | undefined {
+  lazyInit();
+  return logPath;
+}
+
+/** Reset the cached env-var read. Test-only. */
+export function _resetDebugLog(): void {
+  initialized = false;
+  logPath = undefined;
+}

--- a/packages/markspec/lsp/debug_log_test.ts
+++ b/packages/markspec/lsp/debug_log_test.ts
@@ -1,0 +1,41 @@
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { _resetDebugLog, debugLog, getDebugLogPath } from "./debug_log.ts";
+
+Deno.test("debug_log: no-op when env var is unset", () => {
+  Deno.env.delete("MARKSPEC_LSP_DEBUG_LOG");
+  _resetDebugLog();
+  assertEquals(getDebugLogPath(), undefined);
+  // Does not throw.
+  debugLog("noop");
+});
+
+Deno.test("debug_log: writes timestamped lines when env var is set", async () => {
+  const path = await Deno.makeTempFile({ suffix: ".log" });
+  try {
+    Deno.env.set("MARKSPEC_LSP_DEBUG_LOG", path);
+    _resetDebugLog();
+    debugLog("first event");
+    debugLog("second event");
+    const content = await Deno.readTextFile(path);
+    const lines = content.trim().split("\n");
+    assertEquals(lines.length, 2);
+    assertStringIncludes(lines[0], "first event");
+    assertStringIncludes(lines[1], "second event");
+    // ISO-8601 prefix
+    const isoMatch = /^\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z\]/.test(
+      lines[0],
+    );
+    assertEquals(isoMatch, true);
+  } finally {
+    Deno.env.delete("MARKSPEC_LSP_DEBUG_LOG");
+    _resetDebugLog();
+    await Deno.remove(path);
+  }
+});
+
+Deno.test("debug_log: empty env var value is treated as unset", () => {
+  Deno.env.set("MARKSPEC_LSP_DEBUG_LOG", "");
+  _resetDebugLog();
+  assertEquals(getDebugLogPath(), undefined);
+  Deno.env.delete("MARKSPEC_LSP_DEBUG_LOG");
+});

--- a/packages/markspec/lsp/server.ts
+++ b/packages/markspec/lsp/server.ts
@@ -51,6 +51,7 @@ import {
   isSourceFile,
 } from "./context.ts";
 import { debounce, pathToUri, uriToPath } from "./util.ts";
+import { debugLog } from "./debug_log.ts";
 
 export const VERSION = "0.0.1";
 
@@ -64,6 +65,27 @@ const connection = createConnection(
   new StreamMessageWriter(process.stdout),
 );
 const documents = new TextDocuments(TextDocument);
+
+debugLog(
+  `server starting (pid=${Deno.pid}, args=${JSON.stringify(Deno.args)})`,
+);
+
+globalThis.addEventListener("unhandledrejection", (e) => {
+  e.preventDefault();
+  const reason = (e.reason as Error)?.stack ?? String(e.reason);
+  debugLog(`unhandledrejection: ${reason}`);
+  try {
+    connection.console.error(`unhandled rejection: ${reason}`);
+  } catch { /* connection may not be ready */ }
+});
+
+globalThis.addEventListener("error", (e) => {
+  const stack = e.error?.stack ?? e.message;
+  debugLog(`error: ${stack}`);
+  try {
+    connection.console.error(`uncaught error: ${stack}`);
+  } catch { /* connection may not be ready */ }
+});
 
 // ---------------------------------------------------------------------------
 // Server state
@@ -162,6 +184,7 @@ function getEntryTypes(): EntryTypeInfo[] {
 
 connection.onInitialize(
   async (params: InitializeParams): Promise<InitializeResult> => {
+    debugLog("onInitialize: start");
     const rootUri = params.rootUri ?? params.rootPath;
     if (rootUri) {
       const rootPath = rootUri.startsWith("file://")
@@ -193,6 +216,7 @@ connection.onInitialize(
       }
     }
 
+    debugLog("onInitialize: end");
     return {
       capabilities: {
         textDocumentSync: TextDocumentSyncKind.Full,
@@ -209,8 +233,10 @@ connection.onInitialize(
 // ---------------------------------------------------------------------------
 
 connection.onInitialized(async () => {
+  debugLog("onInitialized: start");
   if (!projectRoot) {
     connection.console.log("No project root found — running without index");
+    debugLog("onInitialized: end (no project root)");
     return;
   }
 
@@ -238,12 +264,15 @@ connection.onInitialized(async () => {
     connection.console.log(
       `Indexed ${files.length} files, ${index.getAllEntries().length} entries`,
     );
+    debugLog(`onInitialized: indexed ${files.length} files`);
 
     // Initial cross-file validation
     publishAllDiagnostics();
   } catch (err) {
     connection.console.error(`Indexing failed: ${err}`);
+    debugLog(`onInitialized: indexing failed: ${err}`);
   }
+  debugLog("onInitialized: end");
 });
 
 // ---------------------------------------------------------------------------
@@ -332,7 +361,12 @@ connection.onCompletion((params): CompletionItem[] => {
 // ---------------------------------------------------------------------------
 
 connection.onShutdown(() => {
+  debugLog("onShutdown");
   debouncedValidateAll.cancel();
+});
+
+connection.onExit(() => {
+  debugLog("onExit");
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/markspec/lsp/server.ts
+++ b/packages/markspec/lsp/server.ts
@@ -268,6 +268,11 @@ connection.onInitialized(async () => {
 
     // Initial cross-file validation
     publishAllDiagnostics();
+
+    connection.sendNotification("markspec/indexed", {
+      files: files.length,
+      entries: index.getAllEntries().length,
+    });
   } catch (err) {
     connection.console.error(`Indexing failed: ${err}`);
     debugLog(`onInitialized: indexing failed: ${err}`);


### PR DESCRIPTION
## Summary

- Adds `MARKSPEC_LSP_DEBUG_LOG` env-var-gated debug log to the LSP server, with global handlers for `unhandledrejection` and `error` so the next stacked-bug session leaves a paper trail.
- Wires lifecycle hooks (`onInitialize`, `onInitialized`, `onShutdown`, `onExit`) to the debug log.
- Server emits a custom `markspec/indexed` notification after the first diagnostics pass so the extension can distinguish "running" from "ready."
- Adds a VS Code status bar item that shows ⟳ → ✓ → ✗ based on LanguageClient state and the indexed notification, with a click action that opens the MarkSpec output channel.

## Test plan

- [x] `deno test` — all 669 tests pass (3 new debug_log tests)
- [x] `deno check` — clean across `main.ts`, `core/mod.ts`, `lsp/server.ts`, `mcp/server.ts`
- [x] `deno fmt --check` + `dprint check` + `deno lint` — clean
- [x] `editors/vscode npm run compile && npm test` — 8 unit tests pass
- [x] Smoke test — server with `MARKSPEC_LSP_DEBUG_LOG=...` writes timestamped `server starting` line
- [ ] Manual: reload VS Code window, verify status bar shows ⟳ then ✓, click opens output channel

🤖 Generated with [Claude Code](https://claude.com/claude-code)