### PR TITLE
ci(release): Phase 4 — per-platform binaries + multi-platform VSIX assets

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,6 +23,9 @@ jobs:
           - target: aarch64-apple-darwin
             os: macos-latest
             binary: markspec
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+            binary: markspec.exe
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -55,9 +55,75 @@ jobs:
             markspec-${{ matrix.target }}.tar.gz
             markspec-${{ matrix.target }}.tar.gz.sha256
 
+  package-vsix:
+    name: Package VSIX (${{ matrix.vsce-target }})
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            vsce-target: linux-x64
+            binary: markspec
+          - target: x86_64-apple-darwin
+            vsce-target: darwin-x64
+            binary: markspec
+          - target: aarch64-apple-darwin
+            vsce-target: darwin-arm64
+            binary: markspec
+          - target: x86_64-pc-windows-msvc
+            vsce-target: win32-x64
+            binary: markspec.exe
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: lts/*
+
+      - name: Download binary artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: markspec-${{ matrix.target }}
+          path: artifacts
+
+      - name: Extract binary
+        run: |
+          cd artifacts
+          tar xzf markspec-${{ matrix.target }}.tar.gz
+
+      - name: Bundle binary into extension
+        run: |
+          deno run --allow-read --allow-write \
+            editors/vscode/scripts/bundleBinary.ts \
+            --source artifacts/${{ matrix.binary }} \
+            --name ${{ matrix.binary }}
+
+      - name: Install extension deps
+        run: cd editors/vscode && npm ci
+
+      - name: Compile extension
+        run: cd editors/vscode && npm run compile
+
+      - name: Package VSIX
+        run: |
+          cd editors/vscode
+          npx vsce package --target ${{ matrix.vsce-target }} \
+            --out markspec-ide-${{ matrix.vsce-target }}.vsix
+
+      - name: Upload VSIX
+        uses: actions/upload-artifact@v7
+        with:
+          name: markspec-ide-${{ matrix.vsce-target }}-vsix
+          path: editors/vscode/markspec-ide-${{ matrix.vsce-target }}.vsix
+
   release:
     name: GitHub Release
-    needs: build
+    needs: [build, package-vsix]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -75,6 +141,7 @@ jobs:
           files: |
             artifacts/*.tar.gz
             artifacts/*.sha256
+            artifacts/*.vsix
 
   publish-jsr:
     name: Publish to JSR

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,6 +91,32 @@ Write documentation in Markdown following the
 - Use numbered lists for sequences, bulleted lists for everything else.
 - Put code-related text in code blocks.
 
+## VS Code extension development
+
+The repo is configured for dev-mode LSP. The committed `.vscode/settings.json`
+points the extension at `deno run packages/markspec/main.ts lsp` so changes to
+the LSP source take effect on every VS Code reload — no rebuild required.
+
+First-time setup:
+
+```bash
+cd editors/vscode
+npm install
+npm run compile
+code --install-extension <path-to-built-vsix>  # or use F5 from editors/vscode
+```
+
+To work on the _extension itself_ (not the LSP server):
+
+1. Open `editors/vscode/` in VS Code.
+2. Press F5 — opens an Extension Development Host window with the extension
+   loaded.
+3. In the host window, open the markspec repo. The dev-mode LSP runs against
+   live source.
+
+To debug LSP crashes, set `markspec.trace.debugLog` to a writable file path in
+your workspace settings. Lifecycle events and uncaught errors land there.
+
 <!-- ref links -->
 
 [cc]: https://www.conventionalcommits.org/


### PR DESCRIPTION
## Summary

- Adds `windows-latest` to the release build matrix so we ship a `markspec.exe` artifact alongside the existing linux-x64, darwin-x64, darwin-arm64 builds.
- Introduces a `package-vsix` job that, for each platform, downloads the binary artifact, drops it into `editors/vscode/bin/` via `bundleBinary.ts`, runs `vsce package --target <vscode-target>`, and uploads the per-platform `.vsix`.
- Wires the new VSIX artifacts into the `release` job so the GitHub Release attaches them next to the binaries.
- Documents the VS Code dev-mode LSP workflow (F5 launch, `markspec.trace.debugLog` for crash logging) in CONTRIBUTING.md.

The Phase 1 `bundleBinary.ts` already supports `--source` and `--name` (used to swap in `markspec.exe` for Windows), so no script changes are needed.

## Test plan

- [x] YAML syntax check via `deno run -A npm:js-yaml` — passes
- [ ] Tag a test release on a feature branch to exercise the matrix end-to-end (deferred to actual release cut)

🤖 Generated with [Claude Code](https://claude.com/claude-code)