### PR TITLE
fix(repo): make just compile work with bundled WASM grammars and Typst plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ _site/
 npm/
 *.pdf
 
+# Compile-time WASM mirrors (see scripts/compile_binary.ts)
+*.wasm.bin
+
 # Deno
 .deno/
 

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "tasks": {
     "check": "deno check packages/markspec/main.ts packages/markspec/core/mod.ts packages/markspec/lsp/server.ts packages/markspec/mcp/server.ts",
-    "compile": "deno compile --allow-read --allow-write --allow-run --allow-env --allow-ffi --include grammars/ --include packages/markspec-typst/ --output markspec packages/markspec/main.ts",
+    "compile": "deno run --allow-read --allow-write --allow-run --allow-env scripts/compile_binary.ts --output markspec",
     "test": "deno test --allow-read --allow-write --allow-run --allow-env --allow-ffi",
     "lint": "deno lint",
     "fmt": "deno fmt",
@@ -11,6 +11,7 @@
     "@deno/dnt": "jsr:@deno/dnt@^0.42.3",
     "@std/assert": "jsr:@std/assert@^1",
     "@std/cli": "jsr:@std/cli@^1",
+    "@std/fs": "jsr:@std/fs@^1",
     "@std/ulid": "jsr:@std/ulid@^1",
     "@std/yaml": "jsr:@std/yaml@^1",
     "@std/path": "jsr:@std/path@^1"

--- a/deno.lock
+++ b/deno.lock
@@ -8,6 +8,7 @@
     "jsr:@david/code-block-writer@^13.0.3": "13.0.3",
     "jsr:@deno/dnt@~0.42.3": "0.42.3",
     "jsr:@std/assert@1": "1.0.13",
+    "jsr:@std/cli@1": "1.0.28",
     "jsr:@std/fmt@1": "1.0.8",
     "jsr:@std/fmt@^1.0.9": "1.0.9",
     "jsr:@std/fs@1": "1.0.18",
@@ -75,6 +76,9 @@
       "dependencies": [
         "jsr:@std/internal"
       ]
+    },
+    "@std/cli@1.0.28": {
+      "integrity": "74ef9b976db59ca6b23a5283469c9072be6276853807a83ec6c7ce412135c70a"
     },
     "@std/fmt@1.0.8": {
       "integrity": "71e1fc498787e4434d213647a6e43e794af4fd393ef8f52062246e06f7e372b7"
@@ -823,6 +827,8 @@
     "dependencies": [
       "jsr:@deno/dnt@~0.42.3",
       "jsr:@std/assert@1",
+      "jsr:@std/cli@1",
+      "jsr:@std/fs@1",
       "jsr:@std/path@1",
       "jsr:@std/ulid@1",
       "jsr:@std/yaml@1"

--- a/justfile
+++ b/justfile
@@ -62,10 +62,9 @@ publish: build
 
 # Compile the CLI binary for the current platform
 compile:
-    deno compile --allow-read --allow-write --allow-run --allow-env --allow-ffi \
-        --include packages/markspec-typst/ \
-        --output dist/markspec \
-        packages/markspec/main.ts
+    deno run --allow-read --allow-write --allow-run --allow-env \
+        scripts/compile_binary.ts \
+        --output dist/markspec
 
 # Bump, push tag, and publish (full local release flow)
 release: bump

--- a/packages/markspec/core/parser/grammars.ts
+++ b/packages/markspec/core/parser/grammars.ts
@@ -71,6 +71,14 @@ async function doLoad(grammarName: string): Promise<Parser.Language> {
     await Parser.init();
     initialized = true;
   }
-  const wasmPath = join(GRAMMARS_DIR, `${grammarName}.wasm`);
-  return Parser.Language.load(wasmPath);
+  // The compiled binary embeds grammars as .wasm.bin to bypass Deno's
+  // WASM-import resolver (see scripts/compile_binary.ts). Prefer the
+  // mirror when present; fall back to .wasm in dev mode.
+  const binPath = join(GRAMMARS_DIR, `${grammarName}.wasm.bin`);
+  try {
+    await Deno.stat(binPath);
+    return Parser.Language.load(binPath);
+  } catch {
+    return Parser.Language.load(join(GRAMMARS_DIR, `${grammarName}.wasm`));
+  }
 }

--- a/scripts/compile_binary.ts
+++ b/scripts/compile_binary.ts
@@ -1,0 +1,164 @@
+/**
+ * @module scripts/compile_binary
+ *
+ * Wrapper around `deno compile` that works around Deno's WASM-import
+ * resolution.
+ *
+ * Background: when `deno compile --include <dir>` discovers a `.wasm` file,
+ * Deno parses it as a WebAssembly module and tries to resolve its host
+ * imports (e.g., `env.*` for tree-sitter, `typst_env.*` for cmarker).
+ * Those host imports are satisfied at runtime by the embedding host
+ * (tree-sitter, Typst), not by Deno modules — so resolution fails with:
+ *
+ *     Import "env" not a dependency and not in import map from "...wasm"
+ *
+ * Workaround: mirror each `.wasm` to a sibling `.wasm.bin` file at compile
+ * time. Deno does not parse non-`.wasm` extensions as modules, so it
+ * embeds them as opaque data. The compiled binary then loads `.wasm.bin`
+ * (its `import.meta`-relative paths still work). For cmarker, which
+ * references `plugin.wasm` from a `.typ` file, we also patch
+ * `vendor/cmarker/lib.typ` to point at `plugin.wasm.bin` for the duration
+ * of the compile.
+ *
+ * Outside `deno compile`, source code prefers the original `.wasm` files;
+ * this script's mirrors and patch are reverted on exit.
+ *
+ * Usage:
+ *   deno run --allow-read --allow-write --allow-run --allow-env \
+ *     scripts/compile_binary.ts [--output dist/markspec]
+ */
+
+import { parseArgs } from "@std/cli/parse-args";
+import { dirname, fromFileUrl, join, relative } from "@std/path";
+import { walk } from "@std/fs/walk";
+
+const HERE = dirname(fromFileUrl(import.meta.url));
+const REPO_ROOT = join(HERE, "..");
+const GRAMMARS_DIR = join(REPO_ROOT, "grammars");
+const CMARKER_DIR = join(
+  REPO_ROOT,
+  "packages",
+  "markspec-typst",
+  "vendor",
+  "cmarker",
+);
+const CMARKER_LIB = join(CMARKER_DIR, "lib.typ");
+
+const args = parseArgs(Deno.args, {
+  string: ["output"],
+  default: { output: join(REPO_ROOT, "dist", "markspec") },
+});
+
+const output = args.output as string;
+
+interface Mirror {
+  readonly source: string;
+  readonly mirror: string;
+}
+
+/** Find every .wasm file we need to mirror, return [(source, mirror)…]. */
+async function discoverMirrors(): Promise<Mirror[]> {
+  const mirrors: Mirror[] = [];
+  for (const dir of [GRAMMARS_DIR, CMARKER_DIR]) {
+    for await (
+      const entry of walk(dir, {
+        exts: ["wasm"],
+        includeDirs: false,
+        skip: [/\.bin$/],
+      })
+    ) {
+      mirrors.push({ source: entry.path, mirror: `${entry.path}.bin` });
+    }
+  }
+  return mirrors;
+}
+
+/** Copy each .wasm to its .wasm.bin sibling. */
+async function createMirrors(mirrors: readonly Mirror[]): Promise<void> {
+  for (const m of mirrors) {
+    await Deno.copyFile(m.source, m.mirror);
+  }
+}
+
+/** Remove .wasm.bin sibling files. */
+async function removeMirrors(mirrors: readonly Mirror[]): Promise<void> {
+  for (const m of mirrors) {
+    await Deno.remove(m.mirror).catch(() => {});
+  }
+}
+
+/**
+ * Patch cmarker's lib.typ to reference plugin.wasm.bin. Returns the
+ * original content so the caller can restore it.
+ */
+async function patchCmarkerLib(): Promise<string> {
+  const original = await Deno.readTextFile(CMARKER_LIB);
+  const patched = original.replace(
+    'plugin("./plugin.wasm")',
+    'plugin("./plugin.wasm.bin")',
+  );
+  if (patched === original) {
+    throw new Error(
+      `expected to patch plugin.wasm reference in ${CMARKER_LIB}, ` +
+        "but the literal 'plugin(\"./plugin.wasm\")' was not found",
+    );
+  }
+  await Deno.writeTextFile(CMARKER_LIB, patched);
+  return original;
+}
+
+async function restoreCmarkerLib(original: string): Promise<void> {
+  await Deno.writeTextFile(CMARKER_LIB, original);
+}
+
+async function runDenoCompile(mirrors: readonly Mirror[]): Promise<number> {
+  const excludeFlags: string[] = [];
+  for (const m of mirrors) {
+    excludeFlags.push("--exclude", relative(REPO_ROOT, m.source));
+  }
+
+  const cmd = new Deno.Command("deno", {
+    args: [
+      "compile",
+      "--no-check",
+      "--allow-read",
+      "--allow-write",
+      "--allow-run",
+      "--allow-env",
+      "--allow-ffi",
+      "--include",
+      "grammars/",
+      "--include",
+      "packages/markspec-typst/",
+      ...excludeFlags,
+      "--output",
+      output,
+      "packages/markspec/main.ts",
+    ],
+    cwd: REPO_ROOT,
+    stdout: "inherit",
+    stderr: "inherit",
+  });
+  const result = await cmd.output();
+  return result.code;
+}
+
+const mirrors = await discoverMirrors();
+if (mirrors.length === 0) {
+  console.error("warning: no .wasm files found to mirror — compile may fail");
+}
+
+let originalLib: string | undefined;
+let exitCode = 1;
+try {
+  await createMirrors(mirrors);
+  originalLib = await patchCmarkerLib();
+  exitCode = await runDenoCompile(mirrors);
+} finally {
+  if (originalLib !== undefined) {
+    await restoreCmarkerLib(originalLib).catch(() => {});
+  }
+  await removeMirrors(mirrors);
+}
+
+Deno.exit(exitCode);


### PR DESCRIPTION
## Problem

`just compile` (and `deno task compile`) failed with:

    Import "env" not a dependency and not in import map from "grammars/tree-sitter-kotlin.wasm"

`deno compile --include <dir>` walks every `.wasm` file inside the included tree and tries to resolve its WebAssembly import section as ES module imports. Tree-sitter grammars import `env.*` (host functions provided at runtime by tree-sitter) and cmarker's Typst plugin imports `typst_env.*` (host functions provided by the Typst plugin runtime). Neither is a Deno-resolvable module, so the compile blew up before producing a binary. This was caught by Phase 5 verification but predates Phases 3–5.

## Fix

`scripts/compile_binary.ts` wraps `deno compile` and:

1. Mirrors each `.wasm` to a `.wasm.bin` sibling — Deno embeds non-`.wasm` extensions as opaque data without parsing.
2. Patches `vendor/cmarker/lib.typ` to load `plugin.wasm.bin` (cmarker references the plugin by name in its `.typ` source).
3. Adds `--exclude` flags for the original `.wasm` files so they're not double-bundled.
4. Restores `lib.typ` and removes the mirrors on exit (success or failure).

`packages/markspec/core/parser/grammars.ts` prefers `.wasm.bin` when present (compiled binary) and falls back to `.wasm` (dev mode). Source-tree state is unchanged outside the compile window.

`*.wasm.bin` is gitignored. `just compile` and `deno task compile` both delegate to the script.

## Test plan

- [x] `just compile` produces a working `dist/markspec` binary
- [x] `tests/e2e/lsp_compiled_test.ts` passes against the binary (was previously skipped because the binary didn't exist)
- [x] `just check` — lint + 669 tests + typecheck all clean
- [x] `just lint` — clean
- [x] After compile, `git status` shows no leftover `.wasm.bin` files and `lib.typ` is restored
- [x] Dev mode (`deno run packages/markspec/main.ts`) still works — grammar loader uses the `.wasm` fallback path

🤖 Generated with [Claude Code](https://claude.com/claude-code)
