### PR TITLE
fix(ci): release binaries embed tree-sitter grammars and Typst plugin

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,10 +37,10 @@ jobs:
 
       - name: Compile
         run: |
-          deno compile --allow-read --allow-write --allow-run --allow-env \
+          deno run --allow-read --allow-write --allow-run --allow-env \
+            scripts/compile_binary.ts \
             --target ${{ matrix.target }} \
-            --output ${{ matrix.binary }} \
-            packages/markspec/main.ts
+            --output ${{ matrix.binary }}
 
       - name: Package
         run: |

--- a/scripts/compile_binary.ts
+++ b/scripts/compile_binary.ts
@@ -25,7 +25,10 @@
  *
  * Usage:
  *   deno run --allow-read --allow-write --allow-run --allow-env \
- *     scripts/compile_binary.ts [--output dist/markspec]
+ *     scripts/compile_binary.ts [--output dist/markspec] [--target <triple>]
+ *
+ * --target is forwarded to `deno compile` for cross-compilation
+ * (e.g. x86_64-pc-windows-msvc). Omitting it builds for the host platform.
  */
 
 import { parseArgs } from "@std/cli/parse-args";
@@ -45,11 +48,12 @@ const CMARKER_DIR = join(
 const CMARKER_LIB = join(CMARKER_DIR, "lib.typ");
 
 const args = parseArgs(Deno.args, {
-  string: ["output"],
+  string: ["output", "target"],
   default: { output: join(REPO_ROOT, "dist", "markspec") },
 });
 
 const output = args.output as string;
+const target = args.target as string | undefined;
 
 interface Mirror {
   readonly source: string;
@@ -126,6 +130,7 @@ async function runDenoCompile(mirrors: readonly Mirror[]): Promise<number> {
       "--allow-run",
       "--allow-env",
       "--allow-ffi",
+      ...(target ? ["--target", target] : []),
       "--include",
       "grammars/",
       "--include",


### PR DESCRIPTION
## Problem

Phase 4 (PR #249) added `windows-latest` and a `package-vsix` job to the release pipeline, but the actual `deno compile` step in `release.yaml` is bare:

```yaml
- name: Compile
  run: |
    deno compile --allow-read --allow-write --allow-run --allow-env \
      --target ${{ matrix.target }} \
      --output ${{ matrix.binary }} \
      packages/markspec/main.ts
```

No `--include`, no `--allow-ffi`. The shipped per-platform binaries silently lack:

- Tree-sitter grammars — `markspec validate file.rs`, `markspec compile src/**`, and the LSP's source-file doc-comment parsing all break.
- Cmarker / Typst plugin — `markspec doc build` breaks (no PDF rendering).

PR #250 fixed `just compile` for local dev with [scripts/compile_binary.ts](scripts/compile_binary.ts), which mirrors `.wasm` to `.wasm.bin` and patches `vendor/cmarker/lib.typ` around the compile. CI just doesn't use it.

## Fix

- Extend `scripts/compile_binary.ts` with a `--target <triple>` flag forwarded to `deno compile`. The mirror/patch dance is target-agnostic.
- Replace the inline `deno compile` in `release.yaml`'s compile step with `deno run scripts/compile_binary.ts --target ... --output ...`.

## Test plan

- [x] `just compile` (no `--target`) still produces a working host-platform binary
- [x] `deno fmt --check` / `dprint check` / `deno lint` clean
- [ ] Cross-compile path exercised end-to-end on next tagged release (deferred — not triggering a tag from a PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
