### PR TITLE
chore(repo): gitignore .claude/ (Claude Code local state)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ Thumbs.db
 
 # dprint
 .dprint/
+
+# Claude Code local state (per-developer worktrees and settings)
+.claude/


### PR DESCRIPTION
## Summary

Claude Code stores per-developer state in `.claude/`:

- `settings.local.json` — per-machine settings
- `worktrees/` — isolated checkouts created via the `EnterWorktree` tool

None of this is meant to be committed. Adding `.claude/` to `.gitignore` keeps `git status` clean for any contributor using Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
