### PR TITLE
fix(ci): use bash shell on windows runners in release build matrix

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,6 +11,9 @@ jobs:
   build:
     name: Build (${{ matrix.target }})
     runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
     strategy:
       matrix:
         include:


### PR DESCRIPTION
## Problem

Pushing the v1.1.0 tag triggered the release workflow, and the Windows build job failed at the Compile step:

```
ParserError: D:\a\_temp\....ps1:4
   4 |    --target x86_64-pc-windows-msvc \
     |     ~
     | Missing expression after unary operator '--'.
```

GitHub's Windows runner defaults to PowerShell, which doesn't recognize `\` as line continuation (PowerShell uses backtick `` ` ``). Every multi-line `run:` block in `release.yaml`'s build matrix was therefore broken on Windows. This was a latent issue introduced by Phase 4 (#249) which added `windows-latest` to the matrix without a Windows-specific shell setting.

The release pipeline failed before publishing — no artifacts shipped, no GitHub Release created — so we just need to re-run with the fix.

## Fix

Set `defaults.run.shell: bash` on the `build` job so all platforms (including Windows, where the runner ships Git-Bash) use bash. No per-step changes needed.

After this merges, retag v1.1.0 onto the new HEAD to re-trigger the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
