### PR TITLE
fix(ci): use sha256sum on linux/windows, fall back to shasum on macos

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,7 +48,13 @@ jobs:
       - name: Package
         run: |
           tar czf markspec-${{ matrix.target }}.tar.gz ${{ matrix.binary }}
-          shasum -a 256 markspec-${{ matrix.target }}.tar.gz > markspec-${{ matrix.target }}.tar.gz.sha256
+          # macOS ships shasum (Perl); Linux + Windows Git-Bash ship sha256sum.
+          # Both produce the same "HASH  FILE" output format.
+          if command -v sha256sum >/dev/null; then
+            sha256sum markspec-${{ matrix.target }}.tar.gz > markspec-${{ matrix.target }}.tar.gz.sha256
+          else
+            shasum -a 256 markspec-${{ matrix.target }}.tar.gz > markspec-${{ matrix.target }}.tar.gz.sha256
+          fi
 
       - name: Upload artifact
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
# Summary

The v1.1.1 release run got past the Windows compile fix (#253) but failed at the Package step:

    line 2: shasum: command not found

`shasum` is a Perl script shipped with macOS but not with Linux or Windows Git-Bash. `sha256sum` is the inverse: present on Linux and Windows Git-Bash, missing on macOS.

Pick at runtime:

    if command -v sha256sum >/dev/null; then
      sha256sum file > file.sha256
    else
      shasum -a 256 file > file.sha256
    fi

Both tools produce the same `HASH  FILENAME` output, so consumers verifying with either are unaffected.

After this merges, bump again to retrigger the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
