### PR TITLE
fix(ci): pin deno --config when bundling binary in package-vsix job

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -106,8 +106,12 @@ jobs:
           tar xzf markspec-${{ matrix.target }}.tar.gz
 
       - name: Bundle binary into extension
+        # editors/vscode has its own package.json (which Deno picks up as a
+        # config file by default) but is not part of the root deno.json
+        # workspace. Pin to the root config so the script's @std/* imports
+        # resolve correctly.
         run: |
-          deno run --allow-read --allow-write \
+          deno run --config deno.json --allow-read --allow-write \
             editors/vscode/scripts/bundleBinary.ts \
             --source artifacts/${{ matrix.binary }} \
             --name ${{ matrix.binary }}


### PR DESCRIPTION
# Summary

The v1.1.2 release got past the build matrix (4/4 binaries built and uploaded) but failed at the `package-vsix` Bundle step:

    error: Config file must be a member of the workspace.
      Config: file:///.../editors/vscode/package.json
      Workspace: file:///...

`editors/vscode/` ships its own `package.json` for the VS Code extension. Deno's modern package.json compatibility makes it auto-pick that as the project config — but `editors/vscode` isn't a member of the root `deno.json` workspace.

`editors/vscode/package.json`'s `bundle` script already uses `--config ../../deno.json` for the same reason. CI just doesn't.

Pin `--config deno.json` on the bundle step so `@std/*` imports resolve against the root workspace config.

After this merges, bump again to retrigger the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
