### PR TITLE
chore(core): consolidate palette constants and add MSL-PROFILE-COLOR-004

### DIFF
--- a/packages/markspec/core/mod.ts
+++ b/packages/markspec/core/mod.ts
@@ -14,6 +14,7 @@ export const VERSION = "0.0.1";
 export {
   ConfigError,
   DEFAULT_PROJECT_CONFIG,
+  PALETTE_HUES,
   REFHUB_URL,
 } from "./model/mod.ts";
 export type {
@@ -30,6 +31,7 @@ export type {
   InlineRef,
   Link,
   LinkKind,
+  PaletteHue,
   ProfileChain,
   ProjectConfig,
   Severity,

--- a/packages/markspec/core/model/mod.ts
+++ b/packages/markspec/core/model/mod.ts
@@ -11,6 +11,9 @@ export {
 } from "./attributes.ts";
 export type { AttributeSpec } from "./attributes.ts";
 
+export { COLOR_NAME_RE, PALETTE_HUES } from "./palette.ts";
+export type { PaletteHue } from "./palette.ts";
+
 // ---------------------------------------------------------------------------
 // Display ID
 // ---------------------------------------------------------------------------

--- a/packages/markspec/core/model/palette.ts
+++ b/packages/markspec/core/model/palette.ts
@@ -1,0 +1,28 @@
+/**
+ * @module model/palette
+ *
+ * The seven-hue entry color palette and its semantic-name regex. Single
+ * source of truth — both the profile manifest parser and the renderer
+ * import from here so the two layers can never drift.
+ *
+ * Mirrors the `diagram:` group in `theme/tokens.yaml`. Adding a hue is a
+ * tokens-side change followed by an entry here; the order does not matter
+ * but kept stable for diagnostic message readability.
+ */
+
+/** The seven palette hues a profile may bind a semantic color name to. */
+export const PALETTE_HUES = [
+  "blue",
+  "cyan",
+  "teal",
+  "orange",
+  "red",
+  "purple",
+  "grey",
+] as const;
+
+/** Type of a palette hue name. */
+export type PaletteHue = typeof PALETTE_HUES[number];
+
+/** Regex for a valid semantic color-role name (key into `profile.colors:`). */
+export const COLOR_NAME_RE = /^[a-z][a-z0-9-]*$/;

--- a/packages/markspec/core/profile/manifest.ts
+++ b/packages/markspec/core/profile/manifest.ts
@@ -27,7 +27,6 @@ import {
 
 const VALUE_TYPE_SET: ReadonlySet<string> = new Set(VALUE_TYPES);
 
-
 const ALLOWED_ROOT_KEYS = new Set([
   "id",
   "version",

--- a/packages/markspec/core/profile/manifest.ts
+++ b/packages/markspec/core/profile/manifest.ts
@@ -11,10 +11,12 @@ import type { Diagnostic, ProfileManifest } from "../model/mod.ts";
 import {
   type AttrDecl,
   type Cardinality,
+  COLOR_NAME_RE,
   type DocTypeDef,
   type EnforcementMode,
   type EntryShape,
   LIST_VALUE_TYPES,
+  PALETTE_HUES,
   type ProfileSpecifier,
   type TargetMatcher,
   type TraceRule,
@@ -25,22 +27,6 @@ import {
 
 const VALUE_TYPE_SET: ReadonlySet<string> = new Set(VALUE_TYPES);
 
-/**
- * The seven palette hues a profile may bind a semantic name to.
- * Mirrors the `diagram:` group in `theme/tokens.yaml`.
- */
-const PALETTE_HUES = [
-  "blue",
-  "cyan",
-  "teal",
-  "orange",
-  "red",
-  "purple",
-  "grey",
-] as const;
-
-/** Regex for valid semantic-name keys in `profile.colors:`. */
-const COLOR_NAME_RE = /^[a-z][a-z0-9-]*$/;
 
 const ALLOWED_ROOT_KEYS = new Set([
   "id",
@@ -570,7 +556,7 @@ function parseColorsMap(
   for (const [name, value] of Object.entries(raw as Record<string, unknown>)) {
     if (!COLOR_NAME_RE.test(name)) {
       diagnostics.push({
-        code: "PROFILE-LOAD-003",
+        code: "MSL-PROFILE-COLOR-004",
         severity: "error",
         message:
           `profile.colors: '${name}' is not a valid semantic name (lowercase letters, digits, hyphens; must start with a letter)`,

--- a/packages/markspec/core/profile/manifest_test.ts
+++ b/packages/markspec/core/profile/manifest_test.ts
@@ -654,7 +654,9 @@ profile:
   documents: { types: [], frontMatter: [] }
 `;
   const result = parseManifest(yaml, "test.yaml");
-  const err = result.diagnostics.find((d) => d.code === "MSL-PROFILE-COLOR-004");
+  const err = result.diagnostics.find((d) =>
+    d.code === "MSL-PROFILE-COLOR-004"
+  );
   assertExists(err);
   assertEquals(err.severity, "error");
 });

--- a/packages/markspec/core/profile/manifest_test.ts
+++ b/packages/markspec/core/profile/manifest_test.ts
@@ -639,7 +639,7 @@ profile:
   assertEquals(err.severity, "error");
 });
 
-Deno.test("parseManifest: invalid semantic name is rejected", () => {
+Deno.test("parseManifest: invalid semantic name emits MSL-PROFILE-COLOR-004", () => {
   const yaml = `
 id: test
 version: 1.0.0
@@ -654,10 +654,9 @@ profile:
   documents: { types: [], frontMatter: [] }
 `;
   const result = parseManifest(yaml, "test.yaml");
-  const err = result.diagnostics.find((d) =>
-    d.severity === "error" && d.message.includes("semantic name")
-  );
+  const err = result.diagnostics.find((d) => d.code === "MSL-PROFILE-COLOR-004");
   assertExists(err);
+  assertEquals(err.severity, "error");
 });
 
 Deno.test("parseManifest: per-type color: is parsed", () => {

--- a/packages/markspec/render/typst/colors.ts
+++ b/packages/markspec/render/typst/colors.ts
@@ -8,20 +8,18 @@
  * for the resolution table.
  */
 
-import type { EffectiveProfile, Entry } from "../../core/mod.ts";
+import {
+  type EffectiveProfile,
+  type Entry,
+  PALETTE_HUES,
+  type PaletteHue,
+} from "../../core/mod.ts";
 
-/** The seven palette hues the renderer can emit. */
-export const PALETTE_HUES = [
-  "blue",
-  "cyan",
-  "teal",
-  "orange",
-  "red",
-  "purple",
-  "grey",
-] as const;
-
-export type PaletteHue = typeof PALETTE_HUES[number];
+// Re-export so existing consumers of these symbols (tests, downstream code)
+// don't need to switch imports. The single source of truth lives in
+// `core/model/palette.ts`.
+export { PALETTE_HUES };
+export type { PaletteHue };
 
 /** Default identified-entry hue when no profile / no type color resolves. */
 const DEFAULT_HUE: PaletteHue = "blue";


### PR DESCRIPTION
## Summary

Two follow-up fixes from the [PR #257](https://github.com/driftsys/markspec/pull/257) review:

- **Closes #258** — `PALETTE_HUES`, `PaletteHue`, and `COLOR_NAME_RE` move to a new `core/model/palette.ts` module and are re-exported through `core/model/mod.ts` + `core/mod.ts`. Both `manifest.ts` (parser) and `render/typst/colors.ts` (renderer) now import from the shared module so the seven-hue palette can never drift between the two layers.
- **Closes #259** — the diagnostic emitted when a `profile.colors:` key fails the semantic-name regex is renamed `PROFILE-LOAD-003` → `MSL-PROFILE-COLOR-004` so all color-system errors share the `MSL-PROFILE-COLOR-NNN` namespace and can be grepped uniformly.

## Test plan

- [x] `just check` — 690 passed / 0 failed; lint + type-check clean.
- [x] Existing `parseManifest: invalid semantic name` test updated to assert the new code; passes.
- [ ] CI green on push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
