### PR TITLE
feat(book): wire profile-driven entry colors and add merge integration tests

### DIFF
--- a/packages/markspec/book/mod.ts
+++ b/packages/markspec/book/mod.ts
@@ -17,7 +17,12 @@ export type {
 export { renderChapterHtml } from "./site/mod.ts";
 export type { RenderChapterOptions, RenderChapterResult } from "./site/mod.ts";
 
-import type { CompileResult, Diagnostic, ProjectConfig } from "../core/mod.ts";
+import type {
+  CompileResult,
+  Diagnostic,
+  EffectiveProfile,
+  ProjectConfig,
+} from "../core/mod.ts";
 import { renderChapterHtml } from "./site/mod.ts";
 import type { BookStructure, Chapter } from "./summary/mod.ts";
 
@@ -31,6 +36,8 @@ export interface BuildBookOptions {
   readonly compiled: CompileResult;
   /** Project configuration from `project.yaml`. */
   readonly config: ProjectConfig;
+  /** Active profile chain's merged view, if any. Drives entry coloring. */
+  readonly profile?: EffectiveProfile;
 }
 
 /** A rendered chapter ready for site assembly. */
@@ -74,7 +81,10 @@ export function buildBook(
     const markdown = options.files.get(chapter.path);
     if (!markdown) continue; // skip missing files
 
-    const { html } = renderChapterHtml(markdown, { file: chapter.path });
+    const { html } = renderChapterHtml(markdown, {
+      file: chapter.path,
+      profile: options.profile,
+    });
     chapters.push({
       kind: chapter.kind,
       title: chapter.title,

--- a/packages/markspec/book/site/mod.ts
+++ b/packages/markspec/book/site/mod.ts
@@ -16,11 +16,7 @@ import remarkGfm from "remark-gfm";
 import remarkRehype from "remark-rehype";
 import rehypeStringify from "rehype-stringify";
 import type { Blockquote, Root, Text } from "mdast";
-import type {
-  Caption,
-  EffectiveProfile,
-  Entry,
-} from "../../core/mod.ts";
+import type { Caption, EffectiveProfile, Entry } from "../../core/mod.ts";
 import { detectCaptions, parse, resolveEntryColor } from "../../core/mod.ts";
 
 // ── Types ─────────────────────────────────────────────────────────────────
@@ -259,7 +255,10 @@ function _escapeHtml(s: string): string {
     .replaceAll('"', "&quot;");
 }
 
-function _entryClass(entry: Entry, profile: EffectiveProfile | undefined): string {
+function _entryClass(
+  entry: Entry,
+  profile: EffectiveProfile | undefined,
+): string {
   // Resolves `null` for referenced-shape (uncolored) and a palette hue for
   // identified entries. The CSS in theme/markspec.css defines `.hue-<hue>`
   // for the seven palette hues and `.uncolored` for the null case.

--- a/packages/markspec/book/site/mod.ts
+++ b/packages/markspec/book/site/mod.ts
@@ -56,7 +56,8 @@ const _astParser = unified().use(remarkParse).use(remarkGfm);
  * Render a Markdown chapter to an HTML string.
  *
  * Intercepts MarkSpec-extended elements at their line boundaries:
- * - Entry blocks → `<div class="req-block" data-entry-type="...">` with
+ * - Entry blocks → `<div class="req-block hue-<name>">` (or
+ *   `class="req-block uncolored"` for referenced-shape entries) with
  *   ID, title, label pills, body, and attribute metadata
  * - GFM alerts (`> [!NOTE]`) → `<div class="alert note|tip|...">` with
  *   full border and tint background (Tol vibrant via `markspec.css`)

--- a/packages/markspec/book/site/mod.ts
+++ b/packages/markspec/book/site/mod.ts
@@ -16,8 +16,12 @@ import remarkGfm from "remark-gfm";
 import remarkRehype from "remark-rehype";
 import rehypeStringify from "rehype-stringify";
 import type { Blockquote, Root, Text } from "mdast";
-import type { Caption, Entry } from "../../core/mod.ts";
-import { detectCaptions, parse } from "../../core/mod.ts";
+import type {
+  Caption,
+  EffectiveProfile,
+  Entry,
+} from "../../core/mod.ts";
+import { detectCaptions, parse, resolveEntryColor } from "../../core/mod.ts";
 
 // ── Types ─────────────────────────────────────────────────────────────────
 
@@ -28,6 +32,8 @@ type AlertType = "note" | "tip" | "important" | "warning" | "caution";
 export interface RenderChapterOptions {
   /** File path used in source locations (for diagnostics). */
   readonly file?: string;
+  /** Active profile, if any. Drives per-entry color resolution. */
+  readonly profile?: EffectiveProfile;
 }
 
 /** Result of rendering a chapter to HTML. */
@@ -99,7 +105,7 @@ export function renderChapterHtml(
     }
 
     if (region.kind === "entry") {
-      parts.push(_entryToHtml(region.entry!));
+      parts.push(_entryToHtml(region.entry!, options.profile));
     } else if (region.kind === "alert") {
       const raw = lines.slice(region.start, region.end);
       parts.push(_alertToHtml(region.alertType!, raw));
@@ -253,16 +259,19 @@ function _escapeHtml(s: string): string {
     .replaceAll('"', "&quot;");
 }
 
-function _entryCategory(displayId: string, shape: string): string {
-  if (shape === "referenced") return "req";
-  const prefix = displayId.split("_")[0];
-  if (["ARC", "SAD", "ICD"].includes(prefix)) return "spec";
-  if (["TST", "VAL", "SIT", "SWT"].includes(prefix)) return "test";
-  return "req";
+function _entryClass(entry: Entry, profile: EffectiveProfile | undefined): string {
+  // Resolves `null` for referenced-shape (uncolored) and a palette hue for
+  // identified entries. The CSS in theme/markspec.css defines `.hue-<hue>`
+  // for the seven palette hues and `.uncolored` for the null case.
+  const hue = resolveEntryColor(entry, profile);
+  return hue === null ? "req-block uncolored" : `req-block hue-${hue}`;
 }
 
-function _entryToHtml(entry: Entry): string {
-  const category = _entryCategory(entry.displayId, entry.shape);
+function _entryToHtml(
+  entry: Entry,
+  profile: EffectiveProfile | undefined,
+): string {
+  const blockClass = _entryClass(entry, profile);
 
   const labelsAttr = entry.rawAttributes.find((a) => a.key === "Labels");
   const labels = labelsAttr
@@ -296,7 +305,7 @@ function _entryToHtml(entry: Entry): string {
     }</div>`
     : "";
 
-  return `<div class="req-block" data-entry-type="${category}">
+  return `<div class="${blockClass}">
   <div class="req-title">
     <code class="req-id">${_escapeHtml(entry.displayId)}</code>
     <span class="req-name">${_escapeHtml(entry.title)}</span>

--- a/packages/markspec/core/mod.ts
+++ b/packages/markspec/core/mod.ts
@@ -68,6 +68,7 @@ export {
   loadProfileForCommand,
   mergeChain,
   parseManifest,
+  resolveEntryColor,
   resolveGitSpecifier,
   resolveLocalSpecifier,
 } from "./profile/mod.ts";

--- a/packages/markspec/core/profile/colors.ts
+++ b/packages/markspec/core/profile/colors.ts
@@ -1,25 +1,18 @@
 /**
- * @module render/typst/colors
+ * @module core/profile/colors
  *
  * Profile-driven entry color resolution. Pure function that maps an entry
  * and the active profile to a palette hue name (or `null` for uncolored).
+ *
+ * Lives in core/profile so both rendering layers (Typst PDF and HTML book)
+ * can call it without crossing the peer-module boundary defined in AGENTS.md.
  *
  * See docs/superpowers/specs/2026-05-06-profile-driven-entry-colors-design.md
  * for the resolution table.
  */
 
-import {
-  type EffectiveProfile,
-  type Entry,
-  PALETTE_HUES,
-  type PaletteHue,
-} from "../../core/mod.ts";
-
-// Re-export so existing consumers of these symbols (tests, downstream code)
-// don't need to switch imports. The single source of truth lives in
-// `core/model/palette.ts`.
-export { PALETTE_HUES };
-export type { PaletteHue };
+import type { EffectiveProfile, Entry } from "../model/mod.ts";
+import { PALETTE_HUES, type PaletteHue } from "../model/palette.ts";
 
 /** Default identified-entry hue when no profile / no type color resolves. */
 const DEFAULT_HUE: PaletteHue = "blue";
@@ -52,7 +45,7 @@ export function resolveEntryColor(
   // Defense in depth: the manifest parser already enforces PALETTE_HUES, but
   // EffectiveProfile can in principle be constructed programmatically (tests,
   // future APIs) without going through parseManifest. Guard the cast so an
-  // invalid hue can never reach the Typst interpolation in template.ts.
+  // invalid hue can never reach downstream interpolation.
   const hue = hueEntry.value;
   if (!(PALETTE_HUES as readonly string[]).includes(hue)) return DEFAULT_HUE;
   return hue as PaletteHue;

--- a/packages/markspec/core/profile/colors_test.ts
+++ b/packages/markspec/core/profile/colors_test.ts
@@ -5,7 +5,7 @@
 
 import { assertEquals } from "@std/assert";
 import { resolveEntryColor } from "./colors.ts";
-import type { EffectiveProfile, Entry } from "../../core/mod.ts";
+import type { EffectiveProfile, Entry } from "../model/mod.ts";
 
 function makeIdentifiedEntry(type: string | undefined): Entry {
   return {
@@ -125,4 +125,126 @@ Deno.test("resolveEntryColor: type's color name not in colors map falls back to 
     { req: "unknown" },
   );
   assertEquals(resolveEntryColor(makeIdentifiedEntry("req"), profile), "blue");
+});
+
+// ── Integration: parseManifest → mergeChain → resolveEntryColor ──────────
+// (issue #260 — guards against drift between manifest validator and renderer)
+
+import { parseManifest } from "./manifest.ts";
+import { mergeChain } from "./merge.ts";
+import type { LoadedProfile, ProfileChain } from "../model/mod.ts";
+
+function loadEffective(yaml: string): EffectiveProfile {
+  const parsed = parseManifest(yaml, "test.yaml");
+  if (!parsed.manifest) {
+    throw new Error(
+      `parseManifest failed: ${
+        parsed.diagnostics.map((d) => d.code).join(", ")
+      }`,
+    );
+  }
+  const tier: LoadedProfile = {
+    id: parsed.manifest.id,
+    version: parsed.manifest.version,
+    specifier: { kind: "local", path: "." },
+    manifest: parsed.manifest,
+    sourcePath: "test.yaml",
+    baseDir: ".",
+  };
+  // mergeChain reads only .tiers; effective is filled by mergeChain itself.
+  const chain = { tiers: [tier] } as unknown as ProfileChain;
+  const merged = mergeChain(chain);
+  if (!merged.effective) {
+    throw new Error(
+      `mergeChain failed: ${merged.diagnostics.map((d) => d.code).join(", ")}`,
+    );
+  }
+  return merged.effective;
+}
+
+Deno.test("integration: end-to-end manifest → merge → resolve picks the declared hue", () => {
+  const yaml = `
+id: "@acme/profile"
+version: 1.0.0
+profile:
+  colors:
+    primary: blue
+    danger: red
+  attributes: []
+  labels: []
+  identified: { attributes: [] }
+  referenced: { attributes: [] }
+  types:
+    requirement:
+      shape: identified
+      color: primary
+    test:
+      shape: identified
+      color: danger
+  documents: { types: [], frontMatter: [] }
+`;
+  const profile = loadEffective(yaml);
+
+  assertEquals(
+    resolveEntryColor(makeIdentifiedEntry("requirement"), profile),
+    "blue",
+  );
+  assertEquals(
+    resolveEntryColor(makeIdentifiedEntry("test"), profile),
+    "red",
+  );
+});
+
+Deno.test("integration: manifest with type.color absent → renderer falls back to blue", () => {
+  const yaml = `
+id: "@acme/profile"
+version: 1.0.0
+profile:
+  colors:
+    primary: teal
+  attributes: []
+  labels: []
+  identified: { attributes: [] }
+  referenced: { attributes: [] }
+  types:
+    requirement:
+      shape: identified
+  documents: { types: [], frontMatter: [] }
+`;
+  const profile = loadEffective(yaml);
+
+  // type exists but color is unset — fallback to palette blue, NOT to
+  // any declared role like 'primary' (decoupling renderer from profile
+  // vocabulary, per the design spec's resolution table).
+  assertEquals(
+    resolveEntryColor(makeIdentifiedEntry("requirement"), profile),
+    "blue",
+  );
+});
+
+Deno.test("integration: referenced-shape type stays uncolored even with color authored", () => {
+  // Manifest will emit MSL-PROFILE-COLOR-001 (warning) — manifest still
+  // loads, merge succeeds, and the renderer must return null.
+  const yaml = `
+id: "@acme/profile"
+version: 1.0.0
+profile:
+  colors:
+    primary: blue
+  attributes: []
+  labels: []
+  identified: { attributes: [] }
+  referenced: { attributes: [] }
+  types:
+    standard:
+      shape: referenced
+      color: primary
+  documents: { types: [], frontMatter: [] }
+`;
+  const profile = loadEffective(yaml);
+
+  assertEquals(
+    resolveEntryColor(makeReferencedEntry("standard"), profile),
+    null,
+  );
 });

--- a/packages/markspec/core/profile/mod.ts
+++ b/packages/markspec/core/profile/mod.ts
@@ -40,3 +40,5 @@ export type { CacheEnv } from "./cache.ts";
 
 export { defaultRunNpm, resolveNpmSpecifier } from "./npm.ts";
 export type { ResolveNpmOptions, RunNpm } from "./npm.ts";
+
+export { resolveEntryColor } from "./colors.ts";

--- a/packages/markspec/main.ts
+++ b/packages/markspec/main.ts
@@ -194,7 +194,12 @@ const bookCmd = new Command()
       profile: bookChain?.effective ?? undefined,
     });
 
-    const result = buildBook(structure, { files, compiled, config });
+    const result = buildBook(structure, {
+      files,
+      compiled,
+      config,
+      profile: bookChain?.effective,
+    });
 
     for (const d of result.diagnostics) {
       console.error(`${d.severity}[${d.code}]: ${d.message}`);

--- a/packages/markspec/render/typst/template.ts
+++ b/packages/markspec/render/typst/template.ts
@@ -8,8 +8,11 @@
  * `req-block` calls with admonition-style left borders.
  */
 
-import type { EffectiveProfile, Entry } from "../../core/mod.ts";
-import { resolveEntryColor } from "./colors.ts";
+import {
+  type EffectiveProfile,
+  type Entry,
+  resolveEntryColor,
+} from "../../core/mod.ts";
 
 /** Metadata for the generated Typst document. */
 export interface DocumentMetadata {

--- a/scripts/gen_theme.ts
+++ b/scripts/gen_theme.ts
@@ -233,10 +233,11 @@ function genCss(): string {
   );
   // Entry blocks render via the seven-hue palette — see
   // docs/superpowers/specs/2026-05-06-profile-driven-entry-colors-design.md.
-  // The HTML book pipeline does not yet emit per-entry hue classes; until it
-  // does, every .req-block falls back to the palette `blue` default (matching
-  // the renderer's no-profile fallback). Per-hue classes are defined so the
-  // book module can opt in by emitting `class="req-block hue-<name>"`.
+  // The book HTML renderer (packages/markspec/book/site/mod.ts) emits
+  // class="req-block hue-<name>" for identified entries (or `uncolored`
+  // for referenced entries) using resolveEntryColor and the active
+  // profile. The base .req-block rule supplies the palette-blue fallback
+  // when no profile is loaded.
   lines.push(`.req-block {
   border-left: 2px solid var(--ms-entry-blue);
   padding: 0 0 0 14px;

--- a/tests/e2e/book_build_test.ts
+++ b/tests/e2e/book_build_test.ts
@@ -75,7 +75,7 @@ Deno.test("book build: exits 0 and writes HTML files", async () => {
   assertStringIncludes(stderr, "index.html");
 });
 
-Deno.test("book build: emits req-block for default (req) entry", async () => {
+Deno.test("book build: identified entry without profile gets hue-blue fallback", async () => {
   const dir = await Deno.makeTempDir();
   try {
     for (const [name, content] of Object.entries(FIXTURE)) {
@@ -97,15 +97,20 @@ Deno.test("book build: emits req-block for default (req) entry", async () => {
     await cmd.output();
 
     const html = await Deno.readTextFile(`${dir}/_site/requirements.html`);
-    assertStringIncludes(html, 'class="req-block"');
-    assertStringIncludes(html, 'data-entry-type="req"');
+    // Identified entries with no profile loaded fall back to palette blue;
+    // referenced entries would get .uncolored. The fixture has no profile.
+    assertStringIncludes(html, 'class="req-block hue-blue"');
     assertStringIncludes(html, "STK_BRK_0001");
   } finally {
     await Deno.remove(dir, { recursive: true });
   }
 });
 
-Deno.test("book build: emits correct data-entry-type for spec (ARC) entries", async () => {
+Deno.test("book build: prefix heuristic is gone — ARC entries do NOT auto-color spec", async () => {
+  // Regression test for the V-model prefix removal. Pre-PR-#257, ARC_*
+  // display IDs auto-mapped to data-entry-type="spec". Now color must come
+  // from the active profile's per-type binding; without a profile, every
+  // identified entry falls back to palette blue.
   const dir = await Deno.makeTempDir();
   try {
     for (const [name, content] of Object.entries(FIXTURE)) {
@@ -127,8 +132,13 @@ Deno.test("book build: emits correct data-entry-type for spec (ARC) entries", as
     await cmd.output();
 
     const html = await Deno.readTextFile(`${dir}/_site/specs.html`);
-    assertStringIncludes(html, 'data-entry-type="spec"');
+    assertStringIncludes(html, 'class="req-block hue-blue"');
     assertStringIncludes(html, "ARC_BRK_0001");
+    if (html.includes("data-entry-type") || html.includes("hue-spec")) {
+      throw new Error(
+        "legacy data-entry-type or 'hue-spec' class still present in book HTML",
+      );
+    }
   } finally {
     await Deno.remove(dir, { recursive: true });
   }


### PR DESCRIPTION
## Summary

Two follow-ups from the color-system PR-#257 review:

- **Closes #260** — adds three integration tests in [colors_test.ts](packages/markspec/core/profile/colors_test.ts) that exercise `parseManifest → mergeChain → resolveEntryColor` end-to-end. Guards against drift between the manifest validator and the renderer, including the case where the manifest emits `MSL-PROFILE-COLOR-001` (warning) and the renderer must still produce a sane result.
- **Closes #261** — wires the HTML book renderer to use the resolver. `_entryToHtml` now emits `class="req-block hue-<name>"` for identified entries with a resolved color or `class="req-block uncolored"` for referenced entries. The matching CSS classes were already shipped in PR #257; the book module now opts in.

## Structural changes

- `resolveEntryColor` moves from `render/typst/colors.ts` → [core/profile/colors.ts](packages/markspec/core/profile/colors.ts) so both rendering layers (Typst PDF, HTML book) can call it through `core/mod.ts` (per the library boundary in `AGENTS.md`). The render-side file is deleted; its tests move to `core/profile/colors_test.ts`.
- `BuildBookOptions` and `RenderChapterOptions` gain an optional `profile` field. The book CLI threads `bookChain?.effective` into both `compile()` and `buildBook()`.
- The `_entryCategory` prefix heuristic in the book module is gone (matches the same removal from the Typst path in PR #257).

## Test plan

- [x] `just check` — 693 passed / 0 failed; lint + type-check clean.
- [x] Two existing e2e book tests updated to assert the new class-based output. The `data-entry-type="spec" for ARC entries` test is repurposed as a regression check that the V-model prefix heuristic is gone.
- [ ] CI green on push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
