### PR TITLE
feat(mcp): v1 MCP server with profile/entry resources + 4 tools

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -838,6 +838,7 @@
         "dependencies": [
           "jsr:@cliffy/command@1",
           "jsr:@std/assert@1",
+          "npm:@modelcontextprotocol/sdk@1",
           "npm:@myriaddreamin/typst-ts-node-compiler@0.6",
           "npm:@types/mdast@4",
           "npm:rehype-stringify@10",

--- a/deno.lock
+++ b/deno.lock
@@ -20,6 +20,8 @@
     "jsr:@std/yaml@1": "1.0.12",
     "jsr:@ts-morph/bootstrap@0.27": "0.27.0",
     "jsr:@ts-morph/common@0.27": "0.27.0",
+    "npm:@modelcontextprotocol/sdk@*": "1.29.0_zod@4.4.3",
+    "npm:@modelcontextprotocol/sdk@1": "1.29.0_zod@4.4.3",
     "npm:@myriaddreamin/typst-ts-node-compiler@0.6": "0.6.0",
     "npm:@types/mdast@4": "4.0.4",
     "npm:rehype-stringify@10": "10.0.1",
@@ -122,6 +124,34 @@
     }
   },
   "npm": {
+    "@hono/node-server@1.19.14_hono@4.12.18": {
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "dependencies": [
+        "hono"
+      ]
+    },
+    "@modelcontextprotocol/sdk@1.29.0_zod@4.4.3": {
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "dependencies": [
+        "@hono/node-server",
+        "ajv",
+        "ajv-formats",
+        "content-type",
+        "cors",
+        "cross-spawn",
+        "eventsource",
+        "eventsource-parser",
+        "express",
+        "express-rate-limit",
+        "hono",
+        "jose",
+        "json-schema-typed",
+        "pkce-challenge",
+        "raw-body",
+        "zod",
+        "zod-to-json-schema"
+      ]
+    },
     "@myriaddreamin/typst-ts-node-compiler-android-arm-eabi@0.6.0": {
       "integrity": "sha512-Gfrf9Fky5iYtutGWYwqRC4gvllK1p1q6YELCbycI47NCFptONI++3dfub4PixWRn9m8NrmaNFIBQSyLHWsvbLw==",
       "os": ["android"],
@@ -220,8 +250,64 @@
     "@ungap/structured-clone@1.3.0": {
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="
     },
+    "accepts@2.0.0": {
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "dependencies": [
+        "mime-types",
+        "negotiator"
+      ]
+    },
+    "ajv-formats@3.0.1_ajv@8.17.1": {
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "dependencies": [
+        "ajv"
+      ],
+      "optionalPeers": [
+        "ajv"
+      ]
+    },
+    "ajv@8.17.1": {
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "dependencies": [
+        "fast-deep-equal",
+        "fast-uri",
+        "json-schema-traverse",
+        "require-from-string"
+      ]
+    },
     "bail@2.0.2": {
       "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="
+    },
+    "body-parser@2.2.2": {
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "dependencies": [
+        "bytes",
+        "content-type",
+        "debug",
+        "http-errors",
+        "iconv-lite",
+        "on-finished",
+        "qs",
+        "raw-body",
+        "type-is"
+      ]
+    },
+    "bytes@3.1.2": {
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="
+    },
+    "call-bind-apply-helpers@1.0.2": {
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dependencies": [
+        "es-errors",
+        "function-bind"
+      ]
+    },
+    "call-bound@1.0.4": {
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dependencies": [
+        "call-bind-apply-helpers",
+        "get-intrinsic"
+      ]
     },
     "ccount@2.0.1": {
       "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="
@@ -238,6 +324,33 @@
     "comma-separated-tokens@2.0.3": {
       "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="
     },
+    "content-disposition@1.1.0": {
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="
+    },
+    "content-type@1.0.5": {
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="
+    },
+    "cookie-signature@1.2.2": {
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="
+    },
+    "cookie@0.7.2": {
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="
+    },
+    "cors@2.8.6": {
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "dependencies": [
+        "object-assign",
+        "vary"
+      ]
+    },
+    "cross-spawn@7.0.6": {
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dependencies": [
+        "path-key",
+        "shebang-command",
+        "which"
+      ]
+    },
     "debug@4.4.3": {
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dependencies": [
@@ -250,6 +363,9 @@
         "character-entities"
       ]
     },
+    "depd@2.0.0": {
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
+    },
     "dequal@2.0.3": {
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="
     },
@@ -259,11 +375,152 @@
         "dequal"
       ]
     },
+    "dunder-proto@1.0.1": {
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dependencies": [
+        "call-bind-apply-helpers",
+        "es-errors",
+        "gopd"
+      ]
+    },
+    "ee-first@1.1.1": {
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
+    },
+    "encodeurl@2.0.0": {
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="
+    },
+    "es-define-property@1.0.1": {
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="
+    },
+    "es-errors@1.3.0": {
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="
+    },
+    "es-object-atoms@1.1.1": {
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dependencies": [
+        "es-errors"
+      ]
+    },
+    "escape-html@1.0.3": {
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
+    },
     "escape-string-regexp@5.0.0": {
       "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="
     },
+    "etag@1.8.1": {
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="
+    },
+    "eventsource-parser@3.0.8": {
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ=="
+    },
+    "eventsource@3.0.7": {
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "dependencies": [
+        "eventsource-parser"
+      ]
+    },
+    "express-rate-limit@8.5.1_express@5.2.1": {
+      "integrity": "sha512-5O6KYmyJEpuPJV5hNTXKbAHWRqrzyu+OI3vUnSd2kXFubIVpG7ezpgxQy76Zo5GQZtrQBg86hF+CM/NX+cioiQ==",
+      "dependencies": [
+        "express",
+        "ip-address"
+      ]
+    },
+    "express@5.2.1": {
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "dependencies": [
+        "accepts",
+        "body-parser",
+        "content-disposition",
+        "content-type",
+        "cookie",
+        "cookie-signature",
+        "debug",
+        "depd",
+        "encodeurl",
+        "escape-html",
+        "etag",
+        "finalhandler",
+        "fresh",
+        "http-errors",
+        "merge-descriptors",
+        "mime-types",
+        "on-finished",
+        "once",
+        "parseurl",
+        "proxy-addr",
+        "qs",
+        "range-parser",
+        "router",
+        "send",
+        "serve-static",
+        "statuses",
+        "type-is",
+        "vary"
+      ]
+    },
     "extend@3.0.2": {
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+    },
+    "fast-deep-equal@3.1.3": {
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
+    "fast-uri@3.0.6": {
+      "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw=="
+    },
+    "finalhandler@2.1.1": {
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "dependencies": [
+        "debug",
+        "encodeurl",
+        "escape-html",
+        "on-finished",
+        "parseurl",
+        "statuses"
+      ]
+    },
+    "forwarded@0.2.0": {
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="
+    },
+    "fresh@2.0.0": {
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="
+    },
+    "function-bind@1.1.2": {
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
+    },
+    "get-intrinsic@1.3.0": {
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dependencies": [
+        "call-bind-apply-helpers",
+        "es-define-property",
+        "es-errors",
+        "es-object-atoms",
+        "function-bind",
+        "get-proto",
+        "gopd",
+        "has-symbols",
+        "hasown",
+        "math-intrinsics"
+      ]
+    },
+    "get-proto@1.0.1": {
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dependencies": [
+        "dunder-proto",
+        "es-object-atoms"
+      ]
+    },
+    "gopd@1.2.0": {
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="
+    },
+    "has-symbols@1.1.0": {
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="
+    },
+    "hasown@2.0.2": {
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dependencies": [
+        "function-bind"
+      ]
     },
     "hast-util-to-html@9.0.5": {
       "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
@@ -287,17 +544,63 @@
         "@types/hast"
       ]
     },
+    "hono@4.12.18": {
+      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ=="
+    },
     "html-void-elements@3.0.0": {
       "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg=="
     },
+    "http-errors@2.0.1": {
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "dependencies": [
+        "depd",
+        "inherits",
+        "setprototypeof",
+        "statuses",
+        "toidentifier"
+      ]
+    },
+    "iconv-lite@0.7.2": {
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "dependencies": [
+        "safer-buffer"
+      ]
+    },
+    "inherits@2.0.4": {
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "ip-address@10.2.0": {
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA=="
+    },
+    "ipaddr.js@1.9.1": {
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
+    },
     "is-plain-obj@4.1.0": {
       "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="
+    },
+    "is-promise@4.0.0": {
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="
+    },
+    "isexe@2.0.0": {
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+    },
+    "jose@6.2.3": {
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw=="
+    },
+    "json-schema-traverse@1.0.0": {
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
+    "json-schema-typed@8.0.2": {
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="
     },
     "longest-streak@3.1.0": {
       "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="
     },
     "markdown-table@3.0.4": {
       "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw=="
+    },
+    "math-intrinsics@1.1.0": {
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="
     },
     "mdast-util-find-and-replace@3.0.2": {
       "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
@@ -424,6 +727,12 @@
       "dependencies": [
         "@types/mdast"
       ]
+    },
+    "media-typer@1.1.0": {
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="
+    },
+    "merge-descriptors@2.0.0": {
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="
     },
     "micromark-core-commonmark@2.0.3": {
       "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
@@ -666,11 +975,78 @@
         "micromark-util-types"
       ]
     },
+    "mime-db@1.54.0": {
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="
+    },
+    "mime-types@3.0.2": {
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "dependencies": [
+        "mime-db"
+      ]
+    },
     "ms@2.1.3": {
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
+    "negotiator@1.0.0": {
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="
+    },
+    "object-assign@4.1.1": {
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
+    },
+    "object-inspect@1.13.4": {
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="
+    },
+    "on-finished@2.4.1": {
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "dependencies": [
+        "ee-first"
+      ]
+    },
+    "once@1.4.0": {
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dependencies": [
+        "wrappy"
+      ]
+    },
+    "parseurl@1.3.3": {
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
+    },
+    "path-key@3.1.1": {
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
+    },
+    "path-to-regexp@8.4.2": {
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="
+    },
+    "pkce-challenge@5.0.1": {
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="
+    },
     "property-information@7.1.0": {
       "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="
+    },
+    "proxy-addr@2.0.7": {
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "dependencies": [
+        "forwarded",
+        "ipaddr.js"
+      ]
+    },
+    "qs@6.15.1": {
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "dependencies": [
+        "side-channel"
+      ]
+    },
+    "range-parser@1.2.1": {
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
+    },
+    "raw-body@3.0.2": {
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "dependencies": [
+        "bytes",
+        "http-errors",
+        "iconv-lite",
+        "unpipe"
+      ]
     },
     "rehype-stringify@10.0.1": {
       "integrity": "sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA==",
@@ -718,8 +1094,100 @@
         "unified"
       ]
     },
+    "require-from-string@2.0.2": {
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
+    },
+    "router@2.2.0": {
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "dependencies": [
+        "debug",
+        "depd",
+        "is-promise",
+        "parseurl",
+        "path-to-regexp"
+      ]
+    },
+    "safer-buffer@2.1.2": {
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "send@1.2.1": {
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "dependencies": [
+        "debug",
+        "encodeurl",
+        "escape-html",
+        "etag",
+        "fresh",
+        "http-errors",
+        "mime-types",
+        "ms",
+        "on-finished",
+        "range-parser",
+        "statuses"
+      ]
+    },
+    "serve-static@2.2.1": {
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "dependencies": [
+        "encodeurl",
+        "escape-html",
+        "parseurl",
+        "send"
+      ]
+    },
+    "setprototypeof@1.2.0": {
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
+    },
+    "shebang-command@2.0.0": {
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dependencies": [
+        "shebang-regex"
+      ]
+    },
+    "shebang-regex@3.0.0": {
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
+    },
+    "side-channel-list@1.0.1": {
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "dependencies": [
+        "es-errors",
+        "object-inspect"
+      ]
+    },
+    "side-channel-map@1.0.1": {
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dependencies": [
+        "call-bound",
+        "es-errors",
+        "get-intrinsic",
+        "object-inspect"
+      ]
+    },
+    "side-channel-weakmap@1.0.2": {
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dependencies": [
+        "call-bound",
+        "es-errors",
+        "get-intrinsic",
+        "object-inspect",
+        "side-channel-map"
+      ]
+    },
+    "side-channel@1.1.0": {
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "dependencies": [
+        "es-errors",
+        "object-inspect",
+        "side-channel-list",
+        "side-channel-map",
+        "side-channel-weakmap"
+      ]
+    },
     "space-separated-tokens@2.0.2": {
       "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="
+    },
+    "statuses@2.0.2": {
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="
     },
     "stringify-entities@4.0.4": {
       "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
@@ -728,11 +1196,22 @@
         "character-entities-legacy"
       ]
     },
+    "toidentifier@1.0.1": {
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="
+    },
     "trim-lines@3.0.1": {
       "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="
     },
     "trough@2.2.0": {
       "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw=="
+    },
+    "type-is@2.0.1": {
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "dependencies": [
+        "content-type",
+        "media-typer",
+        "mime-types"
+      ]
     },
     "unified@11.0.5": {
       "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
@@ -779,6 +1258,12 @@
         "unist-util-visit-parents"
       ]
     },
+    "unpipe@1.0.0": {
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="
+    },
+    "vary@1.1.2": {
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="
+    },
     "vfile-message@4.0.3": {
       "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
       "dependencies": [
@@ -818,6 +1303,25 @@
     },
     "web-tree-sitter@0.24.7": {
       "integrity": "sha512-CdC/TqVFbXqR+C51v38hv6wOPatKEUGxa39scAeFSm98wIhZxAYonhRQPSMmfZ2w7JDI0zQDdzdmgtNk06/krQ=="
+    },
+    "which@2.0.2": {
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dependencies": [
+        "isexe"
+      ],
+      "bin": true
+    },
+    "wrappy@1.0.2": {
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+    },
+    "zod-to-json-schema@3.25.2_zod@4.4.3": {
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "dependencies": [
+        "zod"
+      ]
+    },
+    "zod@4.4.3": {
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="
     },
     "zwitch@2.0.4": {
       "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="

--- a/docs/guide/commands.md
+++ b/docs/guide/commands.md
@@ -258,6 +258,80 @@ markspec doctor
 | ---------- | ------ | ------- | ----------------------------- |
 | `--format` | string | `text`  | Output format: `json`, `text` |
 
+## AI agent integration
+
+### mcp
+
+Start the MarkSpec MCP server. Communicates over stdio JSON-RPC. Exposes the
+active project as MCP resources and tools to any MCP-capable AI client (Claude
+Code, Claude Desktop, GitHub Copilot in VS Code, OpenCode).
+
+```sh
+markspec mcp
+```
+
+#### Resources
+
+- `markspec://profile` — distilled profile manifest (types, attributes, link
+  kinds, labels).
+- `markspec://entries` — index of all project entries, grouped by type.
+- `markspec://entry/{displayId}` — one entry per resource, with attributes,
+  body, outgoing/incoming links.
+
+#### Tools
+
+- `entry_search { query, limit? }` — rank-search entries by display ID and
+  title.
+- `entry_context { id, depth? }` — walk the `satisfies` chain upward.
+- `validate { files? }` — run the validator, return a Markdown diagnostics
+  report.
+- `markspec_refresh` — force-invalidate the compile cache (call after agent
+  edits to guarantee freshness).
+
+#### Claude Desktop config
+
+Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "markspec": {
+      "command": "markspec",
+      "args": ["mcp"],
+      "cwd": "/path/to/your/markspec-project"
+    }
+  }
+}
+```
+
+Restart Claude Desktop. The MarkSpec resources and tools appear in the attach
+menu.
+
+#### Claude Code
+
+```sh
+claude mcp add markspec --command markspec --args mcp --cwd /path/to/project
+```
+
+#### VS Code (Copilot)
+
+In your project's `.vscode/mcp.json`:
+
+```json
+{
+  "servers": {
+    "markspec": {
+      "command": "markspec",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+Copilot does not support MCP resource subscriptions today, but the `markspec://`
+resources still work — the server runs a fresh staleness check on every read, so
+a re-read after an edit returns up-to-date content.
+
 ## Not yet implemented
 
 These commands are registered but print an error and exit:
@@ -272,4 +346,3 @@ These commands are registered but print an error and exit:
 | `book dev`         | Live preview with hot reload                             |
 | `deck build`       | Slides → PDF via Touying/Typst                           |
 | `deck dev`         | Live slide preview                                       |
-| `mcp`              | MCP server for AI agent integration                      |

--- a/docs/superpowers/plans/2026-05-10-mcp-server.md
+++ b/docs/superpowers/plans/2026-05-10-mcp-server.md
@@ -1,0 +1,3325 @@
+# MCP Server Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement v1 of the MarkSpec MCP server — a stdio JSON-RPC server
+that exposes the project's traceability data to AI coding agents as MCP
+resources and tools. Covers GitHub issues #60–#62; #63 (write tool) is
+deferred.
+
+**Architecture:** The `markspec mcp` subcommand lazy-loads `mcp/server.ts`,
+which constructs a single `Server` from `@modelcontextprotocol/sdk` on stdio.
+A module-level `ProjectCache` runs `compile()` once on initialize (background)
+and re-runs it on every `resources/read` or `tools/call` whose mtime check
+detects file changes. Three resource families
+(`markspec://profile`, `markspec://entries`, `markspec://entry/{displayId}`)
+and four tools (`entry_search`, `entry_context`, `validate`,
+`markspec_refresh`) all return Markdown bodies. Subscriptions emit
+`notifications/resources/updated` on invalidation for clients that honor them
+(Claude Code today; Copilot ignores).
+
+**Tech Stack:**
+`npm:@modelcontextprotocol/sdk`,
+`@driftsys/markspec/core` (via `core/mod.ts`),
+Deno/TypeScript.
+
+**Spec:**
+[`docs/superpowers/specs/2026-05-10-mcp-server-design.md`](../specs/2026-05-10-mcp-server-design.md)
+
+**Worktree:**
+`/Users/sebastientasson/Workspace/driftsys/markspec/.claude/worktrees/feat+mcp-server-v1`
+(branch `worktree-feat+mcp-server-v1`)
+
+---
+
+## File Map
+
+| File                                              | Responsibility                                          |
+| ------------------------------------------------- | ------------------------------------------------------- |
+| `packages/markspec/deno.json`                     | Add `@modelcontextprotocol/sdk` import                  |
+| `packages/markspec/mcp/uri.ts`                    | MCP URI scheme: parse/format `markspec://...`           |
+| `packages/markspec/mcp/uri_test.ts`               | Unit tests for URI helpers                              |
+| `packages/markspec/mcp/project.ts`                | Project root discovery, compile cache, mtime check      |
+| `packages/markspec/mcp/project_test.ts`           | Unit tests for cache invalidation                       |
+| `packages/markspec/mcp/resources/profile.ts`      | Render `markspec://profile` as Markdown                 |
+| `packages/markspec/mcp/resources/profile_test.ts` | Unit tests for profile renderer                         |
+| `packages/markspec/mcp/resources/entry.ts`        | Render `markspec://entry/{id}` as Markdown              |
+| `packages/markspec/mcp/resources/entry_test.ts`   | Unit tests for entry renderer                           |
+| `packages/markspec/mcp/resources/entries.ts`      | Render `markspec://entries` index as Markdown           |
+| `packages/markspec/mcp/resources/entries_test.ts` | Unit tests for entries-index renderer                   |
+| `packages/markspec/mcp/resources/mod.ts`          | Resource registration: list, read, route by URI         |
+| `packages/markspec/mcp/resources/mod_test.ts`     | Unit tests for resource dispatch                        |
+| `packages/markspec/mcp/tools/search.ts`           | `entry_search`: ranking + Markdown render               |
+| `packages/markspec/mcp/tools/search_test.ts`      | Unit tests for ranking and rendering                    |
+| `packages/markspec/mcp/tools/context.ts`          | `entry_context`: chain walk + Markdown tree             |
+| `packages/markspec/mcp/tools/context_test.ts`     | Unit tests for chain walk                               |
+| `packages/markspec/mcp/tools/validate.ts`         | `validate`: diagnostics → Markdown report               |
+| `packages/markspec/mcp/tools/validate_test.ts`    | Unit tests for diagnostics rendering                    |
+| `packages/markspec/mcp/tools/refresh.ts`          | `markspec_refresh`: force-recompile                     |
+| `packages/markspec/mcp/tools/refresh_test.ts`     | Unit tests for refresh tool                             |
+| `packages/markspec/mcp/tools/mod.ts`              | Tool registration: list, call dispatch                  |
+| `packages/markspec/mcp/server.ts`                 | Server bootstrap, lifecycle, subscriptions              |
+| `packages/markspec/main.ts`                       | Replace `notImplemented("mcp")` with dynamic import     |
+| `tests/e2e/mcp_test.ts`                           | E2E: spawn `markspec mcp`, drive JSON-RPC over stdio    |
+| `docs/guide/commands.md`                          | Document `markspec mcp` and connection examples         |
+
+---
+
+## Task 1: Add MCP SDK dependency and URI helpers
+
+**Files:**
+
+- Modify: `packages/markspec/deno.json`
+- Create: `packages/markspec/mcp/uri.ts`
+- Create: `packages/markspec/mcp/uri_test.ts`
+
+- [ ] **Step 1: Add `@modelcontextprotocol/sdk` to `packages/markspec/deno.json`**
+
+In the `imports` map of `packages/markspec/deno.json`, add:
+
+```json
+"@modelcontextprotocol/sdk": "npm:@modelcontextprotocol/sdk@^1"
+```
+
+The full `imports` block should now contain (additive — keep all existing
+entries):
+
+```json
+{
+  "imports": {
+    "@cliffy/command": "jsr:@cliffy/command@^1",
+    "@std/assert": "jsr:@std/assert@^1",
+    "@modelcontextprotocol/sdk": "npm:@modelcontextprotocol/sdk@^1",
+    "unified": "npm:unified@^11",
+    "remark-parse": "npm:remark-parse@^11",
+    "remark-gfm": "npm:remark-gfm@^4",
+    "remark-rehype": "npm:remark-rehype@^11",
+    "rehype-stringify": "npm:rehype-stringify@^10",
+    "mdast": "npm:@types/mdast@^4",
+    "web-tree-sitter": "npm:web-tree-sitter@^0.24",
+    "typst-ts-node-compiler": "npm:@myriaddreamin/typst-ts-node-compiler@^0.6",
+    "vscode-languageserver/node": "npm:vscode-languageserver@^9/node.js",
+    "vscode-languageserver-textdocument": "npm:vscode-languageserver-textdocument@^1"
+  }
+}
+```
+
+- [ ] **Step 2: Write failing tests for URI helpers**
+
+Create `packages/markspec/mcp/uri_test.ts`:
+
+```typescript
+/**
+ * @module mcp/uri_test
+ *
+ * Unit tests for the markspec:// URI scheme helpers.
+ */
+
+import { assertEquals } from "@std/assert";
+import {
+  ENTRIES_URI,
+  entryUri,
+  isEntryUri,
+  parseEntryUri,
+  PROFILE_URI,
+} from "./uri.ts";
+
+Deno.test("PROFILE_URI is the canonical constant", () => {
+  assertEquals(PROFILE_URI, "markspec://profile");
+});
+
+Deno.test("ENTRIES_URI is the canonical constant", () => {
+  assertEquals(ENTRIES_URI, "markspec://entries");
+});
+
+Deno.test("entryUri: builds entry URI from display ID", () => {
+  assertEquals(entryUri("STK_AEB_0001"), "markspec://entry/STK_AEB_0001");
+});
+
+Deno.test("entryUri: encodes special characters in display ID", () => {
+  // Display IDs are normally [A-Z0-9_] but be defensive.
+  assertEquals(
+    entryUri("FOO BAR"),
+    "markspec://entry/FOO%20BAR",
+  );
+});
+
+Deno.test("parseEntryUri: extracts display ID", () => {
+  assertEquals(
+    parseEntryUri("markspec://entry/STK_AEB_0001"),
+    "STK_AEB_0001",
+  );
+});
+
+Deno.test("parseEntryUri: decodes percent-encoded characters", () => {
+  assertEquals(parseEntryUri("markspec://entry/FOO%20BAR"), "FOO BAR");
+});
+
+Deno.test("parseEntryUri: returns undefined for non-entry URIs", () => {
+  assertEquals(parseEntryUri("markspec://profile"), undefined);
+  assertEquals(parseEntryUri("https://example.com/STK_AEB_0001"), undefined);
+  assertEquals(parseEntryUri("markspec://entry/"), undefined);
+});
+
+Deno.test("isEntryUri: true for entry URIs", () => {
+  assertEquals(isEntryUri("markspec://entry/STK_AEB_0001"), true);
+});
+
+Deno.test("isEntryUri: false for other URIs", () => {
+  assertEquals(isEntryUri("markspec://profile"), false);
+  assertEquals(isEntryUri("markspec://entries"), false);
+  assertEquals(isEntryUri("markspec://entry/"), false);
+});
+```
+
+- [ ] **Step 3: Run tests to confirm they fail**
+
+Run: `deno test packages/markspec/mcp/uri_test.ts`
+Expected: FAIL — module `./uri.ts` not found.
+
+- [ ] **Step 4: Implement `mcp/uri.ts`**
+
+Create `packages/markspec/mcp/uri.ts`:
+
+```typescript
+/**
+ * @module mcp/uri
+ *
+ * The `markspec://` URI scheme used by the MCP server. Three resource
+ * families:
+ *
+ * - `markspec://profile`               — the distilled profile manifest
+ * - `markspec://entries`               — the entry index
+ * - `markspec://entry/{displayId}`     — a single entry
+ *
+ * All helpers are pure and safe to import from any module.
+ */
+
+/** Canonical URI of the profile resource. */
+export const PROFILE_URI = "markspec://profile";
+
+/** Canonical URI of the entries-index resource. */
+export const ENTRIES_URI = "markspec://entries";
+
+/** Prefix for per-entry resource URIs. */
+export const ENTRY_URI_PREFIX = "markspec://entry/";
+
+/** Build an entry resource URI from a display ID. */
+export function entryUri(displayId: string): string {
+  return `${ENTRY_URI_PREFIX}${encodeURIComponent(displayId)}`;
+}
+
+/**
+ * Extract the display ID from a `markspec://entry/...` URI.
+ * Returns `undefined` for any URI that is not a non-empty entry URI.
+ */
+export function parseEntryUri(uri: string): string | undefined {
+  if (!uri.startsWith(ENTRY_URI_PREFIX)) return undefined;
+  const encoded = uri.slice(ENTRY_URI_PREFIX.length);
+  if (encoded.length === 0) return undefined;
+  try {
+    return decodeURIComponent(encoded);
+  } catch {
+    return undefined;
+  }
+}
+
+/** Check whether a URI is a well-formed entry URI. */
+export function isEntryUri(uri: string): boolean {
+  return parseEntryUri(uri) !== undefined;
+}
+```
+
+- [ ] **Step 5: Run tests to confirm they pass**
+
+Run: `deno test packages/markspec/mcp/uri_test.ts`
+Expected: PASS (9 tests, 0 failures).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/markspec/deno.json packages/markspec/mcp/uri.ts packages/markspec/mcp/uri_test.ts
+git commit -m "feat(mcp): add MCP SDK dependency and markspec:// URI helpers"
+```
+
+---
+
+## Task 2: Project context and compile cache
+
+**Files:**
+
+- Create: `packages/markspec/mcp/project.ts`
+- Create: `packages/markspec/mcp/project_test.ts`
+
+`project.ts` owns the project root discovery, the compile cache, and the
+mtime-based invalidation. It exposes:
+
+- `initProject(cwd, env)` — discovers root, kicks off background compile.
+- `getCompiled()` — returns the cached `CompileResult`, recompiling when stale.
+- `forceRefresh()` — for the `markspec_refresh` tool.
+- `getProfile()` — exposes the loaded `ProfileChain | null`.
+- `subscribeInvalidation(handler)` — fire-on-recompile hook for the server.
+
+- [ ] **Step 1: Write failing tests for cache invalidation**
+
+Create `packages/markspec/mcp/project_test.ts`:
+
+```typescript
+/**
+ * @module mcp/project_test
+ *
+ * Unit tests for the MCP project-context cache.
+ *
+ * Uses an in-memory ProjectEnv shim so no filesystem access is required.
+ */
+
+import { assertEquals, assertExists } from "@std/assert";
+import { createProject, type ProjectEnv } from "./project.ts";
+
+/** Build a ProjectEnv that serves a fixed file map. */
+function makeEnv(files: Record<string, { content: string; mtime: number }>): {
+  env: ProjectEnv;
+  bumpMtime: (path: string, content: string, mtime: number) => void;
+  removeFile: (path: string) => void;
+} {
+  const store = new Map(Object.entries(files));
+  return {
+    env: {
+      cwd: () => "/proj",
+      readFile: async (path) => {
+        const f = store.get(path);
+        if (!f) throw new Error(`ENOENT: ${path}`);
+        return f.content;
+      },
+      stat: async (path) => {
+        const f = store.get(path);
+        if (!f) throw new Error(`ENOENT: ${path}`);
+        return { mtime: f.mtime };
+      },
+      walk: async function* () {
+        for (const path of store.keys()) yield path;
+      },
+    },
+    bumpMtime(path, content, mtime) {
+      store.set(path, { content, mtime });
+    },
+    removeFile(path) {
+      store.delete(path);
+    },
+  };
+}
+
+const PROJECT_YAML = `name: test\nversion: 0.0.1\n`;
+
+const REQ_DOC = `- [STK_TEST_0001] Test entry
+
+  Body.
+
+  Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+`;
+
+Deno.test("createProject: discovers root from project.yaml", async () => {
+  const { env } = makeEnv({
+    "/proj/project.yaml": { content: PROJECT_YAML, mtime: 1 },
+    "/proj/req.md": { content: REQ_DOC, mtime: 1 },
+  });
+  const proj = await createProject(env);
+  assertEquals(proj.projectRoot, "/proj");
+});
+
+Deno.test("createProject: returns null when no project.yaml", async () => {
+  const { env } = makeEnv({
+    "/proj/req.md": { content: REQ_DOC, mtime: 1 },
+  });
+  const proj = await createProject(env);
+  assertEquals(proj.projectRoot, undefined);
+});
+
+Deno.test("getCompiled: compiles and caches result", async () => {
+  const { env } = makeEnv({
+    "/proj/project.yaml": { content: PROJECT_YAML, mtime: 1 },
+    "/proj/req.md": { content: REQ_DOC, mtime: 1 },
+  });
+  const proj = await createProject(env);
+  const r1 = await proj.getCompiled();
+  assertExists(r1);
+  assertEquals(r1.entries.size, 1);
+
+  // Second call must return the same object (cached).
+  const r2 = await proj.getCompiled();
+  assertEquals(r1, r2);
+});
+
+Deno.test("getCompiled: recompiles when file mtime changes", async () => {
+  const { env, bumpMtime } = makeEnv({
+    "/proj/project.yaml": { content: PROJECT_YAML, mtime: 1 },
+    "/proj/req.md": { content: REQ_DOC, mtime: 1 },
+  });
+  const proj = await createProject(env);
+  const r1 = await proj.getCompiled();
+  assertEquals(r1.entries.size, 1);
+
+  // Mutate the file and bump mtime above the compiledAt timestamp.
+  const updatedDoc = REQ_DOC + `\n- [STK_TEST_0002] Another
+
+  Body.
+
+  Id: 01HGW2Q8MNP3RSTVWXYZABCDEG
+`;
+  bumpMtime("/proj/req.md", updatedDoc, Date.now() + 1000);
+
+  const r2 = await proj.getCompiled();
+  assertEquals(r2.entries.size, 2);
+});
+
+Deno.test("getCompiled: recompiles when a new file appears", async () => {
+  const { env, bumpMtime } = makeEnv({
+    "/proj/project.yaml": { content: PROJECT_YAML, mtime: 1 },
+    "/proj/req.md": { content: REQ_DOC, mtime: 1 },
+  });
+  const proj = await createProject(env);
+  await proj.getCompiled();
+
+  bumpMtime(
+    "/proj/extra.md",
+    `- [STK_TEST_0002] Another
+
+  Body.
+
+  Id: 01HGW2Q8MNP3RSTVWXYZABCDEG
+`,
+    Date.now() + 1000,
+  );
+
+  const r2 = await proj.getCompiled();
+  assertEquals(r2.entries.size, 2);
+});
+
+Deno.test("forceRefresh: recompiles even with no changes", async () => {
+  const { env } = makeEnv({
+    "/proj/project.yaml": { content: PROJECT_YAML, mtime: 1 },
+    "/proj/req.md": { content: REQ_DOC, mtime: 1 },
+  });
+  const proj = await createProject(env);
+  const r1 = await proj.getCompiled();
+  const r2 = await proj.forceRefresh();
+  // Different object — recompile happened.
+  assertEquals(r1 !== r2, true);
+});
+
+Deno.test("subscribeInvalidation: fires handlers after recompile", async () => {
+  const { env, bumpMtime } = makeEnv({
+    "/proj/project.yaml": { content: PROJECT_YAML, mtime: 1 },
+    "/proj/req.md": { content: REQ_DOC, mtime: 1 },
+  });
+  const proj = await createProject(env);
+  await proj.getCompiled();
+
+  let fired = 0;
+  proj.subscribeInvalidation(() => {
+    fired++;
+  });
+
+  await proj.forceRefresh();
+  bumpMtime("/proj/req.md", REQ_DOC + "\n", Date.now() + 2000);
+  await proj.getCompiled();
+
+  assertEquals(fired, 2);
+});
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+Run: `deno test packages/markspec/mcp/project_test.ts`
+Expected: FAIL — module `./project.ts` not found.
+
+- [ ] **Step 3: Implement `mcp/project.ts`**
+
+Create `packages/markspec/mcp/project.ts`:
+
+```typescript
+/**
+ * @module mcp/project
+ *
+ * Project context for the MCP server. Discovers the project root from a
+ * starting CWD, loads the active profile, caches a `CompileResult`, and
+ * refreshes the cache when tracked files change (mtime check) or when a
+ * caller invokes `forceRefresh()`.
+ *
+ * All I/O is injected via {@linkcode ProjectEnv} so this module is testable
+ * without filesystem access.
+ */
+
+import {
+  compile,
+  type CompileResult,
+  discoverProjectRoot,
+  type EffectiveProfile,
+  loadConfig,
+  loadProfileForCommand,
+  type ProfileChain,
+  type ProjectConfig,
+  type ReadFile,
+} from "../core/mod.ts";
+
+/** Files MarkSpec parses: Markdown plus supported source extensions. */
+const TRACKED_EXTENSIONS = new Set([
+  ".md",
+  ".rs",
+  ".kt",
+  ".kts",
+  ".java",
+  ".c",
+  ".h",
+  ".cpp",
+  ".cc",
+  ".cxx",
+  ".hpp",
+  ".hxx",
+]);
+
+/** Directories never scanned for tracked files. */
+const SKIP_DIRS = new Set([
+  "node_modules",
+  ".git",
+  ".worktrees",
+  "target",
+  "dist",
+  "build",
+  ".claude",
+]);
+
+/** Filesystem + environment shim, injectable for tests. */
+export interface ProjectEnv {
+  cwd(): string;
+  readFile: ReadFile;
+  stat(path: string): Promise<{ mtime: number }>;
+  walk(root: string): AsyncIterable<string>;
+}
+
+/** Per-tracked-file mtime snapshot. */
+interface TrackedFile {
+  path: string;
+  mtime: number;
+}
+
+/** Handler signature for invalidation subscribers. */
+export type InvalidationHandler = (result: CompileResult) => void;
+
+/** Result of {@linkcode createProject}. */
+export interface Project {
+  readonly projectRoot: string | undefined;
+  readonly config: ProjectConfig | undefined;
+  readonly profileChain: ProfileChain | null;
+  readonly profile: EffectiveProfile | undefined;
+  getCompiled(): Promise<CompileResult>;
+  forceRefresh(): Promise<CompileResult>;
+  subscribeInvalidation(handler: InvalidationHandler): () => void;
+}
+
+/** Default {@linkcode ProjectEnv} using Deno APIs. Used in entry points only. */
+export function defaultEnv(): ProjectEnv {
+  return {
+    cwd: () => Deno.cwd(),
+    readFile: async (path) => {
+      try {
+        return await Deno.readTextFile(path);
+      } catch {
+        return undefined;
+      }
+    },
+    stat: async (path) => {
+      const stat = await Deno.stat(path);
+      return { mtime: stat.mtime?.getTime() ?? 0 };
+    },
+    walk: async function* (root) {
+      yield* walkFs(root);
+    },
+  };
+}
+
+async function* walkFs(dir: string): AsyncGenerator<string> {
+  try {
+    for await (const entry of Deno.readDir(dir)) {
+      const path = `${dir}/${entry.name}`;
+      if (entry.isDirectory) {
+        if (!SKIP_DIRS.has(entry.name) && !entry.name.startsWith(".")) {
+          yield* walkFs(path);
+        }
+      } else if (entry.isFile) {
+        yield path;
+      }
+    }
+  } catch {
+    // Skip unreadable directories.
+  }
+}
+
+/**
+ * Initialize a project context from the given environment. Performs
+ * project-root discovery, loads config + profile, and kicks off a
+ * background compile.
+ *
+ * Returns a {@linkcode Project} handle whose {@linkcode Project.getCompiled}
+ * method awaits the background compile on first call.
+ */
+export async function createProject(env: ProjectEnv): Promise<Project> {
+  const cwd = env.cwd();
+  const projectRoot = await discoverProjectRoot(cwd, env.readFile);
+
+  let config: ProjectConfig | undefined;
+  let profileChain: ProfileChain | null = null;
+
+  if (projectRoot) {
+    try {
+      const loaded = await loadConfig(projectRoot, env.readFile);
+      config = loaded?.config;
+    } catch { /* config errors surface on first compile */ }
+
+    try {
+      const result = await loadProfileForCommand(projectRoot, env.readFile);
+      profileChain = result.chain;
+    } catch { /* profile errors surface on first compile */ }
+  }
+
+  // Cache state.
+  let inFlight: Promise<CompileResult> | null = null;
+  let cached: CompileResult | null = null;
+  let compiledAt = 0;
+  let tracked: TrackedFile[] = [];
+  const handlers = new Set<InvalidationHandler>();
+
+  /** Discover all tracked file paths under `projectRoot`. */
+  async function discoverTracked(): Promise<string[]> {
+    if (!projectRoot) return [];
+    const out: string[] = [];
+    for await (const path of env.walk(projectRoot)) {
+      const dot = path.lastIndexOf(".");
+      if (dot < 0) continue;
+      const ext = path.slice(dot).toLowerCase();
+      if (TRACKED_EXTENSIONS.has(ext)) out.push(path);
+    }
+    out.sort();
+    return out;
+  }
+
+  /** Run compile() over current tracked set; update cache. */
+  async function runCompile(): Promise<CompileResult> {
+    const paths = await discoverTracked();
+    const result = await compile(paths, {
+      readFile: async (p) => {
+        const content = await env.readFile(p);
+        if (content === undefined) {
+          throw new Error(`failed to read ${p}`);
+        }
+        return content;
+      },
+      profile: profileChain?.effective ?? undefined,
+    });
+
+    // Snapshot mtimes for next invalidation check.
+    const snapshot: TrackedFile[] = [];
+    for (const path of paths) {
+      try {
+        const { mtime } = await env.stat(path);
+        snapshot.push({ path, mtime });
+      } catch {
+        // File disappeared during compile — ignore.
+      }
+    }
+    tracked = snapshot;
+    compiledAt = Date.now();
+    cached = result;
+    inFlight = null;
+    for (const h of handlers) h(result);
+    return result;
+  }
+
+  /** Detect any change in the tracked file set since the last compile. */
+  async function isStale(): Promise<boolean> {
+    if (!projectRoot) return false;
+    // 1) Any tracked file with newer mtime, or missing?
+    for (const t of tracked) {
+      try {
+        const { mtime } = await env.stat(t.path);
+        if (mtime !== t.mtime) return true;
+      } catch {
+        return true; // file disappeared
+      }
+    }
+    // 2) Any new tracked file?
+    const known = new Set(tracked.map((t) => t.path));
+    for await (const path of env.walk(projectRoot)) {
+      const dot = path.lastIndexOf(".");
+      if (dot < 0) continue;
+      const ext = path.slice(dot).toLowerCase();
+      if (!TRACKED_EXTENSIONS.has(ext)) continue;
+      if (!known.has(path)) return true;
+    }
+    return false;
+  }
+
+  // Kick off background compile so first tool call doesn't pay the cost.
+  if (projectRoot) {
+    inFlight = runCompile().catch(() => {
+      // Errors surface on the awaited call.
+      return null as unknown as CompileResult;
+    });
+  }
+
+  return {
+    projectRoot,
+    config,
+    profileChain,
+    profile: profileChain?.effective,
+    async getCompiled(): Promise<CompileResult> {
+      if (!projectRoot) {
+        throw new Error(
+          "MarkSpec MCP server: no project.yaml found. " +
+            "Operations require project context.",
+        );
+      }
+      if (inFlight) {
+        const result = await inFlight;
+        if (result) return result;
+      }
+      if (cached && !(await isStale())) return cached;
+      inFlight = runCompile();
+      return await inFlight;
+    },
+    async forceRefresh(): Promise<CompileResult> {
+      if (!projectRoot) {
+        throw new Error(
+          "MarkSpec MCP server: no project.yaml found. " +
+            "Operations require project context.",
+        );
+      }
+      inFlight = runCompile();
+      return await inFlight;
+    },
+    subscribeInvalidation(handler: InvalidationHandler): () => void {
+      handlers.add(handler);
+      return () => handlers.delete(handler);
+    },
+  };
+}
+```
+
+- [ ] **Step 4: Run tests to confirm they pass**
+
+Run: `deno test packages/markspec/mcp/project_test.ts`
+Expected: PASS (7 tests, 0 failures).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/markspec/mcp/project.ts packages/markspec/mcp/project_test.ts
+git commit -m "feat(mcp): add project context with compile cache and mtime invalidation"
+```
+
+---
+
+## Task 3: Profile resource renderer
+
+**Files:**
+
+- Create: `packages/markspec/mcp/resources/profile.ts`
+- Create: `packages/markspec/mcp/resources/profile_test.ts`
+
+- [ ] **Step 1: Write failing tests for the profile renderer**
+
+Create `packages/markspec/mcp/resources/profile_test.ts`:
+
+```typescript
+/**
+ * @module mcp/resources/profile_test
+ *
+ * Unit tests for the markspec://profile Markdown renderer.
+ */
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { renderProfile } from "./profile.ts";
+
+Deno.test("renderProfile: 'no profile configured' when chain is null", () => {
+  const md = renderProfile(null);
+  assertStringIncludes(md, "# MarkSpec Profile");
+  assertStringIncludes(md, "No profile configured");
+});
+
+Deno.test("renderProfile: includes active profile id and version", () => {
+  const md = renderProfile({
+    tiers: [
+      {
+        id: "@org/aspice-swe-mini",
+        version: "1.0.0",
+        description: "ASPICE software-engineering subset profile.",
+      },
+      {
+        id: "@driftsys/markspec-default",
+        version: "0.3.0",
+        description: "Default RFC 2119 baseline profile.",
+      },
+    ],
+    types: [
+      {
+        name: "stakeholder-requirement",
+        shape: "identified",
+        displayIdPattern: "STK_{DOMAIN}_{NNNN}",
+        color: "blue",
+        requiredAttributes: ["Id"],
+        allowedAttributes: ["Satisfies", "Labels"],
+        outgoingLinks: ["satisfies"],
+        incomingLinks: ["verified-by"],
+        description: "Stakeholder need or expectation.",
+      },
+    ],
+    universalRequired: ["Id"],
+    universalAllowed: ["Labels"],
+    linkKinds: ["satisfies", "derived-from", "verified-by"],
+    labels: ["ASIL-A", "ASIL-B"],
+  });
+
+  assertStringIncludes(md, "**Active**: @org/aspice-swe-mini@1.0.0");
+  assertStringIncludes(md, "**Inherits**: @driftsys/markspec-default@0.3.0");
+  assertStringIncludes(md, "ASPICE software-engineering subset profile.");
+  assertStringIncludes(md, "### stakeholder-requirement");
+  assertStringIncludes(md, "STK_{DOMAIN}_{NNNN}");
+  assertStringIncludes(md, "ASIL-A, ASIL-B");
+  assertStringIncludes(md, "| satisfies");
+});
+
+Deno.test("renderProfile: omits sections that are empty", () => {
+  const md = renderProfile({
+    tiers: [{ id: "@org/x", version: "1.0.0", description: "" }],
+    types: [],
+    universalRequired: [],
+    universalAllowed: [],
+    linkKinds: [],
+    labels: [],
+  });
+  assertEquals(md.includes("## Entry types"), false);
+  assertEquals(md.includes("## Labels"), false);
+  assertEquals(md.includes("## Link kinds"), false);
+  assertEquals(md.includes("## Universal attributes"), false);
+});
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+Run: `deno test packages/markspec/mcp/resources/profile_test.ts`
+Expected: FAIL — module `./profile.ts` not found.
+
+- [ ] **Step 3: Implement the renderer with a typed view input**
+
+Create `packages/markspec/mcp/resources/profile.ts`:
+
+```typescript
+/**
+ * @module mcp/resources/profile
+ *
+ * Renders the `markspec://profile` resource — a Markdown distillation of
+ * the active profile chain. The renderer takes a typed view (see
+ * {@linkcode ProfileView}) rather than the raw `EffectiveProfile` so it
+ * stays decoupled from internal core types.
+ *
+ * The {@linkcode buildProfileView} helper produces a `ProfileView` from a
+ * `ProfileChain | null`.
+ */
+
+import type {
+  EffectiveProfile,
+  EffectiveTypeDef,
+  ProfileChain,
+} from "../../core/mod.ts";
+
+/** Per-type distillation. */
+export interface ProfileTypeView {
+  readonly name: string;
+  readonly shape: string;
+  readonly displayIdPattern: string | undefined;
+  readonly color: string | undefined;
+  readonly requiredAttributes: readonly string[];
+  readonly allowedAttributes: readonly string[];
+  readonly outgoingLinks: readonly string[];
+  readonly incomingLinks: readonly string[];
+  readonly description: string;
+}
+
+/** Per-tier descriptor. */
+export interface ProfileTierView {
+  readonly id: string;
+  readonly version: string;
+  readonly description: string;
+}
+
+/** Renderer input — typed view of the profile chain. */
+export interface ProfileView {
+  readonly tiers: readonly ProfileTierView[];
+  readonly types: readonly ProfileTypeView[];
+  readonly universalRequired: readonly string[];
+  readonly universalAllowed: readonly string[];
+  readonly linkKinds: readonly string[];
+  readonly labels: readonly string[];
+}
+
+/** Build a {@linkcode ProfileView} from a {@linkcode ProfileChain}. */
+export function buildProfileView(chain: ProfileChain | null): ProfileView | null {
+  if (!chain) return null;
+  const eff: EffectiveProfile = chain.effective;
+
+  const tiers: ProfileTierView[] = chain.tiers.map((t) => ({
+    id: t.id,
+    version: t.version,
+    description: t.manifest.description ?? "",
+  }));
+
+  const universalRequired = [...eff.required.value];
+  const universalAllowed = [...eff.attributes.keys()];
+
+  const types: ProfileTypeView[] = [];
+  for (const [name, entry] of eff.types) {
+    const tdef: EffectiveTypeDef = entry.value;
+    const shape = tdef.shape;
+    const shapeScope = shape === "identified" ? eff.identified : eff.referenced;
+
+    const allowed = new Set<string>([
+      ...tdef.attributes.keys(),
+      ...shapeScope.attributes.keys(),
+      ...eff.attributes.keys(),
+    ]);
+    const required = new Set<string>([
+      ...tdef.required.value,
+      ...shapeScope.required.value,
+      ...eff.required.value,
+    ]);
+    for (const r of required) allowed.delete(r);
+
+    const outgoing = new Set<string>(tdef.traceability.keys());
+    // Incoming links: walk every other type's traceability and pick rules
+    // whose target list contains this type's name as a string matcher.
+    const incoming = new Set<string>();
+    for (const [otherName, otherEntry] of eff.types) {
+      if (otherName === name) continue;
+      for (const [linkKind, rule] of otherEntry.value.traceability) {
+        if (targetIncludesType(rule.value.target, name)) {
+          incoming.add(linkKind);
+        }
+      }
+    }
+
+    types.push({
+      name,
+      shape,
+      displayIdPattern: tdef.displayIdPattern.value,
+      color: tdef.color.value,
+      requiredAttributes: [...required],
+      allowedAttributes: [...allowed],
+      outgoingLinks: [...outgoing],
+      incomingLinks: [...incoming],
+      description: "",
+    });
+  }
+  types.sort((a, b) => a.name.localeCompare(b.name));
+
+  const linkKinds = new Set<string>();
+  for (const [, entry] of eff.types) {
+    for (const k of entry.value.traceability.keys()) linkKinds.add(k);
+  }
+
+  return {
+    tiers,
+    types,
+    universalRequired,
+    universalAllowed,
+    linkKinds: [...linkKinds].sort(),
+    labels: [...eff.labels.value],
+  };
+}
+
+/** Render the profile view to Markdown. */
+export function renderProfile(view: ProfileView | null): string {
+  const lines: string[] = ["# MarkSpec Profile", ""];
+
+  if (!view || view.tiers.length === 0) {
+    lines.push("No profile configured for this project.");
+    return lines.join("\n") + "\n";
+  }
+
+  const active = view.tiers[0];
+  lines.push(`**Active**: ${active.id}@${active.version}`);
+  if (view.tiers.length > 1) {
+    const inherits = view.tiers
+      .slice(1)
+      .map((t) => `${t.id}@${t.version}`)
+      .join(", ");
+    lines.push(`**Inherits**: ${inherits}`);
+  }
+  if (active.description) {
+    lines.push("");
+    lines.push(active.description);
+  }
+
+  if (view.types.length > 0) {
+    lines.push("", "## Entry types", "");
+    for (const t of view.types) {
+      lines.push(`### ${t.name}`, "");
+      if (t.displayIdPattern) {
+        lines.push(`- **Display-ID pattern**: \`${t.displayIdPattern}\``);
+      }
+      lines.push(`- **Shape**: ${t.shape}`);
+      if (t.color) lines.push(`- **Color**: ${t.color}`);
+      if (t.requiredAttributes.length > 0) {
+        lines.push(
+          `- **Required attributes**: ${t.requiredAttributes.join(", ")}`,
+        );
+      }
+      if (t.allowedAttributes.length > 0) {
+        lines.push(
+          `- **Allowed attributes**: ${t.allowedAttributes.join(", ")}`,
+        );
+      }
+      if (t.outgoingLinks.length > 0) {
+        lines.push(`- **Outgoing links**: ${t.outgoingLinks.join(", ")}`);
+      }
+      if (t.incomingLinks.length > 0) {
+        lines.push(`- **Incoming links**: ${t.incomingLinks.join(", ")}`);
+      }
+      if (t.description) {
+        lines.push("", t.description);
+      }
+      lines.push("");
+    }
+  }
+
+  if (view.universalRequired.length > 0 || view.universalAllowed.length > 0) {
+    lines.push("## Universal attributes", "");
+    if (view.universalRequired.length > 0) {
+      lines.push(`- **Required**: ${view.universalRequired.join(", ")}`);
+    }
+    if (view.universalAllowed.length > 0) {
+      lines.push(`- **Allowed**: ${view.universalAllowed.join(", ")}`);
+    }
+    lines.push("");
+  }
+
+  if (view.linkKinds.length > 0) {
+    lines.push("## Link kinds", "");
+    lines.push("| Kind | Used by |");
+    lines.push("| --- | --- |");
+    for (const kind of view.linkKinds) {
+      const sources = view.types
+        .filter((t) => t.outgoingLinks.includes(kind))
+        .map((t) => t.name);
+      lines.push(`| ${kind} | ${sources.join(", ") || "—"} |`);
+    }
+    lines.push("");
+  }
+
+  if (view.labels.length > 0) {
+    lines.push("## Labels", "");
+    lines.push(view.labels.join(", "));
+    lines.push("");
+  }
+
+  return lines.join("\n");
+}
+
+/**
+ * Whether a {@linkcode TraceRule}'s target list contains a string matcher
+ * equal to the given type name. Shape-based matchers (`{ shape: ... }`)
+ * are skipped — they don't pin a single named type.
+ */
+function targetIncludesType(
+  target: readonly (string | { readonly shape: string })[],
+  typeName: string,
+): boolean {
+  for (const matcher of target) {
+    if (typeof matcher === "string" && matcher === typeName) return true;
+  }
+  return false;
+}
+```
+
+- [ ] **Step 4: Run tests to confirm they pass**
+
+Run: `deno test packages/markspec/mcp/resources/profile_test.ts`
+Expected: PASS (3 tests, 0 failures).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/markspec/mcp/resources/profile.ts packages/markspec/mcp/resources/profile_test.ts
+git commit -m "feat(mcp): render markspec://profile as Markdown distillation"
+```
+
+---
+
+## Task 4: Entry resource renderer
+
+**Files:**
+
+- Create: `packages/markspec/mcp/resources/entry.ts`
+- Create: `packages/markspec/mcp/resources/entry_test.ts`
+
+- [ ] **Step 1: Write failing tests for the entry renderer**
+
+Create `packages/markspec/mcp/resources/entry_test.ts`:
+
+```typescript
+/**
+ * @module mcp/resources/entry_test
+ *
+ * Unit tests for the markspec://entry/{id} Markdown renderer.
+ */
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import type { Entry, Link } from "../../core/mod.ts";
+import { renderEntry } from "./entry.ts";
+
+const ENTRY: Entry = {
+  displayId: "STK_AEB_0001",
+  title: "Stop on imminent collision",
+  body:
+    "When the system detects an imminent collision with a stationary object,\nit shall command emergency braking.",
+  rawAttributes: [
+    { key: "Id", value: "01HGW2Q8MNP3RSTVWXYZABCDEF" },
+    { key: "Labels", value: "ASIL-B" },
+  ],
+  typedAttributes: new Map(),
+  id: "01HGW2Q8MNP3RSTVWXYZABCDEF",
+  type: "stakeholder-requirement",
+  shape: "identified",
+  location: {
+    file: "/proj/docs/product/stakeholder-requirements.md",
+    line: 42,
+    column: 1,
+  },
+  source: "markdown",
+};
+
+const FORWARD: Link[] = [
+  {
+    from: "STK_AEB_0001",
+    to: "SYS_AEB_0012",
+    kind: "satisfies",
+    location: {
+      file: "/proj/docs/product/stakeholder-requirements.md",
+      line: 47,
+      column: 1,
+    },
+  },
+];
+
+const REVERSE: Link[] = [
+  {
+    from: "VAL_AEB_0001",
+    to: "STK_AEB_0001",
+    kind: "verified-by",
+    location: { file: "/proj/tests/val_aeb.rs", line: 12, column: 1 },
+  },
+];
+
+const TITLES = new Map<string, string>([
+  ["SYS_AEB_0012", "Object threat assessment"],
+  ["VAL_AEB_0001", "Vehicle stops before collision"],
+]);
+
+Deno.test("renderEntry: includes title and type", () => {
+  const md = renderEntry(ENTRY, [], [], TITLES);
+  assertStringIncludes(md, "# STK_AEB_0001 — Stop on imminent collision");
+  assertStringIncludes(md, "**Type**: stakeholder-requirement");
+  assertStringIncludes(md, "**Shape**: identified");
+});
+
+Deno.test("renderEntry: includes ULID and location", () => {
+  const md = renderEntry(ENTRY, [], [], TITLES);
+  assertStringIncludes(md, "**Id**: `01HGW2Q8MNP3RSTVWXYZABCDEF`");
+  assertStringIncludes(md, "stakeholder-requirements.md:42");
+});
+
+Deno.test("renderEntry: includes body paragraph", () => {
+  const md = renderEntry(ENTRY, [], [], TITLES);
+  assertStringIncludes(md, "When the system detects an imminent collision");
+});
+
+Deno.test("renderEntry: includes non-Id attributes", () => {
+  const md = renderEntry(ENTRY, [], [], TITLES);
+  assertStringIncludes(md, "## Attributes");
+  assertStringIncludes(md, "- **Labels**: ASIL-B");
+});
+
+Deno.test("renderEntry: includes outgoing links with target titles", () => {
+  const md = renderEntry(ENTRY, FORWARD, [], TITLES);
+  assertStringIncludes(md, "## Outgoing links");
+  assertStringIncludes(
+    md,
+    "**satisfies** → [SYS_AEB_0012](markspec://entry/SYS_AEB_0012) — Object threat assessment",
+  );
+});
+
+Deno.test("renderEntry: includes incoming links with source titles", () => {
+  const md = renderEntry(ENTRY, [], REVERSE, TITLES);
+  assertStringIncludes(md, "## Incoming links");
+  assertStringIncludes(
+    md,
+    "**verified-by** ← [VAL_AEB_0001](markspec://entry/VAL_AEB_0001) — Vehicle stops before collision",
+  );
+});
+
+Deno.test("renderEntry: omits Outgoing/Incoming sections when empty", () => {
+  const md = renderEntry(ENTRY, [], [], TITLES);
+  assertEquals(md.includes("## Outgoing links"), false);
+  assertEquals(md.includes("## Incoming links"), false);
+});
+
+Deno.test("renderEntry: omits Attributes section when only Id present", () => {
+  const idOnly: Entry = {
+    ...ENTRY,
+    rawAttributes: [{ key: "Id", value: "01HGW2Q8MNP3RSTVWXYZABCDEF" }],
+  };
+  const md = renderEntry(idOnly, [], [], TITLES);
+  assertEquals(md.includes("## Attributes"), false);
+});
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+Run: `deno test packages/markspec/mcp/resources/entry_test.ts`
+Expected: FAIL — module `./entry.ts` not found.
+
+- [ ] **Step 3: Implement the renderer**
+
+Create `packages/markspec/mcp/resources/entry.ts`:
+
+```typescript
+/**
+ * @module mcp/resources/entry
+ *
+ * Renders the `markspec://entry/{displayId}` resource. Output is Markdown:
+ * title, metadata (type, shape, id, location), body, attributes table,
+ * outgoing links, incoming links.
+ *
+ * `titles` is a lookup from display ID to entry title, used to render
+ * `markspec://entry/...` cross-reference labels.
+ */
+
+import type { Entry, Link } from "../../core/mod.ts";
+import { entryUri } from "../uri.ts";
+
+/** Render one entry to Markdown. */
+export function renderEntry(
+  entry: Entry,
+  forwardLinks: readonly Link[],
+  reverseLinks: readonly Link[],
+  titles: ReadonlyMap<string, string>,
+): string {
+  const lines: string[] = [];
+
+  lines.push(`# ${entry.displayId} — ${entry.title}`, "");
+
+  if (entry.type) lines.push(`**Type**: ${entry.type}`);
+  lines.push(`**Shape**: ${entry.shape}`);
+  if (entry.id) lines.push(`**Id**: \`${entry.id}\``);
+  lines.push(
+    `**Location**: ${entry.location.file}:${entry.location.line}`,
+  );
+  lines.push("");
+
+  if (entry.body.trim().length > 0) {
+    lines.push(entry.body.trimEnd(), "");
+  }
+
+  const nonIdAttrs = entry.rawAttributes.filter(
+    (a) => a.key.toLowerCase() !== "id",
+  );
+  if (nonIdAttrs.length > 0) {
+    lines.push("## Attributes", "");
+    for (const a of nonIdAttrs) {
+      lines.push(`- **${a.key}**: ${a.value}`);
+    }
+    lines.push("");
+  }
+
+  if (forwardLinks.length > 0) {
+    lines.push("## Outgoing links", "");
+    for (const link of forwardLinks) {
+      const title = titles.get(link.to);
+      const titlePart = title ? ` — ${title}` : "";
+      lines.push(
+        `- **${link.kind}** → [${link.to}](${entryUri(link.to)})${titlePart}`,
+      );
+    }
+    lines.push("");
+  }
+
+  if (reverseLinks.length > 0) {
+    lines.push("## Incoming links", "");
+    for (const link of reverseLinks) {
+      const title = titles.get(link.from);
+      const titlePart = title ? ` — ${title}` : "";
+      lines.push(
+        `- **${link.kind}** ← [${link.from}](${entryUri(link.from)})${titlePart}`,
+      );
+    }
+    lines.push("");
+  }
+
+  return lines.join("\n").replace(/\n{3,}/g, "\n\n");
+}
+```
+
+- [ ] **Step 4: Run tests to confirm they pass**
+
+Run: `deno test packages/markspec/mcp/resources/entry_test.ts`
+Expected: PASS (8 tests, 0 failures).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/markspec/mcp/resources/entry.ts packages/markspec/mcp/resources/entry_test.ts
+git commit -m "feat(mcp): render markspec://entry/{id} as Markdown"
+```
+
+---
+
+## Task 5: Entries-index resource renderer
+
+**Files:**
+
+- Create: `packages/markspec/mcp/resources/entries.ts`
+- Create: `packages/markspec/mcp/resources/entries_test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `packages/markspec/mcp/resources/entries_test.ts`:
+
+```typescript
+/**
+ * @module mcp/resources/entries_test
+ *
+ * Unit tests for the markspec://entries index renderer.
+ */
+
+import { assertStringIncludes } from "@std/assert";
+import type { Entry } from "../../core/mod.ts";
+import { renderEntriesIndex } from "./entries.ts";
+
+function mkEntry(displayId: string, title: string, type?: string): Entry {
+  return {
+    displayId,
+    title,
+    body: "",
+    rawAttributes: [],
+    typedAttributes: new Map(),
+    type,
+    shape: "identified",
+    location: { file: "/proj/x.md", line: 1, column: 1 },
+    source: "markdown",
+  };
+}
+
+Deno.test("renderEntriesIndex: groups by type, sorted alphabetically", () => {
+  const md = renderEntriesIndex([
+    mkEntry("STK_AEB_0001", "Stop on collision", "stakeholder-requirement"),
+    mkEntry("SRS_AEB_0010", "Sensor debouncing", "software-requirement"),
+    mkEntry("STK_AEB_0002", "Driver override", "stakeholder-requirement"),
+  ]);
+  assertStringIncludes(md, "# Entries (3)");
+  assertStringIncludes(md, "## software-requirement (1)");
+  assertStringIncludes(md, "## stakeholder-requirement (2)");
+});
+
+Deno.test("renderEntriesIndex: renders entries as Markdown links", () => {
+  const md = renderEntriesIndex([
+    mkEntry("STK_AEB_0001", "Stop on collision", "stakeholder-requirement"),
+  ]);
+  assertStringIncludes(
+    md,
+    "- [STK_AEB_0001](markspec://entry/STK_AEB_0001) — Stop on collision",
+  );
+});
+
+Deno.test("renderEntriesIndex: groups untyped entries under 'untyped'", () => {
+  const md = renderEntriesIndex([
+    mkEntry("FREEFORM_0001", "Untyped entry"),
+  ]);
+  assertStringIncludes(md, "## untyped (1)");
+});
+
+Deno.test("renderEntriesIndex: empty corpus", () => {
+  const md = renderEntriesIndex([]);
+  assertStringIncludes(md, "# Entries (0)");
+  assertStringIncludes(md, "No entries in this project");
+});
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+Run: `deno test packages/markspec/mcp/resources/entries_test.ts`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement the renderer**
+
+Create `packages/markspec/mcp/resources/entries.ts`:
+
+```typescript
+/**
+ * @module mcp/resources/entries
+ *
+ * Renders the `markspec://entries` index — an alphabetical-by-type listing
+ * of every entry in the project, each as a Markdown link to its own entry
+ * resource URI.
+ */
+
+import type { Entry } from "../../core/mod.ts";
+import { entryUri } from "../uri.ts";
+
+/** Render the entries index to Markdown. */
+export function renderEntriesIndex(entries: readonly Entry[]): string {
+  const lines: string[] = [`# Entries (${entries.length})`, ""];
+
+  if (entries.length === 0) {
+    lines.push("No entries in this project.");
+    return lines.join("\n") + "\n";
+  }
+
+  // Group by type (or "untyped").
+  const byType = new Map<string, Entry[]>();
+  for (const entry of entries) {
+    const t = entry.type ?? "untyped";
+    const list = byType.get(t);
+    if (list) list.push(entry);
+    else byType.set(t, [entry]);
+  }
+
+  const types = [...byType.keys()].sort();
+  for (const type of types) {
+    const list = byType.get(type)!;
+    list.sort((a, b) => a.displayId.localeCompare(b.displayId));
+    lines.push(`## ${type} (${list.length})`, "");
+    for (const e of list) {
+      lines.push(
+        `- [${e.displayId}](${entryUri(e.displayId)}) — ${e.title}`,
+      );
+    }
+    lines.push("");
+  }
+
+  return lines.join("\n");
+}
+```
+
+- [ ] **Step 4: Run tests to confirm they pass**
+
+Run: `deno test packages/markspec/mcp/resources/entries_test.ts`
+Expected: PASS (4 tests, 0 failures).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/markspec/mcp/resources/entries.ts packages/markspec/mcp/resources/entries_test.ts
+git commit -m "feat(mcp): render markspec://entries index as Markdown"
+```
+
+---
+
+## Task 6: Resources registration
+
+**Files:**
+
+- Create: `packages/markspec/mcp/resources/mod.ts`
+
+This module wires the SDK's `resources/list` and `resources/read` handlers to
+the three renderers. It also exposes a `listResourceDescriptors()` helper so
+the e2e test can verify advertised resources without invoking the SDK.
+
+- [ ] **Step 1: Implement the registration module**
+
+Create `packages/markspec/mcp/resources/mod.ts`:
+
+```typescript
+/**
+ * @module mcp/resources/mod
+ *
+ * Wires MCP resource handlers. Exposes:
+ *
+ * - {@linkcode listResourceDescriptors} — pure function returning the
+ *   resources/list payload for unit-test verification.
+ * - {@linkcode readResource} — pure function returning the resources/read
+ *   payload for a given URI.
+ * - {@linkcode registerResources} — attaches both handlers to a Server
+ *   instance.
+ */
+
+import type { Server } from "npm:@modelcontextprotocol/sdk/server/index.js";
+import {
+  ListResourcesRequestSchema,
+  ReadResourceRequestSchema,
+} from "npm:@modelcontextprotocol/sdk/types.js";
+import type { Project } from "../project.ts";
+import {
+  ENTRIES_URI,
+  entryUri,
+  isEntryUri,
+  parseEntryUri,
+  PROFILE_URI,
+} from "../uri.ts";
+import { buildProfileView, renderProfile } from "./profile.ts";
+import { renderEntriesIndex } from "./entries.ts";
+import { renderEntry } from "./entry.ts";
+
+/** A resource descriptor as returned by resources/list. */
+export interface ResourceDescriptor {
+  readonly uri: string;
+  readonly name: string;
+  readonly description: string;
+  readonly mimeType: string;
+}
+
+/** Build the resources/list payload from a compiled project. */
+export async function listResourceDescriptors(
+  project: Project,
+): Promise<ResourceDescriptor[]> {
+  const result = await project.getCompiled();
+  const out: ResourceDescriptor[] = [
+    {
+      uri: PROFILE_URI,
+      name: "Active profile",
+      description: "Distilled profile manifest for this project",
+      mimeType: "text/markdown",
+    },
+    {
+      uri: ENTRIES_URI,
+      name: "Entry index",
+      description: "All entries grouped by type",
+      mimeType: "text/markdown",
+    },
+  ];
+  const ids = [...result.entries.keys()].sort();
+  for (const id of ids) {
+    const entry = result.entries.get(id)!;
+    out.push({
+      uri: entryUri(id),
+      name: id,
+      description: entry.title,
+      mimeType: "text/markdown",
+    });
+  }
+  return out;
+}
+
+/** Result of reading a resource. */
+export interface ReadResourceResult {
+  readonly uri: string;
+  readonly mimeType: string;
+  readonly text: string;
+}
+
+/** Read a single resource by URI. Throws on unrecognized URIs. */
+export async function readResource(
+  uri: string,
+  project: Project,
+): Promise<ReadResourceResult> {
+  if (uri === PROFILE_URI) {
+    const view = buildProfileView(project.profileChain);
+    return {
+      uri,
+      mimeType: "text/markdown",
+      text: renderProfile(view),
+    };
+  }
+
+  if (uri === ENTRIES_URI) {
+    const result = await project.getCompiled();
+    return {
+      uri,
+      mimeType: "text/markdown",
+      text: renderEntriesIndex([...result.entries.values()]),
+    };
+  }
+
+  if (isEntryUri(uri)) {
+    const displayId = parseEntryUri(uri)!;
+    const result = await project.getCompiled();
+    const entry = result.entries.get(displayId);
+    if (!entry) {
+      throw new Error(`entry not found: ${displayId}`);
+    }
+    const titles = new Map<string, string>();
+    for (const [id, e] of result.entries) titles.set(id, e.title);
+    return {
+      uri,
+      mimeType: "text/markdown",
+      text: renderEntry(
+        entry,
+        result.forward.get(displayId) ?? [],
+        result.reverse.get(displayId) ?? [],
+        titles,
+      ),
+    };
+  }
+
+  throw new Error(`unknown resource URI: ${uri}`);
+}
+
+/** Attach resources/list and resources/read handlers to a Server. */
+export function registerResources(server: Server, project: Project): void {
+  server.setRequestHandler(ListResourcesRequestSchema, async () => ({
+    resources: await listResourceDescriptors(project),
+  }));
+
+  server.setRequestHandler(ReadResourceRequestSchema, async (req) => {
+    const uri = req.params.uri;
+    const result = await readResource(uri, project);
+    return {
+      contents: [
+        {
+          uri: result.uri,
+          mimeType: result.mimeType,
+          text: result.text,
+        },
+      ],
+    };
+  });
+}
+```
+
+- [ ] **Step 2: Add a unit test for `listResourceDescriptors` and `readResource`**
+
+Create `packages/markspec/mcp/resources/mod_test.ts`:
+
+```typescript
+/**
+ * @module mcp/resources/mod_test
+ *
+ * Unit tests for the resources/list and resources/read dispatch.
+ *
+ * Builds a minimal Project shim and asserts the descriptor list and the
+ * routing logic in readResource.
+ */
+
+import { assertEquals, assertRejects, assertStringIncludes } from "@std/assert";
+import type { CompileResult, Entry, ProfileChain } from "../../core/mod.ts";
+import type { Project } from "../project.ts";
+import { listResourceDescriptors, readResource } from "./mod.ts";
+
+function mkProject(entries: Entry[]): Project {
+  const entriesMap = new Map<string, Entry>();
+  for (const e of entries) entriesMap.set(e.displayId, e);
+  const result: CompileResult = {
+    entries: entriesMap,
+    links: [],
+    forward: new Map(),
+    reverse: new Map(),
+    documents: new Map(),
+    diagnostics: [],
+  };
+  const chain: ProfileChain | null = null;
+  return {
+    projectRoot: "/proj",
+    config: undefined,
+    profileChain: chain,
+    profile: undefined,
+    getCompiled: async () => result,
+    forceRefresh: async () => result,
+    subscribeInvalidation: () => () => {},
+  };
+}
+
+const E1: Entry = {
+  displayId: "STK_TEST_0001",
+  title: "First entry",
+  body: "",
+  rawAttributes: [],
+  typedAttributes: new Map(),
+  shape: "identified",
+  location: { file: "/proj/x.md", line: 1, column: 1 },
+  source: "markdown",
+};
+
+Deno.test("listResourceDescriptors: includes profile + entries + per-entry", async () => {
+  const project = mkProject([E1]);
+  const list = await listResourceDescriptors(project);
+  assertEquals(list.length, 3);
+  assertEquals(list[0].uri, "markspec://profile");
+  assertEquals(list[1].uri, "markspec://entries");
+  assertEquals(list[2].uri, "markspec://entry/STK_TEST_0001");
+});
+
+Deno.test("readResource: routes profile URI", async () => {
+  const project = mkProject([E1]);
+  const r = await readResource("markspec://profile", project);
+  assertStringIncludes(r.text, "# MarkSpec Profile");
+});
+
+Deno.test("readResource: routes entries URI", async () => {
+  const project = mkProject([E1]);
+  const r = await readResource("markspec://entries", project);
+  assertStringIncludes(r.text, "# Entries (1)");
+});
+
+Deno.test("readResource: routes entry URI", async () => {
+  const project = mkProject([E1]);
+  const r = await readResource(
+    "markspec://entry/STK_TEST_0001",
+    project,
+  );
+  assertStringIncludes(r.text, "# STK_TEST_0001 — First entry");
+});
+
+Deno.test("readResource: rejects unknown URI", async () => {
+  const project = mkProject([E1]);
+  await assertRejects(
+    () => readResource("markspec://unknown", project),
+    Error,
+    "unknown resource URI",
+  );
+});
+
+Deno.test("readResource: rejects missing entry", async () => {
+  const project = mkProject([E1]);
+  await assertRejects(
+    () => readResource("markspec://entry/NOPE_0001", project),
+    Error,
+    "entry not found",
+  );
+});
+```
+
+- [ ] **Step 3: Run tests to confirm they pass**
+
+Run: `deno test packages/markspec/mcp/resources/`
+Expected: PASS (all resource tests).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/markspec/mcp/resources/mod.ts packages/markspec/mcp/resources/mod_test.ts
+git commit -m "feat(mcp): register resources/list and resources/read handlers"
+```
+
+---
+
+## Task 7: `entry_search` tool
+
+**Files:**
+
+- Create: `packages/markspec/mcp/tools/search.ts`
+- Create: `packages/markspec/mcp/tools/search_test.ts`
+
+- [ ] **Step 1: Write failing tests for ranking and rendering**
+
+Create `packages/markspec/mcp/tools/search_test.ts`:
+
+```typescript
+/**
+ * @module mcp/tools/search_test
+ *
+ * Unit tests for the entry_search ranking algorithm and Markdown render.
+ */
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import type { Entry } from "../../core/mod.ts";
+import { renderSearchResults, scoreEntries } from "./search.ts";
+
+function mk(displayId: string, title: string): Entry {
+  return {
+    displayId,
+    title,
+    body: "",
+    rawAttributes: [],
+    typedAttributes: new Map(),
+    shape: "identified",
+    location: { file: "/proj/x.md", line: 1, column: 1 },
+    source: "markdown",
+  };
+}
+
+Deno.test("scoreEntries: prefix match on displayId scores highest", () => {
+  const hits = scoreEntries(
+    [mk("STK_AEB_0001", "Brake"), mk("XYZ_AEB_0001", "Braking sensor")],
+    "stk_aeb",
+    10,
+  );
+  assertEquals(hits[0].entry.displayId, "STK_AEB_0001");
+});
+
+Deno.test("scoreEntries: substring match on displayId beats title", () => {
+  const hits = scoreEntries(
+    [mk("FOO_BAR_0001", "Unrelated"), mk("XXX_AEB_0001", "Aeb in title")],
+    "aeb",
+    10,
+  );
+  assertEquals(hits[0].entry.displayId, "XXX_AEB_0001");
+});
+
+Deno.test("scoreEntries: token coverage in title scores", () => {
+  const hits = scoreEntries(
+    [
+      mk("X_0001", "Apply continuous braking force"),
+      mk("X_0002", "Sensor debouncing"),
+    ],
+    "braking",
+    10,
+  );
+  assertEquals(hits[0].entry.displayId, "X_0001");
+});
+
+Deno.test("scoreEntries: drops zero-score entries", () => {
+  const hits = scoreEntries(
+    [mk("X_0001", "Sensor debouncing"), mk("X_0002", "Braking force")],
+    "braking",
+    10,
+  );
+  assertEquals(hits.length, 1);
+  assertEquals(hits[0].entry.displayId, "X_0002");
+});
+
+Deno.test("scoreEntries: respects limit", () => {
+  const entries = Array.from({ length: 30 }, (_, i) =>
+    mk(`X_${String(i).padStart(4, "0")}`, `Braking ${i}`),
+  );
+  const hits = scoreEntries(entries, "braking", 5);
+  assertEquals(hits.length, 5);
+});
+
+Deno.test("renderSearchResults: empty hits message", () => {
+  const md = renderSearchResults([], "nope");
+  assertStringIncludes(md, "No matches for");
+});
+
+Deno.test("renderSearchResults: links each hit", () => {
+  const md = renderSearchResults(
+    [
+      { entry: mk("STK_AEB_0001", "Stop on collision"), score: 11 },
+      { entry: mk("VAL_AEB_0001", "Vehicle stops"), score: 6 },
+    ],
+    "braking",
+  );
+  assertStringIncludes(
+    md,
+    "[STK_AEB_0001](markspec://entry/STK_AEB_0001) — Stop on collision",
+  );
+  assertStringIncludes(md, "score 11");
+});
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+Run: `deno test packages/markspec/mcp/tools/search_test.ts`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement the tool**
+
+Create `packages/markspec/mcp/tools/search.ts`:
+
+```typescript
+/**
+ * @module mcp/tools/search
+ *
+ * `entry_search` MCP tool.
+ *
+ * Inputs: `{ query: string, limit?: number }`.
+ * Output: Markdown list of ranked matches over display IDs and titles.
+ *
+ * Ranking rules:
+ *   +10 query is prefix of displayId
+ *   +5  query is substring of displayId
+ *   +3  per query-token exact-matching a title-token
+ *   +1  per query-token substring-matching a title-token
+ *   +2  all query-tokens appear in title (any order)
+ */
+
+import type { Entry } from "../../core/mod.ts";
+import { entryUri } from "../uri.ts";
+
+/** A ranked search result. */
+export interface ScoredEntry {
+  readonly entry: Entry;
+  readonly score: number;
+}
+
+const TOKEN_RE = /[\s_]+/g;
+
+/** Score a list of entries against a query; return top-N hits with score > 0. */
+export function scoreEntries(
+  entries: readonly Entry[],
+  query: string,
+  limit: number,
+): ScoredEntry[] {
+  const q = query.toLowerCase();
+  const qTokens = q.split(TOKEN_RE).filter(Boolean);
+
+  const hits: ScoredEntry[] = [];
+  for (const entry of entries) {
+    const id = entry.displayId.toLowerCase();
+    const title = entry.title.toLowerCase();
+    const titleTokens = title.split(TOKEN_RE).filter(Boolean);
+
+    let score = 0;
+    if (id.startsWith(q)) score += 10;
+    if (id.includes(q) && !id.startsWith(q)) score += 5;
+
+    for (const qt of qTokens) {
+      if (titleTokens.includes(qt)) score += 3;
+      else if (titleTokens.some((t) => t.includes(qt))) score += 1;
+    }
+    if (qTokens.every((qt) => title.includes(qt))) score += 2;
+
+    if (score > 0) hits.push({ entry, score });
+  }
+
+  hits.sort((a, b) => b.score - a.score || a.entry.displayId.localeCompare(b.entry.displayId));
+  return hits.slice(0, limit);
+}
+
+/** Render search hits as Markdown. */
+export function renderSearchResults(
+  hits: readonly ScoredEntry[],
+  query: string,
+): string {
+  if (hits.length === 0) {
+    return `# Search results\n\nNo matches for \`${query}\`.\n`;
+  }
+  const lines: string[] = [
+    `# Search results for "${query}" (${hits.length} ${
+      hits.length === 1 ? "match" : "matches"
+    })`,
+    "",
+  ];
+  for (const { entry, score } of hits) {
+    lines.push(
+      `- [${entry.displayId}](${entryUri(entry.displayId)}) — ${entry.title} (score ${score})`,
+    );
+  }
+  return lines.join("\n") + "\n";
+}
+
+/** JSON Schema for the entry_search tool input. */
+export const ENTRY_SEARCH_INPUT_SCHEMA = {
+  type: "object",
+  properties: {
+    query: { type: "string", minLength: 1 },
+    limit: { type: "integer", minimum: 1, maximum: 100 },
+  },
+  required: ["query"],
+  additionalProperties: false,
+} as const;
+
+/** Tool descriptor metadata. */
+export const ENTRY_SEARCH_DESCRIPTOR = {
+  name: "entry_search",
+  description:
+    "Search project entries by display ID and title. Returns ranked matches as Markdown links.",
+  inputSchema: ENTRY_SEARCH_INPUT_SCHEMA,
+};
+```
+
+- [ ] **Step 4: Run tests to confirm they pass**
+
+Run: `deno test packages/markspec/mcp/tools/search_test.ts`
+Expected: PASS (7 tests, 0 failures).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/markspec/mcp/tools/search.ts packages/markspec/mcp/tools/search_test.ts
+git commit -m "feat(mcp): add entry_search tool with ranking and Markdown render"
+```
+
+---
+
+## Task 8: `entry_context` tool
+
+**Files:**
+
+- Create: `packages/markspec/mcp/tools/context.ts`
+- Create: `packages/markspec/mcp/tools/context_test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `packages/markspec/mcp/tools/context_test.ts`:
+
+```typescript
+/**
+ * @module mcp/tools/context_test
+ *
+ * Unit tests for entry_context (Satisfies-chain walk).
+ */
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import type { CompileResult, Entry, Link } from "../../core/mod.ts";
+import { renderContext, walkContext } from "./context.ts";
+
+function mk(displayId: string, title: string): Entry {
+  return {
+    displayId,
+    title,
+    body: "",
+    rawAttributes: [],
+    typedAttributes: new Map(),
+    shape: "identified",
+    location: { file: "/proj/x.md", line: 1, column: 1 },
+    source: "markdown",
+  };
+}
+
+function buildResult(
+  entries: Entry[],
+  edges: { from: string; to: string; kind: Link["kind"] }[],
+): CompileResult {
+  const entryMap = new Map<string, Entry>();
+  for (const e of entries) entryMap.set(e.displayId, e);
+
+  const links: Link[] = edges.map((e) => ({
+    from: e.from,
+    to: e.to,
+    kind: e.kind,
+    location: { file: "/x", line: 1, column: 1 },
+  }));
+
+  const forward = new Map<string, Link[]>();
+  for (const link of links) {
+    const list = forward.get(link.from) ?? [];
+    list.push(link);
+    forward.set(link.from, list);
+  }
+
+  return {
+    entries: entryMap,
+    links,
+    forward,
+    reverse: new Map(),
+    documents: new Map(),
+    diagnostics: [],
+  };
+}
+
+Deno.test("walkContext: depth 0 is just the start entry", () => {
+  const result = buildResult(
+    [mk("STK_0001", "Top")],
+    [],
+  );
+  const chain = walkContext(result, "STK_0001", 10);
+  assertEquals(chain.length, 1);
+  assertEquals(chain[0].displayId, "STK_0001");
+  assertEquals(chain[0].depth, 0);
+});
+
+Deno.test("walkContext: walks satisfies edges upward", () => {
+  const result = buildResult(
+    [mk("SRS_0001", "SRS"), mk("SYS_0001", "SYS"), mk("STK_0001", "STK")],
+    [
+      { from: "SRS_0001", to: "SYS_0001", kind: "satisfies" },
+      { from: "SYS_0001", to: "STK_0001", kind: "satisfies" },
+    ],
+  );
+  const chain = walkContext(result, "SRS_0001", 10);
+  assertEquals(chain.map((c) => c.displayId), [
+    "SRS_0001",
+    "SYS_0001",
+    "STK_0001",
+  ]);
+});
+
+Deno.test("walkContext: ignores non-satisfies edges", () => {
+  const result = buildResult(
+    [mk("SRS_0001", "SRS"), mk("SYS_0001", "SYS")],
+    [{ from: "SRS_0001", to: "SYS_0001", kind: "derived-from" }],
+  );
+  const chain = walkContext(result, "SRS_0001", 10);
+  assertEquals(chain.length, 1);
+});
+
+Deno.test("walkContext: stops at depth limit", () => {
+  const result = buildResult(
+    [mk("A_0001", "A"), mk("B_0001", "B"), mk("C_0001", "C")],
+    [
+      { from: "A_0001", to: "B_0001", kind: "satisfies" },
+      { from: "B_0001", to: "C_0001", kind: "satisfies" },
+    ],
+  );
+  const chain = walkContext(result, "A_0001", 1);
+  assertEquals(chain.map((c) => c.displayId), ["A_0001", "B_0001"]);
+});
+
+Deno.test("walkContext: handles cycles", () => {
+  const result = buildResult(
+    [mk("A_0001", "A"), mk("B_0001", "B")],
+    [
+      { from: "A_0001", to: "B_0001", kind: "satisfies" },
+      { from: "B_0001", to: "A_0001", kind: "satisfies" },
+    ],
+  );
+  const chain = walkContext(result, "A_0001", 10);
+  assertEquals(chain.length, 2);
+});
+
+Deno.test("renderContext: nested list with indentation", () => {
+  const md = renderContext(
+    [
+      { displayId: "A_0001", title: "A", depth: 0 },
+      { displayId: "B_0001", title: "B", depth: 1 },
+      { displayId: "C_0001", title: "C", depth: 2 },
+    ],
+    "A_0001",
+  );
+  assertStringIncludes(md, "# Context for [A_0001]");
+  assertStringIncludes(md, "- **A_0001** — A");
+  assertStringIncludes(
+    md,
+    "  - satisfies → [B_0001](markspec://entry/B_0001) — B",
+  );
+  assertStringIncludes(
+    md,
+    "    - satisfies → [C_0001](markspec://entry/C_0001) — C",
+  );
+});
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+Run: `deno test packages/markspec/mcp/tools/context_test.ts`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement the tool**
+
+Create `packages/markspec/mcp/tools/context.ts`:
+
+```typescript
+/**
+ * @module mcp/tools/context
+ *
+ * `entry_context` MCP tool. Walks the `satisfies` edges upward from a given
+ * entry and renders the chain as a nested Markdown list.
+ */
+
+import type { CompileResult } from "../../core/mod.ts";
+import { entryUri } from "../uri.ts";
+
+/** One entry in the context chain. */
+export interface ContextNode {
+  readonly displayId: string;
+  readonly title: string;
+  /** Hops from the start entry — 0 means the start entry itself. */
+  readonly depth: number;
+}
+
+/**
+ * BFS walk of the `satisfies` edge upward from `startId`.
+ * Stops at `maxDepth` hops or when no outgoing satisfies links remain.
+ * Cycle-safe via visited set.
+ */
+export function walkContext(
+  result: CompileResult,
+  startId: string,
+  maxDepth: number,
+): ContextNode[] {
+  const start = result.entries.get(startId);
+  if (!start) return [];
+
+  const out: ContextNode[] = [
+    { displayId: startId, title: start.title, depth: 0 },
+  ];
+  const visited = new Set<string>([startId]);
+  let frontier: string[] = [startId];
+  let depth = 0;
+
+  while (depth < maxDepth && frontier.length > 0) {
+    const next: string[] = [];
+    for (const id of frontier) {
+      const links = result.forward.get(id) ?? [];
+      for (const link of links) {
+        if (link.kind !== "satisfies") continue;
+        if (visited.has(link.to)) continue;
+        visited.add(link.to);
+        const target = result.entries.get(link.to);
+        if (!target) continue;
+        out.push({
+          displayId: link.to,
+          title: target.title,
+          depth: depth + 1,
+        });
+        next.push(link.to);
+      }
+    }
+    frontier = next;
+    depth++;
+  }
+
+  return out;
+}
+
+/** Render a context chain as nested Markdown. */
+export function renderContext(
+  chain: readonly ContextNode[],
+  startId: string,
+): string {
+  if (chain.length === 0) {
+    return `# Context for ${startId}\n\nNo entry with display ID ${startId}.\n`;
+  }
+  const start = chain[0];
+  const lines: string[] = [
+    `# Context for [${start.displayId}](${entryUri(start.displayId)})`,
+    "",
+  ];
+  for (const node of chain) {
+    const indent = "  ".repeat(node.depth);
+    if (node.depth === 0) {
+      lines.push(`${indent}- **${node.displayId}** — ${node.title}`);
+    } else {
+      lines.push(
+        `${indent}- satisfies → [${node.displayId}](${
+          entryUri(node.displayId)
+        }) — ${node.title}`,
+      );
+    }
+  }
+  return lines.join("\n") + "\n";
+}
+
+/** Tool input schema. */
+export const ENTRY_CONTEXT_INPUT_SCHEMA = {
+  type: "object",
+  properties: {
+    id: { type: "string", minLength: 1 },
+    depth: { type: "integer", minimum: 0, maximum: 50 },
+  },
+  required: ["id"],
+  additionalProperties: false,
+} as const;
+
+/** Tool descriptor metadata. */
+export const ENTRY_CONTEXT_DESCRIPTOR = {
+  name: "entry_context",
+  description:
+    "Walk the satisfies chain upward from an entry. Returns a Markdown nested list.",
+  inputSchema: ENTRY_CONTEXT_INPUT_SCHEMA,
+};
+```
+
+- [ ] **Step 4: Run tests to confirm they pass**
+
+Run: `deno test packages/markspec/mcp/tools/context_test.ts`
+Expected: PASS (6 tests, 0 failures).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/markspec/mcp/tools/context.ts packages/markspec/mcp/tools/context_test.ts
+git commit -m "feat(mcp): add entry_context tool with chain-walk renderer"
+```
+
+---
+
+## Task 9: `validate` tool
+
+**Files:**
+
+- Create: `packages/markspec/mcp/tools/validate.ts`
+- Create: `packages/markspec/mcp/tools/validate_test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `packages/markspec/mcp/tools/validate_test.ts`:
+
+```typescript
+/**
+ * @module mcp/tools/validate_test
+ *
+ * Unit tests for the validate tool's Markdown report.
+ */
+
+import { assertStringIncludes } from "@std/assert";
+import type { Diagnostic } from "../../core/mod.ts";
+import { filterDiagnostics, renderDiagnosticsReport } from "./validate.ts";
+
+const ERR: Diagnostic = {
+  code: "MSL-R004",
+  severity: "error",
+  message: "unresolved reference: SYS_NONEXISTENT",
+  location: {
+    file: "/proj/docs/req.md",
+    line: 128,
+    column: 3,
+  },
+};
+
+const WARN: Diagnostic = {
+  code: "MSL-R010",
+  severity: "warning",
+  message: "unrecognized attribute Priority",
+  location: { file: "/proj/docs/req.md", line: 200, column: 3 },
+};
+
+Deno.test("renderDiagnosticsReport: clean report", () => {
+  const md = renderDiagnosticsReport([], "@org/x@1.0.0", 100);
+  assertStringIncludes(md, "✓ All 100 entries pass validation");
+});
+
+Deno.test("renderDiagnosticsReport: errors and warnings sections", () => {
+  const md = renderDiagnosticsReport([ERR, WARN], null, 1);
+  assertStringIncludes(md, "# Validation: 1 error, 1 warning");
+  assertStringIncludes(md, "## Errors");
+  assertStringIncludes(md, "### MSL-R004");
+  assertStringIncludes(md, "unresolved reference: SYS_NONEXISTENT");
+  assertStringIncludes(md, "/proj/docs/req.md:128:3");
+  assertStringIncludes(md, "## Warnings");
+  assertStringIncludes(md, "### MSL-R010");
+});
+
+Deno.test("filterDiagnostics: passes all when files undefined", () => {
+  const out = filterDiagnostics([ERR, WARN], undefined, "/proj");
+  assertStringIncludes(out.length.toString(), "2");
+});
+
+Deno.test("filterDiagnostics: keeps matching relative path", () => {
+  const out = filterDiagnostics([ERR, WARN], ["docs/req.md"], "/proj");
+  assertStringIncludes(out.length.toString(), "2");
+});
+
+Deno.test("filterDiagnostics: drops non-matching paths", () => {
+  const out = filterDiagnostics([ERR, WARN], ["docs/other.md"], "/proj");
+  assertStringIncludes(out.length.toString(), "0");
+});
+
+Deno.test("filterDiagnostics: absolute path match", () => {
+  const out = filterDiagnostics([ERR], ["/proj/docs/req.md"], "/proj");
+  assertStringIncludes(out.length.toString(), "1");
+});
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+Run: `deno test packages/markspec/mcp/tools/validate_test.ts`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement the tool**
+
+Create `packages/markspec/mcp/tools/validate.ts`:
+
+```typescript
+/**
+ * @module mcp/tools/validate
+ *
+ * `validate` MCP tool. Runs the validator pipeline and renders the
+ * diagnostics as a Markdown report. Optional `files` argument filters
+ * diagnostics to a subset of paths (relative paths resolved against the
+ * project root).
+ */
+
+import type { Diagnostic } from "../../core/mod.ts";
+
+/** Filter diagnostics by a list of file paths. */
+export function filterDiagnostics(
+  diagnostics: readonly Diagnostic[],
+  files: readonly string[] | undefined,
+  projectRoot: string,
+): readonly Diagnostic[] {
+  if (!files || files.length === 0) return diagnostics;
+  const absolute = new Set<string>();
+  for (const f of files) {
+    if (f.startsWith("/")) absolute.add(f);
+    else absolute.add(`${projectRoot}/${f}`);
+  }
+  return diagnostics.filter(
+    (d) => d.location && absolute.has(d.location.file),
+  );
+}
+
+/** Render diagnostics as a Markdown report. */
+export function renderDiagnosticsReport(
+  diagnostics: readonly Diagnostic[],
+  profileLabel: string | null,
+  entryCount: number,
+): string {
+  if (diagnostics.length === 0) {
+    const profilePart = profileLabel ? ` under ${profileLabel}` : "";
+    return `✓ All ${entryCount} entries pass validation${profilePart}.\n`;
+  }
+
+  const errors = diagnostics.filter((d) => d.severity === "error");
+  const warnings = diagnostics.filter((d) => d.severity === "warning");
+  const infos = diagnostics.filter((d) => d.severity === "info");
+
+  const summaryParts: string[] = [];
+  if (errors.length) {
+    summaryParts.push(`${errors.length} error${errors.length === 1 ? "" : "s"}`);
+  }
+  if (warnings.length) {
+    summaryParts.push(
+      `${warnings.length} warning${warnings.length === 1 ? "" : "s"}`,
+    );
+  }
+  if (infos.length) {
+    summaryParts.push(`${infos.length} info`);
+  }
+
+  const lines: string[] = [`# Validation: ${summaryParts.join(", ")}`, ""];
+
+  for (const [label, list] of [
+    ["Errors", errors],
+    ["Warnings", warnings],
+    ["Info", infos],
+  ] as const) {
+    if (list.length === 0) continue;
+    lines.push(`## ${label}`, "");
+    for (const d of list) {
+      lines.push(`### ${d.code}`, "");
+      const loc = d.location
+        ? `${d.location.file}:${d.location.line}:${d.location.column}`
+        : "(no location)";
+      lines.push(loc, "");
+      lines.push(d.message, "");
+    }
+  }
+
+  return lines.join("\n");
+}
+
+/** Tool input schema. */
+export const VALIDATE_INPUT_SCHEMA = {
+  type: "object",
+  properties: {
+    files: {
+      type: "array",
+      items: { type: "string" },
+    },
+  },
+  additionalProperties: false,
+} as const;
+
+/** Tool descriptor metadata. */
+export const VALIDATE_DESCRIPTOR = {
+  name: "validate",
+  description:
+    "Run the MarkSpec validator. Optional 'files' filters diagnostics by source path.",
+  inputSchema: VALIDATE_INPUT_SCHEMA,
+};
+```
+
+- [ ] **Step 4: Run tests to confirm they pass**
+
+Run: `deno test packages/markspec/mcp/tools/validate_test.ts`
+Expected: PASS (6 tests, 0 failures).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/markspec/mcp/tools/validate.ts packages/markspec/mcp/tools/validate_test.ts
+git commit -m "feat(mcp): add validate tool with Markdown diagnostics report"
+```
+
+---
+
+## Task 10: `markspec_refresh` tool
+
+**Files:**
+
+- Create: `packages/markspec/mcp/tools/refresh.ts`
+- Create: `packages/markspec/mcp/tools/refresh_test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `packages/markspec/mcp/tools/refresh_test.ts`:
+
+```typescript
+/**
+ * @module mcp/tools/refresh_test
+ */
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { renderRefresh } from "./refresh.ts";
+
+Deno.test("renderRefresh: returns count summary", () => {
+  const md = renderRefresh(1234, 5678);
+  assertStringIncludes(md, "Refreshed.");
+  assertStringIncludes(md, "1234 entries");
+  assertStringIncludes(md, "5678 links");
+});
+
+Deno.test("renderRefresh: zero counts", () => {
+  const md = renderRefresh(0, 0);
+  assertStringIncludes(md, "Refreshed.");
+  assertEquals(md.includes("0 entries"), true);
+});
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+Run: `deno test packages/markspec/mcp/tools/refresh_test.ts`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement the tool**
+
+Create `packages/markspec/mcp/tools/refresh.ts`:
+
+```typescript
+/**
+ * @module mcp/tools/refresh
+ *
+ * `markspec_refresh` MCP tool. Forces an unconditional recompile of the
+ * project, returning a one-line Markdown confirmation. Used by agents that
+ * have just edited files and want to guarantee freshness without relying on
+ * the mtime check.
+ */
+
+/** Render a refresh confirmation. */
+export function renderRefresh(entries: number, links: number): string {
+  return `Refreshed. ${entries} entries, ${links} links.\n`;
+}
+
+/** Tool input schema. */
+export const REFRESH_INPUT_SCHEMA = {
+  type: "object",
+  properties: {},
+  additionalProperties: false,
+} as const;
+
+/** Tool descriptor metadata. */
+export const REFRESH_DESCRIPTOR = {
+  name: "markspec_refresh",
+  description:
+    "Force-invalidate the MarkSpec compile cache. Use after editing files to guarantee subsequent reads see the new state.",
+  inputSchema: REFRESH_INPUT_SCHEMA,
+};
+```
+
+- [ ] **Step 4: Run tests to confirm they pass**
+
+Run: `deno test packages/markspec/mcp/tools/refresh_test.ts`
+Expected: PASS (2 tests, 0 failures).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/markspec/mcp/tools/refresh.ts packages/markspec/mcp/tools/refresh_test.ts
+git commit -m "feat(mcp): add markspec_refresh tool"
+```
+
+---
+
+## Task 11: Tools registration
+
+**Files:**
+
+- Create: `packages/markspec/mcp/tools/mod.ts`
+
+- [ ] **Step 1: Implement the registration module**
+
+Create `packages/markspec/mcp/tools/mod.ts`:
+
+```typescript
+/**
+ * @module mcp/tools/mod
+ *
+ * Registers `tools/list` and `tools/call` handlers on the MCP Server.
+ * Each tool lives in its own file and exposes a descriptor + pure
+ * rendering helpers. This module is the dispatch layer.
+ */
+
+import type { Server } from "npm:@modelcontextprotocol/sdk/server/index.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from "npm:@modelcontextprotocol/sdk/types.js";
+import type { Project } from "../project.ts";
+import {
+  ENTRY_SEARCH_DESCRIPTOR,
+  renderSearchResults,
+  scoreEntries,
+} from "./search.ts";
+import {
+  ENTRY_CONTEXT_DESCRIPTOR,
+  renderContext,
+  walkContext,
+} from "./context.ts";
+import {
+  filterDiagnostics,
+  renderDiagnosticsReport,
+  VALIDATE_DESCRIPTOR,
+} from "./validate.ts";
+import { REFRESH_DESCRIPTOR, renderRefresh } from "./refresh.ts";
+
+/** All tool descriptors, in `tools/list` order. */
+export const TOOL_DESCRIPTORS = [
+  ENTRY_SEARCH_DESCRIPTOR,
+  ENTRY_CONTEXT_DESCRIPTOR,
+  VALIDATE_DESCRIPTOR,
+  REFRESH_DESCRIPTOR,
+];
+
+/** Tool dispatch entry. */
+interface ToolHandler {
+  // deno-lint-ignore no-explicit-any
+  (args: any, project: Project): Promise<string>;
+}
+
+const HANDLERS: Record<string, ToolHandler> = {
+  // deno-lint-ignore no-explicit-any
+  entry_search: async (args: any, project) => {
+    const query = String(args?.query ?? "");
+    const limit = Math.min(100, Math.max(1, Number(args?.limit ?? 20)));
+    const result = await project.getCompiled();
+    const hits = scoreEntries(
+      [...result.entries.values()],
+      query,
+      limit,
+    );
+    return renderSearchResults(hits, query);
+  },
+
+  // deno-lint-ignore no-explicit-any
+  entry_context: async (args: any, project) => {
+    const id = String(args?.id ?? "");
+    const depth = Math.min(50, Math.max(0, Number(args?.depth ?? 10)));
+    const result = await project.getCompiled();
+    const chain = walkContext(result, id, depth);
+    return renderContext(chain, id);
+  },
+
+  // deno-lint-ignore no-explicit-any
+  validate: async (args: any, project) => {
+    const files: readonly string[] | undefined = Array.isArray(args?.files)
+      ? args.files.map((f: unknown) => String(f))
+      : undefined;
+    const result = await project.getCompiled();
+    const filtered = filterDiagnostics(
+      result.diagnostics,
+      files,
+      project.projectRoot ?? "",
+    );
+    const profileLabel = project.profileChain
+      ? `${project.profileChain.tiers[0].id}@${project.profileChain.tiers[0].version}`
+      : null;
+    return renderDiagnosticsReport(filtered, profileLabel, result.entries.size);
+  },
+
+  markspec_refresh: async (_args, project) => {
+    const result = await project.forceRefresh();
+    return renderRefresh(result.entries.size, result.links.length);
+  },
+};
+
+/** Attach the two handlers to a Server instance. */
+export function registerTools(server: Server, project: Project): void {
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({
+    tools: TOOL_DESCRIPTORS,
+  }));
+
+  server.setRequestHandler(CallToolRequestSchema, async (req) => {
+    const name = req.params.name;
+    const handler = HANDLERS[name];
+    if (!handler) {
+      return {
+        isError: true,
+        content: [{ type: "text", text: `unknown tool: ${name}` }],
+      };
+    }
+    try {
+      const text = await handler(req.params.arguments ?? {}, project);
+      return { content: [{ type: "text", text }] };
+    } catch (err) {
+      return {
+        isError: true,
+        content: [{ type: "text", text: (err as Error).message }],
+      };
+    }
+  });
+}
+```
+
+- [ ] **Step 2: Type-check the package**
+
+Run: `deno check packages/markspec/mcp/tools/mod.ts`
+Expected: PASS with no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/markspec/mcp/tools/mod.ts
+git commit -m "feat(mcp): register tools/list and tools/call dispatch"
+```
+
+---
+
+## Task 12: Server entry point
+
+**Files:**
+
+- Create: `packages/markspec/mcp/server.ts`
+
+- [ ] **Step 1: Implement the server bootstrap**
+
+Create `packages/markspec/mcp/server.ts`:
+
+```typescript
+/**
+ * @module mcp/server
+ *
+ * MCP server entry point. Constructs a `Server` over stdio, initializes the
+ * project context, registers resources + tools, and wires resource-change
+ * notifications to the cache invalidation hook.
+ *
+ * This module is dynamically imported by `main.ts` when the user runs
+ * `markspec mcp` — never loaded by other subcommands.
+ */
+
+import { Server } from "npm:@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "npm:@modelcontextprotocol/sdk/server/stdio.js";
+import process from "node:process";
+import { VERSION } from "../core/mod.ts";
+import { createProject, defaultEnv } from "./project.ts";
+import { registerResources } from "./resources/mod.ts";
+import { registerTools } from "./tools/mod.ts";
+import { ENTRIES_URI, entryUri, PROFILE_URI } from "./uri.ts";
+
+export async function startServer(): Promise<void> {
+  const server = new Server(
+    { name: "markspec", version: VERSION },
+    {
+      capabilities: {
+        resources: { subscribe: true, listChanged: true },
+        tools: { listChanged: false },
+      },
+    },
+  );
+
+  const project = await createProject(defaultEnv());
+
+  registerResources(server, project);
+  registerTools(server, project);
+
+  // Fire resource change notifications when the cache invalidates.
+  project.subscribeInvalidation(() => {
+    void server.sendResourceListChanged();
+    void server.sendResourceUpdated({ uri: PROFILE_URI });
+    void server.sendResourceUpdated({ uri: ENTRIES_URI });
+    // Note: we don't enumerate per-entry diffs in v1 — clients reading an
+    // entry resource will hit the fresh cache anyway via getCompiled().
+    // Per-entry notifications are a follow-up if profiling shows value.
+    void 0;
+  });
+
+  // Also notify per-entry resources subscribed today by emitting an updated
+  // notification for each entry on full recompile. Subscriptions are managed
+  // by the SDK; this is a best-effort broadcast.
+  project.subscribeInvalidation(async () => {
+    try {
+      const result = await project.getCompiled();
+      for (const id of result.entries.keys()) {
+        void server.sendResourceUpdated({ uri: entryUri(id) });
+      }
+    } catch {
+      // Recompile failed — skip notifications.
+    }
+  });
+
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+
+  // Keep the process alive until stdin closes.
+  process.stdin.on("end", () => {
+    server.close().finally(() => process.exit(0));
+  });
+}
+
+if (import.meta.main) {
+  await startServer();
+}
+```
+
+- [ ] **Step 2: Type-check the package**
+
+Run: `deno check packages/markspec/mcp/server.ts`
+Expected: PASS with no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/markspec/mcp/server.ts
+git commit -m "feat(mcp): bootstrap MCP server over stdio with resource notifications"
+```
+
+---
+
+## Task 13: Wire `markspec mcp` dispatch in `main.ts`
+
+**Files:**
+
+- Modify: `packages/markspec/main.ts`
+
+- [ ] **Step 1: Locate the `mcp` subcommand block**
+
+Find in `packages/markspec/main.ts` the block:
+
+```typescript
+  .command("mcp")
+  .description("Start MCP server")
+  .action(notImplemented("mcp"))
+```
+
+- [ ] **Step 2: Replace with a dynamic-import action**
+
+Replace the action with:
+
+```typescript
+  .command("mcp")
+  .description("Start MCP server (stdio JSON-RPC)")
+  .action(async () => {
+    const { startServer } = await import("./mcp/server.ts");
+    await startServer();
+  })
+```
+
+- [ ] **Step 3: Type-check**
+
+Run: `deno check packages/markspec/main.ts`
+Expected: PASS.
+
+- [ ] **Step 4: Smoke-test the binary**
+
+Run: `deno run --allow-read --allow-write --allow-env --allow-net=0 packages/markspec/main.ts mcp < /dev/null`
+Expected: process starts, exits cleanly when stdin closes.
+
+If the smoke test fails due to a missing permission (e.g. `--allow-ffi`), add
+it and re-run. The full permission set this command needs is:
+`--allow-read --allow-write --allow-env --allow-net --allow-ffi`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/markspec/main.ts
+git commit -m "feat(mcp): wire markspec mcp subcommand to mcp/server.ts"
+```
+
+---
+
+## Task 14: End-to-end test
+
+**Files:**
+
+- Create: `tests/e2e/mcp_test.ts`
+
+- [ ] **Step 1: Write the e2e test**
+
+Create `tests/e2e/mcp_test.ts`:
+
+```typescript
+/**
+ * @module tests/e2e/mcp_test
+ *
+ * End-to-end tests for `markspec mcp`. Spawns the CLI as a subprocess and
+ * exchanges real MCP JSON-RPC messages over stdio.
+ *
+ * Boundary: this file imports nothing from packages/markspec/ — it interacts
+ * exclusively through Deno.Command.
+ */
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+
+const CLI_ENTRY = new URL(
+  "../../packages/markspec/main.ts",
+  import.meta.url,
+).pathname;
+
+const PROJECT_YAML = `name: e2e\nversion: 0.0.1\n`;
+
+const FIXTURE_DOC = `# Stakeholder requirements
+
+- [STK_E2E_0001] Stop on collision
+
+  Body.
+
+  Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+`;
+
+interface RpcResponse {
+  jsonrpc: "2.0";
+  id?: number;
+  result?: unknown;
+  error?: { code: number; message: string };
+  method?: string;
+  params?: unknown;
+}
+
+/** Manage a running `markspec mcp` subprocess. */
+class McpProcess {
+  private proc: Deno.ChildProcess;
+  private writer: WritableStreamDefaultWriter<Uint8Array>;
+  private buffer = "";
+  private pending = new Map<number, (msg: RpcResponse) => void>();
+  private notifications: RpcResponse[] = [];
+  private nextId = 1;
+
+  constructor(cwd: string) {
+    const cmd = new Deno.Command("deno", {
+      args: [
+        "run",
+        "--allow-read",
+        "--allow-write",
+        "--allow-env",
+        "--allow-net",
+        "--allow-ffi",
+        CLI_ENTRY,
+        "mcp",
+      ],
+      cwd,
+      stdin: "piped",
+      stdout: "piped",
+      stderr: "piped",
+    });
+    this.proc = cmd.spawn();
+    this.writer = this.proc.stdin.getWriter();
+    this.readLoop();
+  }
+
+  private async readLoop(): Promise<void> {
+    const reader = this.proc.stdout.getReader();
+    const decoder = new TextDecoder();
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) return;
+      this.buffer += decoder.decode(value);
+      for (;;) {
+        const newlineIdx = this.buffer.indexOf("\n");
+        if (newlineIdx < 0) break;
+        const line = this.buffer.slice(0, newlineIdx).trim();
+        this.buffer = this.buffer.slice(newlineIdx + 1);
+        if (!line) continue;
+        let msg: RpcResponse;
+        try {
+          msg = JSON.parse(line) as RpcResponse;
+        } catch {
+          continue;
+        }
+        if (typeof msg.id === "number" && this.pending.has(msg.id)) {
+          this.pending.get(msg.id)!(msg);
+          this.pending.delete(msg.id);
+        } else if (msg.method) {
+          this.notifications.push(msg);
+        }
+      }
+    }
+  }
+
+  async request(method: string, params: unknown): Promise<RpcResponse> {
+    const id = this.nextId++;
+    const payload = JSON.stringify({ jsonrpc: "2.0", id, method, params });
+    const promise = new Promise<RpcResponse>((resolve) => {
+      this.pending.set(id, resolve);
+    });
+    await this.writer.write(new TextEncoder().encode(payload + "\n"));
+    return await promise;
+  }
+
+  async notify(method: string, params: unknown): Promise<void> {
+    const payload = JSON.stringify({ jsonrpc: "2.0", method, params });
+    await this.writer.write(new TextEncoder().encode(payload + "\n"));
+  }
+
+  drainNotifications(): RpcResponse[] {
+    const out = this.notifications.slice();
+    this.notifications.length = 0;
+    return out;
+  }
+
+  async close(): Promise<void> {
+    try {
+      await this.writer.close();
+    } catch { /* already closed */ }
+    try {
+      this.proc.kill("SIGTERM");
+    } catch { /* already exited */ }
+    await this.proc.status;
+  }
+}
+
+/** Create a fixture project in a temp dir and start the server. */
+async function setup(): Promise<
+  { proc: McpProcess; cwd: string; initResponse: RpcResponse }
+> {
+  const dir = await Deno.makeTempDir();
+  await Deno.writeTextFile(`${dir}/project.yaml`, PROJECT_YAML);
+  await Deno.writeTextFile(`${dir}/req.md`, FIXTURE_DOC);
+  const proc = new McpProcess(dir);
+  const initResponse = await proc.request("initialize", {
+    protocolVersion: "2024-11-05",
+    capabilities: {},
+    clientInfo: { name: "test", version: "0.0.1" },
+  });
+  await proc.notify("notifications/initialized", {});
+  return { proc, cwd: dir, initResponse };
+}
+
+Deno.test("mcp: initialize advertises resources and tools capabilities", async () => {
+  const { proc, cwd, initResponse } = await setup();
+  try {
+    // deno-lint-ignore no-explicit-any
+    const caps = (initResponse.result as any).capabilities;
+    assertEquals(typeof caps.resources, "object");
+    assertEquals(typeof caps.tools, "object");
+  } finally {
+    await proc.close();
+    await Deno.remove(cwd, { recursive: true });
+  }
+});
+
+Deno.test("mcp: tools/list returns all four tools", async () => {
+  const { proc, cwd } = await setup();
+  try {
+    const resp = await proc.request("tools/list", {});
+    // deno-lint-ignore no-explicit-any
+    const tools = (resp.result as any).tools as Array<{ name: string }>;
+    const names = tools.map((t) => t.name).sort();
+    assertEquals(names, [
+      "entry_context",
+      "entry_search",
+      "markspec_refresh",
+      "validate",
+    ]);
+  } finally {
+    await proc.close();
+    await Deno.remove(cwd, { recursive: true });
+  }
+});
+
+Deno.test("mcp: resources/list returns profile, entries, and per-entry URIs", async () => {
+  const { proc, cwd } = await setup();
+  try {
+    const resp = await proc.request("resources/list", {});
+    // deno-lint-ignore no-explicit-any
+    const resources = (resp.result as any).resources as Array<
+      { uri: string }
+    >;
+    const uris = resources.map((r) => r.uri).sort();
+    assertEquals(uris.includes("markspec://profile"), true);
+    assertEquals(uris.includes("markspec://entries"), true);
+    assertEquals(
+      uris.includes("markspec://entry/STK_E2E_0001"),
+      true,
+    );
+  } finally {
+    await proc.close();
+    await Deno.remove(cwd, { recursive: true });
+  }
+});
+
+Deno.test("mcp: resources/read on entry returns Markdown body", async () => {
+  const { proc, cwd } = await setup();
+  try {
+    const resp = await proc.request("resources/read", {
+      uri: "markspec://entry/STK_E2E_0001",
+    });
+    // deno-lint-ignore no-explicit-any
+    const contents = (resp.result as any).contents as Array<
+      { text: string; mimeType: string }
+    >;
+    assertEquals(contents[0].mimeType, "text/markdown");
+    assertStringIncludes(contents[0].text, "# STK_E2E_0001 — Stop on collision");
+  } finally {
+    await proc.close();
+    await Deno.remove(cwd, { recursive: true });
+  }
+});
+
+Deno.test("mcp: tools/call entry_search returns ranked matches", async () => {
+  const { proc, cwd } = await setup();
+  try {
+    const resp = await proc.request("tools/call", {
+      name: "entry_search",
+      arguments: { query: "collision" },
+    });
+    // deno-lint-ignore no-explicit-any
+    const content = (resp.result as any).content as Array<{ text: string }>;
+    assertStringIncludes(content[0].text, "STK_E2E_0001");
+  } finally {
+    await proc.close();
+    await Deno.remove(cwd, { recursive: true });
+  }
+});
+
+Deno.test("mcp: tools/call validate returns clean report", async () => {
+  const { proc, cwd } = await setup();
+  try {
+    const resp = await proc.request("tools/call", {
+      name: "validate",
+      arguments: {},
+    });
+    // deno-lint-ignore no-explicit-any
+    const content = (resp.result as any).content as Array<{ text: string }>;
+    assertStringIncludes(content[0].text, "All 1 entries pass validation");
+  } finally {
+    await proc.close();
+    await Deno.remove(cwd, { recursive: true });
+  }
+});
+
+Deno.test("mcp: file edit + markspec_refresh fires resources/updated", async () => {
+  const { proc, cwd } = await setup();
+  try {
+    // Edit the fixture file: add a second entry.
+    await Deno.writeTextFile(
+      `${cwd}/req.md`,
+      FIXTURE_DOC +
+        `\n- [STK_E2E_0002] Second\n\n  Body.\n\n  Id: 01HGW2Q8MNP3RSTVWXYZABCDEG\n`,
+    );
+
+    const resp = await proc.request("tools/call", {
+      name: "markspec_refresh",
+      arguments: {},
+    });
+    // deno-lint-ignore no-explicit-any
+    const content = (resp.result as any).content as Array<{ text: string }>;
+    assertStringIncludes(content[0].text, "2 entries");
+
+    const notifs = proc.drainNotifications();
+    const methods = notifs.map((n) => n.method);
+    assertEquals(methods.includes("notifications/resources/list_changed"), true);
+  } finally {
+    await proc.close();
+    await Deno.remove(cwd, { recursive: true });
+  }
+});
+```
+
+- [ ] **Step 2: Run the e2e test**
+
+Run:
+`deno test --allow-read --allow-write --allow-run --allow-env --allow-ffi tests/e2e/mcp_test.ts`
+
+Expected: PASS (7 tests, 0 failures).
+
+If a test hangs, inspect stderr of the subprocess (the `McpProcess` class
+ignores it — for debugging, pipe `proc.stderr` to stdout temporarily).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/e2e/mcp_test.ts
+git commit -m "test(e2e): drive markspec mcp over JSON-RPC stdio"
+```
+
+---
+
+## Task 15: Document the subcommand
+
+**Files:**
+
+- Modify: `docs/guide/commands.md`
+
+- [ ] **Step 1: Locate the existing `mcp` row in the commands table**
+
+In `docs/guide/commands.md`, find the row:
+
+```text
+| `mcp`              | MCP server for AI agent integration                      |
+```
+
+- [ ] **Step 2: Promote `mcp` from not-yet-implemented to documented**
+
+Replace that row with a link to a new subsection:
+
+```text
+| [`mcp`](#mcp)      | MCP server for AI agent integration (stdio JSON-RPC)     |
+```
+
+Then append a new `## mcp` section near the end of `docs/guide/commands.md`:
+
+````markdown
+## mcp
+
+Starts the MarkSpec MCP server. Communicates over stdio JSON-RPC. Exposes
+the active project as MCP resources and tools to any MCP-capable AI client
+(Claude Code, Claude Desktop, GitHub Copilot in VS Code, OpenCode).
+
+```bash
+markspec mcp
+```
+
+### Resources
+
+- `markspec://profile` — distilled profile manifest (types, attributes,
+  link kinds, labels).
+- `markspec://entries` — index of all project entries, grouped by type.
+- `markspec://entry/{displayId}` — one entry per resource, with attributes,
+  body, outgoing/incoming links.
+
+### Tools
+
+- `entry_search { query, limit? }` — rank-search entries by display ID and
+  title.
+- `entry_context { id, depth? }` — walk the `satisfies` chain upward.
+- `validate { files? }` — run the validator, return a Markdown diagnostics
+  report.
+- `markspec_refresh` — force-invalidate the compile cache (call after
+  agent edits to guarantee freshness).
+
+### Claude Desktop config
+
+Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "markspec": {
+      "command": "markspec",
+      "args": ["mcp"],
+      "cwd": "/path/to/your/markspec-project"
+    }
+  }
+}
+```
+
+Restart Claude Desktop. The MarkSpec resources and tools appear in the
+attach menu.
+
+### Claude Code
+
+```bash
+claude mcp add markspec --command markspec --args mcp --cwd /path/to/project
+```
+
+### VS Code (Copilot)
+
+In your project's `.vscode/mcp.json`:
+
+```json
+{
+  "servers": {
+    "markspec": {
+      "command": "markspec",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+Copilot does not support MCP resource subscriptions today, but the
+`markspec://` resources still work — the server runs a fresh validity
+check on every read, so a re-read after an edit returns up-to-date
+content.
+````
+
+- [ ] **Step 3: Format and verify**
+
+Run: `dprint fmt docs/guide/commands.md`
+Run: `dprint check docs/guide/commands.md`
+Expected: clean format check.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/guide/commands.md
+git commit -m "docs(guide): document markspec mcp subcommand and client setup"
+```
+
+---
+
+## Task 16: Update GitHub issues
+
+**Files:** none
+
+- [ ] **Step 1: Update issue #60 with the resource/tool layout**
+
+Run:
+
+```bash
+gh issue comment 60 --body "v1 spec landed: docs/superpowers/specs/2026-05-10-mcp-server-design.md
+
+Final layout differs from the original story:
+- Server scaffold ✓
+- 3 resources: markspec://profile, markspec://entries, markspec://entry/{displayId}
+- 4 tools: entry_search, entry_context, validate, markspec_refresh
+- Request #63 (requirement_insert) deferred until markspec insert lands"
+```
+
+- [ ] **Step 2: Close #61 and #62 as superseded**
+
+Run:
+
+```bash
+gh issue close 61 --comment "Superseded by markspec://entry/{displayId} resource (see PR for MCP v1). Local entry lookup is now a resource read, not a tool. 'Registry' tools (RefHub) are a separate future surface."
+
+gh issue close 62 --comment "Superseded by entry_search tool with ranking on displayId + title. See PR for MCP v1."
+```
+
+- [ ] **Step 3: Add a defer note to #63**
+
+Run:
+
+```bash
+gh issue comment 63 --body "Deferred from MCP v1 (read-only). Blocked on markspec insert (epic:insert, #38-#41). Once insert lands, this tool wraps it and exposes the agent write path."
+```
+
+- [ ] **Step 4: Verify issue state**
+
+Run:
+
+```bash
+gh issue list --search "label:epic:mcp" --state all
+```
+
+Expected: #60 still open with comment, #61 and #62 closed, #63 still open with
+deferral comment.
+
+---
+
+## Final verification
+
+- [ ] **Run full test suite**
+
+Run: `just check`
+Expected: lint passes, type-check passes, all tests pass (including new MCP
+unit tests + the e2e test).
+
+- [ ] **Run a build**
+
+Run: `just build`
+Expected: lint + tests + type-check + binary compile all succeed; `dist/markspec`
+exists and runs.
+
+- [ ] **Manual smoke from binary**
+
+Run:
+
+```bash
+echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"smoke","version":"0.0.1"}}}' | dist/markspec mcp
+```
+
+Expected: a JSON-RPC response with `result.capabilities.resources` and
+`result.capabilities.tools` present.
+
+- [ ] **Open the PR**
+
+Run:
+
+```bash
+git push -u origin worktree-feat+mcp-server-v1
+gh pr create --title "feat(mcp): v1 MCP server with profile/entry resources + 4 tools" --body "$(cat <<'EOF'
+## Summary
+
+Implements v1 of the MarkSpec MCP server per [the spec](docs/superpowers/specs/2026-05-10-mcp-server-design.md).
+
+- 3 resources: `markspec://profile`, `markspec://entries`, `markspec://entry/{displayId}` — all Markdown.
+- 4 tools: `entry_search`, `entry_context`, `validate`, `markspec_refresh`.
+- stdio transport, lazy-loaded from `main.ts`.
+- mtime-based cache invalidation on every read; explicit `markspec_refresh` tool as an escape hatch.
+- Resource-change notifications fire on invalidation for clients that subscribe (Claude Code today; Copilot ignores).
+
+Closes #61, #62. Addresses #60. #63 (requirement_insert) deferred until `markspec insert` lands.
+
+## Test plan
+
+- [ ] `just check` (lint + type-check + tests)
+- [ ] `just build` (compiles to `dist/markspec`)
+- [ ] Manual: Claude Code can `mcp add markspec` and list resources
+- [ ] Manual: VS Code Copilot can connect and read resources
+EOF
+)"
+```
+
+- [ ] **After PR opens — run `/review` and post findings as a PR comment**

--- a/docs/superpowers/plans/2026-05-10-mcp-server.md
+++ b/docs/superpowers/plans/2026-05-10-mcp-server.md
@@ -5,26 +5,22 @@
 > superpowers:executing-plans to implement this plan task-by-task. Steps use
 > checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Implement v1 of the MarkSpec MCP server — a stdio JSON-RPC server
-that exposes the project's traceability data to AI coding agents as MCP
-resources and tools. Covers GitHub issues #60–#62; #63 (write tool) is
-deferred.
+**Goal:** Implement v1 of the MarkSpec MCP server — a stdio JSON-RPC server that
+exposes the project's traceability data to AI coding agents as MCP resources and
+tools. Covers GitHub issues #60–#62; #63 (write tool) is deferred.
 
 **Architecture:** The `markspec mcp` subcommand lazy-loads `mcp/server.ts`,
-which constructs a single `Server` from `@modelcontextprotocol/sdk` on stdio.
-A module-level `ProjectCache` runs `compile()` once on initialize (background)
-and re-runs it on every `resources/read` or `tools/call` whose mtime check
-detects file changes. Three resource families
-(`markspec://profile`, `markspec://entries`, `markspec://entry/{displayId}`)
-and four tools (`entry_search`, `entry_context`, `validate`,
-`markspec_refresh`) all return Markdown bodies. Subscriptions emit
-`notifications/resources/updated` on invalidation for clients that honor them
-(Claude Code today; Copilot ignores).
+which constructs a single `Server` from `@modelcontextprotocol/sdk` on stdio. A
+module-level `ProjectCache` runs `compile()` once on initialize (background) and
+re-runs it on every `resources/read` or `tools/call` whose mtime check detects
+file changes. Three resource families (`markspec://profile`,
+`markspec://entries`, `markspec://entry/{displayId}`) and four tools
+(`entry_search`, `entry_context`, `validate`, `markspec_refresh`) all return
+Markdown bodies. Subscriptions emit `notifications/resources/updated` on
+invalidation for clients that honor them (Claude Code today; Copilot ignores).
 
-**Tech Stack:**
-`npm:@modelcontextprotocol/sdk`,
-`@driftsys/markspec/core` (via `core/mod.ts`),
-Deno/TypeScript.
+**Tech Stack:** `npm:@modelcontextprotocol/sdk`, `@driftsys/markspec/core` (via
+`core/mod.ts`), Deno/TypeScript.
 
 **Spec:**
 [`docs/superpowers/specs/2026-05-10-mcp-server-design.md`](../specs/2026-05-10-mcp-server-design.md)
@@ -37,34 +33,34 @@ Deno/TypeScript.
 
 ## File Map
 
-| File                                              | Responsibility                                          |
-| ------------------------------------------------- | ------------------------------------------------------- |
-| `packages/markspec/deno.json`                     | Add `@modelcontextprotocol/sdk` import                  |
-| `packages/markspec/mcp/uri.ts`                    | MCP URI scheme: parse/format `markspec://...`           |
-| `packages/markspec/mcp/uri_test.ts`               | Unit tests for URI helpers                              |
-| `packages/markspec/mcp/project.ts`                | Project root discovery, compile cache, mtime check      |
-| `packages/markspec/mcp/project_test.ts`           | Unit tests for cache invalidation                       |
-| `packages/markspec/mcp/resources/profile.ts`      | Render `markspec://profile` as Markdown                 |
-| `packages/markspec/mcp/resources/profile_test.ts` | Unit tests for profile renderer                         |
-| `packages/markspec/mcp/resources/entry.ts`        | Render `markspec://entry/{id}` as Markdown              |
-| `packages/markspec/mcp/resources/entry_test.ts`   | Unit tests for entry renderer                           |
-| `packages/markspec/mcp/resources/entries.ts`      | Render `markspec://entries` index as Markdown           |
-| `packages/markspec/mcp/resources/entries_test.ts` | Unit tests for entries-index renderer                   |
-| `packages/markspec/mcp/resources/mod.ts`          | Resource registration: list, read, route by URI         |
-| `packages/markspec/mcp/resources/mod_test.ts`     | Unit tests for resource dispatch                        |
-| `packages/markspec/mcp/tools/search.ts`           | `entry_search`: ranking + Markdown render               |
-| `packages/markspec/mcp/tools/search_test.ts`      | Unit tests for ranking and rendering                    |
-| `packages/markspec/mcp/tools/context.ts`          | `entry_context`: chain walk + Markdown tree             |
-| `packages/markspec/mcp/tools/context_test.ts`     | Unit tests for chain walk                               |
-| `packages/markspec/mcp/tools/validate.ts`         | `validate`: diagnostics → Markdown report               |
-| `packages/markspec/mcp/tools/validate_test.ts`    | Unit tests for diagnostics rendering                    |
-| `packages/markspec/mcp/tools/refresh.ts`          | `markspec_refresh`: force-recompile                     |
-| `packages/markspec/mcp/tools/refresh_test.ts`     | Unit tests for refresh tool                             |
-| `packages/markspec/mcp/tools/mod.ts`              | Tool registration: list, call dispatch                  |
-| `packages/markspec/mcp/server.ts`                 | Server bootstrap, lifecycle, subscriptions              |
-| `packages/markspec/main.ts`                       | Replace `notImplemented("mcp")` with dynamic import     |
-| `tests/e2e/mcp_test.ts`                           | E2E: spawn `markspec mcp`, drive JSON-RPC over stdio    |
-| `docs/guide/commands.md`                          | Document `markspec mcp` and connection examples         |
+| File                                              | Responsibility                                       |
+| ------------------------------------------------- | ---------------------------------------------------- |
+| `packages/markspec/deno.json`                     | Add `@modelcontextprotocol/sdk` import               |
+| `packages/markspec/mcp/uri.ts`                    | MCP URI scheme: parse/format `markspec://...`        |
+| `packages/markspec/mcp/uri_test.ts`               | Unit tests for URI helpers                           |
+| `packages/markspec/mcp/project.ts`                | Project root discovery, compile cache, mtime check   |
+| `packages/markspec/mcp/project_test.ts`           | Unit tests for cache invalidation                    |
+| `packages/markspec/mcp/resources/profile.ts`      | Render `markspec://profile` as Markdown              |
+| `packages/markspec/mcp/resources/profile_test.ts` | Unit tests for profile renderer                      |
+| `packages/markspec/mcp/resources/entry.ts`        | Render `markspec://entry/{id}` as Markdown           |
+| `packages/markspec/mcp/resources/entry_test.ts`   | Unit tests for entry renderer                        |
+| `packages/markspec/mcp/resources/entries.ts`      | Render `markspec://entries` index as Markdown        |
+| `packages/markspec/mcp/resources/entries_test.ts` | Unit tests for entries-index renderer                |
+| `packages/markspec/mcp/resources/mod.ts`          | Resource registration: list, read, route by URI      |
+| `packages/markspec/mcp/resources/mod_test.ts`     | Unit tests for resource dispatch                     |
+| `packages/markspec/mcp/tools/search.ts`           | `entry_search`: ranking + Markdown render            |
+| `packages/markspec/mcp/tools/search_test.ts`      | Unit tests for ranking and rendering                 |
+| `packages/markspec/mcp/tools/context.ts`          | `entry_context`: chain walk + Markdown tree          |
+| `packages/markspec/mcp/tools/context_test.ts`     | Unit tests for chain walk                            |
+| `packages/markspec/mcp/tools/validate.ts`         | `validate`: diagnostics → Markdown report            |
+| `packages/markspec/mcp/tools/validate_test.ts`    | Unit tests for diagnostics rendering                 |
+| `packages/markspec/mcp/tools/refresh.ts`          | `markspec_refresh`: force-recompile                  |
+| `packages/markspec/mcp/tools/refresh_test.ts`     | Unit tests for refresh tool                          |
+| `packages/markspec/mcp/tools/mod.ts`              | Tool registration: list, call dispatch               |
+| `packages/markspec/mcp/server.ts`                 | Server bootstrap, lifecycle, subscriptions           |
+| `packages/markspec/main.ts`                       | Replace `notImplemented("mcp")` with dynamic import  |
+| `tests/e2e/mcp_test.ts`                           | E2E: spawn `markspec mcp`, drive JSON-RPC over stdio |
+| `docs/guide/commands.md`                          | Document `markspec mcp` and connection examples      |
 
 ---
 
@@ -76,7 +72,8 @@ Deno/TypeScript.
 - Create: `packages/markspec/mcp/uri.ts`
 - Create: `packages/markspec/mcp/uri_test.ts`
 
-- [ ] **Step 1: Add `@modelcontextprotocol/sdk` to `packages/markspec/deno.json`**
+- [ ] **Step 1: Add `@modelcontextprotocol/sdk` to
+      `packages/markspec/deno.json`**
 
 In the `imports` map of `packages/markspec/deno.json`, add:
 
@@ -177,8 +174,8 @@ Deno.test("isEntryUri: false for other URIs", () => {
 
 - [ ] **Step 3: Run tests to confirm they fail**
 
-Run: `deno test packages/markspec/mcp/uri_test.ts`
-Expected: FAIL — module `./uri.ts` not found.
+Run: `deno test packages/markspec/mcp/uri_test.ts` Expected: FAIL — module
+`./uri.ts` not found.
 
 - [ ] **Step 4: Implement `mcp/uri.ts`**
 
@@ -235,8 +232,8 @@ export function isEntryUri(uri: string): boolean {
 
 - [ ] **Step 5: Run tests to confirm they pass**
 
-Run: `deno test packages/markspec/mcp/uri_test.ts`
-Expected: PASS (9 tests, 0 failures).
+Run: `deno test packages/markspec/mcp/uri_test.ts` Expected: PASS (9 tests, 0
+failures).
 
 - [ ] **Step 6: Commit**
 
@@ -433,8 +430,8 @@ Deno.test("subscribeInvalidation: fires handlers after recompile", async () => {
 
 - [ ] **Step 2: Run tests to confirm they fail**
 
-Run: `deno test packages/markspec/mcp/project_test.ts`
-Expected: FAIL — module `./project.ts` not found.
+Run: `deno test packages/markspec/mcp/project_test.ts` Expected: FAIL — module
+`./project.ts` not found.
 
 - [ ] **Step 3: Implement `mcp/project.ts`**
 
@@ -710,8 +707,8 @@ export async function createProject(env: ProjectEnv): Promise<Project> {
 
 - [ ] **Step 4: Run tests to confirm they pass**
 
-Run: `deno test packages/markspec/mcp/project_test.ts`
-Expected: PASS (7 tests, 0 failures).
+Run: `deno test packages/markspec/mcp/project_test.ts` Expected: PASS (7 tests,
+0 failures).
 
 - [ ] **Step 5: Commit**
 
@@ -809,8 +806,8 @@ Deno.test("renderProfile: omits sections that are empty", () => {
 
 - [ ] **Step 2: Run tests to confirm they fail**
 
-Run: `deno test packages/markspec/mcp/resources/profile_test.ts`
-Expected: FAIL — module `./profile.ts` not found.
+Run: `deno test packages/markspec/mcp/resources/profile_test.ts` Expected: FAIL
+— module `./profile.ts` not found.
 
 - [ ] **Step 3: Implement the renderer with a typed view input**
 
@@ -1045,8 +1042,8 @@ function targetIncludesType(
 
 - [ ] **Step 4: Run tests to confirm they pass**
 
-Run: `deno test packages/markspec/mcp/resources/profile_test.ts`
-Expected: PASS (3 tests, 0 failures).
+Run: `deno test packages/markspec/mcp/resources/profile_test.ts` Expected: PASS
+(3 tests, 0 failures).
 
 - [ ] **Step 5: Commit**
 
@@ -1187,8 +1184,8 @@ Deno.test("renderEntry: omits Attributes section when only Id present", () => {
 
 - [ ] **Step 2: Run tests to confirm they fail**
 
-Run: `deno test packages/markspec/mcp/resources/entry_test.ts`
-Expected: FAIL — module `./entry.ts` not found.
+Run: `deno test packages/markspec/mcp/resources/entry_test.ts` Expected: FAIL —
+module `./entry.ts` not found.
 
 - [ ] **Step 3: Implement the renderer**
 
@@ -1273,8 +1270,8 @@ export function renderEntry(
 
 - [ ] **Step 4: Run tests to confirm they pass**
 
-Run: `deno test packages/markspec/mcp/resources/entry_test.ts`
-Expected: PASS (8 tests, 0 failures).
+Run: `deno test packages/markspec/mcp/resources/entry_test.ts` Expected: PASS (8
+tests, 0 failures).
 
 - [ ] **Step 5: Commit**
 
@@ -1358,8 +1355,7 @@ Deno.test("renderEntriesIndex: empty corpus", () => {
 
 - [ ] **Step 2: Run tests to confirm they fail**
 
-Run: `deno test packages/markspec/mcp/resources/entries_test.ts`
-Expected: FAIL.
+Run: `deno test packages/markspec/mcp/resources/entries_test.ts` Expected: FAIL.
 
 - [ ] **Step 3: Implement the renderer**
 
@@ -1414,8 +1410,8 @@ export function renderEntriesIndex(entries: readonly Entry[]): string {
 
 - [ ] **Step 4: Run tests to confirm they pass**
 
-Run: `deno test packages/markspec/mcp/resources/entries_test.ts`
-Expected: PASS (4 tests, 0 failures).
+Run: `deno test packages/markspec/mcp/resources/entries_test.ts` Expected: PASS
+(4 tests, 0 failures).
 
 - [ ] **Step 5: Commit**
 
@@ -1433,8 +1429,8 @@ git commit -m "feat(mcp): render markspec://entries index as Markdown"
 - Create: `packages/markspec/mcp/resources/mod.ts`
 
 This module wires the SDK's `resources/list` and `resources/read` handlers to
-the three renderers. It also exposes a `listResourceDescriptors()` helper so
-the e2e test can verify advertised resources without invoking the SDK.
+the three renderers. It also exposes a `listResourceDescriptors()` helper so the
+e2e test can verify advertised resources without invoking the SDK.
 
 - [ ] **Step 1: Implement the registration module**
 
@@ -1587,7 +1583,8 @@ export function registerResources(server: Server, project: Project): void {
 }
 ```
 
-- [ ] **Step 2: Add a unit test for `listResourceDescriptors` and `readResource`**
+- [ ] **Step 2: Add a unit test for `listResourceDescriptors` and
+      `readResource`**
 
 Create `packages/markspec/mcp/resources/mod_test.ts`:
 
@@ -1691,8 +1688,8 @@ Deno.test("readResource: rejects missing entry", async () => {
 
 - [ ] **Step 3: Run tests to confirm they pass**
 
-Run: `deno test packages/markspec/mcp/resources/`
-Expected: PASS (all resource tests).
+Run: `deno test packages/markspec/mcp/resources/` Expected: PASS (all resource
+tests).
 
 - [ ] **Step 4: Commit**
 
@@ -1809,8 +1806,7 @@ Deno.test("renderSearchResults: links each hit", () => {
 
 - [ ] **Step 2: Run tests to confirm they fail**
 
-Run: `deno test packages/markspec/mcp/tools/search_test.ts`
-Expected: FAIL.
+Run: `deno test packages/markspec/mcp/tools/search_test.ts` Expected: FAIL.
 
 - [ ] **Step 3: Implement the tool**
 
@@ -1920,8 +1916,8 @@ export const ENTRY_SEARCH_DESCRIPTOR = {
 
 - [ ] **Step 4: Run tests to confirm they pass**
 
-Run: `deno test packages/markspec/mcp/tools/search_test.ts`
-Expected: PASS (7 tests, 0 failures).
+Run: `deno test packages/markspec/mcp/tools/search_test.ts` Expected: PASS (7
+tests, 0 failures).
 
 - [ ] **Step 5: Commit**
 
@@ -2082,8 +2078,7 @@ Deno.test("renderContext: nested list with indentation", () => {
 
 - [ ] **Step 2: Run tests to confirm they fail**
 
-Run: `deno test packages/markspec/mcp/tools/context_test.ts`
-Expected: FAIL.
+Run: `deno test packages/markspec/mcp/tools/context_test.ts` Expected: FAIL.
 
 - [ ] **Step 3: Implement the tool**
 
@@ -2203,8 +2198,8 @@ export const ENTRY_CONTEXT_DESCRIPTOR = {
 
 - [ ] **Step 4: Run tests to confirm they pass**
 
-Run: `deno test packages/markspec/mcp/tools/context_test.ts`
-Expected: PASS (6 tests, 0 failures).
+Run: `deno test packages/markspec/mcp/tools/context_test.ts` Expected: PASS (6
+tests, 0 failures).
 
 - [ ] **Step 5: Commit**
 
@@ -2294,8 +2289,7 @@ Deno.test("filterDiagnostics: absolute path match", () => {
 
 - [ ] **Step 2: Run tests to confirm they fail**
 
-Run: `deno test packages/markspec/mcp/tools/validate_test.ts`
-Expected: FAIL.
+Run: `deno test packages/markspec/mcp/tools/validate_test.ts` Expected: FAIL.
 
 - [ ] **Step 3: Implement the tool**
 
@@ -2403,8 +2397,8 @@ export const VALIDATE_DESCRIPTOR = {
 
 - [ ] **Step 4: Run tests to confirm they pass**
 
-Run: `deno test packages/markspec/mcp/tools/validate_test.ts`
-Expected: PASS (6 tests, 0 failures).
+Run: `deno test packages/markspec/mcp/tools/validate_test.ts` Expected: PASS (6
+tests, 0 failures).
 
 - [ ] **Step 5: Commit**
 
@@ -2450,8 +2444,7 @@ Deno.test("renderRefresh: zero counts", () => {
 
 - [ ] **Step 2: Run tests to confirm they fail**
 
-Run: `deno test packages/markspec/mcp/tools/refresh_test.ts`
-Expected: FAIL.
+Run: `deno test packages/markspec/mcp/tools/refresh_test.ts` Expected: FAIL.
 
 - [ ] **Step 3: Implement the tool**
 
@@ -2490,8 +2483,8 @@ export const REFRESH_DESCRIPTOR = {
 
 - [ ] **Step 4: Run tests to confirm they pass**
 
-Run: `deno test packages/markspec/mcp/tools/refresh_test.ts`
-Expected: PASS (2 tests, 0 failures).
+Run: `deno test packages/markspec/mcp/tools/refresh_test.ts` Expected: PASS (2
+tests, 0 failures).
 
 - [ ] **Step 5: Commit**
 
@@ -2634,8 +2627,8 @@ export function registerTools(server: Server, project: Project): void {
 
 - [ ] **Step 2: Type-check the package**
 
-Run: `deno check packages/markspec/mcp/tools/mod.ts`
-Expected: PASS with no errors.
+Run: `deno check packages/markspec/mcp/tools/mod.ts` Expected: PASS with no
+errors.
 
 - [ ] **Step 3: Commit**
 
@@ -2734,8 +2727,7 @@ if (import.meta.main) {
 
 - [ ] **Step 2: Type-check the package**
 
-Run: `deno check packages/markspec/mcp/server.ts`
-Expected: PASS with no errors.
+Run: `deno check packages/markspec/mcp/server.ts` Expected: PASS with no errors.
 
 - [ ] **Step 3: Commit**
 
@@ -2757,9 +2749,9 @@ git commit -m "feat(mcp): bootstrap MCP server over stdio with resource notifica
 Find in `packages/markspec/main.ts` the block:
 
 ```typescript
-  .command("mcp")
-  .description("Start MCP server")
-  .action(notImplemented("mcp"))
+.command("mcp")
+.description("Start MCP server")
+.action(notImplemented("mcp"))
 ```
 
 - [ ] **Step 2: Replace with a dynamic-import action**
@@ -2767,26 +2759,26 @@ Find in `packages/markspec/main.ts` the block:
 Replace the action with:
 
 ```typescript
-  .command("mcp")
-  .description("Start MCP server (stdio JSON-RPC)")
-  .action(async () => {
-    const { startServer } = await import("./mcp/server.ts");
-    await startServer();
-  })
+.command("mcp")
+.description("Start MCP server (stdio JSON-RPC)")
+.action(async () => {
+  const { startServer } = await import("./mcp/server.ts");
+  await startServer();
+})
 ```
 
 - [ ] **Step 3: Type-check**
 
-Run: `deno check packages/markspec/main.ts`
-Expected: PASS.
+Run: `deno check packages/markspec/main.ts` Expected: PASS.
 
 - [ ] **Step 4: Smoke-test the binary**
 
-Run: `deno run --allow-read --allow-write --allow-env --allow-net=0 packages/markspec/main.ts mcp < /dev/null`
+Run:
+`deno run --allow-read --allow-write --allow-env --allow-net=0 packages/markspec/main.ts mcp < /dev/null`
 Expected: process starts, exits cleanly when stdin closes.
 
-If the smoke test fails due to a missing permission (e.g. `--allow-ffi`), add
-it and re-run. The full permission set this command needs is:
+If the smoke test fails due to a missing permission (e.g. `--allow-ffi`), add it
+and re-run. The full permission set this command needs is:
 `--allow-read --allow-write --allow-env --allow-net --allow-ffi`.
 
 - [ ] **Step 5: Commit**
@@ -3132,9 +3124,9 @@ Then append a new `## mcp` section near the end of `docs/guide/commands.md`:
 ````markdown
 ## mcp
 
-Starts the MarkSpec MCP server. Communicates over stdio JSON-RPC. Exposes
-the active project as MCP resources and tools to any MCP-capable AI client
-(Claude Code, Claude Desktop, GitHub Copilot in VS Code, OpenCode).
+Starts the MarkSpec MCP server. Communicates over stdio JSON-RPC. Exposes the
+active project as MCP resources and tools to any MCP-capable AI client (Claude
+Code, Claude Desktop, GitHub Copilot in VS Code, OpenCode).
 
 ```bash
 markspec mcp
@@ -3142,8 +3134,8 @@ markspec mcp
 
 ### Resources
 
-- `markspec://profile` — distilled profile manifest (types, attributes,
-  link kinds, labels).
+- `markspec://profile` — distilled profile manifest (types, attributes, link
+  kinds, labels).
 - `markspec://entries` — index of all project entries, grouped by type.
 - `markspec://entry/{displayId}` — one entry per resource, with attributes,
   body, outgoing/incoming links.
@@ -3155,8 +3147,8 @@ markspec mcp
 - `entry_context { id, depth? }` — walk the `satisfies` chain upward.
 - `validate { files? }` — run the validator, return a Markdown diagnostics
   report.
-- `markspec_refresh` — force-invalidate the compile cache (call after
-  agent edits to guarantee freshness).
+- `markspec_refresh` — force-invalidate the compile cache (call after agent
+  edits to guarantee freshness).
 
 ### Claude Desktop config
 
@@ -3174,8 +3166,8 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
 }
 ```
 
-Restart Claude Desktop. The MarkSpec resources and tools appear in the
-attach menu.
+Restart Claude Desktop. The MarkSpec resources and tools appear in the attach
+menu.
 
 ### Claude Code
 
@@ -3198,17 +3190,15 @@ In your project's `.vscode/mcp.json`:
 }
 ```
 
-Copilot does not support MCP resource subscriptions today, but the
-`markspec://` resources still work — the server runs a fresh validity
-check on every read, so a re-read after an edit returns up-to-date
-content.
+Copilot does not support MCP resource subscriptions today, but the `markspec://`
+resources still work — the server runs a fresh validity check on every read, so
+a re-read after an edit returns up-to-date content.
 ````
 
 - [ ] **Step 3: Format and verify**
 
-Run: `dprint fmt docs/guide/commands.md`
-Run: `dprint check docs/guide/commands.md`
-Expected: clean format check.
+Run: `dprint fmt docs/guide/commands.md` Run:
+`dprint check docs/guide/commands.md` Expected: clean format check.
 
 - [ ] **Step 4: Commit**
 
@@ -3272,15 +3262,13 @@ deferral comment.
 
 - [ ] **Run full test suite**
 
-Run: `just check`
-Expected: lint passes, type-check passes, all tests pass (including new MCP
-unit tests + the e2e test).
+Run: `just check` Expected: lint passes, type-check passes, all tests pass
+(including new MCP unit tests + the e2e test).
 
 - [ ] **Run a build**
 
-Run: `just build`
-Expected: lint + tests + type-check + binary compile all succeed; `dist/markspec`
-exists and runs.
+Run: `just build` Expected: lint + tests + type-check + binary compile all
+succeed; `dist/markspec` exists and runs.
 
 - [ ] **Manual smoke from binary**
 

--- a/docs/superpowers/specs/2026-05-10-mcp-server-design.md
+++ b/docs/superpowers/specs/2026-05-10-mcp-server-design.md
@@ -1,0 +1,415 @@
+# MCP Server — Design Specification
+
+**Date**: 2026-05-10 **Scope**: `packages/markspec/mcp/` **References**:
+[ADR-005](../../architecture/adr-005-cli-architecture.md), GitHub issues #60–#63,
+[2026-04-23 LSP design](2026-04-23-lsp-server-design.md)
+
+## 1. Overview
+
+This spec defines v1 of the MarkSpec MCP server — a stdio JSON-RPC server that
+exposes MarkSpec's traceability data to AI coding agents (Claude Desktop, Claude
+Code, and any other MCP client).
+
+V1 is **read-only**. It ships five tools backed by the already-implemented core
+library (`core/mod.ts`), giving agents the same query power as the
+`markspec show / context / dependents / validate` CLI subcommands. Write
+operations (`requirement_insert`) are deferred until `markspec insert` lands as
+its own epic.
+
+| Issue | Feature                          | v1 status                              |
+| ----- | -------------------------------- | -------------------------------------- |
+| #60   | `mcp/` module + `markspec mcp`   | In scope — server scaffold + lifecycle |
+| #61   | Lookup tool (id → entry)         | In scope — renamed `entry_lookup`      |
+| #62   | Search tool (query → entries)    | In scope — renamed `entry_search`      |
+| #63   | `requirement_insert` write tool  | **Deferred** — see §9                  |
+
+### Tool naming
+
+The original issues use `registry_lookup` / `registry_search`. v1 ships them as
+`entry_lookup` / `entry_search` to match current vocabulary; "registry" now
+implies external RefHub-style standard lookup, which is a separate future tool
+family. Issues #61/#62 will be updated when the spec is approved.
+
+## 2. Architecture
+
+### 2.1 Compile target
+
+`mcp/server.ts` is **not** a separate compile target. It is dynamically imported
+by `main.ts` when the user runs `markspec mcp`, identical to how
+`lsp/server.ts` is dispatched. There is one binary — `markspec` — and `markspec
+validate` never loads the MCP SDK.
+
+```bash
+deno compile packages/markspec/main.ts  # → markspec (single binary)
+```
+
+This matches the lazy-loading invariant in
+[CLAUDE.md / AGENTS.md](../../../AGENTS.md): each subcommand pulls in only the
+modules it needs.
+
+### 2.2 Module structure
+
+```text
+packages/markspec/mcp/
+├── server.ts          ← entry: stdio transport, MCP server lifecycle, tool registration
+├── project.ts         ← project context: discoverProjectRoot, compile cache, mtime check, refresh
+├── tools/
+│   ├── mod.ts         ← register all tools; shared input-schema helpers
+│   ├── lookup.ts      ← entry_lookup
+│   ├── search.ts      ← entry_search
+│   ├── context.ts     ← entry_context
+│   ├── dependents.ts  ← entry_dependents
+│   ├── validate.ts    ← validate
+│   └── refresh.ts     ← markspec_refresh
+└── (e2e tests live in tests/e2e/mcp_test.ts; unit tests are colocated)
+```
+
+Each tool is one file with: a name, a JSON Schema for inputs, and a handler.
+`tools/mod.ts` collects them and registers them with the server. No barrel
+`mod.ts` at the top of `mcp/` — nothing outside `mcp/` imports these modules.
+
+### 2.3 Dependency flow
+
+```text
+core/mod.ts ← project.ts
+core/mod.ts ← tools/*.ts
+project.ts  ← tools/*.ts
+tools/mod.ts ← server.ts
+project.ts   ← server.ts
+
+npm:@modelcontextprotocol/sdk ← server.ts, tools/mod.ts
+```
+
+The MCP module imports exclusively from `core/mod.ts` — never from internal core
+paths.
+
+## 3. Server Lifecycle (#60)
+
+### 3.1 Transport
+
+stdio only. The server is launched as a child process by the MCP client; the
+client writes JSON-RPC messages to stdin and reads responses from stdout. This
+matches Claude Desktop's default and matches the LSP's transport choice. HTTP /
+SSE is out of scope for v1.
+
+### 3.2 Capabilities
+
+The server advertises one capability:
+
+- `tools` — list and call tools
+
+Resources, prompts, and sampling are **not** implemented in v1. They are
+plausible follow-ups (resources especially — exposing parsed entries as MCP
+resources would let clients browse the project), but the read-tool set is enough
+for the agent use cases we know about.
+
+### 3.3 Initialize sequence
+
+1. Client connects on stdio. Server constructs `Server` and
+   `StdioServerTransport` from `@modelcontextprotocol/sdk`.
+2. Client sends `initialize`. Server responds with capabilities and version.
+3. **In parallel** (background, fire-and-forget): the server kicks off a
+   `compile()` of the project rooted at `Deno.cwd()`. The in-flight promise is
+   stored in module state. See §4.
+4. Client typically follows up with `tools/list`. This call does not require
+   the compile to be done — the tool list is static.
+5. First `tools/call` awaits the in-flight compile promise. Subsequent calls
+   use the cached result if no files have changed.
+
+### 3.4 Shutdown
+
+The server listens for stdio EOF and the standard MCP `shutdown` notification.
+On either signal it stops accepting new requests and exits the process. The
+in-flight compile (if any) is abandoned by process exit — `compile()` has no
+cancel API, but it touches no shared state, so abandoning is safe.
+
+## 4. Project Context and Caching
+
+### 4.1 Discovery
+
+On `initialize`, the server calls `discoverProjectRoot(Deno.cwd(), readFile)`
+from `core/mod.ts`. If no `project.yaml` is found, the server still starts and
+`tools/list` works, but every `tools/call` returns a clean error:
+
+> `"MarkSpec MCP server: no project.yaml found from <cwd>. Tools require project context."`
+
+This mirrors how the project-aware CLI subcommands behave.
+
+### 4.2 Compile cache
+
+Module-level state in `project.ts`:
+
+```text
+ProjectCache = {
+  projectRoot: string,
+  config: ProjectConfig,
+  profile: ProfileChain | null,
+  inFlight: Promise<CompileResult> | null,    // background compile
+  result: CompileResult | null,               // last successful result
+  compiledAt: number,                         // ms epoch
+  trackedFiles: { path: string, mtime: number }[],
+}
+```
+
+### 4.3 Invalidation: mtime check on every call
+
+`getCompiled()` is the single entry point used by all tools. Algorithm:
+
+1. If `result === null` and `inFlight !== null`: await `inFlight`, populate
+   `result`, return.
+2. Stat every path in `trackedFiles`. Glob the project root for new `.md` and
+   supported source files (same set the CLI uses). Compute:
+   - `anyMtimeNewer` — any tracked file's current mtime > `compiledAt`
+   - `anyNewFile` — a discovered file is not in `trackedFiles`
+   - `anyMissing` — a tracked file no longer exists
+3. If any of those is true: await a fresh `compile()`, swap into `result`,
+   update `compiledAt` and `trackedFiles`, return.
+4. Otherwise: return `result`.
+
+The stat sweep is single-digit milliseconds for projects with hundreds of files
+— well under the cost of a recompile (100–500 ms typical). No filesystem
+watcher is needed in v1; we can add one later if profiling shows the stat sweep
+dominates on very large projects.
+
+### 4.4 Explicit refresh
+
+`markspec_refresh` is a no-arg tool that forces a recompile. It exists as an
+escape hatch: an agent that has just edited several files can call refresh to
+guarantee the next query sees the new state without depending on mtime
+resolution.
+
+### 4.5 Concurrency
+
+`getCompiled()` is `async`. If two tool calls land while a recompile is
+in-flight, both await the same `inFlight` promise — `compile()` is not run
+twice. A simple per-process mutex (one `inFlight: Promise | null` slot) is
+sufficient for stdio's single-client model.
+
+## 5. Tools
+
+All tool inputs use JSON Schema declared inline in the tool file. All outputs
+are JSON-serializable.
+
+Outputs are wrapped in the MCP `CallToolResult` shape: a `content` array with a
+single `text` item containing pretty-printed JSON. Agents parse this back into
+structured data. (The MCP SDK supports structured `content` types but JSON-as-
+text is the broadly compatible idiom.)
+
+### 5.1 `entry_lookup` (#61)
+
+Resolve a single entry by display ID or ULID.
+
+- **Input**: `{ id: string }`
+- **Output**:
+  ```json
+  {
+    "displayId": "STK_AEB_0001",
+    "ulid": "01HGW2...",
+    "title": "...",
+    "type": "stakeholder-requirement",
+    "shape": "identified",
+    "attributes": [{ "key": "Satisfies", "value": "..." }, ...],
+    "location": { "file": "...", "line": 42, "column": 1 },
+    "forwardLinks": [{ "kind": "satisfies", "to": "SYS_AEB_0012" }, ...],
+    "reverseLinks": [{ "kind": "verified-by", "from": "SIT_AEB_0030" }, ...]
+  }
+  ```
+- **Error**: `entry not found: <id>`
+
+Backed by `compile().entries.get(id)` plus `forward.get(id)` and
+`reverse.get(id)`. Mirrors `markspec show <id> --format json` exactly.
+
+### 5.2 `entry_search` (#62)
+
+Rank-search entries by display-ID and title.
+
+- **Input**: `{ query: string, limit?: number }` — `limit` defaults to 20,
+  capped at 100.
+- **Output**: array of `{ displayId, title, type, score }`, sorted by score
+  descending.
+
+#### Ranking algorithm (v1)
+
+1. Normalize `query` and each candidate field to lowercase.
+2. Tokenize on whitespace and underscores.
+3. Score per entry:
+   - +10 if `query` is a prefix of `displayId`
+   - +5 if `query` is a substring of `displayId`
+   - +3 per query-token matching a title-token (exact)
+   - +1 per query-token matching a title-token (substring)
+   - +2 if all query-tokens appear in title (any order)
+4. Drop entries with score 0. Sort descending. Take `limit`.
+
+This is ~30 lines of pure code. It handles the two natural query shapes
+(partial ID, keyword from a known title) and is trivial to upgrade later. We
+explicitly chose not to pull in `fuse.js` for v1 — cost is dependency weight
+and we have no evidence the better fuzziness moves the needle.
+
+### 5.3 `entry_context` (#60-adjacent)
+
+Walk the `Satisfies` chain upward from an entry.
+
+- **Input**: `{ id: string, depth?: number }` — `depth` defaults to 10.
+- **Output**: array of `{ displayId, title, depth }` in BFS order, where
+  `depth` is hops from the start entry (0 = the start entry itself).
+
+Mirrors `markspec context <id> --format json`. Same cycle protection
+(`visited` set).
+
+### 5.4 `entry_dependents` (#60-adjacent)
+
+List all entries that link to the given entry (any link kind).
+
+- **Input**: `{ id: string }`
+- **Output**: array of `{ from, kind, title }` from `compile().reverse.get(id)`.
+
+Mirrors `markspec dependents <id> --format json`.
+
+### 5.5 `validate`
+
+Run the validator pipeline.
+
+- **Input**: `{ files?: string[] }` — when omitted, validate the full project.
+  Relative paths are resolved against the project root; absolute paths are
+  used as-is.
+- **Output**: array of `{ severity, code, message, location }`. Always full
+  diagnostics (no truncation). Cross-file diagnostics are computed against the
+  full corpus regardless; if `files` is provided, the result is filtered to
+  diagnostics whose `location.file` matches one of the input paths after
+  normalizing both sides to absolute paths.
+
+Mirrors `markspec validate --format json`. `--strict` is **not** exposed in v1
+— agents can promote warnings themselves if they need to.
+
+### 5.6 `markspec_refresh`
+
+Force-invalidate the compile cache.
+
+- **Input**: `{}`
+- **Output**: `{ refreshed: true, entries: <number>, links: <number> }`
+
+Always recompiles, even if mtime check would have skipped it. Returns counts
+so agents can sanity-check that the recompile happened.
+
+## 6. SDK and Dependencies
+
+`@modelcontextprotocol/sdk` (TypeScript MCP SDK), imported via `npm:` because
+no JSR mirror exists today:
+
+```typescript
+import { Server } from "npm:@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "npm:@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from "npm:@modelcontextprotocol/sdk/types.js";
+```
+
+This matches the existing precedent (`vscode-languageserver` is also `npm:`).
+Node.js compatibility is preserved — the SDK is npm-published and runs on both
+runtimes.
+
+No additional dependencies. JSON Schema for tool inputs is hand-written
+(schemas are tiny — three fields max). No Zod, no JSON-Schema-from-Zod.
+
+## 7. Errors
+
+Two categories:
+
+**Setup errors** — surface as MCP errors on the offending `tools/call`:
+
+| Code              | Trigger                                              |
+| ----------------- | ---------------------------------------------------- |
+| `NO_PROJECT_ROOT` | No `project.yaml` found from `Deno.cwd()`            |
+| `COMPILE_FAILED`  | `compile()` returned errors of severity `error`      |
+
+**Tool errors** — handler-level, returned as `isError: true` content:
+
+| Code              | Trigger                                       |
+| ----------------- | --------------------------------------------- |
+| `ENTRY_NOT_FOUND` | `entry_lookup`/`context`/`dependents` miss    |
+| `INVALID_INPUT`   | JSON-schema validation failed                 |
+
+`COMPILE_FAILED` is a hard error — the cache is left empty and subsequent
+calls retry. We do **not** silently return partial graphs; the agent should
+know the project is broken.
+
+## 8. Tests
+
+### 8.1 Unit tests
+
+Each `tools/<name>.ts` has a colocated `<name>_test.ts`. Tests build a minimal
+fixture `CompileResult` (or use a shared builder) and assert tool output JSON
+shape and content. No process spawning, no SDK mocking.
+
+The ranking algorithm in `search.ts` gets focused tests for each scoring rule
+(prefix bonus, token coverage, etc.).
+
+`project.ts` gets unit tests for the cache invalidation logic with an
+in-memory readFile / stat shim.
+
+### 8.2 E2E test
+
+`tests/e2e/mcp_test.ts` spawns `deno run main.ts mcp` with a fixture project
+in a temp directory. It exchanges a real JSON-RPC sequence over stdio:
+
+1. `initialize` → assert capabilities include `tools`.
+2. `tools/list` → assert all six tools present, schemas non-empty.
+3. `tools/call entry_lookup { id: "STK_AEB_0001" }` → assert response shape.
+4. `tools/call entry_search { query: "braking" }` → assert at least one hit.
+5. `tools/call validate {}` → assert empty diagnostics on the clean fixture.
+6. Mutate a fixture file to introduce a broken ref. `tools/call validate {}`
+   → assert the broken-ref diagnostic appears (proves auto-invalidation works).
+7. `shutdown` notification → assert clean exit.
+
+This is the integration boundary; it never imports from `mcp/` directly.
+
+### 8.3 Snapshot tests
+
+`tests/e2e/mcp_test.ts` snapshots the `tools/list` response so wording or
+schema regressions are caught on review.
+
+## 9. Out of Scope for v1
+
+| Item                    | Reason                                                    |
+| ----------------------- | --------------------------------------------------------- |
+| `requirement_insert`    | Requires `markspec insert` (epic:insert, #38–#41); land that first, then add the wrapper tool. |
+| External RefHub lookup  | A separate tool family — distinct concept from local entries. |
+| HTTP / SSE transport    | stdio covers Claude Desktop / Claude Code defaults.       |
+| Resources / prompts     | Agent UX is fine without; tools cover known use cases.    |
+| Sampling                | Out of scope; relevant only for nested-LLM workflows.     |
+| Multi-root workspace    | Single project root matches CLI semantics.                |
+| Filesystem watcher      | Stat sweep is cheap enough; revisit if profiling demands. |
+| Hot profile reload      | Profile chain is loaded once on initialize; refresh tool re-reads. |
+
+## 10. Rollout
+
+One PR with the full v1:
+
+1. Add `mcp/server.ts`, `mcp/project.ts`, `mcp/tools/*.ts`, colocated unit
+   tests.
+2. Add `tests/e2e/mcp_test.ts`.
+3. Wire `markspec mcp` in `main.ts` to `await import("./mcp/server.ts")`,
+   removing the `notImplemented("mcp")` placeholder.
+4. Add `npm:@modelcontextprotocol/sdk` to the project's dependency graph (it
+   is pulled in transitively by `import` — no `deno.json` change required
+   beyond what the lockfile records).
+5. Update [docs/guide/commands.md](../../guide/commands.md) — promote `mcp`
+   from "not implemented" to documented, with a worked example connecting
+   from Claude Desktop.
+6. Update GitHub issues #60–#63 with the renamed tools and the deferral of
+   #63.
+
+## 11. Open Questions
+
+None blocking implementation. Items for follow-up after v1 ships:
+
+- **Telemetry**: Should the server log tool invocation counts? Useful for
+  understanding which tools agents actually use, but introduces a logging
+  surface. Defer.
+- **Caching across processes**: Each `markspec mcp` process keeps its own
+  cache. Two MCP clients connecting (e.g., Claude Desktop and Claude Code
+  simultaneously) compile twice. Acceptable for v1.
+- **Profile changes**: Editing `.markspec.yaml` doesn't currently invalidate
+  the cache (mtime check only watches parsed files). If profile-driven
+  attribute validation lands, we add `.markspec.yaml` to the watched set.

--- a/docs/superpowers/specs/2026-05-10-mcp-server-design.md
+++ b/docs/superpowers/specs/2026-05-10-mcp-server-design.md
@@ -2,7 +2,8 @@
 
 **Date**: 2026-05-10 **Scope**: `packages/markspec/mcp/` **References**:
 [ADR-005](../../architecture/adr-005-cli-architecture.md), GitHub issues #60–#63,
-[2026-04-23 LSP design](2026-04-23-lsp-server-design.md)
+[2026-04-23 LSP design](2026-04-23-lsp-server-design.md),
+[MCP specification](https://spec.modelcontextprotocol.io)
 
 ## 1. Overview
 
@@ -10,25 +11,28 @@ This spec defines v1 of the MarkSpec MCP server — a stdio JSON-RPC server that
 exposes MarkSpec's traceability data to AI coding agents (Claude Desktop, Claude
 Code, and any other MCP client).
 
-V1 is **read-only**. It ships five tools backed by the already-implemented core
-library (`core/mod.ts`), giving agents the same query power as the
-`markspec show / context / dependents / validate` CLI subcommands. Write
-operations (`requirement_insert`) are deferred until `markspec insert` lands as
-its own epic.
+**Design principle: idiomatic MCP.** Static, addressable data is exposed as MCP
+**resources** with Markdown bodies. Parameterized actions are exposed as MCP
+**tools** that return Markdown content. Nothing is dumped as JSON-in-a-text-blob
+— agents read Markdown natively, clients render it, and the URI scheme makes
+entries first-class objects that can be browsed and subscribed to.
+
+V1 is **read-only**. Write operations (`requirement_insert`) are deferred until
+`markspec insert` lands as its own epic.
 
 | Issue | Feature                          | v1 status                              |
 | ----- | -------------------------------- | -------------------------------------- |
 | #60   | `mcp/` module + `markspec mcp`   | In scope — server scaffold + lifecycle |
-| #61   | Lookup tool (id → entry)         | In scope — renamed `entry_lookup`      |
-| #62   | Search tool (query → entries)    | In scope — renamed `entry_search`      |
+| #61   | Lookup tool (id → entry)         | In scope — replaced by `markspec://entry/{id}` resource |
+| #62   | Search tool (query → entries)    | In scope — `entry_search` tool         |
 | #63   | `requirement_insert` write tool  | **Deferred** — see §9                  |
 
-### Tool naming
+### Tool/resource naming
 
-The original issues use `registry_lookup` / `registry_search`. v1 ships them as
-`entry_lookup` / `entry_search` to match current vocabulary; "registry" now
-implies external RefHub-style standard lookup, which is a separate future tool
-family. Issues #61/#62 will be updated when the spec is approved.
+The original issues use `registry_*`. "Registry" now implies external
+RefHub-style standard lookup (a separate future tool family); local
+project entries are surfaced under `markspec://entry/...` resources.
+Issues #61/#62 will be updated when the spec is approved.
 
 ## 2. Architecture
 
@@ -44,40 +48,45 @@ deno compile packages/markspec/main.ts  # → markspec (single binary)
 ```
 
 This matches the lazy-loading invariant in
-[CLAUDE.md / AGENTS.md](../../../AGENTS.md): each subcommand pulls in only the
-modules it needs.
+[CLAUDE.md / AGENTS.md](../../../AGENTS.md).
 
 ### 2.2 Module structure
 
 ```text
 packages/markspec/mcp/
-├── server.ts          ← entry: stdio transport, MCP server lifecycle, tool registration
-├── project.ts         ← project context: discoverProjectRoot, compile cache, mtime check, refresh
-├── tools/
-│   ├── mod.ts         ← register all tools; shared input-schema helpers
-│   ├── lookup.ts      ← entry_lookup
-│   ├── search.ts      ← entry_search
-│   ├── context.ts     ← entry_context
-│   ├── dependents.ts  ← entry_dependents
-│   ├── validate.ts    ← validate
-│   └── refresh.ts     ← markspec_refresh
-└── (e2e tests live in tests/e2e/mcp_test.ts; unit tests are colocated)
+├── server.ts          ← entry: stdio transport, server lifecycle, registration
+├── project.ts         ← project context: discover, compile cache, mtime check, refresh
+├── resources/
+│   ├── mod.ts         ← register resources, handle resources/list and resources/read
+│   ├── profile.ts     ← markspec://profile renderer
+│   ├── entries.ts     ← markspec://entries (index) renderer
+│   └── entry.ts       ← markspec://entry/{displayId} renderer
+└── tools/
+    ├── mod.ts         ← register tools
+    ├── search.ts      ← entry_search
+    ├── context.ts     ← entry_context
+    ├── validate.ts    ← validate
+    └── refresh.ts     ← markspec_refresh
 ```
 
-Each tool is one file with: a name, a JSON Schema for inputs, and a handler.
-`tools/mod.ts` collects them and registers them with the server. No barrel
-`mod.ts` at the top of `mcp/` — nothing outside `mcp/` imports these modules.
+Resources and tools are siblings under `mcp/`. Each file has one responsibility.
+No barrel `mod.ts` at the top of `mcp/` — nothing outside `mcp/` imports these
+modules. Unit tests are colocated as `<name>_test.ts`; the e2e test lives at
+`tests/e2e/mcp_test.ts`.
 
 ### 2.3 Dependency flow
 
 ```text
 core/mod.ts ← project.ts
+core/mod.ts ← resources/*.ts
 core/mod.ts ← tools/*.ts
+project.ts  ← resources/*.ts
 project.ts  ← tools/*.ts
-tools/mod.ts ← server.ts
-project.ts   ← server.ts
+resources/mod.ts ← server.ts
+tools/mod.ts     ← server.ts
+project.ts       ← server.ts
 
-npm:@modelcontextprotocol/sdk ← server.ts, tools/mod.ts
+npm:@modelcontextprotocol/sdk ← server.ts, resources/mod.ts, tools/mod.ts
 ```
 
 The MCP module imports exclusively from `core/mod.ts` — never from internal core
@@ -89,19 +98,19 @@ paths.
 
 stdio only. The server is launched as a child process by the MCP client; the
 client writes JSON-RPC messages to stdin and reads responses from stdout. This
-matches Claude Desktop's default and matches the LSP's transport choice. HTTP /
-SSE is out of scope for v1.
+matches Claude Desktop's default and the LSP's transport choice. HTTP / SSE is
+out of scope for v1.
 
 ### 3.2 Capabilities
 
-The server advertises one capability:
+The server advertises three capabilities:
 
-- `tools` — list and call tools
+- `resources` — with `subscribe: true` and `listChanged: true`
+- `tools` — with `listChanged: false` (tool set is static across the session)
+- (no `prompts`, no `sampling`)
 
-Resources, prompts, and sampling are **not** implemented in v1. They are
-plausible follow-ups (resources especially — exposing parsed entries as MCP
-resources would let clients browse the project), but the read-tool set is enough
-for the agent use cases we know about.
+Subscriptions and list-changed notifications are essential for the live-feel
+behaviour described in §4.7.
 
 ### 3.3 Initialize sequence
 
@@ -111,10 +120,11 @@ for the agent use cases we know about.
 3. **In parallel** (background, fire-and-forget): the server kicks off a
    `compile()` of the project rooted at `Deno.cwd()`. The in-flight promise is
    stored in module state. See §4.
-4. Client typically follows up with `tools/list`. This call does not require
-   the compile to be done — the tool list is static.
-5. First `tools/call` awaits the in-flight compile promise. Subsequent calls
-   use the cached result if no files have changed.
+4. Clients typically follow with `resources/list` and/or `tools/list`.
+   `tools/list` does not require the compile (tool list is static).
+   `resources/list` awaits the compile (entries are listed as resources).
+5. `resources/read` and `tools/call` use the cached compile, triggering a
+   recompile only when the mtime check detects changes.
 
 ### 3.4 Shutdown
 
@@ -123,17 +133,18 @@ On either signal it stops accepting new requests and exits the process. The
 in-flight compile (if any) is abandoned by process exit — `compile()` has no
 cancel API, but it touches no shared state, so abandoning is safe.
 
-## 4. Project Context and Caching
+## 4. Project Context, Caching, and Notifications
 
 ### 4.1 Discovery
 
 On `initialize`, the server calls `discoverProjectRoot(Deno.cwd(), readFile)`
 from `core/mod.ts`. If no `project.yaml` is found, the server still starts and
-`tools/list` works, but every `tools/call` returns a clean error:
+`tools/list` works, but every `resources/*` and `tools/call` returns a clean
+error:
 
-> `"MarkSpec MCP server: no project.yaml found from <cwd>. Tools require project context."`
+> `"MarkSpec MCP server: no project.yaml found from <cwd>. Operations require project context."`
 
-This mirrors how the project-aware CLI subcommands behave.
+This mirrors the project-aware CLI subcommands.
 
 ### 4.2 Compile cache
 
@@ -144,16 +155,18 @@ ProjectCache = {
   projectRoot: string,
   config: ProjectConfig,
   profile: ProfileChain | null,
-  inFlight: Promise<CompileResult> | null,    // background compile
-  result: CompileResult | null,               // last successful result
-  compiledAt: number,                         // ms epoch
+  inFlight: Promise<CompileResult> | null,
+  result: CompileResult | null,
+  compiledAt: number,
   trackedFiles: { path: string, mtime: number }[],
+  prevEntryIds: Set<string>,    // last-known entry IDs, for resource list diffing
 }
 ```
 
 ### 4.3 Invalidation: mtime check on every call
 
-`getCompiled()` is the single entry point used by all tools. Algorithm:
+`getCompiled()` is the single entry point used by every resource handler and
+tool. Algorithm:
 
 1. If `result === null` and `inFlight !== null`: await `inFlight`, populate
    `result`, return.
@@ -163,72 +176,208 @@ ProjectCache = {
    - `anyNewFile` — a discovered file is not in `trackedFiles`
    - `anyMissing` — a tracked file no longer exists
 3. If any of those is true: await a fresh `compile()`, swap into `result`,
-   update `compiledAt` and `trackedFiles`, return.
+   update `compiledAt` and `trackedFiles`, fire notifications (§4.7), return.
 4. Otherwise: return `result`.
 
 The stat sweep is single-digit milliseconds for projects with hundreds of files
 — well under the cost of a recompile (100–500 ms typical). No filesystem
-watcher is needed in v1; we can add one later if profiling shows the stat sweep
-dominates on very large projects.
+watcher in v1; we can add one later if profiling shows the stat sweep dominates.
 
 ### 4.4 Explicit refresh
 
 `markspec_refresh` is a no-arg tool that forces a recompile. It exists as an
-escape hatch: an agent that has just edited several files can call refresh to
-guarantee the next query sees the new state without depending on mtime
-resolution.
+escape hatch for agents that just edited files and don't want to depend on mtime
+resolution. It also fires the §4.7 notifications.
 
 ### 4.5 Concurrency
 
-`getCompiled()` is `async`. If two tool calls land while a recompile is
-in-flight, both await the same `inFlight` promise — `compile()` is not run
-twice. A simple per-process mutex (one `inFlight: Promise | null` slot) is
-sufficient for stdio's single-client model.
+`getCompiled()` is `async`. If two calls land while a recompile is in-flight,
+both await the same `inFlight` promise — `compile()` is not run twice. A simple
+per-process mutex (one `inFlight: Promise | null` slot) is sufficient for
+stdio's single-client model.
 
-## 5. Tools
+### 4.6 Subscriptions
 
-All tool inputs use JSON Schema declared inline in the tool file. All outputs
-are JSON-serializable.
+The server tracks per-resource subscribers via the SDK's built-in subscription
+machinery. We do not implement a custom subscription registry; we just call
+`server.sendResourceUpdated(uri)` and `server.sendResourceListChanged()` when
+appropriate.
 
-Outputs are wrapped in the MCP `CallToolResult` shape: a `content` array with a
-single `text` item containing pretty-printed JSON. Agents parse this back into
-structured data. (The MCP SDK supports structured `content` types but JSON-as-
-text is the broadly compatible idiom.)
+### 4.7 Change notifications
 
-### 5.1 `entry_lookup` (#61)
+After a successful recompile (whether from auto-invalidation in step 3 or from
+`markspec_refresh`), the server fires:
 
-Resolve a single entry by display ID or ULID.
+- `notifications/resources/list_changed` — always. Entries may have appeared or
+  disappeared, so the resource list is potentially different.
+- `notifications/resources/updated` for `markspec://profile` — if the profile
+  chain changed (profile mtime tracked separately).
+- `notifications/resources/updated` for `markspec://entries` — always.
+- `notifications/resources/updated` for `markspec://entry/{id}` — for each
+  entry whose attributes, location, forward links, or reverse links changed.
+  The diff is computed by serializing the entry's rendered Markdown and
+  comparing to the previous-rendered version (hashed).
 
-- **Input**: `{ id: string }`
-- **Output**:
-  ```json
-  {
-    "displayId": "STK_AEB_0001",
-    "ulid": "01HGW2...",
-    "title": "...",
-    "type": "stakeholder-requirement",
-    "shape": "identified",
-    "attributes": [{ "key": "Satisfies", "value": "..." }, ...],
-    "location": { "file": "...", "line": 42, "column": 1 },
-    "forwardLinks": [{ "kind": "satisfies", "to": "SYS_AEB_0012" }, ...],
-    "reverseLinks": [{ "kind": "verified-by", "from": "SIT_AEB_0030" }, ...]
-  }
-  ```
-- **Error**: `entry not found: <id>`
+Clients that subscribed to specific entry resources thus get pinpoint update
+notifications; clients that listed resources get list-change notifications.
 
-Backed by `compile().entries.get(id)` plus `forward.get(id)` and
-`reverse.get(id)`. Mirrors `markspec show <id> --format json` exactly.
+## 5. Resources
 
-### 5.2 `entry_search` (#62)
+All resources are read-only. URIs use the `markspec://` scheme. All bodies are
+`text/markdown`.
+
+### 5.1 `markspec://profile`
+
+Distilled summary of the active profile chain, rendered as Markdown.
+
+**MIME**: `text/markdown`
+
+**Body example**:
+
+```markdown
+# MarkSpec Profile
+
+**Active**: @org/aspice-swe-mini@1.0.0
+**Inherits**: @driftsys/markspec-default@0.3.0
+
+ASPICE software-engineering subset profile.
+
+## Entry types
+
+### stakeholder-requirement
+
+- **Display-ID pattern**: `STK_{DOMAIN}_{NNNN}`
+- **Shape**: identified
+- **Color**: blue
+- **Required attributes**: Id
+- **Allowed attributes**: Satisfies, Labels, Status
+- **Outgoing links**: satisfies
+- **Incoming links**: verified-by
+
+A stakeholder need or expectation expressed at the contract level.
+
+### software-requirement
+
+…
+
+## Universal attributes
+
+These apply to all identified entries regardless of type.
+
+- **Id** (required) — ULID or URI
+
+## Link kinds
+
+| Kind          | Direction | Allowed between                       |
+| ------------- | --------- | ------------------------------------- |
+| satisfies     | outgoing  | software-requirement → system-requirement |
+| derived-from  | outgoing  | software-requirement → software-requirement |
+| verified-by   | outgoing  | software-requirement → software-test  |
+
+## Labels
+
+ASIL-A, ASIL-B, ASIL-C, ASIL-D — ISO 26262 ASIL classifications.
+```
+
+Sections are omitted when the profile has nothing in them (e.g., a profile
+with no labels declared has no "Labels" section).
+
+### 5.2 `markspec://entries`
+
+Index of all entries in the project, grouped by type, with display-ID and
+title only — a table of contents.
+
+**MIME**: `text/markdown`
+
+**Body example**:
+
+```markdown
+# Entries (1,247)
+
+## stakeholder-requirement (12)
+
+- [STK_AEB_0001](markspec://entry/STK_AEB_0001) — Stop on imminent collision
+- [STK_AEB_0002](markspec://entry/STK_AEB_0002) — Driver override at any time
+…
+
+## software-requirement (243)
+
+- [SRS_AEB_0001](markspec://entry/SRS_AEB_0001) — Sensor debouncing
+…
+```
+
+Links use the `markspec://entry/...` URI scheme, so MCP clients that follow
+resource links navigate naturally.
+
+### 5.3 `markspec://entry/{displayId}`
+
+A single entry rendered with attributes, location, body, outgoing and incoming
+links. Each entry in the project registers as its own resource, so
+`resources/list` enumerates `entries.size` URIs of this form.
+
+**MIME**: `text/markdown`
+
+**Body example**:
+
+```markdown
+# STK_AEB_0001 — Stop on imminent collision
+
+**Type**: stakeholder-requirement
+**Shape**: identified
+**Id**: `01HGW2Q8MNP3RSTVWXYZABCDEF`
+**Location**: [docs/product/stakeholder-requirements.md:42](file:///…/docs/product/stakeholder-requirements.md)
+
+When the system detects an imminent collision with a stationary object,
+it shall command emergency braking sufficient to stop the vehicle before
+contact.
+
+## Attributes
+
+- **Labels**: ASIL-B
+
+## Outgoing links
+
+- **satisfies** → [SYS_AEB_0012](markspec://entry/SYS_AEB_0012) — Object threat assessment
+
+## Incoming links
+
+- **verified-by** ← [VAL_AEB_0001](markspec://entry/VAL_AEB_0001) — Vehicle stops before collision
+- **verified-by** ← [SIT_AEB_0030](markspec://entry/SIT_AEB_0030) — Threat from radar track
+```
+
+Reverse links are included inline. This is why we do not ship a separate
+`entry_dependents` tool — the entry resource already answers that question
+naturally.
+
+### 5.4 Resource listing
+
+`resources/list` returns descriptors for:
+
+- `markspec://profile` — name "Active profile", description "Distilled
+  profile manifest for this project"
+- `markspec://entries` — name "Entry index", description "All entries grouped
+  by type"
+- one descriptor per entry: name = displayId, description = title
+
+Servers receiving a `resources/list` call with pagination cursors page through
+the entry resources. The SDK handles pagination; we pass it the full list and
+let it slice.
+
+## 6. Tools
+
+All tool outputs are Markdown content in the MCP `CallToolResult.content` array
+(single `{ type: "text", text: <markdown> }` item).
+
+### 6.1 `entry_search`
 
 Rank-search entries by display-ID and title.
 
 - **Input**: `{ query: string, limit?: number }` — `limit` defaults to 20,
   capped at 100.
-- **Output**: array of `{ displayId, title, type, score }`, sorted by score
-  descending.
+- **Output**: Markdown list of ranked matches with links into
+  `markspec://entry/…`.
 
-#### Ranking algorithm (v1)
+**Ranking algorithm (v1)**:
 
 1. Normalize `query` and each candidate field to lowercase.
 2. Tokenize on whitespace and underscores.
@@ -240,58 +389,99 @@ Rank-search entries by display-ID and title.
    - +2 if all query-tokens appear in title (any order)
 4. Drop entries with score 0. Sort descending. Take `limit`.
 
-This is ~30 lines of pure code. It handles the two natural query shapes
-(partial ID, keyword from a known title) and is trivial to upgrade later. We
-explicitly chose not to pull in `fuse.js` for v1 — cost is dependency weight
-and we have no evidence the better fuzziness moves the needle.
+**Body example**:
 
-### 5.3 `entry_context` (#60-adjacent)
+```markdown
+# Search results for "braking" (3 matches)
 
-Walk the `Satisfies` chain upward from an entry.
+1. [STK_AEB_0001](markspec://entry/STK_AEB_0001) — Stop on imminent collision (score 11)
+2. [SRS_AEB_0010](markspec://entry/SRS_AEB_0010) — Apply continuous braking force (score 8)
+3. [VAL_AEB_0001](markspec://entry/VAL_AEB_0001) — Vehicle stops before collision (score 6)
+```
+
+### 6.2 `entry_context`
+
+Walk the `Satisfies` chain upward from an entry. Returns a Markdown tree.
 
 - **Input**: `{ id: string, depth?: number }` — `depth` defaults to 10.
-- **Output**: array of `{ displayId, title, depth }` in BFS order, where
-  `depth` is hops from the start entry (0 = the start entry itself).
+- **Output**: Markdown nested-list rendering of the chain. Cycle protection via
+  `visited` set.
 
-Mirrors `markspec context <id> --format json`. Same cycle protection
-(`visited` set).
+**Body example**:
 
-### 5.4 `entry_dependents` (#60-adjacent)
+```markdown
+# Context for [SRS_AEB_0010](markspec://entry/SRS_AEB_0010)
 
-List all entries that link to the given entry (any link kind).
+- **SRS_AEB_0010** — Apply continuous braking force
+  - satisfies → [SYS_AEB_0012](markspec://entry/SYS_AEB_0012) — Object threat assessment
+    - satisfies → [STK_AEB_0001](markspec://entry/STK_AEB_0001) — Stop on imminent collision
+```
 
-- **Input**: `{ id: string }`
-- **Output**: array of `{ from, kind, title }` from `compile().reverse.get(id)`.
+Indentation level = hops from the start entry.
 
-Mirrors `markspec dependents <id> --format json`.
+### 6.3 `validate`
 
-### 5.5 `validate`
-
-Run the validator pipeline.
+Run the validator pipeline; return a Markdown diagnostics report.
 
 - **Input**: `{ files?: string[] }` — when omitted, validate the full project.
-  Relative paths are resolved against the project root; absolute paths are
-  used as-is.
-- **Output**: array of `{ severity, code, message, location }`. Always full
-  diagnostics (no truncation). Cross-file diagnostics are computed against the
-  full corpus regardless; if `files` is provided, the result is filtered to
-  diagnostics whose `location.file` matches one of the input paths after
-  normalizing both sides to absolute paths.
+  Relative paths resolved against the project root; absolute used as-is.
+  When provided, the result is filtered to diagnostics whose `location.file`
+  matches an input path after normalization.
+- **Output**: Markdown report. Empty diagnostics produce a one-line success
+  message.
 
-Mirrors `markspec validate --format json`. `--strict` is **not** exposed in v1
-— agents can promote warnings themselves if they need to.
+**Body example** (with issues):
 
-### 5.6 `markspec_refresh`
+```markdown
+# Validation: 2 errors, 1 warning
 
-Force-invalidate the compile cache.
+## Errors
+
+### MSL-R004: unresolved reference
+
+[docs/product/software-requirements.md:128:3](file:///…)
+
+> `Satisfies: SYS_NONEXISTENT`
+
+`SYS_NONEXISTENT` is not declared in the project corpus.
+
+### MSL-R001: missing ULID
+
+[docs/product/stakeholder-requirements.md:67:1](file:///…)
+
+Entry `[STK_AEB_0014]` is missing an `Id:` attribute.
+
+## Warnings
+
+### MSL-R010: unrecognized attribute
+
+[docs/product/software-requirements.md:200:3](file:///…)
+
+> `Priority: high`
+
+`Priority` is not an allowed attribute for `software-requirement` under the
+active profile.
+```
+
+**Body example** (clean):
+
+```markdown
+✓ All 1,247 entries pass validation under @org/aspice-swe-mini@1.0.0.
+```
+
+### 6.4 `markspec_refresh`
+
+Force-invalidate the compile cache. Always recompiles. Fires the §4.7
+notifications.
 
 - **Input**: `{}`
-- **Output**: `{ refreshed: true, entries: <number>, links: <number> }`
+- **Output**:
 
-Always recompiles, even if mtime check would have skipped it. Returns counts
-so agents can sanity-check that the recompile happened.
+  ```markdown
+  Refreshed. 1,247 entries, 3,891 links.
+  ```
 
-## 6. SDK and Dependencies
+## 7. SDK and Dependencies
 
 `@modelcontextprotocol/sdk` (TypeScript MCP SDK), imported via `npm:` because
 no JSR mirror exists today:
@@ -301,115 +491,127 @@ import { Server } from "npm:@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "npm:@modelcontextprotocol/sdk/server/stdio.js";
 import {
   CallToolRequestSchema,
+  ListResourcesRequestSchema,
   ListToolsRequestSchema,
+  ReadResourceRequestSchema,
+  SubscribeRequestSchema,
+  UnsubscribeRequestSchema,
 } from "npm:@modelcontextprotocol/sdk/types.js";
 ```
 
 This matches the existing precedent (`vscode-languageserver` is also `npm:`).
-Node.js compatibility is preserved — the SDK is npm-published and runs on both
-runtimes.
+Node.js compatibility is preserved.
 
 No additional dependencies. JSON Schema for tool inputs is hand-written
-(schemas are tiny — three fields max). No Zod, no JSON-Schema-from-Zod.
+(schemas are tiny — three fields max). No Zod.
 
-## 7. Errors
+## 8. Errors
 
 Two categories:
 
-**Setup errors** — surface as MCP errors on the offending `tools/call`:
+**Setup errors** — surface as MCP errors on the offending request:
 
 | Code              | Trigger                                              |
 | ----------------- | ---------------------------------------------------- |
 | `NO_PROJECT_ROOT` | No `project.yaml` found from `Deno.cwd()`            |
 | `COMPILE_FAILED`  | `compile()` returned errors of severity `error`      |
 
-**Tool errors** — handler-level, returned as `isError: true` content:
+**Per-request errors** — returned as `isError: true` content (tools) or as
+JSON-RPC errors (resources):
 
 | Code              | Trigger                                       |
 | ----------------- | --------------------------------------------- |
-| `ENTRY_NOT_FOUND` | `entry_lookup`/`context`/`dependents` miss    |
-| `INVALID_INPUT`   | JSON-schema validation failed                 |
+| `ENTRY_NOT_FOUND` | `markspec://entry/{id}` or `entry_context` miss |
+| `INVALID_INPUT`   | JSON-schema validation failed (tools only)    |
+| `INVALID_URI`     | `resources/read` for an unrecognized URI      |
 
 `COMPILE_FAILED` is a hard error — the cache is left empty and subsequent
-calls retry. We do **not** silently return partial graphs; the agent should
-know the project is broken.
-
-## 8. Tests
-
-### 8.1 Unit tests
-
-Each `tools/<name>.ts` has a colocated `<name>_test.ts`. Tests build a minimal
-fixture `CompileResult` (or use a shared builder) and assert tool output JSON
-shape and content. No process spawning, no SDK mocking.
-
-The ranking algorithm in `search.ts` gets focused tests for each scoring rule
-(prefix bonus, token coverage, etc.).
-
-`project.ts` gets unit tests for the cache invalidation logic with an
-in-memory readFile / stat shim.
-
-### 8.2 E2E test
-
-`tests/e2e/mcp_test.ts` spawns `deno run main.ts mcp` with a fixture project
-in a temp directory. It exchanges a real JSON-RPC sequence over stdio:
-
-1. `initialize` → assert capabilities include `tools`.
-2. `tools/list` → assert all six tools present, schemas non-empty.
-3. `tools/call entry_lookup { id: "STK_AEB_0001" }` → assert response shape.
-4. `tools/call entry_search { query: "braking" }` → assert at least one hit.
-5. `tools/call validate {}` → assert empty diagnostics on the clean fixture.
-6. Mutate a fixture file to introduce a broken ref. `tools/call validate {}`
-   → assert the broken-ref diagnostic appears (proves auto-invalidation works).
-7. `shutdown` notification → assert clean exit.
-
-This is the integration boundary; it never imports from `mcp/` directly.
-
-### 8.3 Snapshot tests
-
-`tests/e2e/mcp_test.ts` snapshots the `tools/list` response so wording or
-schema regressions are caught on review.
+calls retry. We do not silently return partial graphs.
 
 ## 9. Out of Scope for v1
 
 | Item                    | Reason                                                    |
 | ----------------------- | --------------------------------------------------------- |
-| `requirement_insert`    | Requires `markspec insert` (epic:insert, #38–#41); land that first, then add the wrapper tool. |
-| External RefHub lookup  | A separate tool family — distinct concept from local entries. |
+| `requirement_insert`    | Requires `markspec insert` (epic:insert, #38–#41) first.  |
+| External RefHub registry | Separate tool family; distinct concept from local entries. |
 | HTTP / SSE transport    | stdio covers Claude Desktop / Claude Code defaults.       |
-| Resources / prompts     | Agent UX is fine without; tools cover known use cases.    |
-| Sampling                | Out of scope; relevant only for nested-LLM workflows.     |
+| Prompts                 | No agent use case yet.                                    |
+| Sampling                | Relevant only for nested-LLM workflows.                   |
 | Multi-root workspace    | Single project root matches CLI semantics.                |
 | Filesystem watcher      | Stat sweep is cheap enough; revisit if profiling demands. |
-| Hot profile reload      | Profile chain is loaded once on initialize; refresh tool re-reads. |
+| Hot profile reload      | Profile chain loaded once; refresh tool re-reads.         |
+| Document resources      | `markspec://document/{path}` for full source bodies — defer until use case is clear. |
 
-## 10. Rollout
+## 10. Tests
+
+### 10.1 Unit tests
+
+Each `resources/<name>.ts` and `tools/<name>.ts` has a colocated `<name>_test.ts`.
+Tests build a minimal fixture `CompileResult` (or use a shared builder) and
+assert the rendered Markdown body — usually via `assertStringIncludes` for
+behavioural assertions and `assertSnapshot` for layout-level checks.
+
+The ranking algorithm in `tools/search.ts` gets focused tests per scoring rule.
+
+`project.ts` gets unit tests for the cache invalidation logic with an in-memory
+readFile / stat shim.
+
+### 10.2 E2E test
+
+`tests/e2e/mcp_test.ts` spawns `deno run main.ts mcp` with a fixture project in
+a temp directory. It exchanges a real JSON-RPC sequence over stdio:
+
+1. `initialize` → assert capabilities include `resources` and `tools`.
+2. `tools/list` → assert all four tools present.
+3. `resources/list` → assert `markspec://profile`, `markspec://entries`, and at
+   least one `markspec://entry/...` present.
+4. `resources/read markspec://profile` → assert Markdown body includes profile
+   id.
+5. `resources/read markspec://entry/STK_AEB_0001` → assert body includes
+   "Outgoing links" section.
+6. `tools/call entry_search { query: "braking" }` → assert at least one hit
+   formatted as a link.
+7. `tools/call validate {}` → assert success message on the clean fixture.
+8. Subscribe to `markspec://entry/STK_AEB_0001`. Mutate the underlying file to
+   change its title. Trigger `markspec_refresh`. Assert that
+   `notifications/resources/updated` arrives for that URI.
+9. `shutdown` notification → assert clean exit.
+
+This is the integration boundary; it never imports from `mcp/` directly.
+
+### 10.3 Snapshot tests
+
+`tests/e2e/mcp_test.ts` snapshots the `tools/list` response and the rendered
+Markdown of the fixture's `markspec://profile` so wording or schema regressions
+are caught on review.
+
+## 11. Rollout
 
 One PR with the full v1:
 
-1. Add `mcp/server.ts`, `mcp/project.ts`, `mcp/tools/*.ts`, colocated unit
-   tests.
+1. Add `mcp/server.ts`, `mcp/project.ts`, `mcp/resources/*.ts`, `mcp/tools/*.ts`,
+   colocated unit tests.
 2. Add `tests/e2e/mcp_test.ts`.
 3. Wire `markspec mcp` in `main.ts` to `await import("./mcp/server.ts")`,
    removing the `notImplemented("mcp")` placeholder.
-4. Add `npm:@modelcontextprotocol/sdk` to the project's dependency graph (it
-   is pulled in transitively by `import` — no `deno.json` change required
-   beyond what the lockfile records).
+4. Add `npm:@modelcontextprotocol/sdk` to the dependency graph.
 5. Update [docs/guide/commands.md](../../guide/commands.md) — promote `mcp`
-   from "not implemented" to documented, with a worked example connecting
-   from Claude Desktop.
-6. Update GitHub issues #60–#63 with the renamed tools and the deferral of
-   #63.
+   from "not implemented" to documented, with a worked example connecting from
+   Claude Desktop.
+6. Update GitHub issues #60–#63 with the resource/tool layout and the deferral
+   of #63.
 
-## 11. Open Questions
+## 12. Open Questions
 
 None blocking implementation. Items for follow-up after v1 ships:
 
-- **Telemetry**: Should the server log tool invocation counts? Useful for
-  understanding which tools agents actually use, but introduces a logging
-  surface. Defer.
-- **Caching across processes**: Each `markspec mcp` process keeps its own
+- **Telemetry**: tool/resource invocation counts. Defer.
+- **Caching across processes**: each `markspec mcp` process keeps its own
   cache. Two MCP clients connecting (e.g., Claude Desktop and Claude Code
   simultaneously) compile twice. Acceptable for v1.
-- **Profile changes**: Editing `.markspec.yaml` doesn't currently invalidate
+- **Profile changes**: editing `.markspec.yaml` doesn't currently invalidate
   the cache (mtime check only watches parsed files). If profile-driven
-  attribute validation lands, we add `.markspec.yaml` to the watched set.
+  attribute validation lands, add `.markspec.yaml` to the watched set.
+- **Document resources**: exposing whole `.md` files as
+  `markspec://document/{path}` resources may be useful for agents that want
+  to "read the architecture spec." Defer until there's a clear request.

--- a/docs/superpowers/specs/2026-05-10-mcp-server-design.md
+++ b/docs/superpowers/specs/2026-05-10-mcp-server-design.md
@@ -528,13 +528,40 @@ JSON-RPC errors (resources):
 `COMPILE_FAILED` is a hard error — the cache is left empty and subsequent
 calls retry. We do not silently return partial graphs.
 
-## 9. Out of Scope for v1
+## 9. Client Compatibility
+
+The design works in the three MCP clients we care about today. Coverage as of
+2026-05-10:
+
+| Feature                                                      | Claude Code | GitHub Copilot (VS Code) | OpenCode    |
+| ------------------------------------------------------------ | ----------- | ------------------------ | ----------- |
+| stdio transport                                              | ✓           | ✓                        | ✓           |
+| `tools/list`, `tools/call`                                   | ✓           | ✓                        | ✓           |
+| `resources/list`, `resources/read`                           | ✓           | ✓                        | ✓           |
+| `resources/subscribe` + `resources/updated` notifications    | ✓           | ✗ (ignored)              | ⚠ partial   |
+
+Subscriptions (§4.6, §4.7) are a **latency optimization**, never a correctness
+mechanism. Every `resources/read` and `tools/call` runs through
+`getCompiled()` (§4.3), which stats tracked files and recompiles on staleness.
+A Copilot agent that re-reads `markspec://entry/STK_AEB_0001` after an edit
+sees the updated content even though Copilot ignored the `resources/updated`
+notification — because the read itself triggered the recompile.
+
+The server still advertises `subscribe: true` and emits notifications
+unconditionally. Clients that honor them get push updates; clients that don't
+are no worse off than they would be without subscriptions at all.
+
+Stdio is the only transport in v1 (§3.1) because Copilot does not yet support
+HTTP/SSE for MCP and the other two support stdio natively. Adding HTTP later
+is additive.
+
+## 10. Out of Scope for v1
 
 | Item                    | Reason                                                    |
 | ----------------------- | --------------------------------------------------------- |
 | `requirement_insert`    | Requires `markspec insert` (epic:insert, #38–#41) first.  |
 | External RefHub registry | Separate tool family; distinct concept from local entries. |
-| HTTP / SSE transport    | stdio covers Claude Desktop / Claude Code defaults.       |
+| HTTP / SSE transport    | Not supported by Copilot today; stdio is universal.       |
 | Prompts                 | No agent use case yet.                                    |
 | Sampling                | Relevant only for nested-LLM workflows.                   |
 | Multi-root workspace    | Single project root matches CLI semantics.                |
@@ -542,9 +569,9 @@ calls retry. We do not silently return partial graphs.
 | Hot profile reload      | Profile chain loaded once; refresh tool re-reads.         |
 | Document resources      | `markspec://document/{path}` for full source bodies — defer until use case is clear. |
 
-## 10. Tests
+## 11. Tests
 
-### 10.1 Unit tests
+### 11.1 Unit tests
 
 Each `resources/<name>.ts` and `tools/<name>.ts` has a colocated `<name>_test.ts`.
 Tests build a minimal fixture `CompileResult` (or use a shared builder) and
@@ -556,7 +583,7 @@ The ranking algorithm in `tools/search.ts` gets focused tests per scoring rule.
 `project.ts` gets unit tests for the cache invalidation logic with an in-memory
 readFile / stat shim.
 
-### 10.2 E2E test
+### 11.2 E2E test
 
 `tests/e2e/mcp_test.ts` spawns `deno run main.ts mcp` with a fixture project in
 a temp directory. It exchanges a real JSON-RPC sequence over stdio:
@@ -579,13 +606,13 @@ a temp directory. It exchanges a real JSON-RPC sequence over stdio:
 
 This is the integration boundary; it never imports from `mcp/` directly.
 
-### 10.3 Snapshot tests
+### 11.3 Snapshot tests
 
 `tests/e2e/mcp_test.ts` snapshots the `tools/list` response and the rendered
 Markdown of the fixture's `markspec://profile` so wording or schema regressions
 are caught on review.
 
-## 11. Rollout
+## 12. Rollout
 
 One PR with the full v1:
 
@@ -601,7 +628,7 @@ One PR with the full v1:
 6. Update GitHub issues #60–#63 with the resource/tool layout and the deferral
    of #63.
 
-## 12. Open Questions
+## 13. Open Questions
 
 None blocking implementation. Items for follow-up after v1 ships:
 

--- a/docs/superpowers/specs/2026-05-10-mcp-server-design.md
+++ b/docs/superpowers/specs/2026-05-10-mcp-server-design.md
@@ -1,8 +1,8 @@
 # MCP Server — Design Specification
 
 **Date**: 2026-05-10 **Scope**: `packages/markspec/mcp/` **References**:
-[ADR-005](../../architecture/adr-005-cli-architecture.md), GitHub issues #60–#63,
-[2026-04-23 LSP design](2026-04-23-lsp-server-design.md),
+[ADR-005](../../architecture/adr-005-cli-architecture.md), GitHub issues
+#60–#63, [2026-04-23 LSP design](2026-04-23-lsp-server-design.md),
 [MCP specification](https://spec.modelcontextprotocol.io)
 
 ## 1. Overview
@@ -20,28 +20,29 @@ entries first-class objects that can be browsed and subscribed to.
 V1 is **read-only**. Write operations (`requirement_insert`) are deferred until
 `markspec insert` lands as its own epic.
 
-| Issue | Feature                          | v1 status                              |
-| ----- | -------------------------------- | -------------------------------------- |
-| #60   | `mcp/` module + `markspec mcp`   | In scope — server scaffold + lifecycle |
-| #61   | Lookup tool (id → entry)         | In scope — replaced by `markspec://entry/{id}` resource |
-| #62   | Search tool (query → entries)    | In scope — `entry_search` tool         |
-| #63   | `requirement_insert` write tool  | **Deferred** — see §9                  |
+| Issue | Feature                         | v1 status                                               |
+| ----- | ------------------------------- | ------------------------------------------------------- |
+| #60   | `mcp/` module + `markspec mcp`  | In scope — server scaffold + lifecycle                  |
+| #61   | Lookup tool (id → entry)        | In scope — replaced by `markspec://entry/{id}` resource |
+| #62   | Search tool (query → entries)   | In scope — `entry_search` tool                          |
+| #63   | `requirement_insert` write tool | **Deferred** — see §9                                   |
 
 ### Tool/resource naming
 
 The original issues use `registry_*`. "Registry" now implies external
-RefHub-style standard lookup (a separate future tool family); local
-project entries are surfaced under `markspec://entry/...` resources.
-Issues #61/#62 will be updated when the spec is approved.
+RefHub-style standard lookup (a separate future tool family); local project
+entries are surfaced under `markspec://entry/...` resources. Issues #61/#62 will
+be updated when the spec is approved.
 
 ## 2. Architecture
 
 ### 2.1 Compile target
 
 `mcp/server.ts` is **not** a separate compile target. It is dynamically imported
-by `main.ts` when the user runs `markspec mcp`, identical to how
-`lsp/server.ts` is dispatched. There is one binary — `markspec` — and `markspec
-validate` never loads the MCP SDK.
+by `main.ts` when the user runs `markspec mcp`, identical to how `lsp/server.ts`
+is dispatched. There is one binary — `markspec` — and `markspec
+validate` never
+loads the MCP SDK.
 
 ```bash
 deno compile packages/markspec/main.ts  # → markspec (single binary)
@@ -180,8 +181,8 @@ tool. Algorithm:
 4. Otherwise: return `result`.
 
 The stat sweep is single-digit milliseconds for projects with hundreds of files
-— well under the cost of a recompile (100–500 ms typical). No filesystem
-watcher in v1; we can add one later if profiling shows the stat sweep dominates.
+— well under the cost of a recompile (100–500 ms typical). No filesystem watcher
+in v1; we can add one later if profiling shows the stat sweep dominates.
 
 ### 4.4 Explicit refresh
 
@@ -213,10 +214,10 @@ After a successful recompile (whether from auto-invalidation in step 3 or from
 - `notifications/resources/updated` for `markspec://profile` — if the profile
   chain changed (profile mtime tracked separately).
 - `notifications/resources/updated` for `markspec://entries` — always.
-- `notifications/resources/updated` for `markspec://entry/{id}` — for each
-  entry whose attributes, location, forward links, or reverse links changed.
-  The diff is computed by serializing the entry's rendered Markdown and
-  comparing to the previous-rendered version (hashed).
+- `notifications/resources/updated` for `markspec://entry/{id}` — for each entry
+  whose attributes, location, forward links, or reverse links changed. The diff
+  is computed by serializing the entry's rendered Markdown and comparing to the
+  previous-rendered version (hashed).
 
 Clients that subscribed to specific entry resources thus get pinpoint update
 notifications; clients that listed resources get list-change notifications.
@@ -237,8 +238,8 @@ Distilled summary of the active profile chain, rendered as Markdown.
 ```markdown
 # MarkSpec Profile
 
-**Active**: @org/aspice-swe-mini@1.0.0
-**Inherits**: @driftsys/markspec-default@0.3.0
+**Active**: @org/aspice-swe-mini@1.0.0 **Inherits**:
+@driftsys/markspec-default@0.3.0
 
 ASPICE software-engineering subset profile.
 
@@ -268,24 +269,24 @@ These apply to all identified entries regardless of type.
 
 ## Link kinds
 
-| Kind          | Direction | Allowed between                       |
-| ------------- | --------- | ------------------------------------- |
-| satisfies     | outgoing  | software-requirement → system-requirement |
-| derived-from  | outgoing  | software-requirement → software-requirement |
-| verified-by   | outgoing  | software-requirement → software-test  |
+| Kind         | Direction | Allowed between                             |
+| ------------ | --------- | ------------------------------------------- |
+| satisfies    | outgoing  | software-requirement → system-requirement   |
+| derived-from | outgoing  | software-requirement → software-requirement |
+| verified-by  | outgoing  | software-requirement → software-test        |
 
 ## Labels
 
 ASIL-A, ASIL-B, ASIL-C, ASIL-D — ISO 26262 ASIL classifications.
 ```
 
-Sections are omitted when the profile has nothing in them (e.g., a profile
-with no labels declared has no "Labels" section).
+Sections are omitted when the profile has nothing in them (e.g., a profile with
+no labels declared has no "Labels" section).
 
 ### 5.2 `markspec://entries`
 
-Index of all entries in the project, grouped by type, with display-ID and
-title only — a table of contents.
+Index of all entries in the project, grouped by type, with display-ID and title
+only — a table of contents.
 
 **MIME**: `text/markdown`
 
@@ -297,13 +298,11 @@ title only — a table of contents.
 ## stakeholder-requirement (12)
 
 - [STK_AEB_0001](markspec://entry/STK_AEB_0001) — Stop on imminent collision
-- [STK_AEB_0002](markspec://entry/STK_AEB_0002) — Driver override at any time
-…
+- [STK_AEB_0002](markspec://entry/STK_AEB_0002) — Driver override at any time …
 
 ## software-requirement (243)
 
-- [SRS_AEB_0001](markspec://entry/SRS_AEB_0001) — Sensor debouncing
-…
+- [SRS_AEB_0001](markspec://entry/SRS_AEB_0001) — Sensor debouncing …
 ```
 
 Links use the `markspec://entry/...` URI scheme, so MCP clients that follow
@@ -322,14 +321,12 @@ links. Each entry in the project registers as its own resource, so
 ```markdown
 # STK_AEB_0001 — Stop on imminent collision
 
-**Type**: stakeholder-requirement
-**Shape**: identified
-**Id**: `01HGW2Q8MNP3RSTVWXYZABCDEF`
-**Location**: [docs/product/stakeholder-requirements.md:42](file:///…/docs/product/stakeholder-requirements.md)
+**Type**: stakeholder-requirement **Shape**: identified **Id**:
+`01HGW2Q8MNP3RSTVWXYZABCDEF` **Location**:
+[docs/product/stakeholder-requirements.md:42](file:///…/docs/product/stakeholder-requirements.md)
 
-When the system detects an imminent collision with a stationary object,
-it shall command emergency braking sufficient to stop the vehicle before
-contact.
+When the system detects an imminent collision with a stationary object, it shall
+command emergency braking sufficient to stop the vehicle before contact.
 
 ## Attributes
 
@@ -337,12 +334,15 @@ contact.
 
 ## Outgoing links
 
-- **satisfies** → [SYS_AEB_0012](markspec://entry/SYS_AEB_0012) — Object threat assessment
+- **satisfies** → [SYS_AEB_0012](markspec://entry/SYS_AEB_0012) — Object threat
+  assessment
 
 ## Incoming links
 
-- **verified-by** ← [VAL_AEB_0001](markspec://entry/VAL_AEB_0001) — Vehicle stops before collision
-- **verified-by** ← [SIT_AEB_0030](markspec://entry/SIT_AEB_0030) — Threat from radar track
+- **verified-by** ← [VAL_AEB_0001](markspec://entry/VAL_AEB_0001) — Vehicle
+  stops before collision
+- **verified-by** ← [SIT_AEB_0030](markspec://entry/SIT_AEB_0030) — Threat from
+  radar track
 ```
 
 Reverse links are included inline. This is why we do not ship a separate
@@ -353,10 +353,10 @@ naturally.
 
 `resources/list` returns descriptors for:
 
-- `markspec://profile` — name "Active profile", description "Distilled
-  profile manifest for this project"
-- `markspec://entries` — name "Entry index", description "All entries grouped
-  by type"
+- `markspec://profile` — name "Active profile", description "Distilled profile
+  manifest for this project"
+- `markspec://entries` — name "Entry index", description "All entries grouped by
+  type"
 - one descriptor per entry: name = displayId, description = title
 
 Servers receiving a `resources/list` call with pagination cursors page through
@@ -394,9 +394,12 @@ Rank-search entries by display-ID and title.
 ```markdown
 # Search results for "braking" (3 matches)
 
-1. [STK_AEB_0001](markspec://entry/STK_AEB_0001) — Stop on imminent collision (score 11)
-2. [SRS_AEB_0010](markspec://entry/SRS_AEB_0010) — Apply continuous braking force (score 8)
-3. [VAL_AEB_0001](markspec://entry/VAL_AEB_0001) — Vehicle stops before collision (score 6)
+1. [STK_AEB_0001](markspec://entry/STK_AEB_0001) — Stop on imminent collision
+   (score 11)
+2. [SRS_AEB_0010](markspec://entry/SRS_AEB_0010) — Apply continuous braking
+   force (score 8)
+3. [VAL_AEB_0001](markspec://entry/VAL_AEB_0001) — Vehicle stops before
+   collision (score 6)
 ```
 
 ### 6.2 `entry_context`
@@ -413,8 +416,10 @@ Walk the `Satisfies` chain upward from an entry. Returns a Markdown tree.
 # Context for [SRS_AEB_0010](markspec://entry/SRS_AEB_0010)
 
 - **SRS_AEB_0010** — Apply continuous braking force
-  - satisfies → [SYS_AEB_0012](markspec://entry/SYS_AEB_0012) — Object threat assessment
-    - satisfies → [STK_AEB_0001](markspec://entry/STK_AEB_0001) — Stop on imminent collision
+  - satisfies → [SYS_AEB_0012](markspec://entry/SYS_AEB_0012) — Object threat
+    assessment
+    - satisfies → [STK_AEB_0001](markspec://entry/STK_AEB_0001) — Stop on
+      imminent collision
 ```
 
 Indentation level = hops from the start entry.
@@ -424,9 +429,9 @@ Indentation level = hops from the start entry.
 Run the validator pipeline; return a Markdown diagnostics report.
 
 - **Input**: `{ files?: string[] }` — when omitted, validate the full project.
-  Relative paths resolved against the project root; absolute used as-is.
-  When provided, the result is filtered to diagnostics whose `location.file`
-  matches an input path after normalization.
+  Relative paths resolved against the project root; absolute used as-is. When
+  provided, the result is filtered to diagnostics whose `location.file` matches
+  an input path after normalization.
 - **Output**: Markdown report. Empty diagnostics produce a one-line success
   message.
 
@@ -483,8 +488,8 @@ notifications.
 
 ## 7. SDK and Dependencies
 
-`@modelcontextprotocol/sdk` (TypeScript MCP SDK), imported via `npm:` because
-no JSR mirror exists today:
+`@modelcontextprotocol/sdk` (TypeScript MCP SDK), imported via `npm:` because no
+JSR mirror exists today:
 
 ```typescript
 import { Server } from "npm:@modelcontextprotocol/sdk/server/index.js";
@@ -502,8 +507,8 @@ import {
 This matches the existing precedent (`vscode-languageserver` is also `npm:`).
 Node.js compatibility is preserved.
 
-No additional dependencies. JSON Schema for tool inputs is hand-written
-(schemas are tiny — three fields max). No Zod.
+No additional dependencies. JSON Schema for tool inputs is hand-written (schemas
+are tiny — three fields max). No Zod.
 
 ## 8. Errors
 
@@ -511,72 +516,73 @@ Two categories:
 
 **Setup errors** — surface as MCP errors on the offending request:
 
-| Code              | Trigger                                              |
-| ----------------- | ---------------------------------------------------- |
-| `NO_PROJECT_ROOT` | No `project.yaml` found from `Deno.cwd()`            |
-| `COMPILE_FAILED`  | `compile()` returned errors of severity `error`      |
+| Code              | Trigger                                         |
+| ----------------- | ----------------------------------------------- |
+| `NO_PROJECT_ROOT` | No `project.yaml` found from `Deno.cwd()`       |
+| `COMPILE_FAILED`  | `compile()` returned errors of severity `error` |
 
 **Per-request errors** — returned as `isError: true` content (tools) or as
 JSON-RPC errors (resources):
 
-| Code              | Trigger                                       |
-| ----------------- | --------------------------------------------- |
+| Code              | Trigger                                         |
+| ----------------- | ----------------------------------------------- |
 | `ENTRY_NOT_FOUND` | `markspec://entry/{id}` or `entry_context` miss |
-| `INVALID_INPUT`   | JSON-schema validation failed (tools only)    |
-| `INVALID_URI`     | `resources/read` for an unrecognized URI      |
+| `INVALID_INPUT`   | JSON-schema validation failed (tools only)      |
+| `INVALID_URI`     | `resources/read` for an unrecognized URI        |
 
-`COMPILE_FAILED` is a hard error — the cache is left empty and subsequent
-calls retry. We do not silently return partial graphs.
+`COMPILE_FAILED` is a hard error — the cache is left empty and subsequent calls
+retry. We do not silently return partial graphs.
 
 ## 9. Client Compatibility
 
 The design works in the three MCP clients we care about today. Coverage as of
 2026-05-10:
 
-| Feature                                                      | Claude Code | GitHub Copilot (VS Code) | OpenCode    |
-| ------------------------------------------------------------ | ----------- | ------------------------ | ----------- |
-| stdio transport                                              | ✓           | ✓                        | ✓           |
-| `tools/list`, `tools/call`                                   | ✓           | ✓                        | ✓           |
-| `resources/list`, `resources/read`                           | ✓           | ✓                        | ✓           |
-| `resources/subscribe` + `resources/updated` notifications    | ✓           | ✗ (ignored)              | ⚠ partial   |
+| Feature                                                   | Claude Code | GitHub Copilot (VS Code) | OpenCode  |
+| --------------------------------------------------------- | ----------- | ------------------------ | --------- |
+| stdio transport                                           | ✓           | ✓                        | ✓         |
+| `tools/list`, `tools/call`                                | ✓           | ✓                        | ✓         |
+| `resources/list`, `resources/read`                        | ✓           | ✓                        | ✓         |
+| `resources/subscribe` + `resources/updated` notifications | ✓           | ✗ (ignored)              | ⚠ partial |
 
 Subscriptions (§4.6, §4.7) are a **latency optimization**, never a correctness
-mechanism. Every `resources/read` and `tools/call` runs through
-`getCompiled()` (§4.3), which stats tracked files and recompiles on staleness.
-A Copilot agent that re-reads `markspec://entry/STK_AEB_0001` after an edit
-sees the updated content even though Copilot ignored the `resources/updated`
-notification — because the read itself triggered the recompile.
+mechanism. Every `resources/read` and `tools/call` runs through `getCompiled()`
+(§4.3), which stats tracked files and recompiles on staleness. A Copilot agent
+that re-reads `markspec://entry/STK_AEB_0001` after an edit sees the updated
+content even though Copilot ignored the `resources/updated` notification —
+because the read itself triggered the recompile.
 
 The server still advertises `subscribe: true` and emits notifications
 unconditionally. Clients that honor them get push updates; clients that don't
 are no worse off than they would be without subscriptions at all.
 
 Stdio is the only transport in v1 (§3.1) because Copilot does not yet support
-HTTP/SSE for MCP and the other two support stdio natively. Adding HTTP later
-is additive.
+HTTP/SSE for MCP and the other two support stdio natively. Adding HTTP later is
+additive.
 
 ## 10. Out of Scope for v1
 
-| Item                    | Reason                                                    |
-| ----------------------- | --------------------------------------------------------- |
-| `requirement_insert`    | Requires `markspec insert` (epic:insert, #38–#41) first.  |
-| External RefHub registry | Separate tool family; distinct concept from local entries. |
-| HTTP / SSE transport    | Not supported by Copilot today; stdio is universal.       |
-| Prompts                 | No agent use case yet.                                    |
-| Sampling                | Relevant only for nested-LLM workflows.                   |
-| Multi-root workspace    | Single project root matches CLI semantics.                |
-| Filesystem watcher      | Stat sweep is cheap enough; revisit if profiling demands. |
-| Hot profile reload      | Profile chain loaded once; refresh tool re-reads.         |
-| Document resources      | `markspec://document/{path}` for full source bodies — defer until use case is clear. |
+| Item                     | Reason                                                                               |
+| ------------------------ | ------------------------------------------------------------------------------------ |
+| `requirement_insert`     | Requires `markspec insert` (epic:insert, #38–#41) first.                             |
+| External RefHub registry | Separate tool family; distinct concept from local entries.                           |
+| HTTP / SSE transport     | Not supported by Copilot today; stdio is universal.                                  |
+| Prompts                  | No agent use case yet.                                                               |
+| Sampling                 | Relevant only for nested-LLM workflows.                                              |
+| Multi-root workspace     | Single project root matches CLI semantics.                                           |
+| Filesystem watcher       | Stat sweep is cheap enough; revisit if profiling demands.                            |
+| Hot profile reload       | Profile chain loaded once; refresh tool re-reads.                                    |
+| Document resources       | `markspec://document/{path}` for full source bodies — defer until use case is clear. |
 
 ## 11. Tests
 
 ### 11.1 Unit tests
 
-Each `resources/<name>.ts` and `tools/<name>.ts` has a colocated `<name>_test.ts`.
-Tests build a minimal fixture `CompileResult` (or use a shared builder) and
-assert the rendered Markdown body — usually via `assertStringIncludes` for
-behavioural assertions and `assertSnapshot` for layout-level checks.
+Each `resources/<name>.ts` and `tools/<name>.ts` has a colocated
+`<name>_test.ts`. Tests build a minimal fixture `CompileResult` (or use a shared
+builder) and assert the rendered Markdown body — usually via
+`assertStringIncludes` for behavioural assertions and `assertSnapshot` for
+layout-level checks.
 
 The ranking algorithm in `tools/search.ts` gets focused tests per scoring rule.
 
@@ -616,15 +622,15 @@ are caught on review.
 
 One PR with the full v1:
 
-1. Add `mcp/server.ts`, `mcp/project.ts`, `mcp/resources/*.ts`, `mcp/tools/*.ts`,
-   colocated unit tests.
+1. Add `mcp/server.ts`, `mcp/project.ts`, `mcp/resources/*.ts`,
+   `mcp/tools/*.ts`, colocated unit tests.
 2. Add `tests/e2e/mcp_test.ts`.
 3. Wire `markspec mcp` in `main.ts` to `await import("./mcp/server.ts")`,
    removing the `notImplemented("mcp")` placeholder.
 4. Add `npm:@modelcontextprotocol/sdk` to the dependency graph.
-5. Update [docs/guide/commands.md](../../guide/commands.md) — promote `mcp`
-   from "not implemented" to documented, with a worked example connecting from
-   Claude Desktop.
+5. Update [docs/guide/commands.md](../../guide/commands.md) — promote `mcp` from
+   "not implemented" to documented, with a worked example connecting from Claude
+   Desktop.
 6. Update GitHub issues #60–#63 with the resource/tool layout and the deferral
    of #63.
 
@@ -633,12 +639,12 @@ One PR with the full v1:
 None blocking implementation. Items for follow-up after v1 ships:
 
 - **Telemetry**: tool/resource invocation counts. Defer.
-- **Caching across processes**: each `markspec mcp` process keeps its own
-  cache. Two MCP clients connecting (e.g., Claude Desktop and Claude Code
+- **Caching across processes**: each `markspec mcp` process keeps its own cache.
+  Two MCP clients connecting (e.g., Claude Desktop and Claude Code
   simultaneously) compile twice. Acceptable for v1.
-- **Profile changes**: editing `.markspec.yaml` doesn't currently invalidate
-  the cache (mtime check only watches parsed files). If profile-driven
-  attribute validation lands, add `.markspec.yaml` to the watched set.
+- **Profile changes**: editing `.markspec.yaml` doesn't currently invalidate the
+  cache (mtime check only watches parsed files). If profile-driven attribute
+  validation lands, add `.markspec.yaml` to the watched set.
 - **Document resources**: exposing whole `.md` files as
-  `markspec://document/{path}` resources may be useful for agents that want
-  to "read the architecture spec." Defer until there's a clear request.
+  `markspec://document/{path}` resources may be useful for agents that want to
+  "read the architecture spec." Defer until there's a clear request.

--- a/packages/markspec/core/mod.ts
+++ b/packages/markspec/core/mod.ts
@@ -25,6 +25,7 @@ export type {
   Directive,
   DisplayId,
   EffectiveProfile,
+  EffectiveTypeDef,
   Entry,
   EntryShape,
   EntrySource,

--- a/packages/markspec/deno.json
+++ b/packages/markspec/deno.json
@@ -10,6 +10,7 @@
   "imports": {
     "@cliffy/command": "jsr:@cliffy/command@^1",
     "@std/assert": "jsr:@std/assert@^1",
+    "@modelcontextprotocol/sdk": "npm:@modelcontextprotocol/sdk@^1",
     "unified": "npm:unified@^11",
     "remark-parse": "npm:remark-parse@^11",
     "remark-gfm": "npm:remark-gfm@^4",

--- a/packages/markspec/main.ts
+++ b/packages/markspec/main.ts
@@ -994,8 +994,11 @@ const cli = new Command()
     await import("./lsp/server.ts");
   })
   .command("mcp")
-  .description("Start MCP server")
-  .action(notImplemented("mcp"))
+  .description("Start MCP server (stdio JSON-RPC)")
+  .action(async () => {
+    const { startServer } = await import("./mcp/server.ts");
+    await startServer();
+  })
   // Version subcommand (alias for --version)
   .command("version")
   .description("Print version")

--- a/packages/markspec/mcp/path.ts
+++ b/packages/markspec/mcp/path.ts
@@ -1,0 +1,23 @@
+/**
+ * @module mcp/path
+ *
+ * Path normalization helpers for MCP responses. The MCP server should never
+ * leak the user's home directory in rendered output — paths are reported
+ * relative to the project root.
+ */
+
+/**
+ * Return `absolute` rewritten relative to `projectRoot`. When `projectRoot`
+ * is undefined or `absolute` does not live under it, the original path is
+ * returned unchanged.
+ */
+export function relativeToRoot(
+  absolute: string,
+  projectRoot: string | undefined,
+): string {
+  if (!projectRoot) return absolute;
+  const root = projectRoot.endsWith("/") ? projectRoot : projectRoot + "/";
+  if (absolute === projectRoot) return ".";
+  if (absolute.startsWith(root)) return absolute.slice(root.length);
+  return absolute;
+}

--- a/packages/markspec/mcp/path_test.ts
+++ b/packages/markspec/mcp/path_test.ts
@@ -1,0 +1,48 @@
+/**
+ * @module mcp/path_test
+ *
+ * Unit tests for the path normalization helper.
+ */
+
+import { assertEquals } from "@std/assert";
+import { relativeToRoot } from "./path.ts";
+
+Deno.test("relativeToRoot: strips projectRoot prefix", () => {
+  assertEquals(
+    relativeToRoot("/proj/docs/req.md", "/proj"),
+    "docs/req.md",
+  );
+});
+
+Deno.test("relativeToRoot: tolerates trailing slash on projectRoot", () => {
+  assertEquals(
+    relativeToRoot("/proj/docs/req.md", "/proj/"),
+    "docs/req.md",
+  );
+});
+
+Deno.test("relativeToRoot: returns '.' when absolute equals projectRoot", () => {
+  assertEquals(relativeToRoot("/proj", "/proj"), ".");
+});
+
+Deno.test("relativeToRoot: returns absolute unchanged when outside root", () => {
+  assertEquals(
+    relativeToRoot("/other/file.md", "/proj"),
+    "/other/file.md",
+  );
+});
+
+Deno.test("relativeToRoot: returns absolute unchanged when projectRoot missing", () => {
+  assertEquals(
+    relativeToRoot("/proj/docs/req.md", undefined),
+    "/proj/docs/req.md",
+  );
+});
+
+Deno.test("relativeToRoot: does not strip non-boundary prefix", () => {
+  // /projects/docs is NOT under /proj — guard against substring confusion.
+  assertEquals(
+    relativeToRoot("/projects/docs/req.md", "/proj"),
+    "/projects/docs/req.md",
+  );
+});

--- a/packages/markspec/mcp/project.ts
+++ b/packages/markspec/mcp/project.ts
@@ -1,0 +1,281 @@
+/**
+ * @module mcp/project
+ *
+ * Project context for the MCP server. Discovers the project root from a
+ * starting CWD, loads the active profile, caches a `CompileResult`, and
+ * refreshes the cache when tracked files change (mtime check) or when a
+ * caller invokes `forceRefresh()`.
+ *
+ * All I/O is injected via {@linkcode ProjectEnv} so this module is testable
+ * without filesystem access.
+ */
+
+import {
+  compile,
+  type CompileResult,
+  discoverProjectRoot,
+  type EffectiveProfile,
+  loadConfig,
+  loadProfileForCommand,
+  type ProfileChain,
+  type ProjectConfig,
+  type ReadFile,
+} from "../core/mod.ts";
+
+/** Files MarkSpec parses: Markdown plus supported source extensions. */
+const TRACKED_EXTENSIONS = new Set([
+  ".md",
+  ".rs",
+  ".kt",
+  ".kts",
+  ".java",
+  ".c",
+  ".h",
+  ".cpp",
+  ".cc",
+  ".cxx",
+  ".hpp",
+  ".hxx",
+]);
+
+/** Directories never scanned for tracked files. */
+const SKIP_DIRS = new Set([
+  "node_modules",
+  ".git",
+  ".worktrees",
+  "target",
+  "dist",
+  "build",
+  ".claude",
+]);
+
+/** Filesystem + environment shim, injectable for tests. */
+export interface ProjectEnv {
+  /** Return the starting working directory used for root discovery. */
+  cwd(): string;
+  /** Read a file's text content, or undefined if missing. */
+  readFile: ReadFile;
+  /** Return the file's last-modified time in milliseconds since epoch. */
+  stat(path: string): Promise<{ mtime: number }>;
+  /** Async-iterate every file path under `root` (recursive). */
+  walk(root: string): AsyncIterable<string>;
+}
+
+/** Per-tracked-file mtime snapshot. */
+interface TrackedFile {
+  path: string;
+  mtime: number;
+}
+
+/** Handler signature for invalidation subscribers. */
+export type InvalidationHandler = (result: CompileResult) => void;
+
+/** Project context handle returned by {@linkcode createProject}. */
+export interface Project {
+  /** Discovered project root, or undefined when no `project.yaml` was found. */
+  readonly projectRoot: string | undefined;
+  /** Loaded project config, or undefined when no `project.yaml` was found. */
+  readonly config: ProjectConfig | undefined;
+  /** Active profile chain, or null when no profile is configured. */
+  readonly profileChain: ProfileChain | null;
+  /** Effective profile derived from the chain, or undefined. */
+  readonly profile: EffectiveProfile | undefined;
+  /** Return the current compiled graph, recompiling when stale. */
+  getCompiled(): Promise<CompileResult>;
+  /** Force a recompile and return the fresh result. */
+  forceRefresh(): Promise<CompileResult>;
+  /** Subscribe to recompile events. Returns an unsubscribe function. */
+  subscribeInvalidation(handler: InvalidationHandler): () => void;
+}
+
+/**
+ * Default {@linkcode ProjectEnv} backed by Deno APIs.
+ *
+ * Intended for use from entry points (`mcp/server.ts`). Library code should
+ * never construct one of these directly — accept a `ProjectEnv` instead so
+ * tests can supply an in-memory shim.
+ */
+export function defaultEnv(): ProjectEnv {
+  return {
+    cwd: () => Deno.cwd(),
+    readFile: async (path: string) => {
+      try {
+        return await Deno.readTextFile(path);
+      } catch {
+        return undefined;
+      }
+    },
+    stat: async (path: string) => {
+      const stat = await Deno.stat(path);
+      return { mtime: stat.mtime?.getTime() ?? 0 };
+    },
+    walk: (root: string) => walkFs(root),
+  };
+}
+
+/** Recursive filesystem walker used by {@linkcode defaultEnv}. */
+async function* walkFs(dir: string): AsyncGenerator<string> {
+  try {
+    for await (const entry of Deno.readDir(dir)) {
+      const path = `${dir}/${entry.name}`;
+      if (entry.isDirectory) {
+        if (!SKIP_DIRS.has(entry.name) && !entry.name.startsWith(".")) {
+          yield* walkFs(path);
+        }
+      } else if (entry.isFile) {
+        yield path;
+      }
+    }
+  } catch {
+    // Skip unreadable directories.
+  }
+}
+
+/**
+ * Initialize a project context from the given environment. Performs
+ * project-root discovery, loads config + profile, and kicks off a
+ * background compile.
+ *
+ * Returns a {@linkcode Project} handle whose {@linkcode Project.getCompiled}
+ * method awaits the background compile on first call.
+ */
+export async function createProject(env: ProjectEnv): Promise<Project> {
+  const cwd = env.cwd();
+  const projectRoot = await discoverProjectRoot(cwd, env.readFile);
+
+  let config: ProjectConfig | undefined;
+  let profileChain: ProfileChain | null = null;
+
+  if (projectRoot) {
+    try {
+      const loaded = await loadConfig(projectRoot, env.readFile);
+      config = loaded?.config;
+    } catch { /* config errors surface on first compile */ }
+
+    try {
+      const result = await loadProfileForCommand(projectRoot, env.readFile);
+      profileChain = result.chain;
+    } catch { /* profile errors surface on first compile */ }
+  }
+
+  // Cache state.
+  let inFlight: Promise<CompileResult> | null = null;
+  let cached: CompileResult | null = null;
+  let tracked: TrackedFile[] = [];
+  const handlers = new Set<InvalidationHandler>();
+
+  /** Discover all tracked file paths under `projectRoot`. */
+  async function discoverTracked(): Promise<string[]> {
+    if (!projectRoot) return [];
+    const out: string[] = [];
+    for await (const path of env.walk(projectRoot)) {
+      const dot = path.lastIndexOf(".");
+      if (dot < 0) continue;
+      const ext = path.slice(dot).toLowerCase();
+      if (TRACKED_EXTENSIONS.has(ext)) out.push(path);
+    }
+    out.sort();
+    return out;
+  }
+
+  /** Run compile() over current tracked set; update cache. */
+  async function runCompile(): Promise<CompileResult> {
+    const paths = await discoverTracked();
+    const result = await compile(paths, {
+      readFile: async (p: string) => {
+        const content = await env.readFile(p);
+        if (content === undefined) {
+          throw new Error(`failed to read ${p}`);
+        }
+        return content;
+      },
+      profile: profileChain?.effective ?? undefined,
+    });
+
+    // Snapshot mtimes for next invalidation check.
+    const snapshot: TrackedFile[] = [];
+    for (const path of paths) {
+      try {
+        const { mtime } = await env.stat(path);
+        snapshot.push({ path, mtime });
+      } catch {
+        // File disappeared during compile — ignore.
+      }
+    }
+    tracked = snapshot;
+    cached = result;
+    inFlight = null;
+    for (const h of handlers) h(result);
+    return result;
+  }
+
+  /** Detect any change in the tracked file set since the last compile. */
+  async function isStale(): Promise<boolean> {
+    if (!projectRoot) return false;
+    // 1) Any tracked file with newer mtime, or missing?
+    for (const t of tracked) {
+      try {
+        const { mtime } = await env.stat(t.path);
+        if (mtime !== t.mtime) return true;
+      } catch {
+        return true; // file disappeared
+      }
+    }
+    // 2) Any new tracked file?
+    const known = new Set(tracked.map((t) => t.path));
+    for await (const path of env.walk(projectRoot)) {
+      const dot = path.lastIndexOf(".");
+      if (dot < 0) continue;
+      const ext = path.slice(dot).toLowerCase();
+      if (!TRACKED_EXTENSIONS.has(ext)) continue;
+      if (!known.has(path)) return true;
+    }
+    return false;
+  }
+
+  // Kick off background compile so first tool call doesn't pay the cost.
+  if (projectRoot) {
+    inFlight = runCompile().catch(() => {
+      // Errors surface on the awaited call.
+      return null as unknown as CompileResult;
+    });
+  }
+
+  return {
+    projectRoot,
+    config,
+    profileChain,
+    profile: profileChain?.effective,
+    async getCompiled(): Promise<CompileResult> {
+      if (!projectRoot) {
+        throw new Error(
+          "MarkSpec MCP server: no project.yaml found. " +
+            "Operations require project context.",
+        );
+      }
+      if (inFlight) {
+        const result = await inFlight;
+        if (result) return result;
+      }
+      if (cached && !(await isStale())) return cached;
+      inFlight = runCompile();
+      return await inFlight;
+    },
+    async forceRefresh(): Promise<CompileResult> {
+      if (!projectRoot) {
+        throw new Error(
+          "MarkSpec MCP server: no project.yaml found. " +
+            "Operations require project context.",
+        );
+      }
+      inFlight = runCompile();
+      return await inFlight;
+    },
+    subscribeInvalidation(handler: InvalidationHandler): () => void {
+      handlers.add(handler);
+      return () => {
+        handlers.delete(handler);
+      };
+    },
+  };
+}

--- a/packages/markspec/mcp/project.ts
+++ b/packages/markspec/mcp/project.ts
@@ -180,33 +180,58 @@ export async function createProject(env: ProjectEnv): Promise<Project> {
 
   /** Run compile() over current tracked set; update cache. */
   async function runCompile(): Promise<CompileResult> {
-    const paths = await discoverTracked();
-    const result = await compile(paths, {
-      readFile: async (p: string) => {
-        const content = await env.readFile(p);
-        if (content === undefined) {
-          throw new Error(`failed to read ${p}`);
-        }
-        return content;
-      },
-      profile: profileChain?.effective ?? undefined,
-    });
+    try {
+      const paths = await discoverTracked();
+      const result = await compile(paths, {
+        readFile: async (p: string) => {
+          const content = await env.readFile(p);
+          if (content === undefined) {
+            throw new Error(`failed to read ${p}`);
+          }
+          return content;
+        },
+        profile: profileChain?.effective ?? undefined,
+      });
 
-    // Snapshot mtimes for next invalidation check.
-    const snapshot: TrackedFile[] = [];
-    for (const path of paths) {
-      try {
-        const { mtime } = await env.stat(path);
-        snapshot.push({ path, mtime });
-      } catch {
-        // File disappeared during compile — ignore.
+      // Snapshot mtimes for next invalidation check.
+      const snapshot: TrackedFile[] = [];
+      for (const path of paths) {
+        try {
+          const { mtime } = await env.stat(path);
+          snapshot.push({ path, mtime });
+        } catch {
+          // File disappeared during compile — ignore.
+        }
       }
+      tracked = snapshot;
+      cached = result;
+      // Fire handlers AFTER cache is committed but isolate handler errors so
+      // one bad subscriber doesn't break others or abort the compile result.
+      for (const h of handlers) {
+        try {
+          h(result);
+        } catch {
+          // Handler error — ignore.
+        }
+      }
+      return result;
+    } finally {
+      // Always reset the in-flight slot — success or failure — so a subsequent
+      // call can retry. Without this, a single compile failure jams the cache
+      // permanently (every future await re-throws the same rejection).
+      inFlight = null;
     }
-    tracked = snapshot;
-    cached = result;
-    inFlight = null;
-    for (const h of handlers) h(result);
-    return result;
+  }
+
+  /**
+   * Idempotent compile starter. Returns the existing in-flight promise if
+   * one is running; otherwise starts a new compile and stores its promise.
+   * This is the single gate through which all recompiles must pass — it
+   * prevents two concurrent callers from kicking off duplicate compiles.
+   */
+  function ensureCompile(): Promise<CompileResult> {
+    if (!inFlight) inFlight = runCompile();
+    return inFlight;
   }
 
   /** Detect any change in the tracked file set since the last compile. */
@@ -235,10 +260,12 @@ export async function createProject(env: ProjectEnv): Promise<Project> {
 
   // Kick off background compile so first tool call doesn't pay the cost.
   if (projectRoot) {
-    inFlight = runCompile().catch(() => {
-      // Errors surface on the awaited call.
-      return null as unknown as CompileResult;
-    });
+    const promise = ensureCompile();
+    // Prevent unhandled-rejection warnings if no caller awaits this promise
+    // immediately. The error still surfaces naturally on the first
+    // getCompiled() / forceRefresh() call, and inFlight will have been reset
+    // to null by runCompile()'s finally so the next call can retry.
+    promise.catch(() => {});
   }
 
   return {
@@ -253,13 +280,15 @@ export async function createProject(env: ProjectEnv): Promise<Project> {
             "Operations require project context.",
         );
       }
-      if (inFlight) {
-        const result = await inFlight;
-        if (result) return result;
+      // Ride an in-flight compile if one is already running.
+      if (inFlight) return await inFlight;
+      // Stale-check is async — re-check inFlight afterwards in case another
+      // caller raced us into starting a compile during the await.
+      if (cached && !(await isStale())) {
+        if (inFlight) return await inFlight;
+        return cached;
       }
-      if (cached && !(await isStale())) return cached;
-      inFlight = runCompile();
-      return await inFlight;
+      return await ensureCompile();
     },
     async forceRefresh(): Promise<CompileResult> {
       if (!projectRoot) {
@@ -268,8 +297,10 @@ export async function createProject(env: ProjectEnv): Promise<Project> {
             "Operations require project context.",
         );
       }
-      inFlight = runCompile();
-      return await inFlight;
+      // Force-refresh joins an in-flight compile rather than firing a second
+      // one. What matters is that after this resolves, the cache reflects a
+      // fresh compile.
+      return await ensureCompile();
     },
     subscribeInvalidation(handler: InvalidationHandler): () => void {
       handlers.add(handler);

--- a/packages/markspec/mcp/project_test.ts
+++ b/packages/markspec/mcp/project_test.ts
@@ -6,7 +6,7 @@
  * Uses an in-memory ProjectEnv shim so no filesystem access is required.
  */
 
-import { assertEquals, assertExists } from "@std/assert";
+import { assertEquals, assertExists, assertRejects } from "@std/assert";
 import { createProject, type ProjectEnv } from "./project.ts";
 
 /** Build a ProjectEnv that serves a fixed file map. */
@@ -137,6 +137,48 @@ Deno.test("forceRefresh: recompiles even with no changes", async () => {
   const r2 = await proj.forceRefresh();
   // Different object — recompile happened.
   assertEquals(r1 !== r2, true);
+});
+
+Deno.test("getCompiled: recovers from a transient compile error", async () => {
+  // Build an env where the first compile fails (walk throws), then the
+  // underlying problem clears and a subsequent getCompiled() succeeds.
+  // This verifies that runCompile()'s finally resets `inFlight`, so the
+  // cache doesn't get jammed into a permanent error state.
+  const { env } = makeEnv({
+    "/proj/project.yaml": { content: PROJECT_YAML, mtime: 1 },
+    "/proj/req.md": { content: REQ_DOC, mtime: 1 },
+  });
+  let failNextWalk = true;
+  const wrappedEnv: ProjectEnv = {
+    ...env,
+    walk: function (root: string) {
+      if (failNextWalk) {
+        failNextWalk = false;
+        return (async function* () {
+          throw new Error("simulated walk failure");
+          // deno-lint-ignore no-unreachable
+          yield "";
+        })();
+      }
+      return env.walk(root);
+    },
+  };
+
+  const proj = await createProject(wrappedEnv);
+
+  // First call: the background compile failed, so this should reject with
+  // the simulated error.
+  await assertRejects(
+    () => proj.getCompiled(),
+    Error,
+    "simulated walk failure",
+  );
+
+  // Second call: the in-flight slot must have been reset, so this should
+  // start a fresh compile and succeed.
+  const result = await proj.getCompiled();
+  assertExists(result);
+  assertEquals(result.entries.size, 1);
 });
 
 Deno.test("subscribeInvalidation: fires handlers after recompile", async () => {

--- a/packages/markspec/mcp/project_test.ts
+++ b/packages/markspec/mcp/project_test.ts
@@ -1,0 +1,160 @@
+/**
+ * @module mcp/project_test
+ *
+ * Unit tests for the MCP project-context cache.
+ *
+ * Uses an in-memory ProjectEnv shim so no filesystem access is required.
+ */
+
+import { assertEquals, assertExists } from "@std/assert";
+import { createProject, type ProjectEnv } from "./project.ts";
+
+/** Build a ProjectEnv that serves a fixed file map. */
+function makeEnv(files: Record<string, { content: string; mtime: number }>): {
+  env: ProjectEnv;
+  bumpMtime: (path: string, content: string, mtime: number) => void;
+  removeFile: (path: string) => void;
+} {
+  const store = new Map(Object.entries(files));
+  return {
+    env: {
+      cwd: () => "/proj",
+      readFile: (path) => {
+        const f = store.get(path);
+        return Promise.resolve(f?.content);
+      },
+      stat: (path) => {
+        const f = store.get(path);
+        if (!f) return Promise.reject(new Error(`ENOENT: ${path}`));
+        return Promise.resolve({ mtime: f.mtime });
+      },
+      walk: async function* () {
+        for (const path of store.keys()) yield path;
+      },
+    },
+    bumpMtime(path, content, mtime) {
+      store.set(path, { content, mtime });
+    },
+    removeFile(path) {
+      store.delete(path);
+    },
+  };
+}
+
+const PROJECT_YAML = `name: test\nversion: 0.0.1\n`;
+
+const REQ_DOC = `- [STK_TEST_0001] Test entry
+
+  Body.
+
+  Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+`;
+
+Deno.test("createProject: discovers root from project.yaml", async () => {
+  const { env } = makeEnv({
+    "/proj/project.yaml": { content: PROJECT_YAML, mtime: 1 },
+    "/proj/req.md": { content: REQ_DOC, mtime: 1 },
+  });
+  const proj = await createProject(env);
+  assertEquals(proj.projectRoot, "/proj");
+});
+
+Deno.test("createProject: returns null when no project.yaml", async () => {
+  const { env } = makeEnv({
+    "/proj/req.md": { content: REQ_DOC, mtime: 1 },
+  });
+  const proj = await createProject(env);
+  assertEquals(proj.projectRoot, undefined);
+});
+
+Deno.test("getCompiled: compiles and caches result", async () => {
+  const { env } = makeEnv({
+    "/proj/project.yaml": { content: PROJECT_YAML, mtime: 1 },
+    "/proj/req.md": { content: REQ_DOC, mtime: 1 },
+  });
+  const proj = await createProject(env);
+  const r1 = await proj.getCompiled();
+  assertExists(r1);
+  assertEquals(r1.entries.size, 1);
+
+  // Second call must return the same object (cached).
+  const r2 = await proj.getCompiled();
+  assertEquals(r1, r2);
+});
+
+Deno.test("getCompiled: recompiles when file mtime changes", async () => {
+  const { env, bumpMtime } = makeEnv({
+    "/proj/project.yaml": { content: PROJECT_YAML, mtime: 1 },
+    "/proj/req.md": { content: REQ_DOC, mtime: 1 },
+  });
+  const proj = await createProject(env);
+  const r1 = await proj.getCompiled();
+  assertEquals(r1.entries.size, 1);
+
+  // Mutate the file and bump mtime above the compiledAt timestamp.
+  const updatedDoc = REQ_DOC + `\n- [STK_TEST_0002] Another
+
+  Body.
+
+  Id: 01HGW2Q8MNP3RSTVWXYZABCDEG
+`;
+  bumpMtime("/proj/req.md", updatedDoc, Date.now() + 1000);
+
+  const r2 = await proj.getCompiled();
+  assertEquals(r2.entries.size, 2);
+});
+
+Deno.test("getCompiled: recompiles when a new file appears", async () => {
+  const { env, bumpMtime } = makeEnv({
+    "/proj/project.yaml": { content: PROJECT_YAML, mtime: 1 },
+    "/proj/req.md": { content: REQ_DOC, mtime: 1 },
+  });
+  const proj = await createProject(env);
+  await proj.getCompiled();
+
+  bumpMtime(
+    "/proj/extra.md",
+    `- [STK_TEST_0002] Another
+
+  Body.
+
+  Id: 01HGW2Q8MNP3RSTVWXYZABCDEG
+`,
+    Date.now() + 1000,
+  );
+
+  const r2 = await proj.getCompiled();
+  assertEquals(r2.entries.size, 2);
+});
+
+Deno.test("forceRefresh: recompiles even with no changes", async () => {
+  const { env } = makeEnv({
+    "/proj/project.yaml": { content: PROJECT_YAML, mtime: 1 },
+    "/proj/req.md": { content: REQ_DOC, mtime: 1 },
+  });
+  const proj = await createProject(env);
+  const r1 = await proj.getCompiled();
+  const r2 = await proj.forceRefresh();
+  // Different object — recompile happened.
+  assertEquals(r1 !== r2, true);
+});
+
+Deno.test("subscribeInvalidation: fires handlers after recompile", async () => {
+  const { env, bumpMtime } = makeEnv({
+    "/proj/project.yaml": { content: PROJECT_YAML, mtime: 1 },
+    "/proj/req.md": { content: REQ_DOC, mtime: 1 },
+  });
+  const proj = await createProject(env);
+  await proj.getCompiled();
+
+  let fired = 0;
+  proj.subscribeInvalidation(() => {
+    fired++;
+  });
+
+  await proj.forceRefresh();
+  bumpMtime("/proj/req.md", REQ_DOC + "\n", Date.now() + 2000);
+  await proj.getCompiled();
+
+  assertEquals(fired, 2);
+});

--- a/packages/markspec/mcp/resources/entries.ts
+++ b/packages/markspec/mcp/resources/entries.ts
@@ -1,0 +1,51 @@
+/**
+ * @module mcp/resources/entries
+ *
+ * Renders the `markspec://entries` index — an alphabetical-by-type listing
+ * of every entry in the project, each as a Markdown link to its own entry
+ * resource URI.
+ */
+
+import type { Entry } from "../../core/mod.ts";
+import { entryUri } from "../uri.ts";
+
+/**
+ * Render the entries index to Markdown.
+ *
+ * Entries are grouped by type (or `"untyped"` when `entry.type` is
+ * `undefined`). Groups are sorted alphabetically; entries within each
+ * group are sorted by display ID. Each entry is rendered as a Markdown
+ * link to its `markspec://entry/{displayId}` resource URI.
+ */
+export function renderEntriesIndex(entries: readonly Entry[]): string {
+  const lines: string[] = [`# Entries (${entries.length})`, ""];
+
+  if (entries.length === 0) {
+    lines.push("No entries in this project.");
+    return lines.join("\n") + "\n";
+  }
+
+  // Group by type (or "untyped").
+  const byType = new Map<string, Entry[]>();
+  for (const entry of entries) {
+    const t = entry.type ?? "untyped";
+    const list = byType.get(t);
+    if (list) list.push(entry);
+    else byType.set(t, [entry]);
+  }
+
+  const types = [...byType.keys()].sort();
+  for (const type of types) {
+    const list = byType.get(type)!;
+    list.sort((a, b) => a.displayId.localeCompare(b.displayId));
+    lines.push(`## ${type} (${list.length})`, "");
+    for (const e of list) {
+      lines.push(
+        `- [${e.displayId}](${entryUri(e.displayId)}) — ${e.title}`,
+      );
+    }
+    lines.push("");
+  }
+
+  return lines.join("\n");
+}

--- a/packages/markspec/mcp/resources/entries_test.ts
+++ b/packages/markspec/mcp/resources/entries_test.ts
@@ -1,0 +1,57 @@
+/**
+ * @module mcp/resources/entries_test
+ *
+ * Unit tests for the markspec://entries index renderer.
+ */
+
+import { assertStringIncludes } from "@std/assert";
+import type { Entry } from "../../core/mod.ts";
+import { renderEntriesIndex } from "./entries.ts";
+
+function mkEntry(displayId: string, title: string, type?: string): Entry {
+  return {
+    displayId,
+    title,
+    body: "",
+    rawAttributes: [],
+    typedAttributes: new Map(),
+    type,
+    shape: "identified",
+    location: { file: "/proj/x.md", line: 1, column: 1 },
+    source: "markdown",
+  };
+}
+
+Deno.test("renderEntriesIndex: groups by type, sorted alphabetically", () => {
+  const md = renderEntriesIndex([
+    mkEntry("STK_AEB_0001", "Stop on collision", "stakeholder-requirement"),
+    mkEntry("SRS_AEB_0010", "Sensor debouncing", "software-requirement"),
+    mkEntry("STK_AEB_0002", "Driver override", "stakeholder-requirement"),
+  ]);
+  assertStringIncludes(md, "# Entries (3)");
+  assertStringIncludes(md, "## software-requirement (1)");
+  assertStringIncludes(md, "## stakeholder-requirement (2)");
+});
+
+Deno.test("renderEntriesIndex: renders entries as Markdown links", () => {
+  const md = renderEntriesIndex([
+    mkEntry("STK_AEB_0001", "Stop on collision", "stakeholder-requirement"),
+  ]);
+  assertStringIncludes(
+    md,
+    "- [STK_AEB_0001](markspec://entry/STK_AEB_0001) — Stop on collision",
+  );
+});
+
+Deno.test("renderEntriesIndex: groups untyped entries under 'untyped'", () => {
+  const md = renderEntriesIndex([
+    mkEntry("FREEFORM_0001", "Untyped entry"),
+  ]);
+  assertStringIncludes(md, "## untyped (1)");
+});
+
+Deno.test("renderEntriesIndex: empty corpus", () => {
+  const md = renderEntriesIndex([]);
+  assertStringIncludes(md, "# Entries (0)");
+  assertStringIncludes(md, "No entries in this project");
+});

--- a/packages/markspec/mcp/resources/entry.ts
+++ b/packages/markspec/mcp/resources/entry.ts
@@ -1,0 +1,76 @@
+/**
+ * @module mcp/resources/entry
+ *
+ * Renders the `markspec://entry/{displayId}` resource. Output is Markdown:
+ * title, metadata (type, shape, id, location), body, attributes table,
+ * outgoing links, incoming links.
+ *
+ * `titles` is a lookup from display ID to entry title, used to render
+ * `markspec://entry/...` cross-reference labels.
+ */
+
+import type { Entry, Link } from "../../core/mod.ts";
+import { entryUri } from "../uri.ts";
+
+/** Render one entry to Markdown. */
+export function renderEntry(
+  entry: Entry,
+  forwardLinks: readonly Link[],
+  reverseLinks: readonly Link[],
+  titles: ReadonlyMap<string, string>,
+): string {
+  const lines: string[] = [];
+
+  lines.push(`# ${entry.displayId} — ${entry.title}`, "");
+
+  if (entry.type) lines.push(`**Type**: ${entry.type}`);
+  lines.push(`**Shape**: ${entry.shape}`);
+  if (entry.id) lines.push(`**Id**: \`${entry.id}\``);
+  lines.push(
+    `**Location**: ${entry.location.file}:${entry.location.line}`,
+  );
+  lines.push("");
+
+  if (entry.body.trim().length > 0) {
+    lines.push(entry.body.trimEnd(), "");
+  }
+
+  const nonIdAttrs = entry.rawAttributes.filter(
+    (a) => a.key.toLowerCase() !== "id",
+  );
+  if (nonIdAttrs.length > 0) {
+    lines.push("## Attributes", "");
+    for (const a of nonIdAttrs) {
+      lines.push(`- **${a.key}**: ${a.value}`);
+    }
+    lines.push("");
+  }
+
+  if (forwardLinks.length > 0) {
+    lines.push("## Outgoing links", "");
+    for (const link of forwardLinks) {
+      const title = titles.get(link.to);
+      const titlePart = title ? ` — ${title}` : "";
+      lines.push(
+        `- **${link.kind}** → [${link.to}](${entryUri(link.to)})${titlePart}`,
+      );
+    }
+    lines.push("");
+  }
+
+  if (reverseLinks.length > 0) {
+    lines.push("## Incoming links", "");
+    for (const link of reverseLinks) {
+      const title = titles.get(link.from);
+      const titlePart = title ? ` — ${title}` : "";
+      lines.push(
+        `- **${link.kind}** ← [${link.from}](${
+          entryUri(link.from)
+        })${titlePart}`,
+      );
+    }
+    lines.push("");
+  }
+
+  return lines.join("\n").replace(/\n{3,}/g, "\n\n");
+}

--- a/packages/markspec/mcp/resources/entry.ts
+++ b/packages/markspec/mcp/resources/entry.ts
@@ -10,6 +10,7 @@
  */
 
 import type { Entry, Link } from "../../core/mod.ts";
+import { relativeToRoot } from "../path.ts";
 import { entryUri } from "../uri.ts";
 
 /** Render one entry to Markdown. */
@@ -18,6 +19,7 @@ export function renderEntry(
   forwardLinks: readonly Link[],
   reverseLinks: readonly Link[],
   titles: ReadonlyMap<string, string>,
+  projectRoot?: string,
 ): string {
   const lines: string[] = [];
 
@@ -27,7 +29,9 @@ export function renderEntry(
   lines.push(`**Shape**: ${entry.shape}`);
   if (entry.id) lines.push(`**Id**: \`${entry.id}\``);
   lines.push(
-    `**Location**: ${entry.location.file}:${entry.location.line}`,
+    `**Location**: ${
+      relativeToRoot(entry.location.file, projectRoot)
+    }:${entry.location.line}`,
   );
   lines.push("");
 

--- a/packages/markspec/mcp/resources/entry_test.ts
+++ b/packages/markspec/mcp/resources/entry_test.ts
@@ -69,6 +69,18 @@ Deno.test("renderEntry: includes ULID and location", () => {
   assertStringIncludes(md, "stakeholder-requirements.md:42");
 });
 
+Deno.test("renderEntry: renders location relative to projectRoot", () => {
+  const md = renderEntry(ENTRY, [], [], TITLES, "/proj");
+  assertStringIncludes(
+    md,
+    "**Location**: docs/product/stakeholder-requirements.md:42",
+  );
+  assertEquals(
+    md.includes("/proj/docs/product/stakeholder-requirements.md"),
+    false,
+  );
+});
+
 Deno.test("renderEntry: includes body paragraph", () => {
   const md = renderEntry(ENTRY, [], [], TITLES);
   assertStringIncludes(md, "When the system detects an imminent collision");

--- a/packages/markspec/mcp/resources/entry_test.ts
+++ b/packages/markspec/mcp/resources/entry_test.ts
@@ -1,0 +1,114 @@
+/**
+ * @module mcp/resources/entry_test
+ *
+ * Unit tests for the markspec://entry/{id} Markdown renderer.
+ */
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import type { Entry, Link } from "../../core/mod.ts";
+import { renderEntry } from "./entry.ts";
+
+const ENTRY: Entry = {
+  displayId: "STK_AEB_0001",
+  title: "Stop on imminent collision",
+  body:
+    "When the system detects an imminent collision with a stationary object,\nit shall command emergency braking.",
+  rawAttributes: [
+    { key: "Id", value: "01HGW2Q8MNP3RSTVWXYZABCDEF" },
+    { key: "Labels", value: "ASIL-B" },
+  ],
+  typedAttributes: new Map(),
+  id: "01HGW2Q8MNP3RSTVWXYZABCDEF",
+  type: "stakeholder-requirement",
+  shape: "identified",
+  location: {
+    file: "/proj/docs/product/stakeholder-requirements.md",
+    line: 42,
+    column: 1,
+  },
+  source: "markdown",
+};
+
+const FORWARD: Link[] = [
+  {
+    from: "STK_AEB_0001",
+    to: "SYS_AEB_0012",
+    kind: "satisfies",
+    location: {
+      file: "/proj/docs/product/stakeholder-requirements.md",
+      line: 47,
+      column: 1,
+    },
+  },
+];
+
+const REVERSE: Link[] = [
+  {
+    from: "VAL_AEB_0001",
+    to: "STK_AEB_0001",
+    kind: "verifies",
+    location: { file: "/proj/tests/val_aeb.rs", line: 12, column: 1 },
+  },
+];
+
+const TITLES = new Map<string, string>([
+  ["SYS_AEB_0012", "Object threat assessment"],
+  ["VAL_AEB_0001", "Vehicle stops before collision"],
+]);
+
+Deno.test("renderEntry: includes title and type", () => {
+  const md = renderEntry(ENTRY, [], [], TITLES);
+  assertStringIncludes(md, "# STK_AEB_0001 — Stop on imminent collision");
+  assertStringIncludes(md, "**Type**: stakeholder-requirement");
+  assertStringIncludes(md, "**Shape**: identified");
+});
+
+Deno.test("renderEntry: includes ULID and location", () => {
+  const md = renderEntry(ENTRY, [], [], TITLES);
+  assertStringIncludes(md, "**Id**: `01HGW2Q8MNP3RSTVWXYZABCDEF`");
+  assertStringIncludes(md, "stakeholder-requirements.md:42");
+});
+
+Deno.test("renderEntry: includes body paragraph", () => {
+  const md = renderEntry(ENTRY, [], [], TITLES);
+  assertStringIncludes(md, "When the system detects an imminent collision");
+});
+
+Deno.test("renderEntry: includes non-Id attributes", () => {
+  const md = renderEntry(ENTRY, [], [], TITLES);
+  assertStringIncludes(md, "## Attributes");
+  assertStringIncludes(md, "- **Labels**: ASIL-B");
+});
+
+Deno.test("renderEntry: includes outgoing links with target titles", () => {
+  const md = renderEntry(ENTRY, FORWARD, [], TITLES);
+  assertStringIncludes(md, "## Outgoing links");
+  assertStringIncludes(
+    md,
+    "**satisfies** → [SYS_AEB_0012](markspec://entry/SYS_AEB_0012) — Object threat assessment",
+  );
+});
+
+Deno.test("renderEntry: includes incoming links with source titles", () => {
+  const md = renderEntry(ENTRY, [], REVERSE, TITLES);
+  assertStringIncludes(md, "## Incoming links");
+  assertStringIncludes(
+    md,
+    "**verifies** ← [VAL_AEB_0001](markspec://entry/VAL_AEB_0001) — Vehicle stops before collision",
+  );
+});
+
+Deno.test("renderEntry: omits Outgoing/Incoming sections when empty", () => {
+  const md = renderEntry(ENTRY, [], [], TITLES);
+  assertEquals(md.includes("## Outgoing links"), false);
+  assertEquals(md.includes("## Incoming links"), false);
+});
+
+Deno.test("renderEntry: omits Attributes section when only Id present", () => {
+  const idOnly: Entry = {
+    ...ENTRY,
+    rawAttributes: [{ key: "Id", value: "01HGW2Q8MNP3RSTVWXYZABCDEF" }],
+  };
+  const md = renderEntry(idOnly, [], [], TITLES);
+  assertEquals(md.includes("## Attributes"), false);
+});

--- a/packages/markspec/mcp/resources/mod.ts
+++ b/packages/markspec/mcp/resources/mod.ts
@@ -1,0 +1,148 @@
+/**
+ * @module mcp/resources/mod
+ *
+ * Wires MCP resource handlers. Exposes:
+ *
+ * - {@linkcode listResourceDescriptors} — pure function returning the
+ *   resources/list payload for unit-test verification.
+ * - {@linkcode readResource} — pure function returning the resources/read
+ *   payload for a given URI.
+ * - {@linkcode registerResources} — attaches both handlers to a Server
+ *   instance.
+ */
+
+import type { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import {
+  ListResourcesRequestSchema,
+  type ReadResourceRequest,
+  ReadResourceRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import type { Project } from "../project.ts";
+import {
+  ENTRIES_URI,
+  entryUri,
+  isEntryUri,
+  parseEntryUri,
+  PROFILE_URI,
+} from "../uri.ts";
+import { buildProfileView, renderProfile } from "./profile.ts";
+import { renderEntriesIndex } from "./entries.ts";
+import { renderEntry } from "./entry.ts";
+
+/** A resource descriptor as returned by resources/list. */
+export interface ResourceDescriptor {
+  readonly uri: string;
+  readonly name: string;
+  readonly description: string;
+  readonly mimeType: string;
+}
+
+/** Build the resources/list payload from a compiled project. */
+export async function listResourceDescriptors(
+  project: Project,
+): Promise<ResourceDescriptor[]> {
+  const result = await project.getCompiled();
+  const out: ResourceDescriptor[] = [
+    {
+      uri: PROFILE_URI,
+      name: "Active profile",
+      description: "Distilled profile manifest for this project",
+      mimeType: "text/markdown",
+    },
+    {
+      uri: ENTRIES_URI,
+      name: "Entry index",
+      description: "All entries grouped by type",
+      mimeType: "text/markdown",
+    },
+  ];
+  const ids = [...result.entries.keys()].sort();
+  for (const id of ids) {
+    const entry = result.entries.get(id)!;
+    out.push({
+      uri: entryUri(id),
+      name: id,
+      description: entry.title,
+      mimeType: "text/markdown",
+    });
+  }
+  return out;
+}
+
+/** Result of reading a resource. */
+export interface ReadResourceResult {
+  readonly uri: string;
+  readonly mimeType: string;
+  readonly text: string;
+}
+
+/** Read a single resource by URI. Throws on unrecognized URIs. */
+export async function readResource(
+  uri: string,
+  project: Project,
+): Promise<ReadResourceResult> {
+  if (uri === PROFILE_URI) {
+    const view = buildProfileView(project.profileChain);
+    return {
+      uri,
+      mimeType: "text/markdown",
+      text: renderProfile(view),
+    };
+  }
+
+  if (uri === ENTRIES_URI) {
+    const result = await project.getCompiled();
+    return {
+      uri,
+      mimeType: "text/markdown",
+      text: renderEntriesIndex([...result.entries.values()]),
+    };
+  }
+
+  if (isEntryUri(uri)) {
+    const displayId = parseEntryUri(uri)!;
+    const result = await project.getCompiled();
+    const entry = result.entries.get(displayId);
+    if (!entry) {
+      throw new Error(`entry not found: ${displayId}`);
+    }
+    const titles = new Map<string, string>();
+    for (const [id, e] of result.entries) titles.set(id, e.title);
+    return {
+      uri,
+      mimeType: "text/markdown",
+      text: renderEntry(
+        entry,
+        result.forward.get(displayId) ?? [],
+        result.reverse.get(displayId) ?? [],
+        titles,
+      ),
+    };
+  }
+
+  throw new Error(`unknown resource URI: ${uri}`);
+}
+
+/** Attach resources/list and resources/read handlers to a Server. */
+export function registerResources(server: Server, project: Project): void {
+  server.setRequestHandler(ListResourcesRequestSchema, async () => ({
+    resources: await listResourceDescriptors(project),
+  }));
+
+  server.setRequestHandler(
+    ReadResourceRequestSchema,
+    async (req: ReadResourceRequest) => {
+      const uri = req.params.uri;
+      const result = await readResource(uri, project);
+      return {
+        contents: [
+          {
+            uri: result.uri,
+            mimeType: result.mimeType,
+            text: result.text,
+          },
+        ],
+      };
+    },
+  );
+}

--- a/packages/markspec/mcp/resources/mod.ts
+++ b/packages/markspec/mcp/resources/mod.ts
@@ -116,6 +116,7 @@ export async function readResource(
         result.forward.get(displayId) ?? [],
         result.reverse.get(displayId) ?? [],
         titles,
+        project.projectRoot,
       ),
     };
   }

--- a/packages/markspec/mcp/resources/mod_test.ts
+++ b/packages/markspec/mcp/resources/mod_test.ts
@@ -1,0 +1,95 @@
+/**
+ * @module mcp/resources/mod_test
+ *
+ * Unit tests for the resources/list and resources/read dispatch.
+ *
+ * Builds a minimal Project shim and asserts the descriptor list and the
+ * routing logic in readResource.
+ */
+
+import { assertEquals, assertRejects, assertStringIncludes } from "@std/assert";
+import type { CompileResult, Entry, ProfileChain } from "../../core/mod.ts";
+import type { Project } from "../project.ts";
+import { listResourceDescriptors, readResource } from "./mod.ts";
+
+function mkProject(entries: Entry[]): Project {
+  const entriesMap = new Map<string, Entry>();
+  for (const e of entries) entriesMap.set(e.displayId, e);
+  const result: CompileResult = {
+    entries: entriesMap,
+    links: [],
+    forward: new Map(),
+    reverse: new Map(),
+    documents: new Map(),
+    diagnostics: [],
+  };
+  const chain: ProfileChain | null = null;
+  return {
+    projectRoot: "/proj",
+    config: undefined,
+    profileChain: chain,
+    profile: undefined,
+    getCompiled: () => Promise.resolve(result),
+    forceRefresh: () => Promise.resolve(result),
+    subscribeInvalidation: () => () => {},
+  };
+}
+
+const E1: Entry = {
+  displayId: "STK_TEST_0001",
+  title: "First entry",
+  body: "",
+  rawAttributes: [],
+  typedAttributes: new Map(),
+  shape: "identified",
+  location: { file: "/proj/x.md", line: 1, column: 1 },
+  source: "markdown",
+};
+
+Deno.test("listResourceDescriptors: includes profile + entries + per-entry", async () => {
+  const project = mkProject([E1]);
+  const list = await listResourceDescriptors(project);
+  assertEquals(list.length, 3);
+  assertEquals(list[0].uri, "markspec://profile");
+  assertEquals(list[1].uri, "markspec://entries");
+  assertEquals(list[2].uri, "markspec://entry/STK_TEST_0001");
+});
+
+Deno.test("readResource: routes profile URI", async () => {
+  const project = mkProject([E1]);
+  const r = await readResource("markspec://profile", project);
+  assertStringIncludes(r.text, "# MarkSpec Profile");
+});
+
+Deno.test("readResource: routes entries URI", async () => {
+  const project = mkProject([E1]);
+  const r = await readResource("markspec://entries", project);
+  assertStringIncludes(r.text, "# Entries (1)");
+});
+
+Deno.test("readResource: routes entry URI", async () => {
+  const project = mkProject([E1]);
+  const r = await readResource(
+    "markspec://entry/STK_TEST_0001",
+    project,
+  );
+  assertStringIncludes(r.text, "# STK_TEST_0001 — First entry");
+});
+
+Deno.test("readResource: rejects unknown URI", async () => {
+  const project = mkProject([E1]);
+  await assertRejects(
+    () => readResource("markspec://unknown", project),
+    Error,
+    "unknown resource URI",
+  );
+});
+
+Deno.test("readResource: rejects missing entry", async () => {
+  const project = mkProject([E1]);
+  await assertRejects(
+    () => readResource("markspec://entry/NOPE_0001", project),
+    Error,
+    "entry not found",
+  );
+});

--- a/packages/markspec/mcp/resources/profile.ts
+++ b/packages/markspec/mcp/resources/profile.ts
@@ -1,0 +1,226 @@
+/**
+ * @module mcp/resources/profile
+ *
+ * Renders the `markspec://profile` resource — a Markdown distillation of
+ * the active profile chain. The renderer takes a typed view (see
+ * {@linkcode ProfileView}) rather than the raw `EffectiveProfile` so it
+ * stays decoupled from internal core types.
+ *
+ * The {@linkcode buildProfileView} helper produces a `ProfileView` from a
+ * `ProfileChain | null`.
+ */
+
+import type {
+  EffectiveProfile,
+  EffectiveTypeDef,
+  ProfileChain,
+} from "../../core/mod.ts";
+
+/** Per-type distillation. */
+export interface ProfileTypeView {
+  readonly name: string;
+  readonly shape: string;
+  readonly displayIdPattern: string | undefined;
+  readonly color: string | undefined;
+  readonly requiredAttributes: readonly string[];
+  readonly allowedAttributes: readonly string[];
+  readonly outgoingLinks: readonly string[];
+  readonly incomingLinks: readonly string[];
+  readonly description: string;
+}
+
+/** Per-tier descriptor. */
+export interface ProfileTierView {
+  readonly id: string;
+  readonly version: string;
+  readonly description: string;
+}
+
+/** Renderer input — typed view of the profile chain. */
+export interface ProfileView {
+  readonly tiers: readonly ProfileTierView[];
+  readonly types: readonly ProfileTypeView[];
+  readonly universalRequired: readonly string[];
+  readonly universalAllowed: readonly string[];
+  readonly linkKinds: readonly string[];
+  readonly labels: readonly string[];
+}
+
+/** Build a {@linkcode ProfileView} from a {@linkcode ProfileChain}. */
+export function buildProfileView(
+  chain: ProfileChain | null,
+): ProfileView | null {
+  if (!chain) return null;
+  const eff: EffectiveProfile = chain.effective;
+
+  const tiers: ProfileTierView[] = chain.tiers.map((t) => ({
+    id: t.id,
+    version: t.version,
+    description: t.manifest.description ?? "",
+  }));
+
+  const universalRequired = [...eff.required.value];
+  const universalAllowed = [...eff.attributes.keys()];
+
+  const types: ProfileTypeView[] = [];
+  for (const [name, entry] of eff.types) {
+    const tdef: EffectiveTypeDef = entry.value;
+    const shape = tdef.shape;
+    const shapeScope = shape === "identified" ? eff.identified : eff.referenced;
+
+    const allowed = new Set<string>([
+      ...tdef.attributes.keys(),
+      ...shapeScope.attributes.keys(),
+      ...eff.attributes.keys(),
+    ]);
+    const required = new Set<string>([
+      ...tdef.required.value,
+      ...shapeScope.required.value,
+      ...eff.required.value,
+    ]);
+    for (const r of required) allowed.delete(r);
+
+    const outgoing = new Set<string>(tdef.traceability.keys());
+    // Incoming links: walk every other type's traceability and pick rules
+    // whose target list contains this type's name as a string matcher.
+    const incoming = new Set<string>();
+    for (const [otherName, otherEntry] of eff.types) {
+      if (otherName === name) continue;
+      for (const [linkKind, rule] of otherEntry.value.traceability) {
+        if (targetIncludesType(rule.value.target, name)) {
+          incoming.add(linkKind);
+        }
+      }
+    }
+
+    types.push({
+      name,
+      shape,
+      displayIdPattern: tdef.displayIdPattern.value,
+      color: tdef.color.value,
+      requiredAttributes: [...required],
+      allowedAttributes: [...allowed],
+      outgoingLinks: [...outgoing],
+      incomingLinks: [...incoming],
+      description: "",
+    });
+  }
+  types.sort((a, b) => a.name.localeCompare(b.name));
+
+  const linkKinds = new Set<string>();
+  for (const [, entry] of eff.types) {
+    for (const k of entry.value.traceability.keys()) linkKinds.add(k);
+  }
+
+  return {
+    tiers,
+    types,
+    universalRequired,
+    universalAllowed,
+    linkKinds: [...linkKinds].sort(),
+    labels: [...eff.labels.value],
+  };
+}
+
+/** Render the profile view to Markdown. */
+export function renderProfile(view: ProfileView | null): string {
+  const lines: string[] = ["# MarkSpec Profile", ""];
+
+  if (!view || view.tiers.length === 0) {
+    lines.push("No profile configured for this project.");
+    return lines.join("\n") + "\n";
+  }
+
+  const active = view.tiers[0];
+  lines.push(`**Active**: ${active.id}@${active.version}`);
+  if (view.tiers.length > 1) {
+    const inherits = view.tiers
+      .slice(1)
+      .map((t) => `${t.id}@${t.version}`)
+      .join(", ");
+    lines.push(`**Inherits**: ${inherits}`);
+  }
+  if (active.description) {
+    lines.push("");
+    lines.push(active.description);
+  }
+
+  if (view.types.length > 0) {
+    lines.push("", "## Entry types", "");
+    for (const t of view.types) {
+      lines.push(`### ${t.name}`, "");
+      if (t.displayIdPattern) {
+        lines.push(`- **Display-ID pattern**: \`${t.displayIdPattern}\``);
+      }
+      lines.push(`- **Shape**: ${t.shape}`);
+      if (t.color) lines.push(`- **Color**: ${t.color}`);
+      if (t.requiredAttributes.length > 0) {
+        lines.push(
+          `- **Required attributes**: ${t.requiredAttributes.join(", ")}`,
+        );
+      }
+      if (t.allowedAttributes.length > 0) {
+        lines.push(
+          `- **Allowed attributes**: ${t.allowedAttributes.join(", ")}`,
+        );
+      }
+      if (t.outgoingLinks.length > 0) {
+        lines.push(`- **Outgoing links**: ${t.outgoingLinks.join(", ")}`);
+      }
+      if (t.incomingLinks.length > 0) {
+        lines.push(`- **Incoming links**: ${t.incomingLinks.join(", ")}`);
+      }
+      if (t.description) {
+        lines.push("", t.description);
+      }
+      lines.push("");
+    }
+  }
+
+  if (view.universalRequired.length > 0 || view.universalAllowed.length > 0) {
+    lines.push("## Universal attributes", "");
+    if (view.universalRequired.length > 0) {
+      lines.push(`- **Required**: ${view.universalRequired.join(", ")}`);
+    }
+    if (view.universalAllowed.length > 0) {
+      lines.push(`- **Allowed**: ${view.universalAllowed.join(", ")}`);
+    }
+    lines.push("");
+  }
+
+  if (view.linkKinds.length > 0) {
+    lines.push("## Link kinds", "");
+    lines.push("| Kind | Used by |");
+    lines.push("| --- | --- |");
+    for (const kind of view.linkKinds) {
+      const sources = view.types
+        .filter((t) => t.outgoingLinks.includes(kind))
+        .map((t) => t.name);
+      lines.push(`| ${kind} | ${sources.join(", ") || "—"} |`);
+    }
+    lines.push("");
+  }
+
+  if (view.labels.length > 0) {
+    lines.push("## Labels", "");
+    lines.push(view.labels.join(", "));
+    lines.push("");
+  }
+
+  return lines.join("\n");
+}
+
+/**
+ * Whether a {@linkcode TraceRule}'s target list contains a string matcher
+ * equal to the given type name. Shape-based matchers (`{ shape: ... }`)
+ * are skipped — they don't pin a single named type.
+ */
+function targetIncludesType(
+  target: readonly (string | { readonly shape: string })[],
+  typeName: string,
+): boolean {
+  for (const matcher of target) {
+    if (typeof matcher === "string" && matcher === typeName) return true;
+  }
+  return false;
+}

--- a/packages/markspec/mcp/resources/profile_test.ts
+++ b/packages/markspec/mcp/resources/profile_test.ts
@@ -1,0 +1,71 @@
+/**
+ * @module mcp/resources/profile_test
+ *
+ * Unit tests for the markspec://profile Markdown renderer.
+ */
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { renderProfile } from "./profile.ts";
+
+Deno.test("renderProfile: 'no profile configured' when chain is null", () => {
+  const md = renderProfile(null);
+  assertStringIncludes(md, "# MarkSpec Profile");
+  assertStringIncludes(md, "No profile configured");
+});
+
+Deno.test("renderProfile: includes active profile id and version", () => {
+  const md = renderProfile({
+    tiers: [
+      {
+        id: "@org/aspice-swe-mini",
+        version: "1.0.0",
+        description: "ASPICE software-engineering subset profile.",
+      },
+      {
+        id: "@driftsys/markspec-default",
+        version: "0.3.0",
+        description: "Default RFC 2119 baseline profile.",
+      },
+    ],
+    types: [
+      {
+        name: "stakeholder-requirement",
+        shape: "identified",
+        displayIdPattern: "STK_{DOMAIN}_{NNNN}",
+        color: "blue",
+        requiredAttributes: ["Id"],
+        allowedAttributes: ["Satisfies", "Labels"],
+        outgoingLinks: ["satisfies"],
+        incomingLinks: ["verified-by"],
+        description: "Stakeholder need or expectation.",
+      },
+    ],
+    universalRequired: ["Id"],
+    universalAllowed: ["Labels"],
+    linkKinds: ["satisfies", "derived-from", "verified-by"],
+    labels: ["ASIL-A", "ASIL-B"],
+  });
+
+  assertStringIncludes(md, "**Active**: @org/aspice-swe-mini@1.0.0");
+  assertStringIncludes(md, "**Inherits**: @driftsys/markspec-default@0.3.0");
+  assertStringIncludes(md, "ASPICE software-engineering subset profile.");
+  assertStringIncludes(md, "### stakeholder-requirement");
+  assertStringIncludes(md, "STK_{DOMAIN}_{NNNN}");
+  assertStringIncludes(md, "ASIL-A, ASIL-B");
+  assertStringIncludes(md, "| satisfies");
+});
+
+Deno.test("renderProfile: omits sections that are empty", () => {
+  const md = renderProfile({
+    tiers: [{ id: "@org/x", version: "1.0.0", description: "" }],
+    types: [],
+    universalRequired: [],
+    universalAllowed: [],
+    linkKinds: [],
+    labels: [],
+  });
+  assertEquals(md.includes("## Entry types"), false);
+  assertEquals(md.includes("## Labels"), false);
+  assertEquals(md.includes("## Link kinds"), false);
+  assertEquals(md.includes("## Universal attributes"), false);
+});

--- a/packages/markspec/mcp/server.ts
+++ b/packages/markspec/mcp/server.ts
@@ -1,9 +1,79 @@
 /**
- * @module mcp
+ * @module mcp/server
  *
- * MarkSpec MCP server — exposes MarkSpec capabilities to AI coding agents.
- * Provides safe atomic write operations via `markspec insert` and
- * `markspec format` commands.
+ * MCP server entry point. Constructs a `Server` over stdio, initializes the
+ * project context, registers resources + tools, and wires resource-change
+ * notifications to the cache invalidation hook.
+ *
+ * This module is dynamically imported by `main.ts` when the user runs
+ * `markspec mcp` — never loaded by other subcommands.
  */
 
-export const VERSION = "0.0.1";
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import process from "node:process";
+import { VERSION } from "../core/mod.ts";
+import { createProject, defaultEnv } from "./project.ts";
+import { registerResources } from "./resources/mod.ts";
+import { registerTools } from "./tools/mod.ts";
+import { ENTRIES_URI, entryUri, PROFILE_URI } from "./uri.ts";
+
+/**
+ * Start the MarkSpec MCP server.
+ *
+ * Builds the project context, registers resources + tools, hooks the
+ * cache-invalidation signal to MCP `resources/updated` and
+ * `resources/list_changed` notifications, then opens a stdio transport
+ * and blocks until stdin closes.
+ */
+export async function startServer(): Promise<void> {
+  const server = new Server(
+    { name: "markspec", version: VERSION },
+    {
+      capabilities: {
+        resources: { subscribe: true, listChanged: true },
+        tools: { listChanged: false },
+      },
+    },
+  );
+
+  const project = await createProject(defaultEnv());
+
+  registerResources(server, project);
+  registerTools(server, project);
+
+  // Fire resource list / profile / entries-index change notifications on
+  // every cache invalidation. The SDK's typed helpers wrap the protocol
+  // `notifications/resources/list_changed` and `.../updated` messages.
+  project.subscribeInvalidation(() => {
+    void server.sendResourceListChanged();
+    void server.sendResourceUpdated({ uri: PROFILE_URI });
+    void server.sendResourceUpdated({ uri: ENTRIES_URI });
+  });
+
+  // Per-entry resource updates on every recompile — best effort. Failures
+  // are swallowed because resource notifications are advisory; the client
+  // will re-fetch on its own.
+  project.subscribeInvalidation(async () => {
+    try {
+      const result = await project.getCompiled();
+      for (const id of result.entries.keys()) {
+        void server.sendResourceUpdated({ uri: entryUri(id) });
+      }
+    } catch {
+      // Recompile failed — skip notifications.
+    }
+  });
+
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+
+  // Keep the process alive until stdin closes.
+  process.stdin.on("end", () => {
+    server.close().finally(() => process.exit(0));
+  });
+}
+
+if (import.meta.main) {
+  await startServer();
+}

--- a/packages/markspec/mcp/tools/context.ts
+++ b/packages/markspec/mcp/tools/context.ts
@@ -1,0 +1,109 @@
+/**
+ * @module mcp/tools/context
+ *
+ * `entry_context` MCP tool. Walks the `satisfies` edges upward from a given
+ * entry and renders the chain as a nested Markdown list.
+ */
+
+import type { CompileResult } from "../../core/mod.ts";
+import { entryUri } from "../uri.ts";
+
+/** One entry in the context chain. */
+export interface ContextNode {
+  readonly displayId: string;
+  readonly title: string;
+  /** Hops from the start entry — 0 means the start entry itself. */
+  readonly depth: number;
+}
+
+/**
+ * BFS walk of the `satisfies` edge upward from `startId`.
+ * Stops at `maxDepth` hops or when no outgoing satisfies links remain.
+ * Cycle-safe via visited set.
+ */
+export function walkContext(
+  result: CompileResult,
+  startId: string,
+  maxDepth: number,
+): ContextNode[] {
+  const start = result.entries.get(startId);
+  if (!start) return [];
+
+  const out: ContextNode[] = [
+    { displayId: startId, title: start.title, depth: 0 },
+  ];
+  const visited = new Set<string>([startId]);
+  let frontier: string[] = [startId];
+  let depth = 0;
+
+  while (depth < maxDepth && frontier.length > 0) {
+    const next: string[] = [];
+    for (const id of frontier) {
+      const links = result.forward.get(id) ?? [];
+      for (const link of links) {
+        if (link.kind !== "satisfies") continue;
+        if (visited.has(link.to)) continue;
+        visited.add(link.to);
+        const target = result.entries.get(link.to);
+        if (!target) continue;
+        out.push({
+          displayId: link.to,
+          title: target.title,
+          depth: depth + 1,
+        });
+        next.push(link.to);
+      }
+    }
+    frontier = next;
+    depth++;
+  }
+
+  return out;
+}
+
+/** Render a context chain as nested Markdown. */
+export function renderContext(
+  chain: readonly ContextNode[],
+  startId: string,
+): string {
+  if (chain.length === 0) {
+    return `# Context for ${startId}\n\nNo entry with display ID ${startId}.\n`;
+  }
+  const start = chain[0];
+  const lines: string[] = [
+    `# Context for [${start.displayId}](${entryUri(start.displayId)})`,
+    "",
+  ];
+  for (const node of chain) {
+    const indent = "  ".repeat(node.depth);
+    if (node.depth === 0) {
+      lines.push(`${indent}- **${node.displayId}** — ${node.title}`);
+    } else {
+      lines.push(
+        `${indent}- satisfies → [${node.displayId}](${
+          entryUri(node.displayId)
+        }) — ${node.title}`,
+      );
+    }
+  }
+  return lines.join("\n") + "\n";
+}
+
+/** Tool input schema. */
+export const ENTRY_CONTEXT_INPUT_SCHEMA = {
+  type: "object",
+  properties: {
+    id: { type: "string", minLength: 1 },
+    depth: { type: "integer", minimum: 0, maximum: 50 },
+  },
+  required: ["id"],
+  additionalProperties: false,
+} as const;
+
+/** Tool descriptor metadata. */
+export const ENTRY_CONTEXT_DESCRIPTOR = {
+  name: "entry_context",
+  description:
+    "Walk the satisfies chain upward from an entry. Returns a Markdown nested list.",
+  inputSchema: ENTRY_CONTEXT_INPUT_SCHEMA,
+};

--- a/packages/markspec/mcp/tools/context_test.ts
+++ b/packages/markspec/mcp/tools/context_test.ts
@@ -1,0 +1,134 @@
+/**
+ * @module mcp/tools/context_test
+ *
+ * Unit tests for entry_context (Satisfies-chain walk).
+ */
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import type { CompileResult, Entry, Link } from "../../core/mod.ts";
+import { renderContext, walkContext } from "./context.ts";
+
+function mk(displayId: string, title: string): Entry {
+  return {
+    displayId,
+    title,
+    body: "",
+    rawAttributes: [],
+    typedAttributes: new Map(),
+    shape: "identified",
+    location: { file: "/proj/x.md", line: 1, column: 1 },
+    source: "markdown",
+  };
+}
+
+function buildResult(
+  entries: Entry[],
+  edges: { from: string; to: string; kind: Link["kind"] }[],
+): CompileResult {
+  const entryMap = new Map<string, Entry>();
+  for (const e of entries) entryMap.set(e.displayId, e);
+
+  const links: Link[] = edges.map((e) => ({
+    from: e.from,
+    to: e.to,
+    kind: e.kind,
+    location: { file: "/x", line: 1, column: 1 },
+  }));
+
+  const forward = new Map<string, Link[]>();
+  for (const link of links) {
+    const list = forward.get(link.from) ?? [];
+    list.push(link);
+    forward.set(link.from, list);
+  }
+
+  return {
+    entries: entryMap,
+    links,
+    forward,
+    reverse: new Map(),
+    documents: new Map(),
+    diagnostics: [],
+  };
+}
+
+Deno.test("walkContext: depth 0 is just the start entry", () => {
+  const result = buildResult(
+    [mk("STK_0001", "Top")],
+    [],
+  );
+  const chain = walkContext(result, "STK_0001", 10);
+  assertEquals(chain.length, 1);
+  assertEquals(chain[0].displayId, "STK_0001");
+  assertEquals(chain[0].depth, 0);
+});
+
+Deno.test("walkContext: walks satisfies edges upward", () => {
+  const result = buildResult(
+    [mk("SRS_0001", "SRS"), mk("SYS_0001", "SYS"), mk("STK_0001", "STK")],
+    [
+      { from: "SRS_0001", to: "SYS_0001", kind: "satisfies" },
+      { from: "SYS_0001", to: "STK_0001", kind: "satisfies" },
+    ],
+  );
+  const chain = walkContext(result, "SRS_0001", 10);
+  assertEquals(chain.map((c) => c.displayId), [
+    "SRS_0001",
+    "SYS_0001",
+    "STK_0001",
+  ]);
+});
+
+Deno.test("walkContext: ignores non-satisfies edges", () => {
+  const result = buildResult(
+    [mk("SRS_0001", "SRS"), mk("SYS_0001", "SYS")],
+    [{ from: "SRS_0001", to: "SYS_0001", kind: "derived-from" }],
+  );
+  const chain = walkContext(result, "SRS_0001", 10);
+  assertEquals(chain.length, 1);
+});
+
+Deno.test("walkContext: stops at depth limit", () => {
+  const result = buildResult(
+    [mk("A_0001", "A"), mk("B_0001", "B"), mk("C_0001", "C")],
+    [
+      { from: "A_0001", to: "B_0001", kind: "satisfies" },
+      { from: "B_0001", to: "C_0001", kind: "satisfies" },
+    ],
+  );
+  const chain = walkContext(result, "A_0001", 1);
+  assertEquals(chain.map((c) => c.displayId), ["A_0001", "B_0001"]);
+});
+
+Deno.test("walkContext: handles cycles", () => {
+  const result = buildResult(
+    [mk("A_0001", "A"), mk("B_0001", "B")],
+    [
+      { from: "A_0001", to: "B_0001", kind: "satisfies" },
+      { from: "B_0001", to: "A_0001", kind: "satisfies" },
+    ],
+  );
+  const chain = walkContext(result, "A_0001", 10);
+  assertEquals(chain.length, 2);
+});
+
+Deno.test("renderContext: nested list with indentation", () => {
+  const md = renderContext(
+    [
+      { displayId: "A_0001", title: "A", depth: 0 },
+      { displayId: "B_0001", title: "B", depth: 1 },
+      { displayId: "C_0001", title: "C", depth: 2 },
+    ],
+    "A_0001",
+  );
+  assertStringIncludes(md, "# Context for [A_0001]");
+  assertStringIncludes(md, "- **A_0001** — A");
+  assertStringIncludes(
+    md,
+    "  - satisfies → [B_0001](markspec://entry/B_0001) — B",
+  );
+  assertStringIncludes(
+    md,
+    "    - satisfies → [C_0001](markspec://entry/C_0001) — C",
+  );
+});

--- a/packages/markspec/mcp/tools/mod.ts
+++ b/packages/markspec/mcp/tools/mod.ts
@@ -1,0 +1,124 @@
+/**
+ * @module mcp/tools/mod
+ *
+ * Registers `tools/list` and `tools/call` handlers on the MCP Server.
+ * Each tool lives in its own file and exposes a descriptor + pure
+ * rendering helpers. This module is the dispatch layer.
+ */
+
+import type { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import {
+  type CallToolRequest,
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import type { Project } from "../project.ts";
+import {
+  ENTRY_SEARCH_DESCRIPTOR,
+  renderSearchResults,
+  scoreEntries,
+} from "./search.ts";
+import {
+  ENTRY_CONTEXT_DESCRIPTOR,
+  renderContext,
+  walkContext,
+} from "./context.ts";
+import {
+  filterDiagnostics,
+  renderDiagnosticsReport,
+  VALIDATE_DESCRIPTOR,
+} from "./validate.ts";
+import { REFRESH_DESCRIPTOR, renderRefresh } from "./refresh.ts";
+
+/** All tool descriptors, in `tools/list` order. */
+export const TOOL_DESCRIPTORS = [
+  ENTRY_SEARCH_DESCRIPTOR,
+  ENTRY_CONTEXT_DESCRIPTOR,
+  VALIDATE_DESCRIPTOR,
+  REFRESH_DESCRIPTOR,
+];
+
+/** Tool dispatch entry — takes raw arguments and the project context. */
+interface ToolHandler {
+  // deno-lint-ignore no-explicit-any
+  (args: any, project: Project): Promise<string>;
+}
+
+const HANDLERS: Record<string, ToolHandler> = {
+  // deno-lint-ignore no-explicit-any
+  entry_search: async (args: any, project) => {
+    const query = String(args?.query ?? "");
+    const limit = Math.min(100, Math.max(1, Number(args?.limit ?? 20)));
+    const result = await project.getCompiled();
+    const hits = scoreEntries(
+      [...result.entries.values()],
+      query,
+      limit,
+    );
+    return renderSearchResults(hits, query);
+  },
+
+  // deno-lint-ignore no-explicit-any
+  entry_context: async (args: any, project) => {
+    const id = String(args?.id ?? "");
+    const depth = Math.min(50, Math.max(0, Number(args?.depth ?? 10)));
+    const result = await project.getCompiled();
+    const chain = walkContext(result, id, depth);
+    return renderContext(chain, id);
+  },
+
+  // deno-lint-ignore no-explicit-any
+  validate: async (args: any, project) => {
+    const files: readonly string[] | undefined = Array.isArray(args?.files)
+      ? args.files.map((f: unknown) => String(f))
+      : undefined;
+    const result = await project.getCompiled();
+    const filtered = filterDiagnostics(
+      result.diagnostics,
+      files,
+      project.projectRoot ?? "",
+    );
+    const profileLabel = project.profileChain
+      ? `${project.profileChain.tiers[0].id}@${
+        project.profileChain.tiers[0].version
+      }`
+      : null;
+    return renderDiagnosticsReport(filtered, profileLabel, result.entries.size);
+  },
+
+  markspec_refresh: async (_args, project) => {
+    const result = await project.forceRefresh();
+    return renderRefresh(result.entries.size, result.links.length);
+  },
+};
+
+/** Attach `tools/list` and `tools/call` handlers to a Server instance. */
+export function registerTools(server: Server, project: Project): void {
+  server.setRequestHandler(ListToolsRequestSchema, () =>
+    Promise.resolve({
+      tools: TOOL_DESCRIPTORS,
+    }));
+
+  server.setRequestHandler(
+    CallToolRequestSchema,
+    async (req: CallToolRequest) => {
+      const name = req.params.name;
+      const handler = HANDLERS[name];
+      if (!handler) {
+        return {
+          isError: true,
+          content: [{ type: "text", text: `unknown tool: ${name}` }],
+        };
+      }
+      try {
+        const text = await handler(req.params.arguments ?? {}, project);
+        return { content: [{ type: "text", text }] };
+      } catch (err) {
+        return {
+          isError: true,
+          content: [{ type: "text", text: (err as Error).message }],
+        };
+      }
+    },
+  );
+}

--- a/packages/markspec/mcp/tools/mod.ts
+++ b/packages/markspec/mcp/tools/mod.ts
@@ -83,7 +83,12 @@ const HANDLERS: Record<string, ToolHandler> = {
         project.profileChain.tiers[0].version
       }`
       : null;
-    return renderDiagnosticsReport(filtered, profileLabel, result.entries.size);
+    return renderDiagnosticsReport(
+      filtered,
+      profileLabel,
+      result.entries.size,
+      project.projectRoot,
+    );
   },
 
   markspec_refresh: async (_args, project) => {

--- a/packages/markspec/mcp/tools/refresh.ts
+++ b/packages/markspec/mcp/tools/refresh.ts
@@ -1,0 +1,28 @@
+/**
+ * @module mcp/tools/refresh
+ *
+ * `markspec_refresh` MCP tool. Forces an unconditional recompile of the
+ * project, returning a one-line Markdown confirmation. Used by agents that
+ * have just edited files and want to guarantee freshness without relying on
+ * the mtime check.
+ */
+
+/** Render a refresh confirmation. */
+export function renderRefresh(entries: number, links: number): string {
+  return `Refreshed. ${entries} entries, ${links} links.\n`;
+}
+
+/** Tool input schema. */
+export const REFRESH_INPUT_SCHEMA = {
+  type: "object",
+  properties: {},
+  additionalProperties: false,
+} as const;
+
+/** Tool descriptor metadata. */
+export const REFRESH_DESCRIPTOR = {
+  name: "markspec_refresh",
+  description:
+    "Force-invalidate the MarkSpec compile cache. Use after editing files to guarantee subsequent reads see the new state.",
+  inputSchema: REFRESH_INPUT_SCHEMA,
+};

--- a/packages/markspec/mcp/tools/refresh_test.ts
+++ b/packages/markspec/mcp/tools/refresh_test.ts
@@ -1,0 +1,19 @@
+/**
+ * @module mcp/tools/refresh_test
+ */
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { renderRefresh } from "./refresh.ts";
+
+Deno.test("renderRefresh: returns count summary", () => {
+  const md = renderRefresh(1234, 5678);
+  assertStringIncludes(md, "Refreshed.");
+  assertStringIncludes(md, "1234 entries");
+  assertStringIncludes(md, "5678 links");
+});
+
+Deno.test("renderRefresh: zero counts", () => {
+  const md = renderRefresh(0, 0);
+  assertStringIncludes(md, "Refreshed.");
+  assertEquals(md.includes("0 entries"), true);
+});

--- a/packages/markspec/mcp/tools/search.ts
+++ b/packages/markspec/mcp/tools/search.ts
@@ -1,0 +1,124 @@
+/**
+ * @module mcp/tools/search
+ *
+ * `entry_search` MCP tool.
+ *
+ * Inputs: `{ query: string, limit?: number }`.
+ * Output: Markdown list of ranked matches over display IDs and titles.
+ *
+ * Ranking rules:
+ *   +10 query is prefix of displayId
+ *   +5  query is substring of displayId
+ *   +3  per query-token exact-matching a title-token
+ *   +1  per query-token substring-matching a title-token
+ *   +2  all query-tokens appear in title (any order)
+ */
+
+import type { Entry } from "../../core/mod.ts";
+import { entryUri } from "../uri.ts";
+
+/** A ranked search result. */
+export interface ScoredEntry {
+  readonly entry: Entry;
+  readonly score: number;
+}
+
+const TOKEN_RE = /[\s_]+/g;
+
+/**
+ * Score a list of entries against a query; return top-N hits with score > 0.
+ *
+ * Scoring is case-insensitive. Entries with a score of zero are excluded.
+ * Results are sorted descending by score, then ascending by displayId for
+ * stability.
+ */
+export function scoreEntries(
+  entries: readonly Entry[],
+  query: string,
+  limit: number,
+): ScoredEntry[] {
+  const q = query.toLowerCase();
+  const qTokens = q.split(TOKEN_RE).filter(Boolean);
+
+  const hits: ScoredEntry[] = [];
+  for (const entry of entries) {
+    const id = entry.displayId.toLowerCase();
+    const title = entry.title.toLowerCase();
+    const titleTokens = title.split(TOKEN_RE).filter(Boolean);
+
+    let score = 0;
+    if (id.startsWith(q)) {
+      score += 10;
+    } else if (id.includes(q)) {
+      score += 5;
+    }
+
+    for (const qt of qTokens) {
+      if (titleTokens.includes(qt)) {
+        score += 3;
+      } else if (titleTokens.some((t) => t.includes(qt))) {
+        score += 1;
+      }
+    }
+    if (qTokens.length > 0 && qTokens.every((qt) => title.includes(qt))) {
+      score += 2;
+    }
+
+    if (score > 0) hits.push({ entry, score });
+  }
+
+  hits.sort(
+    (a, b) =>
+      b.score - a.score ||
+      a.entry.displayId.localeCompare(b.entry.displayId),
+  );
+  return hits.slice(0, limit);
+}
+
+/**
+ * Render search hits as a Markdown list.
+ *
+ * Each hit is rendered as a link using the `markspec://entry/` URI scheme,
+ * followed by the entry title and its score for transparency.
+ */
+export function renderSearchResults(
+  hits: readonly ScoredEntry[],
+  query: string,
+): string {
+  if (hits.length === 0) {
+    return `# Search results\n\nNo matches for \`${query}\`.\n`;
+  }
+  const lines: string[] = [
+    `# Search results for "${query}" (${hits.length} ${
+      hits.length === 1 ? "match" : "matches"
+    })`,
+    "",
+  ];
+  for (const { entry, score } of hits) {
+    lines.push(
+      `- [${entry.displayId}](${
+        entryUri(entry.displayId)
+      }) — ${entry.title} (score ${score})`,
+    );
+  }
+  return lines.join("\n") + "\n";
+}
+
+/** JSON Schema for the entry_search tool input. */
+export const ENTRY_SEARCH_INPUT_SCHEMA = {
+  type: "object",
+  properties: {
+    query: { type: "string", minLength: 1 },
+    limit: { type: "integer", minimum: 1, maximum: 100 },
+  },
+  required: ["query"],
+  additionalProperties: false,
+} as const;
+
+/** Tool descriptor metadata used by the MCP tools/list handler. */
+export const ENTRY_SEARCH_DESCRIPTOR = {
+  name: "entry_search",
+  description:
+    "Search project entries by display ID and title. Returns ranked matches as Markdown links.",
+  inputSchema: ENTRY_SEARCH_INPUT_SCHEMA,
+};

--- a/packages/markspec/mcp/tools/search_test.ts
+++ b/packages/markspec/mcp/tools/search_test.ts
@@ -1,0 +1,91 @@
+/**
+ * @module mcp/tools/search_test
+ *
+ * Unit tests for the entry_search ranking algorithm and Markdown render.
+ */
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import type { Entry } from "../../core/mod.ts";
+import { renderSearchResults, scoreEntries } from "./search.ts";
+
+function mk(displayId: string, title: string): Entry {
+  return {
+    displayId,
+    title,
+    body: "",
+    rawAttributes: [],
+    typedAttributes: new Map(),
+    shape: "identified",
+    location: { file: "/proj/x.md", line: 1, column: 1 },
+    source: "markdown",
+  };
+}
+
+Deno.test("scoreEntries: prefix match on displayId scores highest", () => {
+  const hits = scoreEntries(
+    [mk("STK_AEB_0001", "Brake"), mk("XYZ_AEB_0001", "Braking sensor")],
+    "stk_aeb",
+    10,
+  );
+  assertEquals(hits[0].entry.displayId, "STK_AEB_0001");
+});
+
+Deno.test("scoreEntries: substring match on displayId beats title", () => {
+  const hits = scoreEntries(
+    [mk("FOO_BAR_0001", "Unrelated"), mk("XXX_AEB_0001", "Aeb in title")],
+    "aeb",
+    10,
+  );
+  assertEquals(hits[0].entry.displayId, "XXX_AEB_0001");
+});
+
+Deno.test("scoreEntries: token coverage in title scores", () => {
+  const hits = scoreEntries(
+    [
+      mk("X_0001", "Apply continuous braking force"),
+      mk("X_0002", "Sensor debouncing"),
+    ],
+    "braking",
+    10,
+  );
+  assertEquals(hits[0].entry.displayId, "X_0001");
+});
+
+Deno.test("scoreEntries: drops zero-score entries", () => {
+  const hits = scoreEntries(
+    [mk("X_0001", "Sensor debouncing"), mk("X_0002", "Braking force")],
+    "braking",
+    10,
+  );
+  assertEquals(hits.length, 1);
+  assertEquals(hits[0].entry.displayId, "X_0002");
+});
+
+Deno.test("scoreEntries: respects limit", () => {
+  const entries = Array.from(
+    { length: 30 },
+    (_, i) => mk(`X_${String(i).padStart(4, "0")}`, `Braking ${i}`),
+  );
+  const hits = scoreEntries(entries, "braking", 5);
+  assertEquals(hits.length, 5);
+});
+
+Deno.test("renderSearchResults: empty hits message", () => {
+  const md = renderSearchResults([], "nope");
+  assertStringIncludes(md, "No matches for");
+});
+
+Deno.test("renderSearchResults: links each hit", () => {
+  const md = renderSearchResults(
+    [
+      { entry: mk("STK_AEB_0001", "Stop on collision"), score: 11 },
+      { entry: mk("VAL_AEB_0001", "Vehicle stops"), score: 6 },
+    ],
+    "braking",
+  );
+  assertStringIncludes(
+    md,
+    "[STK_AEB_0001](markspec://entry/STK_AEB_0001) — Stop on collision",
+  );
+  assertStringIncludes(md, "score 11");
+});

--- a/packages/markspec/mcp/tools/validate.ts
+++ b/packages/markspec/mcp/tools/validate.ts
@@ -1,0 +1,101 @@
+/**
+ * @module mcp/tools/validate
+ *
+ * `validate` MCP tool. Runs the validator pipeline and renders the
+ * diagnostics as a Markdown report. Optional `files` argument filters
+ * diagnostics to a subset of paths (relative paths resolved against the
+ * project root).
+ */
+
+import type { Diagnostic } from "../../core/mod.ts";
+
+/** Filter diagnostics by a list of file paths. */
+export function filterDiagnostics(
+  diagnostics: readonly Diagnostic[],
+  files: readonly string[] | undefined,
+  projectRoot: string,
+): readonly Diagnostic[] {
+  if (!files || files.length === 0) return diagnostics;
+  const absolute = new Set<string>();
+  for (const f of files) {
+    if (f.startsWith("/")) absolute.add(f);
+    else absolute.add(`${projectRoot}/${f}`);
+  }
+  return diagnostics.filter(
+    (d) => d.location && absolute.has(d.location.file),
+  );
+}
+
+/** Render diagnostics as a Markdown report. */
+export function renderDiagnosticsReport(
+  diagnostics: readonly Diagnostic[],
+  profileLabel: string | null,
+  entryCount: number,
+): string {
+  if (diagnostics.length === 0) {
+    const profilePart = profileLabel ? ` under ${profileLabel}` : "";
+    return `✓ All ${entryCount} entries pass validation${profilePart}.\n`;
+  }
+
+  const errors = diagnostics.filter((d) => d.severity === "error");
+  const warnings = diagnostics.filter((d) => d.severity === "warning");
+  const infos = diagnostics.filter((d) => d.severity === "info");
+
+  const summaryParts: string[] = [];
+  if (errors.length) {
+    summaryParts.push(
+      `${errors.length} error${errors.length === 1 ? "" : "s"}`,
+    );
+  }
+  if (warnings.length) {
+    summaryParts.push(
+      `${warnings.length} warning${warnings.length === 1 ? "" : "s"}`,
+    );
+  }
+  if (infos.length) {
+    summaryParts.push(`${infos.length} info`);
+  }
+
+  const lines: string[] = [`# Validation: ${summaryParts.join(", ")}`, ""];
+
+  for (
+    const [label, list] of [
+      ["Errors", errors],
+      ["Warnings", warnings],
+      ["Info", infos],
+    ] as const
+  ) {
+    if (list.length === 0) continue;
+    lines.push(`## ${label}`, "");
+    for (const d of list) {
+      lines.push(`### ${d.code}`, "");
+      const loc = d.location
+        ? `${d.location.file}:${d.location.line}:${d.location.column}`
+        : "(no location)";
+      lines.push(loc, "");
+      lines.push(d.message, "");
+    }
+  }
+
+  return lines.join("\n");
+}
+
+/** Tool input schema. */
+export const VALIDATE_INPUT_SCHEMA = {
+  type: "object",
+  properties: {
+    files: {
+      type: "array",
+      items: { type: "string" },
+    },
+  },
+  additionalProperties: false,
+} as const;
+
+/** Tool descriptor metadata. */
+export const VALIDATE_DESCRIPTOR = {
+  name: "validate",
+  description:
+    "Run the MarkSpec validator. Optional 'files' filters diagnostics by source path.",
+  inputSchema: VALIDATE_INPUT_SCHEMA,
+};

--- a/packages/markspec/mcp/tools/validate.ts
+++ b/packages/markspec/mcp/tools/validate.ts
@@ -8,6 +8,7 @@
  */
 
 import type { Diagnostic } from "../../core/mod.ts";
+import { relativeToRoot } from "../path.ts";
 
 /** Filter diagnostics by a list of file paths. */
 export function filterDiagnostics(
@@ -31,6 +32,7 @@ export function renderDiagnosticsReport(
   diagnostics: readonly Diagnostic[],
   profileLabel: string | null,
   entryCount: number,
+  projectRoot?: string,
 ): string {
   if (diagnostics.length === 0) {
     const profilePart = profileLabel ? ` under ${profileLabel}` : "";
@@ -70,10 +72,17 @@ export function renderDiagnosticsReport(
     for (const d of list) {
       lines.push(`### ${d.code}`, "");
       const loc = d.location
-        ? `${d.location.file}:${d.location.line}:${d.location.column}`
+        ? `${
+          relativeToRoot(d.location.file, projectRoot)
+        }:${d.location.line}:${d.location.column}`
         : "(no location)";
       lines.push(loc, "");
-      lines.push(d.message, "");
+      // Strip any absolute projectRoot prefix that the core validator may
+      // have embedded inside the message (e.g. "also at /abs/path/...").
+      const message = projectRoot
+        ? d.message.split(projectRoot + "/").join("")
+        : d.message;
+      lines.push(message, "");
     }
   }
 

--- a/packages/markspec/mcp/tools/validate_test.ts
+++ b/packages/markspec/mcp/tools/validate_test.ts
@@ -4,7 +4,7 @@
  * Unit tests for the validate tool's Markdown report.
  */
 
-import { assertStringIncludes } from "@std/assert";
+import { assertEquals, assertStringIncludes } from "@std/assert";
 import type { Diagnostic } from "../../core/mod.ts";
 import { filterDiagnostics, renderDiagnosticsReport } from "./validate.ts";
 
@@ -40,6 +40,28 @@ Deno.test("renderDiagnosticsReport: errors and warnings sections", () => {
   assertStringIncludes(md, "/proj/docs/req.md:128:3");
   assertStringIncludes(md, "## Warnings");
   assertStringIncludes(md, "### MSL-R010");
+});
+
+Deno.test("renderDiagnosticsReport: renders locations relative to projectRoot", () => {
+  const md = renderDiagnosticsReport([ERR, WARN], null, 1, "/proj");
+  assertStringIncludes(md, "docs/req.md:128:3");
+  assertStringIncludes(md.split("\n").join(" "), " docs/req.md:128:3");
+});
+
+Deno.test("renderDiagnosticsReport: scrubs projectRoot from embedded message paths", () => {
+  const dup: Diagnostic = {
+    code: "MSL-R006",
+    severity: "error",
+    message:
+      "duplicate display ID 'STK_AEB_0001' (also at /proj/docs/other.md:12)",
+    location: { file: "/proj/docs/req.md", line: 5, column: 1 },
+  };
+  const md = renderDiagnosticsReport([dup], null, 1, "/proj");
+  assertStringIncludes(
+    md,
+    "duplicate display ID 'STK_AEB_0001' (also at docs/other.md:12)",
+  );
+  assertEquals(md.includes("/proj/docs/other.md"), false);
 });
 
 Deno.test("filterDiagnostics: passes all when files undefined", () => {

--- a/packages/markspec/mcp/tools/validate_test.ts
+++ b/packages/markspec/mcp/tools/validate_test.ts
@@ -1,0 +1,63 @@
+/**
+ * @module mcp/tools/validate_test
+ *
+ * Unit tests for the validate tool's Markdown report.
+ */
+
+import { assertStringIncludes } from "@std/assert";
+import type { Diagnostic } from "../../core/mod.ts";
+import { filterDiagnostics, renderDiagnosticsReport } from "./validate.ts";
+
+const ERR: Diagnostic = {
+  code: "MSL-R004",
+  severity: "error",
+  message: "unresolved reference: SYS_NONEXISTENT",
+  location: {
+    file: "/proj/docs/req.md",
+    line: 128,
+    column: 3,
+  },
+};
+
+const WARN: Diagnostic = {
+  code: "MSL-R010",
+  severity: "warning",
+  message: "unrecognized attribute Priority",
+  location: { file: "/proj/docs/req.md", line: 200, column: 3 },
+};
+
+Deno.test("renderDiagnosticsReport: clean report", () => {
+  const md = renderDiagnosticsReport([], "@org/x@1.0.0", 100);
+  assertStringIncludes(md, "✓ All 100 entries pass validation");
+});
+
+Deno.test("renderDiagnosticsReport: errors and warnings sections", () => {
+  const md = renderDiagnosticsReport([ERR, WARN], null, 1);
+  assertStringIncludes(md, "# Validation: 1 error, 1 warning");
+  assertStringIncludes(md, "## Errors");
+  assertStringIncludes(md, "### MSL-R004");
+  assertStringIncludes(md, "unresolved reference: SYS_NONEXISTENT");
+  assertStringIncludes(md, "/proj/docs/req.md:128:3");
+  assertStringIncludes(md, "## Warnings");
+  assertStringIncludes(md, "### MSL-R010");
+});
+
+Deno.test("filterDiagnostics: passes all when files undefined", () => {
+  const out = filterDiagnostics([ERR, WARN], undefined, "/proj");
+  assertStringIncludes(out.length.toString(), "2");
+});
+
+Deno.test("filterDiagnostics: keeps matching relative path", () => {
+  const out = filterDiagnostics([ERR, WARN], ["docs/req.md"], "/proj");
+  assertStringIncludes(out.length.toString(), "2");
+});
+
+Deno.test("filterDiagnostics: drops non-matching paths", () => {
+  const out = filterDiagnostics([ERR, WARN], ["docs/other.md"], "/proj");
+  assertStringIncludes(out.length.toString(), "0");
+});
+
+Deno.test("filterDiagnostics: absolute path match", () => {
+  const out = filterDiagnostics([ERR], ["/proj/docs/req.md"], "/proj");
+  assertStringIncludes(out.length.toString(), "1");
+});

--- a/packages/markspec/mcp/uri.ts
+++ b/packages/markspec/mcp/uri.ts
@@ -1,0 +1,46 @@
+/**
+ * @module mcp/uri
+ *
+ * The `markspec://` URI scheme used by the MCP server. Three resource
+ * families:
+ *
+ * - `markspec://profile`               — the distilled profile manifest
+ * - `markspec://entries`               — the entry index
+ * - `markspec://entry/{displayId}`     — a single entry
+ *
+ * All helpers are pure and safe to import from any module.
+ */
+
+/** Canonical URI of the profile resource. */
+export const PROFILE_URI = "markspec://profile";
+
+/** Canonical URI of the entries-index resource. */
+export const ENTRIES_URI = "markspec://entries";
+
+/** Prefix for per-entry resource URIs. */
+export const ENTRY_URI_PREFIX = "markspec://entry/";
+
+/** Build an entry resource URI from a display ID. */
+export function entryUri(displayId: string): string {
+  return `${ENTRY_URI_PREFIX}${encodeURIComponent(displayId)}`;
+}
+
+/**
+ * Extract the display ID from a `markspec://entry/...` URI.
+ * Returns `undefined` for any URI that is not a non-empty entry URI.
+ */
+export function parseEntryUri(uri: string): string | undefined {
+  if (!uri.startsWith(ENTRY_URI_PREFIX)) return undefined;
+  const encoded = uri.slice(ENTRY_URI_PREFIX.length);
+  if (encoded.length === 0) return undefined;
+  try {
+    return decodeURIComponent(encoded);
+  } catch {
+    return undefined;
+  }
+}
+
+/** Check whether a URI is a well-formed entry URI. */
+export function isEntryUri(uri: string): boolean {
+  return parseEntryUri(uri) !== undefined;
+}

--- a/packages/markspec/mcp/uri_test.ts
+++ b/packages/markspec/mcp/uri_test.ts
@@ -1,0 +1,61 @@
+/**
+ * @module mcp/uri_test
+ *
+ * Unit tests for the markspec:// URI scheme helpers.
+ */
+
+import { assertEquals } from "@std/assert";
+import {
+  ENTRIES_URI,
+  entryUri,
+  isEntryUri,
+  parseEntryUri,
+  PROFILE_URI,
+} from "./uri.ts";
+
+Deno.test("PROFILE_URI is the canonical constant", () => {
+  assertEquals(PROFILE_URI, "markspec://profile");
+});
+
+Deno.test("ENTRIES_URI is the canonical constant", () => {
+  assertEquals(ENTRIES_URI, "markspec://entries");
+});
+
+Deno.test("entryUri: builds entry URI from display ID", () => {
+  assertEquals(entryUri("STK_AEB_0001"), "markspec://entry/STK_AEB_0001");
+});
+
+Deno.test("entryUri: encodes special characters in display ID", () => {
+  // Display IDs are normally [A-Z0-9_] but be defensive.
+  assertEquals(
+    entryUri("FOO BAR"),
+    "markspec://entry/FOO%20BAR",
+  );
+});
+
+Deno.test("parseEntryUri: extracts display ID", () => {
+  assertEquals(
+    parseEntryUri("markspec://entry/STK_AEB_0001"),
+    "STK_AEB_0001",
+  );
+});
+
+Deno.test("parseEntryUri: decodes percent-encoded characters", () => {
+  assertEquals(parseEntryUri("markspec://entry/FOO%20BAR"), "FOO BAR");
+});
+
+Deno.test("parseEntryUri: returns undefined for non-entry URIs", () => {
+  assertEquals(parseEntryUri("markspec://profile"), undefined);
+  assertEquals(parseEntryUri("https://example.com/STK_AEB_0001"), undefined);
+  assertEquals(parseEntryUri("markspec://entry/"), undefined);
+});
+
+Deno.test("isEntryUri: true for entry URIs", () => {
+  assertEquals(isEntryUri("markspec://entry/STK_AEB_0001"), true);
+});
+
+Deno.test("isEntryUri: false for other URIs", () => {
+  assertEquals(isEntryUri("markspec://profile"), false);
+  assertEquals(isEntryUri("markspec://entries"), false);
+  assertEquals(isEntryUri("markspec://entry/"), false);
+});

--- a/tests/e2e/mcp_test.ts
+++ b/tests/e2e/mcp_test.ts
@@ -23,7 +23,7 @@ const FIXTURE_DOC = `# Stakeholder requirements
 
   Body.
 
-  Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
 `;
 
 interface RpcResponse {
@@ -261,7 +261,7 @@ Deno.test("mcp: file edit + markspec_refresh fires resources/updated", async () 
     await Deno.writeTextFile(
       `${cwd}/req.md`,
       FIXTURE_DOC +
-        `\n- [STK_E2E_0002] Second\n\n  Body.\n\n  Id: 01HGW2Q8MNP3RSTVWXYZABCDEG\n`,
+        `\n- [STK_E2E_0002] Second\n\n  Body.\n\n      Id: 01HGW2Q8MNP3RSTVWXYZABCDEG\n`,
     );
 
     const resp = await proc.request("tools/call", {
@@ -272,8 +272,15 @@ Deno.test("mcp: file edit + markspec_refresh fires resources/updated", async () 
     const content = (resp.result as any).content as Array<{ text: string }>;
     assertStringIncludes(content[0].text, "2 entries");
 
-    const notifs = proc.drainNotifications();
-    const methods = notifs.map((n) => n.method);
+    // Subscription handlers fire on the next microtask after the tool call
+    // response; give the runtime up to ~500ms to flush them before draining.
+    const deadline = performance.now() + 500;
+    let methods: (string | undefined)[] = [];
+    while (performance.now() < deadline) {
+      methods = proc.drainNotifications().map((n) => n.method);
+      if (methods.includes("notifications/resources/list_changed")) break;
+      await new Promise((r) => setTimeout(r, 25));
+    }
     assertEquals(
       methods.includes("notifications/resources/list_changed"),
       true,

--- a/tests/e2e/mcp_test.ts
+++ b/tests/e2e/mcp_test.ts
@@ -1,0 +1,285 @@
+/**
+ * @module tests/e2e/mcp_test
+ *
+ * End-to-end tests for `markspec mcp`. Spawns the CLI as a subprocess and
+ * exchanges real MCP JSON-RPC messages over stdio.
+ *
+ * Boundary: this file imports nothing from packages/markspec/ — it interacts
+ * exclusively through Deno.Command.
+ */
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+
+const CLI_ENTRY = new URL(
+  "../../packages/markspec/main.ts",
+  import.meta.url,
+).pathname;
+
+const PROJECT_YAML = `name: e2e\nversion: 0.0.1\n`;
+
+const FIXTURE_DOC = `# Stakeholder requirements
+
+- [STK_E2E_0001] Stop on collision
+
+  Body.
+
+  Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+`;
+
+interface RpcResponse {
+  jsonrpc: "2.0";
+  id?: number;
+  result?: unknown;
+  error?: { code: number; message: string };
+  method?: string;
+  params?: unknown;
+}
+
+/** Manage a running `markspec mcp` subprocess. */
+class McpProcess {
+  private proc: Deno.ChildProcess;
+  private writer: WritableStreamDefaultWriter<Uint8Array>;
+  private buffer = "";
+  private pending = new Map<number, (msg: RpcResponse) => void>();
+  private notifications: RpcResponse[] = [];
+  private nextId = 1;
+
+  constructor(cwd: string) {
+    const cmd = new Deno.Command("deno", {
+      args: [
+        "run",
+        "--allow-read",
+        "--allow-write",
+        "--allow-env",
+        "--allow-net",
+        "--allow-ffi",
+        CLI_ENTRY,
+        "mcp",
+      ],
+      cwd,
+      stdin: "piped",
+      stdout: "piped",
+      stderr: "piped",
+    });
+    this.proc = cmd.spawn();
+    this.writer = this.proc.stdin.getWriter();
+    // Drain stderr so it doesn't leak when the process exits.
+    void this.proc.stderr.pipeTo(
+      new WritableStream({ write() {} }),
+    ).catch(() => {});
+    this.readLoop();
+  }
+
+  private async readLoop(): Promise<void> {
+    const reader = this.proc.stdout.getReader();
+    const decoder = new TextDecoder();
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) return;
+      this.buffer += decoder.decode(value);
+      for (;;) {
+        const newlineIdx = this.buffer.indexOf("\n");
+        if (newlineIdx < 0) break;
+        const line = this.buffer.slice(0, newlineIdx).trim();
+        this.buffer = this.buffer.slice(newlineIdx + 1);
+        if (!line) continue;
+        let msg: RpcResponse;
+        try {
+          msg = JSON.parse(line) as RpcResponse;
+        } catch {
+          continue;
+        }
+        if (typeof msg.id === "number" && this.pending.has(msg.id)) {
+          this.pending.get(msg.id)!(msg);
+          this.pending.delete(msg.id);
+        } else if (msg.method) {
+          this.notifications.push(msg);
+        }
+      }
+    }
+  }
+
+  async request(method: string, params: unknown): Promise<RpcResponse> {
+    const id = this.nextId++;
+    const payload = JSON.stringify({ jsonrpc: "2.0", id, method, params });
+    const promise = new Promise<RpcResponse>((resolve) => {
+      this.pending.set(id, resolve);
+    });
+    await this.writer.write(new TextEncoder().encode(payload + "\n"));
+    return await promise;
+  }
+
+  async notify(method: string, params: unknown): Promise<void> {
+    const payload = JSON.stringify({ jsonrpc: "2.0", method, params });
+    await this.writer.write(new TextEncoder().encode(payload + "\n"));
+  }
+
+  drainNotifications(): RpcResponse[] {
+    const out = this.notifications.slice();
+    this.notifications.length = 0;
+    return out;
+  }
+
+  async close(): Promise<void> {
+    try {
+      await this.writer.close();
+    } catch { /* already closed */ }
+    try {
+      this.proc.kill("SIGTERM");
+    } catch { /* already exited */ }
+    await this.proc.status;
+  }
+}
+
+/** Create a fixture project in a temp dir and start the server. */
+async function setup(): Promise<
+  { proc: McpProcess; cwd: string; initResponse: RpcResponse }
+> {
+  const dir = await Deno.makeTempDir();
+  await Deno.writeTextFile(`${dir}/project.yaml`, PROJECT_YAML);
+  await Deno.writeTextFile(`${dir}/req.md`, FIXTURE_DOC);
+  const proc = new McpProcess(dir);
+  const initResponse = await proc.request("initialize", {
+    protocolVersion: "2024-11-05",
+    capabilities: {},
+    clientInfo: { name: "test", version: "0.0.1" },
+  });
+  await proc.notify("notifications/initialized", {});
+  return { proc, cwd: dir, initResponse };
+}
+
+Deno.test("mcp: initialize advertises resources and tools capabilities", async () => {
+  const { proc, cwd, initResponse } = await setup();
+  try {
+    // deno-lint-ignore no-explicit-any
+    const caps = (initResponse.result as any).capabilities;
+    assertEquals(typeof caps.resources, "object");
+    assertEquals(typeof caps.tools, "object");
+  } finally {
+    await proc.close();
+    await Deno.remove(cwd, { recursive: true });
+  }
+});
+
+Deno.test("mcp: tools/list returns all four tools", async () => {
+  const { proc, cwd } = await setup();
+  try {
+    const resp = await proc.request("tools/list", {});
+    // deno-lint-ignore no-explicit-any
+    const tools = (resp.result as any).tools as Array<{ name: string }>;
+    const names = tools.map((t) => t.name).sort();
+    assertEquals(names, [
+      "entry_context",
+      "entry_search",
+      "markspec_refresh",
+      "validate",
+    ]);
+  } finally {
+    await proc.close();
+    await Deno.remove(cwd, { recursive: true });
+  }
+});
+
+Deno.test("mcp: resources/list returns profile, entries, and per-entry URIs", async () => {
+  const { proc, cwd } = await setup();
+  try {
+    const resp = await proc.request("resources/list", {});
+    // deno-lint-ignore no-explicit-any
+    const resources = (resp.result as any).resources as Array<
+      { uri: string }
+    >;
+    const uris = resources.map((r) => r.uri).sort();
+    assertEquals(uris.includes("markspec://profile"), true);
+    assertEquals(uris.includes("markspec://entries"), true);
+    assertEquals(
+      uris.includes("markspec://entry/STK_E2E_0001"),
+      true,
+    );
+  } finally {
+    await proc.close();
+    await Deno.remove(cwd, { recursive: true });
+  }
+});
+
+Deno.test("mcp: resources/read on entry returns Markdown body", async () => {
+  const { proc, cwd } = await setup();
+  try {
+    const resp = await proc.request("resources/read", {
+      uri: "markspec://entry/STK_E2E_0001",
+    });
+    // deno-lint-ignore no-explicit-any
+    const contents = (resp.result as any).contents as Array<
+      { text: string; mimeType: string }
+    >;
+    assertEquals(contents[0].mimeType, "text/markdown");
+    assertStringIncludes(
+      contents[0].text,
+      "# STK_E2E_0001 — Stop on collision",
+    );
+  } finally {
+    await proc.close();
+    await Deno.remove(cwd, { recursive: true });
+  }
+});
+
+Deno.test("mcp: tools/call entry_search returns ranked matches", async () => {
+  const { proc, cwd } = await setup();
+  try {
+    const resp = await proc.request("tools/call", {
+      name: "entry_search",
+      arguments: { query: "collision" },
+    });
+    // deno-lint-ignore no-explicit-any
+    const content = (resp.result as any).content as Array<{ text: string }>;
+    assertStringIncludes(content[0].text, "STK_E2E_0001");
+  } finally {
+    await proc.close();
+    await Deno.remove(cwd, { recursive: true });
+  }
+});
+
+Deno.test("mcp: tools/call validate returns clean report", async () => {
+  const { proc, cwd } = await setup();
+  try {
+    const resp = await proc.request("tools/call", {
+      name: "validate",
+      arguments: {},
+    });
+    // deno-lint-ignore no-explicit-any
+    const content = (resp.result as any).content as Array<{ text: string }>;
+    assertStringIncludes(content[0].text, "All 1 entries pass validation");
+  } finally {
+    await proc.close();
+    await Deno.remove(cwd, { recursive: true });
+  }
+});
+
+Deno.test("mcp: file edit + markspec_refresh fires resources/updated", async () => {
+  const { proc, cwd } = await setup();
+  try {
+    // Edit the fixture file: add a second entry.
+    await Deno.writeTextFile(
+      `${cwd}/req.md`,
+      FIXTURE_DOC +
+        `\n- [STK_E2E_0002] Second\n\n  Body.\n\n  Id: 01HGW2Q8MNP3RSTVWXYZABCDEG\n`,
+    );
+
+    const resp = await proc.request("tools/call", {
+      name: "markspec_refresh",
+      arguments: {},
+    });
+    // deno-lint-ignore no-explicit-any
+    const content = (resp.result as any).content as Array<{ text: string }>;
+    assertStringIncludes(content[0].text, "2 entries");
+
+    const notifs = proc.drainNotifications();
+    const methods = notifs.map((n) => n.method);
+    assertEquals(
+      methods.includes("notifications/resources/list_changed"),
+      true,
+    );
+  } finally {
+    await proc.close();
+    await Deno.remove(cwd, { recursive: true });
+  }
+});


### PR DESCRIPTION
## Summary

Implements v1 of the MarkSpec MCP server per [the spec](docs/superpowers/specs/2026-05-10-mcp-server-design.md).

- **3 resources** (all Markdown): `markspec://profile`, `markspec://entries`, `markspec://entry/{displayId}`
- **4 tools** (all return Markdown): `entry_search`, `entry_context`, `validate`, `markspec_refresh`
- stdio transport, lazy-loaded from `main.ts` — `markspec validate` etc. never load the MCP SDK
- mtime-based cache invalidation on every read; background prefetch on initialize; explicit `markspec_refresh` tool as escape hatch
- Resource-change notifications (`resources/list_changed`, `resources/updated`) fire on invalidation. Claude Code honors them; Copilot ignores subscriptions but reads always get fresh data via the mtime check.

Implemented as 16 TDD-style commits, two-stage subagent review per task (spec-compliance then code-quality). Code-review caught and we fixed: a concurrent-compile race, a stuck-error state on background compile failure, and a handler-isolation bug — all in [packages/markspec/mcp/project.ts](packages/markspec/mcp/project.ts).

Addresses #60. Closes #61, #62 (registry_lookup / registry_search → folded into the entry resource + entry_search tool). #63 (`requirement_insert`) deferred until `markspec insert` lands (epic:insert, #38–#41).

## Test plan

- [x] `just check` — lint + type-check + 759/759 tests pass (59 new MCP unit + 7 new MCP e2e)
- [x] Manual smoke: `echo '{"jsonrpc":"2.0",…initialize…}' | markspec mcp` returns capabilities advertising `resources` and `tools`
- [ ] Manual: Claude Code can `mcp add markspec` and read resources
- [ ] Manual: VS Code Copilot can connect via `.vscode/mcp.json` and read resources

🤖 Generated with [Claude Code](https://claude.com/claude-code)