### PR TITLE
feat(core): switch attribute block syntax to indented code block

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -486,8 +486,8 @@ Deno.test("parseEntryBlock: extracts display ID", () => {
 
   The sensor driver shall debounce raw inputs.
 
-  Id: 01HGW2Q8MNP3RSTVWXYZABCDEF \\
-  Labels: ASIL-B`;
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      Labels: ASIL-B`;
 
   const entry = parseEntryBlock(block);
   assertEquals(entry.shape, "identified");
@@ -563,9 +563,9 @@ Deno.test("validate: broken upstream link fails", async () => {
   const input = `
 - [SRS_BRK_0001] Sensor debouncing
 
-  Id: 01HGW2Q8MNP3RSTVWXYZABCDEF \\
-  Satisfies: SYS_NONEXISTENT \\
-  Labels: ASIL-B
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      Satisfies: SYS_NONEXISTENT
+      Labels: ASIL-B
 `;
 
   const { code, stderr } = await markspec(["validate"], {
@@ -674,9 +674,9 @@ verification. They live together.
 /// the ratio of range to closing velocity for each tracked
 /// object.
 ///
-/// Id: 01HGW3C4DEF6ABCDEFGHJKMNPQ \
-/// Satisfies: SYS_AEB_0012 \
-/// Labels: ASIL-B
+///     Id: 01HGW3C4DEF6ABCDEFGHJKMNPQ
+///     Satisfies: SYS_AEB_0012
+///     Labels: ASIL-B
 #[test]
 fn swt_aeb_0030_ttc_calculation() {
     let ttc = compute_ttc(50.0, 15.0);
@@ -698,9 +698,9 @@ test across module boundaries using only the crate's public API.
 /// object based on time-to-collision, relative velocity, and
 /// object classification.
 ///
-/// Id: 01HGW3A2BCD5ABCDEFGHJKMNPQ \
-/// Satisfies: STK_AEB_0001 \
-/// Labels: ASIL-B
+///     Id: 01HGW3A2BCD5ABCDEFGHJKMNPQ
+///     Satisfies: STK_AEB_0001
+///     Labels: ASIL-B
 #[test]
 fn sit_aeb_0012_threat_from_radar_track() {
     let frame = mock_radar_frame(50.0, 15.0, ObjectClass::Vehicle);

--- a/docs/architecture/adr-001-markdown-format.md
+++ b/docs/architecture/adr-001-markdown-format.md
@@ -1,9 +1,5 @@
 # ADR-001: Markdown format
 
-Status: Accepted\
-Date: 2026-03-01\
-Scope: MarkSpec
-
 ## Context
 
 MarkSpec needs a documentation format that is simple, portable, Git-native, and

--- a/docs/architecture/adr-002-entry-model.md
+++ b/docs/architecture/adr-002-entry-model.md
@@ -1,11 +1,5 @@
 # ADR-002: Entry Model — Identified and Referenced Entries
 
-Status: Proposed\
-Date: 2026-04-17 (revised 2026-04-20 for ADR-009 alignment)\
-Scope: MarkSpec\
-Depends on: [ADR-001 — Markdown Format](./adr-001-markdown-format.md),
-[ADR-009 — Core / Profile Boundary](./adr-009-core-profile-boundary.md)
-
 ## Context
 
 ADR-001 introduced entry blocks as MarkSpec's mechanism for authoring traceable
@@ -59,8 +53,8 @@ identified or referenced.
 
   Body paragraphs.
 
-  Key: Value \
-  Key: Value
+      Key: Value
+      Key: Value
 ```
 
 An entry block is a Markdown list item whose content between `[` and `]` is a
@@ -382,8 +376,8 @@ Under the default profile's `requirement: display-id-pattern: "REQ-{n:03d}"`:
   The sensor driver SHALL debounce raw inputs to eliminate electrical noise
   before processing. The debounce window SHALL be configurable per sensor type.
 
-  Id: 01HGW2Q8MNP3RSTVWXYZABCDEF\
-  Labels: sensor
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      Labels: sensor
 ```
 
 The profile infers `type: requirement` from the `REQ-` prefix. No `type:`
@@ -403,9 +397,9 @@ Under an ASPICE profile's
   > [!WARNING]
   > Failure to debounce may lead to spurious brake activation.
 
-  Id: 01HGW2Q8MNP3RSTVWXYZABCDEF\
-  Derived-from: 01HGW2R0NPQR4STVWXYZABCDEF\
-  Labels: ASIL-B
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      Derived-from: 01HGW2R0NPQR4STVWXYZABCDEF
+      Labels: ASIL-B
 ```
 
 The profile infers `type: software-requirement` from the `SRS_` prefix.
@@ -419,9 +413,9 @@ When the display ID is a symbolic path with no declared prefix pattern:
 
   Rejects transient noise on raw sensor readings.
 
-  Id: 01HGW3D6QRST7IJKLMNOPQRSTUV\
-  type: unit\
-  Realizes: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      Id: 01HGW3D6QRST7IJKLMNOPQRSTUV
+      type: unit
+      Realizes: 01HGW2Q8MNP3RSTVWXYZABCDEF
 ```
 
 The author writes `type: unit` because no `display-id-pattern` matches a
@@ -561,10 +555,10 @@ locator is preserved verbatim for display and is not validated.
   requirements for software unit design, implementation, and verification across
   ASIL levels A through D.
 
-  Id: urn:iso:std:iso:26262:-6:ed-2\
-  Reference-url: https://www.iso.org/standard/68383.html\
-  Reference-document: ISO 26262-6:2018\
-  Labels: functional-safety, automotive
+      Id: urn:iso:std:iso:26262:-6:ed-2
+      Reference-url: https://www.iso.org/standard/68383.html
+      Reference-document: ISO 26262-6:2018
+      Labels: functional-safety, automotive
 ```
 
 ### Example — dependency (purl)
@@ -572,8 +566,8 @@ locator is preserved verbatim for display and is not validated.
 ```markdown
 - [serde] serde Rust serialization framework
 
-  Id: pkg:cargo/serde@1.0.0\
-  License: Apache-2.0 OR MIT
+      Id: pkg:cargo/serde@1.0.0
+      License: Apache-2.0 OR MIT
 ```
 
 A dependency entry is a referenced entry whose `Id:` is a Package URL (purl).
@@ -585,8 +579,8 @@ risk / verification attributes to dependency entries; see ADR-011.
 ```markdown
 - [RFC-2119] Key words for use in RFCs
 
-  Id: doi:10.17487/RFC2119\
-  Reference-url: https://www.rfc-editor.org/rfc/rfc2119
+      Id: doi:10.17487/RFC2119
+      Reference-url: https://www.rfc-editor.org/rfc/rfc2119
 ```
 
 ---

--- a/docs/architecture/adr-003-diagram-authoring.md
+++ b/docs/architecture/adr-003-diagram-authoring.md
@@ -1,9 +1,5 @@
 # ADR-003: Diagram authoring
 
-Status: Accepted\
-Date: 2026-03-01\
-Scope: MarkSpec
-
 ## Context
 
 MarkSpec documents include diagrams for architecture overviews, state machines,

--- a/docs/architecture/adr-004-book-structure.md
+++ b/docs/architecture/adr-004-book-structure.md
@@ -1,9 +1,5 @@
 # ADR-004: Book structure
 
-Status: Accepted\
-Date: 2026-03-01\
-Scope: MarkSpec
-
 ## Context
 
 Project documentation needs to be rendered as a navigable book for auditors,

--- a/docs/architecture/adr-005-cli-architecture.md
+++ b/docs/architecture/adr-005-cli-architecture.md
@@ -1,9 +1,5 @@
 # ADR-005: CLI architecture
 
-Status: Accepted\
-Date: 2026-03-23\
-Scope: MarkSpec CLI
-
 ## Context
 
 MarkSpec needs a CLI tool that handles multiple subcommands (format, validate,

--- a/docs/architecture/adr-006-property-model.md
+++ b/docs/architecture/adr-006-property-model.md
@@ -1,11 +1,5 @@
 # ADR-006: Property Model
 
-Status: Proposed\
-Date: 2026-04-17 (revised 2026-04-20 for ADR-009 alignment)\
-Scope: MarkSpec\
-Depends on: [ADR-002 — Entry Model](./adr-002-entry-model.md),
-[ADR-009 — Core / Profile Boundary](./adr-009-core-profile-boundary.md)
-
 ## Context
 
 ADR-002 introduces a two-tier model for entries:

--- a/docs/architecture/adr-007-document-structure.md
+++ b/docs/architecture/adr-007-document-structure.md
@@ -1,11 +1,5 @@
 # ADR-007: Document Structure — Front Matter, Title, and Body
 
-Status: Proposed\
-Date: 2026-04-17 (revised 2026-04-20 for ADR-009 alignment)\
-Scope: MarkSpec\
-Depends on: [ADR-002 — Entry Model](./adr-002-entry-model.md),
-[ADR-009 — Core / Profile Boundary](./adr-009-core-profile-boundary.md)
-
 ## Context
 
 ADR-002 (as revised alongside ADR-009) defines the model for entries inside a

--- a/docs/architecture/adr-008-profile-system.md
+++ b/docs/architecture/adr-008-profile-system.md
@@ -1,13 +1,5 @@
 # ADR-008: Profile System — Vocabulary, Rules, and Extension Distribution
 
-Status: Proposed\
-Date: 2026-04-19 (revised 2026-04-20 for ADR-009 alignment)\
-Scope: MarkSpec\
-Depends on: [ADR-002 — Entry Model](./adr-002-entry-model.md),
-[ADR-006 — Property Model](./adr-006-property-model.md),
-[ADR-007 — Document Structure](./adr-007-document-structure.md),
-[ADR-009 — Core / Profile Boundary](./adr-009-core-profile-boundary.md)
-
 ## Context
 
 ADR-009 establishes the core / profile boundary: the core recognizes two

--- a/docs/architecture/adr-009-core-profile-boundary.md
+++ b/docs/architecture/adr-009-core-profile-boundary.md
@@ -1,15 +1,5 @@
 # ADR-009: Core / Profile Boundary
 
-Status: Proposed\
-Date: 2026-04-20\
-Scope: MarkSpec\
-Supersedes: ADR-002 §Part 6 (Family Recognition), ADR-008 §8 (Identity model —
-unchanged)\
-Updates: [ADR-002 — Entry Model](./adr-002-entry-model.md),
-[ADR-006 — Property Model](./adr-006-property-model.md),
-[ADR-007 — Document Structure](./adr-007-document-structure.md),
-[ADR-008 — Profile System](./adr-008-profile-system.md)
-
 ## Context
 
 ADR-001 through ADR-008 gradually built a data model centered on four entry

--- a/docs/architecture/adr-010-default-profile.md
+++ b/docs/architecture/adr-010-default-profile.md
@@ -1,11 +1,5 @@
 # ADR-010: Default Profile — RFC 2119 Hygiene and Generic Types
 
-Status: Proposed\
-Date: 2026-04-20\
-Scope: MarkSpec\
-Depends on: [ADR-008 — Profile System](./adr-008-profile-system.md),
-[ADR-009 — Core / Profile Boundary](./adr-009-core-profile-boundary.md)
-
 ## Context
 
 ADR-009 moves the four-family taxonomy out of the core into the profile layer

--- a/docs/architecture/adr-011-language-pack-and-dependency-ingestion.md
+++ b/docs/architecture/adr-011-language-pack-and-dependency-ingestion.md
@@ -1,12 +1,5 @@
 # ADR-011: Language Pack and Dependency Ingestion
 
-Status: Proposed\
-Date: 2026-04-20\
-Scope: MarkSpec\
-Depends on: [ADR-008 — Profile System](./adr-008-profile-system.md),
-[ADR-009 — Core / Profile Boundary](./adr-009-core-profile-boundary.md),
-[ADR-010 — Default Profile](./adr-010-default-profile.md)
-
 ## Context
 
 ADR-009 introduces an **entry-source abstraction**: entries in the MarkSpec

--- a/docs/cheatsheet/markspec-cheatsheet.typ
+++ b/docs/cheatsheet/markspec-cheatsheet.typ
@@ -120,9 +120,9 @@ Slug: `fig.architecture-overview`
   The sensor driver shall debounce
   raw inputs to eliminate noise.
 
-  Id: 01HGW2Q8MNP3RSTVWXYZABCDEF\
-  Satisfies: SYS_BRK_0042\
-  Labels: ASIL-B
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      Satisfies: SYS_BRK_0042
+      Labels: ASIL-B
 ```]
 
 No `_emphasis_` inside entries. `**Strong**` and `` `code` `` ok.
@@ -169,9 +169,9 @@ entries (external citations) carry a URI (`urn:`, `doi:`, `pkg:`, `https:`,
  * a 5ms noise spike must not alter
  * the stable output.
  *
- * Id: 01HGW3R9QNP4ABCDEFGHJKMNPQ\
- * Verifies: SRS_BRK_0107\
- * Tests: braking_core::controller::debounce
+ *     Id: 01HGW3R9QNP4ABCDEFGHJKMNPQ
+ *     Verifies: SRS_BRK_0107
+ *     Tests: braking_core::controller::debounce
  */
 @Test
 fun `swt_brk_0107 debounce`() { }
@@ -404,8 +404,8 @@ Only in `references` document type. Display ID = slug.
   Road vehicles — Functional
   safety — Part 6: Software.
 
-  Document: ISO 26262-6:2018\
-  URL: https://www.iso.org/...
+      Document: ISO 26262-6:2018
+      URL: https://www.iso.org/...
 ```]
 
 == Reference attributes

--- a/docs/examples/entry-rendering.md
+++ b/docs/examples/entry-rendering.md
@@ -15,26 +15,29 @@ attribute is written in source. Cross-reference relation names (`Satisfies`,
   falls below the configurable threshold and the driver has not applied the
   brake pedal.
 
-  Id: 01HGW3A2BCD5VWXYZABCDEFGHJ\
-  Labels: ASIL-B, safety-critical
+      Id: 01HGW3A2BCD5VWXYZABCDEFGHJ
+      Labels: ASIL-B
+      Labels: safety-critical
 
 - [SYS_AEB_0012] Object threat assessment from radar tracks
 
   The system shall compute a threat level for each tracked object based on
   time-to-collision, relative velocity, and object classification.
 
-  Id: 01HGW3C4DEF6VWXYZABCDEFGHJ\
-  Satisfies: STK_AEB_0001\
-  Labels: ASIL-B
+      Id: 01HGW3C4DEF6VWXYZABCDEFGHJ
+      Satisfies: STK_AEB_0001
+      Labels: ASIL-B
 
 - [SWE_BRK_0107] Median filter implementation
 
   The braking ECU shall apply a 5-sample median filter to the raw brake pressure
   sensor input before processing.
 
-  Id: 01HGW2Q8MNP3RSTVWXYZABCDEF\
-  Satisfies: SYS_AEB_0012\
-  Labels: ASIL-B, real-time, performance
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      Satisfies: SYS_AEB_0012
+      Labels: ASIL-B
+      Labels: real-time
+      Labels: performance
 
 Prose between entries renders normally — no left border, no type coloring. The
 visual separation between entries and prose is provided by the admonition border
@@ -48,17 +51,17 @@ alone.
   tracking) from decision (threat assessment, braking command) via a
   publish-subscribe message bus.
 
-  Id: 01HGW4E5GHJ7VWXYZABCDEFGHJ\
-  Satisfies: STK_AEB_0001
+      Id: 01HGW4E5GHJ7VWXYZABCDEFGHJ
+      Satisfies: STK_AEB_0001
 
 - [ICD_AEB_0010] Radar frame interface
 
   The radar driver shall publish `RadarFrame` messages at 20 Hz containing
   range, velocity, azimuth, and classification for each detected object.
 
-  Id: 01HGW4F6HKM8VWXYZABCDEFGHJ\
-  Satisfies: SAD_AEB_0001\
-  Labels: interface
+      Id: 01HGW4F6HKM8VWXYZABCDEFGHJ
+      Satisfies: SAD_AEB_0001
+      Labels: interface
 
 ## Verification (test — red)
 
@@ -68,17 +71,17 @@ alone.
   positive closing velocity and returns infinity for zero or negative closing
   velocity.
 
-  Id: 01HGW5G7JMN9VWXYZABCDEFGHJ\
-  Verifies: SWE_BRK_0107
+      Id: 01HGW5G7JMN9VWXYZABCDEFGHJ
+      Verifies: SWE_BRK_0107
 
 - [SIT_AEB_0012] Perception-to-decision integration
 
   Verify end-to-end that a radar frame with a stationary object at 40m produces
   a `High` threat level through the full perception–decision pipeline.
 
-  Id: 01HGW5H8KPQ0VWXYZABCDEFGHJ\
-  Verifies: SYS_AEB_0012\
-  Labels: integration
+      Id: 01HGW5H8KPQ0VWXYZABCDEFGHJ
+      Verifies: SYS_AEB_0012
+      Labels: integration
 
 ## Edge cases
 
@@ -89,8 +92,8 @@ Entry with no labels — pill group is not rendered:
   The braking ECU shall reject brake pressure readings outside the valid sensor
   range [0, 250] bar.
 
-  Id: 01HGW6J9NRS1VWXYZABCDEFGHJ\
-  Satisfies: SYS_AEB_0012
+      Id: 01HGW6J9NRS1VWXYZABCDEFGHJ
+      Satisfies: SYS_AEB_0012
 
 Entry with many labels — pill group wraps to the next line:
 
@@ -99,9 +102,14 @@ Entry with many labels — pill group wraps to the next line:
   The braking ECU shall detect open-circuit, short-circuit, and out-of-range
   faults on all brake pressure sensors within one sample period.
 
-  Id: 01HGW6K0MST2VWXYZABCDEFGHJ\
-  Satisfies: SYS_AEB_0012\
-  Labels: ASIL-B, safety-critical, real-time, performance, diagnostics, fault-tolerance
+      Id: 01HGW6K0MST2VWXYZABCDEFGHJ
+      Satisfies: SYS_AEB_0012
+      Labels: ASIL-B
+      Labels: safety-critical
+      Labels: real-time
+      Labels: performance
+      Labels: diagnostics
+      Labels: fault-tolerance
 
 Entry with multiple cross-references:
 
@@ -110,10 +118,11 @@ Entry with multiple cross-references:
   The braking ECU shall use triple-modular redundancy voting across the three
   brake pressure sensors.
 
-  Id: 01HGW6N1NVW3VWXYZABCDEFGHJ\
-  Satisfies: SYS_AEB_0012\
-  Derived-from: STK_AEB_0001\
-  Labels: ASIL-B, redundancy
+      Id: 01HGW6N1NVW3VWXYZABCDEFGHJ
+      Satisfies: SYS_AEB_0012
+      Derived-from: STK_AEB_0001
+      Labels: ASIL-B
+      Labels: redundancy
 
 ## Referenced entries
 
@@ -124,10 +133,12 @@ URI, and the display ID serves as a pandoc-style slug:
 
   Road vehicles — Functional safety — Part 6: Software level.
 
-  Id: urn:iso:std:iso:26262:-6:ed-2\
-  Labels: functional-safety, automotive
+      Id: urn:iso:std:iso:26262:-6:ed-2
+      Labels: functional-safety
+      Labels: automotive
 
 - [serde] serde Rust serialization framework
 
-  Id: pkg:cargo/serde@1.0.0\
-  Labels: dependency, open-source
+      Id: pkg:cargo/serde@1.0.0
+      Labels: dependency
+      Labels: open-source

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -94,13 +94,13 @@ Add a second entry that satisfies the first:
 
   The service shall expose a /health endpoint returning 200 OK.
 
-  Id: 01KPVVC9J2B1ZA64QZEMHF02PX\
-  Satisfies: STK_PRJ_0001
+      Id: 01KPVVC9J2B1ZA64QZEMHF02PX
+      Satisfies: STK_PRJ_0001
 ```
 
 The `Satisfies:` attribute creates a directed link from SRS_PRJ_0001 to
-STK_PRJ_0001 in the traceability graph. The trailing backslash (`\`) separates
-attributes on consecutive lines.
+STK_PRJ_0001 in the traceability graph. Attributes are written as a 4-space
+indented code block at the end of the entry.
 
 ## Compile
 

--- a/docs/spec/language/ast.md
+++ b/docs/spec/language/ast.md
@@ -124,24 +124,29 @@ interface MsAttribute {
 | `displayId`  | Text content inside `[...]` brackets                                    |
 | `title`      | Inline content after the closing `]` on the first line                  |
 | `body`       | All block-level children between title and attribute block              |
-| `attributes` | Parsed from the trailing `Key: Value\` lines                            |
+| `attributes` | Parsed from the trailing indented code block (`code` mdast node)        |
 
 ### Attribute block extraction
 
-The last paragraph in the `listItem` body is inspected for attribute lines. A
-paragraph is an attribute block when every line matches:
+The trailing block of the `listItem` body is inspected. The attribute block is a
+trailing indented `code` mdast node (4-space indent relative to body indent in
+CommonMark) whose content lines each match:
 
 ```
-Key: Value[\]
+Key: Value
 ```
 
-Where `Key` is a capitalized word (`[A-Z][a-z-]*`), `:` is the separator,
-`Value` is the remainder, and `\` is an optional trailing backslash (line
-continuation). The last line has no backslash.
+Where `Key` matches `[A-Z][A-Za-z-]*` and `:` is the separator. The block
+qualifies as an attribute block only when **every** content line matches.
 
-If the trailing paragraph is an attribute block, it is removed from `body` and
-its lines are parsed into `MsAttribute` entries. If it is not an attribute
-block, `attributes` is empty and the paragraph stays in `body`.
+If the trailing `code` node is an attribute block, it is removed from `body` and
+its lines are parsed into `MsAttribute` entries. Otherwise, `attributes` is
+empty and the `code` node stays in `body` (as a regular code block).
+
+**Backward compatibility.** During the transition, the parser also accepts the
+legacy form: a trailing `paragraph` whose text content is `Key: Value` lines
+joined by hard line breaks (the trailing `\` form). When the legacy shape is
+recognized, the parser emits `MSL-DEPRECATED-ATTR-001`.
 
 ### Examples
 
@@ -154,12 +159,8 @@ list (unordered, depth 0)
       text "[SRS_BRK_0001] Sensor debouncing"
     paragraph
       text "The sensor driver shall debounce..."
-    paragraph
-      text "Id: 01HGW2Q8MNP3RSTVWXYZABCDEF\"
-      softBreak
-      text "Satisfies: SYS_BRK_0042\"
-      softBreak
-      text "Labels: ASIL-B"
+    code (indented)
+      "Id: 01HGW2Q8MNP3RSTVWXYZABCDEF\nSatisfies: SYS_BRK_0042\nLabels: ASIL-B"
 ```
 
 **Output:**
@@ -226,12 +227,18 @@ Attribute blocks are always extracted as part of `msEntry` detection (§1). They
 do not exist as standalone nodes — they are a structural component of an entry
 block.
 
-When an entry block is detected, the trailing paragraph is tested for the
-attribute pattern. If it matches, it is consumed into the `msEntry.attributes`
-array and removed from the tree.
+When an entry block is detected, the trailing `code` mdast node is tested for
+the attribute pattern. If every content line matches `Key: Value`, it is
+consumed into the `msEntry.attributes` array and removed from the tree.
+Otherwise, the `code` node stays in `body` as a regular code block.
 
-Outside of entry blocks, `Key: Value\` paragraphs are not recognized as
-attribute blocks — they remain normal paragraphs.
+The trailing position is required: if any block-level content appears after the
+candidate `code` node, it does not qualify as an attribute block.
+
+**Legacy shape.** During the transition, a trailing `paragraph` with
+`Key: Value` lines separated by hard line breaks is also recognized. This
+triggers `MSL-DEPRECATED-ATTR-001`. The legacy form will be removed in a future
+major release.
 
 ---
 

--- a/docs/spec/language/language.md
+++ b/docs/spec/language/language.md
@@ -120,9 +120,8 @@ See [ISO 26262-6] for software-level requirements.
 **Hard line breaks** (trailing `\`):
 
 ```markdown
-Id: 01HGW2Q8MNP3RSTVWXYZABCDE\
-Satisfies: SYS_BRK_0042\
-Labels: ASIL-B
+First line ends here,\
+and the next line continues.
 ```
 
 **Horizontal rules:**
@@ -258,8 +257,8 @@ closing `]`.
 
   Body paragraphs.
 
-  Key: Value\
-  Key: Value
+      Key: Value
+      Key: Value
 ```
 
 A `- [DISPLAY_ID]` with no indented body is a normal list item — not an entry
@@ -461,10 +460,10 @@ optional in doc comments — the bracket pattern alone is sufficient.
 /// Given a debounce window of 10ms, a transient spike shorter
 /// than the window must not alter the stable output.
 ///
-/// Id: 01HGW3R9QLP4ABCDEFGHJKMNPQ \
-/// Verifies: SRS_BRK_0107 \
-/// Tests: braking_core::controller::debounce_input \
-/// Labels: ASIL-B
+///     Id: 01HGW3R9QLP4ABCDEFGHJKMNPQ
+///     Verifies: SRS_BRK_0107
+///     Tests: braking_core::controller::debounce_input
+///     Labels: ASIL-B
 #[test]
 fn swt_brk_0107_debounce_filters_noise() {
     // test implementation
@@ -485,9 +484,9 @@ author writes `type:` explicitly:
 ///
 /// Rejects transient noise on raw sensor readings.
 ///
-/// Id: 01HGW3D6QRST7IJKLMNOPQRSTUV \
-/// type: unit \
-/// Realizes: 01HGW2Q8MNP3RSTVWXYZABCDEF
+///     Id: 01HGW3D6QRST7IJKLMNOPQRSTUV
+///     type: unit
+///     Realizes: 01HGW2Q8MNP3RSTVWXYZABCDEF
 fn debounce_input(raw: u16) -> u16 { ... }
 ```
 
@@ -663,9 +662,9 @@ declarations.
   The sensor driver shall debounce raw inputs to eliminate electrical noise
   before processing.
 
-  Id: 01HGW2Q8MNP3RSTVWXYZABCDE\
-  Derived-from: SYS_BRK_0042\
-  Labels: ASIL-B
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDE
+      Derived-from: SYS_BRK_0042
+      Labels: ASIL-B
 ```
 
 **Example 10 — explicit type override (symbolic path):**
@@ -675,9 +674,9 @@ declarations.
 
   Rejects transient noise on raw sensor readings using a configurable window.
 
-  Id: 01HGW3D6QRST7IJKLMNOPQRSTUV\
-  type: unit\
-  Realizes: 01HGW2Q8MNP3RSTVWXYZABCDE
+      Id: 01HGW3D6QRST7IJKLMNOPQRSTUV
+      type: unit
+      Realizes: 01HGW2Q8MNP3RSTVWXYZABCDE
 ```
 
 The author writes `type: unit` because no `display-id-pattern` matches a
@@ -746,10 +745,10 @@ the canonical `Id:`), `Reference-document:` (canonical citation string),
 
   Road vehicles — Functional safety — Part 6: Software level.
 
-  Id: urn:iso:std:iso:26262:-6:ed-2\
-  Reference-url: https://www.iso.org/standard/68383.html\
-  Reference-document: ISO 26262-6:2018\
-  Labels: functional-safety, automotive
+      Id: urn:iso:std:iso:26262:-6:ed-2
+      Reference-url: https://www.iso.org/standard/68383.html
+      Reference-document: ISO 26262-6:2018
+      Labels: functional-safety, automotive
 ```
 
 **Example 12 — dependency (purl):**
@@ -757,8 +756,8 @@ the canonical `Id:`), `Reference-document:` (canonical citation string),
 ```markdown
 - [serde] serde Rust serialization framework
 
-  Id: pkg:cargo/serde@1.0.0\
-  License: Apache-2.0 OR MIT
+      Id: pkg:cargo/serde@1.0.0
+      License: Apache-2.0 OR MIT
 ```
 
 ### 2.4 Shape discrimination
@@ -1811,10 +1810,10 @@ each supported language.
 /// Given a 10ms debounce window, a 5ms noise spike
 /// must not alter the stable output.
 ///
-/// Id: 01HGW3R9QLP4ABCDEFGHJKMNPQ \
-/// Verifies: SRS_BRK_0107 \
-/// Tests: braking_core::controller::debounce_input \
-/// Labels: ASIL-B
+///     Id: 01HGW3R9QLP4ABCDEFGHJKMNPQ
+///     Verifies: SRS_BRK_0107
+///     Tests: braking_core::controller::debounce_input
+///     Labels: ASIL-B
 #[test]
 fn swt_brk_0107_debounce_filters_noise() {
     // test implementation
@@ -1830,10 +1829,10 @@ fn swt_brk_0107_debounce_filters_noise() {
  * Given a 10ms debounce window, a 5ms noise spike
  * must not alter the stable output.
  *
- * Id: 01HGW3R9QLP4ABCDEFGHJKMNPQ \
- * Verifies: SRS_BRK_0107 \
- * Tests: braking_core::controller::debounce_input \
- * Labels: ASIL-B
+ *     Id: 01HGW3R9QLP4ABCDEFGHJKMNPQ
+ *     Verifies: SRS_BRK_0107
+ *     Tests: braking_core::controller::debounce_input
+ *     Labels: ASIL-B
  */
 @Test
 fun `swt_brk_0107 debounce filters noise`() {
@@ -1849,10 +1848,10 @@ fun `swt_brk_0107 debounce filters noise`() {
 /// Given a 10ms debounce window, a 5ms noise spike
 /// must not alter the stable output.
 ///
-/// Id: 01HGW3R9QLP4ABCDEFGHJKMNPQ \
-/// Verifies: SRS_BRK_0107 \
-/// Tests: braking_core::controller::debounce_input \
-/// Labels: ASIL-B
+///     Id: 01HGW3R9QLP4ABCDEFGHJKMNPQ
+///     Verifies: SRS_BRK_0107
+///     Tests: braking_core::controller::debounce_input
+///     Labels: ASIL-B
 auto debounce_input(uint16_t raw) -> uint16_t;
 ```
 
@@ -1865,10 +1864,10 @@ auto debounce_input(uint16_t raw) -> uint16_t;
  * Given a 10ms debounce window, a 5ms noise spike
  * must not alter the stable output.
  *
- * Id: 01HGW3R9QLP4ABCDEFGHJKMNPQ \
- * Verifies: SRS_BRK_0107 \
- * Tests: braking_core::controller::debounce_input \
- * Labels: ASIL-B
+ *     Id: 01HGW3R9QLP4ABCDEFGHJKMNPQ
+ *     Verifies: SRS_BRK_0107
+ *     Tests: braking_core::controller::debounce_input
+ *     Labels: ASIL-B
  */
 void debounce_input(uint16_t* raw);
 ```
@@ -1881,10 +1880,10 @@ void debounce_input(uint16_t* raw);
 /// Given a 10ms debounce window, a 5ms noise spike
 /// must not alter the stable output.
 ///
-/// Id: 01HGW3R9QLP4ABCDEFGHJKMNPQ \
-/// Verifies: SRS_BRK_0107 \
-/// Tests: braking_core::controller::debounce_input \
-/// Labels: ASIL-B
+///     Id: 01HGW3R9QLP4ABCDEFGHJKMNPQ
+///     Verifies: SRS_BRK_0107
+///     Tests: braking_core::controller::debounce_input
+///     Labels: ASIL-B
 @Test
 void swt_brk_0107_debounce_filters_noise() {
     // test implementation

--- a/docs/spec/language/language.md
+++ b/docs/spec/language/language.md
@@ -281,10 +281,10 @@ block.
   | Speed       | 5           | 200              |
   | Temperature | 50          | 20               |
 
-  Id: 01HGW2Q8MNP3RSTVWXYZABCDE\
-  type: software-requirement\
-  Satisfies: SYS_BRK_0042\
-  Labels: ASIL-B
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDE
+      type: software-requirement
+      Satisfies: SYS_BRK_0042
+      Labels: ASIL-B
 ```
 
 **Example 2 — not an entry block:**
@@ -308,15 +308,25 @@ chapter, §"Entry rendering".
 
 #### §2 Attribute blocks
 
-`Key: Value` lines at the end of an entry block. Separated by trailing `\`
-except the last line.
+An attribute block is the **trailing indented code block** of an entry. Each
+content line is a single `Key: Value` pair. No trailing line-continuation
+characters.
+
+The block is indented 4 spaces relative to the entry body indent (CommonMark
+indented-code-block rule). Inside a Markdown list item, that means **6 spaces of
+indentation** before the `Key`; inside a source-file doc comment (no enclosing
+list), 4 spaces of indentation relative to the comment content column.
 
 **Example 3 — attribute block:**
 
 ```markdown
-Id: 01HGW2Q8MNP3RSTVWXYZABCDE\
-Satisfies: SYS_BRK_0042\
-Labels: ASIL-B
+- [SRS_BRK_0001] Sensor debouncing
+
+  Sensor driver shall debounce raw inputs.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDE
+      Satisfies: SYS_BRK_0042
+      Labels: ASIL-B
 ```
 
 The set of valid attributes is the universal set (Part 2 §2.1) plus whatever the
@@ -325,6 +335,24 @@ active profile declares for the entry's shape and inferred type.
 **Generated attributes** (build-time inverses of authored relations such as
 `Verified-by` from `Verifies`, `Cited-by` from `References`) are computed by
 tooling and never appear in source. The exact set is profile-declared.
+
+**Disambiguation from body code blocks.** The trailing indented code block
+qualifies as an attribute block only when every one of its content lines matches
+the pattern `^[A-Z][A-Za-z-]*:` (followed by a space). Otherwise it remains a
+regular code block and the entry is treated as having no attribute block. Fenced
+code blocks (triple-backtick fences) anywhere in the entry are body content and
+never confused with the attribute block — different syntactic shape.
+
+**Trailing position is required.** If body prose appears after an indented
+`Key: Value` block, that block is not trailing — it is treated as a regular code
+block with no attribute meaning. Authors must place attributes at the very end
+of the entry.
+
+**Backward compatibility.** During the transition, the parser also accepts the
+legacy paragraph-with-trailing-`\` shape. Running `markspec format` rewrites
+legacy blocks to the canonical indented form. The legacy shape emits a
+deprecation diagnostic (`MSL-DEPRECATED-ATTR-001`) and will be removed in a
+future major release.
 
 #### §3 Table captions
 

--- a/docs/spec/site-schema.md
+++ b/docs/spec/site-schema.md
@@ -118,9 +118,9 @@ Authors write entry IDs as usual. Resolution order:
 
 - [SRS_ABS_0001] Wheel speed sampling rate
 
-  Id: 01HGW2Q8MNP3RSTVWXYZABCDEF\
-  Satisfies: SYS_BRK_001\
-  References: ISO-26262-6 §7.4
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      Satisfies: SYS_BRK_001
+      References: ISO-26262-6 §7.4
 ```
 
 `SYS_BRK_001` is not found in the current project, so it is searched in
@@ -603,17 +603,17 @@ Process projects define four things as markspec entries:
 
   Application shall complete startup within 1 second.
 
-  Applies-to: PTYPE_001\
-  Compliance: mandatory\
-  Id: STK_01HGW2Q8MNP8
+      Applies-to: PTYPE_001
+      Compliance: mandatory
+      Id: STK_01HGW2Q8MNP8
 
 - [STK_TRACE_001] Requirement traceability
 
   Every SRS entry must trace to a SYS or STK entry.
 
-  Applies-to: PTYPE_002\
-  Compliance: mandatory\
-  Id: STK_01HGW2Q8MNP9
+      Applies-to: PTYPE_002
+      Compliance: mandatory
+      Id: STK_01HGW2Q8MNP9
 ```
 
 The compiler reads process entries from the declared process dependency and uses

--- a/docs/superpowers/plans/2026-05-10-attribute-block-syntax.md
+++ b/docs/superpowers/plans/2026-05-10-attribute-block-syntax.md
@@ -1,0 +1,1016 @@
+# Attribute Block Syntax — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Spec:**
+[`docs/superpowers/specs/2026-05-10-attribute-block-syntax-design.md`](../specs/2026-05-10-attribute-block-syntax-design.md)
+
+**Goal:** Switch the entry attribute block from `Key: Value\`-trailing-paragraph
+to a 4-space indented code block. One canonical form; no compact variant.
+
+**Architecture:** The current parser is already shape-agnostic —
+`splitBodyAndAttributes`
+([`packages/markspec/core/parser/attributes.ts:118-151`](../../../packages/markspec/core/parser/attributes.ts))
+and `findAttributeBlockRange`
+([`packages/markspec/core/formatter/mod.ts:332-363`](../../../packages/markspec/core/formatter/mod.ts))
+both walk lines, trim, and match the `[A-Z][A-Za-z-]*:` shape after trimming.
+Indented code blocks (where each line is `Key: Value` with leading spaces) parse
+identically once trimmed. The actual implementation is therefore: change the
+**formatter emission** to indented form, update the **spec** and **LSP
+snippet**, migrate **fixtures + project docs**, refresh **snapshots**. No parser
+logic change.
+
+**Tech stack:** Deno + TypeScript, Cliffy CLI, unified/remark/mdast, `just` task
+runner, `assertSnapshot` for prose, `assertEquals` for behavioral.
+
+---
+
+## Pre-flight
+
+You're working in worktree `feat-attribute-block-indented-code`. Verify baseline
+before starting:
+
+```bash
+just check
+```
+
+Expected: PASS.
+
+If anything fails on `main` baseline, stop and ask before continuing.
+
+---
+
+## Task 1: Rewrite language spec §2 — Attribute blocks
+
+**Files:**
+
+- Modify: `docs/spec/language/language.md` (§2 under "Part 1 — Markdown Flavor",
+  lines around 309-323)
+
+- [ ] **Step 1: Read the current section**
+
+```bash
+sed -n '309,330p' docs/spec/language/language.md
+```
+
+Expected: existing `#### §2 Attribute blocks` section describing trailing `\`.
+
+- [ ] **Step 2: Replace the section body**
+
+Replace the current section in `docs/spec/language/language.md` (the block under
+`#### §2 Attribute blocks` up to but not including `#### §3 Table captions`)
+with:
+
+````markdown
+#### §2 Attribute blocks
+
+An attribute block is the **trailing indented code block** of an entry. Each
+content line is a single `Key: Value` pair. No trailing line-continuation
+characters.
+
+The block is indented 4 spaces relative to the entry body indent (CommonMark
+indented-code-block rule). Inside a Markdown list item, that means 6 absolute
+columns before the `Key`; inside a source-file doc comment (no enclosing list),
+4 columns relative to the comment content column.
+
+**Example 3 — attribute block:**
+
+```markdown
+- [SRS_BRK_0001] Sensor debouncing
+
+  Sensor driver shall debounce raw inputs.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDE
+      Satisfies: SYS_BRK_0042
+      Labels: ASIL-B
+```
+
+The set of valid attributes is the universal set (Part 2 §2.1) plus whatever the
+active profile declares for the entry's shape and inferred type.
+
+**Generated attributes** (build-time inverses of authored relations such as
+`Verified-by` from `Verifies`, `Cited-by` from `References`) are computed by
+tooling and never appear in source. The exact set is profile-declared.
+
+**Disambiguation from body code blocks.** The trailing indented code block
+qualifies as an attribute block only when every one of its content lines matches
+`^[A-Z][A-Za-z-]*:` shape. Otherwise it remains a regular code block and the
+entry is treated as having no attribute block. Fenced code blocks (```) anywhere
+in the entry are body content and never confused with the attribute block —
+different syntactic shape.
+
+**Trailing position is required.** If body prose appears after an indented
+`Key: Value` block, that block is not trailing — it is treated as a regular code
+block with no attribute meaning. Authors must place attributes at the very end
+of the entry.
+
+**Backward compatibility.** During the transition, the parser also accepts the
+legacy paragraph-with-trailing-`\` shape. Running `markspec format` rewrites
+legacy blocks to the canonical indented form. The legacy shape emits a
+deprecation diagnostic (`MSL-DEPRECATED-ATTR-001`) and will be removed in a
+future major release.
+````
+
+- [ ] **Step 3: Build the spec book to catch markdown errors**
+
+```bash
+just check
+```
+
+Expected: PASS (lint + type-check + tests).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/spec/language/language.md
+git commit -m "docs(spec): rewrite attribute block syntax to indented code block
+
+Replaces the trailing-backslash paragraph form with a 4-space indented
+code block. References the design doc for trade-offs and migration plan."
+```
+
+---
+
+## Task 2: Update ast.md if it describes the attribute block AST shape
+
+**Files:**
+
+- Check: `docs/spec/language/ast.md`
+
+- [ ] **Step 1: Inspect the file**
+
+```bash
+grep -n -A 5 -i "attribute\|trailing\|backslash" docs/spec/language/ast.md
+```
+
+If no attribute-block AST description exists, skip to Task 3.
+
+- [ ] **Step 2: If a description exists, update it**
+
+Change references from "paragraph with hard line breaks" → "indented code block
+(`code` mdast node)". Keep the description focused on AST representation, not
+authoring syntax (that's language.md's job).
+
+- [ ] **Step 3: Build**
+
+```bash
+just check
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit (if file was modified)**
+
+```bash
+git add docs/spec/language/ast.md
+git commit -m "docs(spec): update AST description for indented-code attribute block"
+```
+
+---
+
+## Task 3: Add formatter test asserting new emission shape (failing)
+
+**Files:**
+
+- Modify: `packages/markspec/core/formatter/mod_test.ts`
+
+- [ ] **Step 1: Find the existing renderAttributeBlock or format-output test**
+
+```bash
+grep -n "renderAttributeBlock\|backslash\|Id: 01H" packages/markspec/core/formatter/mod_test.ts | head -20
+```
+
+Note one existing test name so you can place the new test next to it.
+
+- [ ] **Step 2: Append a new test asserting indented-code-block emission**
+
+Add to `packages/markspec/core/formatter/mod_test.ts`:
+
+```typescript
+Deno.test("renderAttributeBlock: emits indented code block (4-space prefix, no backslash)", () => {
+  const block = renderAttributeBlock(
+    [
+      { key: "Id", value: "01HGW2Q8MNP3RSTVWXYZABCDE" },
+      { key: "Satisfies", value: "SYS_BRK_0042" },
+      { key: "Labels", value: "ASIL-B" },
+    ],
+    2, // body indent of a list-item entry
+  );
+
+  const expected =
+    "      Id: 01HGW2Q8MNP3RSTVWXYZABCDE\n" +
+    "      Satisfies: SYS_BRK_0042\n" +
+    "      Labels: ASIL-B";
+
+  assertEquals(block, expected);
+});
+
+Deno.test("renderAttributeBlock: doc-comment indent (no list wrapper)", () => {
+  const block = renderAttributeBlock(
+    [{ key: "Id", value: "01HGW3C4DEF6ABCDEFGHJKMNPQ" }],
+    0, // doc comment, no list nesting
+  );
+  assertEquals(block, "    Id: 01HGW3C4DEF6ABCDEFGHJKMNPQ");
+});
+```
+
+If `renderAttributeBlock` isn't imported in the test file yet, add the import.
+Look at the existing imports at the top and add `renderAttributeBlock` to the
+list, e.g.:
+
+```typescript
+import {
+  format,
+  renderAttributeBlock,
+  // ... existing imports
+} from "./mod.ts";
+```
+
+- [ ] **Step 3: Run the new tests and verify they fail**
+
+```bash
+deno test packages/markspec/core/formatter/mod_test.ts --filter "renderAttributeBlock: emits indented" --allow-read
+```
+
+Expected: FAIL — current implementation emits `Id: ...\` at 2-space indent, not
+`Id: ...` at 6-space.
+
+- [ ] **Step 4: Commit the failing tests**
+
+```bash
+git add packages/markspec/core/formatter/mod_test.ts
+git commit -m "test(core): add failing tests for indented-code-block attribute emission"
+```
+
+---
+
+## Task 4: Update renderAttributeBlock to emit indented code block
+
+**Files:**
+
+- Modify: `packages/markspec/core/formatter/mod.ts` (function
+  `renderAttributeBlock`, lines 283-298)
+
+- [ ] **Step 1: Replace the function**
+
+In `packages/markspec/core/formatter/mod.ts`, replace lines 283-298 with:
+
+```typescript
+/**
+ * Render attributes as an indented code block.
+ * Each line is `Key: Value` at (indent + 4) absolute columns;
+ * no trailing line-continuation characters.
+ *
+ * @param attributes - The attributes to render, in canonical order.
+ * @param indent - Body indent for the entry (2 for list-wrapped entries,
+ *   0 for entries inside source-file doc comments).
+ */
+export function renderAttributeBlock(
+  attributes: Attribute[],
+  indent: number,
+): string {
+  const prefix = " ".repeat(indent + 4);
+  return attributes
+    .map((attr) => `${prefix}${attr.key}: ${attr.value}`)
+    .join("\n");
+}
+```
+
+- [ ] **Step 2: Run the new tests and verify they pass**
+
+```bash
+deno test packages/markspec/core/formatter/mod_test.ts --filter "renderAttributeBlock" --allow-read
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run the full formatter test file**
+
+```bash
+deno test packages/markspec/core/formatter/ --allow-read --allow-write
+```
+
+Expected: most other tests in `mod_test.ts` will FAIL because their expected
+output strings still use the old `\` form. That's the next task. Note the
+failing test names.
+
+- [ ] **Step 4: Commit the implementation**
+
+```bash
+git add packages/markspec/core/formatter/mod.ts
+git commit -m "feat(core): emit attribute blocks as indented code blocks
+
+Drops the trailing-backslash hard-line-break paragraph in favor of a
+4-space indented code block per the new spec. Parser-side detection is
+unchanged (line-trim + Key: Value match accepts both shapes during the
+transition)."
+```
+
+---
+
+## Task 5: Update cascading formatter tests for the new shape
+
+**Files:**
+
+- Modify: `packages/markspec/core/formatter/mod_test.ts`
+
+- [ ] **Step 1: Identify failing tests**
+
+```bash
+deno test packages/markspec/core/formatter/mod_test.ts --allow-read --allow-write 2>&1 | grep -E "^test |FAIL" | head -30
+```
+
+Expected: a list of tests with their pass/fail status.
+
+- [ ] **Step 2: For each failing test, update the expected output**
+
+For every failing test, locate its expected-output string (the one with
+`Id: 01H...\` or `Labels: ...\`) and rewrite it to the new shape:
+
+- Drop trailing `\` from each line.
+- Indent each `Key: Value` line by (body-indent + 4) spaces.
+- Body indent stays as-is (2 for `.md` list, 0 for doc comments).
+
+Example transformation:
+
+Before:
+
+```typescript
+const expected = `- [SRS_BRK_0001] Title
+
+  Body.
+
+  Id: 01HGW...\\
+  Labels: ASIL-B
+`;
+```
+
+After:
+
+```typescript
+const expected = `- [SRS_BRK_0001] Title
+
+  Body.
+
+      Id: 01HGW...
+      Labels: ASIL-B
+`;
+```
+
+- [ ] **Step 3: Run the full file until green**
+
+```bash
+deno test packages/markspec/core/formatter/mod_test.ts --allow-read --allow-write
+```
+
+Expected: PASS, all tests.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/markspec/core/formatter/mod_test.ts
+git commit -m "test(core): update formatter test fixtures for indented-code attribute shape"
+```
+
+---
+
+## Task 6: Add explicit parser tests asserting both shapes parse identically
+
+**Files:**
+
+- Modify: `packages/markspec/core/parser/attributes_test.ts`
+
+- [ ] **Step 1: Append two paired tests**
+
+Add to `packages/markspec/core/parser/attributes_test.ts`:
+
+```typescript
+Deno.test("splitBodyAndAttributes: indented-code-block form (new canonical)", () => {
+  // Body indent is already stripped by the caller; the input below is what
+  // extractBodyContent returns for an entry whose attribute block is an
+  // indented code block at body+4 columns.
+  const content =
+    "Body sentence.\n" +
+    "\n" +
+    "    Id: 01HGW2Q8MNP3RSTVWXYZABCDE\n" +
+    "    Satisfies: SYS_BRK_0042\n" +
+    "    Labels: ASIL-B";
+
+  const [body, attrs] = splitBodyAndAttributes(content);
+
+  assertEquals(body, "Body sentence.");
+  assertEquals(attrs, [
+    "Id: 01HGW2Q8MNP3RSTVWXYZABCDE",
+    "Satisfies: SYS_BRK_0042",
+    "Labels: ASIL-B",
+  ]);
+});
+
+Deno.test("splitBodyAndAttributes: legacy backslash-paragraph form still parses", () => {
+  const content =
+    "Body sentence.\n" +
+    "\n" +
+    "Id: 01HGW2Q8MNP3RSTVWXYZABCDE\\\n" +
+    "Satisfies: SYS_BRK_0042\\\n" +
+    "Labels: ASIL-B";
+
+  const [body, attrs] = splitBodyAndAttributes(content);
+
+  assertEquals(body, "Body sentence.");
+  // Note: trailing `\` is preserved by splitBodyAndAttributes;
+  // parseAttributes strips it via ATTRIBUTE_RE's optional `\\?`.
+  assertEquals(attrs, [
+    "Id: 01HGW2Q8MNP3RSTVWXYZABCDE\\",
+    "Satisfies: SYS_BRK_0042\\",
+    "Labels: ASIL-B",
+  ]);
+});
+
+Deno.test("parseAttributes: both shapes produce identical Attribute[]", () => {
+  const newShape = parseAttributes([
+    "Id: 01HGW2Q8MNP3RSTVWXYZABCDE",
+    "Satisfies: SYS_BRK_0042",
+  ]);
+  const legacyShape = parseAttributes([
+    "Id: 01HGW2Q8MNP3RSTVWXYZABCDE\\",
+    "Satisfies: SYS_BRK_0042\\",
+  ]);
+  assertEquals(newShape, legacyShape);
+});
+```
+
+If `splitBodyAndAttributes` isn't imported, add it:
+
+```typescript
+import { parseAttributes, splitBodyAndAttributes } from "./attributes.ts";
+```
+
+- [ ] **Step 2: Run the file**
+
+```bash
+deno test packages/markspec/core/parser/attributes_test.ts --allow-read
+```
+
+Expected: PASS, all tests. (These tests document existing behavior — no parser
+change was needed.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/markspec/core/parser/attributes_test.ts
+git commit -m "test(core): assert parser accepts both legacy and indented-code attribute shapes"
+```
+
+---
+
+## Task 7: Update LSP completion snippet to emit indented-code form
+
+**Files:**
+
+- Modify: `packages/markspec/lsp/completions.ts` (function
+  `buildBlockScaffoldItems`, around lines 98-124)
+- Verify: any test file that asserts the snippet text (likely none — completions
+  logic is mostly behavior-asserted).
+
+- [ ] **Step 1: Read the current snippet template**
+
+```bash
+grep -n -B 2 -A 10 "insertText" packages/markspec/lsp/completions.ts
+```
+
+You'll see the generic snippet (lines ~105-109) and the per-type snippet (line
+~119).
+
+- [ ] **Step 2: Replace both insertText templates**
+
+In `packages/markspec/lsp/completions.ts`, replace the generic snippet block:
+
+```typescript
+return [
+  {
+    label: "New entry",
+    insertText:
+      "${1:PREFIX_NNNN}] ${2:Title}\n\n  ${3:Body.}\n\n      Id: \\${ULID}",
+    isSnippet: true,
+    kind: KIND_SNIPPET,
+  },
+];
+```
+
+And the per-type snippet (inside the `.map(...)`):
+
+```typescript
+insertText:
+  `${displayId}] \${1:Title}\n\n  \${2:Body.}\n\n      Id: \\$\{ULID}\n      \${3:Satisfies: }`,
+```
+
+Note the snippet template no longer needs the double-escaped `\\\\`
+line-continuation — each attribute is on its own snippet line at body+4 indent.
+
+- [ ] **Step 3: Test the completions module if tests exist**
+
+```bash
+ls packages/markspec/lsp/*_test.ts 2>/dev/null
+```
+
+If a test file exists, run it:
+
+```bash
+deno test packages/markspec/lsp/ --allow-read
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Manually verify the snippet via the LSP**
+
+This is hard to automate; skip for the plan and rely on the post-merge
+`just build` smoke test.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/markspec/lsp/completions.ts
+git commit -m "feat(lsp): update block-scaffold snippet to indented-code attribute form"
+```
+
+---
+
+## Task 8: Verify render/styles handles the new shape
+
+**Files:**
+
+- Inspect: `packages/markspec/render/styles/mod.ts`
+- Test: `packages/markspec/render/styles/mod_test.ts`
+
+The renderer's `splitBodyAttributes` already uses the same trim + ATTR_LINE_RE
+approach as the core parser, so both shapes should already work. We add a
+regression test to lock that in.
+
+- [ ] **Step 1: Inspect mod_test.ts for an existing styled-render test**
+
+```bash
+grep -n "Deno.test" packages/markspec/render/styles/mod_test.ts
+```
+
+Note the convention (test name shape, imports, fixture style).
+
+- [ ] **Step 2: Add a regression test for the new shape**
+
+Append to `packages/markspec/render/styles/mod_test.ts`:
+
+```typescript
+Deno.test("styleRequirementBlocks: parses attributes from indented-code form", () => {
+  const markdown = [
+    "- [SRS_TEST_0001] Render styles regression",
+    "",
+    "  Body.",
+    "",
+    "      Id: 01HGW2Q8MNP3RSTVWXYZABCDE",
+    "      Labels: ASIL-B",
+    "",
+  ].join("\n");
+
+  // Empty compiled context is fine — styler only needs the entry shape.
+  const compiled = {
+    entries: new Map(),
+    links: [],
+    forward: new Map(),
+    reverse: new Map(),
+  };
+
+  const result = styleRequirementBlocks(markdown, compiled as never);
+
+  // The styled output must include the attribute row(s) from the table.
+  assertStringIncludes(result.output, "**Id**");
+  assertStringIncludes(result.output, "01HGW2Q8MNP3RSTVWXYZABCDE");
+  assertStringIncludes(result.output, "**Labels**");
+});
+```
+
+If `assertStringIncludes` isn't imported, add it from `@std/assert`.
+
+- [ ] **Step 3: Run the test**
+
+```bash
+deno test packages/markspec/render/styles/mod_test.ts --allow-read
+```
+
+Expected: PASS (no implementation change required — confirms the renderer
+accepts the new shape).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/markspec/render/styles/mod_test.ts
+git commit -m "test(render): assert styled renderer accepts indented-code attribute form"
+```
+
+---
+
+## Task 9: Migrate test fixtures via `markspec format`
+
+**Files:**
+
+- Modify: `tests/fixtures/traceability-matrix.md`, `tests/fixtures/glossary.md`,
+  `tests/fixtures/requirement-block.md` (and any other `.md` under
+  `tests/fixtures/` containing `\`-trailer attribute blocks)
+
+- [ ] **Step 1: List fixture files containing the legacy shape**
+
+```bash
+grep -rln '\\$' tests/fixtures/ 2>/dev/null
+```
+
+Note the result.
+
+- [ ] **Step 2: Run `markspec format` on each file**
+
+For each file listed in Step 1, run:
+
+```bash
+deno run --allow-read --allow-write packages/markspec/main.ts format <file>
+```
+
+Expected: `format` rewrites the file's attribute blocks to the indented-code
+form. The CLI prints `1 file(s) formatted, 0 unchanged (1 total)` per call.
+
+- [ ] **Step 3: Review the diff**
+
+```bash
+git diff tests/fixtures/
+```
+
+Expected: each entry's attribute paragraph is replaced by an indented code block
+at 6 columns. Body content and entry headers are unchanged.
+
+- [ ] **Step 4: Run all tests**
+
+```bash
+just test
+```
+
+Expected: PASS. If snapshot tests (`*.snap`) fail because their stored output
+references the old fixtures, refresh them in Step 5.
+
+- [ ] **Step 5: If snapshots failed, refresh them**
+
+```bash
+deno test --allow-run --allow-read --allow-write -- --update
+```
+
+Review the snapshot diff with `git diff tests/`. Each `.snap` change should
+reflect the same paragraph → indented-block transformation.
+
+- [ ] **Step 6: Run all tests again**
+
+```bash
+just test
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit fixtures + snapshots together**
+
+```bash
+git add tests/
+git commit -m "test(repo): migrate fixtures and snapshots to indented-code attribute form"
+```
+
+---
+
+## Task 10: Migrate project docs and example files
+
+**Files:**
+
+- Modify: `docs/product/stakeholder-requirements.md`,
+  `docs/product/software-architecture.md`, `docs/examples/entry-rendering.md`,
+  any other `.md` under `docs/` containing legacy `\` trailers.
+
+Note: `docs/examples/` is excluded from `deno fmt` and `dprint`, but
+`markspec format` operates on entry-block content independently — it will
+rewrite the attribute blocks while leaving the surrounding example prose
+untouched.
+
+- [ ] **Step 1: List files containing the legacy shape**
+
+```bash
+grep -rln '\\$' docs/product/ docs/examples/ 2>/dev/null
+```
+
+- [ ] **Step 2: Run `markspec format` on each file**
+
+For each file listed in Step 1, run:
+
+```bash
+deno run --allow-read --allow-write packages/markspec/main.ts format <file>
+```
+
+- [ ] **Step 3: Review the diff carefully**
+
+```bash
+git diff docs/product/ docs/examples/
+```
+
+Look at each entry: the body should be unchanged; only the attribute block
+should be reshaped.
+
+- [ ] **Step 4: Run `just build` to confirm doc pipelines still work**
+
+```bash
+just build
+```
+
+Expected: PASS (build runs lint + test + type-check + compile).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/
+git commit -m "docs(repo): migrate project STK/SAD and example entries to indented-code attribute form"
+```
+
+---
+
+## Task 11: Update AGENTS.md examples
+
+**Files:**
+
+- Modify: `AGENTS.md` (V-model section, Rust doc-comment examples)
+
+The AGENTS.md contains hand-written Rust code samples whose embedded MarkSpec
+entries still use `\` trailers. These are illustrative — `markspec format` won't
+touch `.md` Rust fences — so they must be hand-edited.
+
+- [ ] **Step 1: Find the affected examples**
+
+```bash
+grep -n '\\$' AGENTS.md
+```
+
+Expected: matches inside the V-model fenced `` ```rust `` blocks (search for
+`/// Id:`, `/// Satisfies:`, etc.).
+
+- [ ] **Step 2: Rewrite each example**
+
+For each entry inside a fenced Rust block in AGENTS.md, transform:
+
+```rust
+/// [SRS_AEB_0030] Time-to-collision calculation
+///
+/// The decision module shall compute time-to-collision as
+/// the ratio of range to closing velocity for each tracked
+/// object.
+///
+/// Id: 01HGW3C4DEF6ABCDEFGHJKMNPQ \
+/// Satisfies: SYS_AEB_0012 \
+/// Labels: ASIL-B
+```
+
+into:
+
+```rust
+/// [SRS_AEB_0030] Time-to-collision calculation
+///
+/// The decision module shall compute time-to-collision as
+/// the ratio of range to closing velocity for each tracked
+/// object.
+///
+///     Id: 01HGW3C4DEF6ABCDEFGHJKMNPQ
+///     Satisfies: SYS_AEB_0012
+///     Labels: ASIL-B
+```
+
+Note: `///` + 4 spaces = 8 columns of doc-comment prefix; this matches the
+spec's doc-comment indent rule.
+
+Apply the same transformation to every `///`-style entry in AGENTS.md.
+Block-comment (`/** */`) examples follow the same rule: 4-space indent on the
+attribute lines, no trailing `\`.
+
+- [ ] **Step 3: Run dprint to confirm formatting still passes**
+
+```bash
+dprint check AGENTS.md
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add AGENTS.md
+git commit -m "docs(repo): update AGENTS.md V-model examples for indented-code attribute form"
+```
+
+---
+
+## Task 12: Add deprecation diagnostic for legacy shape (optional)
+
+This task implements the `MSL-DEPRECATED-ATTR-001` warning mentioned in the
+spec. It requires AST-level inspection (because the string-based parser can't
+tell paragraph-with-`\` from indented-code-block once trimmed). If time-boxed,
+this task can be deferred to a follow-up issue — the migration completes
+correctly without it.
+
+**Files:**
+
+- Modify: `packages/markspec/core/parser/markdown.ts`
+- Modify: `packages/markspec/core/parser/attributes_test.ts` (add diagnostic
+  assertion)
+
+- [ ] **Step 1: Locate the entry-extraction point in markdown.ts**
+
+```bash
+grep -n "extractEntry\|extractBodyContent\|splitBodyAndAttributes" packages/markspec/core/parser/markdown.ts
+```
+
+You'll see `extractEntry` at line 128 and `extractBodyContent` at line 269.
+
+- [ ] **Step 2: Inspect the list-item's children to detect the legacy shape**
+
+Inside `extractEntry`, after the call to `splitBodyAndAttributes` (around line
+205), inspect `item.children` (the mdast ListItem children) to see whether the
+trailing block of `Key: Value` content came from a `paragraph` node (legacy) or
+a `code` node (canonical).
+
+Add helper detection:
+
+```typescript
+function detectLegacyAttributeShape(item: ListItem): boolean {
+  // Walk the list-item children backwards, skipping trailing whitespace.
+  for (let i = item.children.length - 1; i >= 0; i--) {
+    const node = item.children[i];
+    if (node.type === "paragraph") {
+      // Check whether the paragraph's text content matches the legacy
+      // "Key: Value" + hard-break pattern. We test whether the FIRST
+      // child is a Text whose content starts with `[A-Z][A-Za-z-]*: `.
+      const first = node.children[0];
+      if (first && first.type === "text") {
+        return /^[A-Z][A-Za-z-]*: /.test(first.value);
+      }
+      return false;
+    }
+    if (node.type === "code") {
+      return false; // canonical shape
+    }
+  }
+  return false;
+}
+```
+
+If `detectLegacyAttributeShape(item)` returns true AND the parsed attribute list
+is non-empty, push a diagnostic:
+
+```typescript
+if (attributes.length > 0 && detectLegacyAttributeShape(item)) {
+  diagnostics.push({
+    code: "MSL-DEPRECATED-ATTR-001",
+    severity: "warning",
+    message:
+      "legacy attribute block (paragraph + trailing `\\`) is deprecated; " +
+      "run `markspec format` to convert to indented code block",
+    location: { file, line: entryStartLine, column: 1 },
+  });
+}
+```
+
+(Adapt to the parser's existing diagnostic plumbing — look for nearby
+`diagnostics.push` calls.)
+
+- [ ] **Step 3: Write a test asserting the warning fires for legacy shape and is
+      silent for canonical**
+
+Add to `packages/markspec/core/parser/attributes_test.ts` or a more appropriate
+test file (search `grep -l MSL-DEP packages/markspec` first to see if there's a
+convention):
+
+```typescript
+Deno.test("parseFile: legacy shape emits MSL-DEPRECATED-ATTR-001", async () => {
+  const md = [
+    "- [SRS_TEST_0001] Legacy entry",
+    "",
+    "  Body.",
+    "",
+    "  Id: 01HGW2Q8MNP3RSTVWXYZABCDE\\",
+    "  Labels: ASIL-B",
+    "",
+  ].join("\n");
+
+  const result = await parseFile(md, { file: "test.md" });
+  const codes = result.diagnostics.map((d) => d.code);
+  assert(codes.includes("MSL-DEPRECATED-ATTR-001"), `got: ${codes.join(",")}`);
+});
+
+Deno.test("parseFile: canonical indented-code form emits no deprecation warning", async () => {
+  const md = [
+    "- [SRS_TEST_0001] Canonical entry",
+    "",
+    "  Body.",
+    "",
+    "      Id: 01HGW2Q8MNP3RSTVWXYZABCDE",
+    "      Labels: ASIL-B",
+    "",
+  ].join("\n");
+
+  const result = await parseFile(md, { file: "test.md" });
+  const codes = result.diagnostics.map((d) => d.code);
+  assert(
+    !codes.includes("MSL-DEPRECATED-ATTR-001"),
+    `unexpected warning: ${codes.join(",")}`,
+  );
+});
+```
+
+- [ ] **Step 4: Run the tests**
+
+```bash
+deno test packages/markspec/core/parser/ --allow-read
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/markspec/core/parser/markdown.ts packages/markspec/core/parser/attributes_test.ts
+git commit -m "feat(core): warn on legacy attribute block shape via MSL-DEPRECATED-ATTR-001"
+```
+
+---
+
+## Task 13: Final verification
+
+- [ ] **Step 1: Run the full build**
+
+```bash
+just build
+```
+
+Expected: PASS (lint + test + type-check + compile).
+
+- [ ] **Step 2: Spot-check a rendered document**
+
+Pick one project doc that was migrated:
+
+```bash
+deno run --allow-read --allow-write --allow-env --allow-ffi packages/markspec/main.ts doc build docs/product/stakeholder-requirements.md -o /tmp/stk-preview.pdf
+```
+
+Expected: renders without errors. Open the PDF and confirm entry blocks render
+correctly (the change is to authoring syntax; the rendered output should look
+identical to before).
+
+- [ ] **Step 3: Compile the project and inspect the validate output**
+
+```bash
+deno run --allow-read --allow-env packages/markspec/main.ts validate docs/product/stakeholder-requirements.md
+```
+
+Expected: no `MSL-DEPRECATED-ATTR-001` warnings (Task 12 confirms migration is
+complete).
+
+- [ ] **Step 4: Push the branch**
+
+```bash
+git push -u origin worktree-feat-attribute-block-indented-code
+```
+
+(Ask the user before pushing if uncertain.)
+
+---
+
+## Out-of-scope reminders
+
+- Compact one-line attribute form: rejected in spec §4.6; do NOT add.
+- Per-attribute formatting heuristics: the formatter has one rule (indented code
+  block). No conditional compact/block selection.
+- Removing the legacy parser path: that lands in a future major release, not
+  this PR.
+- Citation header-embedded URI (`- [iso-26262-6](urn:...) Title`): separate
+  design.
+
+## Migration guarantees
+
+- **Parser:** accepts both shapes throughout this PR. No source breakage for
+  downstream users.
+- **Formatter:** emits only the canonical form. `markspec format` rewrites old →
+  new losslessly.
+- **Validator:** no semantic change. Old shape emits a warning (Task 12); new
+  shape is silent.
+- **Diff scope:** attribute blocks change form; entry body and headers are
+  untouched.
+
+## Risk
+
+The biggest risk is incomplete fixture migration. Strategy: rely on
+`git grep '\\$' -- '*.md'` after Tasks 9-10 to confirm no `.md` file still uses
+the legacy form. Then Task 13 surfaces any remaining warnings via `validate`.
+
+The Rust doc-comment examples in AGENTS.md are migrated manually in Task 11; the
+formatter does not touch `.rs` files (yet). If users have their own `.rs` source
+files with embedded entries in the legacy form, they migrate via
+`markspec format` on their source files (or hand-edit until the formatter's
+source-file path is wired).

--- a/docs/superpowers/specs/2026-05-10-attribute-block-syntax-design.md
+++ b/docs/superpowers/specs/2026-05-10-attribute-block-syntax-design.md
@@ -1,0 +1,414 @@
+# Attribute Block Syntax — Design
+
+**Status:** Draft **Date:** 2026-05-10 **Topic:** Switch the entry attribute
+block from a hard-line-break paragraph (`Key: Value\` per line) to an indented
+code block (4-space relative indent, plain `Key: Value` per line). Single
+canonical form; no compact variant.
+
+---
+
+## 1. Problem
+
+The current attribute block syntax is a paragraph at body-indent level whose
+lines are joined by trailing `\` (CommonMark hard line breaks):
+
+```markdown
+- [SRS_BRK_0001] Sensor debouncing
+
+  Sensor driver shall debounce raw inputs.
+
+  Id: 01HGW2Q8MNP3RSTVWXYZABCDE\
+  Satisfies: SYS_BRK_0042\
+  Labels: ASIL-B
+```
+
+Recurring friction:
+
+- The trailing `\` is silently easy to forget. When forgotten, CommonMark
+  collapses the lines into a single paragraph; downstream parsing degrades or
+  fails depending on tooling.
+- Adding or removing an attribute line requires fixing up the trailing `\` on
+  the preceding line. Diffs are noisier than they need to be.
+- Authoring the block by hand is fiddly: the cursor lands on the `\`-required
+  line transitions and the writer must remember to maintain them.
+- The syntax exists primarily to make the rendered Markdown show each attribute
+  on its own line in plain Markdown viewers. The cost (the `\` on every line)
+  outweighs the benefit.
+
+A minor secondary friction: the `Key: Value\` paragraph form does not visually
+distinguish attributes from prose. A reader scanning a heavy-metadata entry
+(8–12 attributes) sees a wall of identifier-shaped text in body-prose font; the
+actual requirement statement is dwarfed by the metadata footer.
+
+## 2. Goals
+
+- **Authoring:** remove the trailing-`\` requirement. Each attribute is authored
+  as a plain `Key: Value` line.
+- **Readability:** in heavy-metadata entries (10+ attributes, common under
+  ASPICE / ISO 26262 profiles), the metadata block must read as a single visual
+  unit distinct from the body prose. The body sentence — the actual requirement
+  — must hold its weight.
+- **Diffs:** per-attribute line-level diffs. Adding, removing, or modifying one
+  attribute touches one line.
+- **Plain Markdown rendering:** GitHub / GitLab readers must see something
+  legible. Run-on paragraphs and undifferentiated walls of text are not
+  acceptable.
+- **Doc-comment context:** the syntax must work cleanly inside source-file doc
+  comments (Rust, Kotlin, Java, C, C++) where MarkSpec entries are embedded for
+  V-model SRS/SWT/SIT colocation. Indent depth in doc comments matters.
+- **Single canonical form:** one syntax for all attribute blocks. No conditional
+  compact variant; the formatter has one rule, not a heuristic.
+- **Parser simplicity:** the rule for identifying the attribute block must be
+  unambiguous and trivial to express.
+
+## 3. Decision
+
+The attribute block is an **indented code block** at the end of the entry,
+4-space indented relative to the entry body. Each line is a single `Key: Value`
+pair. No trailing `\`.
+
+```markdown
+- [SRS_BRK_0001] Sensor debouncing
+
+  Sensor driver shall debounce raw inputs over a 50 ms window.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDE
+      Satisfies: SYS_BRK_0042
+      Labels: ASIL-B
+```
+
+**No compact variant.** Body-less entries (citations, drafts) use the same form:
+
+```markdown
+- [iso-26262-6] ISO 26262-6:2018 — Software unit verification
+
+      Id: urn:iso:std:iso:26262:-6:ed-2
+```
+
+### 3.1 Disambiguation rule
+
+Within an entry block, the **trailing indented code block** — if every one of
+its lines matches `Key: Value` shape — is the attribute block. Anything else
+remains a regular code block.
+
+This means the body can still embed code listings via fenced code blocks without
+any conflict:
+
+````markdown
+- [SRS_BRK_0099] Threshold function
+
+  The threshold function is defined as follows:
+
+  ```rust
+  fn threshold(input: f32) -> bool {
+      input.abs() > THRESHOLD
+  }
+  ```
+
+  Implementation must match this reference.
+
+      Id: 01HGW9Z9ABCDEFGHJKLMNPQRST
+      Satisfies: SYS_BRK_0099
+      Labels: ASIL-B
+````
+
+The fenced code block (`rust`) is body content; the trailing indented code block
+(4-space indent, all `Key: Value`) is the attribute block. Different syntactic
+shapes, no ambiguity.
+
+If an entry's trailing code block contains a non-`Key: Value` line, the parser
+does not treat it as an attribute block — it remains a regular code block, and
+the entry is treated as having no attribute block.
+
+"Trailing" means _the last block of the entry_. If body prose appears after an
+indented `Key: Value` block, that block is not trailing and is treated as a
+regular code block (with no attribute meaning). Authors who want attributes must
+place them at the very end of the entry.
+
+### 3.2 Indent rule, precisely
+
+- Inside a Markdown list item: entry body lives at 2-space indent (CommonMark
+  list-item content alignment). Attribute block adds 4 more spaces ⇒ **6
+  absolute columns** before the `Key`.
+- Inside a source-file doc comment (no enclosing list): entry body lives at the
+  doc-comment content column. Attribute block adds 4 spaces ⇒ doc-comment
+  prefix + 4 columns before the `Key`. Example, Rust `///`: `///` + space + 4
+  spaces = 8 columns before `Key`.
+
+### 3.3 Line shape inside the attribute block
+
+Each line is `Key: Value` where:
+
+- `Key` matches `^[A-Z][A-Za-z-]*$` (Title-Case-Word, optionally hyphenated).
+- A single colon and one or more spaces separate `Key` from `Value`.
+- `Value` is the rest of the line, trimmed of trailing whitespace.
+- Values containing commas (e.g., `Labels: ASIL-B, debounce`) are parsed by the
+  attribute reader, not by the block-level rule.
+
+No line continuations within the attribute block. One attribute per line.
+
+### 3.4 No interleaving with prose
+
+Attributes appear only as the trailing block of the entry. They cannot be
+interleaved with body paragraphs. This keeps the visual model simple:
+"requirement statement on top, metadata footer at bottom."
+
+## 4. Alternatives considered
+
+### 4.1 Sub-bullets
+
+```markdown
+- Id: 01HGW2Q8MNP3RSTVWXYZABCDE
+- Satisfies: SYS_BRK_0042
+- Labels: ASIL-B
+```
+
+**Rejected** for the canonical form. Strong contender on authoring ergonomics
+and plain-Markdown rendering. Loses on whole-entry readability under
+heavy-metadata loads: each `-` marker demands attention, so 10 bullets create 10
+visual peers competing with the (single) body sentence. The metadata visually
+outweighs the substance — the opposite of what we want for a requirements
+document.
+
+### 4.2 Soft-break paragraph (drop `\`)
+
+```markdown
+Id: 01HGW2Q8MNP3RSTVWXYZABCDE Satisfies: SYS_BRK_0042 Labels: ASIL-B
+```
+
+**Rejected.** Source is per-line and clean, but CommonMark soft-breaks collapse
+to spaces in HTML rendering. GH/GL readers see a run-on paragraph:
+
+> Id: 01HGW2Q8MNP3RSTVWXYZABCDE Satisfies: SYS_BRK_0042 Labels: ASIL-B
+
+Unscannable. Also imposes a "values cannot start with `Capital-Word:`"
+constraint on the parser, which is fragile against future profile-declared
+free-form attributes.
+
+### 4.3 Fenced `meta` code block
+
+````markdown
+```meta
+Id: 01HGW2Q8MNP3RSTVWXYZABCDE
+Satisfies: SYS_BRK_0042
+Labels: ASIL-B
+```
+````
+
+**Rejected.** Three triple-backticks plus an info string is heavy visual weight
+for what is fundamentally a metadata footer. Nesting fenced code blocks inside
+list items is also fragile across Markdown implementations.
+
+### 4.4 `@`-prefix (Javadoc / JSDoc / Rustdoc style)
+
+```markdown
+@Id 01HGW2Q8MNP3RSTVWXYZABCDE @Satisfies SYS_BRK_0042 @Labels ASIL-B
+```
+
+**Rejected.** Familiar from doc-comment cultures, but `@` is novel in Markdown
+context (no other Markdown construct uses it as a line marker). Plain readers do
+a double-take. Conflicts with `@` in values (`Authors: alice@example.com`).
+Semantic mismatch: Javadoc's `@param` is an _annotation of code_; MarkSpec
+attributes are _structured fields of an entry record_. Git trailers (bare
+`Key: Value`) match the latter mental model better.
+
+### 4.5 Italic-wrapped lines
+
+```markdown
+_Id: 01HGW2Q8MNP3RSTVWXYZABCDE_\
+_Satisfies: SYS_BRK_0042_\
+_Labels: ASIL-B_
+```
+
+**Rejected.** The current spec already excludes emphasis from entry blocks
+([language.md:298]). Even if lifted, italic does not solve the line-break
+problem (still needs `\`). It only adds visual differentiation, which the
+indented code block achieves with a different mechanism (monospace).
+
+### 4.6 Compact one-line variants
+
+`Id: ...; Satisfies: ...; Labels: ...` (semicolon), `Id: ... | Satisfies: ...`
+(pipe), `{Id: ...; Satisfies: ...}` (curly trailer), or
+`Id: ... - Satisfies: ...` (dash) on the title line or as the attribute
+paragraph.
+
+**Rejected.** Two syntaxes invite drift: the same entry can be written one way
+today and another tomorrow; the formatter has to pick a heuristic ("compact when
+short, block when long?") and authors will fight it. Single-line forms are also
+fragile against long URIs and create whole-line-changed diffs that hide which
+attribute actually changed.
+
+The conservative read on the compact form: it solves the citation case
+(body-less entries) at the cost of a parser/formatter/spec doubling. If
+compactness for citations matters enough later, it should be addressed by a
+**different mechanism** entirely (e.g., allowing the URI directly in the entry
+header for referenced entries: `- [iso-26262-6](urn:...) Title`), which is a
+separate design.
+
+### 4.7 Status quo (paragraph + `\`)
+
+**Rejected.** The friction is real and documented above.
+
+## 5. Spec changes
+
+### 5.1 `docs/spec/language/language.md` §2
+
+Replace the attribute-block subsection. The new text covers:
+
+- Block shape: indented code block at the end of the entry, 4 spaces relative to
+  body indent.
+- Line shape: `Key: Value`, one attribute per line, no continuations.
+- Disambiguation: trailing indented code block whose every line matches
+  `Key: Value` is the attribute block; otherwise it is a regular code block and
+  the entry has no attribute block.
+- Examples covering: light entry (3 attrs), heavy-metadata entry (10 attrs),
+  referenced entry (citation), entry with code in body and trailing attribute
+  block.
+- Note: emphasis and italic remain forbidden in entry blocks (unchanged).
+
+### 5.2 `docs/spec/language/ast.md`
+
+Update the AST description for `Entry.rawAttributes`: source representation is
+now the lines of an mdast `code` node at the entry tail, not the hard-broken
+paragraph children.
+
+### 5.3 ADR
+
+No new ADR. This is a syntax refinement of the entry-block format defined in
+ADR-001 (Markdown format) and detailed by language.md §2. Reference this design
+doc from the spec change.
+
+## 6. Implementation scope
+
+### 6.1 Parser (`packages/markspec/core/parser/markdown.ts`)
+
+Replace the attribute-block detector. Current detector consumes the trailing
+paragraph node whose children include hard line breaks; new detector consumes
+the trailing `code` node when its content lines all match `Key: Value` shape.
+
+**Backward compatibility:** the parser must continue to accept the old
+paragraph-with-`\` shape for one release cycle, so existing files keep parsing
+while the formatter migrates them. Old shape produces a `MS-DEPRECATED-ATTR-001`
+warning diagnostic; new shape is silent.
+
+### 6.2 Formatter (`packages/markspec/core/formatter/mod.ts`)
+
+The formatter:
+
+- Reads either old or new shape.
+- Emits the new shape unconditionally.
+- Running `markspec format` on a file with old-shape attribute blocks rewrites
+  them to the new shape. This is the migration path: one pass over the project
+  converts everything.
+
+### 6.3 Validator (`packages/markspec/core/validator/`)
+
+No semantic changes. The validator operates on the parsed `Entry` structure,
+which is unchanged. The deprecation warning emitted by the parser flows through
+unchanged.
+
+### 6.4 Tests
+
+Test fixtures throughout the workspace use the old syntax. Affected:
+
+- `tests/fixtures/*.md`
+- `packages/markspec/core/**/*_test.ts` — many tests assemble inline test
+  documents via template literals.
+- `tests/e2e/*.ts` — end-to-end fixtures.
+
+Strategy:
+
+1. **Add new-shape tests first.** Cover the parser, formatter, and round-trip
+   cases for the indented code block form.
+2. **Keep old-shape tests** as-is during the transition; they verify the
+   parser's backward-compatibility path. Each old-shape test additionally
+   asserts the `MS-DEPRECATED-ATTR-001` warning is emitted.
+3. **Migrate fixture files.** Run `markspec format` over `docs/`,
+   `tests/fixtures/`, and any project source files to convert attribute blocks.
+   Visually inspect the diff.
+4. **Snapshot updates.** E2E snapshot files (`*.snap`) referencing the old shape
+   need refresh. Run `deno test --allow-run --allow-read -- --update`, review,
+   and commit.
+
+### 6.5 LSP server (`packages/markspec/lsp/`)
+
+- `completions.ts` — block-scaffold completion (`buildBlockScaffoldItems`) emits
+  the new shape. Snippet template changes from
+  `Id: \${ULID} \\\\\n  ${3:Satisfies: }` to indented-code-block form.
+- `diagnostics.ts` — surfaces the deprecation warning naturally; no change.
+
+### 6.6 Renderer (`packages/markspec/render/`)
+
+- `render/typst/template.ts` — entry-block splicing operates on parsed `Entry`
+  structure; no change.
+- `render/styles/mod.ts` (`styleRequirementBlocks`) — Markdown-level transformer
+  that recognizes the trailing paragraph; update to recognize the indented code
+  block instead.
+- `book/site/mod.ts` — book renderer same path; verify.
+
+### 6.7 Documentation
+
+Files with example entry blocks that need to be updated for consistency:
+
+- `docs/spec/language/language.md` — already covered by §5.1.
+- `docs/guide/*.md` — any worked examples.
+- `docs/examples/entry-rendering.md` — showcase document; manual review.
+- `docs/product/stakeholder-requirements.md`,
+  `docs/product/software-architecture.md` — project's own STK and SAD entries;
+  migrate via formatter pass.
+- `AGENTS.md` — the V-model code samples in this file use the old syntax; update
+  them.
+
+### 6.8 Migration sequence
+
+1. Implement parser dual-mode (accept both shapes; emit deprecation warning on
+   old shape).
+2. Implement formatter (read both, emit new). Add tests for migration
+   round-trip.
+3. Update the spec (language.md §2).
+4. Run `markspec format` over the entire workspace. Commit the auto-migrated
+   files in a single commit, separate from the implementation commit, so the
+   diff is reviewable.
+5. Update LSP completion snippet.
+6. Update render/styles transformer.
+7. Update AGENTS.md and any other manually-authored examples.
+8. Set a deprecation removal target (e.g., next major release): parser drops
+   old-shape support; deprecation warning becomes an error.
+
+## 7. Risk
+
+- **Dual-mode parser surface area.** Two acceptance paths is a footgun.
+  Mitigation: the dual mode is bounded by a single feature flag, well-tested,
+  and time-limited (deprecate by next minor, remove by next major).
+- **Snapshot churn.** Many tests will flip. Mitigation: do the snapshot refresh
+  in its own commit, after the parser/formatter changes land, with clear review
+  of the diff.
+- **Existing source-file doc comments in user codebases.** If users have
+  embedded entries in `.rs` / `.kt` doc comments using the old syntax, they need
+  migration too. The `markspec format` migration path covers `.md` files; it
+  should also cover supported source-file doc comments. Confirm the formatter's
+  source-file path is updated.
+- **Plain-text rendering surprise.** Users browsing the repo on GH/GL will see
+  attribute blocks switch from prose-shaped paragraphs to monospace indented
+  blocks. The visual change is intentional but worth flagging in the changelog.
+
+## 8. Out of scope
+
+- A compact (single-line) attribute form. Considered and rejected (§4.6).
+- Putting the URI directly in the entry header for referenced entries
+  (`- [iso-26262-6](urn:...) Title`). Plausible separate design for citation
+  ergonomics; not part of this change.
+- Replacing emphasis-block restrictions, definition lists, or any other
+  syntax-level changes to entry blocks beyond the attribute footer.
+
+## 9. Acceptance
+
+This design is accepted when:
+
+1. The author and reviewer agree this trade-off is correct given the heavy
+   weight placed on whole-entry readability under ASPICE / ISO 26262 metadata
+   loads.
+2. The migration path (`markspec format` rewrites; one-cycle deprecation) is
+   judged low-risk for downstream users.
+3. The spec wording in language.md §2 (drafted in §5.1 of this document) is
+   approved.

--- a/docs/templates/adr-nnn-topic.md
+++ b/docs/templates/adr-nnn-topic.md
@@ -32,9 +32,9 @@
        Example: "The sensor pipeline shall use an interrupt-driven architecture
        with a lock-free ring buffer to decouple acquisition from processing." -->
 
-  Id:\
-  Satisfies:\
-  Labels:
+      Id:
+      Satisfies:
+      Labels:
 
   <!-- Id: left empty, assigned by `markspec doc format`.
        Satisfies: upstream requirement ID (e.g., STK_BRK_0001, SYS_BRK_0042).
@@ -49,9 +49,9 @@
 
   Description of the interface contract.
 
-  Id: \
-  Satisfies: \
-  Labels:
+      Id:
+      Satisfies:
+      Labels:
 
 -->
 

--- a/docs/templates/sad-nnn-topic.md
+++ b/docs/templates/sad-nnn-topic.md
@@ -25,9 +25,9 @@
   <!-- Example: "The acquisition module shall use a lock-free ring buffer
        to decouple sensor sampling from processing." -->
 
-  Id:\
-  Satisfies:\
-  Labels:
+      Id:
+      Satisfies:
+      Labels:
 
 ## Interfaces
 
@@ -39,9 +39,9 @@
   <!-- Example: "The sensor gateway shall expose a CAN 2.0B interface
        publishing filtered sensor frames at 100 Hz." -->
 
-  Id:\
-  Satisfies:\
-  Labels:
+      Id:
+      Satisfies:
+      Labels:
 
 ## Constraints
 
@@ -61,9 +61,9 @@ Not applicable.
 
   Description of the regulatory constraint.
 
-  Id:\
-  Satisfies:\
-  Labels:
+      Id:
+      Satisfies:
+      Labels:
 
 -->
 
@@ -78,9 +78,9 @@ Not applicable.
 
   Description of the privacy constraint.
 
-  Id:\
-  Satisfies:\
-  Labels:
+      Id:
+      Satisfies:
+      Labels:
 
 -->
 
@@ -95,9 +95,9 @@ Not applicable.
 
   Description of the safety constraint.
 
-  Id:\
-  Satisfies:\
-  Labels:
+      Id:
+      Satisfies:
+      Labels:
 
 -->
 
@@ -112,9 +112,9 @@ Not applicable.
 
   Description of the cybersecurity constraint.
 
-  Id:\
-  Satisfies:\
-  Labels:
+      Id:
+      Satisfies:
+      Labels:
 
 -->
 
@@ -129,8 +129,8 @@ Not applicable.
 
   Description of the performance or reliability constraint.
 
-  Id:\
-  Satisfies:\
-  Labels:
+      Id:
+      Satisfies:
+      Labels:
 
 -->

--- a/packages/markspec/core/compiler/mod_test.ts
+++ b/packages/markspec/core/compiler/mod_test.ts
@@ -107,8 +107,8 @@ Deno.test("compile: Supersedes produces a link", async () => {
 
   Body.
 
-  Id: ${ULID_B}\\
-  Supersedes: REQ-001
+      Id: ${ULID_B}
+      Supersedes: REQ-001
 `,
   };
   const result = await compile(["req.md"], { readFile: reader(files) });
@@ -128,8 +128,8 @@ Deno.test("compile: References citation produces a link", async () => {
 
   Body.
 
-  Id: ${ULID_A}\\
-  References: ISO-26262-6 §9.4
+      Id: ${ULID_A}
+      References: ISO-26262-6 §9.4
 `,
   };
   const result = await compile(["refs.md", "req.md"], {
@@ -162,8 +162,8 @@ Deno.test("compile: id-list attr value splits into multiple links", async () => 
 
   Body.
 
-  Id: ${ULID_C}\\
-  Satisfies: REQ-PARENT-A, REQ-PARENT-B
+      Id: ${ULID_C}
+      Satisfies: REQ-PARENT-A, REQ-PARENT-B
 `,
   };
   const result = await compile(["req.md"], { readFile: reader(files) });
@@ -188,8 +188,8 @@ Deno.test("compile: forward map carries outgoing links per entry", async () => {
 
   Body.
 
-  Id: ${ULID_B}\\
-  Supersedes: REQ-001
+      Id: ${ULID_B}
+      Supersedes: REQ-001
 `,
   };
   const result = await compile(["req.md"], { readFile: reader(files) });
@@ -210,8 +210,8 @@ Deno.test("compile: reverse map carries incoming links per target", async () => 
 
   Body.
 
-  Id: ${ULID_B}\\
-  Supersedes: REQ-001
+      Id: ${ULID_B}
+      Supersedes: REQ-001
 `,
   };
   const result = await compile(["req.md"], { readFile: reader(files) });

--- a/packages/markspec/core/formatter/mod.ts
+++ b/packages/markspec/core/formatter/mod.ts
@@ -106,7 +106,7 @@ export function format(
   // body only (front-matter `---` could be confused with horizontal rules).
   const fm = extractFrontMatter(markdown, { file });
   const body = fm.hadFrontMatter ? fm.markdown : markdown;
-  const entries = parseMarkdown(body, { file });
+  const { entries } = parseMarkdown(body, { file });
   const diagnostics: Diagnostic[] = [...fm.diagnostics];
 
   if (entries.length === 0 && !fm.hadFrontMatter) {
@@ -281,19 +281,21 @@ export function sortAttributes(
 }
 
 /**
- * Render attributes as indented `Key: Value\` lines.
- * Trailing backslash on all lines except the last.
+ * Render attributes as an indented code block.
+ * Each line is `Key: Value` at (indent + 4) absolute columns;
+ * no trailing line-continuation characters.
+ *
+ * @param attributes - The attributes to render, in canonical order.
+ * @param indent - Body indent for the entry (2 for list-wrapped entries,
+ *   0 for entries inside source-file doc comments).
  */
 export function renderAttributeBlock(
   attributes: Attribute[],
   indent: number,
 ): string {
-  const prefix = " ".repeat(indent);
+  const prefix = " ".repeat(indent + 4);
   return attributes
-    .map((attr, i) => {
-      const sep = i < attributes.length - 1 ? "\\" : "";
-      return `${prefix}${attr.key}: ${attr.value}${sep}`;
-    })
+    .map((attr) => `${prefix}${attr.key}: ${attr.value}`)
     .join("\n");
 }
 

--- a/packages/markspec/core/formatter/mod_test.ts
+++ b/packages/markspec/core/formatter/mod_test.ts
@@ -7,7 +7,7 @@
  */
 
 import { assertEquals, assertStringIncludes } from "@std/assert";
-import { format } from "./mod.ts";
+import { format, renderAttributeBlock } from "./mod.ts";
 
 const MOCK_ULID = "01HGW2Q8MNP3RSTVWXYZABCDEF";
 const MOCK_ULID_2 = "01HGW2Q8MNP3RSTVWXYZABCDEG";
@@ -163,7 +163,7 @@ Deno.test("format: unchanged-input does not mutate source", () => {
 
   Body.
 
-  Id: ${MOCK_ULID}
+      Id: ${MOCK_ULID}
 `;
   const result = format(md);
   // Already canonical form — changed should be false.
@@ -230,4 +230,34 @@ Just prose.
   const result = format(md);
   assertEquals(result.changed, false);
   assertEquals(result.output, md);
+});
+
+// ---------------------------------------------------------------------------
+// renderAttributeBlock — indented code block emission
+// ---------------------------------------------------------------------------
+
+Deno.test("renderAttributeBlock: emits indented code block (4-space prefix, no backslash)", () => {
+  const block = renderAttributeBlock(
+    [
+      { key: "Id", value: "01HGW2Q8MNP3RSTVWXYZABCDE" },
+      { key: "Satisfies", value: "SYS_BRK_0042" },
+      { key: "Labels", value: "ASIL-B" },
+    ],
+    2, // body indent of a list-item entry
+  );
+
+  const expected =
+    "      Id: 01HGW2Q8MNP3RSTVWXYZABCDE\n" +
+    "      Satisfies: SYS_BRK_0042\n" +
+    "      Labels: ASIL-B";
+
+  assertEquals(block, expected);
+});
+
+Deno.test("renderAttributeBlock: doc-comment indent (no list wrapper)", () => {
+  const block = renderAttributeBlock(
+    [{ key: "Id", value: "01HGW3C4DEF6ABCDEFGHJKMNPQ" }],
+    0, // doc comment, no list nesting
+  );
+  assertEquals(block, "    Id: 01HGW3C4DEF6ABCDEFGHJKMNPQ");
 });

--- a/packages/markspec/core/formatter/mod_test.ts
+++ b/packages/markspec/core/formatter/mod_test.ts
@@ -246,8 +246,7 @@ Deno.test("renderAttributeBlock: emits indented code block (4-space prefix, no b
     2, // body indent of a list-item entry
   );
 
-  const expected =
-    "      Id: 01HGW2Q8MNP3RSTVWXYZABCDE\n" +
+  const expected = "      Id: 01HGW2Q8MNP3RSTVWXYZABCDE\n" +
     "      Satisfies: SYS_BRK_0042\n" +
     "      Labels: ASIL-B";
 

--- a/packages/markspec/core/formatter/mod_test.ts
+++ b/packages/markspec/core/formatter/mod_test.ts
@@ -76,9 +76,9 @@ Deno.test("format: canonical order places Id first, universal attrs last", () =>
 
   Body.
 
-  Labels: important\\
-  Id: ${MOCK_ULID}\\
-  Supersedes: OLD-001
+      Labels: important
+      Id: ${MOCK_ULID}
+      Supersedes: OLD-001
 `;
   const result = format(md);
   const output = result.output;
@@ -96,9 +96,9 @@ Deno.test("format: unknown (profile-declared) attributes preserved", () => {
 
   Body.
 
-  Id: ${MOCK_ULID}\\
-  Derived-from: PARENT-001\\
-  Labels: one
+      Id: ${MOCK_ULID}
+      Derived-from: PARENT-001
+      Labels: one
 `;
   const result = format(md);
   // Unknown keys survive the formatter — profile-aware validation handles
@@ -116,8 +116,8 @@ Deno.test("format: Labels CSV expands to multi-line", () => {
 
   Body.
 
-  Id: ${MOCK_ULID}\\
-  Labels: one, two, three
+      Id: ${MOCK_ULID}
+      Labels: one, two, three
 `;
   const result = format(md);
   assertStringIncludes(result.output, "Labels: one");
@@ -132,9 +132,9 @@ Deno.test("format: multi-line Labels preserved", () => {
 
   Body.
 
-  Id: ${MOCK_ULID}\\
-  Labels: one\\
-  Labels: two
+      Id: ${MOCK_ULID}
+      Labels: one
+      Labels: two
 `;
   const result = format(md);
   assertStringIncludes(result.output, "Labels: one");
@@ -150,8 +150,8 @@ Deno.test("format: output is idempotent (format twice = format once)", () => {
 
   Body.
 
-  Id: ${MOCK_ULID}\\
-  Labels: important
+      Id: ${MOCK_ULID}
+      Labels: important
 `;
   const once = format(md);
   const twice = format(once.output);

--- a/packages/markspec/core/parser/attributes_test.ts
+++ b/packages/markspec/core/parser/attributes_test.ts
@@ -226,8 +226,7 @@ Deno.test("splitBodyAndAttributes: indented-code-block form (new canonical)", ()
   // Body indent is already stripped by the caller; the input below is what
   // extractBodyContent returns for an entry whose attribute block is an
   // indented code block at body+4 columns.
-  const content =
-    "Body sentence.\n" +
+  const content = "Body sentence.\n" +
     "\n" +
     "    Id: 01HGW2Q8MNP3RSTVWXYZABCDE\n" +
     "    Satisfies: SYS_BRK_0042\n" +
@@ -244,8 +243,7 @@ Deno.test("splitBodyAndAttributes: indented-code-block form (new canonical)", ()
 });
 
 Deno.test("splitBodyAndAttributes: legacy backslash-paragraph form still parses", () => {
-  const content =
-    "Body sentence.\n" +
+  const content = "Body sentence.\n" +
     "\n" +
     "Id: 01HGW2Q8MNP3RSTVWXYZABCDE\\\n" +
     "Satisfies: SYS_BRK_0042\\\n" +
@@ -296,7 +294,9 @@ Deno.test(
     const codes = result.diagnostics.map((d) => d.code);
     assert(
       codes.includes("MSL-DEPRECATED-ATTR-001"),
-      `expected MSL-DEPRECATED-ATTR-001 in diagnostics, got: ${codes.join(",")}`,
+      `expected MSL-DEPRECATED-ATTR-001 in diagnostics, got: ${
+        codes.join(",")
+      }`,
     );
   },
 );

--- a/packages/markspec/core/parser/attributes_test.ts
+++ b/packages/markspec/core/parser/attributes_test.ts
@@ -4,8 +4,9 @@
  * Unit tests for attribute block parsing.
  */
 
-import { assertEquals, assertStringIncludes } from "@std/assert";
+import { assert, assertEquals, assertStringIncludes } from "@std/assert";
 import { parseAttributes, splitBodyAndAttributes } from "./attributes.ts";
+import { parseFile } from "./mod.ts";
 
 // ---------------------------------------------------------------------------
 // Backslash-separated attributes
@@ -273,3 +274,51 @@ Deno.test("parseAttributes: both shapes produce identical Attribute[]", () => {
   ]);
   assertEquals(newShape, legacyShape);
 });
+
+// ---------------------------------------------------------------------------
+// Deprecation diagnostic (MSL-DEPRECATED-ATTR-001)
+// ---------------------------------------------------------------------------
+
+Deno.test(
+  "parseFile: legacy paragraph + backslash attribute shape emits MSL-DEPRECATED-ATTR-001",
+  async () => {
+    const md = [
+      "- [SRS_TEST_0001] Legacy entry",
+      "",
+      "  Body.",
+      "",
+      "  Id: 01HGW2Q8MNP3RSTVWXYZABCDE\\",
+      "  Labels: ASIL-B",
+      "",
+    ].join("\n");
+
+    const result = await parseFile(md, { file: "test.md" });
+    const codes = result.diagnostics.map((d) => d.code);
+    assert(
+      codes.includes("MSL-DEPRECATED-ATTR-001"),
+      `expected MSL-DEPRECATED-ATTR-001 in diagnostics, got: ${codes.join(",")}`,
+    );
+  },
+);
+
+Deno.test(
+  "parseFile: canonical indented-code attribute form emits no deprecation warning",
+  async () => {
+    const md = [
+      "- [SRS_TEST_0001] Canonical entry",
+      "",
+      "  Body.",
+      "",
+      "      Id: 01HGW2Q8MNP3RSTVWXYZABCDE",
+      "      Labels: ASIL-B",
+      "",
+    ].join("\n");
+
+    const result = await parseFile(md, { file: "test.md" });
+    const codes = result.diagnostics.map((d) => d.code);
+    assert(
+      !codes.includes("MSL-DEPRECATED-ATTR-001"),
+      `unexpected deprecation warning; got: ${codes.join(",")}`,
+    );
+  },
+);

--- a/packages/markspec/core/parser/markdown.ts
+++ b/packages/markspec/core/parser/markdown.ts
@@ -6,7 +6,7 @@
  */
 
 import type { Definition, List, ListItem, Paragraph, Text } from "mdast";
-import type { Attribute, Entry, EntryShape } from "../model/mod.ts";
+import type { Attribute, Diagnostic, Entry, EntryShape } from "../model/mod.ts";
 import { IDENTITY_KEY, shapeFromIdValue } from "../model/mod.ts";
 import {
   collateAttributes,
@@ -53,6 +53,14 @@ function findIdentityAttribute(
   return undefined;
 }
 
+/** Result returned by {@linkcode parseMarkdown}. */
+export interface ParseMarkdownResult {
+  /** Parsed entries found in the Markdown source. */
+  readonly entries: Entry[];
+  /** Parse-level diagnostics (e.g., deprecation warnings). */
+  readonly diagnostics: Diagnostic[];
+}
+
 /**
  * Parse a Markdown string and return all MarkSpec entries found.
  *
@@ -63,12 +71,12 @@ function findIdentityAttribute(
  *
  * @param markdown - Markdown source text
  * @param options - Parse options (file path for source locations)
- * @returns Array of parsed entries
+ * @returns Parsed entries and any parse-level diagnostics
  */
 export function parseMarkdown(
   markdown: string,
   options?: ParseMarkdownOptions,
-): Entry[] {
+): ParseMarkdownResult {
   const file = options?.file ?? "<unknown>";
   const isReferencesDoc = detectReferencesDocument(
     file,
@@ -76,6 +84,7 @@ export function parseMarkdown(
   );
   const tree = processor.parse(markdown);
   const entries: Entry[] = [];
+  const diagnostics: Diagnostic[] = [];
 
   // Collect link definition identifiers for shortcut reference exclusion.
   const definitions = new Set(
@@ -98,12 +107,13 @@ export function parseMarkdown(
         file,
         definitions,
         isReferencesDoc,
+        diagnostics,
       );
       if (entry) entries.push(entry);
     }
   }
 
-  return entries;
+  return { entries, diagnostics };
 }
 
 /**
@@ -124,6 +134,7 @@ function detectReferencesDocument(
 /**
  * Attempt to extract a MarkSpec entry from a list item.
  * Returns undefined if the list item is not an entry block.
+ * Diagnostics (e.g., deprecation warnings) are pushed into the accumulator.
  */
 function extractEntry(
   item: ListItem,
@@ -131,6 +142,7 @@ function extractEntry(
   file: string,
   definitions: Set<string>,
   isReferencesDoc: boolean,
+  diagnostics: Diagnostic[],
 ): Entry | undefined {
   // Task list items (remark-gfm sets checked to true/false) are not entries.
   if (item.checked != null) return undefined;
@@ -204,6 +216,22 @@ function extractEntry(
   const bodyContent = extractBodyContent(item, markdown);
   const [body, attrLines] = splitBodyAndAttributes(bodyContent);
   const attributes = parseAttributes(attrLines);
+
+  // Detect legacy paragraph + trailing-backslash attribute form and warn.
+  if (
+    attributes.length > 0 &&
+    attrLines.some((line) => line.trimEnd().endsWith("\\"))
+  ) {
+    const entryLine = item.position?.start.line ?? 1;
+    diagnostics.push({
+      code: "MSL-DEPRECATED-ATTR-001",
+      severity: "warning",
+      message:
+        "legacy attribute block (paragraph with trailing `\\`) is deprecated; " +
+        "run `markspec format` to convert to the canonical indented code block",
+      location: { file, line: entryLine, column: 1 },
+    });
+  }
 
   // Discriminate shape by the `Id:` attribute's value format.
   let shape: EntryShape | undefined;

--- a/packages/markspec/core/parser/markdown_test.ts
+++ b/packages/markspec/core/parser/markdown_test.ts
@@ -22,7 +22,7 @@ Deno.test("parseMarkdown: extracts display ID and title", () => {
 
   Id: ${ULID}
 `;
-  const [entry] = parseMarkdown(md);
+  const { entries: [entry] } = parseMarkdown(md);
   assertExists(entry);
   assertEquals(entry.displayId, "REQ-001");
   assertEquals(entry.title, "Sensor debouncing");
@@ -35,7 +35,7 @@ Deno.test("parseMarkdown: strips leading @ from display ID (Pandoc compat)", () 
 
   Id: urn:iso:std:iso:26262:-6:ed-2
 `;
-  const [entry] = parseMarkdown(md);
+  const { entries: [entry] } = parseMarkdown(md);
   assertExists(entry);
   assertEquals(entry.displayId, "ISO-26262-6");
   assertEquals(entry.shape, "referenced");
@@ -48,7 +48,7 @@ Deno.test("parseMarkdown: free-form symbolic display ID accepted", () => {
 
   Id: ${ULID}
 `;
-  const [entry] = parseMarkdown(md);
+  const { entries: [entry] } = parseMarkdown(md);
   assertExists(entry);
   assertEquals(entry.displayId, "braking_core::controller::debounce_input");
   assertEquals(entry.shape, "identified");
@@ -65,7 +65,7 @@ Deno.test("parseMarkdown: ULID Id → shape=identified", () => {
 
   Id: ${ULID}
 `;
-  const [entry] = parseMarkdown(md);
+  const { entries: [entry] } = parseMarkdown(md);
   assertEquals(entry.shape, "identified");
   assertEquals(entry.id, ULID);
 });
@@ -77,7 +77,7 @@ Deno.test("parseMarkdown: URN URI → shape=referenced", () => {
 
   Id: urn:iso:std:iso:26262:-6:ed-2
 `;
-  const [entry] = parseMarkdown(md);
+  const { entries: [entry] } = parseMarkdown(md);
   assertEquals(entry.shape, "referenced");
   assertEquals(entry.id, "urn:iso:std:iso:26262:-6:ed-2");
 });
@@ -89,7 +89,7 @@ Deno.test("parseMarkdown: DOI URI → shape=referenced", () => {
 
   Id: doi:10.17487/RFC2119
 `;
-  const [entry] = parseMarkdown(md);
+  const { entries: [entry] } = parseMarkdown(md);
   assertEquals(entry.shape, "referenced");
 });
 
@@ -100,7 +100,7 @@ Deno.test("parseMarkdown: purl URI → shape=referenced", () => {
 
   Id: pkg:cargo/serde@1.0.0
 `;
-  const [entry] = parseMarkdown(md);
+  const { entries: [entry] } = parseMarkdown(md);
   assertEquals(entry.shape, "referenced");
   assertEquals(entry.id, "pkg:cargo/serde@1.0.0");
 });
@@ -112,7 +112,7 @@ Deno.test("parseMarkdown: HTTPS URL → shape=referenced", () => {
 
   Id: https://www.rfc-editor.org/rfc/rfc2119
 `;
-  const [entry] = parseMarkdown(md);
+  const { entries: [entry] } = parseMarkdown(md);
   assertEquals(entry.shape, "referenced");
 });
 
@@ -123,7 +123,7 @@ Deno.test("parseMarkdown: malformed Id still parses (validator surfaces error)",
 
   Id: not-a-ulid-or-uri
 `;
-  const [entry] = parseMarkdown(md);
+  const { entries: [entry] } = parseMarkdown(md);
   assertExists(entry);
   // Parser accepts; shape falls back to identified so validator flags MSL-R004.
   assertEquals(entry.shape, "identified");
@@ -139,7 +139,7 @@ Deno.test("parseMarkdown: slug-shaped display ID in references.md → shape=refe
 
   Body.
 `;
-  const [entry] = parseMarkdown(md, { file: "references.md" });
+  const { entries: [entry] } = parseMarkdown(md, { file: "references.md" });
   assertExists(entry);
   assertEquals(entry.shape, "referenced");
   assertEquals(entry.id, undefined);
@@ -150,7 +150,7 @@ Deno.test("parseMarkdown: non-references doc without Id falls back to identified
 
   Body paragraph.
 `;
-  const [entry] = parseMarkdown(md, { file: "requirements.md" });
+  const { entries: [entry] } = parseMarkdown(md, { file: "requirements.md" });
   assertExists(entry);
   assertEquals(entry.shape, "identified");
   assertEquals(entry.id, undefined);
@@ -161,7 +161,7 @@ Deno.test("parseMarkdown: isReferencesDoc option overrides file-path detection",
 
   Body.
 `;
-  const [entry] = parseMarkdown(md, {
+  const { entries: [entry] } = parseMarkdown(md, {
     file: "deps.md",
     isReferencesDoc: true,
   });
@@ -182,7 +182,7 @@ Deno.test("parseMarkdown: trailing attribute block is parsed", () => {
   Labels: one, two\\
   Supersedes: OLD-001
 `;
-  const [entry] = parseMarkdown(md);
+  const { entries: [entry] } = parseMarkdown(md);
   const attrs = Object.fromEntries(
     entry.rawAttributes.map((a) => [a.key, a.value]),
   );
@@ -196,7 +196,7 @@ Deno.test("parseMarkdown: referenced entry body is optional", () => {
 
   Id: urn:iso:std:iso:26262:-6:ed-2
 `;
-  const [entry] = parseMarkdown(md);
+  const { entries: [entry] } = parseMarkdown(md);
   assertExists(entry);
   assertEquals(entry.shape, "referenced");
 });
@@ -212,7 +212,7 @@ Deno.test("parseMarkdown: ordered list items are never entries", () => {
 
   Id: ${ULID}
 `;
-  const entries = parseMarkdown(md);
+  const { entries } = parseMarkdown(md);
   assertEquals(entries, []);
 });
 
@@ -220,14 +220,14 @@ Deno.test("parseMarkdown: task list item is not an entry", () => {
   const md = `- [ ] Todo item
 - [x] Done item
 `;
-  const entries = parseMarkdown(md);
+  const { entries } = parseMarkdown(md);
   assertEquals(entries, []);
 });
 
 Deno.test("parseMarkdown: inline-link list item is not an entry", () => {
   const md = `- [MarkSpec](https://example.com) a tool
 `;
-  const entries = parseMarkdown(md);
+  const { entries } = parseMarkdown(md);
   assertEquals(entries, []);
 });
 
@@ -236,14 +236,14 @@ Deno.test("parseMarkdown: shortcut-ref with matching definition is not an entry"
 
 [CommonMark]: https://commonmark.org
 `;
-  const entries = parseMarkdown(md);
+  const { entries } = parseMarkdown(md);
   assertEquals(entries, []);
 });
 
 Deno.test("parseMarkdown: identified list item with only title (no body) is skipped", () => {
   const md = `- [REQ-001] Title only
 `;
-  const entries = parseMarkdown(md);
+  const { entries } = parseMarkdown(md);
   assertEquals(entries, []);
 });
 
@@ -266,7 +266,7 @@ Deno.test("parseMarkdown: extracts multiple entries in order", () => {
 
   Id: 01HGW2Q8MNP3RSTVWXYZABCDEG
 `;
-  const entries = parseMarkdown(md);
+  const { entries } = parseMarkdown(md);
   assertEquals(entries.length, 2);
   assertEquals(entries[0].displayId, "REQ-001");
   assertEquals(entries[1].displayId, "REQ-002");
@@ -279,7 +279,7 @@ Deno.test("parseMarkdown: source location carries file path", () => {
 
   Id: ${ULID}
 `;
-  const [entry] = parseMarkdown(md, { file: "src/req.md" });
+  const { entries: [entry] } = parseMarkdown(md, { file: "src/req.md" });
   assertEquals(entry.location.file, "src/req.md");
   assertEquals(entry.location.line, 1);
   assertEquals(entry.source, "markdown");
@@ -299,7 +299,7 @@ Deno.test("parseMarkdown: typedAttributes collates repeatable values", () => {
   Labels: one\\
   Labels: two
 `;
-  const [entry] = parseMarkdown(md);
+  const { entries: [entry] } = parseMarkdown(md);
   const labels = entry.typedAttributes?.get("Labels");
   assertEquals(labels, ["one", "two"]);
 });

--- a/packages/markspec/core/parser/markdown_test.ts
+++ b/packages/markspec/core/parser/markdown_test.ts
@@ -178,9 +178,9 @@ Deno.test("parseMarkdown: trailing attribute block is parsed", () => {
 
   Body.
 
-  Id: ${ULID}\\
-  Labels: one, two\\
-  Supersedes: OLD-001
+      Id: ${ULID}
+      Labels: one, two
+      Supersedes: OLD-001
 `;
   const { entries: [entry] } = parseMarkdown(md);
   const attrs = Object.fromEntries(
@@ -295,9 +295,9 @@ Deno.test("parseMarkdown: typedAttributes collates repeatable values", () => {
 
   Body.
 
-  Id: ${ULID}\\
-  Labels: one\\
-  Labels: two
+      Id: ${ULID}
+      Labels: one
+      Labels: two
 `;
   const { entries: [entry] } = parseMarkdown(md);
   const labels = entry.typedAttributes?.get("Labels");

--- a/packages/markspec/core/parser/mod.ts
+++ b/packages/markspec/core/parser/mod.ts
@@ -57,7 +57,7 @@ export function parse(
   markdown: string,
   options?: ParseOptions,
 ): Entry[] {
-  return parseMarkdown(markdown, options);
+  return parseMarkdown(markdown, options).entries;
 }
 
 /** Result of parsing a file (entries + optional document + diagnostics). */
@@ -114,7 +114,7 @@ export async function parseFile(
   const fm = extractFrontMatter(content, { file: options.file });
   const body = fm.hadFrontMatter ? fm.markdown : content;
   const isReferencesDoc = isReferencesDocument(options.file);
-  const entries = parseMarkdown(body, {
+  const { entries, diagnostics: parseDiagnostics } = parseMarkdown(body, {
     file: options.file,
     isReferencesDoc,
   });
@@ -130,7 +130,7 @@ export async function parseFile(
   return {
     entries,
     document,
-    diagnostics: fm.diagnostics,
+    diagnostics: [...fm.diagnostics, ...parseDiagnostics],
   };
 }
 

--- a/packages/markspec/core/parser/source.ts
+++ b/packages/markspec/core/parser/source.ts
@@ -60,7 +60,7 @@ export function parseSource(
 
   for (const block of blocks) {
     const markdown = wrapAsListItem(block.lines);
-    const parsed = parseMarkdown(markdown, { file });
+    const { entries: parsed } = parseMarkdown(markdown, { file });
 
     for (const entry of parsed) {
       const location = {

--- a/packages/markspec/core/parser/source_test.ts
+++ b/packages/markspec/core/parser/source_test.ts
@@ -42,9 +42,9 @@ Deno.test("parseSource: extracts Rust doc comment entry", async () => {
 ///
 /// The sensor driver shall reject transient noise.
 ///
-/// Id: 01HGW2Q8MNP3RSTVWXYZABCDEF \\
-/// Satisfies: SYS_BRK_0042 \\
-/// Labels: ASIL-B
+///     Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+///     Satisfies: SYS_BRK_0042
+///     Labels: ASIL-B
 #[test]
 fn swt_brk_0001() {}
 `;
@@ -82,9 +82,9 @@ Deno.test("parseSource: extracts attributes from Rust doc comment", async () => 
 ///
 /// Body text.
 ///
-/// Id: SRS_01HGW2Q8MNP3 \\
-/// Satisfies: SYS_BRK_0042 \\
-/// Labels: ASIL-B
+///     Id: SRS_01HGW2Q8MNP3
+///     Satisfies: SYS_BRK_0042
+///     Labels: ASIL-B
 fn foo() {}
 `;
 
@@ -344,8 +344,8 @@ Deno.test("parseSource: links is always empty under the four-family model", asyn
 ///
 /// Body text.
 ///
-/// Id: SRS_01HGW2Q8MNP3 \\
-/// Verifies: STK_BRK_0001
+///     Id: SRS_01HGW2Q8MNP3
+///     Verifies: STK_BRK_0001
 fn foo() {}
 `;
 

--- a/packages/markspec/lsp/completions.ts
+++ b/packages/markspec/lsp/completions.ts
@@ -103,7 +103,7 @@ export function buildBlockScaffoldItems(
       {
         label: "New entry",
         insertText:
-          "${1:PREFIX_NNNN}] ${2:Title}\n\n  ${3:Body.}\n\n  Id: \\${ULID}",
+          "${1:PREFIX_NNNN}] ${2:Title}\n\n  ${3:Body.}\n\n      Id: \\${ULID}",
         isSnippet: true,
         kind: KIND_SNIPPET,
       },
@@ -116,7 +116,7 @@ export function buildBlockScaffoldItems(
       label: `New ${type.name} (${displayId})`,
       detail: type.name,
       insertText:
-        `${displayId}] \${1:Title}\n\n  \${2:Body.}\n\n  Id: \\$\{ULID} \\\\\n  \${3:Satisfies: }`,
+        `${displayId}] \${1:Title}\n\n  \${2:Body.}\n\n      Id: \\$\{ULID}\n      \${3:Satisfies: }`,
       isSnippet: true,
       kind: KIND_SNIPPET,
     };

--- a/packages/markspec/render/styles/mod_test.ts
+++ b/packages/markspec/render/styles/mod_test.ts
@@ -358,3 +358,34 @@ More prose here.
   assertStringIncludes(result.output, "More prose here.");
   assertStringIncludes(result.output, "`SRS_BRK_0001`");
 });
+
+// ---------------------------------------------------------------------------
+// Indented-code attribute form
+// ---------------------------------------------------------------------------
+
+Deno.test("styleRequirementBlocks: parses attributes from indented-code form", () => {
+  const md = `- [SRS_TEST_0001] Render styles regression
+
+  Body.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDE
+      Labels: ASIL-B
+`;
+  const compiled = buildCompiled([{
+    displayId: "SRS_TEST_0001",
+    title: "Render styles regression",
+    id: "01HGW2Q8MNP3RSTVWXYZABCDE",
+    attributes: [
+      { key: "Id", value: "01HGW2Q8MNP3RSTVWXYZABCDE" },
+      { key: "Labels", value: "ASIL-B" },
+    ],
+  }]);
+
+  const result = styleRequirementBlocks(md, compiled);
+
+  // The styled output must include the attribute row(s) from the table.
+  assertStringIncludes(result.output, "**Id**");
+  assertStringIncludes(result.output, "01HGW2Q8MNP3RSTVWXYZABCDE");
+  assertStringIncludes(result.output, "**Labels**");
+  assertStringIncludes(result.output, "ASIL-B");
+});

--- a/packages/markspec/render/styles/mod_test.ts
+++ b/packages/markspec/render/styles/mod_test.ts
@@ -83,9 +83,9 @@ Deno.test("styleRequirementBlocks: attributes rendered as compact table", () => 
 
   Body text.
 
-  Id: SRS_01HGW2Q8MNP3 \\
-  Satisfies: SYS_BRK_0042 \\
-  Labels: ASIL-B
+      Id: SRS_01HGW2Q8MNP3
+      Satisfies: SYS_BRK_0042
+      Labels: ASIL-B
 `;
   const compiled = buildCompiled([{
     displayId: "SRS_BRK_0001",

--- a/tests/e2e/book_build_test.ts
+++ b/tests/e2e/book_build_test.ts
@@ -27,16 +27,16 @@ const REQUIREMENTS_MD = `# Requirements
 
   Braking system shall stop the vehicle within 3 seconds.
 
-  Id: STK_01HGW2Q8MNP3\\
-  Labels: ASIL-B, Safety
+      Id: STK_01HGW2Q8MNP3
+      Labels: ASIL-B, Safety
 
 - [SRS_BRK_0001] Sensor input debouncing
 
   The sensor driver shall debounce raw inputs.
 
-  Id: SRS_01HGW2R9QLP4\\
-  Satisfies: STK_BRK_0001\\
-  Labels: ASIL-B
+      Id: SRS_01HGW2R9QLP4
+      Satisfies: STK_BRK_0001
+      Labels: ASIL-B
 
 > [!WARNING]
 > Failure to debounce may lead to spurious brake activation.
@@ -49,8 +49,8 @@ const SPECS_MD = `# Architecture Specs
 
   The braking ECU shall expose a CAN bus interface.
 
-  Id: ARC_01HGW2S0ABC5\\
-  Satisfies: STK_BRK_0001
+      Id: ARC_01HGW2S0ABC5
+      Satisfies: STK_BRK_0001
 
 ![Braking ECU interface diagram](arch.png)
 

--- a/tests/e2e/format_test.ts
+++ b/tests/e2e/format_test.ts
@@ -65,9 +65,9 @@ Deno.test("format: normalizes attribute order in file", async () => {
 
   Body text.
 
-  Labels: ASIL-B\\
-  Id: SRS_01HGW2Q8MNP3\\
-  Satisfies: SYS_BRK_0042
+      Labels: ASIL-B
+      Id: SRS_01HGW2Q8MNP3
+      Satisfies: SYS_BRK_0042
 `;
   const { code, stderr } = await runFormat({ "req.md": input });
   assertEquals(code, 0);
@@ -81,8 +81,8 @@ Deno.test("format: writes normalized attributes back to file", async () => {
 
   Body text.
 
-  Labels: ASIL-B\\
-  Id: SRS_01HGW2Q8MNP3
+      Labels: ASIL-B
+      Id: SRS_01HGW2Q8MNP3
 `;
   const { readFile } = await runFormat({ "req.md": input });
   const output = await readFile("req.md");
@@ -142,8 +142,8 @@ Deno.test("format: --check exits 1 when changes needed", async () => {
 
   Body text.
 
-  Labels: ASIL-B\\
-  Id: SRS_01HGW2Q8MNP3
+      Labels: ASIL-B
+      Id: SRS_01HGW2Q8MNP3
 `;
   const { code, readFile } = await runFormat({ "req.md": input }, ["--check"]);
   assertEquals(code, 1);
@@ -206,8 +206,8 @@ Deno.test("format: reports summary to stderr", async () => {
 
   Body text.
 
-  Id: SRS_01HGW2Q8MNP3\\
-  Labels: ASIL-B
+      Id: SRS_01HGW2Q8MNP3
+      Labels: ASIL-B
 `;
   const { stderr } = await runFormat({ "req.md": input });
   assertStringIncludes(stderr, "file(s) formatted");

--- a/tests/e2e/format_test.ts
+++ b/tests/e2e/format_test.ts
@@ -123,9 +123,9 @@ Deno.test("format: second run reports 0 formatted", async () => {
 
   Body text.
 
-  Id: SRS_01HGW2Q8MNP3\\
-  Satisfies: SYS_BRK_0042\\
-  Labels: ASIL-B
+      Id: SRS_01HGW2Q8MNP3
+      Satisfies: SYS_BRK_0042
+      Labels: ASIL-B
 `;
   const { stderr } = await runFormat({ "req.md": input });
   assertStringIncludes(stderr, "0 file(s) formatted");
@@ -159,9 +159,9 @@ Deno.test("format: --check exits 0 when clean", async () => {
 
   Body text.
 
-  Id: SRS_01HGW2Q8MNP3\\
-  Satisfies: SYS_BRK_0042\\
-  Labels: ASIL-B
+      Id: SRS_01HGW2Q8MNP3
+      Satisfies: SYS_BRK_0042
+      Labels: ASIL-B
 `;
   const { code } = await runFormat({ "req.md": input }, ["--check"]);
   assertEquals(code, 0);

--- a/tests/e2e/lsp_completions_test.ts
+++ b/tests/e2e/lsp_completions_test.ts
@@ -60,8 +60,8 @@ Deno.test("lsp completions: ID reference on 'Satisfies:'", async () => {
 
   Body text.
 
-  Id: 01HGW2Q8MNP3RSTVWXYZABCDEG \\
-  Satisfies: 
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEG
+      Satisfies:
 `;
   const client = await LspTestClient.create({
     "project.yaml": "name: test-project\n",
@@ -83,10 +83,10 @@ Deno.test("lsp completions: ID reference on 'Satisfies:'", async () => {
     // Give server time to parse and index
     await new Promise((r) => setTimeout(r, 500));
 
-    // Request completion after "Satisfies: " (line 11, char 14)
+    // Request completion after "Satisfies:" (line 11, char 16)
     const result = await client.request("textDocument/completion", {
       textDocument: { uri: fileUri },
-      position: { line: 11, character: 14 },
+      position: { line: 11, character: 16 },
     }) as Array<{ label: string }>;
 
     assertExists(result);

--- a/tests/e2e/profile_attributes_test.ts
+++ b/tests/e2e/profile_attributes_test.ts
@@ -48,12 +48,12 @@ Deno.test("profile attributes e2e: happy path — all required present, types va
 
 - [REQ-0001] A requirement
 
-  Id: 01HGW2Q8MNP3RSTVWXYZABCDEF\\
-  Rationale: Needed for safety\\
-  Count: 42\\
-  Owners: alice\\
-  Owners: bob\\
-  Status: draft\\
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      Rationale: Needed for safety
+      Count: 42
+      Owners: alice
+      Owners: bob
+      Status: draft
 `,
     },
   });
@@ -73,7 +73,7 @@ Deno.test("profile attributes e2e: missing required → MSL-A001", async () => {
 
 - [REQ-0001] Missing rationale
 
-  Id: 01HGW2Q8MNP3RSTVWXYZABCDEF\\
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
 `,
     },
   });
@@ -90,12 +90,12 @@ Deno.test("profile attributes e2e: cardinality upper exceeded → MSL-A002", asy
 
 - [REQ-0001] Too many owners
 
-  Id: 01HGW2Q8MNP3RSTVWXYZABCDEF\\
-  Rationale: needed\\
-  Owners: a\\
-  Owners: b\\
-  Owners: c\\
-  Owners: d\\
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      Rationale: needed
+      Owners: a
+      Owners: b
+      Owners: c
+      Owners: d
 `,
     },
   });
@@ -111,9 +111,9 @@ Deno.test("profile attributes e2e: cardinality lower unmet → MSL-A003", async 
 
 - [REQ-0001] Too few owners
 
-  Id: 01HGW2Q8MNP3RSTVWXYZABCDEF\\
-  Rationale: needed\\
-  Owners: single\\
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      Rationale: needed
+      Owners: single
 `,
     },
   });
@@ -129,9 +129,9 @@ Deno.test("profile attributes e2e: value-type mismatch → MSL-A004", async () =
 
 - [REQ-0001] Count must be integer
 
-  Id: 01HGW2Q8MNP3RSTVWXYZABCDEF\\
-  Rationale: needed\\
-  Count: not-an-integer\\
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      Rationale: needed
+      Count: not-an-integer
 `,
     },
   });
@@ -147,9 +147,9 @@ Deno.test("profile attributes e2e: unknown attribute → MSL-A005 warning", asyn
 
 - [REQ-0001] Unknown attribute
 
-  Id: 01HGW2Q8MNP3RSTVWXYZABCDEF\\
-  Rationale: needed\\
-  Bogus: value\\
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      Rationale: needed
+      Bogus: value
 `,
     },
   });
@@ -169,9 +169,9 @@ Deno.test("profile attributes e2e: enum type-mismatch → MSL-A004 on Status", a
 
 - [REQ-0001] Bad status
 
-  Id: 01HGW2Q8MNP3RSTVWXYZABCDEF\\
-  Rationale: needed\\
-  Status: rejected\\
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      Rationale: needed
+      Status: rejected
 `,
     },
   });
@@ -187,7 +187,7 @@ Deno.test("profile attributes e2e: no profile → no MSL-A diagnostics (core-onl
 
 - [REQ-0001] No profile
 
-  Id: 01HGW2Q8MNP3RSTVWXYZABCDEF\\
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
 `,
     },
   });

--- a/tests/e2e/profile_inverses_test.ts
+++ b/tests/e2e/profile_inverses_test.ts
@@ -38,12 +38,12 @@ const DOC_MD = `# Inverses
 
 - [REQ-0001] A requirement
 
-  Id: 01REQ000000000000000000001\\
+      Id: 01REQ000000000000000000001
 
 - [TEST-0001] A test
 
-  Id: 01TEST00000000000000000001\\
-  Verifies: 01REQ000000000000000000001\\
+      Id: 01TEST00000000000000000001
+      Verifies: 01REQ000000000000000000001
 `;
 
 Deno.test("compile e2e: generated inverse Verified-by appears on requirement", async () => {
@@ -82,13 +82,13 @@ Deno.test("compile e2e: MSL-L005 warning on authored-vs-generated mismatch", asy
 
 - [REQ-0001] A requirement
 
-  Id: 01REQ000000000000000000001\\
-  Verified-by: 01WRONG0000000000000000001\\
+      Id: 01REQ000000000000000000001
+      Verified-by: 01WRONG0000000000000000001
 
 - [TEST-0001] A test
 
-  Id: 01TEST00000000000000000001\\
-  Verifies: 01REQ000000000000000000001\\
+      Id: 01TEST00000000000000000001
+      Verifies: 01REQ000000000000000000001
 `;
 
   const { stderr } = await markspec(

--- a/tests/e2e/profile_merge_test.ts
+++ b/tests/e2e/profile_merge_test.ts
@@ -50,7 +50,7 @@ const REQ_MD = `# Example
 
 - [REQ-0001] A requirement
 
-  Id: 01HGW2Q8MNP3RSTVWXYZABCDEF\\
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
 `;
 
 Deno.test("profile merge e2e: valid two-tier chain loads cleanly", async () => {

--- a/tests/e2e/profile_traceability_test.ts
+++ b/tests/e2e/profile_traceability_test.ts
@@ -41,12 +41,12 @@ Deno.test("traceability e2e: test entry Verifies a requirement → clean", async
 
 - [REQ-0001] A requirement
 
-  Id: 01REQ000000000000000000001\\
+      Id: 01REQ000000000000000000001
 
 - [TEST-0001] A test
 
-  Id: 01TEST00000000000000000001\\
-  Verifies: 01REQ000000000000000000001\\
+      Id: 01TEST00000000000000000001
+      Verifies: 01REQ000000000000000000001
 `,
     },
   });
@@ -63,7 +63,7 @@ Deno.test("traceability e2e: test entry missing Verifies → MSL-L001", async ()
 
 - [TEST-0001] A test with no Verifies
 
-  Id: 01TEST00000000000000000001\\
+      Id: 01TEST00000000000000000001
 `,
     },
   });
@@ -80,22 +80,22 @@ Deno.test("traceability e2e: Verifies too many targets → MSL-L002", async () =
 
 - [REQ-0001] First
 
-  Id: 01REQ000000000000000000001\\
+      Id: 01REQ000000000000000000001
 
 - [REQ-0002] Second
 
-  Id: 01REQ000000000000000000002\\
+      Id: 01REQ000000000000000000002
 
 - [REQ-0003] Third
 
-  Id: 01REQ000000000000000000003\\
+      Id: 01REQ000000000000000000003
 
 - [TEST-0001] A test
 
-  Id: 01TEST00000000000000000001\\
-  Verifies: 01REQ000000000000000000001\\
-  Verifies: 01REQ000000000000000000002\\
-  Verifies: 01REQ000000000000000000003\\
+      Id: 01TEST00000000000000000001
+      Verifies: 01REQ000000000000000000001
+      Verifies: 01REQ000000000000000000002
+      Verifies: 01REQ000000000000000000003
 `,
     },
   });
@@ -111,12 +111,12 @@ Deno.test("traceability e2e: Verifies points at a non-requirement → MSL-L004",
 
 - [TEST-0002] Another test
 
-  Id: 01TEST00000000000000000002\\
+      Id: 01TEST00000000000000000002
 
 - [TEST-0001] A test verifying the wrong type
 
-  Id: 01TEST00000000000000000001\\
-  Verifies: 01TEST00000000000000000002\\
+      Id: 01TEST00000000000000000001
+      Verifies: 01TEST00000000000000000002
 `,
     },
   });
@@ -133,16 +133,16 @@ Deno.test("traceability e2e: comma-separated Verifies is split by Stage 2.5", as
 
 - [REQ-0001] First
 
-  Id: 01REQ000000000000000000001\\
+      Id: 01REQ000000000000000000001
 
 - [REQ-0002] Second
 
-  Id: 01REQ000000000000000000002\\
+      Id: 01REQ000000000000000000002
 
 - [TEST-0001] A test verifying two reqs via CSV syntax
 
-  Id: 01TEST00000000000000000001\\
-  Verifies: 01REQ000000000000000000001, 01REQ000000000000000000002\\
+      Id: 01TEST00000000000000000001
+      Verifies: 01REQ000000000000000000001, 01REQ000000000000000000002
 `,
     },
   });
@@ -161,7 +161,7 @@ Deno.test("traceability e2e: no profile → Stage 4 silent", async () => {
 
 - [TEST-0001] A test
 
-  Id: 01TEST00000000000000000001\\
+      Id: 01TEST00000000000000000001
 `,
     },
   });

--- a/tests/e2e/profile_types_test.ts
+++ b/tests/e2e/profile_types_test.ts
@@ -34,7 +34,7 @@ Deno.test("profile types e2e: entry matching REQ pattern classifies cleanly", as
 
 - [REQ-0001] A requirement
 
-  Id: 01HGW2Q8MNP3RSTVWXYZABCDEF\\
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
 `,
     },
   });
@@ -53,7 +53,7 @@ Deno.test("profile types e2e: un-classified entry emits MSL-T003", async () => {
 
 - [FOO-001] An entry with no matching type
 
-  Id: 01HGW2Q8MNP3RSTVWXYZABCDEF\\
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
 `,
     },
   });
@@ -71,8 +71,8 @@ Deno.test("profile types e2e: explicit Type: attribute overrides display-ID infe
 
 - [FOO-001] Explicitly typed as note
 
-  Id: 01HGW2Q8MNP3RSTVWXYZABCDEF\\
-  Type: note
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      Type: note
 `,
     },
   });
@@ -89,8 +89,8 @@ Deno.test("profile types e2e: explicit Type: unknown value emits MSL-T001", asyn
 
 - [REQ-0001] Unknown type
 
-  Id: 01HGW2Q8MNP3RSTVWXYZABCDEF\\
-  Type: bogus
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      Type: bogus
 `,
     },
   });
@@ -108,8 +108,8 @@ Deno.test("profile types e2e: pattern-enforcement=error + mismatch emits MSL-T00
 
 - [FOO-001] Requirement via explicit Type: but wrong display-ID form
 
-  Id: 01HGW2Q8MNP3RSTVWXYZABCDEF\\
-  Type: requirement
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      Type: requirement
 `,
     },
   });
@@ -125,7 +125,7 @@ Deno.test("profile types e2e: no .markspec.yaml — core-only mode, no MSL-T dia
 
 - [FOO-001] An entry
 
-  Id: 01HGW2Q8MNP3RSTVWXYZABCDEF\\
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
 `,
     },
   });

--- a/tests/e2e/query_test.ts
+++ b/tests/e2e/query_test.ts
@@ -19,9 +19,9 @@ const REQUIREMENTS = `# Requirements
 
   The sensor driver shall debounce raw inputs to eliminate electrical noise.
 
-  Id: SRS_01HGW2R9QLP4\\
-  Satisfies: SYS_BRK_0042\\
-  Labels: ASIL-B
+      Id: SRS_01HGW2R9QLP4
+      Satisfies: SYS_BRK_0042
+      Labels: ASIL-B
 `;
 
 // ---------------------------------------------------------------------------

--- a/tests/e2e/report_test.ts
+++ b/tests/e2e/report_test.ts
@@ -15,24 +15,24 @@ const FIXTURE = {
 
   Emergency braking.
 
-  Id: STK_01HGW2Q8MNP3\\
-  Labels: ASIL-B
+      Id: STK_01HGW2Q8MNP3
+      Labels: ASIL-B
 
 - [SYS_BRK_0042] System requirement
 
   Threat assessment.
 
-  Id: SYS_01HGW2R9QLP4\\
-  Satisfies: STK_BRK_0001\\
-  Labels: ASIL-B
+      Id: SYS_01HGW2R9QLP4
+      Satisfies: STK_BRK_0001
+      Labels: ASIL-B
 
 - [SRS_BRK_0001] Software requirement
 
   Sensor debouncing.
 
-  Id: SRS_01HGW2S0ABC5\\
-  Satisfies: SYS_BRK_0042\\
-  Labels: ASIL-B
+      Id: SRS_01HGW2S0ABC5
+      Satisfies: SYS_BRK_0042
+      Labels: ASIL-B
 `,
 };
 
@@ -103,8 +103,8 @@ Deno.test("report: --scope filters by domain", async () => {
 
   Body.
 
-  Id: SRS_01HGW2T1DEF6\\
-  Labels: ASIL-A
+      Id: SRS_01HGW2T1DEF6
+      Labels: ASIL-A
 `,
   };
   const { code, stdout } = await markspec(

--- a/tests/e2e/validate_test.ts
+++ b/tests/e2e/validate_test.ts
@@ -20,8 +20,8 @@ Deno.test("validate: valid file exits 0", async () => {
 
   Body text.
 
-  Id: 01HGW2Q8MNP3RSTVWXYZABCDEF\\
-  Labels: ASIL-B
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      Labels: ASIL-B
 `,
     },
   });
@@ -59,9 +59,9 @@ Deno.test("validate: unresolved References citation exits 1 (MSL-T005)", async (
 
   Body text.
 
-  Id: 01HGW2Q8MNP3RSTVWXYZABCDEF\\
-  References: UNKNOWN-STANDARD\\
-  Labels: ASIL-B
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      References: UNKNOWN-STANDARD
+      Labels: ASIL-B
 `,
     },
   });
@@ -83,9 +83,9 @@ Deno.test("validate: warning only exits 2", async () => {
 
   Body text.
 
-  Id: 01HGW2Q8MNP3RSTVWXYZABCDEF\\
-  CustomKey: some value\\
-  Labels: ASIL-B
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      CustomKey: some value
+      Labels: ASIL-B
 `,
     },
   });
@@ -107,9 +107,9 @@ Deno.test("validate: --strict promotes warning to error → exit 1", async () =>
 
   Body text.
 
-  Id: 01HGW2Q8MNP3RSTVWXYZABCDEF\\
-  CustomKey: some value\\
-  Labels: ASIL-B
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      CustomKey: some value
+      Labels: ASIL-B
 `,
     },
   });

--- a/tests/fixtures/in-code-kotlin.kt
+++ b/tests/fixtures/in-code-kotlin.kt
@@ -12,9 +12,9 @@
  *   Then the output shall remain 500
  * ```
  *
- * Id: SRS_01HGW2Q8MNP3 \
- * Satisfies: SYS_BRK_0042 \
- * Labels: ASIL-B
+ *     Id: SRS_01HGW2Q8MNP3
+ *     Satisfies: SYS_BRK_0042
+ *     Labels: ASIL-B
  */
 @Test
 fun `swt_brk_0001 debounce filters noise`() {

--- a/tests/fixtures/in-code-rust.rs
+++ b/tests/fixtures/in-code-rust.rs
@@ -17,9 +17,9 @@
 ///   Then the output shall change to 600
 /// ```
 ///
-/// Id: SRS_01HGW2Q8MNP3 \
-/// Satisfies: SYS_BRK_0042 \
-/// Labels: ASIL-B
+///     Id: SRS_01HGW2Q8MNP3
+///     Satisfies: SYS_BRK_0042
+///     Labels: ASIL-B
 #[test]
 fn swt_brk_0001_debounce_filters_noise() {
     // test implementation

--- a/tests/fixtures/requirement-block.md
+++ b/tests/fixtures/requirement-block.md
@@ -12,15 +12,15 @@
   > [!WARNING]
   > Failure to debounce may lead to spurious brake activation.
 
-  Id: SRS_01HGW2Q8MNP3\
-  Satisfies: SYS_BRK_0042\
-  Labels: ASIL-B
+      Id: SRS_01HGW2Q8MNP3
+      Satisfies: SYS_BRK_0042
+      Labels: ASIL-B
 
 - [SRS_BRK_0002] Sensor plausibility check
 
   The sensor driver shall reject readings outside the physically plausible range
   for each sensor type.
 
-  Id: SRS_01HGW2R9QLP4\
-  Satisfies: SYS_BRK_0042\
-  Labels: ASIL-B
+      Id: SRS_01HGW2R9QLP4
+      Satisfies: SYS_BRK_0042
+      Labels: ASIL-B


### PR DESCRIPTION
## Summary

- Switch the entry attribute block from `Key: Value\` paragraph (trailing-backslash hard line breaks) to a 4-space indented code block. One canonical form, no compact variant. Trade-off analysis: [docs/superpowers/specs/2026-05-10-attribute-block-syntax-design.md](docs/superpowers/specs/2026-05-10-attribute-block-syntax-design.md).
- Parser is shape-agnostic by construction and accepts both during the transition. Legacy paragraph + `\` shape now emits `MSL-DEPRECATED-ATTR-001`; `markspec format` rewrites legacy files to the canonical form losslessly.
- Migrates `language.md` §2 + `ast.md`, all test fixtures, project STK/SAD docs, `docs/examples/`, AGENTS.md V-model samples, ADR / guide / template illustrative examples, and the cheatsheet. Removes the orphan metadata header (`Status:`/`Date:`/`Scope:`) from ADR files.

## Test plan

- [ ] CI green (lint + tests + type-check + dprint)
- [ ] `just build` passes locally
- [ ] Open a `.md` file in VSCode and confirm the LSP block-scaffold snippet inserts the new shape (indented code block, no `\`)
- [ ] Author a file with legacy `Id: ...\` form, run `markspec validate`, confirm `MSL-DEPRECATED-ATTR-001` warning fires
- [ ] Run `markspec format` on the same file, confirm output uses the new indented-code form, re-validate produces no deprecation warning
- [ ] Spot-check a rendered PDF (`markspec doc build docs/product/stakeholder-requirements.md`)

Generated with Claude Code
