### PR TITLE
feat(mcp): register MCP server in VS Code extension alongside LSP

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -25,5 +25,13 @@
     "${workspaceFolder}/packages/markspec/main.ts",
     "lsp"
   ],
+  "markspec.mcp.args": [
+    "run",
+    "--allow-read",
+    "--allow-env",
+    "--allow-run",
+    "${workspaceFolder}/packages/markspec/main.ts",
+    "mcp"
+  ],
   "markspec.trace.server": "verbose"
 }

--- a/docs/guide/commands.md
+++ b/docs/guide/commands.md
@@ -315,7 +315,12 @@ claude mcp add markspec --command markspec --args mcp --cwd /path/to/project
 
 #### VS Code (Copilot)
 
-In your project's `.vscode/mcp.json`:
+The `markspec-ide` extension auto-registers the MarkSpec MCP server with VS Code
+1.101+ — install the extension and the server appears in Copilot's MCP picker.
+See [Editor integration — VS Code](editor-integration.md#vs-code).
+
+For users who don't run the extension, the manual recipe still works. Add a
+`.vscode/mcp.json` in your project:
 
 ```json
 {

--- a/docs/guide/editor-integration.md
+++ b/docs/guide/editor-integration.md
@@ -30,7 +30,17 @@ interfere with your language's native LSP (rust-analyzer, kotlin-lsp, etc.).
 ## VS Code
 
 Install the **MarkSpec** extension from the `editors/vscode/` directory in this
-repository.
+repository. The extension requires VS Code **1.101 or newer** (the version that
+introduced the stable MCP extension API).
+
+The extension provides two integrations in one install:
+
+- **LSP** — diagnostics, completions, and entry-block scaffolding in the editor.
+- **MCP** — registers a `markspec` MCP server with VS Code so Copilot (and any
+  other MCP-aware client) can use the project's resources and tools without a
+  separate `.vscode/mcp.json`.
+
+Both point at the same `markspec` binary, resolved from `markspec.server.path`.
 
 ### From source
 
@@ -50,11 +60,13 @@ code --extensionDevelopmentPath=editors/vscode
 
 ### Configuration
 
-| Setting                 | Default      | Description                                   |
-| ----------------------- | ------------ | --------------------------------------------- |
-| `markspec.server.path`  | `"markspec"` | Path to the `markspec` binary.                |
-| `markspec.server.args`  | `["lsp"]`    | Arguments passed to start the LSP server.     |
-| `markspec.trace.server` | `"off"`      | Trace level: `off`, `messages`, or `verbose`. |
+| Setting                 | Default      | Description                                               |
+| ----------------------- | ------------ | --------------------------------------------------------- |
+| `markspec.server.path`  | `"markspec"` | Path to the `markspec` binary (used by both LSP and MCP). |
+| `markspec.server.args`  | `["lsp"]`    | Arguments passed to start the LSP server.                 |
+| `markspec.mcp.enabled`  | `true`       | Register the MarkSpec MCP server with VS Code.            |
+| `markspec.mcp.args`     | `["mcp"]`    | Arguments passed to start the MCP server.                 |
+| `markspec.trace.server` | `"off"`      | Trace level: `off`, `messages`, or `verbose`.             |
 
 If `markspec` is not on your PATH, set the full path:
 
@@ -63,6 +75,22 @@ If `markspec` is not on your PATH, set the full path:
   "markspec.server.path": "/home/you/.local/bin/markspec"
 }
 ```
+
+### MCP server
+
+Once the extension is installed, the **MarkSpec** MCP server appears in
+Copilot's MCP picker — no `.vscode/mcp.json` required. To disable the
+registration:
+
+```json
+{
+  "markspec.mcp.enabled": false
+}
+```
+
+The manual `.vscode/mcp.json` recipe in
+[Commands — `mcp` § VS Code (Copilot)](commands.md#vs-code-copilot) remains
+supported for editors that don't run the extension.
 
 ## Neovim
 

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -13,12 +13,12 @@
       },
       "devDependencies": {
         "@types/node": "^20.19.39",
-        "@types/vscode": "^1.82.0",
+        "@types/vscode": "^1.101.0",
         "@vscode/vsce": "^3.0.0",
         "typescript": "^5.5.0"
       },
       "engines": {
-        "vscode": "^1.82.0"
+        "vscode": "^1.101.0"
       }
     },
     "node_modules/@azu/format-text": {

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -11,7 +11,7 @@
     "directory": "editors/vscode"
   },
   "engines": {
-    "vscode": "^1.82.0"
+    "vscode": "^1.101.0"
   },
   "categories": [
     "Programming Languages",
@@ -37,13 +37,19 @@
         "category": "MarkSpec"
       }
     ],
+    "mcpServerDefinitionProviders": [
+      {
+        "id": "markspec",
+        "label": "MarkSpec"
+      }
+    ],
     "configuration": {
       "title": "MarkSpec",
       "properties": {
         "markspec.server.path": {
           "type": "string",
           "default": "markspec",
-          "description": "Path to the markspec binary. Defaults to 'markspec' on PATH."
+          "description": "Path to the markspec binary. Defaults to 'markspec' on PATH. Used by both the LSP client and the MCP server registration."
         },
         "markspec.server.args": {
           "type": "array",
@@ -61,6 +67,17 @@
           "type": "string",
           "default": "",
           "description": "Path to a writable file for LSP server lifecycle and crash logging. Empty means disabled. Equivalent to setting MARKSPEC_LSP_DEBUG_LOG when spawning the server manually."
+        },
+        "markspec.mcp.enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Register the MarkSpec MCP server with VS Code so Copilot (and other MCP-aware clients) can use it. Disable to remove the registration."
+        },
+        "markspec.mcp.args": {
+          "type": "array",
+          "items": { "type": "string" },
+          "default": ["mcp"],
+          "description": "Arguments passed to the markspec binary to start the MCP server. Mirrors 'markspec.server.args' but for the MCP subcommand."
         }
       }
     }
@@ -71,14 +88,14 @@
     "bundle": "deno run --config ../../deno.json --allow-read --allow-write scripts/bundleBinary.ts",
     "package": "npm run bundle && vsce package",
     "lint": "eslint src",
-    "test": "tsc -p tsconfig.json && node --require ./out/test-setup.js --test out/serverOptions.test.js"
+    "test": "tsc -p tsconfig.json && node --require ./out/test-setup.js --test out/serverOptions.test.js out/mcpDefinition.test.js"
   },
   "dependencies": {
     "vscode-languageclient": "^9.0.1"
   },
   "devDependencies": {
     "@types/node": "^20.19.39",
-    "@types/vscode": "^1.82.0",
+    "@types/vscode": "^1.101.0",
     "@vscode/vsce": "^3.0.0",
     "typescript": "^5.5.0"
   }

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -3,12 +3,20 @@
  *
  * Thin LSP client. Spawns the markspec LSP server (bundled binary by default,
  * or a configured deno + source path for dev mode) and connects it to VS Code.
+ *
+ * Also registers the markspec MCP server with VS Code (1.101+) so Copilot
+ * and other MCP-aware clients see the same binary as the LSP — no
+ * separate `.vscode/mcp.json` required.
  */
 
 import {
   commands,
+  EventEmitter,
   type ExtensionContext,
+  lm,
+  McpStdioServerDefinition,
   type OutputChannel,
+  Uri,
   window,
   workspace,
 } from "vscode";
@@ -18,10 +26,20 @@ import {
   type LanguageClientOptions,
 } from "vscode-languageclient/node";
 import { resolveServerOptions } from "./serverOptions";
+import { resolveMcpDefinition } from "./mcpDefinition";
 import { createStatusBar } from "./statusBar";
 
 let client: LanguageClient | undefined;
 let outputChannel: OutputChannel | undefined;
+
+const MCP_PROVIDER_ID = "markspec";
+
+/** Setting keys whose changes invalidate the MCP definition. */
+const MCP_SETTING_KEYS = [
+  "markspec.mcp.enabled",
+  "markspec.mcp.args",
+  "markspec.server.path",
+];
 
 export function activate(context: ExtensionContext): void {
   const config = workspace.getConfiguration("markspec");
@@ -76,11 +94,71 @@ export function activate(context: ExtensionContext): void {
 
   createStatusBar(context, client);
 
+  registerMcpProvider(context);
+
   context.subscriptions.push({
     dispose: () => {
       client?.stop();
     },
   });
+}
+
+/**
+ * Register the MarkSpec MCP server definition provider with VS Code.
+ *
+ * Uses the stable `vscode.lm.registerMcpServerDefinitionProvider` API
+ * (VS Code 1.101+, June 2025). The provider returns a single stdio
+ * definition that spawns the same binary as the LSP client.
+ *
+ * Changes to `markspec.mcp.*` or `markspec.server.path` settings fire the
+ * `didChange` event so VS Code re-queries the provider.
+ */
+function registerMcpProvider(context: ExtensionContext): void {
+  const didChange = new EventEmitter<void>();
+  context.subscriptions.push(didChange);
+
+  context.subscriptions.push(
+    workspace.onDidChangeConfiguration((event) => {
+      if (MCP_SETTING_KEYS.some((key) => event.affectsConfiguration(key))) {
+        didChange.fire();
+      }
+    }),
+  );
+
+  context.subscriptions.push(
+    lm.registerMcpServerDefinitionProvider(MCP_PROVIDER_ID, {
+      onDidChangeMcpServerDefinitions: didChange.event,
+      provideMcpServerDefinitions: () => {
+        const cfg = workspace.getConfiguration("markspec");
+        const workspaceFolder = workspace.workspaceFolders?.[0]?.uri.fsPath;
+        const resolved = resolveMcpDefinition({
+          extensionPath: context.extensionPath,
+          workspaceFolder,
+          enabled: cfg.get<boolean>("mcp.enabled", true),
+          configuredServerPath: cfg.get<string>("server.path") || undefined,
+          configuredMcpArgs: cfg.get<string[]>("mcp.args"),
+          platform: process.platform,
+          extensionVersion: extensionVersion(context),
+        });
+        if (!resolved) return [];
+        const def = new McpStdioServerDefinition(
+          resolved.label,
+          resolved.command,
+          [...resolved.args],
+          {},
+          resolved.version,
+        );
+        if (resolved.cwd) def.cwd = Uri.file(resolved.cwd);
+        return [def];
+      },
+    }),
+  );
+}
+
+/** Best-effort extension version lookup; falls back to "0.0.0". */
+function extensionVersion(context: ExtensionContext): string {
+  const pkg = (context.extension?.packageJSON ?? {}) as { version?: string };
+  return pkg.version ?? "0.0.0";
 }
 
 export function deactivate(): Thenable<void> | undefined {

--- a/editors/vscode/src/mcpDefinition.test.ts
+++ b/editors/vscode/src/mcpDefinition.test.ts
@@ -1,0 +1,124 @@
+import { test } from "node:test";
+import { strict as assert } from "node:assert";
+import * as path from "node:path";
+import { resolveMcpDefinition } from "./mcpDefinition";
+
+const EXT_PATH = "/fake/extensions/driftsys.markspec-ide-0.5.0";
+const WORKSPACE = "/fake/workspace/markspec";
+const VERSION = "0.5.0";
+
+function base() {
+  return {
+    extensionPath: EXT_PATH,
+    workspaceFolder: WORKSPACE,
+    enabled: true,
+    configuredServerPath: undefined,
+    configuredMcpArgs: undefined,
+    platform: "linux" as NodeJS.Platform,
+    extensionVersion: VERSION,
+  };
+}
+
+test("resolveMcpDefinition: bundled binary by default (linux)", () => {
+  const def = resolveMcpDefinition(base());
+  assert.ok(def, "expected a definition");
+  assert.equal(def!.command, path.join(EXT_PATH, "bin", "markspec"));
+  assert.deepEqual(def!.args, ["mcp"]);
+  assert.equal(def!.cwd, WORKSPACE);
+  assert.equal(def!.label, "MarkSpec");
+  assert.equal(def!.version, VERSION);
+});
+
+test("resolveMcpDefinition: bundled binary uses .exe on win32", () => {
+  const def = resolveMcpDefinition({ ...base(), platform: "win32" });
+  assert.ok(def);
+  assert.equal(def!.command, path.join(EXT_PATH, "bin", "markspec.exe"));
+});
+
+test("resolveMcpDefinition: configured path overrides bundled binary", () => {
+  const def = resolveMcpDefinition({
+    ...base(),
+    configuredServerPath: "/usr/local/bin/markspec",
+  });
+  assert.ok(def);
+  assert.equal(def!.command, "/usr/local/bin/markspec");
+  assert.deepEqual(def!.args, ["mcp"]);
+});
+
+test("resolveMcpDefinition: dev-mode deno path with custom mcp args", () => {
+  const def = resolveMcpDefinition({
+    ...base(),
+    configuredServerPath: "deno",
+    configuredMcpArgs: [
+      "run",
+      "--allow-read",
+      "${workspaceFolder}/packages/markspec/main.ts",
+      "mcp",
+    ],
+  });
+  assert.ok(def);
+  assert.equal(def!.command, "deno");
+  assert.deepEqual(def!.args, [
+    "run",
+    "--allow-read",
+    `${WORKSPACE}/packages/markspec/main.ts`,
+    "mcp",
+  ]);
+});
+
+test("resolveMcpDefinition: custom args work with bundled binary too", () => {
+  const def = resolveMcpDefinition({
+    ...base(),
+    configuredMcpArgs: ["mcp", "--verbose"],
+  });
+  assert.ok(def);
+  assert.equal(def!.command, path.join(EXT_PATH, "bin", "markspec"));
+  assert.deepEqual(def!.args, ["mcp", "--verbose"]);
+});
+
+test("resolveMcpDefinition: ${workspaceFolder} is expanded in args", () => {
+  const def = resolveMcpDefinition({
+    ...base(),
+    configuredServerPath: "deno",
+    configuredMcpArgs: ["run", "${workspaceFolder}/main.ts", "mcp"],
+  });
+  assert.ok(def);
+  assert.deepEqual(def!.args, ["run", `${WORKSPACE}/main.ts`, "mcp"]);
+});
+
+test("resolveMcpDefinition: returns undefined when disabled", () => {
+  const def = resolveMcpDefinition({ ...base(), enabled: false });
+  assert.equal(def, undefined);
+});
+
+test("resolveMcpDefinition: disabled wins over configured path", () => {
+  const def = resolveMcpDefinition({
+    ...base(),
+    enabled: false,
+    configuredServerPath: "/usr/local/bin/markspec",
+    configuredMcpArgs: ["mcp"],
+  });
+  assert.equal(def, undefined);
+});
+
+test("resolveMcpDefinition: configured path with empty args defaults to ['mcp']", () => {
+  const def = resolveMcpDefinition({
+    ...base(),
+    configuredServerPath: "/usr/local/bin/markspec",
+    configuredMcpArgs: undefined,
+  });
+  assert.ok(def);
+  assert.deepEqual(def!.args, ["mcp"]);
+});
+
+test("resolveMcpDefinition: workspaceFolder undefined leaves variables untouched", () => {
+  const def = resolveMcpDefinition({
+    ...base(),
+    workspaceFolder: undefined,
+    configuredServerPath: "deno",
+    configuredMcpArgs: ["run", "${workspaceFolder}/main.ts", "mcp"],
+  });
+  assert.ok(def);
+  assert.equal(def!.cwd, undefined);
+  assert.deepEqual(def!.args, ["run", "${workspaceFolder}/main.ts", "mcp"]);
+});

--- a/editors/vscode/src/mcpDefinition.ts
+++ b/editors/vscode/src/mcpDefinition.ts
@@ -1,0 +1,96 @@
+/**
+ * @module mcpDefinition
+ *
+ * Builds the spawn arguments for the MarkSpec MCP server. Pure functions —
+ * no `vscode` API access — so this module is unit-testable.
+ *
+ * The extension calls `resolveMcpDefinition` from its
+ * `provideMcpServerDefinitions` callback and constructs an
+ * `McpStdioServerDefinition` from the returned shape. The resolver mirrors
+ * `resolveServerOptions` so `markspec.server.path` redirects both the LSP
+ * client and the MCP definition to the same binary.
+ */
+
+import * as path from "node:path";
+import { expandVariables } from "./serverOptions";
+
+export interface ResolveMcpInput {
+  /** Absolute path to the unpacked extension directory. */
+  readonly extensionPath: string;
+  /** Absolute path to the active VS Code workspace folder, if any. */
+  readonly workspaceFolder: string | undefined;
+  /** Value of `markspec.mcp.enabled` setting. */
+  readonly enabled: boolean;
+  /** Value of `markspec.server.path` setting, or undefined. */
+  readonly configuredServerPath: string | undefined;
+  /** Value of `markspec.mcp.args` setting, or undefined. */
+  readonly configuredMcpArgs: readonly string[] | undefined;
+  /** Platform identifier for naming the bundled binary. */
+  readonly platform: NodeJS.Platform;
+  /** Extension version string, surfaced to VS Code as the server version. */
+  readonly extensionVersion: string;
+}
+
+/**
+ * Plain data shape describing a resolved MCP stdio server. The extension
+ * wraps this in `vscode.McpStdioServerDefinition`. Kept as a data record
+ * so unit tests can run outside the VS Code extension host.
+ */
+export interface ResolvedMcpDefinition {
+  readonly label: string;
+  readonly command: string;
+  readonly args: readonly string[];
+  readonly cwd: string | undefined;
+  readonly version: string;
+}
+
+/** Default label shown in the MCP server picker. */
+const DEFAULT_LABEL = "MarkSpec";
+
+/**
+ * Compute the spawn `command` and `args` for the MCP server.
+ *
+ * Returns `undefined` when the user has disabled MCP via
+ * `markspec.mcp.enabled = false`. Otherwise mirrors `resolveServerOptions`:
+ * if `markspec.server.path` is set, use it (developer / configured mode);
+ * otherwise fall back to the bundled binary at
+ * `<extensionPath>/bin/markspec(.exe)`.
+ *
+ * `${workspaceFolder}` is substituted in `configuredMcpArgs`.
+ */
+export function resolveMcpDefinition(
+  input: ResolveMcpInput,
+): ResolvedMcpDefinition | undefined {
+  if (!input.enabled) return undefined;
+
+  const { command, args } = resolveCommand(input);
+
+  return {
+    label: DEFAULT_LABEL,
+    command,
+    args,
+    cwd: input.workspaceFolder,
+    version: input.extensionVersion,
+  };
+}
+
+function resolveCommand(
+  input: ResolveMcpInput,
+): { command: string; args: string[] } {
+  if (input.configuredServerPath) {
+    return {
+      command: input.configuredServerPath,
+      args: expandVariables(
+        input.configuredMcpArgs ?? ["mcp"],
+        input.workspaceFolder,
+      ),
+    };
+  }
+  const binaryName = input.platform === "win32" ? "markspec.exe" : "markspec";
+  return {
+    command: path.join(input.extensionPath, "bin", binaryName),
+    args: input.configuredMcpArgs
+      ? expandVariables(input.configuredMcpArgs, input.workspaceFolder)
+      : ["mcp"],
+  };
+}


### PR DESCRIPTION
Closes #268.

## Summary

- Register the MarkSpec MCP server with VS Code so installing the
  `markspec-ide` VSIX gives users both LSP and MCP (Copilot-accessible)
  in one step, no `.vscode/mcp.json` required.
- Both LSP and MCP pipelines spawn the same binary, resolved by the
  existing `markspec.server.path` — pointing one redirects both.
- New settings: `markspec.mcp.enabled` (toggle) and `markspec.mcp.args`
  (spawn args override), mirroring the existing `markspec.server.args`.
- Bump `engines.vscode` (and `@types/vscode`) to `^1.101.0`.

## API choice

Used `vscode.lm.registerMcpServerDefinitionProvider` (programmatic, stable
in VS Code 1.101 — June 2025) paired with the required
`contributes.mcpServerDefinitionProviders` package.json contribution
point. Both are needed: the contribution declares the provider id, the
programmatic call supplies the actual definition.

Programmatic registration was the right choice because the resolver
needs to:

- read live config (`markspec.server.path`, `markspec.mcp.*`),
- run `${workspaceFolder}` substitution against the active folder,
- fire `onDidChangeMcpServerDefinitions` when settings change so VS Code
  re-queries the provider without a reload.

A purely declarative contribution point wouldn't support live config
reuse with the LSP client.

## Module shape

`editors/vscode/src/mcpDefinition.ts` exports a pure
`resolveMcpDefinition(input)` function mirroring `resolveServerOptions`.
It returns a plain data record so the unit tests run outside the VS
Code extension host. `extension.ts` wraps the result in
`vscode.McpStdioServerDefinition` only at the API boundary.

## Test plan

- [x] `deno fmt --check` — passes
- [x] `dprint check` — passes
- [x] `deno lint` — passes
- [x] `deno task check` — type-check passes
- [x] `deno task test` — 776 passed / 0 failed
- [x] `editors/vscode` `npm test` — 18 passed / 0 failed (10 new
      `resolveMcpDefinition` tests covering bundled, configured,
      dev-mode, and disabled-by-setting paths)
- [x] `markdownlint-cli2` on changed docs — 0 errors
- [x] `scripts/check_tokens.sh` — passes
- [ ] **Manual smoke test (NOT performed in this environment)** —
      install the VSIX in a fresh VS Code 1.101+ profile, open a
      project, confirm Copilot lists the MarkSpec MCP server with no
      `.vscode/mcp.json`, then toggle `markspec.mcp.enabled` off and
      confirm it disappears. I cannot run VS Code from this sandbox;
      flagging explicitly so a reviewer can run this before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
