### PR TITLE
feat(mcp): teach agents discovery via server instructions and tool annotations

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -33,12 +33,16 @@
   },
   "test": {
     "exclude": [
-      "editors/"
+      "editors/",
+      ".worktrees/",
+      ".claude/worktrees/"
     ]
   },
   "lint": {
     "exclude": [
-      "editors/"
+      "editors/",
+      ".worktrees/",
+      ".claude/worktrees/"
     ]
   }
 }

--- a/packages/markspec/mcp/resources/mod.ts
+++ b/packages/markspec/mcp/resources/mod.ts
@@ -46,13 +46,15 @@ export async function listResourceDescriptors(
     {
       uri: PROFILE_URI,
       name: "Active profile",
-      description: "Distilled profile manifest for this project",
+      description:
+        "Distilled profile manifest: declared entry types, attribute definitions, link relations, validation rules. Read once to understand the project's domain vocabulary.",
       mimeType: "text/markdown",
     },
     {
       uri: ENTRIES_URI,
       name: "Entry index",
-      description: "All entries grouped by type",
+      description:
+        "All entries grouped by type. Read for an overview of a small project (<50 entries); for larger projects use the entry_search tool instead.",
       mimeType: "text/markdown",
     },
   ];

--- a/packages/markspec/mcp/server.ts
+++ b/packages/markspec/mcp/server.ts
@@ -19,6 +19,30 @@ import { registerTools } from "./tools/mod.ts";
 import { ENTRIES_URI, entryUri, PROFILE_URI } from "./uri.ts";
 
 /**
+ * Top-level guidance shown to MCP clients on `initialize`. Teaches the agent
+ * what this server is for, which surface to use for which intent, and what to
+ * avoid. Clients typically inject this into the system prompt once per
+ * session — keep it dense and stable.
+ */
+const SERVER_INSTRUCTIONS =
+  `MarkSpec exposes a project's requirements, specifications, and tests as a typed traceability graph. Use it to answer questions about entries, their relationships, and validation status.
+
+Pick the right surface per intent:
+- Find entries by keyword → entry_search tool (scales to thousands of entries; preferred discovery path)
+- Show one entry by display ID → resources/read markspec://entry/{displayId}
+- Walk upward from an entry to see what it satisfies → entry_context tool
+- See what depends on an entry → the "Incoming links" section in markspec://entry/{id}
+- Check project health (broken refs, duplicates, rule violations) → validate tool
+- Refresh after CLI/file edits → markspec_refresh tool
+
+Avoid:
+- Reading markspec://entries on projects with more than ~50 entries; use entry_search instead.
+- Calling markspec_refresh between back-to-back reads — MCP reads are cache-coherent within a session.
+- Using this server to edit entries. Writes are CLI-only (markspec format, markspec insert).
+
+All resource bodies are Markdown with cross-references as markspec:// URIs you can follow with resources/read.`;
+
+/**
  * Start the MarkSpec MCP server.
  *
  * Builds the project context, registers resources + tools, hooks the
@@ -34,6 +58,7 @@ export async function startServer(): Promise<void> {
         resources: { subscribe: true, listChanged: true },
         tools: { listChanged: false },
       },
+      instructions: SERVER_INSTRUCTIONS,
     },
   );
 

--- a/packages/markspec/mcp/tools/context.ts
+++ b/packages/markspec/mcp/tools/context.ts
@@ -104,6 +104,16 @@ export const ENTRY_CONTEXT_INPUT_SCHEMA = {
 export const ENTRY_CONTEXT_DESCRIPTOR = {
   name: "entry_context",
   description:
-    "Walk the satisfies chain upward from an entry. Returns a Markdown nested list.",
+    "Walk the satisfies-chain upward from one entry to discover what higher-level requirements it implements. Returns a nested Markdown list with markspec://entry/{id} links. " +
+    "Use to answer 'why does this entry exist' or 'what does this trace up to'. " +
+    "For the opposite direction (what depends on this entry), read markspec://entry/{id} and inspect its Incoming Links section. " +
+    "Depth defaults to 10; lower it (2–3) for quick orientation, raise it only when full transitive context is needed.",
   inputSchema: ENTRY_CONTEXT_INPUT_SCHEMA,
+  annotations: {
+    title: "Trace satisfies chain",
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
 };

--- a/packages/markspec/mcp/tools/refresh.ts
+++ b/packages/markspec/mcp/tools/refresh.ts
@@ -23,6 +23,16 @@ export const REFRESH_INPUT_SCHEMA = {
 export const REFRESH_DESCRIPTOR = {
   name: "markspec_refresh",
   description:
-    "Force-invalidate the MarkSpec compile cache. Use after editing files to guarantee subsequent reads see the new state.",
+    "Force-invalidate the MarkSpec compile cache so subsequent reads see fresh state. " +
+    "Use only after files were modified outside this MCP session (CLI commands, editor saves, git operations). " +
+    "Do NOT call between back-to-back reads — the cache is already coherent within a session. " +
+    "Returns a one-line confirmation with entry and link counts.",
   inputSchema: REFRESH_INPUT_SCHEMA,
+  annotations: {
+    title: "Refresh compile cache",
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
 };

--- a/packages/markspec/mcp/tools/search.ts
+++ b/packages/markspec/mcp/tools/search.ts
@@ -119,6 +119,16 @@ export const ENTRY_SEARCH_INPUT_SCHEMA = {
 export const ENTRY_SEARCH_DESCRIPTOR = {
   name: "entry_search",
   description:
-    "Search project entries by display ID and title. Returns ranked matches as Markdown links.",
+    "Find entries by keyword across display IDs and titles. Returns up to 100 ranked matches as Markdown links to markspec://entry/{id} resources. " +
+    "Use this for any 'find/search/list entries about X' query. " +
+    "Prefer over reading markspec://entries — search scales to thousands of entries; the full index does not. " +
+    "Limit: keep at 5–20 for broad exploratory queries, 50+ only when listing every match in a domain.",
   inputSchema: ENTRY_SEARCH_INPUT_SCHEMA,
+  annotations: {
+    title: "Search entries",
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
 };

--- a/packages/markspec/mcp/tools/validate.ts
+++ b/packages/markspec/mcp/tools/validate.ts
@@ -105,6 +105,16 @@ export const VALIDATE_INPUT_SCHEMA = {
 export const VALIDATE_DESCRIPTOR = {
   name: "validate",
   description:
-    "Run the MarkSpec validator. Optional 'files' filters diagnostics by source path.",
+    "Run the project's validation pipeline: broken cross-references, missing or duplicate IDs, malformed entries, and profile rule violations. Returns a Markdown report grouped by severity. " +
+    "Use after edits, before committing, or when an entry's relationships look wrong. " +
+    "Optional 'files' restricts diagnostics to a subset of paths (relative to the project root). " +
+    "An empty 'files' list means all files.",
   inputSchema: VALIDATE_INPUT_SCHEMA,
+  annotations: {
+    title: "Validate project",
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
 };

--- a/tests/e2e/mcp_test.ts
+++ b/tests/e2e/mcp_test.ts
@@ -161,6 +161,59 @@ Deno.test("mcp: initialize advertises resources and tools capabilities", async (
   }
 });
 
+Deno.test("mcp: initialize returns top-level instructions guiding agent use", async () => {
+  const { proc, cwd, initResponse } = await setup();
+  try {
+    // deno-lint-ignore no-explicit-any
+    const instructions = (initResponse.result as any).instructions as
+      | string
+      | undefined;
+    assertEquals(typeof instructions, "string");
+    assertStringIncludes(instructions!, "entry_search");
+    assertStringIncludes(instructions!, "markspec://entry/");
+  } finally {
+    await proc.close();
+    await Deno.remove(cwd, { recursive: true });
+  }
+});
+
+Deno.test("mcp: every tool advertises read-only annotations", async () => {
+  const { proc, cwd } = await setup();
+  try {
+    const resp = await proc.request("tools/list", {});
+    // deno-lint-ignore no-explicit-any
+    const tools = (resp.result as any).tools as Array<{
+      name: string;
+      annotations?: {
+        readOnlyHint?: boolean;
+        destructiveHint?: boolean;
+        idempotentHint?: boolean;
+        openWorldHint?: boolean;
+      };
+    }>;
+    for (const tool of tools) {
+      assertEquals(
+        tool.annotations?.readOnlyHint,
+        true,
+        `${tool.name} should declare readOnlyHint: true`,
+      );
+      assertEquals(
+        tool.annotations?.destructiveHint,
+        false,
+        `${tool.name} should declare destructiveHint: false`,
+      );
+      assertEquals(
+        tool.annotations?.openWorldHint,
+        false,
+        `${tool.name} should declare openWorldHint: false`,
+      );
+    }
+  } finally {
+    await proc.close();
+    await Deno.remove(cwd, { recursive: true });
+  }
+});
+
 Deno.test("mcp: tools/list returns all four tools", async () => {
   const { proc, cwd } = await setup();
   try {


### PR DESCRIPTION
## Summary

MCP clients had no top-level guidance about which surface to use for which intent, so agents would naively read `markspec://entries` (the full index) instead of using `entry_search`. At project scale this is the cliff between a usable MCP and a context-window blowout.

This PR adds three discovery primitives the MCP spec provides for free but the server wasn't using:

- **`instructions` field on `initialize`** — a top-level routing block injected once per session. Tells the agent: use `entry_search` for find/list queries; use `markspec://entry/{id}` for single-entry reads; use `entry_context` for traceability walks; avoid `markspec://entries` on projects >50 entries; don't call `markspec_refresh` between back-to-back reads.
- **`annotations` on every tool descriptor** — `readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`. Lets MCP clients decide auto-approve vs. confirmation flows without prompting the human.
- **Sharpened tool + resource descriptions** — each tool's `description` now states when to use, when not to use, and parameter tuning guidance. Resource descriptions for `markspec://profile` and `markspec://entries` steer agents toward `entry_search` once the project grows.

Also fixes a pre-existing repo hygiene issue: `deno test` and `deno lint` were walking into `.worktrees/` and `.claude/worktrees/` and surfacing stale errors from in-progress sibling worktrees. Adds them to the exclude lists in `deno.json`.

## Test plan

- [x] `just build` — 779 tests pass, 0 failures
- [x] `deno check`, `deno lint`, `dprint check`, commit-message lint — all green via pre-commit hooks
- [x] New e2e test: `mcp: initialize returns top-level instructions guiding agent use`
- [x] New e2e test: `mcp: every tool advertises read-only annotations`
- [x] Existing MCP e2e suite (9 tests) unchanged and passing

## Deferred (separate work)

- `resources/list` still enumerates every entry. The protocol-correct fix is to advertise `markspec://entry/{displayId}` as a `resourceTemplates` entry, keeping the list at 2 concrete resources. Bigger code change, not blocking.
- Entries index groups everything under `untyped (N)` because `entry.type` isn't populated by the profile resolver yet. Profile-resolver work is tracked separately and unblocks the type-grouped index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)