### PR TITLE
feat(core): Prompt-1 implementation — incremental TDD slices

### DIFF
--- a/packages/markspec/core/formatter/mod.ts
+++ b/packages/markspec/core/formatter/mod.ts
@@ -46,28 +46,75 @@ const FRONT_MATTER_CORE_ORDER: readonly string[] = [
 ];
 
 /**
- * Canonical attribute ordering per the language spec.
+ * Canonical trailer ordering per spec §3.3.2 (six-group rule).
  *
- * Identity (`Id:`) comes first, then profile-declared attributes appear in
- * the order the author wrote them (or in the order a profile-aware pass
- * may rewrite them), then the universal set
- * (References / Labels / External-id / Supersedes / Deprecated). Unknown
- * keys are placed just before `Labels:`, preserving their relative order.
+ * Groups, top → bottom:
+ *   1. Identity & classification — `Id`, `Type`, `Source`, `Origin`.
+ *   2. Reference-shape navigation — `Reference-document`, `Reference-url`.
+ *   3. Trace upstream relations — authored trace edges (`Part-of`,
+ *      `Derived-from`, `Satisfies`, …).
+ *   4. Type-specific data — payload attributes per concrete type
+ *      (`Schema-language`, `License`, `Manufacturer`, …).
+ *   5. Universal trailing — `References`, `External-id`, `Labels`,
+ *      `Supersedes`, `Deprecated`.
+ *   6. Profile-declared / unknown attributes — preserved in source order
+ *      at the bottom (§3.3.6: fmt never deletes a key it doesn't own).
  *
- * A profile-aware formatter may extend this with profile-declared canonical
- * positions; the core formatter only knows about `Id:` and the universal
- * set.
+ * Generated-origin attributes (`Superseded-by`, every inverse from ADR-003
+ * §Part 3) are stripped from this list; the formatter rejects them with
+ * MSL-A030 when found in source (current code keeps `Superseded-by:` to
+ * round-trip historical fixtures — that hardening lands in a later slice).
  */
 const CANONICAL_ORDER: readonly string[] = [
+  // Group 1 — identity & classification
   "Id",
-  // Profile-declared attributes land here in whatever order the source has
-  // them; the filler slot keeps them between Id and the universal set.
+  "Type",
+  "Source",
+  "Origin",
+  // Group 2 — reference-shape navigation
+  "Reference-document",
+  "Reference-url",
+  // Group 3 — trace upstream (authored relations)
+  "Part-of",
+  "Derived-from",
+  "Satisfies",
+  "Verifies",
+  "Tests",
+  "Realizes",
+  "Provides",
+  "Requires",
+  "Depends-on",
+  "Caused-by",
+  "Mitigated-by",
+  "Allocated-to",
+  "Affects",
+  // Group 4 — type-specific data
+  "Schema-language",
+  "License",
+  "Build-manifest",
+  "Package-manager",
+  "Manufacturer",
+  "Part-number",
+  "Datasheet",
+  "Bus-protocol",
+  "Connector-type",
+  "Voltage-level",
+  "Signal-direction",
+  "Symbol",
+  "Language",
+  "Footprint",
+  "Value",
+  "Aliases",
+  "See-also",
+  // Group 5 — universal trailing
   "References",
-  "Labels",
   "External-id",
+  "Labels",
   "Supersedes",
   "Superseded-by",
   "Deprecated",
+  // Group 6 — profile-declared / unknown keys are appended in source order
+  // after this list by sortAttributes().
 ];
 
 /** Options for {@linkcode format}. */
@@ -235,11 +282,11 @@ export function expandCsvValues(attrs: Attribute[]): Attribute[] {
 }
 
 /**
- * Sort attributes to canonical order per the language spec.
+ * Sort attributes to canonical trailer order per spec §3.3.2.
  *
- * `Id:` first, then profile-declared/unknown keys in source order, then
- * universal attributes (References / Labels / External-id / Supersedes /
- * Superseded-by / Deprecated).
+ * Known core keys appear in their {@linkcode CANONICAL_ORDER} slot.
+ * Unknown / profile-declared keys (group 6) are appended at the end in
+ * source order — `fmt` never deletes a key it doesn't own (§3.3.6).
  */
 export function sortAttributes(
   attributes: Attribute[],
@@ -259,24 +306,12 @@ export function sortAttributes(
   }
 
   const result: Attribute[] = [];
-  const labelsIdx = CANONICAL_ORDER.indexOf("Labels");
-  const hasLabels = known[labelsIdx] != null;
-
   for (let i = 0; i < known.length; i++) {
-    // Insert unknown attributes just before Labels (or at end if no Labels).
-    if (i === labelsIdx && hasLabels) {
-      result.push(...unknown);
-    }
     if (known[i] != null) {
       result.push(...known[i]!);
     }
   }
-
-  // If Labels was not present, unknown attrs go at the end.
-  if (!hasLabels) {
-    result.push(...unknown);
-  }
-
+  result.push(...unknown);
   return result;
 }
 

--- a/packages/markspec/core/model/mod.ts
+++ b/packages/markspec/core/model/mod.ts
@@ -58,6 +58,60 @@ export interface SourceLocation {
 }
 
 // ---------------------------------------------------------------------------
+// Core type taxonomy (ADR-003 §Part 1, spec §1.3)
+// ---------------------------------------------------------------------------
+
+/**
+ * Core abstract item types. Always valid as `Type:` values regardless of
+ * which profile is loaded (core-only mode included). Convention: TitleCase.
+ *
+ * - `Item` is the abstract root and serves as the bottom fallback in the
+ *   type-resolution chain (§1.3.1 step 8).
+ * - `Specification`, `Component`, `Unit` are abstract+concrete parents:
+ *   instantiable as direct fallbacks when no concrete subtype fits, and
+ *   roots for both core concrete subtypes and profile-declared extensions.
+ */
+export const CORE_ABSTRACT_TYPES = [
+  "Item",
+  "Specification",
+  "Component",
+  "Unit",
+] as const;
+
+/**
+ * Core concrete item types (ADR-003 §Part 1). Twelve subtypes plus three
+ * abstract+concrete parents from {@linkcode CORE_ABSTRACT_TYPES} make up
+ * the "15 concrete instantiable types" the spec describes.
+ */
+export const CORE_CONCRETE_TYPES = [
+  // Specification subtypes
+  "Requirement",
+  "Test",
+  "Contract",
+  "Record",
+  "Risk",
+  // Component subtypes
+  "SoftwareComponent",
+  "HardwareComponent",
+  "SoftwareInterface",
+  "HardwareInterface",
+  // Unit subtypes
+  "SoftwareUnit",
+  "HardwareUnit",
+  // Definition (standalone under Item)
+  "Definition",
+] as const;
+
+/**
+ * All core type names. Accepted as `Type:` values in core-only mode and
+ * when any profile is loaded. Profile-declared types extend this set.
+ */
+export const CORE_TYPES: ReadonlySet<string> = new Set<string>([
+  ...CORE_ABSTRACT_TYPES,
+  ...CORE_CONCRETE_TYPES,
+]);
+
+// ---------------------------------------------------------------------------
 // Attributes
 // ---------------------------------------------------------------------------
 

--- a/packages/markspec/core/validator/mod.ts
+++ b/packages/markspec/core/validator/mod.ts
@@ -16,6 +16,7 @@
 
 import type { Attribute, Diagnostic, Entry } from "../model/mod.ts";
 import {
+  attributeSpec,
   IDENTITY_KEY,
   ULID_RE,
   UNIVERSAL_ATTRIBUTE_KEYS,
@@ -141,11 +142,24 @@ function checkStructural(
       }
     }
 
-    // MSL-R010: Unknown attributes are warnings in the core. A
-    // profile-aware validator widens this check to include profile-declared
-    // attributes; until then, anything outside the universal set is
-    // unrecognized.
+    // MSL-A030 / MSL-R010 checks per attribute (§4.4 / §4.8).
     for (const attr of entry.rawAttributes) {
+      // MSL-A030: generated-origin attributes must not appear in source.
+      const spec = attributeSpec(attr.key);
+      if (spec?.origin === "generated") {
+        diagnostics.push({
+          code: "MSL-A030",
+          severity: "error",
+          message:
+            `${entry.displayId}: '${attr.key}' has generated origin and must not appear in source (computed at build time per ADR-003 §Part 3)`,
+          location: entry.location,
+        });
+        continue;
+      }
+      // MSL-R010: Unknown attributes are warnings in the core. A
+      // profile-aware validator widens this check to include profile-declared
+      // attributes; until then, anything outside the universal set is
+      // unrecognized.
       if (!UNIVERSAL_KEYS.has(attr.key) && attr.key !== "Type") {
         diagnostics.push({
           code: "MSL-R010",

--- a/packages/markspec/core/validator/pipeline.ts
+++ b/packages/markspec/core/validator/pipeline.ts
@@ -10,7 +10,11 @@
 
 import type { Diagnostic, EffectiveProfile, Entry } from "../model/mod.ts";
 import { validate } from "./mod.ts";
-import { classifyEntriesStage, validateCoreTypeAttribute } from "./types.ts";
+import {
+  classifyEntriesStage,
+  inferTypeFromDisplayIdShape,
+  validateCoreTypeAttribute,
+} from "./types.ts";
 import { effectiveScope, validateAttributesForEntry } from "./attributes.ts";
 import { normalizeListValues } from "./normalize.ts";
 import { validateTraceabilityForEntry } from "./traceability.ts";
@@ -59,8 +63,10 @@ export function runPipeline(
 
   // Stage 1.5 — core type-attribute check. Runs always (core-only mode
   // included) so unknown `Type:` values fail fast regardless of profile.
+  // Also covers late-stage display-ID-shape inference (step 8 → MSL-T021).
   for (const entry of entries) {
     diagnostics.push(...validateCoreTypeAttribute(entry, profile));
+    diagnostics.push(...inferTypeFromDisplayIdShape(entry));
   }
 
   // Stage 2 — classification (only when a profile is loaded).

--- a/packages/markspec/core/validator/pipeline.ts
+++ b/packages/markspec/core/validator/pipeline.ts
@@ -10,7 +10,7 @@
 
 import type { Diagnostic, EffectiveProfile, Entry } from "../model/mod.ts";
 import { validate } from "./mod.ts";
-import { classifyEntriesStage } from "./types.ts";
+import { classifyEntriesStage, validateCoreTypeAttribute } from "./types.ts";
 import { effectiveScope, validateAttributesForEntry } from "./attributes.ts";
 import { normalizeListValues } from "./normalize.ts";
 import { validateTraceabilityForEntry } from "./traceability.ts";
@@ -56,6 +56,12 @@ export function runPipeline(
       return !profileDeclaredAttrs.has(match[1]);
     });
   diagnostics.push(...filteredStage1);
+
+  // Stage 1.5 — core type-attribute check. Runs always (core-only mode
+  // included) so unknown `Type:` values fail fast regardless of profile.
+  for (const entry of entries) {
+    diagnostics.push(...validateCoreTypeAttribute(entry, profile));
+  }
 
   // Stage 2 — classification (only when a profile is loaded).
   let finalEntries: readonly Entry[] = entries;

--- a/packages/markspec/core/validator/types.ts
+++ b/packages/markspec/core/validator/types.ts
@@ -19,6 +19,14 @@ import { CORE_TYPES } from "../model/mod.ts";
 import { compileDisplayIdPattern } from "./pattern.ts";
 
 /**
+ * Profile-declared concrete-type naming convention (spec §1.3): lowercase
+ * alphanumeric with hyphens, starting with a letter. Used to distinguish a
+ * "looks like a profile type but no profile is loaded" diagnostic
+ * (MSL-T023) from a generic "unknown type" diagnostic (MSL-T020).
+ */
+const PROFILE_TYPE_NAME_RE = /^[a-z][a-z0-9]*(-[a-z0-9]+)*$/;
+
+/**
  * Validate the `Type:` attribute value against the core type taxonomy plus
  * any profile-declared types. Runs in every mode (with or without a loaded
  * profile) — see spec §1.3 and ADR-003 §Part 1.
@@ -26,6 +34,9 @@ import { compileDisplayIdPattern } from "./pattern.ts";
  * Emits:
  *   - `MSL-T020` when `Type:` is present but the value is neither a core
  *     abstract/concrete type nor a profile-declared type.
+ *   - `MSL-T023` when `Type:` matches the profile-declared naming convention
+ *     (lowercase-with-hyphens) but no profile is loaded — i.e., the value
+ *     is plausibly a profile type, just unreachable in core-only mode.
  */
 export function validateCoreTypeAttribute(
   entry: Entry,
@@ -35,6 +46,18 @@ export function validateCoreTypeAttribute(
   if (explicitType === undefined) return [];
   if (CORE_TYPES.has(explicitType)) return [];
   if (profile !== null && profile.types.has(explicitType)) return [];
+
+  // Core-only mode: distinguish "profile-only type" (T023) from "unknown" (T020).
+  if (profile === null && PROFILE_TYPE_NAME_RE.test(explicitType)) {
+    return [{
+      code: "MSL-T023",
+      severity: "error",
+      message: `${entry.displayId}: Type: '${explicitType}' looks like a ` +
+        `profile-declared type but no profile is loaded (core-only mode)`,
+      location: entry.location,
+    }];
+  }
+
   return [{
     code: "MSL-T020",
     severity: "error",

--- a/packages/markspec/core/validator/types.ts
+++ b/packages/markspec/core/validator/types.ts
@@ -27,6 +27,38 @@ import { compileDisplayIdPattern } from "./pattern.ts";
 const PROFILE_TYPE_NAME_RE = /^[a-z][a-z0-9]*(-[a-z0-9]+)*$/;
 
 /**
+ * Display-ID shape that infers Unit at chain step 8 (spec §1.3.1).
+ * Matches when the display ID carries a path-like separator (`::` for
+ * Rust/C++ symbol paths, `/` for filesystem-style hierarchies).
+ */
+const UNIT_DISPLAY_ID_RE = /(::|\/)/;
+
+/**
+ * Late-stage type inference per spec §1.3.1 step 8 (Authored shape).
+ *
+ * When no explicit `Type:` is present and the display ID carries a
+ * path-like separator, infer `Unit` and emit MSL-T021 as a warning so the
+ * author can promote the inferred type to an explicit declaration. This
+ * implements the narrowest slice of the spec's late-stage chain — the
+ * URI-scheme map (step 5), discriminating-attribute inference (step 6),
+ * and document-directive inference (step 7) land in later slices.
+ */
+export function inferTypeFromDisplayIdShape(
+  entry: Entry,
+): readonly Diagnostic[] {
+  if (entry.shape !== "identified") return [];
+  if (findExplicitTypeAttribute(entry) !== undefined) return [];
+  if (!UNIT_DISPLAY_ID_RE.test(entry.displayId)) return [];
+  return [{
+    code: "MSL-T021",
+    severity: "warning",
+    message: `${entry.displayId}: Type inferred as 'Unit' from display-ID ` +
+      `shape (late-stage inference); declare 'Type:' explicitly to silence`,
+    location: entry.location,
+  }];
+}
+
+/**
  * Validate the `Type:` attribute value against the core type taxonomy plus
  * any profile-declared types. Runs in every mode (with or without a loaded
  * profile) — see spec §1.3 and ADR-003 §Part 1.

--- a/packages/markspec/core/validator/types.ts
+++ b/packages/markspec/core/validator/types.ts
@@ -15,7 +15,34 @@ import type {
   Entry,
   ProvenancedMapEntry,
 } from "../model/mod.ts";
+import { CORE_TYPES } from "../model/mod.ts";
 import { compileDisplayIdPattern } from "./pattern.ts";
+
+/**
+ * Validate the `Type:` attribute value against the core type taxonomy plus
+ * any profile-declared types. Runs in every mode (with or without a loaded
+ * profile) — see spec §1.3 and ADR-003 §Part 1.
+ *
+ * Emits:
+ *   - `MSL-T020` when `Type:` is present but the value is neither a core
+ *     abstract/concrete type nor a profile-declared type.
+ */
+export function validateCoreTypeAttribute(
+  entry: Entry,
+  profile: EffectiveProfile | null,
+): readonly Diagnostic[] {
+  const explicitType = findExplicitTypeAttribute(entry);
+  if (explicitType === undefined) return [];
+  if (CORE_TYPES.has(explicitType)) return [];
+  if (profile !== null && profile.types.has(explicitType)) return [];
+  return [{
+    code: "MSL-T020",
+    severity: "error",
+    message: `${entry.displayId}: Type: '${explicitType}' is not a core type ` +
+      `or a profile-declared type`,
+    location: entry.location,
+  }];
+}
 
 /** Result of classifying a single entry. */
 export interface ClassifyResult {

--- a/tests/e2e/format_test.ts
+++ b/tests/e2e/format_test.ts
@@ -93,6 +93,40 @@ Deno.test("format: writes normalized attributes back to file", async () => {
 });
 
 // ---------------------------------------------------------------------------
+// Canonical trailer ordering — spec §3.3.2 six-group rule
+// ---------------------------------------------------------------------------
+
+Deno.test("format: trailer ordering follows §3.3.2 six-group rule", async () => {
+  const input = `# Test
+
+- [SRS_BRK_0001] Title
+
+  Body text.
+
+      Labels: ASIL-B
+      Satisfies: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      Type: Specification
+      Part-of: 01HGW2Q8MNP3RSTVWXYZABCDEG
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEH
+`;
+  const { code, readFile } = await runFormat({ "req.md": input });
+  assertEquals(code, 0);
+  const output = await readFile("req.md");
+
+  const trailerKeys = output
+    .split("\n")
+    .map((l) => l.trim())
+    .filter((l) => /^[A-Z][A-Za-z0-9-]*:\s/.test(l))
+    .map((l) => l.split(":")[0]);
+
+  assertEquals(
+    trailerKeys,
+    ["Id", "Type", "Part-of", "Satisfies", "Labels"],
+    "trailers must follow §3.3.2 order: Id/Type → trace-upstream → Labels",
+  );
+});
+
+// ---------------------------------------------------------------------------
 // ULID assignment
 // ---------------------------------------------------------------------------
 

--- a/tests/e2e/validate_test.ts
+++ b/tests/e2e/validate_test.ts
@@ -29,6 +29,47 @@ Deno.test("validate: valid file exits 0", async () => {
 });
 
 // ---------------------------------------------------------------------------
+// Core data model — core abstract types (ADR-003, spec §1.3)
+// ---------------------------------------------------------------------------
+
+Deno.test("validate: Type: Specification accepted in core-only mode", async () => {
+  const { code, stderr } = await markspec(["validate", "req.md"], {
+    files: {
+      "req.md": `# Test
+
+- [SRS_BRK_0001] Sensor debouncing
+
+  Body text.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      Type: Specification
+      Labels: ASIL-B
+`,
+    },
+  });
+  assertEquals(code, 0, `expected exit 0, got ${code}; stderr: ${stderr}`);
+});
+
+Deno.test("validate: unknown Type value rejected with MSL-T020 in core-only mode", async () => {
+  const { code, stderr } = await markspec(["validate", "req.md"], {
+    files: {
+      "req.md": `# Test
+
+- [SRS_BRK_0001] Sensor debouncing
+
+  Body text.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      Type: NotARealType
+`,
+    },
+  });
+  assertEquals(code, 1, `expected exit 1, got ${code}; stderr: ${stderr}`);
+  assertStringIncludes(stderr, "MSL-T020");
+  assertStringIncludes(stderr, "NotARealType");
+});
+
+// ---------------------------------------------------------------------------
 // Errors
 // ---------------------------------------------------------------------------
 

--- a/tests/e2e/validate_test.ts
+++ b/tests/e2e/validate_test.ts
@@ -50,6 +50,25 @@ Deno.test("validate: Type: Specification accepted in core-only mode", async () =
   assertEquals(code, 0, `expected exit 0, got ${code}; stderr: ${stderr}`);
 });
 
+Deno.test("validate: generated-origin attribute in source rejected with MSL-A030", async () => {
+  const { code, stderr } = await markspec(["validate", "req.md"], {
+    files: {
+      "req.md": `# Test
+
+- [SRS_BRK_0001] Title
+
+  Body text.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      Superseded-by: 01HGW2Q8MNP3RSTVWXYZABCDEG
+`,
+    },
+  });
+  assertEquals(code, 1, `expected exit 1, got ${code}; stderr: ${stderr}`);
+  assertStringIncludes(stderr, "MSL-A030");
+  assertStringIncludes(stderr, "Superseded-by");
+});
+
 Deno.test("validate: unknown Type value rejected with MSL-T020 in core-only mode", async () => {
   const { code, stderr } = await markspec(["validate", "req.md"], {
     files: {

--- a/tests/e2e/validate_test.ts
+++ b/tests/e2e/validate_test.ts
@@ -69,6 +69,27 @@ Deno.test("validate: generated-origin attribute in source rejected with MSL-A030
   assertStringIncludes(stderr, "Superseded-by");
 });
 
+Deno.test("validate: display-ID containing :: emits MSL-T021 inference warning", async () => {
+  const { code, stderr } = await markspec(["validate", "req.md"], {
+    files: {
+      "req.md": `# Test
+
+- [braking::controller::debounce] Debounce function
+
+  Body text.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+`,
+    },
+  });
+  assertEquals(
+    code,
+    2,
+    `expected exit 2 (warning), got ${code}; stderr: ${stderr}`,
+  );
+  assertStringIncludes(stderr, "MSL-T021");
+});
+
 Deno.test("validate: lowercase Type: in core-only mode rejected with MSL-T023", async () => {
   const { code, stderr } = await markspec(["validate", "req.md"], {
     files: {

--- a/tests/e2e/validate_test.ts
+++ b/tests/e2e/validate_test.ts
@@ -69,6 +69,25 @@ Deno.test("validate: generated-origin attribute in source rejected with MSL-A030
   assertStringIncludes(stderr, "Superseded-by");
 });
 
+Deno.test("validate: lowercase Type: in core-only mode rejected with MSL-T023", async () => {
+  const { code, stderr } = await markspec(["validate", "req.md"], {
+    files: {
+      "req.md": `# Test
+
+- [SRS_BRK_0001] Title
+
+  Body text.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      Type: requirement
+`,
+    },
+  });
+  assertEquals(code, 1, `expected exit 1, got ${code}; stderr: ${stderr}`);
+  assertStringIncludes(stderr, "MSL-T023");
+  assertStringIncludes(stderr, "requirement");
+});
+
 Deno.test("validate: unknown Type value rejected with MSL-T020 in core-only mode", async () => {
   const { code, stderr } = await markspec(["validate", "req.md"], {
     files: {


### PR DESCRIPTION
## Summary

First implementation PR against the spec landed in #271 (`docs/specs/markspec-core-data-model.md`). Five small TDD slices, each `just check`-clean on its own, each traceable to a specific section of the spec. Scope: type-attribute validation + canonical trailer ordering.

| Commit | Slice | Spec anchor |
|---|---|---|
| `0453858` | Recognise 16-type core taxonomy in `Type:` validation | §1.3, ADR-003 §Part 1 |
| `b783c39` | Canonical trailer ordering — 6-group rule | §3.3.2, §3.3.6 |
| `15acf22` | Reject generated-origin attrs in source — MSL-A030 | §4.4, ADR-003 §Part 3 |
| `75cc7ab` | MSL-T023 for profile-shaped `Type:` in core-only mode | §1.3.2, §4.3 |
| `5e2faa9` | MSL-T021 late-stage Type inference from display-ID shape | §1.3.1 step 8, §4.3 |

## What's enforced after this PR

- **Core type taxonomy.** Sixteen built-in type names (4 abstract + 12 concrete) are accepted as `Type:` values in core-only mode and when any profile is loaded. The constants live in `core/model/mod.ts` as `CORE_ABSTRACT_TYPES`, `CORE_CONCRETE_TYPES`, and `CORE_TYPES`.
- **`Type:` validation diagnostics.**
  - `MSL-T020` — value is neither a core type nor a profile-declared type.
  - `MSL-T021` — type inferred from late-stage signals (display-ID shape carrying `::` or `/`); promote with explicit `Type:` to silence.
  - `MSL-T023` — value matches the profile-declared naming convention (lowercase-with-hyphens) but no profile is loaded.
- **Canonical trailer ordering.** `core/formatter/mod.ts` now follows the spec §3.3.2 six-group order (Identity → Reference-nav → Trace-upstream → Type-specific → Universal-trailing → Profile-declared). Unknown / profile-declared keys land at the bottom per §3.3.6, not just-before-Labels as before.
- **Generated-origin attribute guard.** `MSL-A030` fires when any attribute whose catalogue entry declares `origin: generated` (currently `Superseded-by`; others as the per-type catalogue lands) appears in source.

## Out of scope for this PR — landing in follow-ups

These slices belong in their own PRs because they each open a new code path. Sketch of intended split:

1. **Body parsing primitives** — modal-keyword normalisation (§3.4.1), `$Identifier` inline marker grammar (§2.5.2), captions (§2.6 + §3.4.3, MSL-C codes), MSL-B body-block exclusions.
2. **Per-type attribute catalogue** — flesh out ADR-003 §Part 2 attributes per concrete type, MSL-T022 (attribute-type compat), MSL-A040 (key shadowing), MSL-A050 (value-type parsing).
3. **Reference shape + Pandoc compat** — URI scheme map (§1.3.1 step 5), `Reference-url` / `Reference-document` validation, slug grammar, MSL-I005/I006.
4. **Cross-file trace + wiring** — MSL-R083 type-compat, MSL-R084 shape-cross supersedes, full inverse-graph generation, LSP/MCP surface updates.

Each follow-up will trace back to a specific spec section the same way this PR does.

## Tests

| Before | After |
|---|---|
| 779 | 785 (+6: 5 new validate + 1 new format) |

All `just check` gates green per commit (lint, dprint, type-check, full test suite, conventional-commit lint).

## Test plan

- [ ] Manual review of each commit against the cited spec section
- [ ] Confirm MSL-T020 / T021 / T023 message wording is useful (especially T021 — "consider declaring Type: explicitly" hint should be actionable)
- [ ] Spot-check that no existing fixture broke under the new trailer order
- [ ] Decide if the narrow MSL-T021 trigger (just `::` / `/`) is right, or whether the slug → Component fallback should also fire (PR comment for the follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
