### PR TITLE
feat(core): per-type attribute catalogue + MSL-T022 (ADR-003 §Part 2)

### DIFF
--- a/packages/markspec/core/model/mod.ts
+++ b/packages/markspec/core/model/mod.ts
@@ -14,6 +14,13 @@ export type { AttributeSpec } from "./attributes.ts";
 export { COLOR_NAME_RE, PALETTE_HUES } from "./palette.ts";
 export type { PaletteHue } from "./palette.ts";
 
+export {
+  attributesForType,
+  CORE_TYPE_HIERARCHY,
+  CORE_TYPE_SCOPED_ATTRS,
+} from "./type_hierarchy.ts";
+export type { CoreTypeDef } from "./type_hierarchy.ts";
+
 // ---------------------------------------------------------------------------
 // Display ID
 // ---------------------------------------------------------------------------

--- a/packages/markspec/core/model/type_hierarchy.ts
+++ b/packages/markspec/core/model/type_hierarchy.ts
@@ -1,0 +1,129 @@
+/**
+ * @module model/type_hierarchy
+ *
+ * Core type hierarchy from ADR-003 §Part 2. Encodes the per-type
+ * attribute catalogue for the 15 built-in concrete types and the four
+ * abstract parents. Attributes flow downward via inheritance; this
+ * module exposes lookup helpers consumed by the validator's MSL-T022
+ * check and by future profile-resolution work.
+ */
+
+/** Per-type definition: parent in the hierarchy + locally declared attrs. */
+export interface CoreTypeDef {
+  /** Parent type name, or `null` for `Item` (the root). */
+  readonly parent: string | null;
+  /**
+   * Attributes declared by this type. Subtype attribute sets include
+   * everything declared on ancestor types, per ADR-003 §Part 2.
+   *
+   * The spec lists a few "not applicable" exceptions on subtypes
+   * (e.g., `Allocated-to` is excluded from `Test`); those land in a
+   * later slice via an explicit `excludedAttrs` field — they are not
+   * yet enforced here.
+   */
+  readonly ownAttrs: readonly string[];
+}
+
+/**
+ * Built-in type hierarchy. Keyed by the canonical TitleCase / lower-with-
+ * hyphens name as it would appear in a `Type:` attribute value.
+ */
+export const CORE_TYPE_HIERARCHY: Readonly<Record<string, CoreTypeDef>> = {
+  // Root
+  Item: { parent: null, ownAttrs: [] },
+
+  // Specification family (ADR-003 §Part 2 — Specification)
+  Specification: {
+    parent: "Item",
+    ownAttrs: ["Derived-from", "Satisfies", "Allocated-to"],
+  },
+  Requirement: { parent: "Specification", ownAttrs: [] },
+  Test: { parent: "Specification", ownAttrs: ["Verifies", "Tests"] },
+  Contract: { parent: "Specification", ownAttrs: ["Schema-language"] },
+  Record: { parent: "Specification", ownAttrs: ["Caused-by", "Affects"] },
+  Risk: { parent: "Specification", ownAttrs: ["Caused-by", "Mitigated-by"] },
+
+  // Component family (ADR-003 §Part 2 — Component)
+  Component: {
+    parent: "Item",
+    ownAttrs: [
+      "Kind",
+      "Part-of",
+      "Realizes",
+      "Depends-on",
+      "Provides",
+      "Requires",
+    ],
+  },
+  SoftwareComponent: {
+    parent: "Component",
+    ownAttrs: ["License", "Build-manifest", "Package-manager"],
+  },
+  HardwareComponent: {
+    parent: "Component",
+    ownAttrs: ["Manufacturer", "Part-number", "Datasheet"],
+  },
+  SoftwareInterface: { parent: "Component", ownAttrs: [] },
+  HardwareInterface: {
+    parent: "Component",
+    ownAttrs: [
+      "Bus-protocol",
+      "Connector-type",
+      "Voltage-level",
+      "Signal-direction",
+    ],
+  },
+
+  // Unit family (ADR-003 §Part 2 — Unit)
+  Unit: {
+    parent: "Item",
+    ownAttrs: ["Part-of", "Realizes", "Depends-on"],
+  },
+  SoftwareUnit: {
+    parent: "Unit",
+    ownAttrs: ["Source", "Symbol", "Language"],
+  },
+  HardwareUnit: {
+    parent: "Unit",
+    ownAttrs: [
+      "Manufacturer",
+      "Part-number",
+      "Datasheet",
+      "Footprint",
+      "Value",
+    ],
+  },
+
+  // Standalone subtype of Item (ADR-003 §Part 2 — Definition)
+  Definition: { parent: "Item", ownAttrs: ["Aliases", "See-also"] },
+};
+
+/**
+ * Collect every attribute valid on `typeName` by walking the parent
+ * chain. Returns a {@linkcode Set} of attribute keys (TitleCase or
+ * lowercase-with-hyphens as declared). Returns an empty set for
+ * unknown type names — the caller treats unknown types separately.
+ */
+export function attributesForType(typeName: string): Set<string> {
+  const result = new Set<string>();
+  let cursor: string | null = typeName;
+  while (cursor !== null && CORE_TYPE_HIERARCHY[cursor]) {
+    for (const a of CORE_TYPE_HIERARCHY[cursor].ownAttrs) result.add(a);
+    cursor = CORE_TYPE_HIERARCHY[cursor].parent;
+  }
+  return result;
+}
+
+/**
+ * Union of every type-scoped attribute name declared anywhere in the
+ * core hierarchy. Used by the validator to suppress `MSL-R010`
+ * (unknown attribute) for keys that are core-known but appear on the
+ * "wrong" type — those cases get the more specific `MSL-T022`.
+ */
+export const CORE_TYPE_SCOPED_ATTRS: ReadonlySet<string> = (() => {
+  const set = new Set<string>();
+  for (const def of Object.values(CORE_TYPE_HIERARCHY)) {
+    for (const a of def.ownAttrs) set.add(a);
+  }
+  return set;
+})();

--- a/packages/markspec/core/validator/mod.ts
+++ b/packages/markspec/core/validator/mod.ts
@@ -17,6 +17,7 @@
 import type { Attribute, Diagnostic, Entry } from "../model/mod.ts";
 import {
   attributeSpec,
+  CORE_TYPE_SCOPED_ATTRS,
   IDENTITY_KEY,
   ULID_RE,
   UNIVERSAL_ATTRIBUTE_KEYS,
@@ -159,8 +160,14 @@ function checkStructural(
       // MSL-R010: Unknown attributes are warnings in the core. A
       // profile-aware validator widens this check to include profile-declared
       // attributes; until then, anything outside the universal set is
-      // unrecognized.
-      if (!UNIVERSAL_KEYS.has(attr.key) && attr.key !== "Type") {
+      // unrecognized. Core-typed attributes (per ADR-003 §Part 2) are
+      // suppressed here — the per-type validator emits a more specific
+      // MSL-T022 when they appear on the "wrong" type.
+      if (
+        !UNIVERSAL_KEYS.has(attr.key) &&
+        attr.key !== "Type" &&
+        !CORE_TYPE_SCOPED_ATTRS.has(attr.key)
+      ) {
         diagnostics.push({
           code: "MSL-R010",
           severity: "warning",

--- a/packages/markspec/core/validator/per_type_attrs.ts
+++ b/packages/markspec/core/validator/per_type_attrs.ts
@@ -1,0 +1,77 @@
+/**
+ * @module core/validator/per_type_attrs
+ *
+ * Per-type attribute compatibility check (spec §4.3 — MSL-T022). When
+ * an entry carries an explicit `Type:` that resolves to a core type,
+ * any attribute that's known to the core hierarchy but not allowed on
+ * that type fires MSL-T022 as a warning. Unknown attributes (neither
+ * universal nor core-typed) fall through to the existing MSL-R010
+ * unknown-attribute warning in `validator/mod.ts`.
+ */
+
+import type { Diagnostic, Entry } from "../model/mod.ts";
+import {
+  attributesForType,
+  CORE_TYPE_HIERARCHY,
+  CORE_TYPE_SCOPED_ATTRS,
+  UNIVERSAL_ATTRIBUTE_KEYS,
+} from "../model/mod.ts";
+
+/**
+ * Attribute keys that are universal to every entry regardless of type
+ * (spec §1.4 + §1.5). The core attribute catalog covers most of these;
+ * a few additional keys (`Type`, `Source`, `Origin`, the Reference-shape
+ * promoted attrs) are core-known but not in {@linkcode UNIVERSAL_ATTRIBUTE_KEYS}
+ * directly, so they're added here.
+ */
+const UNIVERSAL_KEYS: ReadonlySet<string> = new Set<string>([
+  ...UNIVERSAL_ATTRIBUTE_KEYS,
+  "Type",
+  "Source",
+  "Origin",
+  "Reference-url",
+  "Reference-document",
+]);
+
+/** Find the explicit `Type:` attribute on an entry. */
+function explicitType(entry: Entry): string | undefined {
+  for (const attr of entry.rawAttributes) {
+    if (attr.key === "Type") return attr.value.trim();
+  }
+  return undefined;
+}
+
+/**
+ * Emit MSL-T022 warnings for attributes that are core-known but not
+ * valid on the entry's resolved type. Skips entries without an
+ * explicit `Type:`, entries whose `Type:` is not a core type (those
+ * are handled by MSL-T020 / MSL-T023 / MSL-T021), and attributes that
+ * are universal or unknown to the core hierarchy entirely (those go
+ * through MSL-R010).
+ */
+export function validatePerTypeAttributes(
+  entry: Entry,
+): readonly Diagnostic[] {
+  const type = explicitType(entry);
+  if (type === undefined) return [];
+  if (!CORE_TYPE_HIERARCHY[type]) return [];
+
+  const allowed = attributesForType(type);
+  const diagnostics: Diagnostic[] = [];
+
+  for (const attr of entry.rawAttributes) {
+    if (UNIVERSAL_KEYS.has(attr.key)) continue;
+    if (allowed.has(attr.key)) continue;
+    if (!CORE_TYPE_SCOPED_ATTRS.has(attr.key)) continue;
+    diagnostics.push({
+      code: "MSL-T022",
+      severity: "warning",
+      message:
+        `${entry.displayId}: attribute '${attr.key}' is not valid on Type: ${type} ` +
+        `(spec §1.6, ADR-003 §Part 2)`,
+      location: entry.location,
+    });
+  }
+
+  return diagnostics;
+}

--- a/packages/markspec/core/validator/pipeline.ts
+++ b/packages/markspec/core/validator/pipeline.ts
@@ -16,6 +16,7 @@ import {
   validateCoreTypeAttribute,
 } from "./types.ts";
 import { validateCaptions } from "./captions.ts";
+import { validatePerTypeAttributes } from "./per_type_attrs.ts";
 import { effectiveScope, validateAttributesForEntry } from "./attributes.ts";
 import { normalizeListValues } from "./normalize.ts";
 import { validateTraceabilityForEntry } from "./traceability.ts";
@@ -70,6 +71,7 @@ export function runPipeline(
     diagnostics.push(...validateCoreTypeAttribute(entry, profile));
     diagnostics.push(...inferTypeFromDisplayIdShape(entry));
     diagnostics.push(...validateCaptions(entry));
+    diagnostics.push(...validatePerTypeAttributes(entry));
   }
 
   // Stage 2 — classification (only when a profile is loaded).

--- a/tests/e2e/validate_test.ts
+++ b/tests/e2e/validate_test.ts
@@ -129,6 +129,107 @@ Deno.test("validate: unknown Type value rejected with MSL-T020 in core-only mode
 });
 
 // ---------------------------------------------------------------------------
+// Per-type attribute compatibility — spec §1.6, MSL-T022
+// ---------------------------------------------------------------------------
+
+Deno.test("validate: Allocated-to on a Component fires MSL-T022 warning", async () => {
+  const { code, stderr } = await markspec(["validate", "req.md"], {
+    files: {
+      "req.md": `# Test
+
+- [comp-1] My component
+
+  Body text.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      Type: Component
+      Allocated-to: 01HGW2Q8MNP3RSTVWXYZABCDEG
+`,
+    },
+  });
+  assertEquals(
+    code,
+    2,
+    `expected exit 2 (warning), got ${code}; stderr: ${stderr}`,
+  );
+  assertStringIncludes(stderr, "MSL-T022");
+  assertStringIncludes(stderr, "Allocated-to");
+  // The attr is core-known; MSL-R010 should NOT also fire on it.
+  assertEquals(
+    /MSL-R010[^\n]*Allocated-to/.test(stderr),
+    false,
+    `MSL-R010 should be suppressed for core-typed attributes; stderr: ${stderr}`,
+  );
+});
+
+Deno.test("validate: Satisfies on a Requirement passes (inherits Specification)", async () => {
+  const { code, stderr } = await markspec(["validate", "req.md"], {
+    files: {
+      "req.md": `# Test
+
+- [REQ-001] First requirement
+
+  Body text.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      Type: Requirement
+      Satisfies: 01HGW2Q8MNP3RSTVWXYZABCDEG
+
+- [REQ-002] Parent requirement
+
+  Body text.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEG
+      Type: Requirement
+`,
+    },
+  });
+  assertEquals(code, 0, `expected exit 0, got ${code}; stderr: ${stderr}`);
+});
+
+Deno.test("validate: License on a SoftwareComponent passes (own attribute)", async () => {
+  const { code, stderr } = await markspec(["validate", "req.md"], {
+    files: {
+      "req.md": `# Test
+
+- [sw-1] My package
+
+  Body text.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      Type: SoftwareComponent
+      License: Apache-2.0
+`,
+    },
+  });
+  assertEquals(code, 0, `expected exit 0, got ${code}; stderr: ${stderr}`);
+});
+
+Deno.test("validate: License on a Specification fires MSL-T022 warning", async () => {
+  const { code, stderr } = await markspec(["validate", "req.md"], {
+    files: {
+      "req.md": `# Test
+
+- [spec-1] My specification
+
+  Body text.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      Type: Specification
+      License: Apache-2.0
+`,
+    },
+  });
+  assertEquals(
+    code,
+    2,
+    `expected exit 2 (warning), got ${code}; stderr: ${stderr}`,
+  );
+  assertStringIncludes(stderr, "MSL-T022");
+  assertStringIncludes(stderr, "License");
+});
+
+// ---------------------------------------------------------------------------
 // Captions — spec §2.6
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Third implementation PR against `docs/specs/markspec-core-data-model.md`. Follow-up to #272 (type-attribute validation) and #273 (body-prose primitives). This PR introduces the **core type hierarchy** from ADR-003 §Part 2 and the per-type attribute compatibility check (MSL-T022).

| Commit | Slice | Spec anchor |
|---|---|---|
| `4309224` | Per-type attribute compatibility check with MSL-T022 + 16-type hierarchy + MSL-R010 suppression | §1.6, §4.3, ADR-003 §Part 2 |

## What lands

### Core type hierarchy

`core/model/type_hierarchy.ts` encodes the full ADR-003 §Part 2 type taxonomy:

```
Item
├── Specification           [Derived-from, Satisfies, Allocated-to]
│   ├── Requirement
│   ├── Test                [Verifies, Tests]
│   ├── Contract            [Schema-language]
│   ├── Record              [Caused-by, Affects]
│   └── Risk                [Caused-by, Mitigated-by]
├── Component               [Kind, Part-of, Realizes, Depends-on, Provides, Requires]
│   ├── SoftwareComponent   [License, Build-manifest, Package-manager]
│   ├── HardwareComponent   [Manufacturer, Part-number, Datasheet]
│   ├── SoftwareInterface
│   └── HardwareInterface   [Bus-protocol, Connector-type, Voltage-level, Signal-direction]
├── Unit                    [Part-of, Realizes, Depends-on]
│   ├── SoftwareUnit        [Source, Symbol, Language]
│   └── HardwareUnit        [Manufacturer, Part-number, Datasheet, Footprint, Value]
└── Definition              [Aliases, See-also]
```

Inheritance is walked at lookup time via `attributesForType(typeName)`. A SoftwareComponent's allowed attribute set, for example, is the union of `SoftwareComponent.ownAttrs ∪ Component.ownAttrs ∪ Item.ownAttrs`.

### MSL-T022 attribute compatibility (warning)

When an entry carries an explicit `Type:` that resolves to a core type and an attribute is core-known (declared somewhere in `CORE_TYPE_HIERARCHY`) but **not** in the resolved type's inherited attribute set, MSL-T022 fires at warning severity. Examples:

- `Allocated-to` on `Component` → MSL-T022 (Allocated-to is Specification-only)
- `License` on `Specification` → MSL-T022 (License is SoftwareComponent-only)
- `Satisfies` on `Requirement` → no diagnostic (Requirement inherits Specification)
- `License` on `SoftwareComponent` → no diagnostic (own attribute)

### MSL-R010 deconflicting

The existing "unknown attribute" warning is now suppressed for keys that are core-known but appear on the wrong type — those go through the more specific MSL-T022 path. Entries with attributes outside the whole hierarchy still get MSL-R010 as before.

## Out of scope (later slices / PRs)

- **Per-subtype exclusions.** ADR-003 §Part 2 notes that `Allocated-to` is "not applicable" on Test even though Test inherits from Specification. Needs an `excludedAttrs` field; deferred.
- **MSL-R083 link-target type compatibility.** Cross-file check (Satisfies target must be a Specification, etc.). Needs the trace graph + this hierarchy together.
- **MSL-A030 for the full inverse list.** ADR-003 §Part 3 lists ~15 generated inverses. Only `Superseded-by` is in the catalog today; the others need entries with `origin: generated` before the existing MSL-A030 catches them.
- **Profile-declared types feeding into the same hierarchy.** Profiles extend the core hierarchy via `extends` chains; that wiring lands when the per-type catalogue is consumed by the profile-aware passes.

## Tests

| Before | After |
|---|---|
| 790 (post-#273) | 794 (+4 new validate e2e covering MSL-T022 fires/no-fires) |

All `just check` gates green per commit.

## Test plan

- [ ] Manual review of `CORE_TYPE_HIERARCHY` against ADR-003 §Part 2
- [ ] Confirm MSL-T022 wording is actionable
- [ ] Spot-check that no existing fixture is now noisily emitting MSL-T022 because of an unintended attribute/type mismatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)
