### PR TITLE
feat(core): URI scheme → core type inference (ADR-003 §Part 6)

### DIFF
--- a/packages/markspec/core/model/mod.ts
+++ b/packages/markspec/core/model/mod.ts
@@ -21,6 +21,8 @@ export {
 } from "./type_hierarchy.ts";
 export type { CoreTypeDef } from "./type_hierarchy.ts";
 
+export { inferTypeFromUriScheme } from "./uri_scheme_map.ts";
+
 // ---------------------------------------------------------------------------
 // Display ID
 // ---------------------------------------------------------------------------

--- a/packages/markspec/core/model/uri_scheme_map.ts
+++ b/packages/markspec/core/model/uri_scheme_map.ts
@@ -1,0 +1,85 @@
+/**
+ * @module model/uri_scheme_map
+ *
+ * Reference-shape URI → core type inference per ADR-003 §Part 6.
+ * Used by spec §1.3.1 step 5 of the type-resolution chain: a Reference
+ * entry whose `Id:` is a recognised URI scheme can infer its core type
+ * without an explicit `Type:` attribute.
+ *
+ * The map is intentionally conservative: only patterns the spec lists
+ * normatively are encoded. Profile extensions to the scheme map land
+ * in the profile layer.
+ */
+
+/**
+ * Rule: a regex matched against the full URI value plus the core type
+ * the URI infers to. Rules are checked in declaration order; the first
+ * match wins. Patterns are anchored at the start (`^`) but not at the
+ * end so package URLs with versions / subpaths still match.
+ */
+interface UriSchemeRule {
+  readonly pattern: RegExp;
+  readonly type: string;
+}
+
+const URI_SCHEME_RULES: readonly UriSchemeRule[] = [
+  // Package URLs (purl) — Software components
+  { pattern: /^pkg:cargo\//, type: "SoftwareComponent" },
+  { pattern: /^pkg:npm\//, type: "SoftwareComponent" },
+  { pattern: /^pkg:maven\//, type: "SoftwareComponent" },
+  { pattern: /^pkg:pypi\//, type: "SoftwareComponent" },
+  { pattern: /^pkg:go\//, type: "SoftwareComponent" },
+  { pattern: /^pkg:nuget\//, type: "SoftwareComponent" },
+  { pattern: /^pkg:deno\//, type: "SoftwareComponent" },
+  { pattern: /^pkg:swift\//, type: "SoftwareComponent" },
+  { pattern: /^pkg:firmware\//, type: "SoftwareComponent" },
+
+  // Package URLs — Hardware components
+  { pattern: /^pkg:hw\//, type: "HardwareComponent" },
+  { pattern: /^pkg:device\//, type: "HardwareComponent" },
+
+  // Standards / regulations / RFCs / papers
+  { pattern: /^urn:iso:std:iso:/, type: "Requirement" },
+  { pattern: /^urn:iso:std:iec:/, type: "Requirement" },
+  { pattern: /^urn:iso:std:iso:iec:ieee:/, type: "Requirement" },
+  { pattern: /^urn:ietf:rfc:/, type: "Requirement" },
+  { pattern: /^urn:nist:/, type: "Requirement" },
+  { pattern: /^urn:unece:/, type: "Requirement" },
+  { pattern: /^doi:/, type: "Requirement" },
+
+  // External tracker schemes — Requirement (proxy item in external system)
+  { pattern: /^codebeamer:/, type: "Requirement" },
+  { pattern: /^doors:/, type: "Requirement" },
+  { pattern: /^polarion:/, type: "Requirement" },
+
+  // Interface description schemes
+  { pattern: /^urn:openapi:/, type: "Contract" },
+  { pattern: /^urn:asyncapi:/, type: "Contract" },
+  { pattern: /^urn:protobuf:/, type: "Contract" },
+  { pattern: /^urn:wsdl:/, type: "Contract" },
+  { pattern: /^urn:autosar:port:/, type: "Contract" },
+
+  // Hardware interfaces (bus networks)
+  { pattern: /^urn:can-bus:/, type: "HardwareInterface" },
+
+  // Glossary terms
+  { pattern: /^urn:refhub:term:/, type: "Definition" },
+  { pattern: /^urn:driftsys:refhub:term:/, type: "Definition" },
+
+  // PLM
+  { pattern: /^plm:/, type: "HardwareComponent" },
+];
+
+/**
+ * Infer a core type name from a Reference-shape `Id:` value (a URI).
+ * Returns `undefined` when no rule matches — the caller should leave
+ * the entry type unresolved rather than guess.
+ *
+ * @param idValue The raw `Id:` value (a scheme-qualified URI).
+ */
+export function inferTypeFromUriScheme(idValue: string): string | undefined {
+  for (const rule of URI_SCHEME_RULES) {
+    if (rule.pattern.test(idValue)) return rule.type;
+  }
+  return undefined;
+}

--- a/packages/markspec/core/validator/per_type_attrs.ts
+++ b/packages/markspec/core/validator/per_type_attrs.ts
@@ -2,20 +2,22 @@
  * @module core/validator/per_type_attrs
  *
  * Per-type attribute compatibility check (spec §4.3 — MSL-T022). When
- * an entry carries an explicit `Type:` that resolves to a core type,
- * any attribute that's known to the core hierarchy but not allowed on
- * that type fires MSL-T022 as a warning. Unknown attributes (neither
- * universal nor core-typed) fall through to the existing MSL-R010
- * unknown-attribute warning in `validator/mod.ts`.
+ * an entry's effective type resolves to a core type — via explicit
+ * `Type:`, profile classification, or URI-scheme inference for
+ * Reference-shape entries — any attribute that's known to the core
+ * hierarchy but not allowed on that type fires MSL-T022 as a warning.
+ * Unknown attributes (neither universal nor core-typed) fall through
+ * to the existing MSL-R010 unknown-attribute warning in
+ * `validator/mod.ts`.
  */
 
 import type { Diagnostic, Entry } from "../model/mod.ts";
 import {
   attributesForType,
-  CORE_TYPE_HIERARCHY,
   CORE_TYPE_SCOPED_ATTRS,
   UNIVERSAL_ATTRIBUTE_KEYS,
 } from "../model/mod.ts";
+import { resolvedCoreType } from "./type_resolution.ts";
 
 /**
  * Attribute keys that are universal to every entry regardless of type
@@ -33,28 +35,19 @@ const UNIVERSAL_KEYS: ReadonlySet<string> = new Set<string>([
   "Reference-document",
 ]);
 
-/** Find the explicit `Type:` attribute on an entry. */
-function explicitType(entry: Entry): string | undefined {
-  for (const attr of entry.rawAttributes) {
-    if (attr.key === "Type") return attr.value.trim();
-  }
-  return undefined;
-}
-
 /**
  * Emit MSL-T022 warnings for attributes that are core-known but not
- * valid on the entry's resolved type. Skips entries without an
- * explicit `Type:`, entries whose `Type:` is not a core type (those
- * are handled by MSL-T020 / MSL-T023 / MSL-T021), and attributes that
- * are universal or unknown to the core hierarchy entirely (those go
- * through MSL-R010).
+ * valid on the entry's resolved type. Skips entries whose type cannot
+ * be resolved (no explicit `Type:`, no profile classification, no URI
+ * scheme inference — those are handled by MSL-T020 / MSL-T021 /
+ * MSL-T023) and attributes that are universal or entirely unknown to
+ * the core hierarchy (those go through MSL-R010).
  */
 export function validatePerTypeAttributes(
   entry: Entry,
 ): readonly Diagnostic[] {
-  const type = explicitType(entry);
+  const type = resolvedCoreType(entry);
   if (type === undefined) return [];
-  if (!CORE_TYPE_HIERARCHY[type]) return [];
 
   const allowed = attributesForType(type);
   const diagnostics: Diagnostic[] = [];

--- a/packages/markspec/core/validator/trace_types.ts
+++ b/packages/markspec/core/validator/trace_types.ts
@@ -13,7 +13,8 @@
  */
 
 import type { Diagnostic, Entry } from "../model/mod.ts";
-import { CORE_TYPE_HIERARCHY, inferTypeFromUriScheme } from "../model/mod.ts";
+import { CORE_TYPE_HIERARCHY } from "../model/mod.ts";
+import { resolvedCoreType } from "./type_resolution.ts";
 
 /**
  * Trace-relation target-type rules. Each entry maps a trace attribute
@@ -69,38 +70,6 @@ const POLYMORPHIC_CAUSED_BY: readonly {
     allowed: ["Component", "Unit", "Specification"],
   },
 ];
-
-/** Find the explicit `Type:` attribute on an entry. */
-function explicitType(entry: Entry): string | undefined {
-  for (const attr of entry.rawAttributes) {
-    if (attr.key === "Type") return attr.value.trim();
-  }
-  return undefined;
-}
-
-/**
- * Resolve an entry's effective core type. Tries (in order):
- *
- *   1. Explicit `Type:` attribute (spec §1.3.1 step 1).
- *   2. Profile-classified `entry.type` (set upstream when a profile is
- *      loaded — spec §1.3.1 step 2 fall-out).
- *   3. URI-scheme inference for Reference-shape entries
- *      (ADR-003 §Part 6 / spec §1.3.1 step 5).
- *
- * Steps 3-4 + 6-8 of the spec chain are not consulted here — they're
- * handled by validateCoreTypeAttribute / inferTypeFromDisplayIdShape
- * in earlier validator stages.
- */
-function resolvedCoreType(entry: Entry): string | undefined {
-  const explicit = explicitType(entry);
-  if (explicit && CORE_TYPE_HIERARCHY[explicit]) return explicit;
-  if (entry.type && CORE_TYPE_HIERARCHY[entry.type]) return entry.type;
-  if (entry.shape === "referenced" && entry.id) {
-    const inferred = inferTypeFromUriScheme(entry.id);
-    if (inferred && CORE_TYPE_HIERARCHY[inferred]) return inferred;
-  }
-  return undefined;
-}
 
 /** True when the entry carries a non-empty `Deprecated:` attribute. */
 function isRetired(entry: Entry): boolean {

--- a/packages/markspec/core/validator/trace_types.ts
+++ b/packages/markspec/core/validator/trace_types.ts
@@ -13,7 +13,7 @@
  */
 
 import type { Diagnostic, Entry } from "../model/mod.ts";
-import { CORE_TYPE_HIERARCHY } from "../model/mod.ts";
+import { CORE_TYPE_HIERARCHY, inferTypeFromUriScheme } from "../model/mod.ts";
 
 /**
  * Trace-relation target-type rules. Each entry maps a trace attribute
@@ -78,11 +78,27 @@ function explicitType(entry: Entry): string | undefined {
   return undefined;
 }
 
-/** Resolve an entry's effective core type from explicit + inferred sources. */
+/**
+ * Resolve an entry's effective core type. Tries (in order):
+ *
+ *   1. Explicit `Type:` attribute (spec §1.3.1 step 1).
+ *   2. Profile-classified `entry.type` (set upstream when a profile is
+ *      loaded — spec §1.3.1 step 2 fall-out).
+ *   3. URI-scheme inference for Reference-shape entries
+ *      (ADR-003 §Part 6 / spec §1.3.1 step 5).
+ *
+ * Steps 3-4 + 6-8 of the spec chain are not consulted here — they're
+ * handled by validateCoreTypeAttribute / inferTypeFromDisplayIdShape
+ * in earlier validator stages.
+ */
 function resolvedCoreType(entry: Entry): string | undefined {
   const explicit = explicitType(entry);
   if (explicit && CORE_TYPE_HIERARCHY[explicit]) return explicit;
   if (entry.type && CORE_TYPE_HIERARCHY[entry.type]) return entry.type;
+  if (entry.shape === "referenced" && entry.id) {
+    const inferred = inferTypeFromUriScheme(entry.id);
+    if (inferred && CORE_TYPE_HIERARCHY[inferred]) return inferred;
+  }
   return undefined;
 }
 

--- a/packages/markspec/core/validator/type_resolution.ts
+++ b/packages/markspec/core/validator/type_resolution.ts
@@ -1,0 +1,48 @@
+/**
+ * @module core/validator/type_resolution
+ *
+ * Shared helper for resolving an entry's effective core type. Walks
+ * the spec §1.3.1 type-resolution chain at the level needed for
+ * validator passes (explicit `Type:` → profile-classified `entry.type`
+ * → URI scheme inference for Reference-shape entries).
+ *
+ * Display-ID prefix inference (step 4) and document-directive
+ * inference (step 7) are intentionally not consulted here; those have
+ * their own dedicated stages (inferTypeFromDisplayIdShape covers step
+ * 8 with warning telemetry).
+ */
+
+import type { Entry } from "../model/mod.ts";
+import { CORE_TYPE_HIERARCHY, inferTypeFromUriScheme } from "../model/mod.ts";
+
+/** Read an entry's explicit `Type:` attribute, trimmed. */
+export function explicitType(entry: Entry): string | undefined {
+  for (const attr of entry.rawAttributes) {
+    if (attr.key === "Type") return attr.value.trim();
+  }
+  return undefined;
+}
+
+/**
+ * Resolve an entry's effective core type. Tries (in order):
+ *
+ *   1. Explicit `Type:` attribute.
+ *   2. Profile-classified `entry.type` (set upstream when a profile
+ *      is loaded).
+ *   3. URI-scheme inference for Reference-shape entries
+ *      (ADR-003 §Part 6 — Reference entry only).
+ *
+ * Returns `undefined` when none of the sources resolves to a core
+ * type. The caller decides whether to skip validation, fall back to a
+ * less specific check, or report on the unclassified state.
+ */
+export function resolvedCoreType(entry: Entry): string | undefined {
+  const explicit = explicitType(entry);
+  if (explicit && CORE_TYPE_HIERARCHY[explicit]) return explicit;
+  if (entry.type && CORE_TYPE_HIERARCHY[entry.type]) return entry.type;
+  if (entry.shape === "referenced" && entry.id) {
+    const inferred = inferTypeFromUriScheme(entry.id);
+    if (inferred && CORE_TYPE_HIERARCHY[inferred]) return inferred;
+  }
+  return undefined;
+}

--- a/tests/e2e/validate_test.ts
+++ b/tests/e2e/validate_test.ts
@@ -448,6 +448,28 @@ Deno.test("validate: doi: Reference as Allocated-to target fires MSL-R083 (infer
   assertStringIncludes(stderr, "Requirement");
 });
 
+Deno.test("validate: pkg:cargo Reference with Bus-protocol fires MSL-T022 (scheme infers SoftwareComponent)", async () => {
+  const { code, stderr } = await markspec(["validate", "req.md"], {
+    files: {
+      "req.md": `# Test
+
+- [serde] serde framework
+
+      Id: pkg:cargo/serde@1.0.0
+      Bus-protocol: can
+`,
+    },
+  });
+  // pkg:cargo → SoftwareComponent. Bus-protocol is HardwareInterface-only → MSL-T022.
+  assertEquals(
+    code,
+    2,
+    `expected exit 2 (warning), got ${code}; stderr: ${stderr}`,
+  );
+  assertStringIncludes(stderr, "MSL-T022");
+  assertStringIncludes(stderr, "Bus-protocol");
+});
+
 Deno.test("validate: pkg:cargo Reference as Depends-on target passes (infers SoftwareComponent)", async () => {
   const { code, stderr } = await markspec(["validate", "req.md"], {
     files: {

--- a/tests/e2e/validate_test.ts
+++ b/tests/e2e/validate_test.ts
@@ -420,6 +420,58 @@ Deno.test("validate: Allocated-to target of type Specification fires MSL-R083", 
 });
 
 // ---------------------------------------------------------------------------
+// Reference shape — URI scheme map (ADR-003 §Part 6, spec §1.3.1 step 5)
+// ---------------------------------------------------------------------------
+
+Deno.test("validate: doi: Reference as Allocated-to target fires MSL-R083 (infers Requirement)", async () => {
+  const { code, stderr } = await markspec(["validate", "req.md"], {
+    files: {
+      "req.md": `# Test
+
+- [SAD-001] My spec
+
+  Body.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      Type: Specification
+      Allocated-to: doi:10.1109/IEEESTD.2008.4610935
+
+- [IEEE-1234] IEEE Standard cited as predecessor
+
+      Id: doi:10.1109/IEEESTD.2008.4610935
+`,
+    },
+  });
+  // doi: → Requirement (Specification); Allocated-to needs Component → R083
+  assertEquals(code, 1, `expected exit 1, got ${code}; stderr: ${stderr}`);
+  assertStringIncludes(stderr, "MSL-R083");
+  assertStringIncludes(stderr, "Requirement");
+});
+
+Deno.test("validate: pkg:cargo Reference as Depends-on target passes (infers SoftwareComponent)", async () => {
+  const { code, stderr } = await markspec(["validate", "req.md"], {
+    files: {
+      "req.md": `# Test
+
+- [my-app] My app
+
+  Body.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      Type: SoftwareComponent
+      Depends-on: pkg:cargo/serde@1.0.0
+
+- [serde] Serde framework
+
+      Id: pkg:cargo/serde@1.0.0
+`,
+    },
+  });
+  // pkg:cargo → SoftwareComponent → Depends-on accepts Component → OK
+  assertEquals(code, 0, `expected exit 0, got ${code}; stderr: ${stderr}`);
+});
+
+// ---------------------------------------------------------------------------
 // Captions — spec §2.6
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Fifth implementation PR against `docs/specs/markspec-core-data-model.md`. Builds on the type hierarchy (#274) and cross-file trace pass (#275) to wire **URI scheme inference** into the type-resolution chain — spec §1.3.1 step 5, ADR-003 §Part 6.

| Commit | Slice | Spec anchor |
|---|---|---|
| `528f6c9` | URI scheme → core type inference for Reference-shape targets | §1.3.1 step 5, ADR-003 §Part 6 |
| `b95b605` | Share type-resolution helper across trace and per-type passes | §1.3.1, §4.3 |

## What lands

### URI scheme map

A Reference-shape entry whose `Id:` matches a recognised URI scheme pattern infers its core type. Encoded in `core/model/uri_scheme_map.ts`:

| URI pattern | Inferred type |
|---|---|
| `pkg:cargo/*`, `pkg:npm/*`, `pkg:maven/*`, `pkg:pypi/*`, `pkg:go/*`, `pkg:nuget/*`, `pkg:deno/*`, `pkg:swift/*`, `pkg:firmware/*` | SoftwareComponent |
| `pkg:hw/*`, `pkg:device/*`, `plm:*` | HardwareComponent |
| `urn:iso:std:iso:*`, `urn:iso:std:iec:*`, `urn:iso:std:iso:iec:ieee:*`, `urn:ietf:rfc:*`, `urn:nist:*`, `urn:unece:*`, `doi:*` | Requirement |
| `codebeamer:*`, `doors:*`, `polarion:*` | Requirement |
| `urn:openapi:*`, `urn:asyncapi:*`, `urn:protobuf:*`, `urn:wsdl:*`, `urn:autosar:port:*` | Contract |
| `urn:can-bus:*` | HardwareInterface |
| `urn:refhub:term:*`, `urn:driftsys:refhub:term:*` | Definition |

### Wired into both type-aware validator passes

A new `core/validator/type_resolution.ts` module exposes `explicitType()` and `resolvedCoreType()`, which both `trace_types.ts` and `per_type_attrs.ts` now use. Consequences:

- **MSL-R083** (cross-file trace target type) fires correctly against Reference targets without explicit `Type:` — e.g., `Allocated-to: doi:10.…` (DOI infers Requirement, not Component).
- **MSL-T022** (per-type attribute compatibility) now fires on Reference entries with no explicit `Type:` — e.g., `Bus-protocol` on a `pkg:cargo/*` Reference (cargo infers SoftwareComponent; Bus-protocol is HardwareInterface-only).

## What this PR does NOT change

- **MSL-I005** (empty display ID) / **MSL-I006** (Reference slug grammar).
- **MSL-R085** References slug not found among Reference entries.
- **Reference-url / Reference-document** value-type validation.
- Profile-declared URI scheme extensions.

## Tests

| Before | After |
|---|---|
| 801 (post-#275) | 804 (+3 covering doi → Requirement mismatch, pkg:cargo → SoftwareComponent match, pkg:cargo → MSL-T022 on Bus-protocol) |

All `just check` gates green per commit.

## Test plan

- [ ] Manual review of the URI scheme rule table against ADR-003 §Part 6.
- [ ] Confirm `doi:*` mapping to `Requirement` matches your expectation (the spec lists "cited paper / standard" — Requirement is the closest core type).
- [ ] Spot-check existing fixtures with `pkg:cargo` Ids — they should still validate cleanly, just with stricter per-type checks now active.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
