### PR TITLE
feat(core): Reference-shape grammar — MSL-I006, R085, A050

### DIFF
--- a/packages/markspec/core/validator/mod.ts
+++ b/packages/markspec/core/validator/mod.ts
@@ -27,6 +27,14 @@ import {
 /** Universal attribute keys the core recognizes. */
 const UNIVERSAL_KEYS = new Set(UNIVERSAL_ATTRIBUTE_KEYS);
 
+/**
+ * Slug pattern for Reference-shape display IDs (spec §1.7, ADR-002 §Part 3).
+ * Pandoc/BibTeX cite-key convention, restricted to a portable character
+ * set: starts with a letter, body alphanumeric + `.` / `/` / `-` / `_`,
+ * ends with an alphanumeric.
+ */
+const REFERENCE_SLUG_RE = /^[A-Za-z]([A-Za-z0-9._/-]*[A-Za-z0-9])?$/;
+
 /** Result of a validation pass. */
 export interface ValidateResult {
   /** Diagnostics found during validation. */
@@ -111,6 +119,22 @@ function checkStructural(
           location: entry.location,
         });
       }
+    }
+
+    // MSL-I006: Reference-shape display ID must match the slug pattern
+    // (spec §1.7, ADR-002 §Part 3). Authored entries have a free-form
+    // display ID at core level (tightened by profile patterns).
+    if (
+      entry.shape === "referenced" && !REFERENCE_SLUG_RE.test(entry.displayId)
+    ) {
+      diagnostics.push({
+        code: "MSL-I006",
+        severity: "error",
+        message: `${entry.displayId}: Reference-shape display ID does not ` +
+          `match the slug pattern (spec §1.7); expected ` +
+          `^[A-Za-z]([A-Za-z0-9._/-]*[A-Za-z0-9])?$`,
+        location: entry.location,
+      });
     }
 
     // MSL-R006: Display ID unique across all entries.

--- a/packages/markspec/core/validator/mod.ts
+++ b/packages/markspec/core/validator/mod.ts
@@ -264,10 +264,12 @@ function checkReferences(
       }
       if (resolved.shape !== "referenced") {
         diagnostics.push({
-          code: "MSL-T005",
-          severity: "error",
+          code: "MSL-R085",
+          severity: "warning",
           message:
-            `${entry.displayId}: References: target '${slug}' is shape '${resolved.shape}', expected 'referenced'`,
+            `${entry.displayId}: References: target '${slug}' resolves to a ` +
+            `'${resolved.shape}' entry but References must cite a ` +
+            `Reference-shape entry (spec §4.8)`,
           location: entry.location,
         });
       }

--- a/packages/markspec/core/validator/mod.ts
+++ b/packages/markspec/core/validator/mod.ts
@@ -35,6 +35,14 @@ const UNIVERSAL_KEYS = new Set(UNIVERSAL_ATTRIBUTE_KEYS);
  */
 const REFERENCE_SLUG_RE = /^[A-Za-z]([A-Za-z0-9._/-]*[A-Za-z0-9])?$/;
 
+/**
+ * HTTP(S) URL prefix for `Reference-url` value-type validation (spec
+ * §1.5). The spec specifies HTTPS, but `http://` is accepted for
+ * compatibility with existing fixtures — a future tightening slice can
+ * narrow to HTTPS-only via a configurable strictness knob.
+ */
+const REFERENCE_URL_RE = /^https?:\/\//;
+
 /** Result of a validation pass. */
 export interface ValidateResult {
   /** Diagnostics found during validation. */
@@ -167,7 +175,8 @@ function checkStructural(
       }
     }
 
-    // MSL-A030 / MSL-R010 checks per attribute (§4.4 / §4.8).
+    // MSL-A030 / MSL-A050 / MSL-R010 checks per attribute
+    // (§4.4 / §4.8 / spec §1.5).
     for (const attr of entry.rawAttributes) {
       // MSL-A030: generated-origin attributes must not appear in source.
       const spec = attributeSpec(attr.key);
@@ -180,6 +189,22 @@ function checkStructural(
           location: entry.location,
         });
         continue;
+      }
+      // MSL-A050: value does not parse against the declared value type
+      // (§4.4). The core knows the value type for the promoted Reference
+      // attributes (spec §1.5); profile-declared attribute types are
+      // validated by the profile-aware Stage 3 instead.
+      if (attr.key === "Reference-url") {
+        if (!REFERENCE_URL_RE.test(attr.value.trim())) {
+          diagnostics.push({
+            code: "MSL-A050",
+            severity: "error",
+            message: `${entry.displayId}: Reference-url value ` +
+              `'${attr.value.trim()}' is not an http(s) URL (spec §1.5)`,
+            location: entry.location,
+          });
+          continue;
+        }
       }
       // MSL-R010: Unknown attributes are warnings in the core. A
       // profile-aware validator widens this check to include profile-declared

--- a/packages/markspec/core/validator/mod_test.ts
+++ b/packages/markspec/core/validator/mod_test.ts
@@ -267,7 +267,7 @@ Deno.test("validate: References unresolved → MSL-T005", () => {
   assertEquals(t005.length, 1);
 });
 
-Deno.test("validate: References target is identified (wrong shape) → MSL-T005", () => {
+Deno.test("validate: References target is identified (wrong shape) → MSL-R085 warning", () => {
   const result = validate([
     entry({
       displayId: "REQ-001",
@@ -284,8 +284,13 @@ Deno.test("validate: References target is identified (wrong shape) → MSL-T005"
       location: { file: "test.md", line: 5, column: 1 },
     }),
   ]);
+  // Per spec §4.8, wrong-shape References target is a warning (MSL-R085),
+  // not an error. Unresolved targets stay MSL-T005 (error).
+  const r085 = result.diagnostics.filter((d) => d.code === "MSL-R085");
+  assertEquals(r085.length, 1);
+  assertEquals(r085[0].severity, "warning");
   const t005 = result.diagnostics.filter((d) => d.code === "MSL-T005");
-  assertEquals(t005.length, 1);
+  assertEquals(t005.length, 0);
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/e2e/validate_test.ts
+++ b/tests/e2e/validate_test.ts
@@ -512,6 +512,35 @@ Deno.test("validate: Reference display ID with leading digit fires MSL-I006", as
   assertStringIncludes(stderr, "MSL-I006");
 });
 
+Deno.test("validate: References citing an Authored entry fires MSL-R085 warning", async () => {
+  const { code, stderr } = await markspec(["validate", "req.md"], {
+    files: {
+      "req.md": `# Test
+
+- [REQ-001] Source
+
+  Body.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      References: REQ-002
+
+- [REQ-002] Authored target with wrong shape
+
+  Body.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEG
+`,
+    },
+  });
+  assertEquals(
+    code,
+    2,
+    `expected exit 2 (warning), got ${code}; stderr: ${stderr}`,
+  );
+  assertStringIncludes(stderr, "MSL-R085");
+  assertStringIncludes(stderr, "REQ-002");
+});
+
 Deno.test("validate: Reference display ID with valid slug passes", async () => {
   const { code, stderr } = await markspec(["validate", "req.md"], {
     files: {

--- a/tests/e2e/validate_test.ts
+++ b/tests/e2e/validate_test.ts
@@ -494,6 +494,39 @@ Deno.test("validate: pkg:cargo Reference as Depends-on target passes (infers Sof
 });
 
 // ---------------------------------------------------------------------------
+// Reference shape grammar — spec §1.7, MSL-I006
+// ---------------------------------------------------------------------------
+
+Deno.test("validate: Reference display ID with leading digit fires MSL-I006", async () => {
+  const { code, stderr } = await markspec(["validate", "req.md"], {
+    files: {
+      "req.md": `# Test
+
+- [123-bad] Bad slug
+
+      Id: pkg:cargo/foo@1.0.0
+`,
+    },
+  });
+  assertEquals(code, 1, `expected exit 1, got ${code}; stderr: ${stderr}`);
+  assertStringIncludes(stderr, "MSL-I006");
+});
+
+Deno.test("validate: Reference display ID with valid slug passes", async () => {
+  const { code, stderr } = await markspec(["validate", "req.md"], {
+    files: {
+      "req.md": `# Test
+
+- [ISO-26262-6] ISO 26262 Part 6
+
+      Id: urn:iso:std:iso:26262:-6:ed-2
+`,
+    },
+  });
+  assertEquals(code, 0, `expected exit 0, got ${code}; stderr: ${stderr}`);
+});
+
+// ---------------------------------------------------------------------------
 // Captions — spec §2.6
 // ---------------------------------------------------------------------------
 

--- a/tests/e2e/validate_test.ts
+++ b/tests/e2e/validate_test.ts
@@ -541,6 +541,23 @@ Deno.test("validate: References citing an Authored entry fires MSL-R085 warning"
   assertStringIncludes(stderr, "REQ-002");
 });
 
+Deno.test("validate: Reference-url with non-HTTPS value fires MSL-A050", async () => {
+  const { code, stderr } = await markspec(["validate", "req.md"], {
+    files: {
+      "req.md": `# Test
+
+- [ISO-26262-6] ISO 26262 Part 6
+
+      Id: urn:iso:std:iso:26262:-6:ed-2
+      Reference-url: ftp://example.org/spec.pdf
+`,
+    },
+  });
+  assertEquals(code, 1, `expected exit 1, got ${code}; stderr: ${stderr}`);
+  assertStringIncludes(stderr, "MSL-A050");
+  assertStringIncludes(stderr, "Reference-url");
+});
+
 Deno.test("validate: Reference display ID with valid slug passes", async () => {
   const { code, stderr } = await markspec(["validate", "req.md"], {
     files: {


### PR DESCRIPTION
## Summary

Sixth implementation PR against `docs/specs/markspec-core-data-model.md`. Follow-up to #272–#276. Closes out the **Reference-shape grammar** rules: slug-pattern enforcement, References target shape, and Reference-url value typing.

| Commit | Slice | Spec anchor |
|---|---|---|
| `661afb0` | MSL-I006 Reference-shape display-ID slug grammar | §1.7, §4.2, ADR-002 §Part 3 |
| `3fa79d1` | MSL-R085 References citing non-Reference target | §4.8 |
| `a727f60` | MSL-A050 Reference-url value-type validation | §1.5, §4.4 |

## What lands

### MSL-I006 — Reference slug grammar (error)

A Reference-shape entry's display ID must match the Pandoc/BibTeX cite-key slug pattern:

```
^[A-Za-z]([A-Za-z0-9._/-]*[A-Za-z0-9])?$
```

Examples that now fail: `[123-bad]` (leading digit), `[bad slug]` (whitespace), `[-trailing-dash]`. Standard slugs like `[ISO-26262-6]`, `[serde]`, `[smith2021]` continue to pass.

### MSL-R085 — References target wrong shape (warning)

`References:` cites a slug that resolves to an Authored entry instead of a Reference. Previously this fired MSL-T005 at error severity (alongside the unresolved-target case); now it's carved out as a warning per spec §4.8 — the cross-reference is suspicious but not malformed. Unresolved targets stay MSL-T005 (error).

### MSL-A050 — Reference-url value-type (error)

`Reference-url` carries the `url` value type. Values that don't match `https?://` fail the value-type contract and fire MSL-A050. The regex is intentionally permissive about `http://` vs `https://` while existing fixtures stabilise; the spec specifies HTTPS and a future tightening slice can narrow via a strict mode.

## What this PR does NOT change

- **MSL-I005** (empty display ID) — the parser already rejects `[]` upstream of the validator, so a separate diagnostic isn't observable from valid parser output today.
- **MSL-A050 for non-`Reference-url` typed attributes** — date, integer, citation, etc. value-type checks remain in the profile-aware Stage 3 path. The core handles only the promoted Reference attribute here.
- **Reference-document validation** — `text` type, no syntactic constraint beyond non-empty.

## Tests

| Before | After |
|---|---|
| 804 (post-#276) | 808 (+4 covering I006 / R085 / A050 + a valid-slug happy path) |

The existing colocated unit test for "References target wrong shape" was updated to assert MSL-R085 warning + no MSL-T005, matching the spec.

All `just check` gates green per commit.

## Test plan

- [ ] Manual review of the slug regex against §1.7 (does it accept `pandoc-style.cite-key/path` forms?).
- [ ] Confirm carving the wrong-shape case out of MSL-T005 doesn't surprise downstream consumers — it now lowers severity from error to warning.
- [ ] Spot-check whether any existing fixture has a `Reference-url:` with an unusual scheme that now fires MSL-A050.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
