### PR TITLE
feat(core): body block exclusions (MSL-B040-B043)

### DIFF
--- a/packages/markspec/core/validator/body_blocks.ts
+++ b/packages/markspec/core/validator/body_blocks.ts
@@ -1,0 +1,103 @@
+/**
+ * @module core/validator/body_blocks
+ *
+ * Body-block exclusion validator (spec §2.4.1). Detects constructs
+ * forbidden inside entry bodies:
+ *
+ *   - MSL-B040 — headings
+ *   - MSL-B041 — horizontal rules
+ *   - MSL-B042 — task lists
+ *   - MSL-B043 — raw HTML other than `<!-- markspec:* -->` directive
+ *     comments
+ *
+ * The check walks each entry's `body` string line by line and skips
+ * lines inside fenced code blocks (verbatim content is exempt).
+ */
+
+import type { Diagnostic, Entry } from "../model/mod.ts";
+
+const FENCE_RE = /^\s*(```|~~~)/;
+const HEADING_RE = /^\s*#{1,6}\s/;
+const HR_RE = /^\s*(?:-{3,}|\*{3,}|_{3,})\s*$/;
+const TASK_LIST_RE = /^\s*[-*+]\s+\[[ xX]\]/;
+
+/**
+ * Raw HTML detection. Captures any opening, closing, or self-closing
+ * HTML tag (`<tag>`, `</tag>`, `<tag/>`). HTML comments (`<!-- ... -->`)
+ * are intentionally allowed, including non-markspec ones, until the
+ * tighter "markspec directive comments only" rule lands in a later
+ * slice.
+ */
+const RAW_HTML_RE = /<\/?[A-Za-z][A-Za-z0-9]*(\s[^>]*)?\/?>/;
+
+interface BodyDiag {
+  readonly code: string;
+  readonly severity: "error" | "warning" | "info";
+  readonly summary: string;
+}
+
+const HEADING_DIAG: BodyDiag = {
+  code: "MSL-B040",
+  severity: "error",
+  summary: "heading inside entry body — entries are flat (spec §2.4.1)",
+};
+const HR_DIAG: BodyDiag = {
+  code: "MSL-B041",
+  severity: "error",
+  summary:
+    "horizontal rule inside entry body — entry boundaries already separate content (spec §2.4.1)",
+};
+const TASK_LIST_DIAG: BodyDiag = {
+  code: "MSL-B042",
+  severity: "error",
+  summary:
+    "task list inside entry body — semantics conflict with traceability state (spec §2.4.1)",
+};
+const RAW_HTML_DIAG: BodyDiag = {
+  code: "MSL-B043",
+  severity: "error",
+  summary:
+    "raw HTML inside entry body — only `<!-- markspec:* -->` directive comments are permitted (spec §2.4.1)",
+};
+
+/**
+ * Validate that an entry's body contains none of the excluded body
+ * constructs. Emits at most one diagnostic per excluded construct per
+ * line (so a paragraph with `<div>foo</div><span>bar</span>` still
+ * fires MSL-B043 once for that line).
+ */
+export function validateBodyBlocks(entry: Entry): readonly Diagnostic[] {
+  const diagnostics: Diagnostic[] = [];
+  const lines = entry.body.split("\n");
+  let inFence = false;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (FENCE_RE.test(line)) {
+      inFence = !inFence;
+      continue;
+    }
+    if (inFence) continue;
+    if (line.trim() === "") continue;
+
+    let diag: BodyDiag | undefined;
+    if (HEADING_RE.test(line)) diag = HEADING_DIAG;
+    else if (HR_RE.test(line)) diag = HR_DIAG;
+    else if (TASK_LIST_RE.test(line)) diag = TASK_LIST_DIAG;
+    else if (RAW_HTML_RE.test(line)) diag = RAW_HTML_DIAG;
+    if (!diag) continue;
+
+    diagnostics.push({
+      code: diag.code,
+      severity: diag.severity,
+      message: `${entry.displayId}: ${diag.summary}`,
+      location: {
+        file: entry.location.file,
+        line: entry.location.line + 1 + i,
+        column: 1,
+      },
+    });
+  }
+
+  return diagnostics;
+}

--- a/packages/markspec/core/validator/pipeline.ts
+++ b/packages/markspec/core/validator/pipeline.ts
@@ -15,6 +15,7 @@ import {
   inferTypeFromDisplayIdShape,
   validateCoreTypeAttribute,
 } from "./types.ts";
+import { validateBodyBlocks } from "./body_blocks.ts";
 import { validateCaptions } from "./captions.ts";
 import { validatePerTypeAttributes } from "./per_type_attrs.ts";
 import { validateTraceTargetTypes } from "./trace_types.ts";
@@ -72,6 +73,7 @@ export function runPipeline(
     diagnostics.push(...validateCoreTypeAttribute(entry, profile));
     diagnostics.push(...inferTypeFromDisplayIdShape(entry));
     diagnostics.push(...validateCaptions(entry));
+    diagnostics.push(...validateBodyBlocks(entry));
     diagnostics.push(...validatePerTypeAttributes(entry));
   }
 

--- a/tests/e2e/validate_test.ts
+++ b/tests/e2e/validate_test.ts
@@ -573,6 +573,89 @@ Deno.test("validate: Reference display ID with valid slug passes", async () => {
 });
 
 // ---------------------------------------------------------------------------
+// Body block exclusions — spec §2.4.1, MSL-B040-B043
+// ---------------------------------------------------------------------------
+
+Deno.test("validate: heading inside entry body fires MSL-B040", async () => {
+  const { code, stderr } = await markspec(["validate", "req.md"], {
+    files: {
+      "req.md": `# Test
+
+- [REQ-001] My requirement
+
+  Body text.
+
+  ## Sub-heading inside entry
+
+  More body.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+`,
+    },
+  });
+  assertEquals(code, 1, `expected exit 1, got ${code}; stderr: ${stderr}`);
+  assertStringIncludes(stderr, "MSL-B040");
+});
+
+Deno.test("validate: horizontal rule inside entry body fires MSL-B041", async () => {
+  const { code, stderr } = await markspec(["validate", "req.md"], {
+    files: {
+      "req.md": `# Test
+
+- [REQ-001] My requirement
+
+  Body text.
+
+  ---
+
+  More body.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+`,
+    },
+  });
+  assertEquals(code, 1, `expected exit 1, got ${code}; stderr: ${stderr}`);
+  assertStringIncludes(stderr, "MSL-B041");
+});
+
+Deno.test("validate: task list inside entry body fires MSL-B042", async () => {
+  const { code, stderr } = await markspec(["validate", "req.md"], {
+    files: {
+      "req.md": `# Test
+
+- [REQ-001] My requirement
+
+  Body text.
+
+  - [ ] Open task
+  - [x] Closed task
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+`,
+    },
+  });
+  assertEquals(code, 1, `expected exit 1, got ${code}; stderr: ${stderr}`);
+  assertStringIncludes(stderr, "MSL-B042");
+});
+
+Deno.test("validate: raw HTML inside entry body fires MSL-B043", async () => {
+  const { code, stderr } = await markspec(["validate", "req.md"], {
+    files: {
+      "req.md": `# Test
+
+- [REQ-001] My requirement
+
+  Body text with <div class="custom">raw HTML</div> inside.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+`,
+    },
+  });
+  assertEquals(code, 1, `expected exit 1, got ${code}; stderr: ${stderr}`);
+  assertStringIncludes(stderr, "MSL-B043");
+});
+
+// ---------------------------------------------------------------------------
 // Captions — spec §2.6
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Seventh implementation PR against `docs/specs/markspec-core-data-model.md`. Closes the **body-block catalogue enforcement loop** from spec §2.4.1 — forbidden CommonMark/GFM constructs inside entry bodies now fire dedicated MSL-B diagnostics.

| Commit | Slice | Spec anchor |
|---|---|---|
| `701347f` | Body block exclusions — MSL-B040 / B041 / B042 / B043 | §2.4.1 |

## What lands

| Code | Construct | Severity |
|---|---|---|
| `MSL-B040` | Heading (`#`, `##`, …) | error |
| `MSL-B041` | Horizontal rule (`---`, `***`, `___`) | error |
| `MSL-B042` | Task list (`- [ ]`, `- [x]`) | error |
| `MSL-B043` | Raw HTML (other than `<!-- … -->` comments) | error |

Fenced code blocks are skipped — verbatim content is exempt per the §5.1 round-trip invariants.

## What this PR does NOT change

- **Tightening MSL-B043 to "markspec directive comments only"** — currently any `<!-- ... -->` comment is allowed; restricting to `<!-- markspec:* -->` lands when the directive parser surfaces its allowed-comment set.
- **MSL-B044** — Feature block + "Acceptance criteria" list style warning. The spec lists it as a style warning, deferred to a later slice.

## Tests

| Before | After |
|---|---|
| 808 (post-#277) | 812 (+4, one positive case per MSL-B code) |

All `just check` gates green per commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
