### PR TITLE
feat(core): per-subtype attribute exclusions (Test ≠ Allocated-to)

### DIFF
--- a/packages/markspec/core/model/type_hierarchy.ts
+++ b/packages/markspec/core/model/type_hierarchy.ts
@@ -15,13 +15,14 @@ export interface CoreTypeDef {
   /**
    * Attributes declared by this type. Subtype attribute sets include
    * everything declared on ancestor types, per ADR-003 §Part 2.
-   *
-   * The spec lists a few "not applicable" exceptions on subtypes
-   * (e.g., `Allocated-to` is excluded from `Test`); those land in a
-   * later slice via an explicit `excludedAttrs` field — they are not
-   * yet enforced here.
    */
   readonly ownAttrs: readonly string[];
+  /**
+   * Attributes inherited from ancestors that are "not applicable" on
+   * this subtype per ADR-003 §Part 2 (e.g., `Allocated-to` on Test).
+   * Removed during {@linkcode attributesForType} resolution.
+   */
+  readonly excludedAttrs?: readonly string[];
 }
 
 /**
@@ -38,7 +39,13 @@ export const CORE_TYPE_HIERARCHY: Readonly<Record<string, CoreTypeDef>> = {
     ownAttrs: ["Derived-from", "Satisfies", "Allocated-to"],
   },
   Requirement: { parent: "Specification", ownAttrs: [] },
-  Test: { parent: "Specification", ownAttrs: ["Verifies", "Tests"] },
+  Test: {
+    parent: "Specification",
+    ownAttrs: ["Verifies", "Tests"],
+    // ADR-003 §Part 2 — Test: "Allocated-to: not applicable —
+    // tests are not allocated to components".
+    excludedAttrs: ["Allocated-to"],
+  },
   Contract: { parent: "Specification", ownAttrs: ["Schema-language"] },
   Record: { parent: "Specification", ownAttrs: ["Caused-by", "Affects"] },
   Risk: { parent: "Specification", ownAttrs: ["Caused-by", "Mitigated-by"] },
@@ -100,17 +107,28 @@ export const CORE_TYPE_HIERARCHY: Readonly<Record<string, CoreTypeDef>> = {
 
 /**
  * Collect every attribute valid on `typeName` by walking the parent
- * chain. Returns a {@linkcode Set} of attribute keys (TitleCase or
+ * chain and subtracting any `excludedAttrs` declared along the way.
+ * Returns a {@linkcode Set} of attribute keys (TitleCase or
  * lowercase-with-hyphens as declared). Returns an empty set for
  * unknown type names — the caller treats unknown types separately.
+ *
+ * Exclusion semantics: an attribute marked `excludedAttrs` on a
+ * subtype is removed from the final set even if an ancestor declared
+ * it. The subtype cannot re-add the attribute later — only its own
+ * `ownAttrs` list contributes.
  */
 export function attributesForType(typeName: string): Set<string> {
   const result = new Set<string>();
+  const excluded = new Set<string>();
   let cursor: string | null = typeName;
   while (cursor !== null && CORE_TYPE_HIERARCHY[cursor]) {
     for (const a of CORE_TYPE_HIERARCHY[cursor].ownAttrs) result.add(a);
+    for (const a of CORE_TYPE_HIERARCHY[cursor].excludedAttrs ?? []) {
+      excluded.add(a);
+    }
     cursor = CORE_TYPE_HIERARCHY[cursor].parent;
   }
+  for (const a of excluded) result.delete(a);
   return result;
 }
 

--- a/tests/e2e/validate_test.ts
+++ b/tests/e2e/validate_test.ts
@@ -187,6 +187,31 @@ Deno.test("validate: Satisfies on a Requirement passes (inherits Specification)"
   assertEquals(code, 0, `expected exit 0, got ${code}; stderr: ${stderr}`);
 });
 
+Deno.test("validate: Allocated-to on a Test fires MSL-T022 (subtype exclusion)", async () => {
+  const { code, stderr } = await markspec(["validate", "req.md"], {
+    files: {
+      "req.md": `# Test
+
+- [TST-001] My test
+
+  Body.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      Type: Test
+      Allocated-to: 01HGW2Q8MNP3RSTVWXYZABCDEG
+`,
+    },
+  });
+  // Test extends Specification but spec §Part 2 excludes Allocated-to on Test.
+  assertEquals(
+    code,
+    2,
+    `expected exit 2 (warning), got ${code}; stderr: ${stderr}`,
+  );
+  assertStringIncludes(stderr, "MSL-T022");
+  assertStringIncludes(stderr, "Allocated-to");
+});
+
 Deno.test("validate: License on a SoftwareComponent passes (own attribute)", async () => {
   const { code, stderr } = await markspec(["validate", "req.md"], {
     files: {


### PR DESCRIPTION
## Summary

Iteration 2 of the autonomous Prompt-1 follow-up loop. Closes one ADR-003 §Part 2 nuance left over from #274's hierarchy work: per-subtype attribute exclusions.

| Commit | Slice | Spec anchor |
|---|---|---|
| `88e848f` | `excludedAttrs` field on CoreTypeDef + Test ∌ Allocated-to | ADR-003 §Part 2, spec §1.6 |

## What lands

- New optional `excludedAttrs` field on `CoreTypeDef`. A subtype lists attributes inherited from ancestors that don't apply to it.
- `attributesForType(typeName)` walks the parent chain collecting both `ownAttrs` (added) and `excludedAttrs` (subtracted), with subtraction applied once at the end so a subtype cannot accidentally re-add an excluded attribute via its own `ownAttrs`.
- First exclusion encoded: `Allocated-to` on `Test`. Per ADR-003 §Part 2, "tests are not allocated to components".

## Tests

| Before | After |
|---|---|
| 812 (post-#278) | 813 (+1 `Type: Test` + `Allocated-to:` → MSL-T022) |

All `just check` gates green per commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
