### PR TITLE
feat(core): full ADR-003 §Part 3 inverse list in catalog

### DIFF
--- a/packages/markspec/core/model/attributes.ts
+++ b/packages/markspec/core/model/attributes.ts
@@ -113,6 +113,109 @@ export const ATTRIBUTE_CATALOG: readonly AttributeSpec[] = [
     shapes: BOTH_SHAPES,
     required: false,
   },
+
+  // Generated inverses from ADR-003 §Part 3. These are NEVER authored
+  // in source; the compiler computes them from authored relations at
+  // build time. MSL-A030 catches anyone who tries to write them
+  // manually.
+  {
+    key: "Derives",
+    type: "id-list",
+    origin: "generated",
+    shapes: BOTH_SHAPES,
+    required: false,
+  },
+  {
+    key: "Satisfied-by",
+    type: "id-list",
+    origin: "generated",
+    shapes: BOTH_SHAPES,
+    required: false,
+  },
+  {
+    key: "Realized-by",
+    type: "id-list",
+    origin: "generated",
+    shapes: BOTH_SHAPES,
+    required: false,
+  },
+  {
+    key: "Verified-by",
+    type: "id-list",
+    origin: "generated",
+    shapes: BOTH_SHAPES,
+    required: false,
+  },
+  {
+    key: "Tested-by",
+    type: "id-list",
+    origin: "generated",
+    shapes: BOTH_SHAPES,
+    required: false,
+  },
+  {
+    key: "Allocated",
+    type: "id-list",
+    origin: "generated",
+    shapes: BOTH_SHAPES,
+    required: false,
+  },
+  {
+    key: "Contains",
+    type: "id-list",
+    origin: "generated",
+    shapes: BOTH_SHAPES,
+    required: false,
+  },
+  {
+    key: "Provided-by",
+    type: "id-list",
+    origin: "generated",
+    shapes: BOTH_SHAPES,
+    required: false,
+  },
+  {
+    key: "Required-by",
+    type: "id-list",
+    origin: "generated",
+    shapes: BOTH_SHAPES,
+    required: false,
+  },
+  {
+    key: "Used-by",
+    type: "id-list",
+    origin: "generated",
+    shapes: BOTH_SHAPES,
+    required: false,
+  },
+  {
+    key: "Caused",
+    type: "id-list",
+    origin: "generated",
+    shapes: BOTH_SHAPES,
+    required: false,
+  },
+  {
+    key: "Affected-by",
+    type: "id-list",
+    origin: "generated",
+    shapes: BOTH_SHAPES,
+    required: false,
+  },
+  {
+    key: "Mitigates",
+    type: "id-list",
+    origin: "generated",
+    shapes: BOTH_SHAPES,
+    required: false,
+  },
+  {
+    key: "Cited-by",
+    type: "id-list",
+    origin: "generated",
+    shapes: BOTH_SHAPES,
+    required: false,
+  },
 ];
 
 /** Canonical Title-Case attribute keys the core recognizes. */

--- a/tests/e2e/validate_test.ts
+++ b/tests/e2e/validate_test.ts
@@ -50,6 +50,44 @@ Deno.test("validate: Type: Specification accepted in core-only mode", async () =
   assertEquals(code, 0, `expected exit 0, got ${code}; stderr: ${stderr}`);
 });
 
+Deno.test("validate: Derives in source rejected with MSL-A030 (generated inverse)", async () => {
+  const { code, stderr } = await markspec(["validate", "req.md"], {
+    files: {
+      "req.md": `# Test
+
+- [REQ-001] My requirement
+
+  Body text.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      Derives: 01HGW2Q8MNP3RSTVWXYZABCDEG
+`,
+    },
+  });
+  assertEquals(code, 1, `expected exit 1, got ${code}; stderr: ${stderr}`);
+  assertStringIncludes(stderr, "MSL-A030");
+  assertStringIncludes(stderr, "Derives");
+});
+
+Deno.test("validate: Verified-by in source rejected with MSL-A030", async () => {
+  const { code, stderr } = await markspec(["validate", "req.md"], {
+    files: {
+      "req.md": `# Test
+
+- [REQ-001] My requirement
+
+  Body text.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      Verified-by: 01HGW2Q8MNP3RSTVWXYZABCDEG
+`,
+    },
+  });
+  assertEquals(code, 1, `expected exit 1, got ${code}; stderr: ${stderr}`);
+  assertStringIncludes(stderr, "MSL-A030");
+  assertStringIncludes(stderr, "Verified-by");
+});
+
 Deno.test("validate: generated-origin attribute in source rejected with MSL-A030", async () => {
   const { code, stderr } = await markspec(["validate", "req.md"], {
     files: {


### PR DESCRIPTION
## Summary

Iteration 3 of the autonomous Prompt-1 follow-up loop. Completes the ADR-003 §Part 3 generated-inverse coverage of MSL-A030 (PR #272 only had `Superseded-by`).

| Commit | Slice | Spec anchor |
|---|---|---|
| `fcbf755` | Full inverse list in ATTRIBUTE_CATALOG with `origin: generated` | ADR-003 §Part 3, spec §4.4 |

## What lands

Fourteen new attribute-catalog entries, each `origin: generated`:

```
Derives, Satisfied-by, Realized-by, Verified-by, Tested-by,
Allocated, Contains, Provided-by, Required-by, Used-by,
Caused, Affected-by, Mitigates, Cited-by
```

The existing `MSL-A030` check in `checkStructural` reads `origin: generated` from the catalog and emits an error for any of these found in source — no new validator code needed.

## Tests

| Before | After |
|---|---|
| 813 (post-#279) | 815 (+2 sampling `Derives` and `Verified-by` in source) |

All `just check` gates green per commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
