### PR TITLE
feat(core): MSL-C071 for caption / block-type mismatch

### DIFF
--- a/packages/markspec/core/validator/captions.ts
+++ b/packages/markspec/core/validator/captions.ts
@@ -46,6 +46,22 @@ const captionableMatchers: Record<CaptionKeyword, (line: string) => boolean> = {
 };
 
 /**
+ * Return the caption keyword whose matcher recognises the given line,
+ * or `undefined` when no matcher fires. Used to distinguish a
+ * "captionable but wrong type" mismatch from an orphan caption. When
+ * multiple matchers fire (e.g., a fenced code block matches both
+ * `Listing` and `Feature`), the first declaration order wins —
+ * sufficient for MSL-C071 detection because the test "did the caption
+ * keyword's own matcher fire" runs first.
+ */
+function classifyAdjacentBlock(line: string): CaptionKeyword | undefined {
+  for (const kw of CAPTION_KEYWORDS) {
+    if (captionableMatchers[kw](line)) return kw;
+  }
+  return undefined;
+}
+
+/**
  * Validate caption adjacency for one entry. Emits `MSL-C070` for any
  * caption line whose immediate non-blank neighbour (above or below) is
  * not a captionable block of the matching type.
@@ -75,13 +91,37 @@ export function validateCaptions(entry: Entry): readonly Diagnostic[] {
     let above = i - 1;
     while (above >= 0 && lines[above].trim() === "") above--;
     const aboveBlock = above >= 0 && matcher(lines[above]);
+    const aboveKind = above >= 0
+      ? classifyAdjacentBlock(lines[above])
+      : undefined;
 
     // Walk to the nearest non-blank line below.
     let below = i + 1;
     while (below < lines.length && lines[below].trim() === "") below++;
     const belowBlock = below < lines.length && matcher(lines[below]);
+    const belowKind = below < lines.length
+      ? classifyAdjacentBlock(lines[below])
+      : undefined;
 
     if (aboveBlock || belowBlock) continue;
+
+    // No matching block adjacent. Decide between C070 (no captionable
+    // block at all) and C071 (a captionable block of the wrong type).
+    const mismatchKind = aboveKind ?? belowKind;
+    if (mismatchKind !== undefined) {
+      diagnostics.push({
+        code: "MSL-C071",
+        severity: "error",
+        message: `${entry.displayId}: ${keyword}: caption is adjacent to a ` +
+          `${mismatchKind} block, not a ${keyword} block (spec §4.7)`,
+        location: {
+          file: entry.location.file,
+          line: entry.location.line + 1 + i,
+          column: 1,
+        },
+      });
+      continue;
+    }
 
     diagnostics.push({
       code: "MSL-C070",

--- a/tests/e2e/validate_test.ts
+++ b/tests/e2e/validate_test.ts
@@ -743,6 +743,25 @@ Deno.test("validate: orphan Figure: caption emits MSL-C070", async () => {
   assertStringIncludes(stderr, "MSL-C070");
 });
 
+Deno.test("validate: Equation: caption adjacent to a Figure fires MSL-C071", async () => {
+  const { code, stderr } = await markspec(["validate", "req.md"], {
+    files: {
+      "req.md": `# Test
+
+- [REQ-001] My requirement
+
+  ![Sensor diagram](sensor.svg)
+
+  Equation: This claims to be an equation but the block above is an image
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+`,
+    },
+  });
+  assertEquals(code, 1, `expected exit 1, got ${code}; stderr: ${stderr}`);
+  assertStringIncludes(stderr, "MSL-C071");
+});
+
 Deno.test("validate: Figure: caption adjacent to image passes", async () => {
   const { code, stderr } = await markspec(["validate", "req.md"], {
     files: {


### PR DESCRIPTION
## Summary

Iteration 4 of the autonomous Prompt-1 follow-up loop. Distinguishes the "captionable block of the wrong type" case from the orphan caption case, per spec §4.7.

| Commit | Slice | Spec anchor |
|---|---|---|
| `4e6e974` | MSL-C071 caption block-type mismatch | §4.7 |

## What lands

The captions validator now classifies the adjacent line via a keyword-agnostic matcher loop:

- Adjacent line matches the caption keyword's own matcher → OK
- Adjacent line matches some OTHER keyword's matcher → **MSL-C071** (mismatch)
- Adjacent line matches no captionable matcher → **MSL-C070** (orphan, unchanged)

Example: `Equation:` next to an `![image](...)` image now fires MSL-C071 instead of MSL-C070.

## Out of scope

- **MSL-C072** (project-configured caption position) — needs the per-project caption-position config knob; deferred.

## Tests

| Before | After |
|---|---|
| 815 (post-#280) | 816 (+1 covering `Equation:` next to Figure → MSL-C071) |

All `just check` gates green per commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
