### PR TITLE
test(mcp): retry markspec_refresh to absorb CI filesystem lag

### DIFF
--- a/tests/e2e/mcp_test.ts
+++ b/tests/e2e/mcp_test.ts
@@ -317,13 +317,23 @@ Deno.test("mcp: file edit + markspec_refresh fires resources/updated", async () 
         `\n- [STK_E2E_0002] Second\n\n  Body.\n\n      Id: 01HGW2Q8MNP3RSTVWXYZABCDEG\n`,
     );
 
-    const resp = await proc.request("tools/call", {
-      name: "markspec_refresh",
-      arguments: {},
-    });
-    // deno-lint-ignore no-explicit-any
-    const content = (resp.result as any).content as Array<{ text: string }>;
-    assertStringIncludes(content[0].text, "2 entries");
+    // Retry the refresh up to 5 times with short delays. On slow CI
+    // runners the subprocess's view of the file system can lag behind
+    // the test's `writeTextFile` by tens of milliseconds; a single
+    // refresh call can race and report the pre-edit entry count.
+    let lastText = "";
+    for (let attempt = 0; attempt < 5; attempt++) {
+      const resp = await proc.request("tools/call", {
+        name: "markspec_refresh",
+        arguments: {},
+      });
+      // deno-lint-ignore no-explicit-any
+      const content = (resp.result as any).content as Array<{ text: string }>;
+      lastText = content[0].text;
+      if (lastText.includes("2 entries")) break;
+      await new Promise((r) => setTimeout(r, 100));
+    }
+    assertStringIncludes(lastText, "2 entries");
 
     // Subscription handlers fire on the next microtask after the tool call
     // response; give the runtime up to ~500ms to flush them before draining.


### PR DESCRIPTION
## Summary

Iteration 5 of the autonomous Prompt-1 follow-up loop. Hardens the recurring CI flake on `mcp: file edit + markspec_refresh fires resources/updated` that we hit twice during the implementation series.

| Commit | Slice |
|---|---|
| `ee9ad48` | Retry `markspec_refresh` to absorb CI filesystem lag |

## What lands

The test now retries the `markspec_refresh` tool call up to 5 times with 100ms backoff until the response acknowledges the second entry. Max wait ≈ 500ms — generous enough to absorb Linux runner FS-visibility lag, fast enough that locally the first call still wins.

No production code change. The MCP subprocess behaviour is unchanged; only the test's tolerance for FS-visibility lag widens.

Verified locally: 5 consecutive runs pass cleanly (sub-300ms each).

## Tests

| Before | After |
|---|---|
| 816 (post-#281) | 816 (test count unchanged; existing test made resilient) |

All `just check` gates green per commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
