### PR TITLE
fix(core): MSL-T021 over-fire + MSL-B043 message/code mismatch

### DIFF
--- a/packages/markspec/core/validator/body_blocks.ts
+++ b/packages/markspec/core/validator/body_blocks.ts
@@ -22,13 +22,36 @@ const HR_RE = /^\s*(?:-{3,}|\*{3,}|_{3,})\s*$/;
 const TASK_LIST_RE = /^\s*[-*+]\s+\[[ xX]\]/;
 
 /**
- * Raw HTML detection. Captures any opening, closing, or self-closing
- * HTML tag (`<tag>`, `</tag>`, `<tag/>`). HTML comments (`<!-- ... -->`)
- * are intentionally allowed, including non-markspec ones, until the
- * tighter "markspec directive comments only" rule lands in a later
- * slice.
+ * HTML tag detection. Matches an opening, closing, or self-closing tag
+ * (`<tag>`, `</tag>`, `<tag/>`). Doesn't match HTML comments — those
+ * are handled by {@linkcode HTML_COMMENT_RE} below so we can allow
+ * markspec directive comments while still flagging arbitrary HTML
+ * comments (which spec §2.4.1 forbids).
  */
-const RAW_HTML_RE = /<\/?[A-Za-z][A-Za-z0-9]*(\s[^>]*)?\/?>/;
+const HTML_TAG_RE = /<\/?[A-Za-z][A-Za-z0-9]*(\s[^>]*)?\/?>/;
+
+/** Any HTML comment, `<!--…-->`. */
+const HTML_COMMENT_RE = /<!--[\s\S]*?-->/;
+
+/**
+ * A whole-line markspec directive comment: `<!-- markspec:<rest> -->`
+ * occupying the line on its own (optional leading/trailing
+ * whitespace). The directive form is the one exception spec §2.4.1
+ * carves out from the "no raw HTML" rule.
+ */
+const MARKSPEC_DIRECTIVE_LINE_RE = /^\s*<!--\s*markspec:[\s\S]*?-->\s*$/;
+
+/**
+ * Return `true` when `line` contains raw HTML the body model forbids:
+ * any tag, or any comment that isn't a standalone markspec directive.
+ */
+function hasForbiddenHtml(line: string): boolean {
+  if (HTML_TAG_RE.test(line)) return true;
+  if (HTML_COMMENT_RE.test(line) && !MARKSPEC_DIRECTIVE_LINE_RE.test(line)) {
+    return true;
+  }
+  return false;
+}
 
 interface BodyDiag {
   readonly code: string;
@@ -84,7 +107,7 @@ export function validateBodyBlocks(entry: Entry): readonly Diagnostic[] {
     if (HEADING_RE.test(line)) diag = HEADING_DIAG;
     else if (HR_RE.test(line)) diag = HR_DIAG;
     else if (TASK_LIST_RE.test(line)) diag = TASK_LIST_DIAG;
-    else if (RAW_HTML_RE.test(line)) diag = RAW_HTML_DIAG;
+    else if (hasForbiddenHtml(line)) diag = RAW_HTML_DIAG;
     if (!diag) continue;
 
     diagnostics.push({

--- a/packages/markspec/core/validator/types.ts
+++ b/packages/markspec/core/validator/types.ts
@@ -17,6 +17,7 @@ import type {
 } from "../model/mod.ts";
 import { CORE_TYPES } from "../model/mod.ts";
 import { compileDisplayIdPattern } from "./pattern.ts";
+import { explicitType, resolvedCoreType } from "./type_resolution.ts";
 
 /**
  * Profile-declared concrete-type naming convention (spec §1.3): lowercase
@@ -36,18 +37,23 @@ const UNIT_DISPLAY_ID_RE = /(::|\/)/;
 /**
  * Late-stage type inference per spec §1.3.1 step 8 (Authored shape).
  *
- * When no explicit `Type:` is present and the display ID carries a
- * path-like separator, infer `Unit` and emit MSL-T021 as a warning so the
- * author can promote the inferred type to an explicit declaration. This
- * implements the narrowest slice of the spec's late-stage chain — the
- * URI-scheme map (step 5), discriminating-attribute inference (step 6),
- * and document-directive inference (step 7) land in later slices.
+ * When no upstream signal has resolved the entry's type and the display
+ * ID carries a path-like separator, infer `Unit` and emit MSL-T021 as a
+ * warning so the author can promote the inferred type to an explicit
+ * declaration.
+ *
+ * The "no upstream signal" check consults `resolvedCoreType()` so a
+ * profile-classified `entry.type` or any earlier inference branch
+ * suppresses the warning — previously only an explicit `Type:`
+ * attribute did. Step 8 (this function) is the genuinely-late
+ * fallback; firing it on already-classified entries was a false
+ * positive.
  */
 export function inferTypeFromDisplayIdShape(
   entry: Entry,
 ): readonly Diagnostic[] {
   if (entry.shape !== "identified") return [];
-  if (findExplicitTypeAttribute(entry) !== undefined) return [];
+  if (resolvedCoreType(entry) !== undefined) return [];
   if (!UNIT_DISPLAY_ID_RE.test(entry.displayId)) return [];
   return [{
     code: "MSL-T021",
@@ -74,17 +80,17 @@ export function validateCoreTypeAttribute(
   entry: Entry,
   profile: EffectiveProfile | null,
 ): readonly Diagnostic[] {
-  const explicitType = findExplicitTypeAttribute(entry);
-  if (explicitType === undefined) return [];
-  if (CORE_TYPES.has(explicitType)) return [];
-  if (profile !== null && profile.types.has(explicitType)) return [];
+  const value = explicitType(entry);
+  if (value === undefined) return [];
+  if (CORE_TYPES.has(value)) return [];
+  if (profile !== null && profile.types.has(value)) return [];
 
   // Core-only mode: distinguish "profile-only type" (T023) from "unknown" (T020).
-  if (profile === null && PROFILE_TYPE_NAME_RE.test(explicitType)) {
+  if (profile === null && PROFILE_TYPE_NAME_RE.test(value)) {
     return [{
       code: "MSL-T023",
       severity: "error",
-      message: `${entry.displayId}: Type: '${explicitType}' looks like a ` +
+      message: `${entry.displayId}: Type: '${value}' looks like a ` +
         `profile-declared type but no profile is loaded (core-only mode)`,
       location: entry.location,
     }];
@@ -93,7 +99,7 @@ export function validateCoreTypeAttribute(
   return [{
     code: "MSL-T020",
     severity: "error",
-    message: `${entry.displayId}: Type: '${explicitType}' is not a core type ` +
+    message: `${entry.displayId}: Type: '${value}' is not a core type ` +
       `or a profile-declared type`,
     location: entry.location,
   }];
@@ -128,16 +134,16 @@ export function classifyEntry(
   const diagnostics: Diagnostic[] = [];
 
   // 1. Explicit Type: trailer?
-  const explicitType = findExplicitTypeAttribute(entry);
-  if (explicitType !== undefined) {
-    if (profile.types.has(explicitType)) {
-      return { type: explicitType, diagnostics };
+  const explicit = explicitType(entry);
+  if (explicit !== undefined) {
+    if (profile.types.has(explicit)) {
+      return { type: explicit, diagnostics };
     }
     diagnostics.push({
       code: "MSL-T001",
       severity: "error",
       message:
-        `${entry.displayId}: explicit Type: '${explicitType}' is not a declared type`,
+        `${entry.displayId}: explicit Type: '${explicit}' is not a declared type`,
       location: entry.location,
     });
     return { type: undefined, diagnostics };
@@ -184,15 +190,6 @@ export function classifyEntry(
     });
   }
   return { type: undefined, diagnostics };
-}
-
-function findExplicitTypeAttribute(entry: Entry): string | undefined {
-  for (const attr of entry.rawAttributes) {
-    if (attr.key === "Type") {
-      return attr.value.trim();
-    }
-  }
-  return undefined;
 }
 
 /** Result of running the classification stage over a batch of entries. */

--- a/packages/markspec/core/validator/types_unit_test.ts
+++ b/packages/markspec/core/validator/types_unit_test.ts
@@ -1,0 +1,74 @@
+/**
+ * @module core/validator/types_unit_test
+ *
+ * Unit tests for type-resolution helpers in validator/types.ts. These
+ * cover paths that are hard or noisy to exercise via the e2e validate
+ * suite (e.g., entries with profile-classified `entry.type` set
+ * directly).
+ */
+
+import { assertEquals } from "@std/assert";
+import { inferTypeFromDisplayIdShape } from "./types.ts";
+import type { Entry } from "../model/mod.ts";
+
+const ULID = "01HGW2Q8MNP3RSTVWXYZABCDEF";
+
+function authoredEntry(opts: {
+  displayId: string;
+  type?: string;
+  rawAttributes?: Array<{ key: string; value: string }>;
+}): Entry {
+  return {
+    displayId: opts.displayId,
+    title: "Test entry",
+    body: "Body.",
+    rawAttributes: opts.rawAttributes ?? [{ key: "Id", value: ULID }],
+    typedAttributes: new Map(),
+    id: ULID,
+    type: opts.type,
+    shape: "identified",
+    location: { file: "test.md", line: 1, column: 1 },
+    source: "markdown",
+  };
+}
+
+// Regression — B1: when entry.type is already resolved (e.g., by profile
+// classification), the display-ID-shape inference must NOT fire MSL-T021.
+// The "infer Unit" warning only makes sense when no type signal at all
+// has resolved the entry.
+Deno.test("inferTypeFromDisplayIdShape: skipped when entry.type set even if display ID contains ::", () => {
+  const entry = authoredEntry({
+    displayId: "braking::controller::debounce",
+    type: "SoftwareUnit",
+  });
+  const diags = inferTypeFromDisplayIdShape(entry);
+  assertEquals(
+    diags.length,
+    0,
+    `expected no diagnostics when entry.type is set; got ${
+      JSON.stringify(diags)
+    }`,
+  );
+});
+
+Deno.test("inferTypeFromDisplayIdShape: skipped when explicit Type: set", () => {
+  const entry = authoredEntry({
+    displayId: "braking::controller::debounce",
+    rawAttributes: [
+      { key: "Id", value: ULID },
+      { key: "Type", value: "SoftwareUnit" },
+    ],
+  });
+  const diags = inferTypeFromDisplayIdShape(entry);
+  assertEquals(diags.length, 0);
+});
+
+Deno.test("inferTypeFromDisplayIdShape: fires MSL-T021 when no type signal resolves", () => {
+  const entry = authoredEntry({
+    displayId: "braking::controller::debounce",
+  });
+  const diags = inferTypeFromDisplayIdShape(entry);
+  assertEquals(diags.length, 1);
+  assertEquals(diags[0].code, "MSL-T021");
+  assertEquals(diags[0].severity, "warning");
+});

--- a/tests/e2e/validate_test.ts
+++ b/tests/e2e/validate_test.ts
@@ -701,6 +701,44 @@ Deno.test("validate: task list inside entry body fires MSL-B042", async () => {
   assertStringIncludes(stderr, "MSL-B042");
 });
 
+Deno.test("validate: non-markspec HTML comment in body fires MSL-B043", async () => {
+  const { code, stderr } = await markspec(["validate", "req.md"], {
+    files: {
+      "req.md": `# Test
+
+- [REQ-001] My requirement
+
+  Body text. <!-- TODO: revisit --> more text.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+`,
+    },
+  });
+  assertEquals(code, 1, `expected exit 1, got ${code}; stderr: ${stderr}`);
+  assertStringIncludes(stderr, "MSL-B043");
+});
+
+Deno.test("validate: markspec directive comment in body is allowed", async () => {
+  const { code, stderr } = await markspec(["validate", "req.md"], {
+    files: {
+      "req.md": `# Test
+
+- [REQ-001] My requirement
+
+  Body text.
+
+  <!-- markspec:include foo.md -->
+
+  More body.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+`,
+    },
+  });
+  // Markspec directive comments are the one HTML form spec §2.4.1 permits.
+  assertEquals(code, 0, `expected exit 0, got ${code}; stderr: ${stderr}`);
+});
+
 Deno.test("validate: raw HTML inside entry body fires MSL-B043", async () => {
   const { code, stderr } = await markspec(["validate", "req.md"], {
     files: {


### PR DESCRIPTION
## Summary

Iteration 6 of the autonomous Prompt-1 follow-up loop. Fixes the two BLOCKER bugs identified in the post-merge review.

| Commit | Slice |
|---|---|
| `c3b8a6e` | Fix MSL-T021 over-fire + MSL-B043 message/code mismatch |

## What lands

### B1 — MSL-T021 no longer fires on already-typed entries

`inferTypeFromDisplayIdShape` was checking only for an explicit `Type:` attribute, ignoring profile-classified `entry.type`. An Authored entry that the profile classifier had already typed would still get the "infer Unit from display-ID shape" warning if its display ID contained `::` or `/`. Switched the gate to `resolvedCoreType()` so any upstream type signal (explicit, profile, URI scheme) suppresses step 8.

Also drops the duplicated `findExplicitTypeAttribute` helper in `validator/types.ts` in favour of the shared `explicitType` / `resolvedCoreType` exports from `type_resolution.ts`.

### B2 — MSL-B043 message no longer lies

The diagnostic copy claimed *"only `<!-- markspec:* -->` directive comments are permitted"* but the regex accepted any HTML comment. Tightened the detector to flag every comment that isn't a standalone whole-line markspec directive. Existing tag detection unchanged.

## Tests

| Before | After |
|---|---|
| 816 (post-#282) | 821 (+3 unit tests for inferTypeFromDisplayIdShape, +2 e2e for B2) |

All `just check` gates green per commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
