### PR TITLE
refactor(core): extract walkProseLines helper, dedupe FENCE_RE copies

### DIFF
--- a/packages/markspec/core/formatter/mod.ts
+++ b/packages/markspec/core/formatter/mod.ts
@@ -18,6 +18,7 @@ import { attributeSpec, IDENTITY_KEY } from "../model/mod.ts";
 import { ATTR_LINE_RE } from "../parser/attributes.ts";
 import { extractFrontMatter } from "../parser/frontmatter.ts";
 import { parseMarkdown } from "../parser/markdown.ts";
+import { walkProseLines } from "../util/fence.ts";
 
 /**
  * Value types that accept CSV on input but must be emitted as multi-line
@@ -78,15 +79,9 @@ function isSentenceInitial(line: string, offset: number): boolean {
  */
 export function normalizeModalKeywords(markdown: string): string {
   const lines = markdown.split("\n");
-  let inFence = false;
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i];
-    if (/^\s*(```|~~~)/.test(line)) {
-      inFence = !inFence;
-      continue;
-    }
-    if (inFence) continue;
-    if (/^( {4}|\t)/.test(line)) continue;
+  walkProseLines(markdown, (line, i) => {
+    // Indented-code / attribute-trailer lines aren't prose either.
+    if (/^( {4}|\t)/.test(line)) return;
     let normalized = line.replace(RFC2119_MODAL_RE, (m) => m.toLowerCase());
     normalized = normalized.replace(
       EARS_KEYWORD_RE,
@@ -94,7 +89,7 @@ export function normalizeModalKeywords(markdown: string): string {
         isSentenceInitial(normalized, offset) ? m : m.toLowerCase(),
     );
     lines[i] = normalized;
-  }
+  });
   return lines.join("\n");
 }
 

--- a/packages/markspec/core/parser/entity_refs.ts
+++ b/packages/markspec/core/parser/entity_refs.ts
@@ -11,6 +11,7 @@ import type {
   EntityRefConvention,
   SourceLocation,
 } from "../model/mod.ts";
+import { walkProseLines } from "../util/fence.ts";
 
 /**
  * Lexical pattern for an inline entity reference. The leading `$` is the
@@ -62,17 +63,8 @@ export function extractEntityRefs(
   baseLocation: SourceLocation,
 ): EntityRef[] {
   const refs: EntityRef[] = [];
-  const lines = body.split("\n");
-  let inFence = false;
 
-  for (let lineIdx = 0; lineIdx < lines.length; lineIdx++) {
-    const line = lines[lineIdx];
-    if (/^\s*(```|~~~)/.test(line)) {
-      inFence = !inFence;
-      continue;
-    }
-    if (inFence) continue;
-
+  walkProseLines(body, (line, lineIdx) => {
     ENTITY_REF_RE.lastIndex = 0;
     let match: RegExpExecArray | null;
     while ((match = ENTITY_REF_RE.exec(line)) !== null) {
@@ -90,7 +82,7 @@ export function extractEntityRefs(
         },
       });
     }
-  }
+  });
 
   return refs;
 }

--- a/packages/markspec/core/util/fence.ts
+++ b/packages/markspec/core/util/fence.ts
@@ -1,0 +1,44 @@
+/**
+ * @module core/util/fence
+ *
+ * Prose-line walker that skips lines inside fenced code blocks.
+ * Several validator and formatter passes (body-block exclusions,
+ * caption adjacency, `$Identifier` extraction, modal-keyword
+ * normalisation) all needed to walk an entry body line-by-line while
+ * treating fenced code as verbatim. This helper centralises that
+ * pattern so the fence-toggle semantics stay consistent.
+ *
+ * Fence detection follows CommonMark §4.5 — a line whose first
+ * non-whitespace content is three or more backticks or tildes opens
+ * (or closes) a fenced block. The language tag that may follow the
+ * opening fence does not affect detection: we toggle on every fence
+ * marker regardless. (Mismatched marker types — ``` opener / ~~~
+ * closer — are accepted by the walker because real Markdown parsers
+ * already reject those upstream.)
+ */
+
+/** Three or more backticks or tildes at the start of a line. */
+export const FENCE_RE = /^\s*(```|~~~)/;
+
+/** Callback for {@linkcode walkProseLines}. Receives one line + its 0-based index. */
+export type ProseLineCallback = (line: string, index: number) => void;
+
+/**
+ * Walk `body` line by line, invoking `cb` for every line that's NOT
+ * inside a fenced code block. The first fence marker opens the block;
+ * the next closes it. The fence-marker lines themselves are also
+ * skipped (they're structural, not prose).
+ */
+export function walkProseLines(body: string, cb: ProseLineCallback): void {
+  const lines = body.split("\n");
+  let inFence = false;
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (FENCE_RE.test(line)) {
+      inFence = !inFence;
+      continue;
+    }
+    if (inFence) continue;
+    cb(line, i);
+  }
+}

--- a/packages/markspec/core/util/fence_test.ts
+++ b/packages/markspec/core/util/fence_test.ts
@@ -1,0 +1,68 @@
+/**
+ * @module core/util/fence_test
+ *
+ * Unit tests for {@linkcode walkProseLines} — the prose-line walker
+ * that skips lines inside fenced code blocks. These cover the
+ * boundary conditions the prior copy-pasted code couldn't easily
+ * exercise.
+ */
+
+import { assertEquals } from "@std/assert";
+import { walkProseLines } from "./fence.ts";
+
+Deno.test("walkProseLines: yields every line when there are no fences", () => {
+  const body = "alpha\nbeta\ngamma";
+  const yielded: string[] = [];
+  walkProseLines(body, (line) => yielded.push(line));
+  assertEquals(yielded, ["alpha", "beta", "gamma"]);
+});
+
+Deno.test("walkProseLines: skips lines inside backtick fenced code", () => {
+  const body = [
+    "before",
+    "```ts",
+    "const x = 1;",
+    "```",
+    "after",
+  ].join("\n");
+  const yielded: string[] = [];
+  walkProseLines(body, (line) => yielded.push(line));
+  assertEquals(yielded, ["before", "after"]);
+});
+
+Deno.test("walkProseLines: skips lines inside tilde fenced code", () => {
+  const body = ["pre", "~~~", "verbatim", "~~~", "post"].join("\n");
+  const yielded: string[] = [];
+  walkProseLines(body, (line) => yielded.push(line));
+  assertEquals(yielded, ["pre", "post"]);
+});
+
+Deno.test("walkProseLines: index argument is the original 0-based line index", () => {
+  const body = ["a", "```", "code", "```", "b"].join("\n");
+  const indices: number[] = [];
+  walkProseLines(body, (_line, i) => indices.push(i));
+  assertEquals(indices, [0, 4]);
+});
+
+Deno.test("walkProseLines: nested-looking fences toggle on every marker", () => {
+  // Mixed `~~~` opener and ``` closer — real Markdown would reject,
+  // but the walker treats any fence marker as toggle.
+  const body = ["a", "~~~", "x", "```", "b"].join("\n");
+  const yielded: string[] = [];
+  walkProseLines(body, (line) => yielded.push(line));
+  assertEquals(yielded, ["a", "b"]);
+});
+
+Deno.test("walkProseLines: leading whitespace on fence marker is ignored", () => {
+  const body = ["a", "   ```", "x", "   ```", "b"].join("\n");
+  const yielded: string[] = [];
+  walkProseLines(body, (line) => yielded.push(line));
+  assertEquals(yielded, ["a", "b"]);
+});
+
+Deno.test("walkProseLines: empty body yields nothing", () => {
+  let calls = 0;
+  walkProseLines("", () => calls++);
+  // `"".split("\n")` is `[""]`, so one empty line still goes to cb.
+  assertEquals(calls, 1);
+});

--- a/packages/markspec/core/validator/body_blocks.ts
+++ b/packages/markspec/core/validator/body_blocks.ts
@@ -15,8 +15,8 @@
  */
 
 import type { Diagnostic, Entry } from "../model/mod.ts";
+import { walkProseLines } from "../util/fence.ts";
 
-const FENCE_RE = /^\s*(```|~~~)/;
 const HEADING_RE = /^\s*#{1,6}\s/;
 const HR_RE = /^\s*(?:-{3,}|\*{3,}|_{3,})\s*$/;
 const TASK_LIST_RE = /^\s*[-*+]\s+\[[ xX]\]/;
@@ -91,24 +91,16 @@ const RAW_HTML_DIAG: BodyDiag = {
  */
 export function validateBodyBlocks(entry: Entry): readonly Diagnostic[] {
   const diagnostics: Diagnostic[] = [];
-  const lines = entry.body.split("\n");
-  let inFence = false;
 
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i];
-    if (FENCE_RE.test(line)) {
-      inFence = !inFence;
-      continue;
-    }
-    if (inFence) continue;
-    if (line.trim() === "") continue;
+  walkProseLines(entry.body, (line, i) => {
+    if (line.trim() === "") return;
 
     let diag: BodyDiag | undefined;
     if (HEADING_RE.test(line)) diag = HEADING_DIAG;
     else if (HR_RE.test(line)) diag = HR_DIAG;
     else if (TASK_LIST_RE.test(line)) diag = TASK_LIST_DIAG;
     else if (hasForbiddenHtml(line)) diag = RAW_HTML_DIAG;
-    if (!diag) continue;
+    if (!diag) return;
 
     diagnostics.push({
       code: diag.code,
@@ -120,7 +112,7 @@ export function validateBodyBlocks(entry: Entry): readonly Diagnostic[] {
         column: 1,
       },
     });
-  }
+  });
 
   return diagnostics;
 }

--- a/packages/markspec/core/validator/captions.ts
+++ b/packages/markspec/core/validator/captions.ts
@@ -8,6 +8,7 @@
  */
 
 import type { Diagnostic, Entry } from "../model/mod.ts";
+import { FENCE_RE } from "../util/fence.ts";
 
 /** Caption keywords recognised by the core. */
 const CAPTION_KEYWORDS = [
@@ -24,9 +25,6 @@ type CaptionKeyword = typeof CAPTION_KEYWORDS[number];
 const CAPTION_LINE_RE = new RegExp(
   `^\\s*(${CAPTION_KEYWORDS.join("|")}):\\s+(\\S.*)$`,
 );
-
-/** Fence open/close marker for ``` and ~~~ blocks. */
-const FENCE_RE = /^\s*(```|~~~)/;
 
 /** Heuristic captionable-block matchers keyed by caption keyword. */
 const captionableMatchers: Record<CaptionKeyword, (line: string) => boolean> = {


### PR DESCRIPTION
## Summary

Iteration 7 of the autonomous Prompt-1 follow-up loop. Eliminates the M1 finding from the review: four call sites had grown identical inline copies of `FENCE_RE` + the `inFence` toggle walker.

| Commit | Slice |
|---|---|
| `<sha>` | Extract `walkProseLines` helper and dedupe FENCE_RE across four files |

## What lands

New `core/util/fence.ts` exposes:

- `FENCE_RE` — three-or-more backticks or tildes at line start (CommonMark §4.5)
- `walkProseLines(body, cb)` — iterate body lines, skipping everything inside fenced blocks and the fence-marker lines themselves

Updated call sites:

- `core/validator/body_blocks.ts` — full walker replaced with `walkProseLines`
- `core/validator/captions.ts` — kept its lookahead/lookbehind walker (needs adjacent lines, doesn't fit the callback shape) but imports `FENCE_RE` from `util/fence.ts` instead of redeclaring it
- `core/parser/entity_refs.ts` — walker replaced with `walkProseLines`
- `core/formatter/mod.ts` (`normalizeModalKeywords`) — walker replaced

7 new unit tests in `core/util/fence_test.ts` cover patterns the inline copies couldn't easily exercise (mixed marker types, leading whitespace, empty body, index reporting after fence).

Behaviour is unchanged.

## Tests

| Before | After |
|---|---|
| 821 (post-#283) | 828 (+7 fence unit tests) |

All `just check` gates green per commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
