### PR TITLE
refactor(core): consolidate ATTRIBUTE_CATALOG + dedupe URL regex

### DIFF
--- a/packages/markspec/core/model/attributes.ts
+++ b/packages/markspec/core/model/attributes.ts
@@ -70,6 +70,51 @@ export const ATTRIBUTE_CATALOG: readonly AttributeSpec[] = [
     required: true,
   },
 
+  // Universal classification (spec §1.3 / §1.4) — apply to every entry.
+  // `Type` carries the information-layer classification; `Source` and
+  // `Origin` are universal authoring metadata (SSoT pointer, synthesis
+  // flag). They live in the catalogue so validators / formatters can
+  // look them up without per-call special-casing.
+  {
+    key: "Type",
+    type: "enum",
+    origin: "authored",
+    shapes: BOTH_SHAPES,
+    required: false,
+  },
+  {
+    key: "Source",
+    type: "path-or-id",
+    origin: "authored",
+    shapes: BOTH_SHAPES,
+    required: false,
+  },
+  {
+    key: "Origin",
+    type: "enum",
+    origin: "authored",
+    shapes: BOTH_SHAPES,
+    required: false,
+    enumValues: ["authored", "synthesized"],
+  },
+
+  // Reference-shape navigation (spec §1.5) — promoted from the RefHub
+  // profile to core in PR #277.
+  {
+    key: "Reference-url",
+    type: "url",
+    origin: "authored",
+    shapes: ["referenced"],
+    required: false,
+  },
+  {
+    key: "Reference-document",
+    type: "text",
+    origin: "authored",
+    shapes: ["referenced"],
+    required: false,
+  },
+
   // Universal — apply to every entry
   {
     key: "Labels",

--- a/packages/markspec/core/validator/mod.ts
+++ b/packages/markspec/core/validator/mod.ts
@@ -23,6 +23,7 @@ import {
   UNIVERSAL_ATTRIBUTE_KEYS,
   URI_SCHEME_RE,
 } from "../model/mod.ts";
+import { HTTP_URL_RE } from "./value_types.ts";
 
 /** Universal attribute keys the core recognizes. */
 const UNIVERSAL_KEYS = new Set(UNIVERSAL_ATTRIBUTE_KEYS);
@@ -34,14 +35,6 @@ const UNIVERSAL_KEYS = new Set(UNIVERSAL_ATTRIBUTE_KEYS);
  * ends with an alphanumeric.
  */
 const REFERENCE_SLUG_RE = /^[A-Za-z]([A-Za-z0-9._/-]*[A-Za-z0-9])?$/;
-
-/**
- * HTTP(S) URL prefix for `Reference-url` value-type validation (spec
- * §1.5). The spec specifies HTTPS, but `http://` is accepted for
- * compatibility with existing fixtures — a future tightening slice can
- * narrow to HTTPS-only via a configurable strictness knob.
- */
-const REFERENCE_URL_RE = /^https?:\/\//;
 
 /** Result of a validation pass. */
 export interface ValidateResult {
@@ -195,7 +188,7 @@ function checkStructural(
       // attributes (spec §1.5); profile-declared attribute types are
       // validated by the profile-aware Stage 3 instead.
       if (attr.key === "Reference-url") {
-        if (!REFERENCE_URL_RE.test(attr.value.trim())) {
+        if (!HTTP_URL_RE.test(attr.value.trim())) {
           diagnostics.push({
             code: "MSL-A050",
             severity: "error",

--- a/packages/markspec/core/validator/per_type_attrs.ts
+++ b/packages/markspec/core/validator/per_type_attrs.ts
@@ -21,19 +21,14 @@ import { resolvedCoreType } from "./type_resolution.ts";
 
 /**
  * Attribute keys that are universal to every entry regardless of type
- * (spec §1.4 + §1.5). The core attribute catalog covers most of these;
- * a few additional keys (`Type`, `Source`, `Origin`, the Reference-shape
- * promoted attrs) are core-known but not in {@linkcode UNIVERSAL_ATTRIBUTE_KEYS}
- * directly, so they're added here.
+ * (spec §1.4 + §1.5). Sourced entirely from {@linkcode UNIVERSAL_ATTRIBUTE_KEYS}
+ * — `Type`, `Source`, `Origin`, `Reference-url`, and `Reference-document`
+ * are now first-class catalogue entries, so the previous hand-maintained
+ * extension list is no longer needed.
  */
-const UNIVERSAL_KEYS: ReadonlySet<string> = new Set<string>([
-  ...UNIVERSAL_ATTRIBUTE_KEYS,
-  "Type",
-  "Source",
-  "Origin",
-  "Reference-url",
-  "Reference-document",
-]);
+const UNIVERSAL_KEYS: ReadonlySet<string> = new Set<string>(
+  UNIVERSAL_ATTRIBUTE_KEYS,
+);
 
 /**
  * Emit MSL-T022 warnings for attributes that are core-known but not

--- a/packages/markspec/core/validator/value_types.ts
+++ b/packages/markspec/core/validator/value_types.ts
@@ -69,7 +69,14 @@ const validateId: ValueValidator = (value, _decl) => {
   return `not a valid id: '${value}' (expected 26-char ULID or scheme-qualified URI)`;
 };
 
-const HTTP_URL_RE = /^https?:\/\//;
+/**
+ * HTTP(S) URL prefix used by the `url` value type (spec §1.8). The
+ * spec specifies HTTPS but `http://` is accepted for compatibility
+ * with existing fixtures; tightening to HTTPS-only is a future
+ * config-driven slice. Exported so other validator passes (e.g.,
+ * file-local `Reference-url` checks) can share one regex.
+ */
+export const HTTP_URL_RE = /^https?:\/\//;
 const validateUrl: ValueValidator = (value, _decl) => {
   return HTTP_URL_RE.test(value) ? null : `not a valid http(s) URL: '${value}'`;
 };

--- a/tests/e2e/validate_test.ts
+++ b/tests/e2e/validate_test.ts
@@ -864,6 +864,28 @@ Deno.test("validate: unresolved References citation exits 1 (MSL-T005)", async (
 // Warnings
 // ---------------------------------------------------------------------------
 
+Deno.test("validate: Origin: synthesized recognised as universal (no MSL-R010)", async () => {
+  const { code, stderr } = await markspec(["validate", "req.md"], {
+    files: {
+      "req.md": `# Test
+
+- [REQ-001] My requirement
+
+  Body text.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      Origin: synthesized
+`,
+    },
+  });
+  assertEquals(code, 0, `expected exit 0, got ${code}; stderr: ${stderr}`);
+  assertEquals(
+    /MSL-R010[^\n]*Origin/.test(stderr),
+    false,
+    `Origin is a universal attribute (spec §1.4); MSL-R010 must not fire on it; stderr: ${stderr}`,
+  );
+});
+
 Deno.test("validate: warning only exits 2", async () => {
   const { code, stderr } = await markspec(["validate", "req.md"], {
     files: {


### PR DESCRIPTION
## Summary

Iteration 8 of the autonomous Prompt-1 follow-up loop. Closes review findings M2 (duplicated URL regex) and N5 (hand-maintained universal-attribute extension).

| Commit | Slice |
|---|---|
| `5d13903` | Consolidate ATTRIBUTE_CATALOG + dedupe URL regex |

## What lands

**Five universal attributes added to `ATTRIBUTE_CATALOG`:**

| Key | Type | Origin | Shapes |
|---|---|---|---|
| `Type` | enum | authored | both |
| `Source` | path-or-id | authored | both |
| `Origin` | enum `{authored, synthesized}` | authored | both |
| `Reference-url` | url | authored | referenced |
| `Reference-document` | text | authored | referenced |

**URL regex consolidated.** `validator/mod.ts` no longer carries its own `REFERENCE_URL_RE`; the existing `HTTP_URL_RE` from `value_types.ts` is now exported and used in both places. One regex, one source of truth.

**`per_type_attrs.ts` UNIVERSAL_KEYS** now derives directly from `UNIVERSAL_ATTRIBUTE_KEYS` — the previous hand-maintained union with five extra keys is gone, because those keys are first-class catalog entries.

## Side benefit

`Origin: synthesized` no longer trips `MSL-R010` (unknown attribute) — fixed as a side effect of catalog promotion. New e2e test pins the behaviour.

## Tests

| Before | After |
|---|---|
| 828 (post-#284) | 829 (+1 e2e for Origin recognised as universal) |

All `just check` gates green per commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
