### PR TITLE
test(core): unit-test coverage for previously-untested helpers

### DIFF
--- a/packages/markspec/core/model/type_hierarchy_test.ts
+++ b/packages/markspec/core/model/type_hierarchy_test.ts
@@ -1,0 +1,70 @@
+/**
+ * @module core/model/type_hierarchy_test
+ *
+ * Unit tests for {@linkcode attributesForType}, particularly the
+ * `excludedAttrs` subtype-exclusion semantics that the spec lists
+ * under ADR-003 §Part 2.
+ */
+
+import { assertEquals } from "@std/assert";
+import { attributesForType, CORE_TYPE_SCOPED_ATTRS } from "./type_hierarchy.ts";
+
+Deno.test("attributesForType: Requirement inherits Specification attrs", () => {
+  const attrs = attributesForType("Requirement");
+  assertEquals(attrs.has("Satisfies"), true);
+  assertEquals(attrs.has("Derived-from"), true);
+  assertEquals(attrs.has("Allocated-to"), true);
+});
+
+Deno.test("attributesForType: Test inherits Specification BUT excludes Allocated-to", () => {
+  const attrs = attributesForType("Test");
+  assertEquals(attrs.has("Verifies"), true); // own
+  assertEquals(attrs.has("Tests"), true); // own
+  assertEquals(attrs.has("Satisfies"), true); // inherited from Specification
+  assertEquals(attrs.has("Derived-from"), true); // inherited
+  // The spec exclusion — `Allocated-to` is not applicable on Test.
+  assertEquals(attrs.has("Allocated-to"), false);
+});
+
+Deno.test("attributesForType: SoftwareComponent inherits Component attrs + own", () => {
+  const attrs = attributesForType("SoftwareComponent");
+  // Own
+  assertEquals(attrs.has("License"), true);
+  assertEquals(attrs.has("Build-manifest"), true);
+  assertEquals(attrs.has("Package-manager"), true);
+  // Inherited from Component
+  assertEquals(attrs.has("Kind"), true);
+  assertEquals(attrs.has("Part-of"), true);
+  assertEquals(attrs.has("Realizes"), true);
+  // Not a Component attribute
+  assertEquals(attrs.has("Satisfies"), false);
+});
+
+Deno.test("attributesForType: HardwareInterface inherits Component + own bus protocol attrs", () => {
+  const attrs = attributesForType("HardwareInterface");
+  assertEquals(attrs.has("Bus-protocol"), true);
+  assertEquals(attrs.has("Connector-type"), true);
+  assertEquals(attrs.has("Provides"), true); // inherited
+});
+
+Deno.test("attributesForType: Item root → empty set", () => {
+  const attrs = attributesForType("Item");
+  assertEquals(attrs.size, 0);
+});
+
+Deno.test("attributesForType: unknown type → empty set", () => {
+  const attrs = attributesForType("NotAType");
+  assertEquals(attrs.size, 0);
+});
+
+Deno.test("CORE_TYPE_SCOPED_ATTRS contains union of every typed attr", () => {
+  // Sample a few across families.
+  assertEquals(CORE_TYPE_SCOPED_ATTRS.has("Allocated-to"), true);
+  assertEquals(CORE_TYPE_SCOPED_ATTRS.has("Bus-protocol"), true);
+  assertEquals(CORE_TYPE_SCOPED_ATTRS.has("License"), true);
+  assertEquals(CORE_TYPE_SCOPED_ATTRS.has("Symbol"), true);
+  assertEquals(CORE_TYPE_SCOPED_ATTRS.has("Aliases"), true);
+  // Universal attrs are not "typed" — they live in the catalogue.
+  assertEquals(CORE_TYPE_SCOPED_ATTRS.has("Labels"), false);
+  assertEquals(CORE_TYPE_SCOPED_ATTRS.has("Id"), false);
+});

--- a/packages/markspec/core/model/uri_scheme_map_test.ts
+++ b/packages/markspec/core/model/uri_scheme_map_test.ts
@@ -1,0 +1,91 @@
+/**
+ * @module core/model/uri_scheme_map_test
+ *
+ * Unit tests for {@linkcode inferTypeFromUriScheme}. Covers the
+ * patterns in ADR-003 §Part 6 and the unmapped-scheme behaviour.
+ */
+
+import { assertEquals } from "@std/assert";
+import { inferTypeFromUriScheme } from "./uri_scheme_map.ts";
+
+Deno.test("inferTypeFromUriScheme: pkg:cargo → SoftwareComponent", () => {
+  assertEquals(
+    inferTypeFromUriScheme("pkg:cargo/serde@1.0.0"),
+    "SoftwareComponent",
+  );
+});
+
+Deno.test("inferTypeFromUriScheme: pkg:npm → SoftwareComponent", () => {
+  assertEquals(inferTypeFromUriScheme("pkg:npm/lodash"), "SoftwareComponent");
+});
+
+Deno.test("inferTypeFromUriScheme: pkg:hw → HardwareComponent", () => {
+  assertEquals(
+    inferTypeFromUriScheme("pkg:hw/bosch/0285008010"),
+    "HardwareComponent",
+  );
+});
+
+Deno.test("inferTypeFromUriScheme: urn:iso:std:iso → Requirement", () => {
+  assertEquals(
+    inferTypeFromUriScheme("urn:iso:std:iso:26262:-6:ed-2"),
+    "Requirement",
+  );
+});
+
+Deno.test("inferTypeFromUriScheme: urn:ietf:rfc → Requirement", () => {
+  assertEquals(inferTypeFromUriScheme("urn:ietf:rfc:2119"), "Requirement");
+});
+
+Deno.test("inferTypeFromUriScheme: doi → Requirement", () => {
+  assertEquals(
+    inferTypeFromUriScheme("doi:10.1109/IEEESTD.2008.4610935"),
+    "Requirement",
+  );
+});
+
+Deno.test("inferTypeFromUriScheme: urn:openapi → Contract", () => {
+  assertEquals(
+    inferTypeFromUriScheme("urn:openapi:braking:1.0.0"),
+    "Contract",
+  );
+});
+
+Deno.test("inferTypeFromUriScheme: urn:can-bus → HardwareInterface", () => {
+  assertEquals(
+    inferTypeFromUriScheme("urn:can-bus:powertrain:2024"),
+    "HardwareInterface",
+  );
+});
+
+Deno.test("inferTypeFromUriScheme: urn:refhub:term → Definition", () => {
+  assertEquals(
+    inferTypeFromUriScheme("urn:refhub:term:asil"),
+    "Definition",
+  );
+});
+
+Deno.test("inferTypeFromUriScheme: codebeamer → Requirement", () => {
+  assertEquals(
+    inferTypeFromUriScheme("codebeamer:Braking:1234"),
+    "Requirement",
+  );
+});
+
+Deno.test("inferTypeFromUriScheme: unmapped scheme → undefined", () => {
+  assertEquals(inferTypeFromUriScheme("jira:FOO-1"), undefined);
+});
+
+Deno.test("inferTypeFromUriScheme: empty string → undefined", () => {
+  assertEquals(inferTypeFromUriScheme(""), undefined);
+});
+
+Deno.test("inferTypeFromUriScheme: ULID-looking value → undefined", () => {
+  // Defensive: a value that looks like a ULID rather than a URI
+  // should fall through to undefined (caller should have already
+  // shape-discriminated, but the function is robust).
+  assertEquals(
+    inferTypeFromUriScheme("01HGW2Q8MNP3RSTVWXYZABCDEF"),
+    undefined,
+  );
+});

--- a/packages/markspec/core/parser/entity_refs_test.ts
+++ b/packages/markspec/core/parser/entity_refs_test.ts
@@ -1,0 +1,108 @@
+/**
+ * @module core/parser/entity_refs_test
+ *
+ * Unit tests for `$Identifier` entity-reference extraction.
+ */
+
+import { assertEquals } from "@std/assert";
+import { classifyConvention, extractEntityRefs } from "./entity_refs.ts";
+
+const baseLocation = { file: "test.md", line: 1, column: 1 };
+
+// ---------------------------------------------------------------------------
+// classifyConvention
+// ---------------------------------------------------------------------------
+
+Deno.test("classifyConvention: PascalCase single segment → type", () => {
+  assertEquals(classifyConvention("BrakeController"), "type");
+});
+
+Deno.test("classifyConvention: PascalCase single-uppercase segment → type", () => {
+  assertEquals(classifyConvention("Asil"), "type");
+});
+
+Deno.test("classifyConvention: all-uppercase no underscore → type", () => {
+  // Per spec §2.5.2, `$ASIL` parses as PascalCase (single uppercase
+  // segment), not as a constant. Constants must include `_` or a
+  // digit to distinguish.
+  assertEquals(classifyConvention("ASIL"), "type");
+});
+
+Deno.test("classifyConvention: camelCase → instance", () => {
+  assertEquals(classifyConvention("rawPressure"), "instance");
+});
+
+Deno.test("classifyConvention: camelCase single lowercase letter → instance", () => {
+  assertEquals(classifyConvention("x"), "instance");
+});
+
+Deno.test("classifyConvention: SCREAMING_SNAKE → constant", () => {
+  assertEquals(classifyConvention("DEBOUNCE_WINDOW"), "constant");
+});
+
+Deno.test("classifyConvention: uppercase with digit → constant", () => {
+  // Digit qualifies it as a constant under the same "needs _ or digit"
+  // disambiguation rule.
+  assertEquals(classifyConvention("ASIL3"), "constant");
+});
+
+// ---------------------------------------------------------------------------
+// extractEntityRefs
+// ---------------------------------------------------------------------------
+
+Deno.test("extractEntityRefs: extracts a single $Identifier from prose", () => {
+  const refs = extractEntityRefs("The $brakeSensor reports.", baseLocation);
+  assertEquals(refs.length, 1);
+  assertEquals(refs[0].ident, "$brakeSensor");
+  assertEquals(refs[0].convention, "instance");
+});
+
+Deno.test("extractEntityRefs: skips $-prefixed tokens inside fenced code", () => {
+  const body = [
+    "The $sensor outside.",
+    "```",
+    "let $foo = 1;",
+    "```",
+  ].join("\n");
+  const refs = extractEntityRefs(body, baseLocation);
+  assertEquals(refs.map((r) => r.ident), ["$sensor"]);
+});
+
+Deno.test("extractEntityRefs: skips both halves of an inline $$math$$ fence", () => {
+  // The regex matches `$<letter>...`, so `$$math$$` matches just once
+  // — at the second `$` of the opening fence, where the next char is
+  // a letter. That match is rejected by the "preceded by another $"
+  // guard. Net result: zero refs.
+  const refs = extractEntityRefs("Inline $$math$$ here.", baseLocation);
+  assertEquals(refs.length, 0);
+});
+
+Deno.test("extractEntityRefs: standalone $ident inside inline math still fires (known limitation)", () => {
+  // Spec §2.5.2 says entity refs aren't recognised in math content,
+  // but the current implementation tracks `$$` opener/closer only at
+  // the regex level — it doesn't model an inline single-`$` math
+  // region. A `$ident` mid-formula therefore extracts. Pinned for
+  // visibility; a future slice could pre-scan inline math fences.
+  const refs = extractEntityRefs("$$x = $foo + 1$$", baseLocation);
+  assertEquals(refs.length, 1);
+  assertEquals(refs[0].ident, "$foo");
+});
+
+Deno.test("extractEntityRefs: discards backslash-escaped $ident", () => {
+  const refs = extractEntityRefs("Literal \\$dollar text.", baseLocation);
+  assertEquals(refs.length, 0);
+});
+
+Deno.test("extractEntityRefs: reports line and column for each ref", () => {
+  const body = "line one\nThe $sensor is here.\nline three";
+  const refs = extractEntityRefs(body, baseLocation);
+  assertEquals(refs.length, 1);
+  assertEquals(refs[0].location.line, 2); // baseLocation.line + 1
+  // "The $sensor" — `$` is at column 5 (1-based).
+  assertEquals(refs[0].location.column, 5);
+});
+
+Deno.test("extractEntityRefs: returns empty array for body with no refs", () => {
+  const refs = extractEntityRefs("Plain prose with no dollars.", baseLocation);
+  assertEquals(refs.length, 0);
+});

--- a/packages/markspec/core/validator/captions.ts
+++ b/packages/markspec/core/validator/captions.ts
@@ -35,7 +35,12 @@ const captionableMatchers: Record<CaptionKeyword, (line: string) => boolean> = {
   // Fenced code block (any language).
   Listing: (l) => FENCE_RE.test(l),
   // Gherkin-tagged fenced code block; the loose check is fence-only
-  // because the language tag is on the opening fence line.
+  // because the language tag is on the opening fence line — when the
+  // caption sits BELOW the block, only the closing fence is the
+  // adjacent line and that line has no tag. Tightening to require
+  // `gherkin` would produce false MSL-C071s for valid caption-below
+  // placements. A future cleaner fix would pre-scan fence pairs to
+  // attach language metadata to both opener and closer.
   Feature: (l) => FENCE_RE.test(l),
   // Math fence (`$$`).
   Equation: (l) => /^\s*\$\$/.test(l),


### PR DESCRIPTION
## Summary

Iteration 10 of the autonomous Prompt-1 follow-up loop. Closes the unit-test coverage gap surfaced in the post-Prompt-1 review: several helpers had been exercised only indirectly via e2e fixtures.

| Commit | Slice |
|---|---|
| `<sha>` | Unit-test coverage for previously-untested helpers |

## What lands

Three new test files (34 tests total):

| File | Tests | Covers |
|---|---|---|
| `core/parser/entity_refs_test.ts` | 14 | `classifyConvention` (Type / instance / constant + the `$ASIL` disambiguation rule), `extractEntityRefs` (fence skip, backslash escape, position reporting, `$$math$$` pair, mid-formula limitation) |
| `core/model/uri_scheme_map_test.ts` | 13 | `inferTypeFromUriScheme` — one test per ADR-003 §Part 6 scheme family + unmapped / empty / ULID edges |
| `core/model/type_hierarchy_test.ts` | 7 | `attributesForType` inheritance + `Test ∌ Allocated-to` exclusion + `CORE_TYPE_SCOPED_ATTRS` union |

Two tests pin known limitations for future cleanup, documented in their bodies:

- `extractEntityRefs` doesn't model single-`$` inline math regions — `$ident` mid-formula still extracts.
- `classifyConvention` treats `$ASIL` as a type (PascalCase single segment) rather than a constant. Spec §2.5.2's disambiguation rule requires at least one underscore or digit for the constant convention.

## What was attempted but rolled back

**T5 — Feature matcher tightens to gherkin tag.** Tightening to `^\s*(```|~~~)\s*gherkin\b` produced false `MSL-C071`s when a `Feature:` caption sits **below** a Gherkin block, because the adjacent line is then the bare closing fence with no language tag. A clean fix requires pre-scanned fence-pair metadata; deferred. `captions.ts` is reverted to the original loose-matcher behaviour with a clarifying comment explaining why.

## Tests

| Before | After |
|---|---|
| 841 (post-#286) | 875 (+34 new unit tests) |

All `just check` gates green per commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
