### PR TITLE
feat(core): display-ID prefix → core type inference (step 4)

### DIFF
--- a/packages/markspec/core/validator/type_resolution.ts
+++ b/packages/markspec/core/validator/type_resolution.ts
@@ -3,17 +3,62 @@
  *
  * Shared helper for resolving an entry's effective core type. Walks
  * the spec §1.3.1 type-resolution chain at the level needed for
- * validator passes (explicit `Type:` → profile-classified `entry.type`
- * → URI scheme inference for Reference-shape entries).
+ * validator passes:
  *
- * Display-ID prefix inference (step 4) and document-directive
- * inference (step 7) are intentionally not consulted here; those have
- * their own dedicated stages (inferTypeFromDisplayIdShape covers step
- * 8 with warning telemetry).
+ *   1. Explicit `Type:` attribute.
+ *   2. Profile-classified `entry.type` (set upstream).
+ *   4. Authored display-ID prefix (`REQ` / `TST` / `ICD` / `REC` /
+ *      `RSK`) → corresponding core Specification subtype.
+ *   5. Reference-shape URI scheme inference (ADR-003 §Part 6).
+ *
+ * Step 3 (`Source:` introspection), step 6 (discriminating attribute),
+ * and step 7 (document directive) are not consulted here; step 8
+ * (display-ID shape) has its own warning-emitting stage in
+ * `validator/types.ts` (`inferTypeFromDisplayIdShape`).
  */
 
 import type { Entry } from "../model/mod.ts";
 import { CORE_TYPE_HIERARCHY, inferTypeFromUriScheme } from "../model/mod.ts";
+
+/**
+ * Map from Authored display-ID prefix to the core type the prefix
+ * implies (spec §1.3.1 step 4, ADR-003 §Part 1 "Display-ID prefixes").
+ * Matched as `<PREFIX><sep><rest>` where `<sep>` is `-` or `_` — the
+ * two conventions in widespread use. Case-sensitive: the prefix is
+ * part of the canonical-style ID, not a free-form alias.
+ */
+const DISPLAY_ID_PREFIX_TYPE: ReadonlyMap<string, string> = new Map([
+  ["REQ", "Requirement"],
+  ["TST", "Test"],
+  ["ICD", "Contract"],
+  ["REC", "Record"],
+  ["RSK", "Risk"],
+]);
+
+/**
+ * Infer a core type from an Authored entry's display-ID prefix.
+ * Returns the type when the display ID starts with one of the
+ * recognised prefixes followed by `-` or `_`. Returns `undefined`
+ * otherwise.
+ *
+ * Per spec §1.3.1 this is step 4 of the resolution chain — earlier
+ * than late-stage inference at step 8, so a matching prefix does
+ * not produce an MSL-T021 warning.
+ */
+export function inferTypeFromDisplayIdPrefix(
+  displayId: string,
+): string | undefined {
+  for (const [prefix, type] of DISPLAY_ID_PREFIX_TYPE) {
+    if (
+      displayId.startsWith(prefix) &&
+      displayId.length > prefix.length &&
+      (displayId[prefix.length] === "-" || displayId[prefix.length] === "_")
+    ) {
+      return type;
+    }
+  }
+  return undefined;
+}
 
 /**
  * Read an entry's explicit `Type:` attribute, trimmed. Returns
@@ -47,6 +92,12 @@ export function resolvedCoreType(entry: Entry): string | undefined {
   const explicit = explicitType(entry);
   if (explicit && CORE_TYPE_HIERARCHY[explicit]) return explicit;
   if (entry.type && CORE_TYPE_HIERARCHY[entry.type]) return entry.type;
+  // Step 4: Authored display-ID prefix.
+  if (entry.shape === "identified") {
+    const inferred = inferTypeFromDisplayIdPrefix(entry.displayId);
+    if (inferred && CORE_TYPE_HIERARCHY[inferred]) return inferred;
+  }
+  // Step 5: Reference-shape URI scheme.
   if (entry.shape === "referenced" && entry.id) {
     const inferred = inferTypeFromUriScheme(entry.id);
     if (inferred && CORE_TYPE_HIERARCHY[inferred]) return inferred;

--- a/packages/markspec/core/validator/type_resolution_test.ts
+++ b/packages/markspec/core/validator/type_resolution_test.ts
@@ -8,7 +8,11 @@
  */
 
 import { assertEquals } from "@std/assert";
-import { explicitType, resolvedCoreType } from "./type_resolution.ts";
+import {
+  explicitType,
+  inferTypeFromDisplayIdPrefix,
+  resolvedCoreType,
+} from "./type_resolution.ts";
 import type { Entry } from "../model/mod.ts";
 
 const ULID = "01HGW2Q8MNP3RSTVWXYZABCDEF";
@@ -101,4 +105,60 @@ Deno.test("resolvedCoreType: returns undefined when no source resolves to a core
     attrs: [{ key: "Id", value: ULID }],
   });
   assertEquals(resolvedCoreType(entry), undefined);
+});
+
+// ---------------------------------------------------------------------------
+// inferTypeFromDisplayIdPrefix (spec §1.3.1 step 4)
+// ---------------------------------------------------------------------------
+
+Deno.test("inferTypeFromDisplayIdPrefix: REQ-001 → Requirement", () => {
+  assertEquals(inferTypeFromDisplayIdPrefix("REQ-001"), "Requirement");
+});
+
+Deno.test("inferTypeFromDisplayIdPrefix: TST_AEB_0001 → Test", () => {
+  assertEquals(inferTypeFromDisplayIdPrefix("TST_AEB_0001"), "Test");
+});
+
+Deno.test("inferTypeFromDisplayIdPrefix: ICD-OpenAPI-1 → Contract", () => {
+  assertEquals(inferTypeFromDisplayIdPrefix("ICD-OpenAPI-1"), "Contract");
+});
+
+Deno.test("inferTypeFromDisplayIdPrefix: REC_ADR_001 → Record", () => {
+  assertEquals(inferTypeFromDisplayIdPrefix("REC_ADR_001"), "Record");
+});
+
+Deno.test("inferTypeFromDisplayIdPrefix: RSK-Hazard-001 → Risk", () => {
+  assertEquals(inferTypeFromDisplayIdPrefix("RSK-Hazard-001"), "Risk");
+});
+
+Deno.test("inferTypeFromDisplayIdPrefix: requires - or _ separator", () => {
+  // `REQ` alone or `REQ001` (no separator) doesn't qualify — these
+  // are ambiguous IDs that shouldn't auto-infer.
+  assertEquals(inferTypeFromDisplayIdPrefix("REQ"), undefined);
+  assertEquals(inferTypeFromDisplayIdPrefix("REQ001"), undefined);
+});
+
+Deno.test("inferTypeFromDisplayIdPrefix: case-sensitive", () => {
+  assertEquals(inferTypeFromDisplayIdPrefix("req-001"), undefined);
+  assertEquals(inferTypeFromDisplayIdPrefix("Req-001"), undefined);
+});
+
+Deno.test("inferTypeFromDisplayIdPrefix: unrelated prefix → undefined", () => {
+  assertEquals(inferTypeFromDisplayIdPrefix("SAD-001"), undefined);
+  assertEquals(inferTypeFromDisplayIdPrefix("braking::sensor"), undefined);
+});
+
+Deno.test("resolvedCoreType: step 4 falls back to prefix when no explicit Type and no profile classification", () => {
+  const entry = makeEntry({
+    attrs: [{ key: "Id", value: ULID }],
+  });
+  // makeEntry produces displayId "TEST-001" which doesn't match a
+  // prefix — verify undefined.
+  assertEquals(resolvedCoreType(entry), undefined);
+
+  const reqEntry = {
+    ...entry,
+    displayId: "REQ-001",
+  };
+  assertEquals(resolvedCoreType(reqEntry), "Requirement");
 });

--- a/tests/e2e/validate_test.ts
+++ b/tests/e2e/validate_test.ts
@@ -170,6 +170,55 @@ Deno.test("validate: unknown Type value rejected with MSL-T020 in core-only mode
 // Per-type attribute compatibility — spec §1.6, MSL-T022
 // ---------------------------------------------------------------------------
 
+Deno.test("validate: [REQ-001] infers Requirement at step 4; Bus-protocol fires MSL-T022", async () => {
+  const { code, stderr } = await markspec(["validate", "req.md"], {
+    files: {
+      "req.md": `# Test
+
+- [REQ-001] My requirement
+
+  Body text.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      Bus-protocol: can
+`,
+    },
+  });
+  // REQ_ prefix should infer Requirement at chain step 4. Bus-protocol
+  // is HardwareInterface-only → MSL-T022 (warning).
+  assertEquals(
+    code,
+    2,
+    `expected exit 2 (warning), got ${code}; stderr: ${stderr}`,
+  );
+  assertStringIncludes(stderr, "MSL-T022");
+  assertStringIncludes(stderr, "Bus-protocol");
+});
+
+Deno.test("validate: [TST-001] infers Test at step 4; Allocated-to fires MSL-T022", async () => {
+  const { code, stderr } = await markspec(["validate", "req.md"], {
+    files: {
+      "req.md": `# Test
+
+- [TST-001] My test
+
+  Body text.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      Allocated-to: 01HGW2Q8MNP3RSTVWXYZABCDEG
+`,
+    },
+  });
+  // TST_ prefix infers Test; Test excludes Allocated-to per ADR-003 §Part 2.
+  assertEquals(
+    code,
+    2,
+    `expected exit 2 (warning), got ${code}; stderr: ${stderr}`,
+  );
+  assertStringIncludes(stderr, "MSL-T022");
+  assertStringIncludes(stderr, "Allocated-to");
+});
+
 Deno.test("validate: Allocated-to on a Component fires MSL-T022 warning", async () => {
   const { code, stderr } = await markspec(["validate", "req.md"], {
     files: {


### PR DESCRIPTION
## Summary

Iteration 11 of the autonomous Prompt-1 follow-up loop. Implements **step 4 of the type-resolution chain** — Authored display-ID prefix inference (spec §1.3.1, ADR-003 §Part 1).

| Commit | Slice |
|---|---|
| `af6f01d` | Display-ID prefix → core type inference (step 4) |

## What lands

Authored entries whose display ID starts with one of the five core prefixes (followed by `-` or `_`) now infer the corresponding Specification subtype:

| Prefix | Type |
|---|---|
| `REQ_` / `REQ-` | Requirement |
| `TST_` / `TST-` | Test |
| `ICD_` / `ICD-` | Contract |
| `REC_` / `REC-` | Record |
| `RSK_` / `RSK-` | Risk |

Per spec §1.3.1, step 4 is NOT late-stage inference (that's step 8 and emits MSL-T021). A prefix match resolves the type silently — the ergonomic payoff is that `[REQ-001]` no longer requires `Type: Requirement` in the trailer to participate in MSL-T022 / MSL-R083 checks.

The two new e2e tests demonstrate the payoff:

- `[REQ-001]` with `Bus-protocol: can` → MSL-T022 (Bus-protocol is HardwareInterface-only, Requirement doesn't allow it).
- `[TST-001]` with `Allocated-to: …` → MSL-T022 (Test inherits Specification but excludes Allocated-to per ADR-003 §Part 2).

Match is case-sensitive and requires the `-` / `_` separator to avoid false positives on free-form display IDs like `REQUEST` or `REQ001`.

## Tests

| Before | After |
|---|---|
| 875 (post-#287) | 886 (+9 unit + +2 e2e) |

All `just check` gates green per commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
