### PR TITLE
feat(core): canonical bullet character on entry title lines (spec §3.2)

### DIFF
--- a/packages/markspec/core/formatter/mod.ts
+++ b/packages/markspec/core/formatter/mod.ts
@@ -239,6 +239,22 @@ export function format(
     const indent = (entry.location.column - 1) + 2;
     let attrs = [...entry.rawAttributes];
 
+    // Title-line bullet canonicalisation per spec §3.2: rewrite `*`
+    // or `+` to `-`. The list-item position from the parser is the
+    // line carrying the bullet marker; we only touch the marker
+    // character itself, leaving the rest of the title alone.
+    const titleLineIdx = entry.location.line - 1;
+    if (titleLineIdx >= 0 && titleLineIdx < lines.length) {
+      const titleLine = lines[titleLineIdx];
+      const markerCol = entry.location.column - 1;
+      const markerChar = titleLine.charAt(markerCol);
+      if (markerChar === "*" || markerChar === "+") {
+        lines[titleLineIdx] = titleLine.slice(0, markerCol) +
+          "-" + titleLine.slice(markerCol + 1);
+        changed = true;
+      }
+    }
+
     // Assign a bare ULID `Id:` to identified entries that carry no
     // identity yet. Referenced entries are left alone — their `Id:` is a
     // URI that must be author-provided.

--- a/tests/e2e/format_test.ts
+++ b/tests/e2e/format_test.ts
@@ -93,6 +93,41 @@ Deno.test("format: writes normalized attributes back to file", async () => {
 });
 
 // ---------------------------------------------------------------------------
+// Title-line normalisation — bullet character (spec §3.2)
+// ---------------------------------------------------------------------------
+
+Deno.test("format: rewrites * bullet to - on entry title line", async () => {
+  const input = "# Test\n\n" +
+    "* [REQ-001] Title\n\n" +
+    "  Body.\n\n" +
+    "      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF\n";
+  const { readFile } = await runFormat({ "req.md": input });
+  const output = await readFile("req.md");
+  // Bullet should have been rewritten.
+  assertEquals(
+    output.includes("* [REQ-001]"),
+    false,
+    `'*' bullet should be normalised to '-'; output:\n${output}`,
+  );
+  assertEquals(
+    output.includes("- [REQ-001]"),
+    true,
+    `'-' bullet should be in output; output:\n${output}`,
+  );
+});
+
+Deno.test("format: rewrites + bullet to - on entry title line", async () => {
+  const input = "# Test\n\n" +
+    "+ [REQ-001] Title\n\n" +
+    "  Body.\n\n" +
+    "      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF\n";
+  const { readFile } = await runFormat({ "req.md": input });
+  const output = await readFile("req.md");
+  assertEquals(output.includes("+ [REQ-001]"), false);
+  assertEquals(output.includes("- [REQ-001]"), true);
+});
+
+// ---------------------------------------------------------------------------
 // Body normalisation — modal keywords (spec §3.4.1)
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Iteration 12 of the autonomous Prompt-1 follow-up loop. Adds the canonical-bullet rewrite from spec §3.2 — one of the four "may be rewritten" transforms the §5.2 round-trip contract owes.

| Commit | Slice |
|---|---|
| `04a0aa5` | Canonical bullet character on entry title lines |

## What lands

`markspec format` now rewrites `*` and `+` list-item markers to `-` on entry title lines. The rest of the title is untouched — only the marker character changes — so source offsets and column positions are preserved for downstream passes.

## Why it matters

Previously this transform was effectively delegated to `dprint`, which normalises bullets globally. But spec §3.2 lists bullet normalisation as a `markspec format` responsibility, so a user running `markspec format` without `dprint fmt` would have left the bullets unchanged. Now `markspec format` is self-contained on this rule.

## Out of scope

The other §3.2 transforms still missing: blank-line collapse, trailer key re-casing, deterministic synthesized-ULID minting. They'll get their own slices.

## Tests

| Before | After |
|---|---|
| 886 (post-#288) | 888 (+2 covering `*` and `+` rewrites) |

All `just check` gates green per commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
