### PR TITLE
feat(core): canonicalise trailer keys to TitleCase-Hyphenated (§3.3.4)

### DIFF
--- a/packages/markspec/core/formatter/mod.ts
+++ b/packages/markspec/core/formatter/mod.ts
@@ -365,11 +365,29 @@ export function expandCsvValues(attrs: Attribute[]): Attribute[] {
 }
 
 /**
- * Sort attributes to canonical trailer order per spec §3.3.2.
+ * Canonicalise a trailer key to TitleCase-Hyphenated per spec §3.3.4.
+ * First character of the key uppercase, every other character
+ * lowercase; hyphens preserved. Examples (from the spec):
  *
- * Known core keys appear in their {@linkcode CANONICAL_ORDER} slot.
- * Unknown / profile-declared keys (group 6) are appended at the end in
- * source order — `fmt` never deletes a key it doesn't own (§3.3.6).
+ *   `Id`, `Derived-from`, `Reference-url`, `Bus-protocol`.
+ *
+ * Inputs like `ID`, `BUS-PROTOCOL`, `reference-URL`, `Derived-From`
+ * all canonicalise to the spec form regardless of casing in source.
+ */
+export function canonicalizeKey(key: string): string {
+  if (key.length === 0) return key;
+  return key[0].toUpperCase() + key.slice(1).toLowerCase();
+}
+
+/**
+ * Sort attributes to canonical trailer order per spec §3.3.2 and
+ * re-case each key per spec §3.3.4.
+ *
+ * Known core keys appear in their {@linkcode CANONICAL_ORDER} slot
+ * (lookup is case-insensitive via {@linkcode canonicalizeKey}).
+ * Unknown / profile-declared keys (group 6) are appended at the end
+ * in source order — `fmt` never deletes a key it doesn't own
+ * (§3.3.6). Every emitted attribute carries the canonical key form.
  */
 export function sortAttributes(
   attributes: Attribute[],
@@ -378,13 +396,17 @@ export function sortAttributes(
   const unknown: Attribute[] = [];
 
   for (const attr of attributes) {
-    const idx = CANONICAL_ORDER.indexOf(attr.key);
+    const canonical = canonicalizeKey(attr.key);
+    const recased: Attribute = canonical === attr.key
+      ? attr
+      : { ...attr, key: canonical };
+    const idx = CANONICAL_ORDER.indexOf(canonical);
     if (idx >= 0) {
       // Preserve duplicates — keep all occurrences of the same key.
       if (!known[idx]) known[idx] = [];
-      known[idx]!.push(attr);
+      known[idx]!.push(recased);
     } else {
-      unknown.push(attr);
+      unknown.push(recased);
     }
   }
 

--- a/tests/e2e/format_test.ts
+++ b/tests/e2e/format_test.ts
@@ -93,6 +93,52 @@ Deno.test("format: writes normalized attributes back to file", async () => {
 });
 
 // ---------------------------------------------------------------------------
+// Trailer key re-casing (spec §3.3.4)
+// ---------------------------------------------------------------------------
+
+Deno.test("format: rewrites trailer keys to TitleCase-Hyphenated", async () => {
+  const input = "# Test\n\n" +
+    "- [REQ-001] Title\n\n" +
+    "  Body.\n\n" +
+    "      ID: 01HGW2Q8MNP3RSTVWXYZABCDEF\n" +
+    "      LABELS: ASIL-B\n";
+  const { readFile } = await runFormat({ "req.md": input });
+  const output = await readFile("req.md");
+  // Keys must land in canonical TitleCase-Hyphenated form.
+  assertEquals(
+    /^\s*Id:\s/m.test(output),
+    true,
+    `'Id:' should be canonical; output:\n${output}`,
+  );
+  assertEquals(
+    /^\s*Labels:\s/m.test(output),
+    true,
+    `'Labels:' should be canonical; output:\n${output}`,
+  );
+  // Loud-case inputs must be gone.
+  assertEquals(output.includes("ID: "), false);
+  assertEquals(output.includes("LABELS: "), false);
+});
+
+Deno.test("format: lowercases interior of hyphenated key", async () => {
+  const input = "# Test\n\n" +
+    "- [REF-001] My reference\n\n" +
+    "  Body.\n\n" +
+    "      Id: urn:iso:std:iso:26262:-6:ed-2\n" +
+    "      Reference-URL: https://example.org/spec\n";
+  const { readFile } = await runFormat({ "req.md": input });
+  const output = await readFile("req.md");
+  // Canonical form is `Reference-url` (lowercase after hyphen) per
+  // spec §3.3.4 examples.
+  assertEquals(
+    /^\s*Reference-url:\s/m.test(output),
+    true,
+    `'Reference-url:' should be the canonical form; output:\n${output}`,
+  );
+  assertEquals(output.includes("Reference-URL: "), false);
+});
+
+// ---------------------------------------------------------------------------
 // Title-line normalisation — bullet character (spec §3.2)
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Iteration 13 of the autonomous Prompt-1 follow-up loop. Adds the canonical trailer-key casing transform from spec §3.3.4 — another of the four "may be rewritten" formatter transforms still missing post-review.

| Commit | Slice |
|---|---|
| `459cbe2` | Canonicalise trailer keys to TitleCase-Hyphenated |

## What lands

`canonicalizeKey()` rewrites every emitted trailer key to first-letter-uppercase, everything-else-lowercase, hyphens preserved. Examples:

| Input | Canonical |
|---|---|
| `ID` | `Id` |
| `BUS-PROTOCOL` | `Bus-protocol` |
| `reference-URL` | `Reference-url` |
| `Derived-From` | `Derived-from` |
| `Id` | `Id` (no-op) |

The `CANONICAL_ORDER` lookup also runs against the canonical form, so loud-case variants land in the correct §3.3.2 group rather than being shunted to group 6 "unknown" by case-mismatch.

## Tests

| Before | After |
|---|---|
| 888 (post-#289) | 890 (+2 covering `ID:`/`LABELS:` → canonical and `Reference-URL:` → `Reference-url:`) |

All `just check` gates green per commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
