### PR TITLE
test(core): pin formatter idempotence across new canonical transforms

### DIFF
--- a/tests/e2e/format_test.ts
+++ b/tests/e2e/format_test.ts
@@ -139,6 +139,58 @@ Deno.test("format: lowercases interior of hyphenated key", async () => {
 });
 
 // ---------------------------------------------------------------------------
+// Idempotence — spec §3.1 / §5.3
+// ---------------------------------------------------------------------------
+
+Deno.test("format: idempotent after bullet rewrite", async () => {
+  const input = "# Test\n\n" +
+    "* [REQ-001] Title\n\n" +
+    "  Body.\n\n" +
+    "      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF\n";
+  const pass1 = await runFormat({ "req.md": input });
+  const out1 = await pass1.readFile("req.md");
+
+  const pass2 = await runFormat({ "req.md": out1 });
+  const out2 = await pass2.readFile("req.md");
+
+  assertEquals(out1, out2, "format must be idempotent on bullet rewrite");
+});
+
+Deno.test("format: idempotent after key re-casing", async () => {
+  const input = "# Test\n\n" +
+    "- [REQ-001] Title\n\n" +
+    "  Body.\n\n" +
+    "      ID: 01HGW2Q8MNP3RSTVWXYZABCDEF\n" +
+    "      LABELS: ASIL-B\n";
+  const pass1 = await runFormat({ "req.md": input });
+  const out1 = await pass1.readFile("req.md");
+
+  const pass2 = await runFormat({ "req.md": out1 });
+  const out2 = await pass2.readFile("req.md");
+
+  assertEquals(out1, out2, "format must be idempotent on key re-casing");
+});
+
+Deno.test("format: idempotent across combined transforms", async () => {
+  const input = "# Test\n\n" +
+    "* [REQ-001] Title\n\n" +
+    "  The driver SHALL debounce raw inputs.\n\n" +
+    "      ID: 01HGW2Q8MNP3RSTVWXYZABCDEF\n" +
+    "      LABELS: ASIL-B\n";
+  const pass1 = await runFormat({ "req.md": input });
+  const out1 = await pass1.readFile("req.md");
+
+  const pass2 = await runFormat({ "req.md": out1 });
+  const out2 = await pass2.readFile("req.md");
+
+  assertEquals(
+    out1,
+    out2,
+    "format must be idempotent across bullet + key-case + modal normalisation",
+  );
+});
+
+// ---------------------------------------------------------------------------
 // Title-line normalisation — bullet character (spec §3.2)
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Iteration 14 of the autonomous Prompt-1 follow-up loop. Pins formatter idempotence — spec §3.1 / §5.3 — across the new canonical transforms landed in #284 (modal keywords), #289 (bullet), and #290 (key re-casing).

| Commit | Slice |
|---|---|
| `f9c073f` | Idempotence regression tests for new canonical transforms |

## What lands

Three new e2e tests, each running `markspec format` twice and asserting output stability:

1. Bullet rewrite alone (`*` → `-`)
2. Key re-casing alone (`ID:` / `LABELS:` → canonical)
3. Combined: bullet + key-case + modal-keyword normalisation in one fixture

The tests don't change formatter behaviour — they pin existing correctness so a future regression that breaks idempotence shows up immediately.

## What was deferred

**Blank-line collapse (§3.4.3)** — a pre-entry-pass collapse would shift parser-reported line indices and break the trailer-block splicing the formatter relies on. A clean fix needs either a deferred post-pass or restructured line tracking. Deferred.

## Tests

| Before | After |
|---|---|
| 890 (post-#290) | 893 (+3 idempotence) |

All `just check` gates green per commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
