### PR TITLE
feat(core): blank-line collapse in body (spec §3.4.3 / §5.2)

### DIFF
--- a/packages/markspec/core/formatter/mod.ts
+++ b/packages/markspec/core/formatter/mod.ts
@@ -297,7 +297,14 @@ export function format(
     }
   }
 
-  const formattedBody = lines.join("\n");
+  // Spec §3.4.3 / §5.2 — collapse consecutive blank lines to one.
+  // Runs after entry-block splicing so the in-progress line indices
+  // stay aligned with parser-reported positions. Operates inside
+  // fenced code regions only outside-code; verbatim regions keep
+  // their blank-line counts.
+  const collapsedLines = collapseBlankLines(lines);
+  if (collapsedLines.length !== lines.length) changed = true;
+  const formattedBody = collapsedLines.join("\n");
 
   if (fm.hadFrontMatter) {
     const canonicalFm = renderFrontMatter(fm.attributes);
@@ -335,6 +342,36 @@ function renderFrontMatter(attrs: DocumentAttributes): string {
 
   const yaml = stringifyYaml(ordered).trimEnd();
   return `---\n${yaml}\n---\n\n`;
+}
+
+/**
+ * Collapse consecutive blank lines to a single blank line per spec
+ * §3.4.3 (caption boundary) / §5.2 (general body rule). Fenced code
+ * regions are preserved verbatim — blank-line counts inside fenced
+ * blocks are author intent, not noise.
+ */
+function collapseBlankLines(lines: readonly string[]): string[] {
+  const out: string[] = [];
+  let inFence = false;
+  let prevBlank = false;
+  for (const line of lines) {
+    if (/^\s*(```|~~~)/.test(line)) {
+      out.push(line);
+      inFence = !inFence;
+      prevBlank = false;
+      continue;
+    }
+    if (inFence) {
+      out.push(line);
+      prevBlank = false;
+      continue;
+    }
+    const isBlank = line.trim() === "";
+    if (isBlank && prevBlank) continue;
+    out.push(line);
+    prevBlank = isBlank;
+  }
+  return out;
 }
 
 /**

--- a/tests/e2e/format_test.ts
+++ b/tests/e2e/format_test.ts
@@ -139,6 +139,39 @@ Deno.test("format: lowercases interior of hyphenated key", async () => {
 });
 
 // ---------------------------------------------------------------------------
+// Blank-line collapse (spec §3.4.3 / §5.2)
+// ---------------------------------------------------------------------------
+
+Deno.test("format: collapses consecutive blank lines to one", async () => {
+  const input = "# Test\n\n" +
+    "- [REQ-001] Title\n\n" +
+    "  Body line one.\n\n\n\n" +
+    "  Body line two.\n\n" +
+    "      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF\n";
+  const { readFile } = await runFormat({ "req.md": input });
+  const output = await readFile("req.md");
+  assertEquals(
+    /\n\n\n/.test(output),
+    false,
+    `multi-blank should collapse to a single blank line; output:\n${output}`,
+  );
+});
+
+Deno.test("format: blank-line collapse is idempotent", async () => {
+  const input = "# Test\n\n" +
+    "- [REQ-001] Title\n\n\n\n" +
+    "  Body.\n\n\n" +
+    "      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF\n";
+  const pass1 = await runFormat({ "req.md": input });
+  const out1 = await pass1.readFile("req.md");
+
+  const pass2 = await runFormat({ "req.md": out1 });
+  const out2 = await pass2.readFile("req.md");
+
+  assertEquals(out1, out2);
+});
+
+// ---------------------------------------------------------------------------
 // Idempotence — spec §3.1 / §5.3
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Iteration 15 of the autonomous Prompt-1 follow-up loop. Closes one of the four "may be rewritten" transforms from spec §5.2 — blank-line collapse.

| Commit | Slice |
|---|---|
| `c29ce05` | Blank-line collapse in body |

## What lands

`markspec format` now collapses runs of consecutive blank lines to a single blank line outside fenced code regions. The collapse runs after the entry-block splicing loop so line indices stay aligned with parser-reported positions.

Fenced code is preserved verbatim: blank-line counts inside ``` / ~~~ blocks are author intent, not noise.

## Tests

| Before | After |
|---|---|
| 893 (post-#291) | 895 (+2 covering collapse + idempotence) |

All `just check` gates green per commit.

## Remaining transforms still missing

- Deterministic synthesized-ULID (§3.5) — `Origin: synthesized` path. Deferred.
- (Bullet, key re-casing, modal keywords, blank-line collapse — all landed across recent iterations.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
