### PR TITLE
feat(core): Source: introspection (spec §1.3.1 step 3)

### DIFF
--- a/packages/markspec/core/model/mod.ts
+++ b/packages/markspec/core/model/mod.ts
@@ -23,6 +23,8 @@ export type { CoreTypeDef } from "./type_hierarchy.ts";
 
 export { inferTypeFromUriScheme } from "./uri_scheme_map.ts";
 
+export { inferTypeFromSource } from "./source_introspection.ts";
+
 // ---------------------------------------------------------------------------
 // Display ID
 // ---------------------------------------------------------------------------

--- a/packages/markspec/core/model/source_introspection.ts
+++ b/packages/markspec/core/model/source_introspection.ts
@@ -1,0 +1,86 @@
+/**
+ * @module model/source_introspection
+ *
+ * `Source:` → core type inference per spec §1.3.1 step 3 and
+ * ADR-003 §Part 5. Returns the inferred core type when the
+ * `Source:` value looks like a recognised manifest, source-code
+ * file, interface description, or bus description; `undefined`
+ * otherwise.
+ *
+ * Match order is significant — manifests must run before generic
+ * extension matches so `path/to/something.json` doesn't shadow
+ * `package.json`. The list is conservative: only patterns ADR-003
+ * §Part 5 lists normatively are encoded here; profiles extend the
+ * map later.
+ */
+
+interface SourcePattern {
+  readonly pattern: RegExp;
+  readonly type: string;
+}
+
+const SOURCE_PATTERNS: readonly SourcePattern[] = [
+  // Build manifests → SoftwareComponent. Anchored at filename
+  // boundary so `weird-Cargo.toml` doesn't match unintentionally.
+  { pattern: /(?:^|\/)Cargo\.toml$/, type: "SoftwareComponent" },
+  { pattern: /(?:^|\/)package\.json$/, type: "SoftwareComponent" },
+  { pattern: /(?:^|\/)pom\.xml$/, type: "SoftwareComponent" },
+  { pattern: /(?:^|\/)deno\.json$/, type: "SoftwareComponent" },
+  { pattern: /(?:^|\/)go\.mod$/, type: "SoftwareComponent" },
+  { pattern: /(?:^|\/)pyproject\.toml$/, type: "SoftwareComponent" },
+  { pattern: /(?:^|\/)setup\.py$/, type: "SoftwareComponent" },
+  { pattern: /(?:^|\/)pubspec\.yaml$/, type: "SoftwareComponent" },
+  { pattern: /(?:^|\/)[^/]+\.csproj$/, type: "SoftwareComponent" },
+
+  // Interface description files → SoftwareInterface. Run BEFORE the
+  // generic source-code extensions so `.openapi.yaml` wins over `.yaml`.
+  { pattern: /\.openapi\.(?:yaml|yml|json)$/, type: "SoftwareInterface" },
+  { pattern: /\.asyncapi\.(?:yaml|yml|json)$/, type: "SoftwareInterface" },
+  { pattern: /\.proto$/, type: "SoftwareInterface" },
+  { pattern: /\.graphql$/, type: "SoftwareInterface" },
+  { pattern: /\.wsdl$/, type: "SoftwareInterface" },
+  { pattern: /\.arxml$/, type: "SoftwareInterface" },
+  { pattern: /\.idl$/, type: "SoftwareInterface" },
+  { pattern: /\.ridl$/, type: "SoftwareInterface" },
+
+  // Bus description files → HardwareInterface.
+  { pattern: /\.dbc$/, type: "HardwareInterface" },
+  { pattern: /\.ldf$/, type: "HardwareInterface" },
+  { pattern: /\.fibex$/, type: "HardwareInterface" },
+
+  // Source-code files → SoftwareUnit.
+  { pattern: /\.rs$/, type: "SoftwareUnit" },
+  { pattern: /\.kt$/, type: "SoftwareUnit" },
+  { pattern: /\.kts$/, type: "SoftwareUnit" },
+  { pattern: /\.java$/, type: "SoftwareUnit" },
+  { pattern: /\.py$/, type: "SoftwareUnit" },
+  { pattern: /\.ts$/, type: "SoftwareUnit" },
+  { pattern: /\.tsx$/, type: "SoftwareUnit" },
+  { pattern: /\.js$/, type: "SoftwareUnit" },
+  { pattern: /\.jsx$/, type: "SoftwareUnit" },
+  { pattern: /\.go$/, type: "SoftwareUnit" },
+  { pattern: /\.cpp$/, type: "SoftwareUnit" },
+  { pattern: /\.cc$/, type: "SoftwareUnit" },
+  { pattern: /\.cxx$/, type: "SoftwareUnit" },
+  { pattern: /\.c$/, type: "SoftwareUnit" },
+  { pattern: /\.h$/, type: "SoftwareUnit" },
+  { pattern: /\.hpp$/, type: "SoftwareUnit" },
+  { pattern: /\.hxx$/, type: "SoftwareUnit" },
+];
+
+/**
+ * Infer a core type from a `Source:` attribute value. The value
+ * may be a filesystem path or a URI — only the filename portion
+ * is matched. Whitespace is trimmed before matching.
+ *
+ * Returns `undefined` when no pattern matches; callers should treat
+ * that as "Source: didn't classify" and fall through to step 4 of
+ * the resolution chain.
+ */
+export function inferTypeFromSource(source: string): string | undefined {
+  const trimmed = source.trim();
+  for (const { pattern, type } of SOURCE_PATTERNS) {
+    if (pattern.test(trimmed)) return type;
+  }
+  return undefined;
+}

--- a/packages/markspec/core/model/source_introspection_test.ts
+++ b/packages/markspec/core/model/source_introspection_test.ts
@@ -1,0 +1,116 @@
+/**
+ * @module core/model/source_introspection_test
+ *
+ * Unit tests for {@linkcode inferTypeFromSource} — the spec §1.3.1
+ * step 3 `Source:` introspection pattern matcher.
+ */
+
+import { assertEquals } from "@std/assert";
+import { inferTypeFromSource } from "./source_introspection.ts";
+
+// SoftwareComponent — build manifests
+Deno.test("inferTypeFromSource: Cargo.toml → SoftwareComponent", () => {
+  assertEquals(
+    inferTypeFromSource("crates/foo/Cargo.toml"),
+    "SoftwareComponent",
+  );
+});
+
+Deno.test("inferTypeFromSource: package.json → SoftwareComponent", () => {
+  assertEquals(inferTypeFromSource("ui/package.json"), "SoftwareComponent");
+});
+
+Deno.test("inferTypeFromSource: deno.json → SoftwareComponent", () => {
+  assertEquals(inferTypeFromSource("deno.json"), "SoftwareComponent");
+});
+
+Deno.test("inferTypeFromSource: .csproj → SoftwareComponent", () => {
+  assertEquals(
+    inferTypeFromSource("src/MyService/MyService.csproj"),
+    "SoftwareComponent",
+  );
+});
+
+// SoftwareUnit — source-code files
+Deno.test("inferTypeFromSource: .rs → SoftwareUnit", () => {
+  assertEquals(
+    inferTypeFromSource("src/braking/controller.rs"),
+    "SoftwareUnit",
+  );
+});
+
+Deno.test("inferTypeFromSource: .kt → SoftwareUnit", () => {
+  assertEquals(
+    inferTypeFromSource("app/src/main/kotlin/Foo.kt"),
+    "SoftwareUnit",
+  );
+});
+
+Deno.test("inferTypeFromSource: .py → SoftwareUnit", () => {
+  assertEquals(inferTypeFromSource("foo/bar.py"), "SoftwareUnit");
+});
+
+// SoftwareInterface — interface description files
+Deno.test("inferTypeFromSource: .proto → SoftwareInterface", () => {
+  assertEquals(
+    inferTypeFromSource("schemas/braking.proto"),
+    "SoftwareInterface",
+  );
+});
+
+Deno.test("inferTypeFromSource: .openapi.yaml → SoftwareInterface", () => {
+  assertEquals(
+    inferTypeFromSource("api/braking.openapi.yaml"),
+    "SoftwareInterface",
+  );
+});
+
+Deno.test("inferTypeFromSource: .arxml → SoftwareInterface", () => {
+  assertEquals(
+    inferTypeFromSource("vendor/BrakingPort.arxml"),
+    "SoftwareInterface",
+  );
+});
+
+// HardwareInterface — bus description files
+Deno.test("inferTypeFromSource: .dbc → HardwareInterface", () => {
+  assertEquals(
+    inferTypeFromSource("vehicle/powertrain.dbc"),
+    "HardwareInterface",
+  );
+});
+
+Deno.test("inferTypeFromSource: .ldf → HardwareInterface", () => {
+  assertEquals(inferTypeFromSource("body/cabin.ldf"), "HardwareInterface");
+});
+
+// Edge cases
+Deno.test("inferTypeFromSource: leading/trailing whitespace ignored", () => {
+  assertEquals(
+    inferTypeFromSource("   src/foo.rs\n"),
+    "SoftwareUnit",
+  );
+});
+
+Deno.test("inferTypeFromSource: extensionless path → undefined", () => {
+  assertEquals(inferTypeFromSource("src/braking/controller"), undefined);
+});
+
+Deno.test("inferTypeFromSource: unknown extension → undefined", () => {
+  assertEquals(inferTypeFromSource("docs/notes.txt"), undefined);
+});
+
+Deno.test("inferTypeFromSource: empty string → undefined", () => {
+  assertEquals(inferTypeFromSource(""), undefined);
+});
+
+Deno.test("inferTypeFromSource: openapi.yaml beats .yaml (interface beats source-code)", () => {
+  // Confirms the rule ordering: a `.openapi.yaml` file is treated as
+  // an interface description, not an arbitrary YAML source file
+  // (which wouldn't match any rule anyway, but the test pins the
+  // intended precedence).
+  assertEquals(
+    inferTypeFromSource("api/svc.openapi.yaml"),
+    "SoftwareInterface",
+  );
+});

--- a/packages/markspec/core/validator/type_resolution.ts
+++ b/packages/markspec/core/validator/type_resolution.ts
@@ -7,18 +7,24 @@
  *
  *   1. Explicit `Type:` attribute.
  *   2. Profile-classified `entry.type` (set upstream).
+ *   3. `Source:` introspection (Cargo.toml → SoftwareComponent,
+ *      *.rs → SoftwareUnit, *.proto → SoftwareInterface, …).
  *   4. Authored display-ID prefix (`REQ` / `TST` / `ICD` / `REC` /
  *      `RSK`) → corresponding core Specification subtype.
  *   5. Reference-shape URI scheme inference (ADR-003 §Part 6).
  *
- * Step 3 (`Source:` introspection), step 6 (discriminating attribute),
- * and step 7 (document directive) are not consulted here; step 8
- * (display-ID shape) has its own warning-emitting stage in
- * `validator/types.ts` (`inferTypeFromDisplayIdShape`).
+ * Step 6 (discriminating attribute) and step 7 (document directive)
+ * are not consulted here; step 8 (display-ID shape) has its own
+ * warning-emitting stage in `validator/types.ts`
+ * (`inferTypeFromDisplayIdShape`).
  */
 
 import type { Entry } from "../model/mod.ts";
-import { CORE_TYPE_HIERARCHY, inferTypeFromUriScheme } from "../model/mod.ts";
+import {
+  CORE_TYPE_HIERARCHY,
+  inferTypeFromSource,
+  inferTypeFromUriScheme,
+} from "../model/mod.ts";
 
 /**
  * Map from Authored display-ID prefix to the core type the prefix
@@ -88,10 +94,26 @@ export function explicitType(entry: Entry): string | undefined {
  * type. The caller decides whether to skip validation, fall back to a
  * less specific check, or report on the unclassified state.
  */
+/** Read an entry's `Source:` attribute, trimmed; empty values yield `undefined`. */
+function sourceValue(entry: Entry): string | undefined {
+  for (const attr of entry.rawAttributes) {
+    if (attr.key !== "Source") continue;
+    const trimmed = attr.value.trim();
+    return trimmed.length === 0 ? undefined : trimmed;
+  }
+  return undefined;
+}
+
 export function resolvedCoreType(entry: Entry): string | undefined {
   const explicit = explicitType(entry);
   if (explicit && CORE_TYPE_HIERARCHY[explicit]) return explicit;
   if (entry.type && CORE_TYPE_HIERARCHY[entry.type]) return entry.type;
+  // Step 3: Source: introspection (filename / extension pattern match).
+  const source = sourceValue(entry);
+  if (source !== undefined) {
+    const inferred = inferTypeFromSource(source);
+    if (inferred && CORE_TYPE_HIERARCHY[inferred]) return inferred;
+  }
   // Step 4: Authored display-ID prefix.
   if (entry.shape === "identified") {
     const inferred = inferTypeFromDisplayIdPrefix(entry.displayId);

--- a/tests/e2e/validate_test.ts
+++ b/tests/e2e/validate_test.ts
@@ -170,6 +170,57 @@ Deno.test("validate: unknown Type value rejected with MSL-T020 in core-only mode
 // Per-type attribute compatibility — spec §1.6, MSL-T022
 // ---------------------------------------------------------------------------
 
+Deno.test("validate: Source: Cargo.toml infers SoftwareComponent at step 3", async () => {
+  const { code, stderr } = await markspec(["validate", "req.md"], {
+    files: {
+      "req.md": `# Test
+
+- [my-crate] My crate
+
+  Body text.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      Source: crates/my-crate/Cargo.toml
+      Bus-protocol: can
+`,
+    },
+  });
+  // Cargo.toml → SoftwareComponent at step 3. Bus-protocol is
+  // HardwareInterface-only → MSL-T022 (warning).
+  assertEquals(
+    code,
+    2,
+    `expected exit 2 (warning), got ${code}; stderr: ${stderr}`,
+  );
+  assertStringIncludes(stderr, "MSL-T022");
+  assertStringIncludes(stderr, "Bus-protocol");
+});
+
+Deno.test("validate: Source: .rs file infers SoftwareUnit at step 3", async () => {
+  const { code, stderr } = await markspec(["validate", "req.md"], {
+    files: {
+      "req.md": `# Test
+
+- [debounce] Debounce function
+
+  Body text.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      Source: src/braking/controller.rs
+      License: Apache-2.0
+`,
+    },
+  });
+  // .rs → SoftwareUnit. License is SoftwareComponent-only → MSL-T022.
+  assertEquals(
+    code,
+    2,
+    `expected exit 2 (warning), got ${code}; stderr: ${stderr}`,
+  );
+  assertStringIncludes(stderr, "MSL-T022");
+  assertStringIncludes(stderr, "License");
+});
+
 Deno.test("validate: [REQ-001] infers Requirement at step 4; Bus-protocol fires MSL-T022", async () => {
   const { code, stderr } = await markspec(["validate", "req.md"], {
     files: {


### PR DESCRIPTION
## Summary

Iteration 16 of the autonomous Prompt-1 follow-up loop. Implements **step 3 of the type-resolution chain** — `Source:` attribute introspection per spec §1.3.1 and ADR-003 §Part 5.

| Commit | Slice |
|---|---|
| `<sha>` | Source: introspection (step 3) |

## What lands

When an entry's `Source:` value matches a known filename / extension pattern, the validator infers the corresponding core type:

| Source pattern | Inferred type |
|---|---|
| `Cargo.toml`, `package.json`, `pom.xml`, `deno.json`, `go.mod`, `pyproject.toml`, `setup.py`, `pubspec.yaml`, `*.csproj` | SoftwareComponent |
| `*.rs`, `*.kt`, `*.java`, `*.py`, `*.ts`, `*.tsx`, `*.js`, `*.jsx`, `*.go`, `*.cpp`/`*.cc`/`*.cxx`, `*.c`/`*.h`, `*.hpp`/`*.hxx` | SoftwareUnit |
| `*.proto`, `*.graphql`, `*.wsdl`, `*.arxml`, `*.idl`, `*.ridl`, `*.openapi.{yaml,yml,json}`, `*.asyncapi.{yaml,yml,json}` | SoftwareInterface |
| `*.dbc`, `*.ldf`, `*.fibex` | HardwareInterface |

Match order: interface descriptions before generic source-code extensions (so `*.openapi.yaml` doesn't shadow against arbitrary YAML). Build manifests anchored at filename boundary (so `weird-Cargo.toml` doesn't match).

`resolvedCoreType()` now slots step 3 between profile-classified `entry.type` (step 2) and display-ID prefix fallback (step 4), exactly where ADR-003 places it.

## Tests

| Before | After |
|---|---|
| 895 (post-#292) | 914 (+17 unit + +2 e2e covering Cargo.toml → SoftwareComponent and `.rs` → SoftwareUnit triggering MSL-T022 on incompatible attrs) |

All `just check` gates green per commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
