### PR TITLE
feat(core): discriminating-attribute inference (spec §1.3.1 step 6)

### DIFF
--- a/packages/markspec/core/model/discriminating_attr.ts
+++ b/packages/markspec/core/model/discriminating_attr.ts
@@ -1,0 +1,77 @@
+/**
+ * @module core/model/discriminating_attr
+ *
+ * Spec §1.3.1 step 6 — discriminating-attribute introspection.
+ *
+ * The presence of a type-specific attribute key on an entry whose core
+ * type is otherwise unresolved infers that type. Only attribute keys
+ * **uniquely owned** by a single concrete core type are listed here; keys
+ * shared between siblings (e.g., `Caused-by` between Record and Risk, or
+ * `Manufacturer` between HardwareComponent and HardwareUnit) are not
+ * discriminating and intentionally absent.
+ *
+ * Owner mapping is derived from spec §1.6 “Per-abstract-type and
+ * per-concrete-type attributes” (ADR-003 §Part 2 catalogue).
+ *
+ * `Source:` could in principle also discriminate to `SoftwareUnit`, but
+ * step 3 introspection already runs ahead of step 6 and would have
+ * matched filename/extension first — listing it here would only fire
+ * when the filename pattern misses, which is fine to support.
+ */
+
+/**
+ * Map from discriminating attribute key → unique-owner core type. Each
+ * key here appears in exactly one concrete type's attribute list per
+ * §1.6, so its presence is sufficient to infer that type.
+ */
+const DISCRIMINATING_ATTRIBUTES: ReadonlyMap<string, string> = new Map([
+  // Test
+  ["Verifies", "Test"],
+  ["Tests", "Test"],
+  // Contract
+  ["Schema-language", "Contract"],
+  // Record
+  ["Affects", "Record"],
+  // Risk
+  ["Mitigated-by", "Risk"],
+  // SoftwareComponent
+  ["License", "SoftwareComponent"],
+  ["Build-manifest", "SoftwareComponent"],
+  ["Package-manager", "SoftwareComponent"],
+  // HardwareInterface
+  ["Bus-protocol", "HardwareInterface"],
+  ["Connector-type", "HardwareInterface"],
+  ["Voltage-level", "HardwareInterface"],
+  ["Signal-direction", "HardwareInterface"],
+  // SoftwareUnit
+  ["Source", "SoftwareUnit"],
+  ["Symbol", "SoftwareUnit"],
+  ["Language", "SoftwareUnit"],
+  // HardwareUnit
+  ["Footprint", "HardwareUnit"],
+  ["Value", "HardwareUnit"],
+  // Definition
+  ["Aliases", "Definition"],
+  ["See-also", "Definition"],
+]);
+
+/**
+ * Infer a core type from the first discriminating attribute key present
+ * on the entry. `attributeKeys` is the source-order list of attribute
+ * keys (TitleCase-Hyphenated form, as parsed). Returns `undefined` when
+ * no discriminating key is found.
+ *
+ * Source order matters: if an entry mistakenly carries discriminators
+ * for two different types (e.g., `Verifies:` and `Schema-language:`),
+ * the first one in source order wins for step-6 purposes. The MSL-T022
+ * pass then flags the second one as incompatible.
+ */
+export function inferTypeFromDiscriminatingAttr(
+  attributeKeys: readonly string[],
+): string | undefined {
+  for (const key of attributeKeys) {
+    const type = DISCRIMINATING_ATTRIBUTES.get(key);
+    if (type !== undefined) return type;
+  }
+  return undefined;
+}

--- a/packages/markspec/core/model/discriminating_attr_test.ts
+++ b/packages/markspec/core/model/discriminating_attr_test.ts
@@ -1,0 +1,148 @@
+/**
+ * @module core/model/discriminating_attr_test
+ *
+ * Unit tests for {@linkcode inferTypeFromDiscriminatingAttr} — the spec
+ * §1.3.1 step 6 discriminating-attribute pattern matcher.
+ */
+
+import { assertEquals } from "@std/assert";
+import { inferTypeFromDiscriminatingAttr } from "./discriminating_attr.ts";
+
+// Test — Verifies / Tests
+Deno.test("inferTypeFromDiscriminatingAttr: Verifies → Test", () => {
+  assertEquals(inferTypeFromDiscriminatingAttr(["Verifies"]), "Test");
+});
+
+Deno.test("inferTypeFromDiscriminatingAttr: Tests → Test", () => {
+  assertEquals(inferTypeFromDiscriminatingAttr(["Tests"]), "Test");
+});
+
+// Contract — Schema-language
+Deno.test("inferTypeFromDiscriminatingAttr: Schema-language → Contract", () => {
+  assertEquals(
+    inferTypeFromDiscriminatingAttr(["Schema-language"]),
+    "Contract",
+  );
+});
+
+// Record / Risk — single-owner discriminators only
+Deno.test("inferTypeFromDiscriminatingAttr: Affects → Record", () => {
+  assertEquals(inferTypeFromDiscriminatingAttr(["Affects"]), "Record");
+});
+
+Deno.test("inferTypeFromDiscriminatingAttr: Mitigated-by → Risk", () => {
+  assertEquals(inferTypeFromDiscriminatingAttr(["Mitigated-by"]), "Risk");
+});
+
+// SoftwareComponent
+Deno.test("inferTypeFromDiscriminatingAttr: License → SoftwareComponent", () => {
+  assertEquals(
+    inferTypeFromDiscriminatingAttr(["License"]),
+    "SoftwareComponent",
+  );
+});
+
+Deno.test("inferTypeFromDiscriminatingAttr: Build-manifest → SoftwareComponent", () => {
+  assertEquals(
+    inferTypeFromDiscriminatingAttr(["Build-manifest"]),
+    "SoftwareComponent",
+  );
+});
+
+Deno.test("inferTypeFromDiscriminatingAttr: Package-manager → SoftwareComponent", () => {
+  assertEquals(
+    inferTypeFromDiscriminatingAttr(["Package-manager"]),
+    "SoftwareComponent",
+  );
+});
+
+// HardwareInterface
+Deno.test("inferTypeFromDiscriminatingAttr: Bus-protocol → HardwareInterface", () => {
+  assertEquals(
+    inferTypeFromDiscriminatingAttr(["Bus-protocol"]),
+    "HardwareInterface",
+  );
+});
+
+Deno.test("inferTypeFromDiscriminatingAttr: Connector-type → HardwareInterface", () => {
+  assertEquals(
+    inferTypeFromDiscriminatingAttr(["Connector-type"]),
+    "HardwareInterface",
+  );
+});
+
+Deno.test("inferTypeFromDiscriminatingAttr: Voltage-level → HardwareInterface", () => {
+  assertEquals(
+    inferTypeFromDiscriminatingAttr(["Voltage-level"]),
+    "HardwareInterface",
+  );
+});
+
+Deno.test("inferTypeFromDiscriminatingAttr: Signal-direction → HardwareInterface", () => {
+  assertEquals(
+    inferTypeFromDiscriminatingAttr(["Signal-direction"]),
+    "HardwareInterface",
+  );
+});
+
+// SoftwareUnit
+Deno.test("inferTypeFromDiscriminatingAttr: Symbol → SoftwareUnit", () => {
+  assertEquals(inferTypeFromDiscriminatingAttr(["Symbol"]), "SoftwareUnit");
+});
+
+Deno.test("inferTypeFromDiscriminatingAttr: Language → SoftwareUnit", () => {
+  assertEquals(inferTypeFromDiscriminatingAttr(["Language"]), "SoftwareUnit");
+});
+
+// HardwareUnit
+Deno.test("inferTypeFromDiscriminatingAttr: Footprint → HardwareUnit", () => {
+  assertEquals(inferTypeFromDiscriminatingAttr(["Footprint"]), "HardwareUnit");
+});
+
+Deno.test("inferTypeFromDiscriminatingAttr: Value → HardwareUnit", () => {
+  assertEquals(inferTypeFromDiscriminatingAttr(["Value"]), "HardwareUnit");
+});
+
+// Definition
+Deno.test("inferTypeFromDiscriminatingAttr: Aliases → Definition", () => {
+  assertEquals(inferTypeFromDiscriminatingAttr(["Aliases"]), "Definition");
+});
+
+Deno.test("inferTypeFromDiscriminatingAttr: See-also → Definition", () => {
+  assertEquals(inferTypeFromDiscriminatingAttr(["See-also"]), "Definition");
+});
+
+// Source-order: first matching discriminator wins
+Deno.test("inferTypeFromDiscriminatingAttr: first matching key wins (Verifies before Schema-language)", () => {
+  assertEquals(
+    inferTypeFromDiscriminatingAttr(["Verifies", "Schema-language"]),
+    "Test",
+  );
+});
+
+Deno.test("inferTypeFromDiscriminatingAttr: first matching key wins (Schema-language before Bus-protocol)", () => {
+  assertEquals(
+    inferTypeFromDiscriminatingAttr(["Schema-language", "Bus-protocol"]),
+    "Contract",
+  );
+});
+
+// Non-discriminating keys (ambiguous or universal) → ignored
+Deno.test("inferTypeFromDiscriminatingAttr: Caused-by ignored (Record OR Risk — ambiguous)", () => {
+  assertEquals(inferTypeFromDiscriminatingAttr(["Caused-by"]), undefined);
+});
+
+Deno.test("inferTypeFromDiscriminatingAttr: Manufacturer ignored (HardwareComponent OR HardwareUnit — ambiguous)", () => {
+  assertEquals(inferTypeFromDiscriminatingAttr(["Manufacturer"]), undefined);
+});
+
+Deno.test("inferTypeFromDiscriminatingAttr: universal trace keys ignored (Satisfies, Derived-from)", () => {
+  assertEquals(
+    inferTypeFromDiscriminatingAttr(["Satisfies", "Derived-from"]),
+    undefined,
+  );
+});
+
+Deno.test("inferTypeFromDiscriminatingAttr: empty input → undefined", () => {
+  assertEquals(inferTypeFromDiscriminatingAttr([]), undefined);
+});

--- a/packages/markspec/core/model/mod.ts
+++ b/packages/markspec/core/model/mod.ts
@@ -25,6 +25,8 @@ export { inferTypeFromUriScheme } from "./uri_scheme_map.ts";
 
 export { inferTypeFromSource } from "./source_introspection.ts";
 
+export { inferTypeFromDiscriminatingAttr } from "./discriminating_attr.ts";
+
 // ---------------------------------------------------------------------------
 // Display ID
 // ---------------------------------------------------------------------------

--- a/packages/markspec/core/validator/type_resolution.ts
+++ b/packages/markspec/core/validator/type_resolution.ts
@@ -12,16 +12,18 @@
  *   4. Authored display-ID prefix (`REQ` / `TST` / `ICD` / `REC` /
  *      `RSK`) → corresponding core Specification subtype.
  *   5. Reference-shape URI scheme inference (ADR-003 §Part 6).
+ *   6. Discriminating-attribute presence (Verifies → Test,
+ *      Schema-language → Contract, …).
  *
- * Step 6 (discriminating attribute) and step 7 (document directive)
- * are not consulted here; step 8 (display-ID shape) has its own
- * warning-emitting stage in `validator/types.ts`
- * (`inferTypeFromDisplayIdShape`).
+ * Step 7 (document directive) is not consulted here; step 8
+ * (display-ID shape) has its own warning-emitting stage in
+ * `validator/types.ts` (`inferTypeFromDisplayIdShape`).
  */
 
 import type { Entry } from "../model/mod.ts";
 import {
   CORE_TYPE_HIERARCHY,
+  inferTypeFromDiscriminatingAttr,
   inferTypeFromSource,
   inferTypeFromUriScheme,
 } from "../model/mod.ts";
@@ -123,6 +125,12 @@ export function resolvedCoreType(entry: Entry): string | undefined {
   if (entry.shape === "referenced" && entry.id) {
     const inferred = inferTypeFromUriScheme(entry.id);
     if (inferred && CORE_TYPE_HIERARCHY[inferred]) return inferred;
+  }
+  // Step 6: Discriminating attribute presence — first matching key wins.
+  const attrKeys = entry.rawAttributes.map((a) => a.key);
+  const fromDiscriminator = inferTypeFromDiscriminatingAttr(attrKeys);
+  if (fromDiscriminator && CORE_TYPE_HIERARCHY[fromDiscriminator]) {
+    return fromDiscriminator;
   }
   return undefined;
 }

--- a/tests/e2e/validate_test.ts
+++ b/tests/e2e/validate_test.ts
@@ -170,6 +170,58 @@ Deno.test("validate: unknown Type value rejected with MSL-T020 in core-only mode
 // Per-type attribute compatibility — spec §1.6, MSL-T022
 // ---------------------------------------------------------------------------
 
+Deno.test("validate: Verifies attr infers Test at step 6; Allocated-to fires MSL-T022", async () => {
+  const { code, stderr } = await markspec(["validate", "req.md"], {
+    files: {
+      "req.md": `# Test
+
+- [my-test] My test entry
+
+  Body text.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      Verifies: 01HGW2Q8MNP3RSTVWXYZABCDEG
+      Allocated-to: 01HGW2Q8MNP3RSTVWXYZABCDEH
+`,
+    },
+  });
+  // Verifies present → Test inferred at step 6. Test excludes
+  // Allocated-to per ADR-003 §Part 2 → MSL-T022 (warning).
+  assertEquals(
+    code,
+    2,
+    `expected exit 2 (warning), got ${code}; stderr: ${stderr}`,
+  );
+  assertStringIncludes(stderr, "MSL-T022");
+  assertStringIncludes(stderr, "Allocated-to");
+});
+
+Deno.test("validate: Schema-language infers Contract at step 6", async () => {
+  const { code, stderr } = await markspec(["validate", "req.md"], {
+    files: {
+      "req.md": `# Test
+
+- [my-contract] My contract
+
+  Body text.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      Schema-language: openapi
+      Bus-protocol: can
+`,
+    },
+  });
+  // Schema-language → Contract. Bus-protocol is HardwareInterface-only
+  // → MSL-T022.
+  assertEquals(
+    code,
+    2,
+    `expected exit 2 (warning), got ${code}; stderr: ${stderr}`,
+  );
+  assertStringIncludes(stderr, "MSL-T022");
+  assertStringIncludes(stderr, "Bus-protocol");
+});
+
 Deno.test("validate: Source: Cargo.toml infers SoftwareComponent at step 3", async () => {
   const { code, stderr } = await markspec(["validate", "req.md"], {
     files: {


### PR DESCRIPTION
## Summary

Iteration 17 of the autonomous Prompt-1 follow-up loop. Implements **step 6 of the type-resolution chain** — discriminating-attribute introspection per spec §1.3.1 and ADR-003 §Part 5 (item 5).

| Commit | Slice |
|---|---|
| `4cad7a5` | Discriminating-attribute inference (step 6) |

## What lands

When an entry's resolved type is still undecided after steps 1–5, the validator now consults the entry's attribute keys: any attribute that is *uniquely owned* by a single concrete core type infers that type.

| Discriminating key(s) | Inferred type |
|---|---|
| `Verifies`, `Tests` | Test |
| `Schema-language` | Contract |
| `Affects` | Record |
| `Mitigated-by` | Risk |
| `License`, `Build-manifest`, `Package-manager` | SoftwareComponent |
| `Bus-protocol`, `Connector-type`, `Voltage-level`, `Signal-direction` | HardwareInterface |
| `Source`, `Symbol`, `Language` | SoftwareUnit |
| `Footprint`, `Value` | HardwareUnit |
| `Aliases`, `See-also` | Definition |

Single-owner only. Keys shared between siblings — `Caused-by` (Record vs Risk), `Manufacturer` / `Part-number` / `Datasheet` (HardwareComponent vs HardwareUnit) — stay non-discriminating and intentionally fall through past step 6.

Source order matters: if an entry carries two discriminators for different types, the first in source order wins. The MSL-T022 incompatible-attribute pass then flags the second one. This makes the `Verifies:` + `Allocated-to:` case behave intuitively — entry is inferred as Test, and `Allocated-to` (Specification-only) warns.

`resolvedCoreType()` now consults step 6 between step 5 (URI scheme) and the fallthrough, exactly where ADR-003 §Part 5 places it.

## Tests

| Before | After |
|---|---|
| 914 (post-#293) | 940 (+24 unit + +2 e2e covering `Verifies:` → Test triggering MSL-T022 on `Allocated-to`, and `Schema-language:` → Contract triggering MSL-T022 on `Bus-protocol`) |

All `just check` gates green per commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
