### PR TITLE
feat(core): broaden MSL-T021 to fire at steps 5/6 (spec §1.3.2)

### DIFF
--- a/packages/markspec/core/validator/pipeline.ts
+++ b/packages/markspec/core/validator/pipeline.ts
@@ -13,6 +13,7 @@ import { validate } from "./mod.ts";
 import {
   classifyEntriesStage,
   inferTypeFromDisplayIdShape,
+  inferTypeFromLateStageChain,
   validateCoreTypeAttribute,
 } from "./types.ts";
 import { validateBodyBlocks } from "./body_blocks.ts";
@@ -88,6 +89,15 @@ export function runPipeline(
     const stage2 = classifyEntriesStage(entries, profile);
     finalEntries = stage2.entries;
     diagnostics.push(...stage2.diagnostics);
+  }
+
+  // Stage 2.4 — late-stage inference warnings (MSL-T021 for steps 5/6).
+  // Runs after Stage 2 so that profile-classified `entry.type` suppresses
+  // the warning correctly. In core-only mode `finalEntries === entries`
+  // and `entry.type` is always undefined, so this stage produces the same
+  // diagnostics regardless of mode.
+  for (const entry of finalEntries) {
+    diagnostics.push(...inferTypeFromLateStageChain(entry));
   }
 
   // Stage 2.5 — normalize profile-declared list-value attributes. Splits

--- a/packages/markspec/core/validator/type_resolution.ts
+++ b/packages/markspec/core/validator/type_resolution.ts
@@ -83,19 +83,6 @@ export function explicitType(entry: Entry): string | undefined {
   return undefined;
 }
 
-/**
- * Resolve an entry's effective core type. Tries (in order):
- *
- *   1. Explicit `Type:` attribute.
- *   2. Profile-classified `entry.type` (set upstream when a profile
- *      is loaded).
- *   3. URI-scheme inference for Reference-shape entries
- *      (ADR-003 §Part 6 — Reference entry only).
- *
- * Returns `undefined` when none of the sources resolves to a core
- * type. The caller decides whether to skip validation, fall back to a
- * less specific check, or report on the unclassified state.
- */
 /** Read an entry's `Source:` attribute, trimmed; empty values yield `undefined`. */
 function sourceValue(entry: Entry): string | undefined {
   for (const attr of entry.rawAttributes) {
@@ -106,31 +93,75 @@ function sourceValue(entry: Entry): string | undefined {
   return undefined;
 }
 
-export function resolvedCoreType(entry: Entry): string | undefined {
+/** Which step of the §1.3.1 chain resolved a type. Steps 7 and 8 are
+ * not reported here; step 8 has its own warning-emitting stage. */
+export type TypeResolutionStep = 1 | 2 | 3 | 4 | 5 | 6;
+
+/** A type together with the step of the §1.3.1 chain that resolved it. */
+export interface ResolvedTypeWithProvenance {
+  readonly type: string;
+  readonly step: TypeResolutionStep;
+}
+
+/**
+ * Resolve an entry's effective core type and report which step of the
+ * spec §1.3.1 chain matched. First match wins. Returns `undefined` when
+ * no step in {1..6} resolves to a known core type — callers may then
+ * consult late-stage step-8 inference (`inferTypeFromDisplayIdShape`)
+ * or treat the entry as unclassified (fallback to `Item`).
+ */
+export function resolvedCoreTypeWithProvenance(
+  entry: Entry,
+): ResolvedTypeWithProvenance | undefined {
+  // Step 1: explicit Type:
   const explicit = explicitType(entry);
-  if (explicit && CORE_TYPE_HIERARCHY[explicit]) return explicit;
-  if (entry.type && CORE_TYPE_HIERARCHY[entry.type]) return entry.type;
-  // Step 3: Source: introspection (filename / extension pattern match).
+  if (explicit && CORE_TYPE_HIERARCHY[explicit]) {
+    return { type: explicit, step: 1 };
+  }
+  // Step 2: profile-classified entry.type
+  if (entry.type && CORE_TYPE_HIERARCHY[entry.type]) {
+    return { type: entry.type, step: 2 };
+  }
+  // Step 3: Source: introspection
   const source = sourceValue(entry);
   if (source !== undefined) {
     const inferred = inferTypeFromSource(source);
-    if (inferred && CORE_TYPE_HIERARCHY[inferred]) return inferred;
+    if (inferred && CORE_TYPE_HIERARCHY[inferred]) {
+      return { type: inferred, step: 3 };
+    }
   }
-  // Step 4: Authored display-ID prefix.
+  // Step 4: Authored display-ID prefix
   if (entry.shape === "identified") {
     const inferred = inferTypeFromDisplayIdPrefix(entry.displayId);
-    if (inferred && CORE_TYPE_HIERARCHY[inferred]) return inferred;
+    if (inferred && CORE_TYPE_HIERARCHY[inferred]) {
+      return { type: inferred, step: 4 };
+    }
   }
-  // Step 5: Reference-shape URI scheme.
+  // Step 5: Reference-shape URI scheme
   if (entry.shape === "referenced" && entry.id) {
     const inferred = inferTypeFromUriScheme(entry.id);
-    if (inferred && CORE_TYPE_HIERARCHY[inferred]) return inferred;
+    if (inferred && CORE_TYPE_HIERARCHY[inferred]) {
+      return { type: inferred, step: 5 };
+    }
   }
   // Step 6: Discriminating attribute presence — first matching key wins.
   const attrKeys = entry.rawAttributes.map((a) => a.key);
   const fromDiscriminator = inferTypeFromDiscriminatingAttr(attrKeys);
   if (fromDiscriminator && CORE_TYPE_HIERARCHY[fromDiscriminator]) {
-    return fromDiscriminator;
+    return { type: fromDiscriminator, step: 6 };
   }
   return undefined;
+}
+
+/**
+ * Resolve an entry's effective core type without provenance. Convenience
+ * wrapper around {@linkcode resolvedCoreTypeWithProvenance} for callers
+ * that don't need to know which step matched.
+ *
+ * Returns `undefined` when no step in {1..6} resolves to a known core
+ * type. The caller decides whether to skip validation, fall back to a
+ * less specific check, or report on the unclassified state.
+ */
+export function resolvedCoreType(entry: Entry): string | undefined {
+  return resolvedCoreTypeWithProvenance(entry)?.type;
 }

--- a/packages/markspec/core/validator/type_resolution_test.ts
+++ b/packages/markspec/core/validator/type_resolution_test.ts
@@ -12,6 +12,7 @@ import {
   explicitType,
   inferTypeFromDisplayIdPrefix,
   resolvedCoreType,
+  resolvedCoreTypeWithProvenance,
 } from "./type_resolution.ts";
 import type { Entry } from "../model/mod.ts";
 
@@ -161,4 +162,102 @@ Deno.test("resolvedCoreType: step 4 falls back to prefix when no explicit Type a
     displayId: "REQ-001",
   };
   assertEquals(resolvedCoreType(reqEntry), "Requirement");
+});
+
+// ---------------------------------------------------------------------------
+// resolvedCoreTypeWithProvenance — tracks which step matched (spec §1.3.1)
+// ---------------------------------------------------------------------------
+
+Deno.test("resolvedCoreTypeWithProvenance: step 1 — explicit Type:", () => {
+  const entry = makeEntry({
+    attrs: [
+      { key: "Id", value: ULID },
+      { key: "Type", value: "Requirement" },
+    ],
+  });
+  assertEquals(
+    resolvedCoreTypeWithProvenance(entry),
+    { type: "Requirement", step: 1 },
+  );
+});
+
+Deno.test("resolvedCoreTypeWithProvenance: step 2 — profile-classified entry.type", () => {
+  const entry = makeEntry({
+    attrs: [{ key: "Id", value: ULID }],
+    type: "SoftwareUnit",
+  });
+  assertEquals(
+    resolvedCoreTypeWithProvenance(entry),
+    { type: "SoftwareUnit", step: 2 },
+  );
+});
+
+Deno.test("resolvedCoreTypeWithProvenance: step 3 — Source: introspection", () => {
+  const entry = makeEntry({
+    attrs: [
+      { key: "Id", value: ULID },
+      { key: "Source", value: "crates/foo/Cargo.toml" },
+    ],
+  });
+  assertEquals(
+    resolvedCoreTypeWithProvenance(entry),
+    { type: "SoftwareComponent", step: 3 },
+  );
+});
+
+Deno.test("resolvedCoreTypeWithProvenance: step 4 — display-ID prefix", () => {
+  const entry = {
+    ...makeEntry({ attrs: [{ key: "Id", value: ULID }] }),
+    displayId: "REQ-001",
+  };
+  assertEquals(
+    resolvedCoreTypeWithProvenance(entry),
+    { type: "Requirement", step: 4 },
+  );
+});
+
+Deno.test("resolvedCoreTypeWithProvenance: step 5 — URI scheme", () => {
+  const entry = makeEntry({
+    attrs: [{ key: "Id", value: "pkg:cargo/serde@1.0.0" }],
+    shape: "referenced",
+    id: "pkg:cargo/serde@1.0.0",
+  });
+  assertEquals(
+    resolvedCoreTypeWithProvenance(entry),
+    { type: "SoftwareComponent", step: 5 },
+  );
+});
+
+Deno.test("resolvedCoreTypeWithProvenance: step 6 — discriminating attribute", () => {
+  const entry = makeEntry({
+    attrs: [
+      { key: "Id", value: ULID },
+      { key: "Verifies", value: "01HGW2Q8MNP3RSTVWXYZABCDEG" },
+    ],
+  });
+  assertEquals(
+    resolvedCoreTypeWithProvenance(entry),
+    { type: "Test", step: 6 },
+  );
+});
+
+Deno.test("resolvedCoreTypeWithProvenance: undefined when nothing resolves", () => {
+  const entry = makeEntry({
+    attrs: [{ key: "Id", value: ULID }],
+  });
+  assertEquals(resolvedCoreTypeWithProvenance(entry), undefined);
+});
+
+Deno.test("resolvedCoreTypeWithProvenance: earliest step wins (explicit Type beats discriminator)", () => {
+  const entry = makeEntry({
+    attrs: [
+      { key: "Id", value: ULID },
+      { key: "Type", value: "Requirement" },
+      { key: "Verifies", value: "01HGW2Q8MNP3RSTVWXYZABCDEG" },
+    ],
+  });
+  assertEquals(
+    resolvedCoreTypeWithProvenance(entry),
+    { type: "Requirement", step: 1 },
+  );
 });

--- a/packages/markspec/core/validator/types.ts
+++ b/packages/markspec/core/validator/types.ts
@@ -17,7 +17,11 @@ import type {
 } from "../model/mod.ts";
 import { CORE_TYPES } from "../model/mod.ts";
 import { compileDisplayIdPattern } from "./pattern.ts";
-import { explicitType, resolvedCoreType } from "./type_resolution.ts";
+import {
+  explicitType,
+  resolvedCoreType,
+  resolvedCoreTypeWithProvenance,
+} from "./type_resolution.ts";
 
 /**
  * Profile-declared concrete-type naming convention (spec §1.3): lowercase
@@ -60,6 +64,42 @@ export function inferTypeFromDisplayIdShape(
     severity: "warning",
     message: `${entry.displayId}: Type inferred as 'Unit' from display-ID ` +
       `shape (late-stage inference); declare 'Type:' explicitly to silence`,
+    location: entry.location,
+  }];
+}
+
+/**
+ * Late-stage type-inference warning for steps 5 and 6 of the §1.3.1
+ * resolution chain (URI scheme inference; discriminating-attribute
+ * presence). Per spec §1.3.2, MSL-T021 fires for any inference at
+ * step ≥ 5 — step 8 (display-ID shape) is covered by
+ * {@linkcode inferTypeFromDisplayIdShape} above, this function covers
+ * steps 5 and 6. Step 7 (document directive) is not yet wired through.
+ *
+ * Suppressed when the entry already carries a profile-classified
+ * `entry.type` — even if that profile type is not itself in the core
+ * hierarchy (e.g., `test` rather than `Test`). The author has already
+ * provided a type signal through the profile's display-ID-pattern
+ * mechanism; a late-stage warning about a different core type that
+ * happens to also resolve would be noise.
+ */
+export function inferTypeFromLateStageChain(
+  entry: Entry,
+): readonly Diagnostic[] {
+  if (entry.type !== undefined) return [];
+  const resolved = resolvedCoreTypeWithProvenance(entry);
+  if (!resolved) return [];
+  if (resolved.step < 5) return [];
+  const source = resolved.step === 5
+    ? "URI scheme"
+    : "discriminating attribute";
+  return [{
+    code: "MSL-T021",
+    severity: "warning",
+    message:
+      `${entry.displayId}: Type inferred as '${resolved.type}' from ${source} ` +
+      `(late-stage inference, step ${resolved.step}); declare 'Type:' ` +
+      `explicitly to silence`,
     location: entry.location,
   }];
 }

--- a/tests/e2e/validate_test.ts
+++ b/tests/e2e/validate_test.ts
@@ -170,6 +170,91 @@ Deno.test("validate: unknown Type value rejected with MSL-T020 in core-only mode
 // Per-type attribute compatibility — spec §1.6, MSL-T022
 // ---------------------------------------------------------------------------
 
+Deno.test("validate: URI-scheme inference (step 5) emits MSL-T021 late-stage warning", async () => {
+  const { code, stderr } = await markspec(["validate", "req.md"], {
+    files: {
+      "req.md": `# Test
+
+- [serde] Serde framework
+
+      Id: pkg:cargo/serde@1.0.0
+`,
+    },
+  });
+  // pkg:cargo → SoftwareComponent inferred at step 5 (Reference shape,
+  // URI scheme) → MSL-T021 late-stage warning per spec §1.3.2.
+  assertEquals(
+    code,
+    2,
+    `expected exit 2 (warning), got ${code}; stderr: ${stderr}`,
+  );
+  assertStringIncludes(stderr, "MSL-T021");
+  assertStringIncludes(stderr, "SoftwareComponent");
+});
+
+Deno.test("validate: discriminating-attr inference (step 6) emits MSL-T021 late-stage warning", async () => {
+  const { code, stderr } = await markspec(["validate", "req.md"], {
+    files: {
+      "req.md": `# Test
+
+- [my-test] My test entry
+
+  Body text.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      Verifies: 01HGW2Q8MNP3RSTVWXYZABCDEG
+`,
+    },
+  });
+  // Verifies present → Test inferred at step 6 → MSL-T021 late-stage warning.
+  assertEquals(
+    code,
+    2,
+    `expected exit 2 (warning), got ${code}; stderr: ${stderr}`,
+  );
+  assertStringIncludes(stderr, "MSL-T021");
+  assertStringIncludes(stderr, "Test");
+});
+
+Deno.test("validate: explicit Type: (step 1) does not emit MSL-T021", async () => {
+  const { code, stderr } = await markspec(["validate", "req.md"], {
+    files: {
+      "req.md": `# Test
+
+- [my-test] My test entry
+
+  Body text.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      Type: Test
+      Verifies: 01HGW2Q8MNP3RSTVWXYZABCDEG
+`,
+    },
+  });
+  // Explicit Type: wins at step 1 — no late-stage warning even though
+  // Verifies would also resolve via step 6.
+  assertEquals(code, 0, `expected exit 0, got ${code}; stderr: ${stderr}`);
+  assertEquals(stderr.includes("MSL-T021"), false, "MSL-T021 should not fire");
+});
+
+Deno.test("validate: display-ID prefix (step 4) does not emit MSL-T021", async () => {
+  const { code, stderr } = await markspec(["validate", "req.md"], {
+    files: {
+      "req.md": `# Test
+
+- [REQ-001] My requirement
+
+  Body text.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+`,
+    },
+  });
+  // REQ prefix matches at step 4 — earlier than the step-5 threshold.
+  assertEquals(code, 0, `expected exit 0, got ${code}; stderr: ${stderr}`);
+  assertEquals(stderr.includes("MSL-T021"), false, "MSL-T021 should not fire");
+});
+
 Deno.test("validate: Verifies attr infers Test at step 6; Allocated-to fires MSL-T022", async () => {
   const { code, stderr } = await markspec(["validate", "req.md"], {
     files: {
@@ -701,10 +786,13 @@ Deno.test("validate: pkg:cargo Reference as Depends-on target passes (infers Sof
 - [serde] Serde framework
 
       Id: pkg:cargo/serde@1.0.0
+      Type: SoftwareComponent
 `,
     },
   });
-  // pkg:cargo → SoftwareComponent → Depends-on accepts Component → OK
+  // pkg:cargo → SoftwareComponent → Depends-on accepts Component → OK.
+  // Explicit Type: on the Reference entry silences the step-5
+  // late-stage MSL-T021 warning that would otherwise fire.
   assertEquals(code, 0, `expected exit 0, got ${code}; stderr: ${stderr}`);
 });
 
@@ -781,9 +869,12 @@ Deno.test("validate: Reference display ID with valid slug passes", async () => {
 - [ISO-26262-6] ISO 26262 Part 6
 
       Id: urn:iso:std:iso:26262:-6:ed-2
+      Type: Requirement
 `,
     },
   });
+  // Explicit Type: silences the step-5 late-stage MSL-T021 that the
+  // urn:iso: scheme would otherwise produce.
   assertEquals(code, 0, `expected exit 0, got ${code}; stderr: ${stderr}`);
 });
 


### PR DESCRIPTION
## Summary

Iteration 18 of the autonomous Prompt-1 follow-up loop. Broadens **MSL-T021 late-stage-inference warning** to fire at chain steps 5 and 6, per spec §1.3.2 ("type resolved via late-stage inference (step ≥ 5)").

| Commit | Slice |
|---|---|
| `152264b` | MSL-T021 for steps 5/6 |

## What lands

Previously only step 8 (display-ID shape) emitted MSL-T021. The spec mandates the warning for any inference at step ≥ 5. This PR adds:

- `resolvedCoreTypeWithProvenance(entry): { type, step } | undefined` — same six-step walk, but reports which step matched.
- `resolvedCoreType(entry)` becomes a one-line wrapper.
- `inferTypeFromLateStageChain(entry)` — emits MSL-T021 when the resolved step is 5 (URI scheme) or 6 (discriminating attribute).
- **Suppressed when `entry.type` is set** — when a profile classified the entry via display-ID pattern, that's already an explicit type signal even if the profile type name (`test`) isn't itself a core type. A late-stage warning about an incidentally-matching core type (`Test` via `Verifies:`) would be noise.
- Pipeline runs the new emitter in **Stage 2.4**, after Stage 2 classification, so profile-classified `entry.type` reliably suppresses. Step 8's emitter stays in Stage 1.5 — its `::`/`/` guard already tolerated pre-classification.

## Test fallout

Two existing tests relied on URI-scheme inference without an explicit `Type:`:

| Test | Update |
|---|---|
| `validate: pkg:cargo Reference as Depends-on target passes` | Added `Type: SoftwareComponent` on the Reference entry — the test exercised cross-type Depends-on compatibility, not late-stage inference, and silencing MSL-T021 there is the spec-correct authoring pattern. |
| `validate: Reference display ID with valid slug passes` | Added `Type: Requirement` on the `urn:iso:...` entry — same reasoning. |

## Tests

| Before | After |
|---|---|
| 940 (post-#294) | 952 (+7 unit `resolvedCoreTypeWithProvenance` + +4 e2e covering MSL-T021 emission at steps 5/6 and suppression at steps 1/4 — net +12 once the two existing tests' adjustments are counted) |

All `just check` gates green per commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
