### PR TITLE
feat(core): MSL-A013 — single-cardinality attribute used more than once

### DIFF
--- a/packages/markspec/core/validator/mod.ts
+++ b/packages/markspec/core/validator/mod.ts
@@ -29,6 +29,19 @@ import { HTTP_URL_RE } from "./value_types.ts";
 const UNIVERSAL_KEYS = new Set(UNIVERSAL_ATTRIBUTE_KEYS);
 
 /**
+ * Value-type set that's repeatable per spec §1.8 — these attributes
+ * accept multiple lines for distinct values, so multiple trailers with
+ * the same key are legal. Single-cardinality attributes are anything
+ * not in this set.
+ */
+const REPEATABLE_VALUE_TYPES: ReadonlySet<string> = new Set([
+  "id-list",
+  "tag-list",
+  "citation",
+  "external-id",
+]);
+
+/**
  * Slug pattern for Reference-shape display IDs (spec §1.7, ADR-002 §Part 3).
  * Pandoc/BibTeX cite-key convention, restricted to a portable character
  * set: starts with a letter, body alphanumeric + `.` / `/` / `-` / `_`,
@@ -165,6 +178,34 @@ function checkStructural(
         });
       } else {
         ids.set(entry.id, entry);
+      }
+    }
+
+    // MSL-A013 — single-cardinality core attribute used more than once.
+    // `Id:` is excluded because MSL-R003 (above) reports its duplicates
+    // with a more specific message. Profile-declared attribute
+    // cardinality is enforced by the profile-aware Stage 3 (MSL-A002).
+    const seenSingleKeys = new Set<string>();
+    const reportedA013 = new Set<string>();
+    for (const attr of entry.rawAttributes) {
+      if (attr.key === IDENTITY_KEY) continue;
+      const spec = attributeSpec(attr.key);
+      if (!spec) continue;
+      if (REPEATABLE_VALUE_TYPES.has(spec.type)) continue;
+      if (seenSingleKeys.has(attr.key)) {
+        if (!reportedA013.has(attr.key)) {
+          diagnostics.push({
+            code: "MSL-A013",
+            severity: "error",
+            message:
+              `${entry.displayId}: '${attr.key}' is single-cardinality ` +
+              `but appears more than once (spec §1.8)`,
+            location: entry.location,
+          });
+          reportedA013.add(attr.key);
+        }
+      } else {
+        seenSingleKeys.add(attr.key);
       }
     }
 

--- a/tests/e2e/validate_test.ts
+++ b/tests/e2e/validate_test.ts
@@ -107,6 +107,70 @@ Deno.test("validate: generated-origin attribute in source rejected with MSL-A030
   assertStringIncludes(stderr, "Superseded-by");
 });
 
+// MSL-A013 — single-cardinality core attribute used more than once
+Deno.test("validate: duplicate Type: trailers fire MSL-A013", async () => {
+  const { code, stderr } = await markspec(["validate", "req.md"], {
+    files: {
+      "req.md": `# Test
+
+- [REQ-001] My requirement
+
+  Body text.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      Type: Requirement
+      Type: Specification
+`,
+    },
+  });
+  assertEquals(code, 1, `expected exit 1, got ${code}; stderr: ${stderr}`);
+  assertStringIncludes(stderr, "MSL-A013");
+  assertStringIncludes(stderr, "Type");
+});
+
+Deno.test("validate: duplicate Source: trailers fire MSL-A013", async () => {
+  const { code, stderr } = await markspec(["validate", "req.md"], {
+    files: {
+      "req.md": `# Test
+
+- [REQ-001] My requirement
+
+  Body text.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      Source: Cargo.toml
+      Source: package.json
+`,
+    },
+  });
+  assertEquals(code, 1, `expected exit 1, got ${code}; stderr: ${stderr}`);
+  assertStringIncludes(stderr, "MSL-A013");
+  assertStringIncludes(stderr, "Source");
+});
+
+Deno.test("validate: repeated Labels: trailers do NOT fire MSL-A013 (tag-list is repeatable)", async () => {
+  const { code, stderr } = await markspec(["validate", "req.md"], {
+    files: {
+      "req.md": `# Test
+
+- [REQ-001] My requirement
+
+  Body text.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      Labels: ASIL-B
+      Labels: safety
+`,
+    },
+  });
+  assertEquals(
+    code,
+    0,
+    `expected exit 0 (clean), got ${code}; stderr: ${stderr}`,
+  );
+  assertEquals(stderr.includes("MSL-A013"), false);
+});
+
 Deno.test("validate: display-ID containing :: emits MSL-T021 inference warning", async () => {
   const { code, stderr } = await markspec(["validate", "req.md"], {
     files: {


### PR DESCRIPTION
## Summary

Iteration 20 of the autonomous Prompt-1 follow-up loop. Implements **MSL-A013 — single-cardinality attribute used more than once** per spec §1.8.

| Commit | Slice |
|---|---|
| `167d2fe` | MSL-A013 emitter |

## What lands

Single-cardinality core attributes (everything whose value type is not in `{id-list, tag-list, citation, external-id}`) must appear at most once per entry. The structural validator now scans an entry's `rawAttributes`, looks up each key in `ATTRIBUTE_CATALOG`, and emits MSL-A013 when a known single-cardinality key appears more than once.

| Fires for | Stays clean |
|---|---|
| `Type:`, `Source:`, `Origin:`, `Reference-url:`, `Reference-document:`, `Supersedes:`, `Deprecated:` | `Labels:` (tag-list), `References:` (citation), `External-id:` (external-id) — all spec §1.8 repeatable |

`Id:` is excluded — MSL-R003 already reports its duplicates with a more specific message. Profile-declared attribute cardinality stays in the profile-aware Stage 3 (MSL-A002).

Reported **once per key per entry** rather than per redundant line, so a paste-of-four-lines accident produces one MSL-A013 rather than three.

## Tests

| Before | After |
|---|---|
| 960 (post-#296) | 963 (+2 e2e for `Type:` and `Source:` duplicates firing MSL-A013, +1 negative test that repeated `Labels:` stays clean) |

All `just check` gates green per commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
