### PR TITLE
feat(core): MSL-M060 — uppercase modal keyword warning (spec §3.4.1)

### DIFF
--- a/packages/markspec/core/validator/modal_keywords.ts
+++ b/packages/markspec/core/validator/modal_keywords.ts
@@ -1,0 +1,53 @@
+/**
+ * @module core/validator/modal_keywords
+ *
+ * MSL-M060 — uppercase modal keyword (`SHALL`, `SHOULD`, `MAY`, `MUST`,
+ * optionally `… NOT`) in entry-body prose. The formatter normalises
+ * these to lowercase per spec §3.4.1; the validator flags them so a
+ * lint-only flow (no `fmt` run) surfaces the deviation from canonical
+ * form. Profiles may promote the severity.
+ *
+ * Fence-aware: matches inside fenced code blocks are intentionally
+ * skipped (code samples and verbatim quotes from RFC 2119 itself stay
+ * uppercase). Attribute trailers (4-space-indented blocks) sit below
+ * the body and never appear in the body string the parser hands us, so
+ * no additional skipping is needed for them.
+ */
+
+import type { Diagnostic, Entry } from "../model/mod.ts";
+import { walkProseLines } from "../util/fence.ts";
+
+/**
+ * RFC 2119 modal keywords in uppercase form, with optional ` NOT`.
+ * Matched as whole words (`\b...\b`) so `SHALLOW` is not flagged.
+ */
+const UPPERCASE_MODAL_RE = /\b(SHALL|SHOULD|MAY|MUST)(\s+NOT)?\b/g;
+
+/**
+ * Scan an entry's body for uppercase modal keywords and emit MSL-M060
+ * for each occurrence. Severity is `warning`; the formatter rewrites
+ * them on the next run.
+ */
+export function validateModalKeywords(entry: Entry): readonly Diagnostic[] {
+  const diagnostics: Diagnostic[] = [];
+  walkProseLines(entry.body, (line, lineOffset) => {
+    UPPERCASE_MODAL_RE.lastIndex = 0;
+    let match: RegExpExecArray | null;
+    while ((match = UPPERCASE_MODAL_RE.exec(line)) !== null) {
+      const keyword = match[0];
+      diagnostics.push({
+        code: "MSL-M060",
+        severity: "warning",
+        message: `${entry.displayId}: modal keyword '${keyword}' in body ` +
+          `prose is uppercase (spec §3.4.1 canonical form is lowercase; ` +
+          `'markspec format' will rewrite it)`,
+        location: {
+          file: entry.location.file,
+          line: entry.location.line + lineOffset,
+          column: match.index + 1,
+        },
+      });
+    }
+  });
+  return diagnostics;
+}

--- a/packages/markspec/core/validator/pipeline.ts
+++ b/packages/markspec/core/validator/pipeline.ts
@@ -18,6 +18,7 @@ import {
 } from "./types.ts";
 import { validateBodyBlocks } from "./body_blocks.ts";
 import { validateCaptions } from "./captions.ts";
+import { validateModalKeywords } from "./modal_keywords.ts";
 import { validatePerTypeAttributes } from "./per_type_attrs.ts";
 import { validateTraceTargetTypes } from "./trace_types.ts";
 import { effectiveScope, validateAttributesForEntry } from "./attributes.ts";
@@ -76,6 +77,7 @@ export function runPipeline(
     diagnostics.push(...validateCaptions(entry));
     diagnostics.push(...validateBodyBlocks(entry));
     diagnostics.push(...validatePerTypeAttributes(entry));
+    diagnostics.push(...validateModalKeywords(entry));
   }
 
   // Stage 1.6 — cross-file trace target-type compatibility (MSL-R083).

--- a/tests/e2e/validate_test.ts
+++ b/tests/e2e/validate_test.ts
@@ -148,6 +148,90 @@ Deno.test("validate: duplicate Source: trailers fire MSL-A013", async () => {
   assertStringIncludes(stderr, "Source");
 });
 
+// MSL-M060 — uppercase modal keywords in entry-body prose
+Deno.test("validate: uppercase SHALL in body fires MSL-M060", async () => {
+  const { code, stderr } = await markspec(["validate", "req.md"], {
+    files: {
+      "req.md": `# Test
+
+- [REQ-001] My requirement
+
+  The system SHALL debounce raw inputs.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+`,
+    },
+  });
+  // SHALL in prose is a style warning — exit 2.
+  assertEquals(
+    code,
+    2,
+    `expected exit 2 (warning), got ${code}; stderr: ${stderr}`,
+  );
+  assertStringIncludes(stderr, "MSL-M060");
+  assertStringIncludes(stderr, "SHALL");
+});
+
+Deno.test("validate: uppercase MUST NOT in body fires MSL-M060", async () => {
+  const { code, stderr } = await markspec(["validate", "req.md"], {
+    files: {
+      "req.md": `# Test
+
+- [REQ-001] My requirement
+
+  The driver MUST NOT block the main thread.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+`,
+    },
+  });
+  assertEquals(
+    code,
+    2,
+    `expected exit 2 (warning), got ${code}; stderr: ${stderr}`,
+  );
+  assertStringIncludes(stderr, "MSL-M060");
+  assertStringIncludes(stderr, "MUST NOT");
+});
+
+Deno.test("validate: lowercase modal in body does NOT fire MSL-M060", async () => {
+  const { code, stderr } = await markspec(["validate", "req.md"], {
+    files: {
+      "req.md": `# Test
+
+- [REQ-001] My requirement
+
+  The system shall debounce raw inputs and may queue them.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+`,
+    },
+  });
+  assertEquals(code, 0, `expected exit 0, got ${code}; stderr: ${stderr}`);
+  assertEquals(stderr.includes("MSL-M060"), false);
+});
+
+Deno.test("validate: SHALL inside fenced code block is NOT flagged", async () => {
+  const { code, stderr } = await markspec(["validate", "req.md"], {
+    files: {
+      "req.md": `# Test
+
+- [REQ-001] My requirement
+
+  Example showing the literal RFC 2119 text:
+
+  \`\`\`text
+  The system SHALL respond within 100ms.
+  \`\`\`
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+`,
+    },
+  });
+  assertEquals(code, 0, `expected exit 0, got ${code}; stderr: ${stderr}`);
+  assertEquals(stderr.includes("MSL-M060"), false);
+});
+
 Deno.test("validate: repeated Labels: trailers do NOT fire MSL-A013 (tag-list is repeatable)", async () => {
   const { code, stderr } = await markspec(["validate", "req.md"], {
     files: {


### PR DESCRIPTION
## Summary

Iteration 21 of the autonomous Prompt-1 follow-up loop. Implements **MSL-M060 — uppercase modal keyword warning** per spec §3.4.1.

| Commit | Slice |
|---|---|
| `c459f55` | Modal-uppercase validator pass |

## What lands

The formatter already lowercases uppercase RFC 2119 modals (`SHALL`, `SHOULD`, `MAY`, `MUST`, optionally `… NOT`) to the canonical form per spec §3.4.1. A new validator pass surfaces the same deviation as **MSL-M060 (warning)** so a lint-only workflow — no `markspec format` run in between — still reports it.

[packages/markspec/core/validator/modal_keywords.ts](packages/markspec/core/validator/modal_keywords.ts):

- Walks the entry body via the shared `walkProseLines` helper — same fence-aware iterator the formatter uses.
- Matches `\b(SHALL|SHOULD|MAY|MUST)(\s+NOT)?\b` (whole-word so `SHALLOW` doesn't get flagged) and emits one MSL-M060 per occurrence with per-character position.
- Skips fenced code blocks so verbatim RFC 2119 quotes and code samples can legitimately stay uppercase.

Wired into Stage 1.5 alongside `validateBodyBlocks` / `validateCaptions` / `validatePerTypeAttributes`.

## Tests

| Before | After |
|---|---|
| 963 (post-#297) | 967 (+4 e2e: SHALL → warning, MUST NOT → warning, lowercase clean, fenced-code suppression) |

All `just check` gates green per commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
