### PR TITLE
feat(core): MSL-M061 — Requirement entry without modal keyword (info)

### DIFF
--- a/packages/markspec/core/validator/modal_keywords.ts
+++ b/packages/markspec/core/validator/modal_keywords.ts
@@ -16,6 +16,7 @@
 
 import type { Diagnostic, Entry } from "../model/mod.ts";
 import { walkProseLines } from "../util/fence.ts";
+import { resolvedCoreType } from "./type_resolution.ts";
 
 /**
  * RFC 2119 modal keywords in uppercase form, with optional ` NOT`.
@@ -24,13 +25,21 @@ import { walkProseLines } from "../util/fence.ts";
 const UPPERCASE_MODAL_RE = /\b(SHALL|SHOULD|MAY|MUST)(\s+NOT)?\b/g;
 
 /**
+ * RFC 2119 modal keywords in any case (used by MSL-M061 to detect
+ * Requirement entries that have no modal verb at all). Whole-word.
+ */
+const ANY_MODAL_RE = /\b(shall|should|may|must)(\s+not)?\b/i;
+
+/**
  * Scan an entry's body for uppercase modal keywords and emit MSL-M060
  * for each occurrence. Severity is `warning`; the formatter rewrites
  * them on the next run.
  */
 export function validateModalKeywords(entry: Entry): readonly Diagnostic[] {
   const diagnostics: Diagnostic[] = [];
+  let anyModalSeen = false;
   walkProseLines(entry.body, (line, lineOffset) => {
+    if (ANY_MODAL_RE.test(line)) anyModalSeen = true;
     UPPERCASE_MODAL_RE.lastIndex = 0;
     let match: RegExpExecArray | null;
     while ((match = UPPERCASE_MODAL_RE.exec(line)) !== null) {
@@ -49,5 +58,21 @@ export function validateModalKeywords(entry: Entry): readonly Diagnostic[] {
       });
     }
   });
+
+  // MSL-M061 — Requirement-type entry contains no modal keyword
+  // (info; style hint). Gated on the resolved core type being
+  // `Requirement` so non-requirement entries (Tests, Contracts, etc.)
+  // are not flagged. The hint stays at info severity so it doesn't
+  // affect exit codes; profiles may promote.
+  if (!anyModalSeen && resolvedCoreType(entry) === "Requirement") {
+    diagnostics.push({
+      code: "MSL-M061",
+      severity: "info",
+      message: `${entry.displayId}: Requirement entry contains no modal ` +
+        `keyword (shall / should / may / must) — consider declaring one ` +
+        `to make the obligation explicit (spec §3.4.1 “Modal keywords”)`,
+      location: entry.location,
+    });
+  }
   return diagnostics;
 }

--- a/tests/e2e/validate_test.ts
+++ b/tests/e2e/validate_test.ts
@@ -148,6 +148,61 @@ Deno.test("validate: duplicate Source: trailers fire MSL-A013", async () => {
   assertStringIncludes(stderr, "Source");
 });
 
+// MSL-M061 — Requirement entry contains no modal keyword (info)
+Deno.test("validate: Requirement entry with no modal keyword emits MSL-M061 (info)", async () => {
+  const { code, stderr } = await markspec(["validate", "req.md"], {
+    files: {
+      "req.md": `# Test
+
+- [REQ-001] My requirement
+
+  The system processes inputs and emits results.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+`,
+    },
+  });
+  // Info doesn't trigger exit 2 — exit 0, but the diagnostic prints.
+  assertEquals(code, 0, `expected exit 0, got ${code}; stderr: ${stderr}`);
+  assertStringIncludes(stderr, "MSL-M061");
+});
+
+Deno.test("validate: Requirement entry with lowercase modal stays clean (no MSL-M061)", async () => {
+  const { code, stderr } = await markspec(["validate", "req.md"], {
+    files: {
+      "req.md": `# Test
+
+- [REQ-001] My requirement
+
+  The system shall process inputs and emit results.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+`,
+    },
+  });
+  assertEquals(code, 0, `expected exit 0, got ${code}; stderr: ${stderr}`);
+  assertEquals(stderr.includes("MSL-M061"), false);
+});
+
+Deno.test("validate: non-Requirement entry without modal does NOT fire MSL-M061", async () => {
+  const { code, stderr } = await markspec(["validate", "req.md"], {
+    files: {
+      "req.md": `# Test
+
+- [my-test] My test entry
+
+  Body text without any modal keyword.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      Type: Test
+`,
+    },
+  });
+  // Type: Test → not Requirement → MSL-M061 is requirement-only.
+  assertEquals(code, 0, `expected exit 0, got ${code}; stderr: ${stderr}`);
+  assertEquals(stderr.includes("MSL-M061"), false);
+});
+
 // MSL-M060 — uppercase modal keywords in entry-body prose
 Deno.test("validate: uppercase SHALL in body fires MSL-M060", async () => {
   const { code, stderr } = await markspec(["validate", "req.md"], {


### PR DESCRIPTION
## Summary

Iteration 22 of the autonomous Prompt-1 follow-up loop. Implements **MSL-M061 — Requirement entry without modal keyword** per spec §3.4.1.

| Commit | Slice |
|---|---|
| `325a5fc` | Requirement-modal-missing style hint |

## What lands

Extends the body-prose walker added for MSL-M060 to also emit **MSL-M061 (info)** when both:

- the entry's resolved core type is `Requirement`, **and**
- the body contains no RFC 2119 modal keyword (`shall` / `should` / `may` / `must`, optionally `… not`, case-insensitive).

Severity is `info`, so it prints to stderr but does not raise the exit code. Profiles may promote per spec §1.3.2.

Same `walkProseLines` pass — one fence-aware iteration tracks both "any modal seen?" for M061 and the per-occurrence uppercase matches for M060.

## Tests

| Before | After |
|---|---|
| 967 (post-#298) | 970 (+3 e2e: positive Requirement-no-modal → MSL-M061 + exit 0; lowercase modal clean; non-Requirement type-gate clean) |

All `just check` gates green per commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
