### PR TITLE
feat(core): MSL-A012 — empty repeatable attribute value list (spec §1.8)

### DIFF
--- a/packages/markspec/core/validator/mod.ts
+++ b/packages/markspec/core/validator/mod.ts
@@ -181,6 +181,31 @@ function checkStructural(
       }
     }
 
+    // MSL-A012 — repeatable attribute value list is empty (spec §1.8).
+    // Fires when an authored repeatable attribute (id-list, tag-list,
+    // citation, external-id) carries no non-empty values after trimming
+    // and CSV splitting. `citation` is not CSV-splittable, so its check
+    // is a plain trim-and-empty test.
+    for (const attr of entry.rawAttributes) {
+      const spec = attributeSpec(attr.key);
+      if (!spec) continue;
+      if (!REPEATABLE_VALUE_TYPES.has(spec.type)) continue;
+      const raw = attr.value;
+      const isCitation = spec.type === "citation";
+      const values = isCitation
+        ? [raw.trim()].filter((s) => s.length > 0)
+        : raw.split(",").map((s) => s.trim()).filter((s) => s.length > 0);
+      if (values.length === 0) {
+        diagnostics.push({
+          code: "MSL-A012",
+          severity: "error",
+          message: `${entry.displayId}: '${attr.key}' is a repeatable ` +
+            `attribute but the value list is empty (spec §1.8)`,
+          location: entry.location,
+        });
+      }
+    }
+
     // MSL-A013 — single-cardinality core attribute used more than once.
     // `Id:` is excluded because MSL-R003 (above) reports its duplicates
     // with a more specific message. Profile-declared attribute

--- a/tests/e2e/validate_test.ts
+++ b/tests/e2e/validate_test.ts
@@ -148,6 +148,63 @@ Deno.test("validate: duplicate Source: trailers fire MSL-A013", async () => {
   assertStringIncludes(stderr, "Source");
 });
 
+// MSL-A012 — repeatable attribute value list is empty
+Deno.test("validate: Labels with only commas fires MSL-A012", async () => {
+  const { code, stderr } = await markspec(["validate", "req.md"], {
+    files: {
+      "req.md": `# Test
+
+- [REQ-001] My requirement
+
+  Body text.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      Labels: , ,
+`,
+    },
+  });
+  assertEquals(code, 1, `expected exit 1, got ${code}; stderr: ${stderr}`);
+  assertStringIncludes(stderr, "MSL-A012");
+  assertStringIncludes(stderr, "Labels");
+});
+
+Deno.test("validate: External-id with empty CSV fires MSL-A012", async () => {
+  const { code, stderr } = await markspec(["validate", "req.md"], {
+    files: {
+      "req.md": `# Test
+
+- [REQ-001] My requirement
+
+  Body text.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      External-id: ,,
+`,
+    },
+  });
+  assertEquals(code, 1, `expected exit 1, got ${code}; stderr: ${stderr}`);
+  assertStringIncludes(stderr, "MSL-A012");
+  assertStringIncludes(stderr, "External-id");
+});
+
+Deno.test("validate: Labels with one non-empty value stays clean (no MSL-A012)", async () => {
+  const { code, stderr } = await markspec(["validate", "req.md"], {
+    files: {
+      "req.md": `# Test
+
+- [REQ-001] My requirement
+
+  Body text.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      Labels: safety
+`,
+    },
+  });
+  assertEquals(code, 0, `expected exit 0, got ${code}; stderr: ${stderr}`);
+  assertEquals(stderr.includes("MSL-A012"), false);
+});
+
 // MSL-M061 — Requirement entry contains no modal keyword (info)
 Deno.test("validate: Requirement entry with no modal keyword emits MSL-M061 (info)", async () => {
   const { code, stderr } = await markspec(["validate", "req.md"], {


### PR DESCRIPTION
## Summary

Iteration 23 of the autonomous Prompt-1 follow-up loop. Implements **MSL-A012 — empty repeatable attribute value list** per spec §1.8.

| Commit | Slice |
|---|---|
| `552cf9b` | Empty-list emitter |

## What lands

Repeatable core attributes (`id-list`, `tag-list`, `citation`, `external-id`) must carry at least one non-empty value per spec §1.8. The structural validator now scans each entry's `rawAttributes`, applies the spec's canonicalisation, and emits **MSL-A012 (error)** when the effective list is empty.

| Value type | Canonicalisation |
|---|---|
| `id-list`, `tag-list`, `external-id` | split on `,`, trim, drop empties → empty if none survive |
| `citation` | trim whole value (commas may be locators) → empty if blank |

Profile-declared repeatable attributes keep flowing through Stage 3's `MSL-A002` / `MSL-A003` cardinality checks against the profile's declared range; this PR is scoped to the core catalogue.

## Tests

| Before | After |
|---|---|
| 970 (post-#299) | 973 (+2 e2e: `Labels: , ,` and `External-id: ,,` both fire MSL-A012; +1 negative confirming `Labels: safety` stays clean) |

All `just check` gates green per commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
