### PR TITLE
feat(core): MSL-A011 — citation attribute used CSV form (spec §2.3.2)

### DIFF
--- a/packages/markspec/core/validator/mod.ts
+++ b/packages/markspec/core/validator/mod.ts
@@ -181,6 +181,36 @@ function checkStructural(
       }
     }
 
+    // MSL-A011 — `citation`-typed attribute (References:) used CSV
+    // form. The canonical form is multi-line per spec §2.3.2: locators
+    // may contain commas (e.g. `[@iso26262, p. 42]`), so the parser
+    // never CSV-splits citation values. Detection scans for a `,` at
+    // bracket-depth zero — commas inside `[…]` are locators and OK.
+    for (const attr of entry.rawAttributes) {
+      const spec = attributeSpec(attr.key);
+      if (spec?.type !== "citation") continue;
+      let depth = 0;
+      let sawTopLevelComma = false;
+      for (const ch of attr.value) {
+        if (ch === "[") depth++;
+        else if (ch === "]" && depth > 0) depth--;
+        else if (ch === "," && depth === 0) {
+          sawTopLevelComma = true;
+          break;
+        }
+      }
+      if (sawTopLevelComma) {
+        diagnostics.push({
+          code: "MSL-A011",
+          severity: "error",
+          message: `${entry.displayId}: '${attr.key}' is citation-typed and ` +
+            `must use multi-line form (spec §2.3.2); CSV is rejected because ` +
+            `Pandoc locators may contain commas`,
+          location: entry.location,
+        });
+      }
+    }
+
     // MSL-A012 — repeatable attribute value list is empty (spec §1.8).
     // Fires when an authored repeatable attribute (id-list, tag-list,
     // citation, external-id) carries no non-empty values after trimming

--- a/tests/e2e/validate_test.ts
+++ b/tests/e2e/validate_test.ts
@@ -148,6 +148,88 @@ Deno.test("validate: duplicate Source: trailers fire MSL-A013", async () => {
   assertStringIncludes(stderr, "Source");
 });
 
+// MSL-A011 — citation attribute used CSV form (always multi-line per §2.3.2)
+Deno.test("validate: References with CSV form fires MSL-A011", async () => {
+  const { code, stderr } = await markspec(["validate", "req.md"], {
+    files: {
+      "req.md": `# Test
+
+- [ISO-1] First reference
+
+      Id: urn:iso:std:iso:1:ed-1
+
+- [ISO-2] Second reference
+
+      Id: urn:iso:std:iso:2:ed-1
+
+- [REQ-001] My requirement
+
+  Body text.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      References: ISO-1, ISO-2
+`,
+    },
+  });
+  assertEquals(code, 1, `expected exit 1, got ${code}; stderr: ${stderr}`);
+  assertStringIncludes(stderr, "MSL-A011");
+  assertStringIncludes(stderr, "References");
+});
+
+Deno.test("validate: single-citation References stays clean (no MSL-A011)", async () => {
+  const { code, stderr } = await markspec(["validate", "req.md"], {
+    files: {
+      "req.md": `# Test
+
+- [ISO-26262-6] ISO 26262 Part 6
+
+      Id: urn:iso:std:iso:26262:-6:ed-2
+      Type: Requirement
+
+- [REQ-001] My requirement
+
+  Body text.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      References: ISO-26262-6 §9.4
+`,
+    },
+  });
+  // No comma in citation value → no MSL-A011.
+  assertEquals(code, 0, `expected exit 0, got ${code}; stderr: ${stderr}`);
+  assertEquals(stderr.includes("MSL-A011"), false);
+});
+
+Deno.test("validate: multi-line References stays clean (no MSL-A011)", async () => {
+  const { code, stderr } = await markspec(["validate", "req.md"], {
+    files: {
+      "req.md": `# Test
+
+- [ISO-1] First reference
+
+      Id: urn:iso:std:iso:1:ed-1
+      Type: Requirement
+
+- [ISO-2] Second reference
+
+      Id: urn:iso:std:iso:2:ed-1
+      Type: Requirement
+
+- [REQ-001] My requirement
+
+  Body text.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      References: ISO-1
+      References: ISO-2
+`,
+    },
+  });
+  // Canonical form: one cite per line.
+  assertEquals(code, 0, `expected exit 0, got ${code}; stderr: ${stderr}`);
+  assertEquals(stderr.includes("MSL-A011"), false);
+});
+
 // MSL-A012 — repeatable attribute value list is empty
 Deno.test("validate: Labels with only commas fires MSL-A012", async () => {
   const { code, stderr } = await markspec(["validate", "req.md"], {


### PR DESCRIPTION
## Summary

Iteration 24 of the autonomous Prompt-1 follow-up loop. Implements **MSL-A011 — citation attribute used CSV form** per spec §2.3.2.

| Commit | Slice |
|---|---|
| `684a595` | Citation CSV-form emitter |

## What lands

Per spec §2.3.2, the `citation` value type is multi-line only — CSV is rejected because citation locators may contain commas, making any top-level comma ambiguous between a CSV separator and a locator. The structural validator now scans each `citation`-typed attribute value and emits **MSL-A011 (error)** when a top-level comma is present.

Detection walks the value char-by-char tracking bracket depth so a comma inside `[…]` (Pandoc inline-citation locator form) is not flagged — only top-level commas trigger. This keeps the rule robust against any bracket-notation MarkSpec might adopt while staying correct for the current bare-slug form:

- `References: ISO-1, ISO-2` → MSL-A011
- `References: ISO-26262-6 §9.4` → clean
- `References: ISO-1\nReferences: ISO-2` → clean (canonical multi-line)

## Tests

| Before | After |
|---|---|
| 973 (post-#300) | 976 (+1 e2e for the CSV-form case firing MSL-A011, +2 negatives — single-citation and multi-line both stay clean) |

All `just check` gates green per commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
