### PR TITLE
feat(core): MSL-A040 — profile must not redefine reserved core keys/types

### DIFF
--- a/packages/markspec/core/profile/load.ts
+++ b/packages/markspec/core/profile/load.ts
@@ -15,6 +15,7 @@ import {
 } from "../config/markspec.ts";
 import type { ReadFile } from "../config/mod.ts";
 import type { Diagnostic, ProfileChain } from "../model/mod.ts";
+import { CORE_TYPES } from "../model/mod.ts";
 import { loadChain } from "./chain.ts";
 
 /** Result of `loadProfileForCommand`. */
@@ -75,5 +76,83 @@ export async function loadProfileForCommand(
     readFile,
   );
   diagnostics.push(...chainResult.diagnostics);
+
+  // MSL-A040 — profile must not redefine reserved core keys / types.
+  if (chainResult.chain) {
+    diagnostics.push(...checkReservedRedefinitions(chainResult.chain));
+  }
   return { chain: chainResult.chain, diagnostics };
+}
+
+/**
+ * Reserved attribute names a profile must never declare. Per spec
+ * §4.4 MSL-A040 and ADR-009 §6: the identity slot (`Id`) and the
+ * type attribute (`Type`) are the absolutely reserved keys; their
+ * meaning is fixed by the core and any profile redefinition would
+ * silently break shape discrimination or type resolution.
+ */
+const RESERVED_ATTRIBUTE_KEYS: ReadonlySet<string> = new Set([
+  "Id",
+  "Type",
+]);
+
+/**
+ * Scan the loaded profile chain for declarations that shadow core
+ * reserved names and emit MSL-A040 diagnostics. The check inspects:
+ *
+ *   - universal `attributes:` scope,
+ *   - per-shape `identified.attributes:` and `referenced.attributes:`,
+ *   - every per-type `attributes:` map under `types:`,
+ *   - each declared type name itself (must not match a core type).
+ */
+function checkReservedRedefinitions(chain: ProfileChain): Diagnostic[] {
+  const diagnostics: Diagnostic[] = [];
+  const effective = chain.effective;
+
+  // Build origin → sourcePath index from the chain's tiers so diagnostics
+  // can point at the manifest file that introduced each declaration.
+  const originToPath = new Map<string, string>();
+  for (const tier of chain.tiers) {
+    originToPath.set(tier.id, tier.sourcePath);
+  }
+  // Fallback file when an origin somehow isn't in the tier list.
+  const fallbackPath = chain.tiers[0]?.sourcePath ?? "<profile>";
+
+  function pathFor(origin: string): string {
+    return originToPath.get(origin) ?? fallbackPath;
+  }
+
+  function checkAttrMap(
+    map: ReadonlyMap<string, { origin: string }>,
+    scope: string,
+  ): void {
+    for (const [key, entry] of map) {
+      if (RESERVED_ATTRIBUTE_KEYS.has(key)) {
+        diagnostics.push({
+          code: "MSL-A040",
+          severity: "error",
+          message: `profile ${scope} attribute '${key}' shadows a core ` +
+            `reserved key (spec §4.4, ADR-009 §6); choose a different name`,
+          location: { file: pathFor(entry.origin), line: 1, column: 1 },
+        });
+      }
+    }
+  }
+
+  checkAttrMap(effective.attributes, "universal");
+  checkAttrMap(effective.identified.attributes, "identified");
+  checkAttrMap(effective.referenced.attributes, "referenced");
+  for (const [typeName, typeEntry] of effective.types) {
+    checkAttrMap(typeEntry.value.attributes, `type '${typeName}'`);
+    if (CORE_TYPES.has(typeName)) {
+      diagnostics.push({
+        code: "MSL-A040",
+        severity: "error",
+        message: `profile type '${typeName}' shadows a core type name ` +
+          `(spec §4.4); the 15-type core vocabulary is reserved`,
+        location: { file: pathFor(typeEntry.origin), line: 1, column: 1 },
+      });
+    }
+  }
+  return diagnostics;
 }

--- a/tests/e2e/profile_loader_test.ts
+++ b/tests/e2e/profile_loader_test.ts
@@ -82,6 +82,70 @@ Deno.test("profile loader e2e: malformed .markspec.yaml fails with MARKSPEC-YAML
   assertStringIncludes(stderr, "MARKSPEC-YAML-002");
 });
 
+// MSL-A040 — profile must not redefine reserved core keys / types.
+Deno.test("profile loader e2e: profile declaring attribute 'Id' fires MSL-A040", async () => {
+  const profile = `id: "@acme/redefines-id"
+version: 0.1.0
+profile:
+  attributes:
+    - name: Id
+      type: text
+`;
+  const { code, stderr } = await markspec(["validate", "req.md"], {
+    files: {
+      "project.yaml": PROJECT_YAML,
+      ".markspec.yaml": `profiles:\n  - ./profiles/bad\n`,
+      "profiles/bad/markspec.yaml": profile,
+      "req.md": REQ_MD,
+    },
+  });
+  assertEquals(code, 1);
+  assertStringIncludes(stderr, "MSL-A040");
+  assertStringIncludes(stderr, "Id");
+});
+
+Deno.test("profile loader e2e: profile declaring attribute 'Type' fires MSL-A040", async () => {
+  const profile = `id: "@acme/redefines-type"
+version: 0.1.0
+profile:
+  attributes:
+    - name: Type
+      type: text
+`;
+  const { code, stderr } = await markspec(["validate", "req.md"], {
+    files: {
+      "project.yaml": PROJECT_YAML,
+      ".markspec.yaml": `profiles:\n  - ./profiles/bad\n`,
+      "profiles/bad/markspec.yaml": profile,
+      "req.md": REQ_MD,
+    },
+  });
+  assertEquals(code, 1);
+  assertStringIncludes(stderr, "MSL-A040");
+  assertStringIncludes(stderr, "Type");
+});
+
+Deno.test("profile loader e2e: profile declaring core type name 'Requirement' fires MSL-A040", async () => {
+  const profile = `id: "@acme/redefines-requirement"
+version: 0.1.0
+profile:
+  types:
+    Requirement:
+      shape: identified
+`;
+  const { code, stderr } = await markspec(["validate", "req.md"], {
+    files: {
+      "project.yaml": PROJECT_YAML,
+      ".markspec.yaml": `profiles:\n  - ./profiles/bad\n`,
+      "profiles/bad/markspec.yaml": profile,
+      "req.md": REQ_MD,
+    },
+  });
+  assertEquals(code, 1);
+  assertStringIncludes(stderr, "MSL-A040");
+  assertStringIncludes(stderr, "Requirement");
+});
+
 Deno.test("profile loader e2e: unknown .markspec.yaml key warns but doesn't block", async () => {
   const { code, stderr } = await markspec(["validate", "req.md"], {
     files: {


### PR DESCRIPTION
## Summary

Iteration 25 of the autonomous Prompt-1 follow-up loop. Implements **MSL-A040 — profile must not redefine reserved core keys/types** per spec §4.4 / ADR-009 §6.

| Commit | Slice |
|---|---|
| `175759a` | Reserved-name shadowing emitter |

## What lands

The identity slot (`Id:`), the type attribute (`Type:`), and the 15-type core vocabulary are reserved by the core. A profile declaring an attribute named `Id` or `Type`, or a type whose name matches a core type (`Item`, `Specification`, `Requirement`, `Test`, `Contract`, `Record`, `Risk`, `SoftwareComponent`, `HardwareComponent`, `SoftwareInterface`, `HardwareInterface`, `SoftwareUnit`, `HardwareUnit`, `Component`, `Unit`, `Definition`), would silently break shape discrimination or type resolution.

`loadProfileForCommand` now scans the merged effective profile across:

- the universal `attributes:` scope,
- per-shape `identified.attributes:` and `referenced.attributes:`,
- every per-type `attributes:` map,
- each declared type name,

and emits **MSL-A040 (error)** for each shadowing case. Diagnostics point at the manifest tier that introduced the declaration (via the chain's `origin → sourcePath` mapping).

Runs in the profile loader so any profile-aware subcommand (validate, doctor, compile, doc build, book build) surfaces the violation uniformly.

## Tests

| Before | After |
|---|---|
| 976 (post-#301) | 979 (+3 e2e: `Id` attribute redefinition, `Type` attribute redefinition, `Requirement` type-name redefinition — all firing MSL-A040) |

All `just check` gates green per commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
