### PR TITLE
feat(core): MSL-P010 — entry title is empty after trimming (spec §4.2)

### DIFF
--- a/packages/markspec/core/validator/mod.ts
+++ b/packages/markspec/core/validator/mod.ts
@@ -181,6 +181,20 @@ function checkStructural(
       }
     }
 
+    // MSL-P010 — entry title is empty after trimming. The parser
+    // accepts an empty title for shape stability (`[REQ-001]` with
+    // nothing after) but the canonical form per spec §4.2 requires a
+    // non-empty human-readable title. Fires regardless of shape.
+    if (entry.title.trim().length === 0) {
+      diagnostics.push({
+        code: "MSL-P010",
+        severity: "error",
+        message: `${entry.displayId}: title is empty after trimming ` +
+          `(spec §4.2); add a non-empty human-readable title after ']'`,
+        location: entry.location,
+      });
+    }
+
     // MSL-A011 — `citation`-typed attribute (References:) used CSV
     // form. The canonical form is multi-line per spec §2.3.2: locators
     // may contain commas (e.g. `[@iso26262, p. 42]`), so the parser

--- a/packages/markspec/core/validator/pipeline_test.ts
+++ b/packages/markspec/core/validator/pipeline_test.ts
@@ -29,7 +29,7 @@ function buildEntry(opts: {
   }
   return {
     displayId: opts.displayId,
-    title: "",
+    title: opts.displayId,
     body: "",
     id: opts.id ?? "01HGW2Q8MNP3RSTVWXYZABCDEF",
     shape: opts.shape,

--- a/tests/e2e/validate_test.ts
+++ b/tests/e2e/validate_test.ts
@@ -148,6 +148,59 @@ Deno.test("validate: duplicate Source: trailers fire MSL-A013", async () => {
   assertStringIncludes(stderr, "Source");
 });
 
+// MSL-P010 — title is empty after trimming
+Deno.test("validate: entry with empty title fires MSL-P010", async () => {
+  const { code, stderr } = await markspec(["validate", "req.md"], {
+    files: {
+      "req.md": `# Test
+
+- [REQ-001]
+
+  The system shall debounce inputs.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+`,
+    },
+  });
+  assertEquals(code, 1, `expected exit 1, got ${code}; stderr: ${stderr}`);
+  assertStringIncludes(stderr, "MSL-P010");
+  assertStringIncludes(stderr, "REQ-001");
+});
+
+Deno.test("validate: entry with whitespace-only title fires MSL-P010", async () => {
+  const { code, stderr } = await markspec(["validate", "req.md"], {
+    files: {
+      "req.md": `# Test
+
+- [REQ-001]
+
+  The system shall debounce inputs.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+`,
+    },
+  });
+  assertEquals(code, 1, `expected exit 1, got ${code}; stderr: ${stderr}`);
+  assertStringIncludes(stderr, "MSL-P010");
+});
+
+Deno.test("validate: entry with non-empty title stays clean (no MSL-P010)", async () => {
+  const { code, stderr } = await markspec(["validate", "req.md"], {
+    files: {
+      "req.md": `# Test
+
+- [REQ-001] A real title
+
+  The system shall debounce inputs.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+`,
+    },
+  });
+  assertEquals(code, 0, `expected exit 0, got ${code}; stderr: ${stderr}`);
+  assertEquals(stderr.includes("MSL-P010"), false);
+});
+
 // MSL-A011 — citation attribute used CSV form (always multi-line per §2.3.2)
 Deno.test("validate: References with CSV form fires MSL-A011", async () => {
   const { code, stderr } = await markspec(["validate", "req.md"], {


### PR DESCRIPTION
## Summary

Iteration 26 of the autonomous Prompt-1 follow-up loop. Implements **MSL-P010 — entry title is empty after trimming** per spec §4.2.

| Commit | Slice |
|---|---|
| `5503de4` | Empty-title structural check |

## What lands

Every entry needs a non-empty human-readable title per spec §4.2. The parser accepts an empty title for shape stability so the rest of the entry block can still be parsed downstream, but the canonical form requires a real title. The structural validator now emits **MSL-P010 (error)** when `entry.title.trim()` is empty. Fires regardless of shape — Reference entries also need titles (slugs alone are rarely human-friendly).

One small test-harness fix: `pipeline_test.ts:buildEntry` defaulted `title: ""`; switched the default to `opts.displayId` so the three existing pipeline tests that built entries via the helper keep their `valid: true` assertion.

## Process note

Initially scoped to MSL-P030 (Authored entry without body block, also from spec §4.3). That check has a wide blast radius — 13+ existing tests use minimal `[ID] Title` + trailer fixtures with no body, all valid usage for the test's own concern. Pivoted mid-iteration to MSL-P010 which has no fixture blast (no existing test depends on empty titles). MSL-P030 stays on the backlog as a dedicated "fixture sweep" PR.

## Tests

| Before | After |
|---|---|
| 979 (post-#302) | 982 (+2 e2e: empty `[ID]` title fires MSL-P010, whitespace-only title fires MSL-P010; +1 negative confirming a real title stays clean) |

All `just check` gates green per commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
