### PR TITLE
feat(cli): implement markspec next-id <type> <paths...>

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -207,6 +207,7 @@ pass. `CHANGELOG.md` and `docs/examples/` are excluded from dprint.
 | `markspec report <kind> <paths...>`   | `core/reporter`                   | Generate traceability matrix or coverage report.                     |
 | `markspec profile show`               | `core/profile`                    | Show the active profile chain and effective configuration.           |
 | `markspec doctor`                     | `core/profile` + `core/validator` | Project health check: profile, config, and validation summary.       |
+| `markspec next-id <type> <paths...>`  | `core/compiler` + `core/profile`  | Print the next available display ID for a profile-declared type.     |
 | `markspec doc build <file>`           | `render/typst`                    | Single document → PDF via Typst WASM.                                |
 | `markspec book build`                 | `book/site`                       | Multi-chapter → static HTML site.                                    |
 | `markspec lsp`                        | `lsp/server`                      | LSP server for editor integration (stdio JSON-RPC).                  |
@@ -221,7 +222,6 @@ invoke them.
 | `markspec export`     | Compiled JSON → json, csv, reqif, yaml.                   |
 | `markspec insert`     | Agent write path: insert a requirement block into a file. |
 | `markspec create`     | Scaffold a new requirement block.                         |
-| `markspec next-id`    | Print the next available display ID for a type.           |
 | `markspec hook`       | Run format + validate as a pre-commit hook.               |
 | `markspec book dev`   | Live preview with hot reload.                             |
 | `markspec deck build` | Slides → PDF via Touying/Typst.                           |
@@ -230,8 +230,8 @@ invoke them.
 
 **Project context:** `format` and `validate` work file-locally without a
 `project.yaml`. All other commands (`compile`, `show`, `context`, `dependents`,
-`report`, `doc build`, `book build`) require a `project.yaml` found by walking
-up from the working directory.
+`report`, `next-id`, `doc build`, `book build`) require a `project.yaml` found
+by walking up from the working directory.
 
 ## Entry block rendering pipeline
 

--- a/packages/markspec/main.ts
+++ b/packages/markspec/main.ts
@@ -714,9 +714,68 @@ const cli = new Command()
   .command("create")
   .description("Scaffold a new requirement block")
   .action(notImplemented("create"))
-  .command("next-id")
+  .command("next-id <type:string> <paths...:string>")
   .description("Print the next available display ID for a type")
-  .action(notImplemented("next-id"))
+  .option("--format <format:string>", "Output format (json|text)", {
+    default: "text",
+  })
+  .action(
+    async (
+      options: { format?: string },
+      typeName: string,
+      ...paths: string[]
+    ) => {
+      const { result, chain } = await compileProject(paths);
+      if (!chain) {
+        console.error(`error: next-id requires a profile; none configured`);
+        Deno.exit(1);
+      }
+      const typeEntry = chain.effective.types.get(typeName);
+      if (!typeEntry) {
+        console.error(
+          `error: type '${typeName}' is not declared by the active profile`,
+        );
+        Deno.exit(1);
+      }
+      const pattern = typeEntry.value.displayIdPattern.value;
+      if (!pattern) {
+        console.error(`error: type '${typeName}' has no display-id-pattern`);
+        Deno.exit(1);
+      }
+      const placeholderMatch = /\{n:(\d+)d\}/.exec(pattern);
+      if (!placeholderMatch) {
+        console.error(
+          `error: type '${typeName}' display-id-pattern '${pattern}' does ` +
+            `not contain a recognised number placeholder ('{n:Nd}')`,
+        );
+        Deno.exit(1);
+      }
+      const width = parseInt(placeholderMatch[1], 10);
+      const prefix = pattern.slice(0, placeholderMatch.index);
+      const suffix = pattern.slice(
+        placeholderMatch.index + placeholderMatch[0].length,
+      );
+
+      let max = 0;
+      for (const entry of result.entries.values()) {
+        const id = entry.displayId;
+        if (!id.startsWith(prefix)) continue;
+        if (suffix && !id.endsWith(suffix)) continue;
+        const numberPart = id.slice(prefix.length, id.length - suffix.length);
+        const n = parseInt(numberPart, 10);
+        if (!isNaN(n) && n > max) max = n;
+      }
+      const next = max + 1;
+      const padded = String(next).padStart(width, "0");
+      const displayId = `${prefix}${padded}${suffix}`;
+
+      if (options.format === "json") {
+        console.log(JSON.stringify({ type: typeName, displayId }));
+      } else {
+        console.log(displayId);
+      }
+    },
+  )
   .command("show <id:string> <paths...:string>")
   .description("Show details of a single entry by ID")
   .option("--format <format:string>", "Output format (json|text)", {

--- a/tests/e2e/next_id_test.ts
+++ b/tests/e2e/next_id_test.ts
@@ -1,0 +1,120 @@
+/**
+ * @module tests/e2e/next_id_test
+ *
+ * E2E tests for `markspec next-id <type> <paths...>` — prints the next
+ * available display ID for a profile-declared type by scanning the
+ * project's existing entries.
+ */
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { markspec } from "./helpers.ts";
+
+const PROJECT_YAML = `name: phase5-e2e\nversion: 0.1.0\n`;
+
+const PROFILE_YAML = `id: "@acme/phase5-typed"
+version: 0.1.0
+profile:
+  types:
+    requirement:
+      shape: identified
+      display-id-pattern: "REQ-{n:04d}"
+    note:
+      shape: identified
+      display-id-pattern: "NOTE-{n:03d}"
+`;
+
+const BASE_FILES = {
+  "project.yaml": PROJECT_YAML,
+  ".markspec.yaml": `profiles:\n  - ./profiles/typed\n`,
+  "profiles/typed/markspec.yaml": PROFILE_YAML,
+};
+
+Deno.test("next-id: empty project returns REQ-0001 for requirement type", async () => {
+  const { code, stdout } = await markspec(
+    ["next-id", "requirement", "req.md"],
+    {
+      files: {
+        ...BASE_FILES,
+        "req.md": `# Empty\n`,
+      },
+    },
+  );
+  assertEquals(code, 0);
+  assertEquals(stdout.trim(), "REQ-0001");
+});
+
+Deno.test("next-id: with existing REQ entries returns next number", async () => {
+  const { code, stdout } = await markspec(
+    ["next-id", "requirement", "req.md"],
+    {
+      files: {
+        ...BASE_FILES,
+        "req.md": `# Example
+
+- [REQ-0001] First
+
+  Body.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+
+- [REQ-0003] Third
+
+  Body.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEG
+`,
+      },
+    },
+  );
+  assertEquals(code, 0);
+  // Max of {0001, 0003} = 3 → next is 0004 (gaps preserved).
+  assertEquals(stdout.trim(), "REQ-0004");
+});
+
+Deno.test("next-id: NOTE-{n:03d} pattern uses 3-digit padding", async () => {
+  const { code, stdout } = await markspec(["next-id", "note", "req.md"], {
+    files: {
+      ...BASE_FILES,
+      "req.md": `# Example
+
+- [NOTE-005] An existing note
+
+  Body.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+`,
+    },
+  });
+  assertEquals(code, 0);
+  assertEquals(stdout.trim(), "NOTE-006");
+});
+
+Deno.test("next-id: unknown type fails with error", async () => {
+  const { code, stderr } = await markspec(
+    ["next-id", "no-such-type", "req.md"],
+    {
+      files: {
+        ...BASE_FILES,
+        "req.md": `# Empty\n`,
+      },
+    },
+  );
+  assertEquals(code, 1);
+  assertStringIncludes(stderr, "no-such-type");
+});
+
+Deno.test("next-id: --format json emits a JSON object", async () => {
+  const { code, stdout } = await markspec(
+    ["next-id", "requirement", "--format", "json", "req.md"],
+    {
+      files: {
+        ...BASE_FILES,
+        "req.md": `# Empty\n`,
+      },
+    },
+  );
+  assertEquals(code, 0);
+  const parsed = JSON.parse(stdout);
+  assertEquals(parsed.type, "requirement");
+  assertEquals(parsed.displayId, "REQ-0001");
+});


### PR DESCRIPTION
## Summary

Iteration 27 of the autonomous Prompt-1 follow-up loop. Implements **`markspec next-id <type> <paths...>`** — the CLI command was a `notImplemented` stub before this PR.

| Commit | Slice |
|---|---|
| `0a6fe73` | next-id command + AGENTS.md doc update |

## What lands

Prints the next available display ID for a profile-declared type by scanning the project's existing entries.

Behaviour:

- Loads the active profile chain via `compileProject`, looks up the given type name in `chain.effective.types`, extracts its `display-id-pattern`.
- Recognises the `{n:Nd}` numeric placeholder (`REQ-{n:04d}`, `NOTE-{n:03d}`, …) and splits the pattern into prefix/suffix.
- Scans all compiled entries' display IDs matching prefix+suffix, extracts the numeric segment, returns `max + 1` left-padded to the pattern's width.
- Empty project → returns the first ID (`REQ-0001` for 4-digit width).
- Gaps in existing numbering are preserved — `[REQ-0001, REQ-0003]` → next is `REQ-0004`.

Errors (exit 1):

- No profile configured.
- Type name not declared by the active profile.
- Type missing `display-id-pattern`.
- Pattern lacks a `{n:Nd}` placeholder.

Output:

- Text (default): bare display ID to stdout.
- `--format json`: `{ type, displayId }` to stdout.

`AGENTS.md` moves `next-id` from the "Not yet implemented" table to the "Implemented" table.

## Tests

| Before | After |
|---|---|
| 982 (post-#303) | 987 (+5 e2e: empty project, gapped numbering, 3-digit pattern, unknown-type error, JSON output) |

All `just check` gates green per commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
