### PR TITLE
feat(core): MSL-A050 — validate enum-typed core attributes (Origin)

### DIFF
--- a/packages/markspec/core/validator/mod.ts
+++ b/packages/markspec/core/validator/mod.ts
@@ -295,8 +295,9 @@ function checkStructural(
       }
       // MSL-A050: value does not parse against the declared value type
       // (§4.4). The core knows the value type for the promoted Reference
-      // attributes (spec §1.5); profile-declared attribute types are
-      // validated by the profile-aware Stage 3 instead.
+      // attributes (spec §1.5) and the universal enum attributes;
+      // profile-declared attribute types are validated by the
+      // profile-aware Stage 3 instead.
       if (attr.key === "Reference-url") {
         if (!HTTP_URL_RE.test(attr.value.trim())) {
           diagnostics.push({
@@ -304,6 +305,20 @@ function checkStructural(
             severity: "error",
             message: `${entry.displayId}: Reference-url value ` +
               `'${attr.value.trim()}' is not an http(s) URL (spec §1.5)`,
+            location: entry.location,
+          });
+          continue;
+        }
+      }
+      if (spec?.type === "enum" && spec.enumValues) {
+        const trimmed = attr.value.trim();
+        if (trimmed.length > 0 && !spec.enumValues.includes(trimmed)) {
+          diagnostics.push({
+            code: "MSL-A050",
+            severity: "error",
+            message: `${entry.displayId}: ${attr.key} value '${trimmed}' ` +
+              `is not in the allowed set ` +
+              `{${spec.enumValues.join(", ")}} (spec §1.8 enum)`,
             location: entry.location,
           });
           continue;

--- a/tests/e2e/validate_test.ts
+++ b/tests/e2e/validate_test.ts
@@ -148,6 +148,63 @@ Deno.test("validate: duplicate Source: trailers fire MSL-A013", async () => {
   assertStringIncludes(stderr, "Source");
 });
 
+// MSL-A050 — Origin: value must match the enum {authored, synthesized}
+Deno.test("validate: Origin: invalid value fires MSL-A050", async () => {
+  const { code, stderr } = await markspec(["validate", "req.md"], {
+    files: {
+      "req.md": `# Test
+
+- [REQ-001] My requirement
+
+  Body text.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      Origin: nonsense
+`,
+    },
+  });
+  assertEquals(code, 1, `expected exit 1, got ${code}; stderr: ${stderr}`);
+  assertStringIncludes(stderr, "MSL-A050");
+  assertStringIncludes(stderr, "Origin");
+});
+
+Deno.test("validate: Origin: authored stays clean (no MSL-A050)", async () => {
+  const { code, stderr } = await markspec(["validate", "req.md"], {
+    files: {
+      "req.md": `# Test
+
+- [REQ-001] My requirement
+
+  Body text.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      Origin: authored
+`,
+    },
+  });
+  assertEquals(code, 0, `expected exit 0, got ${code}; stderr: ${stderr}`);
+  assertEquals(stderr.includes("MSL-A050"), false);
+});
+
+Deno.test("validate: Origin: synthesized stays clean (no MSL-A050)", async () => {
+  const { code, stderr } = await markspec(["validate", "req.md"], {
+    files: {
+      "req.md": `# Test
+
+- [REQ-001] My requirement
+
+  Body text.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      Origin: synthesized
+      Source: crates/foo/Cargo.toml
+`,
+    },
+  });
+  assertEquals(code, 0, `expected exit 0, got ${code}; stderr: ${stderr}`);
+  assertEquals(stderr.includes("MSL-A050"), false);
+});
+
 // MSL-P010 — title is empty after trimming
 Deno.test("validate: entry with empty title fires MSL-P010", async () => {
   const { code, stderr } = await markspec(["validate", "req.md"], {


### PR DESCRIPTION
## Summary

Iteration 28 of the autonomous Prompt-1 follow-up loop. Extends **MSL-A050** to validate enum-typed core attributes — today this catches malformed `Origin:` values.

| Commit | Slice |
|---|---|
| `5120487` | Enum value validation in MSL-A050 |

## What lands

The existing MSL-A050 emitter previously only checked `Reference-url` (http(s) URL form). It now also walks any core attribute whose `ATTRIBUTE_CATALOG` spec declares `type: "enum"` with a non-empty `enumValues` and emits **MSL-A050 (error)** when the authored value isn't in the allowed set.

Today the only universal-scope enum core attribute with `enumValues` is `Origin: authored | synthesized` (spec §1.4):

- `Origin: nonsense` → MSL-A050.
- `Origin: authored` / `Origin: synthesized` → clean.
- `Origin:` empty / whitespace → left alone; parser drop and presence checks handle that path.

`Type:` is declared as `enum` in the catalog but with no `enumValues` (its allowed set is `CORE_TYPES + profile.types`, not a closed enum), so the `&& spec.enumValues` guard leaves `Type:` validation to the existing MSL-T020 / MSL-T023 path.

## Tests

| Before | After |
|---|---|
| 987 (post-#304) | 990 (+1 e2e for the invalid-value case firing MSL-A050; +2 negatives confirming the two enum values stay clean) |

All `just check` gates green per commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
