### PR TITLE
feat(lsp): completion for Type: attribute values

### DIFF
--- a/packages/markspec/lsp/completions.ts
+++ b/packages/markspec/lsp/completions.ts
@@ -11,6 +11,7 @@
  * The server module calls these and wraps results in LSP CompletionItem.
  */
 
+import { CORE_ABSTRACT_TYPES, CORE_CONCRETE_TYPES } from "../core/model/mod.ts";
 import type { DisplayIdEntry } from "./workspace.ts";
 
 /** Block scaffold trigger pattern: `- [` at the start of a list item. */
@@ -19,6 +20,9 @@ const BLOCK_SCAFFOLD_RE = /^\s*-\s*\[$/;
 /** Pattern matching a trace attribute keyword at line start. */
 const TRACE_ATTR_RE =
   /^\s*(Satisfies|Derived-from|Verified-by|References|Tests|Depends-on|Part-of|Allocated-to|Realizes|Generated-from|Supersedes)\s*:/;
+
+/** Pattern matching the `Type:` attribute keyword at line start. */
+const TYPE_ATTR_RE = /^\s*Type\s*:/;
 
 /**
  * Check if the text before cursor triggers a block scaffold completion.
@@ -34,6 +38,15 @@ export function isBlockScaffoldTrigger(textBefore: string): boolean {
  */
 export function isTraceAttributeTrigger(textBefore: string): boolean {
   return TRACE_ATTR_RE.test(textBefore);
+}
+
+/**
+ * Check if the text before cursor triggers a `Type:` completion.
+ * Matches the `Type:` attribute keyword at line start, optionally
+ * followed by partial value text.
+ */
+export function isTypeAttributeTrigger(textBefore: string): boolean {
+  return TYPE_ATTR_RE.test(textBefore);
 }
 
 /**
@@ -95,6 +108,43 @@ export function buildIdReferenceItems(
  * with pre-filled display ID and attribute skeleton. Otherwise returns
  * a single generic scaffold item.
  */
+/**
+ * Build completion items for a `Type:` attribute trigger. Lists the
+ * 16 core types (4 abstract + 12 concrete) followed by any
+ * profile-declared type names. Core types come first so authors see
+ * the spec-defined vocabulary before profile extensions.
+ */
+export function buildTypeAttributeItems(
+  profileTypeNames: readonly string[],
+): CompletionItemData[] {
+  const items: CompletionItemData[] = [];
+  for (const name of CORE_ABSTRACT_TYPES) {
+    items.push({
+      label: name,
+      detail: "core abstract type",
+      isSnippet: false,
+      kind: KIND_REFERENCE,
+    });
+  }
+  for (const name of CORE_CONCRETE_TYPES) {
+    items.push({
+      label: name,
+      detail: "core concrete type",
+      isSnippet: false,
+      kind: KIND_REFERENCE,
+    });
+  }
+  for (const name of profileTypeNames) {
+    items.push({
+      label: name,
+      detail: "profile-declared type",
+      isSnippet: false,
+      kind: KIND_REFERENCE,
+    });
+  }
+  return items;
+}
+
 export function buildBlockScaffoldItems(
   types: readonly EntryTypeInfo[],
 ): CompletionItemData[] {

--- a/packages/markspec/lsp/completions_test.ts
+++ b/packages/markspec/lsp/completions_test.ts
@@ -8,9 +8,11 @@ import { assertEquals } from "@std/assert";
 import {
   buildBlockScaffoldItems,
   buildIdReferenceItems,
+  buildTypeAttributeItems,
   extractRelationName,
   isBlockScaffoldTrigger,
   isTraceAttributeTrigger,
+  isTypeAttributeTrigger,
 } from "./completions.ts";
 import type { DisplayIdEntry } from "./workspace.ts";
 
@@ -93,4 +95,45 @@ Deno.test("buildBlockScaffoldItems: returns one item per type", () => {
   assertEquals(items.length, 2);
   assertEquals(items[0].label, "New stakeholder-requirement (STK_AEB_0004)");
   assertEquals(items[1].label, "New architecture (SAD_AEB_0002)");
+});
+
+// --- Type-attribute completion ---
+
+Deno.test("isTypeAttributeTrigger: matches '      Type:'", () => {
+  assertEquals(isTypeAttributeTrigger("      Type:"), true);
+});
+
+Deno.test("isTypeAttributeTrigger: matches 'Type: ' with trailing space", () => {
+  assertEquals(isTypeAttributeTrigger("      Type: "), true);
+});
+
+Deno.test("isTypeAttributeTrigger: matches partial value 'Type: Req'", () => {
+  assertEquals(isTypeAttributeTrigger("      Type: Req"), true);
+});
+
+Deno.test("isTypeAttributeTrigger: rejects unrelated key 'Source:'", () => {
+  assertEquals(isTypeAttributeTrigger("      Source: foo"), false);
+});
+
+Deno.test("isTypeAttributeTrigger: rejects 'Type-foo:' suffix", () => {
+  assertEquals(isTypeAttributeTrigger("      Type-foo:"), false);
+});
+
+Deno.test("buildTypeAttributeItems: returns core types when no profile types", () => {
+  const items = buildTypeAttributeItems([]);
+  // 4 abstract + 12 concrete = 16 core types.
+  assertEquals(items.length, 16);
+  const labels = items.map((i) => i.label);
+  // Spot-check a couple of core types are present.
+  assertEquals(labels.includes("Item"), true);
+  assertEquals(labels.includes("Requirement"), true);
+  assertEquals(labels.includes("SoftwareUnit"), true);
+});
+
+Deno.test("buildTypeAttributeItems: appends profile-declared types after core", () => {
+  const items = buildTypeAttributeItems(["requirement", "test"]);
+  assertEquals(items.length, 18);
+  // Profile types come after core types in the listing.
+  assertEquals(items[16].label, "requirement");
+  assertEquals(items[17].label, "test");
 });

--- a/packages/markspec/lsp/server.ts
+++ b/packages/markspec/lsp/server.ts
@@ -41,9 +41,11 @@ import { groupDiagnosticsByFile, toLspDiagnostic } from "./diagnostics.ts";
 import {
   buildBlockScaffoldItems,
   buildIdReferenceItems,
+  buildTypeAttributeItems,
   type EntryTypeInfo,
   isBlockScaffoldTrigger,
   isTraceAttributeTrigger,
+  isTypeAttributeTrigger,
 } from "./completions.ts";
 import {
   isDocCommentContext,
@@ -351,6 +353,17 @@ connection.onCompletion((params): CompletionItem[] => {
   if (isTraceAttributeTrigger(line)) {
     const displayIds = index.getAllDisplayIds();
     const items = buildIdReferenceItems(displayIds);
+    return items.map((item) => ({
+      label: item.label,
+      detail: item.detail,
+      kind: CompletionItemKind.Reference,
+    }));
+  }
+
+  // Trigger 3: Type: attribute value — core types + profile types.
+  if (isTypeAttributeTrigger(line)) {
+    const profileTypeNames = profile ? [...profile.types.keys()] : [];
+    const items = buildTypeAttributeItems(profileTypeNames);
     return items.map((item) => ({
       label: item.label,
       detail: item.detail,


### PR DESCRIPTION
## Summary

Iteration 29 of the autonomous Prompt-1 follow-up loop. Adds a third LSP completion trigger: when the author types `Type:` at the start of a trailer line, the LSP offers the 16 core types plus profile-declared types.

| Commit | Slice |
|---|---|
| `f38849e` | `Type:` LSP completion |

## What lands

[packages/markspec/lsp/completions.ts](packages/markspec/lsp/completions.ts):

- `isTypeAttributeTrigger(textBefore)` — regex `^\s*Type\s*:` matches `Type:` at line start with optional partial-value text after the colon.
- `buildTypeAttributeItems(profileTypeNames)` — flat list, core-first ordering. Each item carries a `detail` indicating origin (`core abstract type`, `core concrete type`, `profile-declared type`).

[packages/markspec/lsp/server.ts](packages/markspec/lsp/server.ts): the new trigger is wired into `connection.onCompletion` alongside the existing block-scaffold and ID-reference triggers, pulling `profile.types.keys()` when a profile is loaded.

## Tests

| Before | After |
|---|---|
| 990 (post-#305) | 997 (+5 trigger-regex unit tests; +2 builder unit tests) |

All `just check` gates green per commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
