### PR TITLE
feat(lsp): hover support for display IDs

### DIFF
--- a/packages/markspec/lsp/hover.ts
+++ b/packages/markspec/lsp/hover.ts
@@ -1,0 +1,72 @@
+/**
+ * @module lsp/hover
+ *
+ * Hover-content helpers for the MarkSpec LSP. Two pure, testable
+ * functions:
+ *
+ *   - {@linkcode displayIdAtPosition}: extract the display-ID token
+ *     under a cursor position on a line, if any.
+ *   - {@linkcode formatHoverContent}: render an {@linkcode Entry} as
+ *     a short Markdown block suitable for an LSP `MarkupContent`
+ *     payload.
+ *
+ * The server module composes these with the workspace index to
+ * implement `connection.onHover`.
+ */
+
+import type { Entry } from "../core/model/mod.ts";
+
+/**
+ * Display-ID token grammar matching what the parser accepts inside
+ * `[...]` brackets and on the right-hand side of trace attributes.
+ * MarkSpec display IDs are letters / digits / hyphen / underscore /
+ * dot / slash, at least 3 chars (so `at`, `if` etc. don't accidentally
+ * match prose) and must start with an alphanumeric.
+ */
+const DISPLAY_ID_TOKEN_RE = /^[A-Za-z0-9][A-Za-z0-9._/-]{2,}$/;
+
+/**
+ * Return the display-ID token at the given column on `line`, or
+ * `undefined` when the column lies on whitespace, past the line end,
+ * or on a token that doesn't look like a display ID.
+ */
+export function displayIdAtPosition(
+  line: string,
+  column: number,
+): string | undefined {
+  if (column < 0 || column >= line.length) return undefined;
+  if (/\s/.test(line[column])) return undefined;
+  // Scan left and right for the token boundaries — anything in the
+  // grammar's character set continues the token.
+  const CHAR_RE = /[A-Za-z0-9._/-]/;
+  let start = column;
+  while (start > 0 && CHAR_RE.test(line[start - 1])) start--;
+  let end = column;
+  while (end < line.length && CHAR_RE.test(line[end])) end++;
+  const token = line.slice(start, end);
+  return DISPLAY_ID_TOKEN_RE.test(token) ? token : undefined;
+}
+
+/**
+ * Format an entry for hover display. Produces a short Markdown block:
+ * a heading with the display ID + title, a metadata line listing the
+ * resolved type (when set) and the `Id:` (ULID/URI), and the first
+ * body paragraph as preview prose.
+ */
+export function formatHoverContent(entry: Entry): string {
+  const lines: string[] = [];
+  lines.push(`### ${entry.displayId} — ${entry.title}`);
+  const metadata: string[] = [];
+  if (entry.type) metadata.push(`**Type:** ${entry.type}`);
+  if (entry.id) metadata.push(`**Id:** \`${entry.id}\``);
+  if (metadata.length > 0) {
+    lines.push("");
+    lines.push(metadata.join(" · "));
+  }
+  const firstParagraph = entry.body.split(/\n\s*\n/)[0]?.trim();
+  if (firstParagraph) {
+    lines.push("");
+    lines.push(firstParagraph);
+  }
+  return lines.join("\n");
+}

--- a/packages/markspec/lsp/hover_test.ts
+++ b/packages/markspec/lsp/hover_test.ts
@@ -1,0 +1,105 @@
+/**
+ * @module lsp/hover_test
+ *
+ * Unit tests for the LSP hover helpers — display-ID extraction at a
+ * cursor position and Markdown-formatted hover content from an Entry.
+ */
+
+import { assertEquals } from "@std/assert";
+import type { Entry } from "../core/model/mod.ts";
+import { displayIdAtPosition, formatHoverContent } from "./hover.ts";
+
+const ULID = "01HGW2Q8MNP3RSTVWXYZABCDEF";
+
+function makeEntry(opts: {
+  displayId: string;
+  title: string;
+  type?: string;
+  body?: string;
+}): Entry {
+  return {
+    displayId: opts.displayId,
+    title: opts.title,
+    body: opts.body ?? "",
+    rawAttributes: [{ key: "Id", value: ULID }],
+    typedAttributes: new Map(),
+    id: ULID,
+    shape: "identified",
+    type: opts.type,
+    location: { file: "t.md", line: 1, column: 1 },
+    source: "markdown",
+  };
+}
+
+// --- displayIdAtPosition ---
+
+Deno.test("displayIdAtPosition: extracts ID from inside [BRACKETED]", () => {
+  const line = "- [REQ-001] My requirement";
+  // Cursor at index 5 — middle of REQ-001.
+  assertEquals(displayIdAtPosition(line, 5), "REQ-001");
+});
+
+Deno.test("displayIdAtPosition: extracts ID from trace value", () => {
+  const line = "      Satisfies: REQ-001";
+  // Cursor at index 20 — middle of REQ-001.
+  assertEquals(displayIdAtPosition(line, 20), "REQ-001");
+});
+
+Deno.test("displayIdAtPosition: extracts ID from underscored form", () => {
+  const line = "      Satisfies: SRS_BRK_0042";
+  assertEquals(displayIdAtPosition(line, 23), "SRS_BRK_0042");
+});
+
+Deno.test("displayIdAtPosition: returns undefined when cursor is on whitespace", () => {
+  const line = "      Satisfies:    ";
+  assertEquals(displayIdAtPosition(line, 19), undefined);
+});
+
+Deno.test("displayIdAtPosition: returns undefined when cursor is past end", () => {
+  const line = "- [REQ-001] My req";
+  assertEquals(displayIdAtPosition(line, 999), undefined);
+});
+
+Deno.test("displayIdAtPosition: rejects short / non-ID-like tokens", () => {
+  const line = "- [REQ-001] my requirement";
+  // Cursor on the word "my".
+  assertEquals(displayIdAtPosition(line, 13), undefined);
+});
+
+// --- formatHoverContent ---
+
+Deno.test("formatHoverContent: returns title + type + Id when type is set", () => {
+  const entry = makeEntry({
+    displayId: "REQ-001",
+    title: "Sensor debouncing",
+    type: "Requirement",
+  });
+  const md = formatHoverContent(entry);
+  assertEquals(md.includes("REQ-001"), true);
+  assertEquals(md.includes("Sensor debouncing"), true);
+  assertEquals(md.includes("Requirement"), true);
+  assertEquals(md.includes(ULID), true);
+});
+
+Deno.test("formatHoverContent: omits type line when no type is set", () => {
+  const entry = makeEntry({
+    displayId: "TST-001",
+    title: "Unit test",
+  });
+  const md = formatHoverContent(entry);
+  assertEquals(md.includes("TST-001"), true);
+  // 'Type:' label should be absent.
+  assertEquals(md.includes("**Type:**"), false);
+});
+
+Deno.test("formatHoverContent: includes body excerpt (first paragraph)", () => {
+  const entry = makeEntry({
+    displayId: "REQ-001",
+    title: "Title",
+    body: "First paragraph.\n\nSecond paragraph.",
+  });
+  const md = formatHoverContent(entry);
+  assertEquals(md.includes("First paragraph."), true);
+  // Hover only previews first paragraph.
+  assertEquals(md.includes("Second paragraph."), false);
+});

--- a/packages/markspec/lsp/server.ts
+++ b/packages/markspec/lsp/server.ts
@@ -38,6 +38,7 @@ import {
 } from "../core/mod.ts";
 import { WorkspaceIndex } from "./workspace.ts";
 import { groupDiagnosticsByFile, toLspDiagnostic } from "./diagnostics.ts";
+import { displayIdAtPosition, formatHoverContent } from "./hover.ts";
 import {
   buildBlockScaffoldItems,
   buildIdReferenceItems,
@@ -225,6 +226,7 @@ connection.onInitialize(
         completionProvider: {
           triggerCharacters: ["[", ":"],
         },
+        hoverProvider: true,
       },
     };
   },
@@ -372,6 +374,39 @@ connection.onCompletion((params): CompletionItem[] => {
   }
 
   return [];
+});
+
+// ---------------------------------------------------------------------------
+// Hover
+// ---------------------------------------------------------------------------
+
+connection.onHover((params) => {
+  const document = documents.get(params.textDocument.uri);
+  if (!document) return null;
+
+  const filePath = uriToPath(params.textDocument.uri);
+
+  // Source-file position guard — only consider doc-comment context.
+  if (isSourceFile(filePath)) {
+    const lines = document.getText().split("\n");
+    if (!isDocCommentContext(lines, params.position.line)) {
+      return null;
+    }
+  }
+
+  const line = document.getText({
+    start: { line: params.position.line, character: 0 },
+    end: { line: params.position.line, character: Number.MAX_SAFE_INTEGER },
+  });
+
+  const id = displayIdAtPosition(line, params.position.character);
+  if (!id) return null;
+  const entry = index.getEntryByDisplayId(id);
+  if (!entry) return null;
+
+  return {
+    contents: { kind: "markdown", value: formatHoverContent(entry) },
+  };
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Iteration 30 of the autonomous Prompt-1 follow-up loop. Adds **LSP hover support** — editors now show a preview of the resolved entry when the cursor lands on a display ID.

| Commit | Slice |
|---|---|
| `561a6fb` | LSP hover provider |

## What lands

`textDocument/hover` is now advertised in the LSP server's initialize capabilities. The handler fires on display-ID tokens both inside `[REQ-001]` brackets on title lines and on the right-hand side of trace attributes (`Satisfies: REQ-001`).

Two pure helpers in [packages/markspec/lsp/hover.ts](packages/markspec/lsp/hover.ts):

- `displayIdAtPosition(line, column)` — extracts the token under the cursor using the MarkSpec display-ID grammar (alphanumerics plus `._/-`, ≥3 chars so prose words don't match accidentally).
- `formatHoverContent(entry)` — renders an `Entry` as Markdown: `### displayId — title`, a metadata line combining `**Type:**` and `**Id:**`, and the first body paragraph as preview.

`server.ts` reads the current line, calls `displayIdAtPosition`, looks up the resolved Entry via `index.getEntryByDisplayId`, and returns `MarkupContent` with `kind: "markdown"` (or `null` when nothing resolves). Same source-file doc-comment guard the completion path uses.

## Tests

| Before | After |
|---|---|
| 997 (post-#306) | 1006 (+6 unit tests for `displayIdAtPosition` edge cases; +3 for `formatHoverContent`) |

All `just check` gates green per commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
