### PR TITLE
feat(lsp): go-to-definition for display IDs

### DIFF
--- a/packages/markspec/lsp/definition.ts
+++ b/packages/markspec/lsp/definition.ts
@@ -1,0 +1,41 @@
+/**
+ * @module lsp/definition
+ *
+ * Go-to-definition helper. Converts an Entry's core `SourceLocation`
+ * (file path with 1-based line/column) into an LSP `Location` (URI
+ * with zero-based range). The range is a zero-width cursor placed at
+ * the entry's start so editors land on the title line without an
+ * incidental selection.
+ *
+ * The server module composes this with `displayIdAtPosition` (from
+ * `hover.ts`) and the workspace index to implement `onDefinition`.
+ */
+
+import type { Entry } from "../core/model/mod.ts";
+import { pathToUri } from "./util.ts";
+
+/** A subset of the LSP `Location` type — sufficient for `onDefinition`. */
+export interface LspLocation {
+  readonly uri: string;
+  readonly range: {
+    readonly start: { readonly line: number; readonly character: number };
+    readonly end: { readonly line: number; readonly character: number };
+  };
+}
+
+/**
+ * Convert an Entry's source location to an LSP `Location` pointing at
+ * the entry's start (zero-width range). 1-based core line/column are
+ * shifted to 0-based per the LSP spec.
+ */
+export function entryToLspLocation(entry: Entry): LspLocation {
+  const line = Math.max(0, entry.location.line - 1);
+  const character = Math.max(0, entry.location.column - 1);
+  return {
+    uri: pathToUri(entry.location.file),
+    range: {
+      start: { line, character },
+      end: { line, character },
+    },
+  };
+}

--- a/packages/markspec/lsp/definition_test.ts
+++ b/packages/markspec/lsp/definition_test.ts
@@ -1,0 +1,54 @@
+/**
+ * @module lsp/definition_test
+ *
+ * Unit tests for {@linkcode entryToLspLocation} — converts a core
+ * Entry's source location to an LSP `Location` (URI + zero-based
+ * range).
+ */
+
+import { assertEquals } from "@std/assert";
+import type { Entry } from "../core/model/mod.ts";
+import { entryToLspLocation } from "./definition.ts";
+
+function makeEntry(file: string, line: number, column: number): Entry {
+  return {
+    displayId: "REQ-001",
+    title: "Test",
+    body: "",
+    rawAttributes: [{ key: "Id", value: "01HGW2Q8MNP3RSTVWXYZABCDEF" }],
+    typedAttributes: new Map(),
+    id: "01HGW2Q8MNP3RSTVWXYZABCDEF",
+    shape: "identified",
+    location: { file, line, column },
+    source: "markdown",
+  };
+}
+
+Deno.test("entryToLspLocation: converts file path to file:// URI", () => {
+  const entry = makeEntry("/abs/path/req.md", 5, 1);
+  const loc = entryToLspLocation(entry);
+  assertEquals(loc.uri, "file:///abs/path/req.md");
+});
+
+Deno.test("entryToLspLocation: line and column are 0-based (LSP convention)", () => {
+  const entry = makeEntry("/x/req.md", 5, 3);
+  const loc = entryToLspLocation(entry);
+  // Core uses 1-based line/column; LSP uses 0-based.
+  assertEquals(loc.range.start.line, 4);
+  assertEquals(loc.range.start.character, 2);
+  assertEquals(loc.range.end.line, 4);
+  assertEquals(loc.range.end.character, 2);
+});
+
+Deno.test("entryToLspLocation: percent-encodes path segments with special chars", () => {
+  const entry = makeEntry("/path with spaces/req.md", 1, 1);
+  const loc = entryToLspLocation(entry);
+  assertEquals(loc.uri, "file:///path%20with%20spaces/req.md");
+});
+
+Deno.test("entryToLspLocation: line 1 column 1 → 0,0 range", () => {
+  const entry = makeEntry("/x.md", 1, 1);
+  const loc = entryToLspLocation(entry);
+  assertEquals(loc.range.start.line, 0);
+  assertEquals(loc.range.start.character, 0);
+});

--- a/packages/markspec/lsp/server.ts
+++ b/packages/markspec/lsp/server.ts
@@ -38,6 +38,7 @@ import {
 } from "../core/mod.ts";
 import { WorkspaceIndex } from "./workspace.ts";
 import { groupDiagnosticsByFile, toLspDiagnostic } from "./diagnostics.ts";
+import { entryToLspLocation } from "./definition.ts";
 import { displayIdAtPosition, formatHoverContent } from "./hover.ts";
 import {
   buildBlockScaffoldItems,
@@ -227,6 +228,7 @@ connection.onInitialize(
           triggerCharacters: ["[", ":"],
         },
         hoverProvider: true,
+        definitionProvider: true,
       },
     };
   },
@@ -407,6 +409,37 @@ connection.onHover((params) => {
   return {
     contents: { kind: "markdown", value: formatHoverContent(entry) },
   };
+});
+
+// ---------------------------------------------------------------------------
+// Definition (go to entry source)
+// ---------------------------------------------------------------------------
+
+connection.onDefinition((params) => {
+  const document = documents.get(params.textDocument.uri);
+  if (!document) return null;
+
+  const filePath = uriToPath(params.textDocument.uri);
+
+  // Source-file position guard.
+  if (isSourceFile(filePath)) {
+    const lines = document.getText().split("\n");
+    if (!isDocCommentContext(lines, params.position.line)) {
+      return null;
+    }
+  }
+
+  const line = document.getText({
+    start: { line: params.position.line, character: 0 },
+    end: { line: params.position.line, character: Number.MAX_SAFE_INTEGER },
+  });
+
+  const id = displayIdAtPosition(line, params.position.character);
+  if (!id) return null;
+  const entry = index.getEntryByDisplayId(id);
+  if (!entry) return null;
+
+  return entryToLspLocation(entry);
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Iteration 31 of the autonomous Prompt-1 follow-up loop. Adds **LSP go-to-definition** — editors can now jump from a display-ID reference (e.g. `Satisfies: REQ-001`) to the referenced entry's title line.

| Commit | Slice |
|---|---|
| `fce0576` | LSP definition provider |

## What lands

Companion to the hover provider in #307.

[packages/markspec/lsp/definition.ts](packages/markspec/lsp/definition.ts):

- `entryToLspLocation(entry)` — converts the Entry's core `SourceLocation` (file path with 1-based line/column) to an LSP `Location` (file:// URI with zero-width 0-based range at the entry's start). Reuses `pathToUri` from `util.ts`.

[packages/markspec/lsp/server.ts](packages/markspec/lsp/server.ts):

- Advertises `definitionProvider: true` in initialize capabilities.
- `onDefinition` mirrors the hover handler: reads the current line, calls `displayIdAtPosition`, looks up via `index.getEntryByDisplayId`, returns the LSP `Location` (or `null`). Same source-file doc-comment guard.

## Tests

| Before | After |
|---|---|
| 1006 (post-#307) | 1010 (+4 unit tests for `entryToLspLocation`: file://URI conversion, 0-based offset, percent-encoding, line-1/col-1 edge case) |

All `just check` gates green per commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
