### PR TITLE
feat(lsp): find-references for display IDs

### DIFF
--- a/packages/markspec/lsp/references.ts
+++ b/packages/markspec/lsp/references.ts
@@ -1,0 +1,55 @@
+/**
+ * @module lsp/references
+ *
+ * Find-references helper. Given a target display ID and the set of
+ * entries indexed by the workspace, returns the subset of entries
+ * whose attribute values reference the target.
+ *
+ * Walks `rawAttributes` rather than `typedAttributes` because the
+ * core typed map is keyed by canonical attribute name and value-type
+ * categories; for the LSP we just need any attribute whose value
+ * lists the target ID, regardless of whether the key is core- or
+ * profile-declared.
+ *
+ * The identity slot (`Id`) is skipped — that's the *declaration* of
+ * the entry, not a reference to another one. The entry whose
+ * `displayId` matches the target (the definition site) is also
+ * skipped; the LSP server adds it back when the request's
+ * `includeDeclaration` is true.
+ */
+
+import type { Entry } from "../core/model/mod.ts";
+
+/**
+ * Word-boundary splitter for values that may carry multiple ID
+ * references separated by commas or whitespace (id-list attributes,
+ * citation locators preceded by whitespace, etc.).
+ */
+const TOKEN_SEPARATORS_RE = /[\s,]+/;
+
+/**
+ * Return entries whose attribute values reference `targetDisplayId`.
+ * Performs whole-token matches after splitting each value on
+ * `[\s,]+`, so `REQ-001` does not match `REQ-0010` or partial
+ * substrings.
+ */
+export function findReferencingEntries(
+  entries: readonly Entry[],
+  targetDisplayId: string,
+): Entry[] {
+  const out: Entry[] = [];
+  for (const entry of entries) {
+    if (entry.displayId === targetDisplayId) continue;
+    let matched = false;
+    for (const attr of entry.rawAttributes) {
+      if (attr.key === "Id") continue;
+      const tokens = attr.value.split(TOKEN_SEPARATORS_RE);
+      if (tokens.includes(targetDisplayId)) {
+        matched = true;
+        break;
+      }
+    }
+    if (matched) out.push(entry);
+  }
+  return out;
+}

--- a/packages/markspec/lsp/references_test.ts
+++ b/packages/markspec/lsp/references_test.ts
@@ -1,0 +1,111 @@
+/**
+ * @module lsp/references_test
+ *
+ * Unit tests for {@linkcode findReferencingEntries} — walks a set of
+ * entries and returns those whose trace attribute values include the
+ * target display ID.
+ */
+
+import { assertEquals } from "@std/assert";
+import type { Entry } from "../core/model/mod.ts";
+import { findReferencingEntries } from "./references.ts";
+
+function makeEntry(
+  displayId: string,
+  attrs: Array<[string, string]>,
+  line = 1,
+): Entry {
+  return {
+    displayId,
+    title: displayId,
+    body: "",
+    rawAttributes: attrs.map(([key, value]) => ({ key, value })),
+    typedAttributes: new Map(),
+    id: "01HGW2Q8MNP3RSTVWXYZABCDEF",
+    shape: "identified",
+    location: { file: "t.md", line, column: 1 },
+    source: "markdown",
+  };
+}
+
+Deno.test("findReferencingEntries: returns entries whose Satisfies points at target", () => {
+  const entries = [
+    makeEntry("REQ-001", [["Id", "01"]], 1),
+    makeEntry("REQ-002", [["Id", "02"], ["Satisfies", "REQ-001"]], 5),
+    makeEntry("REQ-003", [["Id", "03"]], 10),
+  ];
+  const refs = findReferencingEntries(entries, "REQ-001");
+  assertEquals(refs.length, 1);
+  assertEquals(refs[0].displayId, "REQ-002");
+});
+
+Deno.test("findReferencingEntries: matches id-list (multi-value) attributes", () => {
+  const entries = [
+    makeEntry("REQ-001", [["Id", "01"]]),
+    makeEntry("REQ-002", [
+      ["Id", "02"],
+      ["Derived-from", "REQ-001, REQ-003"],
+    ]),
+  ];
+  const refs = findReferencingEntries(entries, "REQ-001");
+  assertEquals(refs.length, 1);
+  assertEquals(refs[0].displayId, "REQ-002");
+});
+
+Deno.test("findReferencingEntries: multi-line repeatable trace attribute", () => {
+  const entries = [
+    makeEntry("REQ-001", [["Id", "01"]]),
+    makeEntry("TST-001", [
+      ["Id", "tst"],
+      ["Verifies", "REQ-001"],
+      ["Verifies", "REQ-002"],
+    ]),
+  ];
+  const refs = findReferencingEntries(entries, "REQ-001");
+  assertEquals(refs.length, 1);
+  assertEquals(refs[0].displayId, "TST-001");
+});
+
+Deno.test("findReferencingEntries: substring match on a partial token is rejected", () => {
+  const entries = [
+    makeEntry("REQ-001", [["Id", "01"]]),
+    // 'REQ-0010' shouldn't match 'REQ-001' as a substring.
+    makeEntry("REQ-0010", [["Id", "10"], ["Satisfies", "REQ-001-extra"]]),
+  ];
+  const refs = findReferencingEntries(entries, "REQ-001");
+  assertEquals(refs.length, 0);
+});
+
+Deno.test("findReferencingEntries: does NOT match against Id attribute (declaration site)", () => {
+  const entries = [
+    makeEntry("REQ-001", [["Id", "01HGW2Q8MNP3REQ001"]]),
+    makeEntry("REQ-002", [["Id", "02"], ["Satisfies", "REQ-001"]]),
+  ];
+  const refs = findReferencingEntries(entries, "REQ-001");
+  // Only REQ-002 references REQ-001 via Satisfies; REQ-001 itself (with
+  // matching displayId) is not counted as a referencing entry.
+  assertEquals(refs.length, 1);
+  assertEquals(refs[0].displayId, "REQ-002");
+});
+
+Deno.test("findReferencingEntries: matches profile-declared trace attributes too", () => {
+  // 'Mitigates' is a profile-declared trace attribute. The function
+  // walks every attribute except Id, so it matches regardless of
+  // whether the key is in a known core list.
+  const entries = [
+    makeEntry("RSK-001", [["Id", "rsk"]]),
+    makeEntry("MIT-001", [["Id", "mit"], ["Mitigates", "RSK-001"]]),
+  ];
+  const refs = findReferencingEntries(entries, "RSK-001");
+  assertEquals(refs.length, 1);
+  assertEquals(refs[0].displayId, "MIT-001");
+});
+
+Deno.test("findReferencingEntries: returns empty when no entries reference the target", () => {
+  const entries = [
+    makeEntry("REQ-001", [["Id", "01"]]),
+    makeEntry("REQ-002", [["Id", "02"]]),
+  ];
+  const refs = findReferencingEntries(entries, "REQ-001");
+  assertEquals(refs, []);
+});

--- a/packages/markspec/lsp/server.ts
+++ b/packages/markspec/lsp/server.ts
@@ -40,6 +40,7 @@ import { WorkspaceIndex } from "./workspace.ts";
 import { groupDiagnosticsByFile, toLspDiagnostic } from "./diagnostics.ts";
 import { entryToLspLocation } from "./definition.ts";
 import { displayIdAtPosition, formatHoverContent } from "./hover.ts";
+import { findReferencingEntries } from "./references.ts";
 import {
   buildBlockScaffoldItems,
   buildIdReferenceItems,
@@ -229,6 +230,7 @@ connection.onInitialize(
         },
         hoverProvider: true,
         definitionProvider: true,
+        referencesProvider: true,
       },
     };
   },
@@ -440,6 +442,42 @@ connection.onDefinition((params) => {
   if (!entry) return null;
 
   return entryToLspLocation(entry);
+});
+
+// ---------------------------------------------------------------------------
+// References (find all references to an entry)
+// ---------------------------------------------------------------------------
+
+connection.onReferences((params) => {
+  const document = documents.get(params.textDocument.uri);
+  if (!document) return null;
+
+  const filePath = uriToPath(params.textDocument.uri);
+  if (isSourceFile(filePath)) {
+    const lines = document.getText().split("\n");
+    if (!isDocCommentContext(lines, params.position.line)) {
+      return null;
+    }
+  }
+
+  const line = document.getText({
+    start: { line: params.position.line, character: 0 },
+    end: { line: params.position.line, character: Number.MAX_SAFE_INTEGER },
+  });
+
+  const id = displayIdAtPosition(line, params.position.character);
+  if (!id) return null;
+
+  const referencing = findReferencingEntries(index.getAllEntries(), id);
+  const locations = referencing.map(entryToLspLocation);
+
+  // includeDeclaration: prepend the declaration's location when asked.
+  if (params.context?.includeDeclaration) {
+    const decl = index.getEntryByDisplayId(id);
+    if (decl) locations.unshift(entryToLspLocation(decl));
+  }
+
+  return locations;
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Iteration 32 of the autonomous Prompt-1 follow-up loop. Adds **LSP find-references** — editors can list every entry that references a given display ID. Completes the hover (#307) / definition (#308) / references triad.

| Commit | Slice |
|---|---|
| `17ea64b` | LSP references provider |

## What lands

[packages/markspec/lsp/references.ts](packages/markspec/lsp/references.ts):

- `findReferencingEntries(entries, targetDisplayId)` walks each entry's `rawAttributes`, skips the identity slot (`Id`), and splits values on `[\s,]+` so a whole-token match — not a substring — is required. Catches single-value trace attributes (`Satisfies: REQ-001`) and id-list / multi-line forms (`Derived-from: REQ-001, REQ-003`).
- The declaration site (entry whose `displayId` equals the target) is omitted from the helper's result; the server handler re-adds it when the request's `includeDeclaration` is true.
- Walks any attribute key, not only the core trace set, so profile-declared attributes (`Mitigates`, etc.) are also picked up.

[packages/markspec/lsp/server.ts](packages/markspec/lsp/server.ts):

- Advertises `referencesProvider: true`.
- `onReferences` mirrors hover/definition: reads the cursor line, extracts the token via `displayIdAtPosition`, walks the index, maps each referencing entry through `entryToLspLocation`. Honors `params.context.includeDeclaration`.

## Tests

| Before | After |
|---|---|
| 1010 (post-#308) | 1017 (+7 unit tests: Satisfies, id-list multi-value, multi-line repeatable, substring rejection, Id-attribute exclusion, profile-declared trace, empty result) |

All `just check` gates green per commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
