### PR TITLE
feat(lsp): document symbols for outline view

### DIFF
--- a/packages/markspec/lsp/server.ts
+++ b/packages/markspec/lsp/server.ts
@@ -41,6 +41,7 @@ import { groupDiagnosticsByFile, toLspDiagnostic } from "./diagnostics.ts";
 import { entryToLspLocation } from "./definition.ts";
 import { displayIdAtPosition, formatHoverContent } from "./hover.ts";
 import { findReferencingEntries } from "./references.ts";
+import { entriesToDocumentSymbols } from "./symbols.ts";
 import {
   buildBlockScaffoldItems,
   buildIdReferenceItems,
@@ -231,6 +232,7 @@ connection.onInitialize(
         hoverProvider: true,
         definitionProvider: true,
         referencesProvider: true,
+        documentSymbolProvider: true,
       },
     };
   },
@@ -478,6 +480,21 @@ connection.onReferences((params) => {
   }
 
   return locations;
+});
+
+// ---------------------------------------------------------------------------
+// Document symbols (outline view)
+// ---------------------------------------------------------------------------
+
+connection.onDocumentSymbol((params) => {
+  const filePath = uriToPath(params.textDocument.uri);
+  if (!isMarkspecFile(filePath)) return null;
+  const entries = index.getEntriesForFile(filePath);
+  // The result conforms to LSP `DocumentSymbol[]`; cast to satisfy the
+  // node-server.d.ts overload that returns `SymbolInformation[]` by
+  // default when the parameter is unannotated.
+  // deno-lint-ignore no-explicit-any
+  return entriesToDocumentSymbols(entries) as any;
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/markspec/lsp/symbols.ts
+++ b/packages/markspec/lsp/symbols.ts
@@ -1,0 +1,57 @@
+/**
+ * @module lsp/symbols
+ *
+ * Document-symbol helper. Converts a file's parsed Entry list into
+ * the `DocumentSymbol[]` payload the LSP outline view consumes.
+ *
+ * The server module composes this with the workspace index to
+ * implement `connection.onDocumentSymbol`.
+ */
+
+import type { Entry } from "../core/model/mod.ts";
+
+/** LSP `SymbolKind.Class` numeric constant. */
+export const SymbolKindClass = 5;
+
+/** A subset of the LSP `DocumentSymbol` interface. */
+export interface DocumentSymbol {
+  readonly name: string;
+  readonly detail?: string;
+  readonly kind: number;
+  readonly range: {
+    readonly start: { readonly line: number; readonly character: number };
+    readonly end: { readonly line: number; readonly character: number };
+  };
+  readonly selectionRange: {
+    readonly start: { readonly line: number; readonly character: number };
+    readonly end: { readonly line: number; readonly character: number };
+  };
+}
+
+/**
+ * Build a DocumentSymbol list for a single file's entries. Each entry
+ * becomes a top-level symbol named by its display ID, with `detail`
+ * carrying the title (and resolved type, when set).
+ *
+ * Ranges and selection ranges are zero-width cursors at the entry's
+ * start. A future iteration could compute a true range covering the
+ * full entry block — for now the cursor placement is enough for
+ * outline navigation.
+ */
+export function entriesToDocumentSymbols(
+  entries: readonly Entry[],
+): DocumentSymbol[] {
+  return entries.map((entry) => {
+    const line = Math.max(0, entry.location.line - 1);
+    const character = Math.max(0, entry.location.column - 1);
+    const position = { line, character };
+    const detail = entry.type ? `${entry.type} — ${entry.title}` : entry.title;
+    return {
+      name: entry.displayId,
+      detail,
+      kind: SymbolKindClass,
+      range: { start: position, end: position },
+      selectionRange: { start: position, end: position },
+    };
+  });
+}

--- a/packages/markspec/lsp/symbols_test.ts
+++ b/packages/markspec/lsp/symbols_test.ts
@@ -1,0 +1,80 @@
+/**
+ * @module lsp/symbols_test
+ *
+ * Unit tests for {@linkcode entriesToDocumentSymbols} — produces the
+ * `DocumentSymbol[]` list for the LSP outline view.
+ */
+
+import { assertEquals } from "@std/assert";
+import type { Entry } from "../core/model/mod.ts";
+import { entriesToDocumentSymbols, SymbolKindClass } from "./symbols.ts";
+
+function makeEntry(opts: {
+  displayId: string;
+  title: string;
+  line: number;
+  column?: number;
+  type?: string;
+  shape?: "identified" | "referenced";
+}): Entry {
+  return {
+    displayId: opts.displayId,
+    title: opts.title,
+    body: "",
+    rawAttributes: [{ key: "Id", value: "01HGW2Q8MNP3RSTVWXYZABCDEF" }],
+    typedAttributes: new Map(),
+    id: "01HGW2Q8MNP3RSTVWXYZABCDEF",
+    shape: opts.shape ?? "identified",
+    type: opts.type,
+    location: { file: "t.md", line: opts.line, column: opts.column ?? 1 },
+    source: "markdown",
+  };
+}
+
+Deno.test("entriesToDocumentSymbols: one symbol per entry", () => {
+  const entries = [
+    makeEntry({ displayId: "REQ-001", title: "First", line: 3 }),
+    makeEntry({ displayId: "REQ-002", title: "Second", line: 9 }),
+  ];
+  const symbols = entriesToDocumentSymbols(entries);
+  assertEquals(symbols.length, 2);
+  assertEquals(symbols[0].name, "REQ-001");
+  assertEquals(symbols[0].detail, "First");
+  assertEquals(symbols[1].name, "REQ-002");
+});
+
+Deno.test("entriesToDocumentSymbols: range/selectionRange use 0-based lines", () => {
+  const entries = [
+    makeEntry({ displayId: "REQ-001", title: "X", line: 5, column: 3 }),
+  ];
+  const sym = entriesToDocumentSymbols(entries)[0];
+  assertEquals(sym.range.start.line, 4);
+  assertEquals(sym.range.start.character, 2);
+  assertEquals(sym.selectionRange.start.line, 4);
+  assertEquals(sym.selectionRange.start.character, 2);
+});
+
+Deno.test("entriesToDocumentSymbols: detail prepends type when set", () => {
+  const entries = [
+    makeEntry({
+      displayId: "REQ-001",
+      title: "Sensor debouncing",
+      line: 1,
+      type: "Requirement",
+    }),
+  ];
+  const sym = entriesToDocumentSymbols(entries)[0];
+  // detail should include both type and title.
+  assertEquals(sym.detail, "Requirement — Sensor debouncing");
+});
+
+Deno.test("entriesToDocumentSymbols: kind is the Class constant", () => {
+  const entries = [makeEntry({ displayId: "REQ-001", title: "X", line: 1 })];
+  const sym = entriesToDocumentSymbols(entries)[0];
+  // LSP `SymbolKind.Class` = 5; assert via the named export.
+  assertEquals(sym.kind, SymbolKindClass);
+});
+
+Deno.test("entriesToDocumentSymbols: empty entry list yields empty array", () => {
+  assertEquals(entriesToDocumentSymbols([]), []);
+});


### PR DESCRIPTION
## Summary

Iteration 33 of the autonomous Prompt-1 follow-up loop. Adds **LSP document symbols** so editors populate the outline view with one item per entry in the current MarkSpec file.

| Commit | Slice |
|---|---|
| `a5b9991` | LSP documentSymbol provider |

## What lands

[packages/markspec/lsp/symbols.ts](packages/markspec/lsp/symbols.ts):

- `entriesToDocumentSymbols(entries)` maps each entry to a flat `DocumentSymbol` named by its display ID. `detail` carries the title and, when set, the resolved type — e.g. `"Requirement — Sensor debouncing"`. `range` and `selectionRange` are zero-width cursors at the entry's start (a future iteration can widen them to cover the full entry block).
- `SymbolKind.Class` (5) is used so editors pick a consistent icon.

[packages/markspec/lsp/server.ts](packages/markspec/lsp/server.ts):

- Advertises `documentSymbolProvider: true`.
- `onDocumentSymbol` filters to MarkSpec files, pulls the file's entries from the index, returns the symbol array. A small `as any` cast nudges TypeScript past the LSP overload that defaults to `SymbolInformation[]`.

## Tests

| Before | After |
|---|---|
| 1017 (post-#309) | 1022 (+5 unit tests: one-per-entry mapping, 0-based line/column conversion, type-prepended detail format, `SymbolKind.Class` constant, empty input) |

All `just check` gates green per commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
