### PR TITLE
feat(lsp): workspace symbol search

### DIFF
--- a/packages/markspec/lsp/server.ts
+++ b/packages/markspec/lsp/server.ts
@@ -41,7 +41,10 @@ import { groupDiagnosticsByFile, toLspDiagnostic } from "./diagnostics.ts";
 import { entryToLspLocation } from "./definition.ts";
 import { displayIdAtPosition, formatHoverContent } from "./hover.ts";
 import { findReferencingEntries } from "./references.ts";
-import { entriesToDocumentSymbols } from "./symbols.ts";
+import {
+  entriesToDocumentSymbols,
+  entriesToWorkspaceSymbols,
+} from "./symbols.ts";
 import {
   buildBlockScaffoldItems,
   buildIdReferenceItems,
@@ -233,6 +236,7 @@ connection.onInitialize(
         definitionProvider: true,
         referencesProvider: true,
         documentSymbolProvider: true,
+        workspaceSymbolProvider: true,
       },
     };
   },
@@ -495,6 +499,17 @@ connection.onDocumentSymbol((params) => {
   // default when the parameter is unannotated.
   // deno-lint-ignore no-explicit-any
   return entriesToDocumentSymbols(entries) as any;
+});
+
+// ---------------------------------------------------------------------------
+// Workspace symbols (fuzzy entry search)
+// ---------------------------------------------------------------------------
+
+connection.onWorkspaceSymbol((params) => {
+  // The result conforms to LSP `SymbolInformation[]`; cast to satisfy
+  // the typed `SymbolKind` enum the d.ts expects.
+  // deno-lint-ignore no-explicit-any
+  return entriesToWorkspaceSymbols(index.getAllEntries(), params.query) as any;
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/markspec/lsp/symbols.ts
+++ b/packages/markspec/lsp/symbols.ts
@@ -9,6 +9,7 @@
  */
 
 import type { Entry } from "../core/model/mod.ts";
+import { pathToUri } from "./util.ts";
 
 /** LSP `SymbolKind.Class` numeric constant. */
 export const SymbolKindClass = 5;
@@ -38,6 +39,57 @@ export interface DocumentSymbol {
  * full entry block — for now the cursor placement is enough for
  * outline navigation.
  */
+/** A subset of the LSP `SymbolInformation` interface. */
+export interface SymbolInformation {
+  readonly name: string;
+  readonly kind: number;
+  readonly location: {
+    readonly uri: string;
+    readonly range: {
+      readonly start: { readonly line: number; readonly character: number };
+      readonly end: { readonly line: number; readonly character: number };
+    };
+  };
+  readonly containerName?: string;
+}
+
+/**
+ * Filter and project the workspace's entries to LSP
+ * `SymbolInformation[]` for the `workspace/symbol` request.
+ *
+ * `query` is matched case-insensitively as a substring against both
+ * the entry's display ID and its title; an empty query matches every
+ * entry. `containerName` carries the title so editor results lists
+ * still show both pieces of identifying info.
+ */
+export function entriesToWorkspaceSymbols(
+  entries: readonly Entry[],
+  query: string,
+): SymbolInformation[] {
+  const needle = query.toLowerCase();
+  const out: SymbolInformation[] = [];
+  for (const entry of entries) {
+    if (needle.length > 0) {
+      const matches = entry.displayId.toLowerCase().includes(needle) ||
+        entry.title.toLowerCase().includes(needle);
+      if (!matches) continue;
+    }
+    const line = Math.max(0, entry.location.line - 1);
+    const character = Math.max(0, entry.location.column - 1);
+    const position = { line, character };
+    out.push({
+      name: entry.displayId,
+      kind: SymbolKindClass,
+      location: {
+        uri: pathToUri(entry.location.file),
+        range: { start: position, end: position },
+      },
+      containerName: entry.title,
+    });
+  }
+  return out;
+}
+
 export function entriesToDocumentSymbols(
   entries: readonly Entry[],
 ): DocumentSymbol[] {

--- a/packages/markspec/lsp/symbols_test.ts
+++ b/packages/markspec/lsp/symbols_test.ts
@@ -7,7 +7,11 @@
 
 import { assertEquals } from "@std/assert";
 import type { Entry } from "../core/model/mod.ts";
-import { entriesToDocumentSymbols, SymbolKindClass } from "./symbols.ts";
+import {
+  entriesToDocumentSymbols,
+  entriesToWorkspaceSymbols,
+  SymbolKindClass,
+} from "./symbols.ts";
 
 function makeEntry(opts: {
   displayId: string;
@@ -77,4 +81,55 @@ Deno.test("entriesToDocumentSymbols: kind is the Class constant", () => {
 
 Deno.test("entriesToDocumentSymbols: empty entry list yields empty array", () => {
   assertEquals(entriesToDocumentSymbols([]), []);
+});
+
+// --- entriesToWorkspaceSymbols ---
+
+Deno.test("entriesToWorkspaceSymbols: empty query returns all entries", () => {
+  const entries = [
+    makeEntry({ displayId: "REQ-001", title: "First", line: 1 }),
+    makeEntry({ displayId: "TST-001", title: "Test", line: 5 }),
+  ];
+  const symbols = entriesToWorkspaceSymbols(entries, "");
+  assertEquals(symbols.length, 2);
+});
+
+Deno.test("entriesToWorkspaceSymbols: matches by displayId substring (case-insensitive)", () => {
+  const entries = [
+    makeEntry({ displayId: "REQ-001", title: "Foo", line: 1 }),
+    makeEntry({ displayId: "TST-001", title: "Bar", line: 5 }),
+  ];
+  const symbols = entriesToWorkspaceSymbols(entries, "req");
+  assertEquals(symbols.length, 1);
+  assertEquals(symbols[0].name, "REQ-001");
+});
+
+Deno.test("entriesToWorkspaceSymbols: matches by title substring (case-insensitive)", () => {
+  const entries = [
+    makeEntry({ displayId: "REQ-001", title: "Sensor debouncing", line: 1 }),
+    makeEntry({ displayId: "TST-001", title: "Other thing", line: 5 }),
+  ];
+  const symbols = entriesToWorkspaceSymbols(entries, "Sensor");
+  assertEquals(symbols.length, 1);
+  assertEquals(symbols[0].name, "REQ-001");
+});
+
+Deno.test("entriesToWorkspaceSymbols: SymbolInformation carries location with file URI", () => {
+  const entries = [
+    makeEntry({ displayId: "REQ-001", title: "X", line: 3, column: 1 }),
+  ];
+  // Override location.file to an absolute path.
+  entries[0] = {
+    ...entries[0],
+    location: { file: "/abs/path/req.md", line: 3, column: 1 },
+  };
+  const sym = entriesToWorkspaceSymbols(entries, "")[0];
+  assertEquals(sym.location.uri, "file:///abs/path/req.md");
+  assertEquals(sym.location.range.start.line, 2);
+});
+
+Deno.test("entriesToWorkspaceSymbols: kind is the Class constant", () => {
+  const entries = [makeEntry({ displayId: "REQ-001", title: "X", line: 1 })];
+  const sym = entriesToWorkspaceSymbols(entries, "")[0];
+  assertEquals(sym.kind, SymbolKindClass);
 });


### PR DESCRIPTION
## Summary

Iteration 34 of the autonomous Prompt-1 follow-up loop. Adds **LSP workspace symbol search** — editors can fuzzy-search MarkSpec entries by display ID or title across the entire project (Cmd+T / Ctrl+T in VS Code).

| Commit | Slice |
|---|---|
| `0233bbd` | LSP workspace symbol provider |

## What lands

`entriesToWorkspaceSymbols(entries, query)` in [packages/markspec/lsp/symbols.ts](packages/markspec/lsp/symbols.ts):

- Empty query → every entry.
- Non-empty query → case-insensitive substring match against both `entry.displayId` and `entry.title`.
- Each match becomes a `SymbolInformation` with `kind: Class`, file:// URI + zero-based range built from `entry.location`, and `containerName: entry.title` so editors show both ID and title in result lists.

[packages/markspec/lsp/server.ts](packages/markspec/lsp/server.ts):

- Advertises `workspaceSymbolProvider: true`.
- `onWorkspaceSymbol` delegates to the helper. The `as any` cast on the return matches the `SymbolKind` enum typing the d.ts expects.

## Tests

| Before | After |
|---|---|
| 1022 (post-#310) | 1027 (+5 unit tests: empty-query returns all, displayId substring, title substring, location URI + 0-based range, kind constant) |

All `just check` gates green per commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
