### PR TITLE
feat(lsp): workspace rename for display IDs

### DIFF
--- a/packages/markspec/lsp/rename.ts
+++ b/packages/markspec/lsp/rename.ts
@@ -1,0 +1,68 @@
+/**
+ * @module lsp/rename
+ *
+ * Workspace-rename helper. Finds every whole-token occurrence of a
+ * display ID in a file's text and builds the `TextEdit[]` payload an
+ * LSP `WorkspaceEdit` needs.
+ *
+ * Whole-token matching means `REQ-001` does not match `REQ-0010` or
+ * `REQ-001-extra` — both ends of the token must be at a non-ID
+ * character. The ID character set matches the parser's display-ID
+ * grammar: letters, digits, `._/-`.
+ */
+
+/** A subset of the LSP `TextEdit` interface. */
+export interface TextEdit {
+  readonly range: {
+    readonly start: { readonly line: number; readonly character: number };
+    readonly end: { readonly line: number; readonly character: number };
+  };
+  readonly newText: string;
+}
+
+/** Display-ID character set — letters, digits, dot, slash, hyphen, underscore. */
+const ID_CHAR_RE = /[A-Za-z0-9._/-]/;
+
+/**
+ * Walk every line of `text`, scan for `oldId`, and emit a TextEdit
+ * for each whole-token occurrence that replaces it with `newId`.
+ *
+ * Positions are returned as zero-based line/character (LSP
+ * convention). Each occurrence's range covers only the `oldId`
+ * characters — the editor uses the textual replacement to perform
+ * the rename, so the range must be exact.
+ */
+export function findIdOccurrencesInFile(
+  text: string,
+  oldId: string,
+  newId: string,
+): TextEdit[] {
+  if (oldId.length === 0) return [];
+  const edits: TextEdit[] = [];
+  const lines = text.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    let start = 0;
+    while (true) {
+      const idx = line.indexOf(oldId, start);
+      if (idx < 0) break;
+      const before = idx === 0 ? "" : line[idx - 1];
+      const after = idx + oldId.length >= line.length
+        ? ""
+        : line[idx + oldId.length];
+      const boundedLeft = before === "" || !ID_CHAR_RE.test(before);
+      const boundedRight = after === "" || !ID_CHAR_RE.test(after);
+      if (boundedLeft && boundedRight) {
+        edits.push({
+          range: {
+            start: { line: i, character: idx },
+            end: { line: i, character: idx + oldId.length },
+          },
+          newText: newId,
+        });
+      }
+      start = idx + oldId.length;
+    }
+  }
+  return edits;
+}

--- a/packages/markspec/lsp/rename_test.ts
+++ b/packages/markspec/lsp/rename_test.ts
@@ -1,0 +1,72 @@
+/**
+ * @module lsp/rename_test
+ *
+ * Unit tests for {@linkcode findIdOccurrencesInFile} — locates every
+ * whole-word occurrence of a display ID in a file's text, returning
+ * `TextEdit`s ready to feed into an LSP `WorkspaceEdit`.
+ */
+
+import { assertEquals } from "@std/assert";
+import { findIdOccurrencesInFile } from "./rename.ts";
+
+Deno.test("findIdOccurrencesInFile: finds bracketed declaration", () => {
+  const text = `# Test
+
+- [REQ-001] My req
+
+  Body.
+`;
+  const edits = findIdOccurrencesInFile(text, "REQ-001", "REQ-100");
+  assertEquals(edits.length, 1);
+  assertEquals(edits[0].newText, "REQ-100");
+  // Line 3 (0-based: 2), starting after the `[`.
+  assertEquals(edits[0].range.start.line, 2);
+  assertEquals(edits[0].range.start.character, 3);
+  assertEquals(edits[0].range.end.character, 10);
+});
+
+Deno.test("findIdOccurrencesInFile: finds trace attribute reference", () => {
+  const text = `# Test
+
+- [TST-001] My test
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      Verifies: REQ-001
+`;
+  const edits = findIdOccurrencesInFile(text, "REQ-001", "REQ-100");
+  assertEquals(edits.length, 1);
+  // Position of REQ-001 on the Verifies line.
+  assertEquals(edits[0].range.start.line, 5);
+});
+
+Deno.test("findIdOccurrencesInFile: finds multiple occurrences", () => {
+  const text = `- [REQ-001] First
+
+      Satisfies: SYS-001
+
+- [REQ-002] Second
+
+      Satisfies: REQ-001
+      Derived-from: REQ-001
+`;
+  const edits = findIdOccurrencesInFile(text, "REQ-001", "REQ-100");
+  assertEquals(edits.length, 3);
+});
+
+Deno.test("findIdOccurrencesInFile: whole-token only — REQ-001 does not match REQ-0010", () => {
+  const text = `- [REQ-0010] Renamed sibling
+
+      Satisfies: REQ-001-extra
+`;
+  const edits = findIdOccurrencesInFile(text, "REQ-001", "REQ-100");
+  assertEquals(edits, []);
+});
+
+Deno.test("findIdOccurrencesInFile: empty text yields empty result", () => {
+  assertEquals(findIdOccurrencesInFile("", "REQ-001", "REQ-100"), []);
+});
+
+Deno.test("findIdOccurrencesInFile: no match yields empty result", () => {
+  const text = `- [TST-001] Just a test\n\n  Body.\n`;
+  assertEquals(findIdOccurrencesInFile(text, "REQ-001", "REQ-100"), []);
+});

--- a/packages/markspec/lsp/server.ts
+++ b/packages/markspec/lsp/server.ts
@@ -24,6 +24,7 @@ import {
   StreamMessageWriter,
   TextDocuments,
   TextDocumentSyncKind,
+  type TextEdit as LspTextEdit,
 } from "vscode-languageserver/node";
 import { TextDocument } from "vscode-languageserver-textdocument";
 import process from "node:process";
@@ -41,6 +42,7 @@ import { groupDiagnosticsByFile, toLspDiagnostic } from "./diagnostics.ts";
 import { entryToLspLocation } from "./definition.ts";
 import { displayIdAtPosition, formatHoverContent } from "./hover.ts";
 import { findReferencingEntries } from "./references.ts";
+import { findIdOccurrencesInFile } from "./rename.ts";
 import {
   entriesToDocumentSymbols,
   entriesToWorkspaceSymbols,
@@ -237,6 +239,7 @@ connection.onInitialize(
         referencesProvider: true,
         documentSymbolProvider: true,
         workspaceSymbolProvider: true,
+        renameProvider: true,
       },
     };
   },
@@ -510,6 +513,53 @@ connection.onWorkspaceSymbol((params) => {
   // the typed `SymbolKind` enum the d.ts expects.
   // deno-lint-ignore no-explicit-any
   return entriesToWorkspaceSymbols(index.getAllEntries(), params.query) as any;
+});
+
+// ---------------------------------------------------------------------------
+// Rename (workspace-wide rename of a display ID)
+// ---------------------------------------------------------------------------
+
+connection.onRenameRequest(async (params) => {
+  const document = documents.get(params.textDocument.uri);
+  if (!document) return null;
+
+  const filePath = uriToPath(params.textDocument.uri);
+  if (isSourceFile(filePath)) {
+    const lines = document.getText().split("\n");
+    if (!isDocCommentContext(lines, params.position.line)) {
+      return null;
+    }
+  }
+
+  const line = document.getText({
+    start: { line: params.position.line, character: 0 },
+    end: { line: params.position.line, character: Number.MAX_SAFE_INTEGER },
+  });
+  const oldId = displayIdAtPosition(line, params.position.character);
+  if (!oldId) return null;
+  const newId = params.newName;
+  if (!newId || newId === oldId) return null;
+
+  // Build per-file TextEdits across the entire workspace. For each
+  // tracked file, prefer the open-document text (live editor state)
+  // and fall back to reading from disk.
+  const changes: Record<string, LspTextEdit[]> = {};
+  for (const path of index.getFilePaths()) {
+    const uri = pathToUri(path);
+    let text: string | undefined;
+    const openDoc = documents.get(uri);
+    if (openDoc) {
+      text = openDoc.getText();
+    } else {
+      text = await readFile(path);
+    }
+    if (text === undefined) continue;
+    const fileEdits = findIdOccurrencesInFile(text, oldId, newId);
+    if (fileEdits.length > 0) {
+      changes[uri] = fileEdits as unknown as LspTextEdit[];
+    }
+  }
+  return { changes };
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Iteration 35 of the autonomous Prompt-1 follow-up loop. Adds **LSP workspace rename** — authors can rename a display ID project-wide from the editor: cursor on `REQ-001` → Rename Symbol → every occurrence updates atomically as one `WorkspaceEdit`.

| Commit | Slice |
|---|---|
| `1659983` | LSP rename provider |

## What lands

[packages/markspec/lsp/rename.ts](packages/markspec/lsp/rename.ts):

- `findIdOccurrencesInFile(text, oldId, newId)` walks each line, scans for `oldId`, emits a `TextEdit` for every whole-token occurrence. Whole-token = neither neighbour character is in the display-ID charset (`[A-Za-z0-9._/-]`), so `REQ-001` does not match `REQ-0010` or `REQ-001-extra`.
- Ranges are zero-based line / character (LSP convention) covering just the `oldId` span.

[packages/markspec/lsp/server.ts](packages/markspec/lsp/server.ts):

- Advertises `renameProvider: true`.
- `onRenameRequest` extracts the token at the cursor via `displayIdAtPosition`, validates the new name is non-empty and different from the old, walks every tracked file in `index.getFilePaths()`, builds per-file `TextEdit` arrays, returns a `WorkspaceEdit` with `changes` keyed by URI.
- Prefers open-document text (live editor state) over disk reads so unsaved buffers participate correctly.
- Source-file doc-comment guard mirrors hover/definition.

## Tests

| Before | After |
|---|---|
| 1027 (post-#311) | 1033 (+6 unit tests: bracketed declaration, trace attribute reference, multiple occurrences, whole-token boundary, empty text, no-match) |

All `just check` gates green per commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
