### PR TITLE
docs(repo): sync AGENTS.md LSP section with current modules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,11 +69,23 @@ markspec/
 │       ├── cli/
 │       │   └── commands/            ← one file per subcommand
 │       ├── lsp/
-│       │   ├── server.ts            ← LSP server entry point (stdio JSON-RPC,
-│       │   │                          diagnostics + completions)
+│       │   ├── server.ts            ← LSP server entry point (stdio JSON-RPC).
+│       │   │                          Capabilities: diagnostics, completions,
+│       │   │                          hover, definition, references, document /
+│       │   │                          workspace symbols, rename.
 │       │   ├── workspace.ts         ← in-memory entry index, incremental updates
 │       │   ├── diagnostics.ts       ← core Diagnostic → LSP Diagnostic bridge
-│       │   ├── completions.ts       ← block scaffold + ID reference completion
+│       │   ├── completions.ts       ← block scaffold + ID reference + Type:
+│       │   │                          value completion triggers
+│       │   ├── hover.ts             ← hover provider: display-ID extraction +
+│       │   │                          Markdown-rendered Entry preview
+│       │   ├── definition.ts        ← Entry → LSP Location for go-to-definition
+│       │   ├── references.ts        ← find-all-references: walks entry
+│       │   │                          attributes for whole-token matches
+│       │   ├── rename.ts            ← workspace rename: whole-token text edits
+│       │   │                          across every tracked file
+│       │   ├── symbols.ts           ← document-symbol (outline) + workspace-
+│       │   │                          symbol (fuzzy entry search) builders
 │       │   ├── context.ts           ← doc comment context guard (source files)
 │       │   └── util.ts              ← URI↔path conversion, debounce
 │       └── mcp/
@@ -109,9 +121,11 @@ markspec/
 alone:**
 
 @packages/markspec/lsp/server.ts @packages/markspec/lsp/workspace.ts
-@packages/markspec/lsp/completions.ts @packages/markspec/lsp/context.ts
-@packages/markspec/lsp/diagnostics.ts @packages/markspec/lsp/util.ts
-@packages/markspec/main.ts
+@packages/markspec/lsp/completions.ts @packages/markspec/lsp/hover.ts
+@packages/markspec/lsp/definition.ts @packages/markspec/lsp/references.ts
+@packages/markspec/lsp/rename.ts @packages/markspec/lsp/symbols.ts
+@packages/markspec/lsp/context.ts @packages/markspec/lsp/diagnostics.ts
+@packages/markspec/lsp/util.ts @packages/markspec/main.ts
 
 ## Key rules
 


### PR DESCRIPTION
## Summary

Iteration 36 of the autonomous Prompt-1 follow-up loop. Documentation sync: the LSP section of AGENTS.md is updated to match the modules added across PRs #306 – #312.

| Commit | Slice |
|---|---|
| `7195338` | AGENTS.md LSP module tree + read-list |

## What lands

The LSP folder gained six new modules:

| Module | PR | What it provides |
|---|---|---|
| `completions.ts` (Type:) | #306 | `Type:` value completion trigger |
| `hover.ts` | #307 | display-ID hover preview |
| `definition.ts` | #308 | go-to-definition |
| `references.ts` | #309 | find-all-references |
| `symbols.ts` (doc) | #310 | document-symbol outline |
| `symbols.ts` (ws) | #311 | workspace-symbol fuzzy search |
| `rename.ts` | #312 | workspace-wide rename |

`AGENTS.md`:

- Updated the repository tree under `packages/markspec/lsp/` to list every module with a one-line purpose.
- Updated the "Read these files for current LSP implementation" pointer list to reference all current `.ts` files in the folder.

No code changes; no test count change.

All `just check` gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
