### PR TITLE
feat(cli): implement markspec hook [...files] for pre-commit use

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -210,21 +210,23 @@ pass. `CHANGELOG.md` and `docs/examples/` are excluded from dprint.
 
 ### Implemented
 
-| Command                               | Module                            | Purpose                                                              |
-| ------------------------------------- | --------------------------------- | -------------------------------------------------------------------- |
-| `markspec format [...files]`          | `core/formatter`                  | Stamp ULIDs, fix indentation, normalize attributes. Pre-commit hook. |
-| `markspec validate [...files]`        | `core/validator`                  | Check broken refs, missing Ids, malformed entries, duplicates.       |
-| `markspec compile <paths...>`         | `core/compiler`                   | Parse all files, build traceability graph, output compiled JSON.     |
-| `markspec show <id> <paths...>`       | `core/compiler`                   | Show details of a single entry by display ID or ULID.                |
-| `markspec context <id> <paths...>`    | `core/compiler`                   | Walk the Satisfies chain upward from an entry.                       |
-| `markspec dependents <id> <paths...>` | `core/compiler`                   | List all entries that depend on a given entry.                       |
-| `markspec report <kind> <paths...>`   | `core/reporter`                   | Generate traceability matrix or coverage report.                     |
-| `markspec profile show`               | `core/profile`                    | Show the active profile chain and effective configuration.           |
-| `markspec doctor`                     | `core/profile` + `core/validator` | Project health check: profile, config, and validation summary.       |
-| `markspec next-id <type> <paths...>`  | `core/compiler` + `core/profile`  | Print the next available display ID for a profile-declared type.     |
-| `markspec doc build <file>`           | `render/typst`                    | Single document → PDF via Typst WASM.                                |
-| `markspec book build`                 | `book/site`                       | Multi-chapter → static HTML site.                                    |
-| `markspec lsp`                        | `lsp/server`                      | LSP server for editor integration (stdio JSON-RPC).                  |
+| Command                               | Module                              | Purpose                                                              |
+| ------------------------------------- | ----------------------------------- | -------------------------------------------------------------------- |
+| `markspec format [...files]`          | `core/formatter`                    | Stamp ULIDs, fix indentation, normalize attributes. Pre-commit hook. |
+| `markspec validate [...files]`        | `core/validator`                    | Check broken refs, missing Ids, malformed entries, duplicates.       |
+| `markspec compile <paths...>`         | `core/compiler`                     | Parse all files, build traceability graph, output compiled JSON.     |
+| `markspec show <id> <paths...>`       | `core/compiler`                     | Show details of a single entry by display ID or ULID.                |
+| `markspec context <id> <paths...>`    | `core/compiler`                     | Walk the Satisfies chain upward from an entry.                       |
+| `markspec dependents <id> <paths...>` | `core/compiler`                     | List all entries that depend on a given entry.                       |
+| `markspec report <kind> <paths...>`   | `core/reporter`                     | Generate traceability matrix or coverage report.                     |
+| `markspec profile show`               | `core/profile`                      | Show the active profile chain and effective configuration.           |
+| `markspec doctor`                     | `core/profile` + `core/validator`   | Project health check: profile, config, and validation summary.       |
+| `markspec next-id <type> <paths...>`  | `core/compiler` + `core/profile`    | Print the next available display ID for a profile-declared type.     |
+| `markspec hook [...files]`            | `core/formatter` + `core/validator` | Pre-commit hook: run format --check + validate on the given files.   |
+| `markspec doc build <file>`           | `render/typst`                      | Single document → PDF via Typst WASM.                                |
+| `markspec book build`                 | `book/site`                         | Multi-chapter → static HTML site.                                    |
+| `markspec lsp`                        | `lsp/server`                        | LSP server for editor integration (stdio JSON-RPC).                  |
+| `markspec mcp`                        | `mcp/server`                        | MCP server for AI agent integration (stdio JSON-RPC).                |
 
 ### Not yet implemented
 
@@ -236,11 +238,9 @@ invoke them.
 | `markspec export`     | Compiled JSON → json, csv, reqif, yaml.                   |
 | `markspec insert`     | Agent write path: insert a requirement block into a file. |
 | `markspec create`     | Scaffold a new requirement block.                         |
-| `markspec hook`       | Run format + validate as a pre-commit hook.               |
 | `markspec book dev`   | Live preview with hot reload.                             |
 | `markspec deck build` | Slides → PDF via Touying/Typst.                           |
 | `markspec deck dev`   | Live slide preview.                                       |
-| `markspec mcp`        | MCP server for AI agent integration.                      |
 
 **Project context:** `format` and `validate` work file-locally without a
 `project.yaml`. All other commands (`compile`, `show`, `context`, `dependents`,

--- a/packages/markspec/main.ts
+++ b/packages/markspec/main.ts
@@ -983,9 +983,72 @@ const cli = new Command()
       }
     },
   )
-  .command("hook")
-  .description("Run format + validate as a pre-commit hook")
-  .action(notImplemented("hook"))
+  .command("hook [...files:string]")
+  .description("Run format --check + validate as a pre-commit hook")
+  .action(async (_options: Record<string, unknown>, ...files: string[]) => {
+    if (files.length === 0) {
+      // Nothing to do — exit clean. Pre-commit frameworks call with
+      // zero files when no tracked file matches the hook's filter.
+      Deno.exit(0);
+    }
+
+    const { discoverProjectRoot, format, parseFile, runPipeline } =
+      await import("./core/mod.ts");
+
+    const projectRoot = await discoverProjectRoot(Deno.cwd(), readFile);
+    const chain = projectRoot !== undefined
+      ? await loadActiveProfile(projectRoot)
+      : null;
+
+    let hadError = false;
+    const allEntries = [];
+
+    for (const filePath of files) {
+      let content: string;
+      try {
+        content = await Deno.readTextFile(filePath);
+      } catch {
+        console.error(`error: ${filePath}: file not found`);
+        hadError = true;
+        continue;
+      }
+
+      // Stage 1 — format check. `result.changed` means the file is
+      // not in canonical form; reject the commit.
+      const formatResult = format(content, { file: filePath });
+      for (const d of formatResult.diagnostics) {
+        const loc = d.location ? `${d.location.file}:${d.location.line}` : "";
+        console.error(`${d.severity}: ${loc} ${d.message}`);
+      }
+      if (formatResult.changed) {
+        console.error(`${filePath}: needs formatting (run 'markspec format')`);
+        hadError = true;
+      }
+
+      // Stage 2 — collect entries for validation.
+      const parsed = await parseFile(content, { file: filePath });
+      allEntries.push(...parsed.entries);
+    }
+
+    if (!hadError) {
+      const result = runPipeline(allEntries, chain?.effective ?? null);
+      for (const d of result.diagnostics) {
+        const loc = d.location ? `${d.location.file}:${d.location.line}` : "";
+        console.error(`${d.severity}[${d.code}]: ${loc} ${d.message}`);
+      }
+      if (result.diagnostics.some((d) => d.severity === "error")) {
+        hadError = true;
+      }
+    }
+
+    console.error(
+      hadError
+        ? `hook: ${files.length} file(s) checked — failed`
+        : `hook: ${files.length} file(s) checked — clean`,
+    );
+
+    if (hadError) Deno.exit(1);
+  })
   // Nested commands
   .command("profile", profileCmd)
   .command("doctor")

--- a/tests/e2e/hook_test.ts
+++ b/tests/e2e/hook_test.ts
@@ -1,0 +1,64 @@
+/**
+ * @module tests/e2e/hook_test
+ *
+ * E2E tests for `markspec hook <files...>` — composes
+ * `format --check` and `validate` for use as a pre-commit hook.
+ */
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { markspec } from "./helpers.ts";
+
+Deno.test("hook: clean files exit 0", async () => {
+  const input = `# Test
+
+- [REQ-001] My requirement
+
+  The system shall debounce inputs.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+`;
+  const { code } = await markspec(["hook", "req.md"], {
+    files: { "req.md": input },
+  });
+  assertEquals(code, 0);
+});
+
+Deno.test("hook: file needing format fails with code 1", async () => {
+  // Missing Id — format would assign one (file is not clean).
+  const input = `# Test
+
+- [REQ-001] My requirement
+
+  The system shall debounce inputs.
+`;
+  const { code, stderr } = await markspec(["hook", "req.md"], {
+    files: { "req.md": input },
+  });
+  assertEquals(code, 1);
+  // The format check stage emits a per-file "needs formatting" notice.
+  assertStringIncludes(stderr, "needs formatting");
+});
+
+Deno.test("hook: file with validation error fails with code 1", async () => {
+  const input = `# Test
+
+- [REQ-001] My requirement
+
+  The system shall debounce inputs.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      Type: NotARealType
+`;
+  const { code, stderr } = await markspec(["hook", "req.md"], {
+    files: { "req.md": input },
+  });
+  assertEquals(code, 1);
+  assertStringIncludes(stderr, "MSL-T020");
+});
+
+Deno.test("hook: no files exit 0", async () => {
+  const { code } = await markspec(["hook"], {
+    files: {},
+  });
+  assertEquals(code, 0);
+});


### PR DESCRIPTION
## Summary

Iteration 37 of the autonomous Prompt-1 follow-up loop. Implements **`markspec hook [...files]`** — replaces the `notImplemented` stub with a concrete pre-commit hook that composes `format` and `validate`.

| Commit | Slice |
|---|---|
| `6246855` | hook command + AGENTS.md docs sync |

## What lands

The hook composes existing pipelines:

- For each file passed on the command line, run `format()` in diagnostic-only mode (no write). When `result.changed` is true, emit `"needs formatting"` and flag the run as failed.
- Collect parsed entries across all files and run `runPipeline` with the active profile. Surface every diagnostic to stderr; treat any error-severity diagnostic as a failed run.
- Exit 0 when clean, 1 when any file needs formatting or any error-level diagnostic fires.
- Zero-args is a clean exit — pre-commit frameworks pass an empty argv when no tracked file matches the hook's file filter.

Canonical config for pre-commit / husky / lefthook:

```yaml
- id: markspec
  entry: markspec hook
  files: \.(md|rs|kt|java|c|cpp|h)$
```

AGENTS.md updates:

- Move `markspec hook` and `markspec mcp` from "Not yet implemented" to "Implemented". (`mcp` was already implemented in code; the table was stale.)

## Tests

| Before | After |
|---|---|
| 1033 (post-#313) | 1037 (+4 e2e: clean files exit 0, needs-format → exit 1 with "needs formatting", validation error → exit 1 with MSL-T020 surfaced, zero-args exit 0) |

All `just check` gates green per commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
