### PR TITLE
feat(cli): markspec export csv

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -210,38 +210,38 @@ pass. `CHANGELOG.md` and `docs/examples/` are excluded from dprint.
 
 ### Implemented
 
-| Command                               | Module                              | Purpose                                                                    |
-| ------------------------------------- | ----------------------------------- | -------------------------------------------------------------------------- |
-| `markspec format [...files]`          | `core/formatter`                    | Stamp ULIDs, fix indentation, normalize attributes. Pre-commit hook.       |
-| `markspec validate [...files]`        | `core/validator`                    | Check broken refs, missing Ids, malformed entries, duplicates.             |
-| `markspec compile <paths...>`         | `core/compiler`                     | Parse all files, build traceability graph, output compiled JSON.           |
-| `markspec show <id> <paths...>`       | `core/compiler`                     | Show details of a single entry by display ID or ULID.                      |
-| `markspec context <id> <paths...>`    | `core/compiler`                     | Walk the Satisfies chain upward from an entry.                             |
-| `markspec dependents <id> <paths...>` | `core/compiler`                     | List all entries that depend on a given entry.                             |
-| `markspec report <kind> <paths...>`   | `core/reporter`                     | Generate traceability matrix or coverage report.                           |
-| `markspec profile show`               | `core/profile`                      | Show the active profile chain and effective configuration.                 |
-| `markspec doctor`                     | `core/profile` + `core/validator`   | Project health check: profile, config, and validation summary.             |
-| `markspec next-id <type> <paths...>`  | `core/compiler` + `core/profile`    | Print the next available display ID for a profile-declared type.           |
-| `markspec create <type> <paths...>`   | `core/compiler` + `core/profile`    | Scaffold a new entry block for a profile-declared type (stdout).           |
-| `markspec insert <type> <file>`       | `core/compiler` + `core/profile`    | Append a scaffolded entry block to the file (agent write path).            |
-| `markspec export <format> <paths...>` | `core/compiler`                     | Emit the compiled traceability graph as json or yaml (csv, reqif pending). |
-| `markspec hook [...files]`            | `core/formatter` + `core/validator` | Pre-commit hook: run format --check + validate on the given files.         |
-| `markspec doc build <file>`           | `render/typst`                      | Single document → PDF via Typst WASM.                                      |
-| `markspec book build`                 | `book/site`                         | Multi-chapter → static HTML site.                                          |
-| `markspec lsp`                        | `lsp/server`                        | LSP server for editor integration (stdio JSON-RPC).                        |
-| `markspec mcp`                        | `mcp/server`                        | MCP server for AI agent integration (stdio JSON-RPC).                      |
+| Command                               | Module                              | Purpose                                                                     |
+| ------------------------------------- | ----------------------------------- | --------------------------------------------------------------------------- |
+| `markspec format [...files]`          | `core/formatter`                    | Stamp ULIDs, fix indentation, normalize attributes. Pre-commit hook.        |
+| `markspec validate [...files]`        | `core/validator`                    | Check broken refs, missing Ids, malformed entries, duplicates.              |
+| `markspec compile <paths...>`         | `core/compiler`                     | Parse all files, build traceability graph, output compiled JSON.            |
+| `markspec show <id> <paths...>`       | `core/compiler`                     | Show details of a single entry by display ID or ULID.                       |
+| `markspec context <id> <paths...>`    | `core/compiler`                     | Walk the Satisfies chain upward from an entry.                              |
+| `markspec dependents <id> <paths...>` | `core/compiler`                     | List all entries that depend on a given entry.                              |
+| `markspec report <kind> <paths...>`   | `core/reporter`                     | Generate traceability matrix or coverage report.                            |
+| `markspec profile show`               | `core/profile`                      | Show the active profile chain and effective configuration.                  |
+| `markspec doctor`                     | `core/profile` + `core/validator`   | Project health check: profile, config, and validation summary.              |
+| `markspec next-id <type> <paths...>`  | `core/compiler` + `core/profile`    | Print the next available display ID for a profile-declared type.            |
+| `markspec create <type> <paths...>`   | `core/compiler` + `core/profile`    | Scaffold a new entry block for a profile-declared type (stdout).            |
+| `markspec insert <type> <file>`       | `core/compiler` + `core/profile`    | Append a scaffolded entry block to the file (agent write path).             |
+| `markspec export <format> <paths...>` | `core/compiler`                     | Emit the compiled traceability graph as json, yaml, or csv (reqif pending). |
+| `markspec hook [...files]`            | `core/formatter` + `core/validator` | Pre-commit hook: run format --check + validate on the given files.          |
+| `markspec doc build <file>`           | `render/typst`                      | Single document → PDF via Typst WASM.                                       |
+| `markspec book build`                 | `book/site`                         | Multi-chapter → static HTML site.                                           |
+| `markspec lsp`                        | `lsp/server`                        | LSP server for editor integration (stdio JSON-RPC).                         |
+| `markspec mcp`                        | `mcp/server`                        | MCP server for AI agent integration (stdio JSON-RPC).                       |
 
 ### Not yet implemented
 
 These commands are registered in `main.ts` but print an error and exit. Do not
 invoke them.
 
-| Command               | Intended purpose                |
-| --------------------- | ------------------------------- |
-| `markspec export csv` | Tabular export (csv, reqif).    |
-| `markspec book dev`   | Live preview with hot reload.   |
-| `markspec deck build` | Slides → PDF via Touying/Typst. |
-| `markspec deck dev`   | Live slide preview.             |
+| Command                 | Intended purpose                |
+| ----------------------- | ------------------------------- |
+| `markspec export reqif` | ReqIF XML export.               |
+| `markspec book dev`     | Live preview with hot reload.   |
+| `markspec deck build`   | Slides → PDF via Touying/Typst. |
+| `markspec deck dev`     | Live slide preview.             |
 
 **Project context:** `format` and `validate` work file-locally without a
 `project.yaml`. All other commands (`compile`, `show`, `context`, `dependents`,

--- a/packages/markspec/main.ts
+++ b/packages/markspec/main.ts
@@ -297,6 +297,16 @@ function _escHtml(s: string): string {
   );
 }
 
+/** RFC-4180 quoting: surround with double quotes when the value contains
+ * a comma, a double quote, a carriage return, or a newline; double any
+ * embedded quotes inside. */
+function csvQuote(value: string): string {
+  if (/[",\r\n]/.test(value)) {
+    return `"${value.replaceAll('"', '""')}"`;
+  }
+  return value;
+}
+
 // ── Profile command group ─────────────────────────────────────────────
 
 const profileCmd = new Command()
@@ -707,12 +717,12 @@ const cli = new Command()
   })
   .command("export <format:string> <paths...:string>")
   .description(
-    "Emit the compiled traceability graph in json or yaml (csv, reqif pending)",
+    "Emit the compiled traceability graph in json, yaml, or csv (reqif pending)",
   )
   .action(async (_options, format: string, ...paths: string[]) => {
-    if (format !== "json" && format !== "yaml") {
+    if (format !== "json" && format !== "yaml" && format !== "csv") {
       console.error(
-        `error: unknown export format '${format}' (supported: json, yaml)`,
+        `error: unknown export format '${format}' (supported: json, yaml, csv)`,
       );
       Deno.exit(1);
     }
@@ -721,7 +731,7 @@ const cli = new Command()
     const output = serializeCompileResult(result);
     if (format === "json") {
       console.log(JSON.stringify(output, null, 2));
-    } else {
+    } else if (format === "yaml") {
       // Round-trip through JSON to strip undefined values — @std/yaml's
       // stringify throws on undefined, but the Entry shape carries
       // optional fields (type, id, properties) that may legitimately
@@ -729,6 +739,33 @@ const cli = new Command()
       const jsonSafe = JSON.parse(JSON.stringify(output));
       const { stringify } = await import("@std/yaml");
       console.log(stringify(jsonSafe));
+    } else {
+      // CSV: one row per entry, fixed-shape header. Values are
+      // RFC-4180 quoted when they contain a comma, double quote,
+      // or newline; internal quotes are doubled.
+      const headers = [
+        "displayId",
+        "title",
+        "type",
+        "shape",
+        "id",
+        "file",
+        "line",
+      ];
+      const lines = [headers.join(",")];
+      for (const entry of Object.values(output.entries)) {
+        const row = [
+          entry.displayId,
+          entry.title,
+          entry.type ?? "",
+          entry.shape,
+          entry.id ?? "",
+          entry.location.file,
+          String(entry.location.line),
+        ].map(csvQuote);
+        lines.push(row.join(","));
+      }
+      console.log(lines.join("\n"));
     }
   })
   .command("insert <type:string> <file:string>")

--- a/tests/e2e/export_test.ts
+++ b/tests/e2e/export_test.ts
@@ -57,6 +57,53 @@ Deno.test("export: unknown format fails with error", async () => {
   assertStringIncludes(stderr, "xml");
 });
 
+Deno.test("export csv: emits header row + one row per entry", async () => {
+  const { code, stdout } = await markspec(["export", "csv", "req.md"], {
+    files: BASE_FILES,
+  });
+  assertEquals(code, 0);
+  const lines = stdout.split("\n").filter((l) => l.length > 0);
+  // Header + 1 entry.
+  assertEquals(lines.length, 2);
+  assertEquals(
+    lines[0],
+    "displayId,title,type,shape,id,file,line",
+  );
+  // Row contains the display ID, title, ULID, and "req.md" location.
+  assertStringIncludes(lines[1], "REQ-001");
+  assertStringIncludes(lines[1], "First requirement");
+  assertStringIncludes(lines[1], "01HGW2Q8MNP3RSTVWXYZABCDEF");
+  assertStringIncludes(lines[1], "req.md");
+});
+
+Deno.test("export csv: quotes values that contain commas", async () => {
+  const sample = `# Example
+
+- [REQ-001] Title, with, commas
+
+  Body.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+`;
+  const { code, stdout } = await markspec(["export", "csv", "req.md"], {
+    files: { ...BASE_FILES, "req.md": sample },
+  });
+  assertEquals(code, 0);
+  const lines = stdout.split("\n").filter((l) => l.length > 0);
+  // The title cell must be quoted so commas inside don't split.
+  assertStringIncludes(lines[1], `"Title, with, commas"`);
+});
+
+Deno.test("export csv: empty project emits header only", async () => {
+  const { code, stdout } = await markspec(["export", "csv", "req.md"], {
+    files: { ...BASE_FILES, "req.md": `# Empty\n` },
+  });
+  assertEquals(code, 0);
+  const lines = stdout.split("\n").filter((l) => l.length > 0);
+  assertEquals(lines.length, 1);
+  assertEquals(lines[0], "displayId,title,type,shape,id,file,line");
+});
+
 Deno.test("export json: matches the compile --format json output", async () => {
   const exportRun = await markspec(["export", "json", "req.md"], {
     files: BASE_FILES,


### PR DESCRIPTION
## Summary

Iteration 41 of the autonomous Prompt-1 follow-up loop. Extends **`markspec export`** (json + yaml from #316) with a `csv` format. ReqIF remains on the backlog.

| Commit | Slice |
|---|---|
| `47f8008` | csv export + AGENTS.md sync |

## What lands

Fixed schema, one row per entry: `displayId, title, type, shape, id, file, line`. Iteration order matches the serialized compile result (parse order across the input files).

RFC-4180 quoting: a cell is double-quoted when it contains a comma, double quote, or newline; embedded quotes are doubled. Helper lives next to `_escHtml` in `main.ts`.

### Limitations (kept for follow-ups)

- Profile-declared trace attributes (Verifies, Satisfies, …) are not flattened into columns yet because the column set varies per profile. A `--columns ...` flag can grow this later without breaking the default.
- ReqIF XML export is still pending.

`AGENTS.md`:

- Export description widens to include csv.
- Not-yet-implemented entry renamed `markspec export reqif`.

## Tests

| Before | After |
|---|---|
| 1050 (post-#317) | 1053 (+3 e2e: header + one row, RFC-4180 quoting when a title contains commas, empty project emits header only) |

All `just check` gates green per commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
