### PR TITLE
feat(lsp): prepareRename for tighter rename UX

### DIFF
--- a/packages/markspec/lsp/rename.ts
+++ b/packages/markspec/lsp/rename.ts
@@ -23,6 +23,54 @@ export interface TextEdit {
 /** Display-ID character set — letters, digits, dot, slash, hyphen, underscore. */
 const ID_CHAR_RE = /[A-Za-z0-9._/-]/;
 
+/** Whole-token display-ID grammar — must look like an identifier (≥3 chars, starts with alphanumeric). */
+const DISPLAY_ID_TOKEN_RE = /^[A-Za-z0-9][A-Za-z0-9._/-]{2,}$/;
+
+/** Result of {@linkcode prepareRenameRange}. */
+export interface PrepareRenameResult {
+  readonly range: {
+    readonly start: { readonly line: number; readonly character: number };
+    readonly end: { readonly line: number; readonly character: number };
+  };
+  readonly placeholder: string;
+}
+
+/**
+ * Validate that the cursor sits on a renameable display ID and return
+ * the LSP `prepareRename` response payload: the exact range of the
+ * token plus the placeholder text the editor pre-fills in the rename
+ * input.
+ *
+ * Returns `null` when:
+ *   - the cursor lies on whitespace or past the line end, or
+ *   - the token at that position doesn't satisfy the display-ID
+ *     grammar (≥3 chars, alphanumeric start, valid ID chars only).
+ *
+ * The returned range covers only the display-ID token so the rename
+ * UI underlines the right span.
+ */
+export function prepareRenameRange(
+  line: string,
+  column: number,
+  lspLine: number,
+): PrepareRenameResult | null {
+  if (column < 0 || column >= line.length) return null;
+  if (/\s/.test(line[column])) return null;
+  let start = column;
+  while (start > 0 && ID_CHAR_RE.test(line[start - 1])) start--;
+  let end = column;
+  while (end < line.length && ID_CHAR_RE.test(line[end])) end++;
+  const token = line.slice(start, end);
+  if (!DISPLAY_ID_TOKEN_RE.test(token)) return null;
+  return {
+    range: {
+      start: { line: lspLine, character: start },
+      end: { line: lspLine, character: end },
+    },
+    placeholder: token,
+  };
+}
+
 /**
  * Walk every line of `text`, scan for `oldId`, and emit a TextEdit
  * for each whole-token occurrence that replaces it with `newId`.

--- a/packages/markspec/lsp/rename_test.ts
+++ b/packages/markspec/lsp/rename_test.ts
@@ -7,7 +7,7 @@
  */
 
 import { assertEquals } from "@std/assert";
-import { findIdOccurrencesInFile } from "./rename.ts";
+import { findIdOccurrencesInFile, prepareRenameRange } from "./rename.ts";
 
 Deno.test("findIdOccurrencesInFile: finds bracketed declaration", () => {
   const text = `# Test
@@ -69,4 +69,37 @@ Deno.test("findIdOccurrencesInFile: empty text yields empty result", () => {
 Deno.test("findIdOccurrencesInFile: no match yields empty result", () => {
   const text = `- [TST-001] Just a test\n\n  Body.\n`;
   assertEquals(findIdOccurrencesInFile(text, "REQ-001", "REQ-100"), []);
+});
+
+// --- prepareRenameRange ---
+
+Deno.test("prepareRenameRange: returns range + placeholder when cursor is on a display ID", () => {
+  const line = "      Satisfies: REQ-001";
+  const result = prepareRenameRange(line, 20, 5);
+  assertEquals(result, {
+    range: {
+      start: { line: 5, character: 17 },
+      end: { line: 5, character: 24 },
+    },
+    placeholder: "REQ-001",
+  });
+});
+
+Deno.test("prepareRenameRange: returns null when cursor lies on whitespace", () => {
+  const line = "      Satisfies:    ";
+  assertEquals(prepareRenameRange(line, 19, 3), null);
+});
+
+Deno.test("prepareRenameRange: returns null when cursor lands on a short token", () => {
+  const line = "- [REQ-001] my requirement";
+  // Cursor on the word 'my' — too short to be a display ID.
+  assertEquals(prepareRenameRange(line, 13, 0), null);
+});
+
+Deno.test("prepareRenameRange: handles bracketed declaration", () => {
+  const line = "- [REQ-001] Title";
+  const result = prepareRenameRange(line, 5, 0);
+  assertEquals(result?.placeholder, "REQ-001");
+  assertEquals(result?.range.start.character, 3);
+  assertEquals(result?.range.end.character, 10);
 });

--- a/packages/markspec/lsp/server.ts
+++ b/packages/markspec/lsp/server.ts
@@ -42,7 +42,7 @@ import { groupDiagnosticsByFile, toLspDiagnostic } from "./diagnostics.ts";
 import { entryToLspLocation } from "./definition.ts";
 import { displayIdAtPosition, formatHoverContent } from "./hover.ts";
 import { findReferencingEntries } from "./references.ts";
-import { findIdOccurrencesInFile } from "./rename.ts";
+import { findIdOccurrencesInFile, prepareRenameRange } from "./rename.ts";
 import {
   entriesToDocumentSymbols,
   entriesToWorkspaceSymbols,
@@ -239,7 +239,7 @@ connection.onInitialize(
         referencesProvider: true,
         documentSymbolProvider: true,
         workspaceSymbolProvider: true,
-        renameProvider: true,
+        renameProvider: { prepareProvider: true },
       },
     };
   },
@@ -518,6 +518,29 @@ connection.onWorkspaceSymbol((params) => {
 // ---------------------------------------------------------------------------
 // Rename (workspace-wide rename of a display ID)
 // ---------------------------------------------------------------------------
+
+connection.onPrepareRename((params) => {
+  const document = documents.get(params.textDocument.uri);
+  if (!document) return null;
+
+  const filePath = uriToPath(params.textDocument.uri);
+  if (isSourceFile(filePath)) {
+    const lines = document.getText().split("\n");
+    if (!isDocCommentContext(lines, params.position.line)) {
+      return null;
+    }
+  }
+
+  const line = document.getText({
+    start: { line: params.position.line, character: 0 },
+    end: { line: params.position.line, character: Number.MAX_SAFE_INTEGER },
+  });
+  return prepareRenameRange(
+    line,
+    params.position.character,
+    params.position.line,
+  );
+});
 
 connection.onRenameRequest(async (params) => {
   const document = documents.get(params.textDocument.uri);


### PR DESCRIPTION
## Summary

Iteration 42 of the autonomous Prompt-1 follow-up loop. Adds **`textDocument/prepareRename`** alongside the rename provider from #312 so editors can refuse rename on non-symbols rather than silently producing an empty edit.

| Commit | Slice |
|---|---|
| `eaa1dd1` | LSP prepareRename |

## What lands

When the editor invokes "Rename Symbol", it first asks the server whether the cursor sits on a renameable token and gets back the exact token range plus the placeholder text for the rename popup.

[packages/markspec/lsp/rename.ts](packages/markspec/lsp/rename.ts):

- `prepareRenameRange(line, column, lspLine)` returns `null` when the cursor lies on whitespace, past the line end, or on a non-display-ID token (short tokens like prose words). Otherwise returns `{ range, placeholder }` covering the token.
- Uses the same display-ID character set and ≥3-char alphanumeric-start grammar that `displayIdAtPosition` enforces, so prepare and rename agree on which tokens qualify.

[packages/markspec/lsp/server.ts](packages/markspec/lsp/server.ts):

- Capability widens from `renameProvider: true` to `renameProvider: { prepareProvider: true }`.
- `onPrepareRename` mirrors the rename handler's setup (source-file doc-comment guard + line read) and delegates to the helper.

## Tests

| Before | After |
|---|---|
| 1053 (post-#318) | 1057 (+4 unit tests for `prepareRenameRange`: happy path, whitespace rejection, short-token rejection, bracketed declaration) |

All `just check` gates green per commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
