### PR TITLE
feat(lsp): folding ranges for entry blocks

### DIFF
--- a/packages/markspec/lsp/folding.ts
+++ b/packages/markspec/lsp/folding.ts
@@ -1,0 +1,55 @@
+/**
+ * @module lsp/folding
+ *
+ * Folding-range helper. One foldable region per entry block; each
+ * region spans from the entry's title line to one line before the
+ * next entry's title line (or to the document's last line for the
+ * final entry).
+ *
+ * Single-line regions (start == end) are dropped because folding a
+ * one-line block does nothing useful and just clutters the gutter.
+ *
+ * This is a heuristic — it doesn't try to track the precise
+ * trailer-block end line. A future iteration can tighten the end
+ * line once the parser surfaces per-entry end positions.
+ */
+
+import type { Entry } from "../core/model/mod.ts";
+
+/** A subset of the LSP `FoldingRange` interface. */
+export interface FoldingRange {
+  readonly startLine: number;
+  readonly endLine: number;
+  readonly kind?: string;
+}
+
+/**
+ * Convert a file's entries to FoldingRanges. `totalLines` is the
+ * 1-based count of lines in the document (used to bound the last
+ * entry's fold range).
+ */
+export function entriesToFoldingRanges(
+  entries: readonly Entry[],
+  totalLines: number,
+): FoldingRange[] {
+  if (entries.length === 0) return [];
+  const sorted = [...entries].sort(
+    (a, b) => a.location.line - b.location.line,
+  );
+  const ranges: FoldingRange[] = [];
+  for (let i = 0; i < sorted.length; i++) {
+    const start = sorted[i].location.line;
+    const nextStart = i + 1 < sorted.length
+      ? sorted[i + 1].location.line
+      : totalLines + 1;
+    const end = nextStart - 1;
+    // LSP uses 0-based lines; convert and skip single-line regions.
+    if (end <= start) continue;
+    ranges.push({
+      startLine: start - 1,
+      endLine: end - 1,
+      kind: "region",
+    });
+  }
+  return ranges;
+}

--- a/packages/markspec/lsp/folding_test.ts
+++ b/packages/markspec/lsp/folding_test.ts
@@ -1,0 +1,75 @@
+/**
+ * @module lsp/folding_test
+ *
+ * Unit tests for {@linkcode entriesToFoldingRanges} — one foldable
+ * region per entry block, spanning from the entry's title line to
+ * one line before the next entry (or the file's last line for the
+ * final entry).
+ */
+
+import { assertEquals } from "@std/assert";
+import type { Entry } from "../core/model/mod.ts";
+import { entriesToFoldingRanges } from "./folding.ts";
+
+function makeEntry(displayId: string, line: number): Entry {
+  return {
+    displayId,
+    title: displayId,
+    body: "",
+    rawAttributes: [{ key: "Id", value: "01HGW2Q8MNP3RSTVWXYZABCDEF" }],
+    typedAttributes: new Map(),
+    id: "01HGW2Q8MNP3RSTVWXYZABCDEF",
+    shape: "identified",
+    location: { file: "t.md", line, column: 1 },
+    source: "markdown",
+  };
+}
+
+Deno.test("entriesToFoldingRanges: empty entries yields empty array", () => {
+  assertEquals(entriesToFoldingRanges([], 10), []);
+});
+
+Deno.test("entriesToFoldingRanges: single entry folds to end of file", () => {
+  const entries = [makeEntry("REQ-001", 3)];
+  // Total document is 10 lines (1-based count); fold from entry start
+  // to last line.
+  const ranges = entriesToFoldingRanges(entries, 10);
+  assertEquals(ranges.length, 1);
+  // LSP uses 0-based line numbers.
+  assertEquals(ranges[0].startLine, 2);
+  assertEquals(ranges[0].endLine, 9);
+});
+
+Deno.test("entriesToFoldingRanges: two entries fold up to the next entry's previous line", () => {
+  const entries = [
+    makeEntry("REQ-001", 3),
+    makeEntry("REQ-002", 9),
+  ];
+  const ranges = entriesToFoldingRanges(entries, 15);
+  assertEquals(ranges.length, 2);
+  // REQ-001: lines 3 to 8 (1-based) → 2 to 7 (0-based).
+  assertEquals(ranges[0].startLine, 2);
+  assertEquals(ranges[0].endLine, 7);
+  // REQ-002: lines 9 to 15 → 8 to 14.
+  assertEquals(ranges[1].startLine, 8);
+  assertEquals(ranges[1].endLine, 14);
+});
+
+Deno.test("entriesToFoldingRanges: drops single-line entries (start == end)", () => {
+  // If two entries are on adjacent lines, the first's range collapses
+  // to a single line and shouldn't be returned — folding a 1-line
+  // region is meaningless.
+  const entries = [
+    makeEntry("REQ-001", 3),
+    makeEntry("REQ-002", 4),
+  ];
+  const ranges = entriesToFoldingRanges(entries, 20);
+  assertEquals(ranges.length, 1);
+  assertEquals(ranges[0].startLine, 3);
+});
+
+Deno.test("entriesToFoldingRanges: kind defaults to 'region'", () => {
+  const entries = [makeEntry("REQ-001", 1)];
+  const ranges = entriesToFoldingRanges(entries, 10);
+  assertEquals(ranges[0].kind, "region");
+});

--- a/packages/markspec/lsp/server.ts
+++ b/packages/markspec/lsp/server.ts
@@ -41,6 +41,7 @@ import { WorkspaceIndex } from "./workspace.ts";
 import { groupDiagnosticsByFile, toLspDiagnostic } from "./diagnostics.ts";
 import { entryToLspLocation } from "./definition.ts";
 import { displayIdAtPosition, formatHoverContent } from "./hover.ts";
+import { entriesToFoldingRanges } from "./folding.ts";
 import { findReferencingEntries } from "./references.ts";
 import { findIdOccurrencesInFile, prepareRenameRange } from "./rename.ts";
 import {
@@ -240,6 +241,7 @@ connection.onInitialize(
         documentSymbolProvider: true,
         workspaceSymbolProvider: true,
         renameProvider: { prepareProvider: true },
+        foldingRangeProvider: true,
       },
     };
   },
@@ -583,6 +585,21 @@ connection.onRenameRequest(async (params) => {
     }
   }
   return { changes };
+});
+
+// ---------------------------------------------------------------------------
+// Folding ranges (one foldable region per entry block)
+// ---------------------------------------------------------------------------
+
+connection.onFoldingRanges((params) => {
+  const document = documents.get(params.textDocument.uri);
+  if (!document) return null;
+  const filePath = uriToPath(params.textDocument.uri);
+  if (!isMarkspecFile(filePath)) return null;
+  const entries = index.getEntriesForFile(filePath);
+  const totalLines = document.getText().split("\n").length;
+  // deno-lint-ignore no-explicit-any
+  return entriesToFoldingRanges(entries, totalLines) as any;
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Iteration 43 of the autonomous Prompt-1 follow-up loop. Adds **LSP folding ranges** — editors now put a fold marker per entry block, so collapsing hides title + body + trailers and leaves only surrounding prose.

| Commit | Slice |
|---|---|
| `37d98fb` | LSP folding ranges |

## What lands

[packages/markspec/lsp/folding.ts](packages/markspec/lsp/folding.ts):

- `entriesToFoldingRanges(entries, totalLines)` sorts entries by start line and emits one `FoldingRange` each. The range runs from the entry's title line to one line before the next entry's title line; the last entry extends to the document's last line.
- Drops single-line regions (start == end) — folding a one-line block isn't useful.
- Heuristic: doesn't yet track precise trailer-block end. Once the parser surfaces per-entry end positions, the helper can tighten bounds without changing callers.

[packages/markspec/lsp/server.ts](packages/markspec/lsp/server.ts):

- Advertises `foldingRangeProvider: true`.
- `onFoldingRanges` filters to MarkSpec files, pulls entries for the file from the index, delegates to the helper using the open document's line count.

## Tests

| Before | After |
|---|---|
| 1057 (post-#319) | 1062 (+5 unit tests: empty entries, single entry → end of file, two entries → next-entry boundary, single-line skip, `kind: "region"` default) |

All `just check` gates green per commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
