### PR TITLE
feat(lsp): document highlights for display IDs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,7 +72,8 @@ markspec/
 │       │   ├── server.ts            ← LSP server entry point (stdio JSON-RPC).
 │       │   │                          Capabilities: diagnostics, completions,
 │       │   │                          hover, definition, references, document /
-│       │   │                          workspace symbols, rename.
+│       │   │                          workspace symbols, rename, folding,
+│       │   │                          document highlights.
 │       │   ├── workspace.ts         ← in-memory entry index, incremental updates
 │       │   ├── diagnostics.ts       ← core Diagnostic → LSP Diagnostic bridge
 │       │   ├── completions.ts       ← block scaffold + ID reference + Type:
@@ -82,10 +83,13 @@ markspec/
 │       │   ├── definition.ts        ← Entry → LSP Location for go-to-definition
 │       │   ├── references.ts        ← find-all-references: walks entry
 │       │   │                          attributes for whole-token matches
-│       │   ├── rename.ts            ← workspace rename: whole-token text edits
-│       │   │                          across every tracked file
+│       │   ├── rename.ts            ← workspace rename + prepareRename:
+│       │   │                          whole-token text edits across every file
 │       │   ├── symbols.ts           ← document-symbol (outline) + workspace-
 │       │   │                          symbol (fuzzy entry search) builders
+│       │   ├── folding.ts           ← one foldable region per entry block
+│       │   ├── highlights.ts        ← document highlights (read / write) for
+│       │   │                          whole-token display-ID matches in file
 │       │   ├── context.ts           ← doc comment context guard (source files)
 │       │   └── util.ts              ← URI↔path conversion, debounce
 │       └── mcp/
@@ -124,6 +128,7 @@ alone:**
 @packages/markspec/lsp/completions.ts @packages/markspec/lsp/hover.ts
 @packages/markspec/lsp/definition.ts @packages/markspec/lsp/references.ts
 @packages/markspec/lsp/rename.ts @packages/markspec/lsp/symbols.ts
+@packages/markspec/lsp/folding.ts @packages/markspec/lsp/highlights.ts
 @packages/markspec/lsp/context.ts @packages/markspec/lsp/diagnostics.ts
 @packages/markspec/lsp/util.ts @packages/markspec/main.ts
 

--- a/packages/markspec/lsp/highlights.ts
+++ b/packages/markspec/lsp/highlights.ts
@@ -1,0 +1,77 @@
+/**
+ * @module lsp/highlights
+ *
+ * Document-highlights helper. Locates every whole-token occurrence
+ * of a display ID in a single file's text and returns LSP
+ * `DocumentHighlight[]` payloads so the editor can highlight all
+ * matches when the cursor sits on a display-ID token.
+ *
+ * The declaration site (bracketed token on a title line, e.g.
+ * `- [REQ-001] Title`) is classified as `Write`; every other
+ * occurrence is `Read`. This matches the LSP/IDE convention where
+ * a "write" highlight marks the symbol's binding location and
+ * "read" marks usages.
+ */
+
+/** Display-ID character set — letters, digits, dot, slash, hyphen, underscore. */
+const ID_CHAR_RE = /[A-Za-z0-9._/-]/;
+
+/** LSP `DocumentHighlightKind` numeric constants (spec §). */
+export const DocumentHighlightKindText = 1;
+export const DocumentHighlightKindRead = 2;
+export const DocumentHighlightKindWrite = 3;
+
+/** A subset of the LSP `DocumentHighlight` interface. */
+export interface DocumentHighlight {
+  readonly range: {
+    readonly start: { readonly line: number; readonly character: number };
+    readonly end: { readonly line: number; readonly character: number };
+  };
+  readonly kind: number;
+}
+
+/**
+ * Walk every line of `text` and emit one `DocumentHighlight` per
+ * whole-token occurrence of `displayId`. The token at the start of
+ * a Markdown list-item bracket (`- [REQ-001]`) is classified as
+ * `Write` — it's the declaration. All other matches are `Read`.
+ */
+export function findOccurrencesInFile(
+  text: string,
+  displayId: string,
+): DocumentHighlight[] {
+  if (displayId.length === 0) return [];
+  const out: DocumentHighlight[] = [];
+  const lines = text.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    let start = 0;
+    while (true) {
+      const idx = line.indexOf(displayId, start);
+      if (idx < 0) break;
+      const before = idx === 0 ? "" : line[idx - 1];
+      const after = idx + displayId.length >= line.length
+        ? ""
+        : line[idx + displayId.length];
+      const boundedLeft = before === "" || !ID_CHAR_RE.test(before);
+      const boundedRight = after === "" || !ID_CHAR_RE.test(after);
+      if (boundedLeft && boundedRight) {
+        // Declaration heuristic: the character immediately before the
+        // token is `[`. Holds for both `- [REQ-001]` title lines and
+        // any reference written with brackets.
+        const kind = before === "["
+          ? DocumentHighlightKindWrite
+          : DocumentHighlightKindRead;
+        out.push({
+          range: {
+            start: { line: i, character: idx },
+            end: { line: i, character: idx + displayId.length },
+          },
+          kind,
+        });
+      }
+      start = idx + displayId.length;
+    }
+  }
+  return out;
+}

--- a/packages/markspec/lsp/highlights_test.ts
+++ b/packages/markspec/lsp/highlights_test.ts
@@ -1,0 +1,72 @@
+/**
+ * @module lsp/highlights_test
+ *
+ * Unit tests for {@linkcode findOccurrencesInFile} — the document-
+ * highlights helper that locates every whole-token occurrence of a
+ * display ID in a file's text and returns LSP `DocumentHighlight`
+ * payloads.
+ */
+
+import { assertEquals } from "@std/assert";
+import {
+  DocumentHighlightKindRead,
+  DocumentHighlightKindText,
+  DocumentHighlightKindWrite,
+  findOccurrencesInFile,
+} from "./highlights.ts";
+
+Deno.test("findOccurrencesInFile: bracketed declaration is a Write kind", () => {
+  const text = `- [REQ-001] My req\n\n  Body.\n`;
+  const highlights = findOccurrencesInFile(text, "REQ-001");
+  assertEquals(highlights.length, 1);
+  assertEquals(highlights[0].kind, DocumentHighlightKindWrite);
+  assertEquals(highlights[0].range.start.line, 0);
+  assertEquals(highlights[0].range.start.character, 3);
+  assertEquals(highlights[0].range.end.character, 10);
+});
+
+Deno.test("findOccurrencesInFile: trace-attribute reference is a Read kind", () => {
+  const text = `- [TST-001] My test
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      Verifies: REQ-001
+`;
+  const highlights = findOccurrencesInFile(text, "REQ-001");
+  assertEquals(highlights.length, 1);
+  assertEquals(highlights[0].kind, DocumentHighlightKindRead);
+});
+
+Deno.test("findOccurrencesInFile: multiple occurrences across lines", () => {
+  const text = `- [REQ-001] First
+
+      Satisfies: SYS-001
+
+- [REQ-002] Second
+
+      Satisfies: REQ-001
+`;
+  const highlights = findOccurrencesInFile(text, "REQ-001");
+  assertEquals(highlights.length, 2);
+  // Declaration first (line 0), then reference (line 6).
+  assertEquals(highlights[0].kind, DocumentHighlightKindWrite);
+  assertEquals(highlights[1].kind, DocumentHighlightKindRead);
+});
+
+Deno.test("findOccurrencesInFile: whole-token only", () => {
+  const text = `- [REQ-0010] Renamed sibling
+
+      Satisfies: REQ-001-extra
+`;
+  assertEquals(findOccurrencesInFile(text, "REQ-001"), []);
+});
+
+Deno.test("findOccurrencesInFile: empty input yields empty result", () => {
+  assertEquals(findOccurrencesInFile("", "REQ-001"), []);
+});
+
+Deno.test("findOccurrencesInFile: kind constants are the LSP-defined integers", () => {
+  // Spec: Text=1, Read=2, Write=3.
+  assertEquals(DocumentHighlightKindText, 1);
+  assertEquals(DocumentHighlightKindRead, 2);
+  assertEquals(DocumentHighlightKindWrite, 3);
+});

--- a/packages/markspec/lsp/server.ts
+++ b/packages/markspec/lsp/server.ts
@@ -42,6 +42,7 @@ import { groupDiagnosticsByFile, toLspDiagnostic } from "./diagnostics.ts";
 import { entryToLspLocation } from "./definition.ts";
 import { displayIdAtPosition, formatHoverContent } from "./hover.ts";
 import { entriesToFoldingRanges } from "./folding.ts";
+import { findOccurrencesInFile } from "./highlights.ts";
 import { findReferencingEntries } from "./references.ts";
 import { findIdOccurrencesInFile, prepareRenameRange } from "./rename.ts";
 import {
@@ -242,6 +243,7 @@ connection.onInitialize(
         workspaceSymbolProvider: true,
         renameProvider: { prepareProvider: true },
         foldingRangeProvider: true,
+        documentHighlightProvider: true,
       },
     };
   },
@@ -585,6 +587,32 @@ connection.onRenameRequest(async (params) => {
     }
   }
   return { changes };
+});
+
+// ---------------------------------------------------------------------------
+// Document highlights (mark every occurrence in the current file)
+// ---------------------------------------------------------------------------
+
+connection.onDocumentHighlight((params) => {
+  const document = documents.get(params.textDocument.uri);
+  if (!document) return null;
+
+  const filePath = uriToPath(params.textDocument.uri);
+  if (isSourceFile(filePath)) {
+    const lines = document.getText().split("\n");
+    if (!isDocCommentContext(lines, params.position.line)) {
+      return null;
+    }
+  }
+
+  const line = document.getText({
+    start: { line: params.position.line, character: 0 },
+    end: { line: params.position.line, character: Number.MAX_SAFE_INTEGER },
+  });
+  const id = displayIdAtPosition(line, params.position.character);
+  if (!id) return null;
+  // deno-lint-ignore no-explicit-any
+  return findOccurrencesInFile(document.getText(), id) as any;
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Iteration 44 of the autonomous Prompt-1 follow-up loop. Adds **LSP document highlights** so editors highlight every whole-token occurrence of the symbol under the cursor in the current file. Completes the in-file navigation triad alongside hover (#307) and definition (#308).

| Commit | Slice |
|---|---|
| `98e591c` | LSP document highlights + AGENTS.md sync |

## What lands

[packages/markspec/lsp/highlights.ts](packages/markspec/lsp/highlights.ts):

- `findOccurrencesInFile(text, displayId)` scans each line for whole-token matches (same `[A-Za-z0-9._/-]` boundary rules as hover / definition / references / rename) and classifies each: the bracketed declaration (`- [REQ-001]`) is `Write`, every other occurrence is `Read`.
- Exports `DocumentHighlightKindText | Read | Write` constants so tests assert against names rather than magic numbers.

[packages/markspec/lsp/server.ts](packages/markspec/lsp/server.ts):

- Advertises `documentHighlightProvider: true`.
- `onDocumentHighlight` mirrors hover/definition: reads the cursor line, extracts via `displayIdAtPosition`, scans the open document, returns the highlight array.

`AGENTS.md`:

- Repository tree gains rows for `lsp/folding.ts` (#320) and `lsp/highlights.ts`; the server.ts capabilities one-liner widens to mention folding + document highlights.
- "Read these files" pointer list includes both new modules.

## Tests

| Before | After |
|---|---|
| 1062 (post-#320) | 1068 (+6 unit tests: declaration → Write, trace-attribute reference → Read, mixed-kind multiple, whole-token boundary, empty input, kind constants) |

All `just check` gates green per commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
