### PR TITLE
feat(lsp): code action quick fix for MSL-M060

### DIFF
--- a/packages/markspec/lsp/code_actions.ts
+++ b/packages/markspec/lsp/code_actions.ts
@@ -1,0 +1,87 @@
+/**
+ * @module lsp/code_actions
+ *
+ * Code-action builder. Walks the diagnostics the editor has on a
+ * range and emits LSP `CodeAction[]` quick fixes for the ones
+ * MarkSpec knows how to mechanically repair.
+ *
+ * Currently handles:
+ *
+ *   - **MSL-M060** — uppercase modal keyword in body prose. Action:
+ *     replace the keyword with its lowercase form. Single-token
+ *     (`SHALL`, `SHOULD`, `MAY`, `MUST`) and two-token (`MUST NOT`,
+ *     etc.) forms both supported.
+ *
+ * The validator already emits MSL-M060 with a per-character
+ * position pointing at the keyword's start, so the fix's range is
+ * `[start, start + keyword.length]`. The keyword itself comes from
+ * the diagnostic message (`'<keyword>'`).
+ */
+
+/** A subset of the LSP `Diagnostic` interface — just what the
+ * code-action walker needs. */
+export interface LspDiagnosticLike {
+  readonly code: string;
+  readonly severity?: number;
+  readonly message: string;
+  readonly range: {
+    readonly start: { readonly line: number; readonly character: number };
+    readonly end: { readonly line: number; readonly character: number };
+  };
+}
+
+/** A subset of the LSP `TextEdit` interface. */
+export interface TextEdit {
+  readonly range: {
+    readonly start: { readonly line: number; readonly character: number };
+    readonly end: { readonly line: number; readonly character: number };
+  };
+  readonly newText: string;
+}
+
+/** A subset of the LSP `CodeAction` interface. */
+export interface CodeAction {
+  readonly title: string;
+  readonly kind: string;
+  readonly diagnostics?: readonly LspDiagnosticLike[];
+  readonly isPreferred?: boolean;
+  readonly edit?: { readonly changes?: Record<string, TextEdit[]> };
+}
+
+/** Capture the keyword inside `'…'` in an MSL-M060 message. */
+const KEYWORD_RE = /modal keyword '([^']+)'/;
+
+/**
+ * Build quick-fix actions for the supplied diagnostics. Returns an
+ * empty array when none of the diagnostics has a known fix.
+ */
+export function buildCodeActions(
+  uri: string,
+  diagnostics: readonly LspDiagnosticLike[],
+): CodeAction[] {
+  const out: CodeAction[] = [];
+  for (const diag of diagnostics) {
+    if (diag.code !== "MSL-M060") continue;
+    const match = KEYWORD_RE.exec(diag.message);
+    if (!match) continue;
+    const keyword = match[1];
+    const lowercase = keyword.toLowerCase();
+    const startLine = diag.range.start.line;
+    const startChar = diag.range.start.character;
+    const edit: TextEdit = {
+      range: {
+        start: { line: startLine, character: startChar },
+        end: { line: startLine, character: startChar + keyword.length },
+      },
+      newText: lowercase,
+    };
+    out.push({
+      title: `Lowercase '${lowercase}'`,
+      kind: "quickfix",
+      diagnostics: [diag],
+      isPreferred: true,
+      edit: { changes: { [uri]: [edit] } },
+    });
+  }
+  return out;
+}

--- a/packages/markspec/lsp/code_actions_test.ts
+++ b/packages/markspec/lsp/code_actions_test.ts
@@ -1,0 +1,94 @@
+/**
+ * @module lsp/code_actions_test
+ *
+ * Unit tests for {@linkcode buildCodeActions} — produces LSP code
+ * actions (quick fixes) for the diagnostics MarkSpec knows how to
+ * mechanically repair.
+ */
+
+import { assertEquals } from "@std/assert";
+import { buildCodeActions, type LspDiagnosticLike } from "./code_actions.ts";
+
+function diag(opts: {
+  code: string;
+  message: string;
+  line: number;
+  character: number;
+}): LspDiagnosticLike {
+  return {
+    code: opts.code,
+    severity: 2,
+    message: opts.message,
+    range: {
+      start: { line: opts.line, character: opts.character },
+      end: { line: opts.line, character: Number.MAX_SAFE_INTEGER },
+    },
+  };
+}
+
+Deno.test("buildCodeActions: MSL-M060 → lowercase keyword quick fix", () => {
+  const actions = buildCodeActions("file:///x.md", [
+    diag({
+      code: "MSL-M060",
+      message: "REQ-001: modal keyword 'SHALL' in body prose is uppercase",
+      line: 4,
+      character: 14,
+    }),
+  ]);
+  assertEquals(actions.length, 1);
+  const a = actions[0];
+  assertEquals(a.title, "Lowercase 'shall'");
+  assertEquals(a.kind, "quickfix");
+  assertEquals(a.isPreferred, true);
+  const edit = a.edit!.changes!["file:///x.md"][0];
+  assertEquals(edit.newText, "shall");
+  assertEquals(edit.range.start.line, 4);
+  assertEquals(edit.range.start.character, 14);
+  assertEquals(edit.range.end.line, 4);
+  // 'SHALL' is 5 chars.
+  assertEquals(edit.range.end.character, 19);
+});
+
+Deno.test("buildCodeActions: MSL-M060 with NOT suffix → lowercases both tokens", () => {
+  const actions = buildCodeActions("file:///x.md", [
+    diag({
+      code: "MSL-M060",
+      message: "REQ-001: modal keyword 'MUST NOT' in body prose is uppercase",
+      line: 0,
+      character: 10,
+    }),
+  ]);
+  assertEquals(actions.length, 1);
+  const edit = actions[0].edit!.changes!["file:///x.md"][0];
+  assertEquals(edit.newText, "must not");
+  assertEquals(edit.range.end.character, 18);
+});
+
+Deno.test("buildCodeActions: unrelated diagnostic code yields no action", () => {
+  const actions = buildCodeActions("file:///x.md", [
+    diag({
+      code: "MSL-T020",
+      message: "REQ-001: Type: 'NotARealType' is not a core type",
+      line: 5,
+      character: 0,
+    }),
+  ]);
+  assertEquals(actions, []);
+});
+
+Deno.test("buildCodeActions: empty diagnostics list yields empty actions", () => {
+  assertEquals(buildCodeActions("file:///x.md", []), []);
+});
+
+Deno.test("buildCodeActions: MSL-M060 with malformed message yields no action", () => {
+  // Missing the 'KEYWORD' single-quoted token in the message.
+  const actions = buildCodeActions("file:///x.md", [
+    diag({
+      code: "MSL-M060",
+      message: "REQ-001: something went wrong",
+      line: 0,
+      character: 0,
+    }),
+  ]);
+  assertEquals(actions, []);
+});

--- a/packages/markspec/lsp/server.ts
+++ b/packages/markspec/lsp/server.ts
@@ -39,6 +39,7 @@ import {
 } from "../core/mod.ts";
 import { WorkspaceIndex } from "./workspace.ts";
 import { groupDiagnosticsByFile, toLspDiagnostic } from "./diagnostics.ts";
+import { buildCodeActions } from "./code_actions.ts";
 import { entryToLspLocation } from "./definition.ts";
 import { displayIdAtPosition, formatHoverContent } from "./hover.ts";
 import { entriesToFoldingRanges } from "./folding.ts";
@@ -244,6 +245,7 @@ connection.onInitialize(
         renameProvider: { prepareProvider: true },
         foldingRangeProvider: true,
         documentHighlightProvider: true,
+        codeActionProvider: { codeActionKinds: ["quickfix"] },
       },
     };
   },
@@ -587,6 +589,19 @@ connection.onRenameRequest(async (params) => {
     }
   }
   return { changes };
+});
+
+// ---------------------------------------------------------------------------
+// Code actions (quick fixes for diagnostics)
+// ---------------------------------------------------------------------------
+
+connection.onCodeAction((params) => {
+  const filePath = uriToPath(params.textDocument.uri);
+  if (!isMarkspecFile(filePath)) return null;
+  // deno-lint-ignore no-explicit-any
+  const diagnostics = params.context.diagnostics as any;
+  // deno-lint-ignore no-explicit-any
+  return buildCodeActions(params.textDocument.uri, diagnostics) as any;
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Iteration 45 of the autonomous Prompt-1 follow-up loop. Adds **LSP code actions** so editors offer one-click quick fixes for diagnostics MarkSpec knows how to repair. Initial coverage: MSL-M060 (uppercase modal keyword).

| Commit | Slice |
|---|---|
| `957a53c` | LSP code actions (MSL-M060 quick fix) |

## What lands

[packages/markspec/lsp/code_actions.ts](packages/markspec/lsp/code_actions.ts):

- `buildCodeActions(uri, diagnostics)` walks each diagnostic. On **MSL-M060** it parses the keyword from the message (`'<KEYWORD>'`) and builds a `WorkspaceEdit` replacing the range `[start, start + keyword.length]` with the lowercase form. Single-token (`SHALL` → `shall`) and two-token (`MUST NOT` → `must not`) forms both work.
- Action carries `isPreferred: true` so the editor auto-applies with the keyboard shortcut.
- Unrelated codes and malformed messages return no action — safer than emitting a broken fix.

[packages/markspec/lsp/server.ts](packages/markspec/lsp/server.ts):

- Advertises `codeActionProvider: { codeActionKinds: ["quickfix"] }`.
- `onCodeAction` filters to MarkSpec files and delegates to the helper.

The module is structured to grow: future fixes (MSL-T020 type suggestions, MSL-A030 generated-attr removal, MSL-A013 duplicate-key removal, …) drop in alongside the M060 branch without touching the server.

## Tests

| Before | After |
|---|---|
| 1068 (post-#321) | 1073 (+5 unit tests: single-token, two-token NOT, unrelated code → no action, empty input, malformed message → no action) |

All `just check` gates green per commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
