### PR TITLE
feat(lsp): code action quick fix for MSL-A030

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,7 +73,7 @@ markspec/
 │       │   │                          Capabilities: diagnostics, completions,
 │       │   │                          hover, definition, references, document /
 │       │   │                          workspace symbols, rename, folding,
-│       │   │                          document highlights.
+│       │   │                          document highlights, code actions.
 │       │   ├── workspace.ts         ← in-memory entry index, incremental updates
 │       │   ├── diagnostics.ts       ← core Diagnostic → LSP Diagnostic bridge
 │       │   ├── completions.ts       ← block scaffold + ID reference + Type:
@@ -90,6 +90,8 @@ markspec/
 │       │   ├── folding.ts           ← one foldable region per entry block
 │       │   ├── highlights.ts        ← document highlights (read / write) for
 │       │   │                          whole-token display-ID matches in file
+│       │   ├── code_actions.ts      ← quick-fix code actions for diagnostics
+│       │   │                          (MSL-M060 lowercase, MSL-A030 remove)
 │       │   ├── context.ts           ← doc comment context guard (source files)
 │       │   └── util.ts              ← URI↔path conversion, debounce
 │       └── mcp/
@@ -129,8 +131,9 @@ alone:**
 @packages/markspec/lsp/definition.ts @packages/markspec/lsp/references.ts
 @packages/markspec/lsp/rename.ts @packages/markspec/lsp/symbols.ts
 @packages/markspec/lsp/folding.ts @packages/markspec/lsp/highlights.ts
-@packages/markspec/lsp/context.ts @packages/markspec/lsp/diagnostics.ts
-@packages/markspec/lsp/util.ts @packages/markspec/main.ts
+@packages/markspec/lsp/code_actions.ts @packages/markspec/lsp/context.ts
+@packages/markspec/lsp/diagnostics.ts @packages/markspec/lsp/util.ts
+@packages/markspec/main.ts
 
 ## Key rules
 

--- a/packages/markspec/lsp/code_actions.ts
+++ b/packages/markspec/lsp/code_actions.ts
@@ -51,37 +51,95 @@ export interface CodeAction {
 /** Capture the keyword inside `'…'` in an MSL-M060 message. */
 const KEYWORD_RE = /modal keyword '([^']+)'/;
 
+/** Capture the attribute key inside `'…'` in an MSL-A030 message. */
+const ATTRIBUTE_KEY_RE = /'([A-Z][A-Za-z-]*)'/;
+
 /**
  * Build quick-fix actions for the supplied diagnostics. Returns an
  * empty array when none of the diagnostics has a known fix.
+ *
+ * `documentText` is optional; it's only needed for fixes that locate
+ * a specific line in the source (e.g. MSL-A030 attribute removal).
+ * MSL-M060 only invocations may omit it.
  */
 export function buildCodeActions(
   uri: string,
   diagnostics: readonly LspDiagnosticLike[],
+  documentText?: string,
 ): CodeAction[] {
   const out: CodeAction[] = [];
   for (const diag of diagnostics) {
-    if (diag.code !== "MSL-M060") continue;
-    const match = KEYWORD_RE.exec(diag.message);
-    if (!match) continue;
-    const keyword = match[1];
-    const lowercase = keyword.toLowerCase();
-    const startLine = diag.range.start.line;
-    const startChar = diag.range.start.character;
-    const edit: TextEdit = {
-      range: {
-        start: { line: startLine, character: startChar },
-        end: { line: startLine, character: startChar + keyword.length },
-      },
-      newText: lowercase,
-    };
-    out.push({
-      title: `Lowercase '${lowercase}'`,
+    if (diag.code === "MSL-M060") {
+      const action = buildM060Fix(uri, diag);
+      if (action) out.push(action);
+    } else if (diag.code === "MSL-A030" && documentText !== undefined) {
+      const action = buildA030Fix(uri, diag, documentText);
+      if (action) out.push(action);
+    }
+  }
+  return out;
+}
+
+function buildM060Fix(
+  uri: string,
+  diag: LspDiagnosticLike,
+): CodeAction | undefined {
+  const match = KEYWORD_RE.exec(diag.message);
+  if (!match) return undefined;
+  const keyword = match[1];
+  const lowercase = keyword.toLowerCase();
+  const startLine = diag.range.start.line;
+  const startChar = diag.range.start.character;
+  const edit: TextEdit = {
+    range: {
+      start: { line: startLine, character: startChar },
+      end: { line: startLine, character: startChar + keyword.length },
+    },
+    newText: lowercase,
+  };
+  return {
+    title: `Lowercase '${lowercase}'`,
+    kind: "quickfix",
+    diagnostics: [diag],
+    isPreferred: true,
+    edit: { changes: { [uri]: [edit] } },
+  };
+}
+
+function buildA030Fix(
+  uri: string,
+  diag: LspDiagnosticLike,
+  documentText: string,
+): CodeAction | undefined {
+  const match = ATTRIBUTE_KEY_RE.exec(diag.message);
+  if (!match) return undefined;
+  const attrKey = match[1];
+  // Walk forward from the diagnostic's line and find the trailer
+  // line that defines this attribute — `<indent><Key>:`. The parser
+  // canonicalises trailer indent to 6 spaces but accepts any indent
+  // ≥4 (one tab), so we match leniently.
+  const lines = documentText.split("\n");
+  const startLine = diag.range.start.line;
+  const lineRe = new RegExp(`^\\s{4,}${attrKey}\\s*:`);
+  for (let i = startLine; i < lines.length; i++) {
+    if (!lineRe.test(lines[i])) continue;
+    return {
+      title: `Remove '${attrKey}' line`,
       kind: "quickfix",
       diagnostics: [diag],
       isPreferred: true,
-      edit: { changes: { [uri]: [edit] } },
-    });
+      edit: {
+        changes: {
+          [uri]: [{
+            range: {
+              start: { line: i, character: 0 },
+              end: { line: i + 1, character: 0 },
+            },
+            newText: "",
+          }],
+        },
+      },
+    };
   }
-  return out;
+  return undefined;
 }

--- a/packages/markspec/lsp/code_actions_test.ts
+++ b/packages/markspec/lsp/code_actions_test.ts
@@ -26,6 +26,53 @@ function diag(opts: {
   };
 }
 
+const DOC_WITH_GENERATED = `# Test
+
+- [REQ-001] My requirement
+
+  Body.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      Superseded-by: 01HGW2Q8MNP3RSTVWXYZABCDEG
+`;
+
+Deno.test("buildCodeActions: MSL-A030 → remove generated-attribute line", () => {
+  const actions = buildCodeActions("file:///x.md", [
+    diag({
+      code: "MSL-A030",
+      message:
+        "REQ-001: 'Superseded-by' has generated origin and must not appear in source",
+      line: 2,
+      character: 0,
+    }),
+  ], DOC_WITH_GENERATED);
+  assertEquals(actions.length, 1);
+  const a = actions[0];
+  assertEquals(a.title, "Remove 'Superseded-by' line");
+  assertEquals(a.kind, "quickfix");
+  const edit = a.edit!.changes!["file:///x.md"][0];
+  // The Superseded-by line is line 7 (0-based) of DOC_WITH_GENERATED.
+  // The TextEdit covers the entire line including its trailing newline.
+  assertEquals(edit.newText, "");
+  assertEquals(edit.range.start.line, 7);
+  assertEquals(edit.range.start.character, 0);
+  assertEquals(edit.range.end.line, 8);
+  assertEquals(edit.range.end.character, 0);
+});
+
+Deno.test("buildCodeActions: MSL-A030 with missing source text yields no action", () => {
+  // Without the document text, the helper can't locate the line.
+  const actions = buildCodeActions("file:///x.md", [
+    diag({
+      code: "MSL-A030",
+      message: "REQ-001: 'Derives' has generated origin",
+      line: 2,
+      character: 0,
+    }),
+  ]);
+  assertEquals(actions, []);
+});
+
 Deno.test("buildCodeActions: MSL-M060 → lowercase keyword quick fix", () => {
   const actions = buildCodeActions("file:///x.md", [
     diag({

--- a/packages/markspec/lsp/server.ts
+++ b/packages/markspec/lsp/server.ts
@@ -598,10 +598,17 @@ connection.onRenameRequest(async (params) => {
 connection.onCodeAction((params) => {
   const filePath = uriToPath(params.textDocument.uri);
   if (!isMarkspecFile(filePath)) return null;
+  const document = documents.get(params.textDocument.uri);
+  const documentText = document?.getText();
   // deno-lint-ignore no-explicit-any
   const diagnostics = params.context.diagnostics as any;
+  const actions = buildCodeActions(
+    params.textDocument.uri,
+    diagnostics,
+    documentText,
+  );
   // deno-lint-ignore no-explicit-any
-  return buildCodeActions(params.textDocument.uri, diagnostics) as any;
+  return actions as any;
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Iteration 46 of the autonomous Prompt-1 follow-up loop. Extends the LSP code-actions module (M060 from #322) with a second quick fix: **MSL-A030 → remove the offending generated-attribute line**.

| Commit | Slice |
|---|---|
| `77f2c49` | MSL-A030 quick fix + AGENTS.md sync |

## What lands

`buildCodeActions` now takes an optional `documentText` argument because MSL-A030 needs the source to locate the line.

For MSL-A030 diagnostics:

- Parse the attribute key out of the message (`'<Key>'`).
- Scan forward from the diagnostic's line for `<indent><Key>:`.
- Emit a `TextEdit` deleting that whole line (range covers `[line:0, line+1:0]` so the trailing newline goes too).

[packages/markspec/lsp/server.ts](packages/markspec/lsp/server.ts) passes `documents.get(uri)?.getText()` through to the helper so live editor buffers participate correctly.

`AGENTS.md`:

- Repository tree gains `lsp/code_actions.ts` row.
- "Read these files" pointer list includes `code_actions.ts`.
- `server.ts` capabilities line widens to mention code actions.

## Tests

| Before | After |
|---|---|
| 1073 (post-#322) | 1075 (+2 unit tests: Superseded-by removal happy path with exact TextEdit range, missing-source-text path returning no action) |

All `just check` gates green per commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
