### PR TITLE
feat(lsp): code action quick fix for MSL-T020

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,7 +91,8 @@ markspec/
 │       │   ├── highlights.ts        ← document highlights (read / write) for
 │       │   │                          whole-token display-ID matches in file
 │       │   ├── code_actions.ts      ← quick-fix code actions for diagnostics
-│       │   │                          (MSL-M060 lowercase, MSL-A030 remove)
+│       │   │                          (MSL-M060 lowercase, MSL-A030 remove,
+│       │   │                          MSL-T020 suggest)
 │       │   ├── context.ts           ← doc comment context guard (source files)
 │       │   └── util.ts              ← URI↔path conversion, debounce
 │       └── mcp/

--- a/packages/markspec/lsp/code_actions.ts
+++ b/packages/markspec/lsp/code_actions.ts
@@ -7,16 +7,15 @@
  *
  * Currently handles:
  *
- *   - **MSL-M060** — uppercase modal keyword in body prose. Action:
- *     replace the keyword with its lowercase form. Single-token
- *     (`SHALL`, `SHOULD`, `MAY`, `MUST`) and two-token (`MUST NOT`,
- *     etc.) forms both supported.
- *
- * The validator already emits MSL-M060 with a per-character
- * position pointing at the keyword's start, so the fix's range is
- * `[start, start + keyword.length]`. The keyword itself comes from
- * the diagnostic message (`'<keyword>'`).
+ *   - **MSL-M060** — uppercase modal keyword. Action: lowercase it.
+ *   - **MSL-A030** — generated attribute in source. Action: remove
+ *     the offending trailer line.
+ *   - **MSL-T020** — unknown `Type:` value. Action: replace with the
+ *     closest core type, when one is within Levenshtein distance 3.
+ *     "Did you mean …" rather than exhaustive suggestions.
  */
+
+import { CORE_ABSTRACT_TYPES, CORE_CONCRETE_TYPES } from "../core/model/mod.ts";
 
 /** A subset of the LSP `Diagnostic` interface — just what the
  * code-action walker needs. */
@@ -54,6 +53,18 @@ const KEYWORD_RE = /modal keyword '([^']+)'/;
 /** Capture the attribute key inside `'…'` in an MSL-A030 message. */
 const ATTRIBUTE_KEY_RE = /'([A-Z][A-Za-z-]*)'/;
 
+/** Capture the bad type value inside `'…'` in an MSL-T020 message. */
+const T020_VALUE_RE = /Type: '([^']+)'/;
+
+/** All core type names — search target for MSL-T020 "did you mean" fixes. */
+const ALL_CORE_TYPES: readonly string[] = [
+  ...CORE_ABSTRACT_TYPES,
+  ...CORE_CONCRETE_TYPES,
+];
+
+/** Max acceptable Levenshtein distance for a type-name suggestion. */
+const MAX_SUGGESTION_DISTANCE = 3;
+
 /**
  * Build quick-fix actions for the supplied diagnostics. Returns an
  * empty array when none of the diagnostics has a known fix.
@@ -74,6 +85,9 @@ export function buildCodeActions(
       if (action) out.push(action);
     } else if (diag.code === "MSL-A030" && documentText !== undefined) {
       const action = buildA030Fix(uri, diag, documentText);
+      if (action) out.push(action);
+    } else if (diag.code === "MSL-T020" && documentText !== undefined) {
+      const action = buildT020Fix(uri, diag, documentText);
       if (action) out.push(action);
     }
   }
@@ -142,4 +156,84 @@ function buildA030Fix(
     };
   }
   return undefined;
+}
+
+function buildT020Fix(
+  uri: string,
+  diag: LspDiagnosticLike,
+  documentText: string,
+): CodeAction | undefined {
+  const match = T020_VALUE_RE.exec(diag.message);
+  if (!match) return undefined;
+  const badValue = match[1];
+  const suggestion = closestCoreType(badValue);
+  if (!suggestion) return undefined;
+  // Scan forward from the diagnostic line for the matching Type:
+  // trailer line, then locate the bad value's column within it.
+  const lines = documentText.split("\n");
+  for (let i = diag.range.start.line; i < lines.length; i++) {
+    const line = lines[i];
+    const idx = line.indexOf(badValue);
+    if (idx < 0) continue;
+    // Confirm this line is a `Type:` trailer (defensive against an
+    // accidental occurrence of the bad value in body prose).
+    if (!/^\s{4,}Type\s*:/.test(line)) continue;
+    return {
+      title: `Replace with '${suggestion}'`,
+      kind: "quickfix",
+      diagnostics: [diag],
+      isPreferred: true,
+      edit: {
+        changes: {
+          [uri]: [{
+            range: {
+              start: { line: i, character: idx },
+              end: { line: i, character: idx + badValue.length },
+            },
+            newText: suggestion,
+          }],
+        },
+      },
+    };
+  }
+  return undefined;
+}
+
+/** Return the closest core type name within {@linkcode MAX_SUGGESTION_DISTANCE}
+ * Levenshtein distance, or `undefined` when nothing is close enough. */
+function closestCoreType(value: string): string | undefined {
+  let best: string | undefined;
+  let bestDistance = MAX_SUGGESTION_DISTANCE + 1;
+  for (const candidate of ALL_CORE_TYPES) {
+    const d = levenshtein(value, candidate);
+    if (d < bestDistance) {
+      bestDistance = d;
+      best = candidate;
+    }
+  }
+  return bestDistance <= MAX_SUGGESTION_DISTANCE ? best : undefined;
+}
+
+/** Iterative O(n·m) Levenshtein distance with a single row buffer. */
+function levenshtein(a: string, b: string): number {
+  if (a === b) return 0;
+  if (a.length === 0) return b.length;
+  if (b.length === 0) return a.length;
+  let prev = new Array(b.length + 1);
+  for (let j = 0; j <= b.length; j++) prev[j] = j;
+  const curr = new Array(b.length + 1);
+  for (let i = 1; i <= a.length; i++) {
+    curr[0] = i;
+    for (let j = 1; j <= b.length; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      curr[j] = Math.min(
+        curr[j - 1] + 1,
+        prev[j] + 1,
+        prev[j - 1] + cost,
+      );
+    }
+    [prev, curr[0]] = [curr.slice(), 0];
+    for (let j = 0; j <= b.length; j++) prev[j] = curr[j];
+  }
+  return prev[b.length];
 }

--- a/packages/markspec/lsp/code_actions_test.ts
+++ b/packages/markspec/lsp/code_actions_test.ts
@@ -36,6 +36,58 @@ const DOC_WITH_GENERATED = `# Test
       Superseded-by: 01HGW2Q8MNP3RSTVWXYZABCDEG
 `;
 
+const DOC_WITH_TYPO = `# Test
+
+- [REQ-001] My requirement
+
+  Body.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      Type: Requirment
+`;
+
+Deno.test("buildCodeActions: MSL-T020 → suggest closest core type", () => {
+  const actions = buildCodeActions("file:///x.md", [
+    diag({
+      code: "MSL-T020",
+      message:
+        "REQ-001: Type: 'Requirment' is not a core type or a profile-declared type",
+      line: 2,
+      character: 0,
+    }),
+  ], DOC_WITH_TYPO);
+  // Should suggest 'Requirement' (closest match).
+  const reqAction = actions.find((a) => a.title.includes("Requirement"));
+  assertEquals(
+    reqAction !== undefined,
+    true,
+    `expected a 'Requirement' suggestion, got: ${
+      actions.map((a) => a.title).join(", ")
+    }`,
+  );
+  const edit = reqAction!.edit!.changes!["file:///x.md"][0];
+  assertEquals(edit.newText, "Requirement");
+  // Line 7 (0-based) is the `Type: Requirment` line. Column 12 is
+  // where 'Requirment' starts (after `      Type: `).
+  assertEquals(edit.range.start.line, 7);
+  assertEquals(edit.range.start.character, 12);
+  assertEquals(edit.range.end.character, 22); // 12 + 'Requirment'.length
+});
+
+Deno.test("buildCodeActions: MSL-T020 with valid core type far from any match yields no action", () => {
+  // 'Xyz' has edit distance >3 to every core type → no suggestion.
+  const doc = `# Test\n\n      Type: Xyz\n`;
+  const actions = buildCodeActions("file:///x.md", [
+    diag({
+      code: "MSL-T020",
+      message: "REQ-001: Type: 'Xyz' is not a core type",
+      line: 0,
+      character: 0,
+    }),
+  ], doc);
+  assertEquals(actions, []);
+});
+
 Deno.test("buildCodeActions: MSL-A030 → remove generated-attribute line", () => {
   const actions = buildCodeActions("file:///x.md", [
     diag({


### PR DESCRIPTION
## Summary

- Adds a third LSP quick fix to the code-actions module (after MSL-M060 #322 and MSL-A030 #323): **MSL-T020** — unknown `Type:` value.
- The action suggests the closest core type within Levenshtein distance 3 ("did you mean …"). Suggestion target is exactly `[...CORE_ABSTRACT_TYPES, ...CORE_CONCRETE_TYPES]` — the same set the validator's `CORE_TYPES` accepts — so a fix can never propose a value the validator still rejects. Values >3 edits from every core type yield no action.
- `server.ts` unchanged: the `documentText` plumbing added in #323 already feeds the helper; dispatch happens inside `buildCodeActions`.
- AGENTS.md `lsp/code_actions.ts` inventory line widened to mention MSL-T020.

## Test Plan

- [x] `just check` — 1077 passed, 0 failed (lint + test + typecheck)
- [x] `deno fmt --check` + `dprint check` clean
- [x] 2 new unit tests: happy path (typo `Requirment` → `Requirement`, exact TextEdit range) and no-suggestion path (value >3 edits from any core type → `[]`)
- [x] Verified the test's diagnostic message matches the real validator output (`core/validator/types.ts:142`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
