### PR TITLE
feat(lsp): code action quick fix for MSL-A013

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,7 +92,7 @@ markspec/
 │       │   │                          whole-token display-ID matches in file
 │       │   ├── code_actions.ts      ← quick-fix code actions for diagnostics
 │       │   │                          (MSL-M060 lowercase, MSL-A030 remove,
-│       │   │                          MSL-T020 suggest)
+│       │   │                          MSL-T020 suggest, MSL-A013 dedup)
 │       │   ├── context.ts           ← doc comment context guard (source files)
 │       │   └── util.ts              ← URI↔path conversion, debounce
 │       └── mcp/

--- a/packages/markspec/lsp/code_actions.ts
+++ b/packages/markspec/lsp/code_actions.ts
@@ -13,6 +13,9 @@
  *   - **MSL-T020** — unknown `Type:` value. Action: replace with the
  *     closest core type, when one is within Levenshtein distance 3.
  *     "Did you mean …" rather than exhaustive suggestions.
+ *   - **MSL-A013** — single-cardinality attribute appears more than
+ *     once. Action: delete every duplicate trailer line, keeping the
+ *     first occurrence.
  */
 
 import { CORE_ABSTRACT_TYPES, CORE_CONCRETE_TYPES } from "../core/model/mod.ts";
@@ -88,6 +91,9 @@ export function buildCodeActions(
       if (action) out.push(action);
     } else if (diag.code === "MSL-T020" && documentText !== undefined) {
       const action = buildT020Fix(uri, diag, documentText);
+      if (action) out.push(action);
+    } else if (diag.code === "MSL-A013" && documentText !== undefined) {
+      const action = buildA013Fix(uri, diag, documentText);
       if (action) out.push(action);
     }
   }
@@ -197,6 +203,51 @@ function buildT020Fix(
     };
   }
   return undefined;
+}
+
+function buildA013Fix(
+  uri: string,
+  diag: LspDiagnosticLike,
+  documentText: string,
+): CodeAction | undefined {
+  const match = ATTRIBUTE_KEY_RE.exec(diag.message);
+  if (!match) return undefined;
+  const attrKey = match[1];
+  // Collect every trailer line that defines this attribute, from the
+  // diagnostic's line forward. Keep the first; emit a delete edit
+  // for each subsequent one. Stop scanning once a non-trailer,
+  // non-blank line is hit (end of the trailer block).
+  const lines = documentText.split("\n");
+  const lineRe = new RegExp(`^\\s{4,}${attrKey}\\s*:`);
+  const trailerRe = /^\s{4,}[A-Z][A-Za-z-]*\s*:/;
+  const dupLines: number[] = [];
+  let seenFirst = false;
+  let inBlock = false;
+  for (let i = diag.range.start.line; i < lines.length; i++) {
+    const line = lines[i];
+    if (lineRe.test(line)) {
+      inBlock = true;
+      if (seenFirst) dupLines.push(i);
+      else seenFirst = true;
+    } else if (inBlock && line.trim() !== "" && !trailerRe.test(line)) {
+      break;
+    }
+  }
+  if (dupLines.length === 0) return undefined;
+  const edits: TextEdit[] = dupLines.map((i) => ({
+    range: {
+      start: { line: i, character: 0 },
+      end: { line: i + 1, character: 0 },
+    },
+    newText: "",
+  }));
+  return {
+    title: `Remove duplicate '${attrKey}' line(s)`,
+    kind: "quickfix",
+    diagnostics: [diag],
+    isPreferred: true,
+    edit: { changes: { [uri]: edits } },
+  };
 }
 
 /** Return the closest core type name within {@linkcode MAX_SUGGESTION_DISTANCE}

--- a/packages/markspec/lsp/code_actions_test.ts
+++ b/packages/markspec/lsp/code_actions_test.ts
@@ -46,6 +46,57 @@ const DOC_WITH_TYPO = `# Test
       Type: Requirment
 `;
 
+const DOC_WITH_DUP_TYPE = `# Test
+
+- [REQ-001] My requirement
+
+  Body.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      Type: Requirement
+      Type: Specification
+`;
+
+Deno.test("buildCodeActions: MSL-A013 → remove duplicate single-cardinality lines", () => {
+  const actions = buildCodeActions("file:///x.md", [
+    diag({
+      code: "MSL-A013",
+      message:
+        "REQ-001: 'Type' is single-cardinality but appears more than once (spec §1.8)",
+      line: 2,
+      character: 0,
+    }),
+  ], DOC_WITH_DUP_TYPE);
+  assertEquals(actions.length, 1);
+  const a = actions[0];
+  assertEquals(a.title, "Remove duplicate 'Type' line(s)");
+  assertEquals(a.kind, "quickfix");
+  const edits = a.edit!.changes!["file:///x.md"];
+  // First Type line (line 7) is kept; the duplicate (line 8) is
+  // deleted. Exactly one edit, covering line 8's full line.
+  assertEquals(edits.length, 1);
+  assertEquals(edits[0].newText, "");
+  assertEquals(edits[0].range.start.line, 8);
+  assertEquals(edits[0].range.start.character, 0);
+  assertEquals(edits[0].range.end.line, 9);
+  assertEquals(edits[0].range.end.character, 0);
+});
+
+Deno.test("buildCodeActions: MSL-A013 with only one occurrence yields no action", () => {
+  // Defensive: a single Type line means nothing to dedup.
+  const doc = `# Test\n\n      Type: Requirement\n`;
+  const actions = buildCodeActions("file:///x.md", [
+    diag({
+      code: "MSL-A013",
+      message:
+        "REQ-001: 'Type' is single-cardinality but appears more than once",
+      line: 0,
+      character: 0,
+    }),
+  ], doc);
+  assertEquals(actions, []);
+});
+
 Deno.test("buildCodeActions: MSL-T020 → suggest closest core type", () => {
   const actions = buildCodeActions("file:///x.md", [
     diag({


### PR DESCRIPTION
## Summary

Iteration 48 of the autonomous Prompt-1 follow-up loop. Extends the LSP code-actions module with a fourth quick fix: **MSL-A013 → remove duplicate single-cardinality trailer lines**.

| Commit | Slice |
|---|---|
| `5255341` | MSL-A013 dedup quick fix |

## What lands

`buildA013Fix`:

- Parses the attribute key from the message (`'<Key>'`).
- Walks the trailer block from the diagnostic's line, records every `<indent><Key>:` row past the first, stops at the end of the trailer block (first non-blank non-trailer line).
- Emits one delete `TextEdit` per duplicate line (range `[i:0, i+1:0]` so the newline goes too); the first occurrence is kept.
- Returns no action when only one occurrence is found — defensive against a stale diagnostic.

`AGENTS.md`: `code_actions.ts` tree row now lists MSL-A013 dedup alongside M060 / A030 / T020.

## Tests

| Before | After |
|---|---|
| 1077 (post-#324) | 1079 (+2 unit tests: two-`Type` dedup happy path with the correct single delete edit, single-occurrence no-action guard) |

All `just check` gates green per commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
