### PR TITLE
feat(lsp): code action quick fix for MSL-A011

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,7 +92,8 @@ markspec/
 │       │   │                          whole-token display-ID matches in file
 │       │   ├── code_actions.ts      ← quick-fix code actions for diagnostics
 │       │   │                          (MSL-M060 lowercase, MSL-A030 remove,
-│       │   │                          MSL-T020 suggest, MSL-A013 dedup)
+│       │   │                          MSL-T020 suggest, MSL-A013 dedup,
+│       │   │                          MSL-A011 multi-line)
 │       │   ├── context.ts           ← doc comment context guard (source files)
 │       │   └── util.ts              ← URI↔path conversion, debounce
 │       └── mcp/

--- a/packages/markspec/lsp/code_actions.ts
+++ b/packages/markspec/lsp/code_actions.ts
@@ -16,6 +16,9 @@
  *   - **MSL-A013** — single-cardinality attribute appears more than
  *     once. Action: delete every duplicate trailer line, keeping the
  *     first occurrence.
+ *   - **MSL-A011** — citation attribute in CSV form. Action: rewrite
+ *     the single CSV line as one trailer line per value (the
+ *     canonical multi-line form), splitting on top-level commas.
  */
 
 import { CORE_ABSTRACT_TYPES, CORE_CONCRETE_TYPES } from "../core/model/mod.ts";
@@ -95,9 +98,70 @@ export function buildCodeActions(
     } else if (diag.code === "MSL-A013" && documentText !== undefined) {
       const action = buildA013Fix(uri, diag, documentText);
       if (action) out.push(action);
+    } else if (diag.code === "MSL-A011" && documentText !== undefined) {
+      const action = buildA011Fix(uri, diag, documentText);
+      if (action) out.push(action);
     }
   }
   return out;
+}
+
+function buildA011Fix(
+  uri: string,
+  diag: LspDiagnosticLike,
+  documentText: string,
+): CodeAction | undefined {
+  const match = ATTRIBUTE_KEY_RE.exec(diag.message);
+  if (!match) return undefined;
+  const attrKey = match[1];
+  const lines = documentText.split("\n");
+  const lineRe = new RegExp(`^(\\s{4,})${attrKey}\\s*:\\s*(.*)$`);
+  for (let i = diag.range.start.line; i < lines.length; i++) {
+    const m = lineRe.exec(lines[i]);
+    if (!m) continue;
+    const indent = m[1];
+    const rawValue = m[2];
+    // Split on top-level commas (depth-0). Commas inside `[…]` are
+    // citation locators and must not split — same rule the
+    // MSL-A011 validator uses.
+    const values: string[] = [];
+    let depth = 0;
+    let current = "";
+    for (const ch of rawValue) {
+      if (ch === "[") depth++;
+      else if (ch === "]" && depth > 0) depth--;
+      if (ch === "," && depth === 0) {
+        values.push(current.trim());
+        current = "";
+      } else {
+        current += ch;
+      }
+    }
+    values.push(current.trim());
+    const nonEmpty = values.filter((v) => v.length > 0);
+    if (nonEmpty.length < 2) return undefined;
+    const newText = nonEmpty
+      .map((v) => `${indent}${attrKey}: ${v}\n`)
+      .join("");
+    return {
+      title: `Rewrite '${attrKey}' as multi-line`,
+      kind: "quickfix",
+      diagnostics: [diag],
+      isPreferred: true,
+      edit: {
+        changes: {
+          [uri]: [{
+            range: {
+              start: { line: i, character: 0 },
+              end: { line: i + 1, character: 0 },
+            },
+            newText,
+          }],
+        },
+      },
+    };
+  }
+  return undefined;
 }
 
 function buildM060Fix(

--- a/packages/markspec/lsp/code_actions_test.ts
+++ b/packages/markspec/lsp/code_actions_test.ts
@@ -57,6 +57,57 @@ const DOC_WITH_DUP_TYPE = `# Test
       Type: Specification
 `;
 
+const DOC_WITH_CSV_REFS = `# Test
+
+- [REQ-001] My requirement
+
+  Body.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      References: ISO-1, ISO-2, ISO-3
+`;
+
+Deno.test("buildCodeActions: MSL-A011 → rewrite citation CSV as multi-line", () => {
+  const actions = buildCodeActions("file:///x.md", [
+    diag({
+      code: "MSL-A011",
+      message:
+        "REQ-001: 'References' is citation-typed and must use multi-line form (spec §2.3.2)",
+      line: 2,
+      character: 0,
+    }),
+  ], DOC_WITH_CSV_REFS);
+  assertEquals(actions.length, 1);
+  const a = actions[0];
+  assertEquals(a.title, "Rewrite 'References' as multi-line");
+  assertEquals(a.kind, "quickfix");
+  const edit = a.edit!.changes!["file:///x.md"][0];
+  // The CSV line (line 7) is replaced with three indented lines,
+  // preserving the original 6-space indent.
+  assertEquals(edit.range.start.line, 7);
+  assertEquals(edit.range.start.character, 0);
+  assertEquals(edit.range.end.line, 8);
+  assertEquals(edit.range.end.character, 0);
+  assertEquals(
+    edit.newText,
+    "      References: ISO-1\n      References: ISO-2\n      References: ISO-3\n",
+  );
+});
+
+Deno.test("buildCodeActions: MSL-A011 with a single value yields no action", () => {
+  const doc = `# Test\n\n      References: ISO-1\n`;
+  const actions = buildCodeActions("file:///x.md", [
+    diag({
+      code: "MSL-A011",
+      message:
+        "REQ-001: 'References' is citation-typed and must use multi-line form",
+      line: 0,
+      character: 0,
+    }),
+  ], doc);
+  assertEquals(actions, []);
+});
+
 Deno.test("buildCodeActions: MSL-A013 → remove duplicate single-cardinality lines", () => {
   const actions = buildCodeActions("file:///x.md", [
     diag({


### PR DESCRIPTION
## Summary

Iteration 49 of the autonomous Prompt-1 follow-up loop. Extends the LSP code-actions module with a fifth quick fix: **MSL-A011 → rewrite citation CSV as canonical multi-line form**.

| Commit | Slice |
|---|---|
| `8c6872d` | MSL-A011 multi-line quick fix |

## What lands

`buildA011Fix`:

- Parses the attribute key from the message.
- Locates the trailer line, splits its value on **top-level commas** using the same bracket-depth rule the MSL-A011 validator uses (commas inside `[…]` are citation locators and must not split).
- Preserves the original leading indent on every emitted line.
- Replaces the single CSV line with the multi-line block via one `TextEdit` covering `[i:0, i+1:0]`.
- Returns no action when fewer than two values survive the split.

`AGENTS.md`: `code_actions.ts` tree row now lists MSL-A011 alongside M060 / A030 / T020 / A013.

## Tests

| Before | After |
|---|---|
| 1079 (post-#325) | 1081 (+2 unit tests: three-value CSV → three-line happy path with exact indent + newText, single-value no-action guard) |

All `just check` gates green per commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
