### PR TITLE
feat(lsp): code action quick fix for MSL-A012

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,7 +93,7 @@ markspec/
 │       │   ├── code_actions.ts      ← quick-fix code actions for diagnostics
 │       │   │                          (MSL-M060 lowercase, MSL-A030 remove,
 │       │   │                          MSL-T020 suggest, MSL-A013 dedup,
-│       │   │                          MSL-A011 multi-line)
+│       │   │                          MSL-A011 multi-line, MSL-A012 remove)
 │       │   ├── context.ts           ← doc comment context guard (source files)
 │       │   └── util.ts              ← URI↔path conversion, debounce
 │       └── mcp/

--- a/packages/markspec/lsp/code_actions.ts
+++ b/packages/markspec/lsp/code_actions.ts
@@ -19,6 +19,8 @@
  *   - **MSL-A011** — citation attribute in CSV form. Action: rewrite
  *     the single CSV line as one trailer line per value (the
  *     canonical multi-line form), splitting on top-level commas.
+ *   - **MSL-A012** — repeatable attribute with an empty value list.
+ *     Action: remove the empty trailer line.
  */
 
 import { CORE_ABSTRACT_TYPES, CORE_CONCRETE_TYPES } from "../core/model/mod.ts";
@@ -101,9 +103,45 @@ export function buildCodeActions(
     } else if (diag.code === "MSL-A011" && documentText !== undefined) {
       const action = buildA011Fix(uri, diag, documentText);
       if (action) out.push(action);
+    } else if (diag.code === "MSL-A012" && documentText !== undefined) {
+      const action = buildA012Fix(uri, diag, documentText);
+      if (action) out.push(action);
     }
   }
   return out;
+}
+
+function buildA012Fix(
+  uri: string,
+  diag: LspDiagnosticLike,
+  documentText: string,
+): CodeAction | undefined {
+  const match = ATTRIBUTE_KEY_RE.exec(diag.message);
+  if (!match) return undefined;
+  const attrKey = match[1];
+  const lines = documentText.split("\n");
+  const lineRe = new RegExp(`^\\s{4,}${attrKey}\\s*:`);
+  for (let i = diag.range.start.line; i < lines.length; i++) {
+    if (!lineRe.test(lines[i])) continue;
+    return {
+      title: `Remove empty '${attrKey}' line`,
+      kind: "quickfix",
+      diagnostics: [diag],
+      isPreferred: true,
+      edit: {
+        changes: {
+          [uri]: [{
+            range: {
+              start: { line: i, character: 0 },
+              end: { line: i + 1, character: 0 },
+            },
+            newText: "",
+          }],
+        },
+      },
+    };
+  }
+  return undefined;
 }
 
 function buildA011Fix(

--- a/packages/markspec/lsp/code_actions_test.ts
+++ b/packages/markspec/lsp/code_actions_test.ts
@@ -67,6 +67,52 @@ const DOC_WITH_CSV_REFS = `# Test
       References: ISO-1, ISO-2, ISO-3
 `;
 
+const DOC_WITH_EMPTY_LABELS = `# Test
+
+- [REQ-001] My requirement
+
+  Body.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      Labels: , ,
+`;
+
+Deno.test("buildCodeActions: MSL-A012 → remove empty repeatable line", () => {
+  const actions = buildCodeActions("file:///x.md", [
+    diag({
+      code: "MSL-A012",
+      message:
+        "REQ-001: 'Labels' is a repeatable attribute but the value list is empty (spec §1.8)",
+      line: 2,
+      character: 0,
+    }),
+  ], DOC_WITH_EMPTY_LABELS);
+  assertEquals(actions.length, 1);
+  const a = actions[0];
+  assertEquals(a.title, "Remove empty 'Labels' line");
+  assertEquals(a.kind, "quickfix");
+  const edit = a.edit!.changes!["file:///x.md"][0];
+  // Labels line is line 7 (0-based); the edit deletes the whole line.
+  assertEquals(edit.newText, "");
+  assertEquals(edit.range.start.line, 7);
+  assertEquals(edit.range.start.character, 0);
+  assertEquals(edit.range.end.line, 8);
+  assertEquals(edit.range.end.character, 0);
+});
+
+Deno.test("buildCodeActions: MSL-A012 with missing source text yields no action", () => {
+  const actions = buildCodeActions("file:///x.md", [
+    diag({
+      code: "MSL-A012",
+      message:
+        "REQ-001: 'Labels' is a repeatable attribute but the value list is empty",
+      line: 2,
+      character: 0,
+    }),
+  ]);
+  assertEquals(actions, []);
+});
+
 Deno.test("buildCodeActions: MSL-A011 → rewrite citation CSV as multi-line", () => {
   const actions = buildCodeActions("file:///x.md", [
     diag({


### PR DESCRIPTION
## Summary

Iteration 50 of the autonomous Prompt-1 follow-up loop. Extends the LSP code-actions module with a sixth quick fix: **MSL-A012 → remove the empty repeatable trailer line**.

| Commit | Slice |
|---|---|
| `9fce224` | MSL-A012 remove quick fix |

## What lands

`buildA012Fix` mirrors the A030 fix shape: parses the attribute key from the message, scans forward from the diagnostic's line for the `<indent><Key>:` row, emits one delete `TextEdit` covering the whole line (range `[i:0, i+1:0]`).

With this the code-action module covers the full set of mechanically-repairable attribute / modal diagnostics:

| Code | Fix |
|---|---|
| MSL-M060 | lowercase modal keyword |
| MSL-A030 | remove generated-origin line |
| MSL-T020 | suggest closest core type |
| MSL-A013 | dedup single-cardinality lines |
| MSL-A011 | citation CSV → multi-line |
| **MSL-A012** | **remove empty repeatable line** |

`AGENTS.md`: `code_actions.ts` tree row updated.

## Tests

| Before | After |
|---|---|
| 1081 (post-#326) | 1083 (+2 unit tests: empty-`Labels` removal happy path with exact full-line delete range, missing-source-text no-action guard) |

All `just check` gates green per commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
