### PR TITLE
refactor(core): finish FENCE_RE dedup via shared walkProseLines/FENCE_RE

### DIFF
--- a/packages/markspec/core/formatter/mod.ts
+++ b/packages/markspec/core/formatter/mod.ts
@@ -18,7 +18,7 @@ import { attributeSpec, IDENTITY_KEY } from "../model/mod.ts";
 import { ATTR_LINE_RE } from "../parser/attributes.ts";
 import { extractFrontMatter } from "../parser/frontmatter.ts";
 import { parseMarkdown } from "../parser/markdown.ts";
-import { walkProseLines } from "../util/fence.ts";
+import { FENCE_RE, walkProseLines } from "../util/fence.ts";
 import { synthesizedUlid } from "./synth_ulid.ts";
 
 /**
@@ -366,7 +366,7 @@ function collapseBlankLines(lines: readonly string[]): string[] {
   let inFence = false;
   let prevBlank = false;
   for (const line of lines) {
-    if (/^\s*(```|~~~)/.test(line)) {
+    if (FENCE_RE.test(line)) {
       out.push(line);
       inFence = !inFence;
       prevBlank = false;

--- a/packages/markspec/core/validator/captions.ts
+++ b/packages/markspec/core/validator/captions.ts
@@ -8,7 +8,7 @@
  */
 
 import type { Diagnostic, Entry } from "../model/mod.ts";
-import { FENCE_RE } from "../util/fence.ts";
+import { FENCE_RE, walkProseLines } from "../util/fence.ts";
 
 /** Caption keywords recognised by the core. */
 const CAPTION_KEYWORDS = [
@@ -76,17 +76,14 @@ function classifyAdjacentBlock(line: string): CaptionKeyword | undefined {
 export function validateCaptions(entry: Entry): readonly Diagnostic[] {
   const diagnostics: Diagnostic[] = [];
   const lines = entry.body.split("\n");
-  let inFence = false;
 
-  for (let i = 0; i < lines.length; i++) {
-    if (FENCE_RE.test(lines[i])) {
-      inFence = !inFence;
-      continue;
-    }
-    if (inFence) continue;
-
+  // `walkProseLines` invokes the callback for exactly the lines the
+  // old hand-rolled fence toggle reached — fenced code and the fence
+  // markers themselves are skipped. We keep the split `lines` array
+  // for the above/below neighbour scan, indexed by the callback's `i`.
+  walkProseLines(entry.body, (_line, i) => {
     const match = CAPTION_LINE_RE.exec(lines[i]);
-    if (!match) continue;
+    if (!match) return;
     const keyword = match[1] as CaptionKeyword;
     const matcher = captionableMatchers[keyword];
 
@@ -106,7 +103,7 @@ export function validateCaptions(entry: Entry): readonly Diagnostic[] {
       ? classifyAdjacentBlock(lines[below])
       : undefined;
 
-    if (aboveBlock || belowBlock) continue;
+    if (aboveBlock || belowBlock) return;
 
     // No matching block adjacent. Decide between C070 (no captionable
     // block at all) and C071 (a captionable block of the wrong type).
@@ -123,7 +120,7 @@ export function validateCaptions(entry: Entry): readonly Diagnostic[] {
           column: 1,
         },
       });
-      continue;
+      return;
     }
 
     diagnostics.push({
@@ -138,7 +135,7 @@ export function validateCaptions(entry: Entry): readonly Diagnostic[] {
         column: 1,
       },
     });
-  }
+  });
 
   return diagnostics;
 }

--- a/tests/e2e/validate_test.ts
+++ b/tests/e2e/validate_test.ts
@@ -1513,6 +1513,31 @@ Deno.test("validate: Figure: caption adjacent to image passes", async () => {
   assertEquals(code, 0, `expected exit 0, got ${code}; stderr: ${stderr}`);
 });
 
+Deno.test("validate: caption keyword inside a fenced code block is not flagged", async () => {
+  const { code, stderr } = await markspec(["validate", "req.md"], {
+    files: {
+      "req.md": `# Test
+
+- [SRS_BRK_0001] Sensor input
+
+  Body text.
+
+  \`\`\`
+  Figure: this is sample code, not a real caption
+  \`\`\`
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+`,
+    },
+  });
+  assertEquals(code, 0, `expected exit 0, got ${code}; stderr: ${stderr}`);
+  assertEquals(
+    stderr.includes("MSL-C070") || stderr.includes("MSL-C071"),
+    false,
+    `caption inside fence must not be flagged; stderr: ${stderr}`,
+  );
+});
+
 // ---------------------------------------------------------------------------
 // Errors
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes Prompt-1 review code-quality finding #1 (PARTIAL → FIXED): the FENCE_RE / inFence walker was duplicated. PR #284 extracted `core/util/fence.ts` and migrated `body_blocks.ts` + `entity_refs.ts`; this finishes the last two sites.

- **`validator/captions.ts`** — replaced the hand-rolled `FENCE_RE.test + inFence` loop with `walkProseLines`. The split `lines` array is kept for the above/below neighbour scan, indexed by the callback's `i`. `walkProseLines` invokes the callback for exactly the line set the old loop reached → **behaviour-preserving** (MSL-C070/C071 logic untouched).
- **`formatter/mod.ts` `collapseBlankLines`** — carried a duplicate inline `/^\s*(```|~~~)/` literal (the "subtly different copy" the review flagged) even though the module already imports from `util/fence.ts`. It must *emit* fence/in-fence lines so the callback-style `walkProseLines` doesn't fit, but it now uses the shared `FENCE_RE` constant — drift risk eliminated.

No `FENCE_RE` literal remains outside `core/util/fence.ts`.

## Test Plan

- [x] +1 e2e regression guard: caption keyword inside a fenced code block must not be flagged — verified passing **before** the refactor (characterization) and after
- [x] Caption e2e (C070/C071/pass) — 4/4 green
- [x] `format_test.ts` + `fence_test.ts` — 28/28 green
- [x] `just check` — **1084 passed, 0 failed**, lint + typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
