### PR TITLE
fix(core): multi-line $$ math blocks + honest C071 Listing/Feature wording

### DIFF
--- a/packages/markspec/core/parser/entity_refs.ts
+++ b/packages/markspec/core/parser/entity_refs.ts
@@ -46,8 +46,10 @@ export function classifyConvention(ident: string): EntityRefConvention {
  *
  * Skips fenced code blocks (between paired ` ``` ` or `~~~` markers) per
  * spec §2.5.2 (markers are recognised in prose only, not in verbatim
- * content). Skips math-fence `$$…$$` sequences by discarding any `$ident`
- * match preceded by another `$`.
+ * content). Math content is skipped two ways: an inline `$$…$$` fence by
+ * discarding any `$ident` match preceded by another `$`; a multi-line
+ * display-math block (a line that is exactly `$$`, its interior lines,
+ * and the closing `$$`) by tracking the delimiter across lines.
  *
  * The reported {@linkcode SourceLocation} uses 1-based line numbers
  * relative to the body string; callers add the entry's body offset to
@@ -64,7 +66,18 @@ export function extractEntityRefs(
 ): EntityRef[] {
   const refs: EntityRef[] = [];
 
+  // A line whose only content is `$$` opens (or closes) a display-math
+  // block; its interior lines are verbatim math, not prose. Inline
+  // `$$…$$` on a single line is *not* a fence (trimmed ≠ `$$`) and is
+  // still handled by the per-match "preceded by another $" guard below.
+  let inMathFence = false;
+
   walkProseLines(body, (line, lineIdx) => {
+    if (line.trim() === "$$") {
+      inMathFence = !inMathFence;
+      return;
+    }
+    if (inMathFence) return;
     ENTITY_REF_RE.lastIndex = 0;
     let match: RegExpExecArray | null;
     while ((match = ENTITY_REF_RE.exec(line)) !== null) {

--- a/packages/markspec/core/parser/entity_refs_test.ts
+++ b/packages/markspec/core/parser/entity_refs_test.ts
@@ -88,6 +88,18 @@ Deno.test("extractEntityRefs: standalone $ident inside inline math still fires (
   assertEquals(refs[0].ident, "$foo");
 });
 
+Deno.test("extractEntityRefs: skips $ident inside a multi-line $$ display-math block", () => {
+  const body = [
+    "Before $alpha here.",
+    "$$",
+    "E = $betaMatrix + 1",
+    "$$",
+    "After $gamma here.",
+  ].join("\n");
+  const refs = extractEntityRefs(body, baseLocation);
+  assertEquals(refs.map((r) => r.ident), ["$alpha", "$gamma"]);
+});
+
 Deno.test("extractEntityRefs: discards backslash-escaped $ident", () => {
   const refs = extractEntityRefs("Literal \\$dollar text.", baseLocation);
   assertEquals(refs.length, 0);

--- a/packages/markspec/core/validator/captions.ts
+++ b/packages/markspec/core/validator/captions.ts
@@ -109,11 +109,20 @@ export function validateCaptions(entry: Entry): readonly Diagnostic[] {
     // block at all) and C071 (a captionable block of the wrong type).
     const mismatchKind = aboveKind ?? belowKind;
     if (mismatchKind !== undefined) {
+      // `Listing` and `Feature` share a fence-only matcher and the
+      // closing ``` carries no language tag, so a fenced block is
+      // genuinely ambiguous between the two (classifyAdjacentBlock
+      // can only ever return `Listing` for a fence). Name the
+      // ambiguity instead of asserting one — disambiguation needs
+      // the deferred fence-language pre-scan.
+      const mismatchLabel = mismatchKind === "Listing"
+        ? "Listing or Feature (fenced)"
+        : mismatchKind;
       diagnostics.push({
         code: "MSL-C071",
         severity: "error",
         message: `${entry.displayId}: ${keyword}: caption is adjacent to a ` +
-          `${mismatchKind} block, not a ${keyword} block (spec §4.7)`,
+          `${mismatchLabel} block, not a ${keyword} block (spec §4.7)`,
         location: {
           file: entry.location.file,
           line: entry.location.line + 1 + i,

--- a/tests/e2e/validate_test.ts
+++ b/tests/e2e/validate_test.ts
@@ -1538,6 +1538,31 @@ Deno.test("validate: caption keyword inside a fenced code block is not flagged",
   );
 });
 
+Deno.test("validate: C071 names the Listing/Feature ambiguity for a fenced block", async () => {
+  const { code, stderr } = await markspec(["validate", "req.md"], {
+    files: {
+      "req.md": `# Test
+
+- [REQ-001] My requirement
+
+  \`\`\`
+  some code
+  \`\`\`
+
+  Table: claims to be a table but the block above is a fenced block
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+`,
+    },
+  });
+  assertEquals(code, 1, `expected exit 1, got ${code}; stderr: ${stderr}`);
+  assertStringIncludes(stderr, "MSL-C071");
+  // A fenced block is indistinguishable between Listing and Feature
+  // (Gherkin) from the closing fence — the message must say so rather
+  // than asserting one.
+  assertStringIncludes(stderr, "Listing or Feature");
+});
+
 // ---------------------------------------------------------------------------
 // Errors
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Two Prompt-1 review **minor** findings closed; the third deliberately left as-is (documented).

- **entity-ref multi-line `$$` math block (NOT ADDRESSED → fixed).** Only inline `$$…$$` was skipped. A multi-line display-math block walked as prose and interior `$Ident` tokens were extracted. A line whose trimmed content is exactly `$$` now toggles a math-fence state (symmetric to code-fence handling); interior lines are skipped. Inline `$$x$$` unaffected — the pinned inline known-limitation test still holds.
- **C071 Listing/Feature ambiguity (NOT ADDRESSED → fixed).** `Listing` and `Feature` share a fence-only matcher and the closing fence has no language tag, so `classifyAdjacentBlock` can only return `Listing` for a fence — the message blamed "Listing" even for a Gherkin Feature block. Now reads **"Listing or Feature (fenced)"**. True disambiguation needs the deferred fence-language pre-scan.
- **Caption mismatch above/below (NOT ADDRESSED → left by decision).** `aboveKind ?? belowKind` is a deterministic, defensible default; reporting both sides adds message complexity for the common single-sided case with marginal benefit. Left as-is intentionally, not by oversight.

## Test Plan

- [x] TDD: each fix has a test that was **RED on current code, GREEN after** (multi-line `$$`; C071 wording)
- [x] Existing caption e2e (C070/C071/pass/fence-skip) — 4/4 green; existing entity_refs — 15/15 green
- [x] `just check` — **1094 passed, 0 failed**, lint + typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
