### PR TITLE
feat(core): MSL-T024 — type-specific attr on an unresolved-type entry

### DIFF
--- a/docs/spec/language/language.md
+++ b/docs/spec/language/language.md
@@ -1506,6 +1506,16 @@ carrying an `Id:` attribute.
 `MSL-T014` is reserved for a future registry-chain check on `References:`
 (warning severity) when reference resolution via upstream registries lands.
 
+Type resolution and per-type attribute validation (spec §1.3, §1.6):
+
+| ID         | Severity | Rule                                                                                                                           |
+| ---------- | -------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `MSL-T020` | error    | `Type:` value is neither a core type nor a profile-declared type.                                                              |
+| `MSL-T021` | warning  | Core type inferred (display-ID prefix, URI scheme, or discriminating attribute); declare `Type:` explicitly to silence.        |
+| `MSL-T022` | warning  | Attribute is core-known but not valid on the entry's resolved type.                                                            |
+| `MSL-T023` | error    | `Type:` value looks like a profile-declared type but no profile is loaded (core-only mode).                                    |
+| `MSL-T024` | warning  | Entry carries a type-specific attribute but its core type could not be resolved (no `Type:`, no profile, no inferable signal). |
+
 Profile-declared enum attributes (e.g., `ASIL`, `Test-level`, `Element-kind`)
 are validated against the vocabulary declared in the active profile's manifest.
 The core defines no enum vocabularies of its own.

--- a/packages/markspec/core/validator/per_type_attrs.ts
+++ b/packages/markspec/core/validator/per_type_attrs.ts
@@ -31,18 +31,40 @@ const UNIVERSAL_KEYS: ReadonlySet<string> = new Set<string>(
 );
 
 /**
- * Emit MSL-T022 warnings for attributes that are core-known but not
- * valid on the entry's resolved type. Skips entries whose type cannot
- * be resolved (no explicit `Type:`, no profile classification, no URI
- * scheme inference — those are handled by MSL-T020 / MSL-T021 /
- * MSL-T023) and attributes that are universal or entirely unknown to
- * the core hierarchy (those go through MSL-R010).
+ * Emit per-type attribute diagnostics:
+ *
+ *   - **MSL-T022** (warning) — an attribute is core-known but not
+ *     valid on the entry's *resolved* type.
+ *   - **MSL-T024** (warning) — the entry's core type could not be
+ *     resolved (no explicit `Type:`, no profile classification, no
+ *     inferable signal — display-ID prefix / URI scheme /
+ *     discriminating attribute) yet it carries a core-type-scoped
+ *     attribute, so that attribute cannot be validated. Without this,
+ *     such attributes slipped through silently (e.g. `Manufacturer:`
+ *     on a `jira:`-scheme reference). Universal and entirely unknown
+ *     attributes are exempt — those go through MSL-R010.
  */
 export function validatePerTypeAttributes(
   entry: Entry,
 ): readonly Diagnostic[] {
   const type = resolvedCoreType(entry);
-  if (type === undefined) return [];
+  if (type === undefined) {
+    const diagnostics: Diagnostic[] = [];
+    for (const attr of entry.rawAttributes) {
+      if (UNIVERSAL_KEYS.has(attr.key)) continue;
+      if (!CORE_TYPE_SCOPED_ATTRS.has(attr.key)) continue;
+      diagnostics.push({
+        code: "MSL-T024",
+        severity: "warning",
+        message:
+          `${entry.displayId}: attribute '${attr.key}' is type-specific but ` +
+          `the entry's core type could not be resolved; it cannot be ` +
+          `validated (spec §8.3)`,
+        location: entry.location,
+      });
+    }
+    return diagnostics;
+  }
 
   const allowed = attributesForType(type);
   const diagnostics: Diagnostic[] = [];

--- a/tests/e2e/validate_test.ts
+++ b/tests/e2e/validate_test.ts
@@ -618,6 +618,51 @@ Deno.test("validate: unknown Type value rejected with MSL-T020 in core-only mode
   assertStringIncludes(stderr, "NotARealType");
 });
 
+Deno.test("validate: type-specific attr on an unresolved-type entry warns (MSL-T024)", async () => {
+  // `Manufacturer` is a core-type-scoped attribute but NOT a
+  // discriminating one, so step-6 inference does not rescue it; the
+  // `jira:` scheme is unknown and there is no `Type:`. Previously
+  // silent — now MSL-T024 (warning, exit 2).
+  const { code, stderr } = await markspec(["validate", "req.md"], {
+    files: {
+      "req.md": `# Test
+
+- [widget] An external widget
+
+  Body.
+
+      Id: jira:FOO-1
+      Manufacturer: Acme Corp
+`,
+    },
+  });
+  assertEquals(code, 2, `expected exit 2, got ${code}; stderr: ${stderr}`);
+  assertStringIncludes(stderr, "MSL-T024");
+  assertStringIncludes(stderr, "Manufacturer");
+});
+
+Deno.test("validate: reference with only universal attrs stays clean (no MSL-T024)", async () => {
+  const { code, stderr } = await markspec(["validate", "req.md"], {
+    files: {
+      "req.md": `# Test
+
+- [extlib] An external library reference
+
+  Body.
+
+      Id: https://example.com/x
+      Labels: ASIL-B
+`,
+    },
+  });
+  assertEquals(code, 0, `expected exit 0, got ${code}; stderr: ${stderr}`);
+  assertEquals(
+    stderr.includes("MSL-T024"),
+    false,
+    `universal-only reference must not fire MSL-T024; stderr: ${stderr}`,
+  );
+});
+
 // ---------------------------------------------------------------------------
 // Per-type attribute compatibility — spec §1.6, MSL-T022
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes Prompt-1 review **Major 4** (no-resolvable-type entries bypass per-type attribute checks).

**Verification correction (surfaced, not silently worked around):** the review's literal repro `[foo]` + `Id: jira:FOO-1` + `Bus-protocol: CAN` is **already handled** on current `main` — `Bus-protocol` is a *discriminating* attribute, so post-review step-6 inference (#294/#295) resolves it to `HardwareInterface` and emits `MSL-T021`. Audit agent 4's "validates cleanly" claim was stale. The real residual gap is a core-type-scoped attribute that is **not** discriminating (`Manufacturer:`, `Part-number:`, `Datasheet:`) — step 6 can't rescue it, so it slipped silently.

- **New `MSL-T024` (warning)** — fires only when core type is unresolved **and** the entry carries ≥1 core-type-scoped, non-universal attribute. References with only universal attrs stay clean (no collateral on the common valid reference case).
- Severity `warning` (not error) per ADR-012 / MSL-R004 reasoning — a URI-scheme reference is valid; the attribute simply can't be checked. Matches sibling MSL-T022.
- `language.md §8.3` gains a type-resolution sub-table documenting **MSL-T020–T024** (T020–T023 were emitted but undocumented; ADR-012 makes §8 authoritative).

## Test Plan

- [x] TDD: positive (`Manufacturer` on `jira:` → exit 2 `MSL-T024`) **RED before, GREEN after**; negative (universal-only reference → clean) green throughout
- [x] All 7 existing `MSL-T022` e2e tests still pass (no regression)
- [x] `just check` — **1096 passed, 0 failed**, dprint/lint/typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
