### PR TITLE
feat(core): canonical body-AST node type contract (Path A PR 1)

### DIFF
--- a/packages/markspec/core/ast/nodes.ts
+++ b/packages/markspec/core/ast/nodes.ts
@@ -1,0 +1,191 @@
+/**
+ * @module core/ast/nodes
+ *
+ * Canonical body-AST node taxonomy. Authoritative spec:
+ * `docs/specs/markspec-core-data-model.md` §2.4 (closed 10-block
+ * catalogue), §2.5 (inline markers), §2.6 (captions).
+ *
+ * PR 1 of the canonical-body-AST plan: pure type contract, zero
+ * behaviour. The builder (`build.ts`) and renderer (`render.ts`)
+ * land in later PRs.
+ */
+
+import type { EntityRefConvention } from "../model/mod.ts";
+
+/** Body-relative source span. 1-based line/column, matching the
+ * codebase's {@link SourceLocation} convention. No `file`: that
+ * lives on the owning {@link Entry}. */
+export interface SourceRange {
+  readonly start: { readonly line: number; readonly column: number };
+  readonly end: { readonly line: number; readonly column: number };
+}
+
+/** RFC 2119 vs EARS modal class (spec §2.5.1). */
+export type ModalMarkerClass = "rfc2119" | "ears";
+
+/** A recognised modal keyword occurrence in prose (spec §2.5.1). */
+export interface ModalMarker {
+  readonly kind: "modal";
+  readonly cls: ModalMarkerClass;
+  /** Canonical (lowercased RFC 2119 / case-preserved EARS) form. */
+  readonly canonical: string;
+  readonly range: SourceRange;
+}
+
+/** An inline `$Identifier` entity reference (spec §2.5.2). Reuses
+ * the existing {@link EntityRefConvention}. */
+export interface EntityRefMarker {
+  readonly kind: "entity";
+  /** Identifier including the leading `$`. */
+  readonly ident: string;
+  readonly convention: EntityRefConvention;
+  readonly range: SourceRange;
+}
+
+/** Inline marker union (spec §2.5). */
+export type InlineMarker = ModalMarker | EntityRefMarker;
+
+/** Prose text plus the inline markers recognised within it. */
+export interface InlineContent {
+  readonly text: string;
+  readonly markers: readonly InlineMarker[];
+}
+
+/** A list item: a sequence of blocks (spec §2.4 `List`). */
+export interface ListItemNode {
+  readonly blocks: readonly BodyBlock[];
+  readonly range: SourceRange;
+}
+
+/** One `Term : definition` pair (spec §2.4 `DefinitionList`). */
+export interface DefinitionPair {
+  readonly term: InlineContent;
+  readonly definition: InlineContent;
+}
+
+/** GitHub-style admonition kinds (spec §2.4 `Note`). */
+export type AdmonitionKind =
+  | "NOTE"
+  | "TIP"
+  | "IMPORTANT"
+  | "WARNING"
+  | "CAUTION";
+
+/** CommonMark paragraph; carries inline markers (spec §2.4). */
+export interface ParagraphNode {
+  readonly kind: "paragraph";
+  readonly content: InlineContent;
+  readonly range: SourceRange;
+}
+
+/** Ordered or unordered list, nestable (spec §2.4). */
+export interface ListNode {
+  readonly kind: "list";
+  readonly ordered: boolean;
+  readonly items: readonly ListItemNode[];
+  readonly range: SourceRange;
+}
+
+/** GFM pipe table (spec §2.4). */
+export interface TableNode {
+  readonly kind: "table";
+  readonly header: readonly InlineContent[];
+  readonly rows: readonly (readonly InlineContent[])[];
+  readonly range: SourceRange;
+}
+
+/** Image link `![alt](path)` (spec §2.4). */
+export interface FigureNode {
+  readonly kind: "figure";
+  readonly alt: string;
+  readonly path: string;
+  readonly range: SourceRange;
+}
+
+/** Fenced code block; info-string language tag, or none (spec §2.4). */
+export interface CodeNode {
+  readonly kind: "code";
+  /** Info-string language tag, or `undefined` for a bare fence. */
+  readonly lang: string | undefined;
+  readonly text: string;
+  readonly range: SourceRange;
+}
+
+/** Fenced code with info-string `gherkin`. Gherkin is kept verbatim
+ * for now; structured scenario parsing is deferred to a later PR
+ * (see the canonical-body-AST plan). */
+export interface FeatureNode {
+  readonly kind: "feature";
+  readonly source: string;
+  readonly range: SourceRange;
+}
+
+/** `$$ … $$` math block (spec §2.4). */
+export interface MathNode {
+  readonly kind: "math";
+  readonly tex: string;
+  readonly range: SourceRange;
+}
+
+/** `Term` / `: definition` list, GLFM (spec §2.4). */
+export interface DefinitionListNode {
+  readonly kind: "definition-list";
+  readonly items: readonly DefinitionPair[];
+  readonly range: SourceRange;
+}
+
+/** GitHub-style admonition blockquote (spec §2.4). */
+export interface NoteNode {
+  readonly kind: "note";
+  readonly admonition: AdmonitionKind;
+  readonly content: InlineContent;
+  readonly range: SourceRange;
+}
+
+/** Plain `>` blockquote, for external citation excerpts (spec §2.4). */
+export interface BlockquoteNode {
+  readonly kind: "blockquote";
+  readonly content: InlineContent;
+  readonly range: SourceRange;
+}
+
+/** §2.6 caption. Distinct from the render-pipeline `Caption`
+ * (model/mod.ts) — unrelated concept. `block` (resolved owner) is
+ * populated by the builder/validator in later PRs. */
+export interface CaptionNode {
+  readonly kind: "caption";
+  readonly keyword:
+    | "Figure"
+    | "Table"
+    | "Listing"
+    | "Feature"
+    | "Equation"
+    | "List";
+  readonly text: string;
+  readonly position: "above" | "below";
+  readonly block?: BodyBlock;
+  readonly range: SourceRange;
+}
+
+/** Fallback for malformed / excluded constructs so content is never
+ * lost (spec §5.4). Excluded constructs still emit MSL-B040–B043. */
+export interface UnknownNode {
+  readonly kind: "unknown";
+  readonly raw: string;
+  readonly range: SourceRange;
+}
+
+/** The closed body-block union (spec §2.4) + `caption` + `unknown`. */
+export type BodyBlock =
+  | ParagraphNode
+  | ListNode
+  | TableNode
+  | FigureNode
+  | CodeNode
+  | FeatureNode
+  | MathNode
+  | DefinitionListNode
+  | NoteNode
+  | BlockquoteNode
+  | CaptionNode
+  | UnknownNode;

--- a/packages/markspec/core/ast/nodes_test.ts
+++ b/packages/markspec/core/ast/nodes_test.ts
@@ -1,0 +1,96 @@
+import { assertEquals } from "@std/assert";
+import type {
+  BodyBlock,
+  CaptionNode,
+  CodeNode,
+  EntityRefMarker,
+  InlineContent,
+  ModalMarker,
+  ParagraphNode,
+  SourceRange,
+} from "./nodes.ts";
+
+const R: SourceRange = {
+  start: { line: 1, column: 1 },
+  end: { line: 1, column: 2 },
+};
+
+Deno.test("nodes: InlineContent carries text + typed markers", () => {
+  const modal: ModalMarker = {
+    kind: "modal",
+    cls: "rfc2119",
+    canonical: "shall",
+    range: R,
+  };
+  const ent: EntityRefMarker = {
+    kind: "entity",
+    ident: "$Sensor",
+    convention: "type",
+    range: R,
+  };
+  const ic: InlineContent = {
+    text: "The system shall read $Sensor.",
+    markers: [modal, ent],
+  };
+  assertEquals(ic.markers.length, 2);
+  assertEquals(ic.markers[0].kind, "modal");
+  assertEquals(ic.markers[1].kind, "entity");
+});
+
+Deno.test("nodes: block union is discriminated and exhaustive", () => {
+  const para: ParagraphNode = {
+    kind: "paragraph",
+    content: { text: "x", markers: [] },
+    range: R,
+  };
+  const code: CodeNode = {
+    kind: "code",
+    lang: "rust",
+    text: "fn main() {}",
+    range: R,
+  };
+  const cap: CaptionNode = {
+    kind: "caption",
+    keyword: "Figure",
+    text: "A diagram",
+    position: "below",
+    range: R,
+  };
+
+  const label = (b: BodyBlock): string => {
+    switch (b.kind) {
+      case "paragraph":
+        return "paragraph";
+      case "list":
+        return "list";
+      case "table":
+        return "table";
+      case "figure":
+        return "figure";
+      case "code":
+        return "code";
+      case "feature":
+        return "feature";
+      case "math":
+        return "math";
+      case "definition-list":
+        return "definition-list";
+      case "note":
+        return "note";
+      case "blockquote":
+        return "blockquote";
+      case "caption":
+        return "caption";
+      case "unknown":
+        return "unknown";
+      default: {
+        const _exhaustive: never = b;
+        return _exhaustive;
+      }
+    }
+  };
+
+  assertEquals(label(para), "paragraph");
+  assertEquals(label(code), "code");
+  assertEquals(label(cap), "caption");
+});

--- a/packages/markspec/core/mod.ts
+++ b/packages/markspec/core/mod.ts
@@ -42,6 +42,33 @@ export type {
   Ulid,
 } from "./model/mod.ts";
 
+// AST (canonical body-AST — spec docs/specs/markspec-core-data-model.md §2)
+// SourceRange is body-relative (no `file`); use SourceLocation for file-absolute positions.
+export type {
+  AdmonitionKind,
+  BlockquoteNode,
+  BodyBlock,
+  CaptionNode,
+  CodeNode,
+  DefinitionListNode,
+  DefinitionPair,
+  EntityRefMarker,
+  FeatureNode,
+  FigureNode,
+  InlineContent,
+  InlineMarker,
+  ListItemNode,
+  ListNode,
+  MathNode,
+  ModalMarker,
+  ModalMarkerClass,
+  NoteNode,
+  ParagraphNode,
+  SourceRange,
+  TableNode,
+  UnknownNode,
+} from "./ast/nodes.ts";
+
 // Config
 export {
   discoverProjectRoot,


### PR DESCRIPTION
## Summary
PR 1 of 7 — canonical body-AST (spec/plan 2026-05-15). Pure node type contract: §2.4 closed 10-block catalogue + §2.5 inline markers (ModalMarker/EntityRefMarker) + §2.6 CaptionNode (distinct from the unrelated render-pipeline Caption). EntityRefConvention reused from model. Zero behaviour; builder/renderer/validators land in PRs 2-7. Re-exported from core/mod.ts (library boundary unchanged).

Reviewed via subagent-driven-development: spec-compliance ✅, code-quality ✅ (doc comments on all 22 exports, CI green).

## Test Plan
- [x] colocated nodes_test.ts: marker typing + exhaustive discriminated-union switch (never guard)
- [x] just check — 1098 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
