### PR TITLE
feat(core): mdast → BodyBlock[] builder; additive Entry.bodyAst (Path A PR 2)

### DIFF
--- a/packages/markspec/core/ast/build.ts
+++ b/packages/markspec/core/ast/build.ts
@@ -1,0 +1,515 @@
+/**
+ * @module core/ast/build
+ *
+ * Body-string → BodyBlock[] builder. Parses the entry body string
+ * (post-`splitBodyAndAttributes`) with the shared remark processor and
+ * maps each mdast block child to the §2.4-2.6 node taxonomy.
+ *
+ * Inline markers (modal + $Identifier) are extracted for prose-bearing
+ * nodes: Paragraph, List items, Table cells, Note bodies, Blockquotes,
+ * and DefinitionList term/definitions. They are NOT extracted inside
+ * Code, Feature, or Math blocks (spec §2.5).
+ *
+ * This module is pure library code: no `Deno.*` APIs.
+ */
+
+import type { Root } from "mdast";
+import { processor } from "../parser/remark.ts";
+import { classifyConvention } from "../parser/entity_refs.ts";
+import type {
+  AdmonitionKind,
+  BlockquoteNode,
+  BodyBlock,
+  CaptionNode,
+  CodeNode,
+  DefinitionListNode,
+  EntityRefMarker,
+  FeatureNode,
+  FigureNode,
+  InlineContent,
+  InlineMarker,
+  ListItemNode,
+  ListNode,
+  MathNode,
+  ModalMarker,
+  ModalMarkerClass,
+  NoteNode,
+  ParagraphNode,
+  SourceRange,
+  TableNode,
+  UnknownNode,
+} from "./nodes.ts";
+
+// ---------------------------------------------------------------------------
+// Inline marker recognition — modal keywords
+// ---------------------------------------------------------------------------
+
+/**
+ * RFC 2119 tokens (lowercase canonical; matched case-insensitively in prose).
+ * Multi-word forms listed first so the alternation greedily matches them.
+ */
+const RFC2119_RE =
+  /\b(shall not|should not|must not|shall|should|must|may)\b/gi;
+
+// EARS keywords recognised: When, While, Where, Unless.
+const EARS_RE = /\b(When|While|Where|Unless)\b/g;
+
+/** `$Identifier` entity reference — must not be preceded by another `$`. */
+const ENTITY_REF_RE = /\$([A-Za-z][A-Za-z0-9_]*)/g;
+
+/**
+ * Extract all inline markers from a prose text string.
+ * `lineOffset` is the 0-based line index of the text within the body
+ * (used for SourceRange line numbers).
+ *
+ * For multi-line text the SourceRange carries the first line's 1-based
+ * column; this is best-effort for PR 2 (noted as DONE_WITH_CONCERNS:
+ * multi-line paragraph ranges are approximated to the starting line).
+ */
+function extractMarkersFromText(
+  text: string,
+  startRange: SourceRange,
+): readonly InlineMarker[] {
+  const markers: InlineMarker[] = [];
+  const lines = text.split("\n");
+
+  for (let li = 0; li < lines.length; li++) {
+    const line = lines[li];
+    const lineNo = startRange.start.line + li;
+
+    // ---- RFC 2119 ---------------------------------------------------
+    RFC2119_RE.lastIndex = 0;
+    let m: RegExpExecArray | null;
+    while ((m = RFC2119_RE.exec(line)) !== null) {
+      const raw = m[1];
+      const canonical = raw.toLowerCase() as string;
+      const col = m.index + 1;
+      markers.push(
+        {
+          kind: "modal",
+          cls: "rfc2119" as ModalMarkerClass,
+          canonical,
+          range: {
+            start: { line: lineNo, column: col },
+            end: { line: lineNo, column: col + raw.length },
+          },
+        } satisfies ModalMarker,
+      );
+    }
+
+    // ---- EARS -------------------------------------------------------
+    EARS_RE.lastIndex = 0;
+    while ((m = EARS_RE.exec(line)) !== null) {
+      const raw = m[1];
+      const col = m.index + 1;
+      markers.push(
+        {
+          kind: "modal",
+          cls: "ears" as ModalMarkerClass,
+          canonical: raw, // EARS: source form is canonical
+          range: {
+            start: { line: lineNo, column: col },
+            end: { line: lineNo, column: col + raw.length },
+          },
+        } satisfies ModalMarker,
+      );
+    }
+
+    // ---- $Identifier ------------------------------------------------
+    ENTITY_REF_RE.lastIndex = 0;
+    while ((m = ENTITY_REF_RE.exec(line)) !== null) {
+      // Discard if preceded by another `$` (math fence `$$…$$`)
+      if (m.index > 0 && line[m.index - 1] === "$") continue;
+      // Discard if preceded by `\` (escaped)
+      if (m.index > 0 && line[m.index - 1] === "\\") continue;
+      const ident = m[0]; // includes leading `$`
+      const bare = m[1];
+      const col = m.index + 1;
+      markers.push(
+        {
+          kind: "entity",
+          ident,
+          convention: classifyConvention(bare),
+          range: {
+            start: { line: lineNo, column: col },
+            end: { line: lineNo, column: col + ident.length },
+          },
+        } satisfies EntityRefMarker,
+      );
+    }
+  }
+
+  return markers;
+}
+
+/** Build an InlineContent from a prose text string. */
+function inlineContent(text: string, range: SourceRange): InlineContent {
+  const markers = extractMarkersFromText(text, range);
+  return { text, markers };
+}
+
+// ---------------------------------------------------------------------------
+// mdast position → SourceRange
+// ---------------------------------------------------------------------------
+
+function positionToRange(
+  pos: {
+    start: { line: number; column: number };
+    end: { line: number; column: number };
+  } | undefined,
+): SourceRange {
+  if (!pos) {
+    return { start: { line: 1, column: 1 }, end: { line: 1, column: 1 } };
+  }
+  return {
+    start: { line: pos.start.line, column: pos.start.column },
+    end: { line: pos.end.line, column: pos.end.column },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Caption detection
+// ---------------------------------------------------------------------------
+
+/** Caption keywords from spec §2.6. */
+const CAPTION_KEYWORDS = [
+  "Figure",
+  "Table",
+  "Listing",
+  "Feature",
+  "Equation",
+  "List",
+] as const;
+
+type CaptionKeyword = (typeof CAPTION_KEYWORDS)[number];
+
+const CAPTION_RE = /^(Figure|Table|Listing|Feature|Equation|List):\s+(\S.*)/;
+
+function tryCaptionParagraph(text: string): {
+  keyword: CaptionKeyword;
+  text: string;
+} | undefined {
+  const m = CAPTION_RE.exec(text.trim());
+  if (!m) return undefined;
+  return { keyword: m[1] as CaptionKeyword, text: m[2].trim() };
+}
+
+// ---------------------------------------------------------------------------
+// Math detection — `$$` delimited paragraphs
+// ---------------------------------------------------------------------------
+
+const MATH_BLOCK_RE = /^\$\$([\s\S]*?)\$\$$/;
+
+function tryMathParagraph(
+  text: string,
+): string | undefined {
+  // Plain text that is exactly `$$ ... $$` → math block
+  const m = MATH_BLOCK_RE.exec(text.trim());
+  if (m) return m[1];
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Admonition detection
+// ---------------------------------------------------------------------------
+
+const ADMONITION_FIRST_LINE_RE = /^\[!(NOTE|TIP|IMPORTANT|WARNING|CAUTION)\]/;
+
+// ---------------------------------------------------------------------------
+// Definition-list detection (GLFM `Term\n: def` pattern)
+//
+// remark-gfm does NOT parse GLFM definition lists; they come through as
+// Paragraph nodes. We detect the pattern in the body string before parsing
+// and handle them via our pre-pass.
+//
+// DONE_WITH_CONCERNS: single-item best-effort as documented in the PR brief.
+// ---------------------------------------------------------------------------
+
+const DEFLIST_RE = /^([^\n:][^\n]*)\n:\s+(.+)$/m;
+
+function tryDefinitionList(
+  text: string,
+): { term: string; definition: string } | undefined {
+  const m = DEFLIST_RE.exec(text.trim());
+  if (!m) return undefined;
+  return { term: m[1].trim(), definition: m[2].trim() };
+}
+
+// ---------------------------------------------------------------------------
+// mdast text extraction helper
+// ---------------------------------------------------------------------------
+
+// deno-lint-ignore no-explicit-any
+function extractMdastText(node: any): string {
+  if (!node) return "";
+  if (typeof node.value === "string") return node.value;
+  if (Array.isArray(node.children)) {
+    return node.children.map(extractMdastText).join("");
+  }
+  return "";
+}
+
+// ---------------------------------------------------------------------------
+// Caption position computation
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute caption positions: "above" or "below" relative to adjacent blocks.
+ * This is a post-processing pass that examines caption nodes relative to their
+ * neighbours.
+ *
+ * DONE_WITH_CONCERNS: position is determined by source order heuristic —
+ * if the block *after* the caption is a non-caption, non-paragraph block,
+ * caption is "above"; if the block *before* is such a block, it's "below".
+ * For PR 2, defaults to "below" when adjacent block type is unclear.
+ */
+function assignCaptionPositions(blocks: BodyBlock[]): BodyBlock[] {
+  const result: BodyBlock[] = [];
+  for (let i = 0; i < blocks.length; i++) {
+    if (blocks[i].kind !== "caption") {
+      result.push(blocks[i]);
+      continue;
+    }
+    const cap = blocks[i] as CaptionNode;
+
+    // Look ahead for a non-caption, non-paragraph block
+    const nextBlock = blocks[i + 1];
+    const prevBlock = result[result.length - 1];
+
+    const isCaptionable = (b: BodyBlock | undefined): boolean => {
+      if (!b) return false;
+      return (
+        b.kind === "figure" ||
+        b.kind === "table" ||
+        b.kind === "code" ||
+        b.kind === "feature" ||
+        b.kind === "math" ||
+        b.kind === "list"
+      );
+    };
+
+    let position: "above" | "below";
+    if (isCaptionable(nextBlock)) {
+      position = "above";
+    } else if (isCaptionable(prevBlock)) {
+      position = "below";
+    } else {
+      // Default: below (conservative)
+      position = "below";
+    }
+
+    result.push({ ...cap, position } satisfies CaptionNode);
+  }
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Main builder — mdast node → BodyBlock
+// ---------------------------------------------------------------------------
+
+// deno-lint-ignore no-explicit-any
+function mapMdastNode(node: any): BodyBlock {
+  const range = positionToRange(node.position);
+
+  switch (node.type) {
+    case "paragraph": {
+      const text = extractMdastText(node);
+
+      // Check for lone image → FigureNode
+      if (
+        node.children.length === 1 &&
+        node.children[0].type === "image"
+      ) {
+        const img = node.children[0];
+        return {
+          kind: "figure",
+          alt: img.alt ?? "",
+          path: img.url ?? "",
+          range,
+        } satisfies FigureNode;
+      }
+
+      // Check for math `$$ ... $$` paragraph
+      const mathTex = tryMathParagraph(text);
+      if (mathTex !== undefined) {
+        return { kind: "math", tex: mathTex, range } satisfies MathNode;
+      }
+
+      // Check for definition-list pattern `Term\n: def`
+      const defList = tryDefinitionList(text);
+      if (defList) {
+        const termRange: SourceRange = {
+          start: range.start,
+          end: range.start,
+        };
+        const defRange: SourceRange = {
+          start: range.start,
+          end: range.end,
+        };
+        return {
+          kind: "definition-list",
+          items: [
+            {
+              term: inlineContent(defList.term, termRange),
+              definition: inlineContent(defList.definition, defRange),
+            },
+          ],
+          range,
+        } satisfies DefinitionListNode;
+      }
+
+      // Check for caption `Figure: text` etc.
+      const caption = tryCaptionParagraph(text);
+      if (caption) {
+        // Position is resolved in a post-pass; default "below" for now
+        return {
+          kind: "caption",
+          keyword: caption.keyword,
+          text: caption.text,
+          position: "below",
+          range,
+        } satisfies CaptionNode;
+      }
+
+      // Plain paragraph with prose markers
+      return {
+        kind: "paragraph",
+        content: inlineContent(text, range),
+        range,
+      } satisfies ParagraphNode;
+    }
+
+    case "list": {
+      const items: ListItemNode[] = node.children.map(
+        // deno-lint-ignore no-explicit-any
+        (item: any): ListItemNode => {
+          const itemRange = positionToRange(item.position);
+          const subBlocks: BodyBlock[] = (item.children ?? []).map(
+            // deno-lint-ignore no-explicit-any
+            (child: any) => mapMdastNode(child),
+          );
+          return { blocks: subBlocks, range: itemRange };
+        },
+      );
+      return {
+        kind: "list",
+        ordered: node.ordered ?? false,
+        items,
+        range,
+      } satisfies ListNode;
+    }
+
+    case "table": {
+      // deno-lint-ignore no-explicit-any
+      const rows: (readonly InlineContent[])[] = node.children.map((row: any) =>
+        // deno-lint-ignore no-explicit-any
+        (row.children ?? []).map((cell: any) => {
+          const cellText = extractMdastText(cell);
+          const cellRange = positionToRange(cell.position);
+          return inlineContent(cellText, cellRange);
+        })
+      );
+      const [header = [], ...dataRows] = rows;
+      return {
+        kind: "table",
+        header,
+        rows: dataRows,
+        range,
+      } satisfies TableNode;
+    }
+
+    case "code": {
+      const lang = node.lang ?? undefined; // empty string → undefined
+      if (lang === "gherkin") {
+        return {
+          kind: "feature",
+          source: node.value ?? "",
+          range,
+        } satisfies FeatureNode;
+      }
+      return {
+        kind: "code",
+        lang: lang || undefined,
+        text: node.value ?? "",
+        range,
+      } satisfies CodeNode;
+    }
+
+    case "blockquote": {
+      // Admonition heuristic: first text content starts with `[!KIND]`
+      const firstChild = node.children?.[0];
+      if (firstChild?.type === "paragraph") {
+        const paraText = extractMdastText(firstChild);
+        const admonMatch = ADMONITION_FIRST_LINE_RE.exec(paraText.trim());
+        if (admonMatch) {
+          const kind = admonMatch[1] as AdmonitionKind;
+          // Rest of the text after the admonition marker
+          const rest = paraText.replace(ADMONITION_FIRST_LINE_RE, "").trim();
+          // Collect text from remaining children too
+          const otherText = node.children
+            .slice(1)
+            // deno-lint-ignore no-explicit-any
+            .map((c: any) => extractMdastText(c))
+            .join(" ");
+          const fullText = [rest, otherText].filter(Boolean).join(" ");
+          const content = inlineContent(fullText, range);
+          return {
+            kind: "note",
+            admonition: kind,
+            content,
+            range,
+          } satisfies NoteNode;
+        }
+      }
+      // Plain blockquote
+      const bqText = node.children
+        // deno-lint-ignore no-explicit-any
+        .map((c: any) => extractMdastText(c))
+        .join(" ");
+      return {
+        kind: "blockquote",
+        content: inlineContent(bqText, range),
+        range,
+      } satisfies BlockquoteNode;
+    }
+
+    default:
+      // Headings, HR, HTML, and anything else → UnknownNode so content is never lost
+      return {
+        kind: "unknown",
+        raw: extractMdastText(node),
+        range,
+      } satisfies UnknownNode;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the canonical body AST from an entry body string.
+ *
+ * Re-parses `body` via the shared remark processor (CommonMark+GFM) and
+ * maps each block-level mdast node to a `BodyBlock`. SourceRange positions
+ * are body-relative (1-based line/column) matching the mdast output directly.
+ *
+ * DONE_WITH_CONCERNS notes:
+ * - DefinitionList: single-item best-effort. `Term\n: def` patterns in
+ *   multi-item lists are parsed as one DefinitionListNode per paragraph
+ *   block; the validator would need to coalesce them (deferred).
+ * - Caption position: assigned by adjacent-block heuristic (post-pass).
+ *   `block` (resolved owner) is `undefined` for PR 2 per spec.
+ * - Multi-line paragraph marker ranges: SourceRange is approximated to
+ *   the paragraph start line; intra-paragraph column tracking is correct
+ *   only for single-line paragraphs.
+ */
+export function buildBodyAst(body: string): BodyBlock[] {
+  if (!body.trim()) return [];
+
+  const tree = processor.parse(body) as Root;
+  const blocks: BodyBlock[] = tree.children.map(mapMdastNode);
+
+  // Post-pass: assign caption positions
+  return assignCaptionPositions(blocks);
+}

--- a/packages/markspec/core/ast/build_test.ts
+++ b/packages/markspec/core/ast/build_test.ts
@@ -1,0 +1,329 @@
+/**
+ * @module core/ast/build_test
+ *
+ * TDD tests for buildBodyAst(). Written before the implementation.
+ *
+ * Coverage:
+ *   1. Per-kind unit tests (all 12 node kinds).
+ *   2. Inline marker tests (modal + entity-ref; excluded in Code/Feature).
+ *   3. Characterisation tests (existing fixture files have bodyAst populated).
+ */
+
+import { assertEquals, assertExists, assertStringIncludes } from "@std/assert";
+import type {
+  BlockquoteNode,
+  CaptionNode,
+  CodeNode,
+  DefinitionListNode,
+  FeatureNode,
+  FigureNode,
+  ListNode,
+  MathNode,
+  NoteNode,
+  ParagraphNode,
+  TableNode,
+  UnknownNode,
+} from "./nodes.ts";
+
+// ----------------------------------------------------------------------------
+// Helper — import lazily so tests can stub before loading (future).
+// For now just import at the top.
+// ----------------------------------------------------------------------------
+import { buildBodyAst } from "./build.ts";
+import { parseMarkdown } from "../parser/markdown.ts";
+
+// ============================================================================
+// 1. Per-kind unit tests
+// ============================================================================
+
+Deno.test("build: paragraph → ParagraphNode with text", () => {
+  const blocks = buildBodyAst("Simple paragraph text.");
+  assertEquals(blocks.length, 1);
+  const p = blocks[0] as ParagraphNode;
+  assertEquals(p.kind, "paragraph");
+  assertEquals(p.content.text, "Simple paragraph text.");
+  assertEquals(p.range.start.line, 1);
+});
+
+Deno.test("build: image-only paragraph → FigureNode", () => {
+  const blocks = buildBodyAst("![a diagram](path/to/diagram.svg)");
+  assertEquals(blocks.length, 1);
+  const fig = blocks[0] as FigureNode;
+  assertEquals(fig.kind, "figure");
+  assertEquals(fig.alt, "a diagram");
+  assertEquals(fig.path, "path/to/diagram.svg");
+});
+
+Deno.test("build: unordered list → ListNode", () => {
+  const body = `- item one\n- item two`;
+  const blocks = buildBodyAst(body);
+  assertEquals(blocks.length, 1);
+  const list = blocks[0] as ListNode;
+  assertEquals(list.kind, "list");
+  assertEquals(list.ordered, false);
+  assertEquals(list.items.length, 2);
+});
+
+Deno.test("build: ordered list → ListNode with ordered=true", () => {
+  const body = `1. first\n2. second`;
+  const blocks = buildBodyAst(body);
+  assertEquals(blocks.length, 1);
+  const list = blocks[0] as ListNode;
+  assertEquals(list.kind, "list");
+  assertEquals(list.ordered, true);
+});
+
+Deno.test("build: GFM table → TableNode", () => {
+  const body = `| A | B |\n|---|---|\n| 1 | 2 |`;
+  const blocks = buildBodyAst(body);
+  assertEquals(blocks.length, 1);
+  const tbl = blocks[0] as TableNode;
+  assertEquals(tbl.kind, "table");
+  assertEquals(tbl.header.length, 2);
+  assertEquals(tbl.header[0].text, "A");
+  assertEquals(tbl.header[1].text, "B");
+  assertEquals(tbl.rows.length, 1);
+  assertEquals(tbl.rows[0][0].text, "1");
+  assertEquals(tbl.rows[0][1].text, "2");
+});
+
+Deno.test("build: fenced code block → CodeNode", () => {
+  const body = "```rust\nfn main() {}\n```";
+  const blocks = buildBodyAst(body);
+  assertEquals(blocks.length, 1);
+  const code = blocks[0] as CodeNode;
+  assertEquals(code.kind, "code");
+  assertEquals(code.lang, "rust");
+  assertEquals(code.text, "fn main() {}");
+});
+
+Deno.test("build: code block with no lang → CodeNode with lang undefined", () => {
+  const body = "```\nsome text\n```";
+  const blocks = buildBodyAst(body);
+  assertEquals(blocks.length, 1);
+  const code = blocks[0] as CodeNode;
+  assertEquals(code.kind, "code");
+  assertEquals(code.lang, undefined);
+  assertEquals(code.text, "some text");
+});
+
+Deno.test("build: gherkin fence → FeatureNode", () => {
+  const body = "```gherkin\nFeature: braking\n  Scenario: stop\n```";
+  const blocks = buildBodyAst(body);
+  assertEquals(blocks.length, 1);
+  const feat = blocks[0] as FeatureNode;
+  assertEquals(feat.kind, "feature");
+  assertEquals(feat.source, "Feature: braking\n  Scenario: stop");
+});
+
+Deno.test("build: $$ math block → MathNode", () => {
+  const body = "$$\nE = mc^2\n$$";
+  const blocks = buildBodyAst(body);
+  assertEquals(blocks.length, 1);
+  const math = blocks[0] as MathNode;
+  assertEquals(math.kind, "math");
+  assertEquals(math.tex.trim(), "E = mc^2");
+});
+
+Deno.test("build: GitHub admonition blockquote → NoteNode", () => {
+  const body = "> [!WARNING]\n> This is a warning.";
+  const blocks = buildBodyAst(body);
+  assertEquals(blocks.length, 1);
+  const note = blocks[0] as NoteNode;
+  assertEquals(note.kind, "note");
+  assertEquals(note.admonition, "WARNING");
+  assertExists(note.content.text);
+});
+
+Deno.test("build: plain blockquote → BlockquoteNode", () => {
+  const body = "> An external citation.";
+  const blocks = buildBodyAst(body);
+  assertEquals(blocks.length, 1);
+  const bq = blocks[0] as BlockquoteNode;
+  assertEquals(bq.kind, "blockquote");
+  assertExists(bq.content.text);
+});
+
+Deno.test("build: definition-list pattern → DefinitionListNode", () => {
+  const body = "Term\n: A definition here.";
+  const blocks = buildBodyAst(body);
+  assertEquals(blocks.length, 1);
+  const dl = blocks[0] as DefinitionListNode;
+  assertEquals(dl.kind, "definition-list");
+  assertEquals(dl.items.length, 1);
+  assertEquals(dl.items[0].term.text, "Term");
+  assertEquals(dl.items[0].definition.text, "A definition here.");
+});
+
+Deno.test("build: heading → UnknownNode (excluded construct)", () => {
+  const body = "# A heading";
+  const blocks = buildBodyAst(body);
+  assertEquals(blocks.length, 1);
+  const unk = blocks[0] as UnknownNode;
+  assertEquals(unk.kind, "unknown");
+});
+
+Deno.test("build: caption paragraph → CaptionNode", () => {
+  const body = "Figure: A system overview diagram.";
+  const blocks = buildBodyAst(body);
+  assertEquals(blocks.length, 1);
+  const cap = blocks[0] as CaptionNode;
+  assertEquals(cap.kind, "caption");
+  assertEquals(cap.keyword, "Figure");
+  assertEquals(cap.text, "A system overview diagram.");
+});
+
+Deno.test("build: caption with Table keyword", () => {
+  const body = "Table: Attribute definitions.";
+  const blocks = buildBodyAst(body);
+  assertEquals(blocks.length, 1);
+  const cap = blocks[0] as CaptionNode;
+  assertEquals(cap.kind, "caption");
+  assertEquals(cap.keyword, "Table");
+});
+
+Deno.test("build: SourceRange is body-relative 1-based", () => {
+  const body = "First paragraph.\n\nSecond paragraph.";
+  const blocks = buildBodyAst(body);
+  assertEquals(blocks.length, 2);
+  assertEquals(blocks[0].range.start.line, 1);
+  assertEquals(blocks[1].range.start.line, 3);
+});
+
+// ============================================================================
+// 2. Marker tests
+// ============================================================================
+
+Deno.test("build: paragraph with RFC2119 modal + entity ref → markers extracted", () => {
+  const body = "The system shall read $Sensor.";
+  const blocks = buildBodyAst(body);
+  assertEquals(blocks.length, 1);
+  const p = blocks[0] as ParagraphNode;
+  assertEquals(p.kind, "paragraph");
+
+  const modalMarkers = p.content.markers.filter((m) => m.kind === "modal");
+  const entityMarkers = p.content.markers.filter((m) => m.kind === "entity");
+
+  assertEquals(modalMarkers.length, 1);
+  assertEquals(modalMarkers[0].kind, "modal");
+  if (modalMarkers[0].kind === "modal") {
+    assertEquals(modalMarkers[0].cls, "rfc2119");
+    assertEquals(modalMarkers[0].canonical, "shall");
+  }
+
+  assertEquals(entityMarkers.length, 1);
+  assertEquals(entityMarkers[0].kind, "entity");
+  if (entityMarkers[0].kind === "entity") {
+    assertEquals(entityMarkers[0].ident, "$Sensor");
+    assertEquals(entityMarkers[0].convention, "type");
+  }
+});
+
+Deno.test("build: 'shall not' recognised as single RFC2119 modal", () => {
+  const body = "The system shall not fail.";
+  const blocks = buildBodyAst(body);
+  const p = blocks[0] as ParagraphNode;
+  const modals = p.content.markers.filter((m) => m.kind === "modal");
+  assertEquals(modals.length, 1);
+  if (modals[0].kind === "modal") {
+    assertEquals(modals[0].canonical, "shall not");
+  }
+});
+
+Deno.test("build: EARS 'When' recognised as ears modal", () => {
+  const body = "When the sensor fails, the system shall stop.";
+  const blocks = buildBodyAst(body);
+  const p = blocks[0] as ParagraphNode;
+  const modals = p.content.markers.filter((m) => m.kind === "modal");
+  // At least a "When" EARS marker and a "shall" RFC2119 marker
+  const ears = modals.filter((m) => m.kind === "modal" && m.cls === "ears");
+  const rfc = modals.filter((m) => m.kind === "modal" && m.cls === "rfc2119");
+  assertEquals(ears.length >= 1, true);
+  assertEquals(rfc.length >= 1, true);
+});
+
+Deno.test("build: markers NOT extracted inside code fence", () => {
+  const body = "```\nshall $Sensor\n```";
+  const blocks = buildBodyAst(body);
+  assertEquals(blocks.length, 1);
+  const code = blocks[0] as CodeNode;
+  assertEquals(code.kind, "code");
+  assertEquals(code.text, "shall $Sensor");
+  assertEquals("markers" in code, false);
+  assertEquals("content" in code, false);
+});
+
+Deno.test("build: markers NOT extracted inside $$ math block", () => {
+  const body = "$$\nshall $Sensor\n$$";
+  const blocks = buildBodyAst(body);
+  assertEquals(blocks.length, 1);
+  const math = blocks[0] as MathNode;
+  assertEquals(math.kind, "math");
+  assertEquals("markers" in math, false);
+  assertEquals("content" in math, false);
+  assertStringIncludes(math.tex, "shall $Sensor");
+});
+
+Deno.test("build: markers NOT extracted inside gherkin Feature fence", () => {
+  const body = "```gherkin\nGiven the sensor shall read $Sensor\n```";
+  const blocks = buildBodyAst(body);
+  assertEquals(blocks.length, 1);
+  const feat = blocks[0] as FeatureNode;
+  assertEquals(feat.kind, "feature");
+  // FeatureNode has no markers field
+});
+
+Deno.test("build: entity refs with different conventions", () => {
+  const body = "Use $BrakeController for $rawPressure and $DEBOUNCE_WINDOW.";
+  const blocks = buildBodyAst(body);
+  const p = blocks[0] as ParagraphNode;
+  const entities = p.content.markers.filter((m) => m.kind === "entity");
+  assertEquals(entities.length, 3);
+  if (entities[0].kind === "entity") {
+    assertEquals(entities[0].convention, "type");
+  }
+  if (entities[1].kind === "entity") {
+    assertEquals(entities[1].convention, "instance");
+  }
+  if (entities[2].kind === "entity") {
+    assertEquals(entities[2].convention, "constant");
+  }
+});
+
+// ============================================================================
+// 3. Characterisation tests — wiring into Entry.bodyAst
+// ============================================================================
+
+Deno.test("characterisation: requirement-block.md entries all have bodyAst", async () => {
+  const fixtureUrl = new URL(
+    "../../../../tests/fixtures/requirement-block.md",
+    import.meta.url,
+  );
+  const content = await Deno.readTextFile(fixtureUrl.pathname);
+  const result = parseMarkdown(content, {
+    file: fixtureUrl.pathname,
+  });
+  assertEquals(result.entries.length > 0, true, "fixture should have entries");
+  for (const entry of result.entries) {
+    assertExists(
+      entry.bodyAst,
+      `entry ${entry.displayId} should have bodyAst`,
+    );
+    assertEquals(
+      Array.isArray(entry.bodyAst),
+      true,
+      `entry ${entry.displayId} bodyAst should be an array`,
+    );
+  }
+});
+
+Deno.test("build: file with no entries does not crash buildBodyAst", async () => {
+  const md = await Deno.readTextFile(
+    new URL(
+      "../../../../tests/fixtures/traceability-matrix.md",
+      import.meta.url,
+    ),
+  );
+  const result = parseMarkdown(md, { file: "traceability-matrix.md" });
+  assertEquals(result.entries.length, 0);
+});

--- a/packages/markspec/core/model/mod.ts
+++ b/packages/markspec/core/model/mod.ts
@@ -4,6 +4,11 @@
  * MarkSpec document model — AST types, ID types, and project configuration.
  */
 
+// model/mod.ts ↔ ast/nodes.ts is a mutual type-only import cycle
+// (nodes.ts imports EntityRefConvention here); TypeScript resolves it
+// cleanly because both directions are `import type`.
+import type { BodyBlock } from "../ast/nodes.ts";
+
 export {
   ATTRIBUTE_CATALOG,
   attributeSpec,
@@ -311,6 +316,8 @@ export interface Entry {
   readonly title: string;
   /** Body content (paragraphs, alerts, code blocks) between title and attributes. */
   readonly body: string;
+  /** Canonical body AST (PR 2: additive, not yet consumed). */
+  readonly bodyAst?: readonly BodyBlock[];
   /**
    * Source-order raw attribute array. Used by the formatter for round-trip
    * fidelity (preserving key casing, line order, and trailing backslashes).

--- a/packages/markspec/core/parser/markdown.ts
+++ b/packages/markspec/core/parser/markdown.ts
@@ -15,6 +15,7 @@ import {
 } from "./attributes.ts";
 import { extractEntityRefs } from "./entity_refs.ts";
 import { processor } from "./remark.ts";
+import { buildBodyAst } from "../ast/build.ts";
 
 /** Options for {@linkcode parseMarkdown}. */
 export interface ParseMarkdownOptions {
@@ -217,6 +218,7 @@ function extractEntry(
   const bodyContent = extractBodyContent(item, markdown);
   const [body, attrLines] = splitBodyAndAttributes(bodyContent);
   const attributes = parseAttributes(attrLines);
+  const bodyAst = buildBodyAst(body);
 
   // Detect legacy paragraph + trailing-backslash attribute form and warn.
   if (
@@ -291,6 +293,7 @@ function extractEntry(
     displayId,
     title: title ?? "",
     body,
+    bodyAst,
     rawAttributes: attributes,
     typedAttributes: collateAttributes(attributes),
     id,


### PR DESCRIPTION
## Summary
PR 2 of 7 — canonical body-AST. `buildBodyAst(body)` re-parses the body string via the shared remark processor and maps mdast block children to the §2.4-2.6 node taxonomy (Feature=gherkin fence, Note=`[!X]` blockquote, Math=`$$`, captions, Unknown fallback so content is never lost). Inline markers (modal + $Identifier) recognised in prose nodes only. `Entry.bodyAst` added **additively and NOT consumed** — formatter/validators/`Entry.body` string unchanged; full suite green.

Reviewed via subagent-driven-development: spec-compliance ✅ (no correctness gaps), code-quality ✅ after fixes (strengthened code-fence + new math marker-exclusion tests, fixed mislabeled characterization test, comment corrections).

**Scoped limitations (per plan, resolved in later PRs):** DefinitionList single-item best-effort; CaptionNode.position heuristic / block owner deferred.

**Known follow-up (out of additive PR-2 scope):** `ENTITY_REF_RE` + RFC2119/EARS regexes are duplicated between `build.ts` and `entity_refs.ts`/`modal_keywords.ts` (constraint-driven — no shared recogniser exists). Extract a shared marker recogniser in a later refactor.

## Test Plan
- [x] 25 build_test.ts tests: per-node-kind, marker recognition incl. NOT-inside Code/Feature/Math, empty-entry-file edge case, characterization (entries get defined bodyAst)
- [x] just check — 1123 passed, 0 failed; behaviour-preserving (additive only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
