### PR TITLE
feat(core): route formatter body emission through the AST (Path A PR 4)

### DIFF
--- a/packages/markspec/core/formatter/mod.ts
+++ b/packages/markspec/core/formatter/mod.ts
@@ -20,6 +20,8 @@ import { extractFrontMatter } from "../parser/frontmatter.ts";
 import { parseMarkdown } from "../parser/markdown.ts";
 import { FENCE_RE, walkProseLines } from "../util/fence.ts";
 import { synthesizedUlid } from "./synth_ulid.ts";
+import { buildBodyAst } from "../ast/build.ts";
+import { render as renderBodyAst } from "../ast/render.ts";
 
 /**
  * Value types that accept CSV on input but must be emitted as multi-line
@@ -181,6 +183,103 @@ const CANONICAL_ORDER: readonly string[] = [
   // after this list by sortAttributes().
 ];
 
+/**
+ * Post-pass: route each entry's canonical body through the AST.
+ *
+ * Called on the already-canonicalized `lines` array (after
+ * `normalizeModalKeywords`, attribute-block splicing, and
+ * `collapseBlankLines`). Re-parses the lines to get entries with
+ * correct post-collapse line numbers, then for each entry:
+ *
+ *   1. Takes `entry.body` — the canonical body string from the parser
+ *      (indent-stripped, trimmed, attrs split off).
+ *   2. Emits via `render(buildBodyAst(entry.body))` — byte-identical per
+ *      the equivalence gate, but the AST is now the load-bearing path for
+ *      body emission.
+ *   3. Reconstructs the body segment in `lines` from the emitted string,
+ *      preserving the leading/trailing blank-line delimiters that
+ *      separate the body from the title and attr block.
+ *
+ * This is the PR 4 formatter cutover (Option A, user-approved).
+ * `Entry.body` stays `string`; no other module is affected.
+ */
+function emitBodyViaAst(lines: string[], file: string): void {
+  // Diagnostics from this re-parse are intentionally discarded: the input is already canonical (post-collapse) output.
+  const { entries } = parseMarkdown(lines.join("\n"), { file });
+  if (entries.length === 0) return;
+
+  // Process bottom-to-top so splices don't shift earlier entry positions.
+  const sorted = [...entries].sort((a, b) => b.location.line - a.location.line);
+
+  for (const entry of sorted) {
+    if (!entry.body.trim()) continue; // empty or whitespace-only body
+
+    const indent = (entry.location.column - 1) + 2; // marker column (0-based) + 2 spaces = list-item continuation indent
+    const indentStr = " ".repeat(indent);
+    const titleLineIdx = entry.location.line - 1; // 0-based
+
+    // Locate the body segment in `lines` — between the title line and
+    // the attr block start (or item end when there is no attr block).
+    const range = findAttributeBlockRange(lines, entry.location.line, indent);
+    const bodyStart = titleLineIdx + 1;
+    const bodyEnd = range
+      ? range.start
+      : findItemEnd(lines, titleLineIdx, indent);
+
+    if (bodyEnd <= bodyStart) continue; // no body lines to replace
+
+    // Route the canonical body through the AST.
+    // Per the equivalence gate: renderBodyAst(buildBodyAst(body)) === body
+    // for every canonical body shape covered by the gate.
+    const emittedBody = renderBodyAst(buildBodyAst(entry.body));
+
+    if (emittedBody !== entry.body) {
+      // Safe fallback: the AST round-trip is NOT total over all valid
+      // Markdown body constructs (thematic breaks `---`, setext headings,
+      // hard line breaks, link reference definitions, and other shapes not
+      // yet covered by the equivalence gate). For these shapes the rendered
+      // string differs from the source body, meaning we cannot yet guarantee
+      // lossless re-emission via the AST. Keep the original body lines
+      // exactly as-is — zero corruption, zero spurious errors, graceful
+      // degradation. PR 5/6 and future gate hardening will close this gap as
+      // each body shape is brought under equivalence-test coverage.
+      continue;
+    }
+
+    // AST round-trips this body byte-identically (the gate-covered majority).
+    // Splice `emittedBody` back into the document — the AST is now the
+    // load-bearing emission path for these shapes. Output is unchanged
+    // (emittedBody === entry.body by construction) but the value flowing to
+    // the document is the AST's render, proving the pipeline is wired end-to-end.
+    // Changing this splice to a bare `continue` would revert to the old string path and defeat the PR 4 cutover intent — do not.
+    // Reconstruct the body segment: re-add the continuation indent to each
+    // non-blank line, preserving the blank-line delimiters that separate the
+    // body from the title and attr block.
+    const rawSegment = lines.slice(bodyStart, bodyEnd);
+    // Preserve the blank delimiter lines at the start/end of the segment.
+    const leadBlanks: string[] = [];
+    const trailBlanks: string[] = [];
+    let si = 0;
+    while (si < rawSegment.length && rawSegment[si].trim() === "") {
+      leadBlanks.push(rawSegment[si++]);
+    }
+    let ei = rawSegment.length - 1;
+    while (ei >= si && rawSegment[ei].trim() === "") {
+      trailBlanks.unshift(rawSegment[ei--]);
+    }
+    const emittedLines = emittedBody.split("\n").map((l) =>
+      l ? `${indentStr}${l}` : l
+    );
+    lines.splice(
+      bodyStart,
+      bodyEnd - bodyStart,
+      ...leadBlanks,
+      ...emittedLines,
+      ...trailBlanks,
+    );
+  }
+}
+
 /** Options for {@linkcode format}. */
 export interface FormatOptions {
   /** File path for diagnostic messages. */
@@ -315,6 +414,18 @@ export function format(
   // their blank-line counts.
   const collapsedLines = collapseBlankLines(lines);
   if (collapsedLines.length !== lines.length) changed = true;
+
+  // PR 4 formatter cutover (Option A): route each entry's canonical body
+  // through the AST — `render(buildBodyAst(canonicalBody))`. This makes
+  // the body-AST the load-bearing emission path. The call is byte-identical
+  // for all shapes covered by the equivalence gate; it is therefore a
+  // pure-canonicalization no-op that preserves all prior transforms
+  // (normalizeModalKeywords / collapseBlankLines / attr-block rewriting).
+  // emitBodyViaAst re-parses collapsedLines to get post-collapse entry
+  // positions, scoped only to the body segment (title/trailer/front-matter
+  // are untouched).
+  emitBodyViaAst(collapsedLines, file);
+
   const formattedBody = collapsedLines.join("\n");
 
   if (fm.hadFrontMatter) {

--- a/tests/e2e/format_test.ts
+++ b/tests/e2e/format_test.ts
@@ -487,6 +487,274 @@ Deno.test("format: no files exits 1", async () => {
 });
 
 // ---------------------------------------------------------------------------
+// PR 4 formatter cutover — canonicalization survives AST routing
+// ---------------------------------------------------------------------------
+
+/**
+ * Verifies that formatting a NON-canonical body that exercises multiple AST
+ * block shapes (UPPERCASE modal, extra blank lines, fenced code block, GFM
+ * table) still produces the fully canonical output AND is idempotent.
+ *
+ * This test is the PR 4 "watch it pass" case: it proves that
+ * normalizeModalKeywords and collapseBlankLines are still applied BEFORE
+ * the body is emitted via render(buildBodyAst(canonicalBody)), i.e.
+ * canonicalization survives the AST routing introduced in PR 4.
+ */
+Deno.test(
+  "format: canonicalization survives AST routing (PR 4 cutover)",
+  async () => {
+    // Non-canonical input:
+    //   - UPPERCASE modal keywords (SHALL, MUST) — must be lowercased
+    //   - Extra consecutive blank lines in the body — must be collapsed
+    //   - A fenced code block — must be preserved verbatim
+    //   - A GFM table — must round-trip byte-identically
+    const input = `# Test
+
+- [SRS_BRK_0001] Sensor debouncing
+
+  The sensor driver SHALL debounce raw inputs.
+
+
+  It MUST reject spikes shorter than the configured window.
+
+  \`\`\`rust
+  fn debounce(v: u32) -> u32 { v }
+  \`\`\`
+
+  | Signal | Threshold |
+  |--------|-----------|
+  | Raw    | 50 ms     |
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+`;
+    const pass1 = await runFormat({ "req.md": input });
+    assertEquals(pass1.code, 0);
+    const out1 = await pass1.readFile("req.md");
+
+    // Modal keywords must be lowercased.
+    assertEquals(out1.includes("SHALL"), false, "SHALL must be lowercased");
+    assertEquals(out1.includes("MUST"), false, "MUST must be lowercased");
+    assertStringIncludes(out1, "shall debounce");
+    assertStringIncludes(out1, "must reject");
+
+    // Extra blank lines must be collapsed (no triple newlines).
+    assertEquals(
+      /\n\n\n/.test(out1),
+      false,
+      "multiple blank lines must collapse to one",
+    );
+
+    // Code block must be preserved verbatim.
+    assertStringIncludes(
+      out1,
+      "```rust\n  fn debounce(v: u32) -> u32 { v }\n  ```",
+    );
+
+    // Table must be present (byte-identical round-trip via AST).
+    assertStringIncludes(out1, "| Signal | Threshold |");
+    assertStringIncludes(out1, "|--------|-----------|");
+
+    // Idempotence: second format produces the exact same output.
+    const pass2 = await runFormat({ "req.md": out1 });
+    const out2 = await pass2.readFile("req.md");
+    assertEquals(
+      out1,
+      out2,
+      "format must be idempotent after AST routing (PR 4 cutover)",
+    );
+  },
+);
+
+// ---------------------------------------------------------------------------
+// PR 4 safe fallback — §5.4 loss-of-information guarantee
+//
+// Bodies containing Markdown constructs not yet covered by the AST
+// equivalence gate (thematic break `---`, hard line break, link reference
+// definition, setext heading) must be preserved byte-for-byte by the
+// formatter — the safe-conditional-fallback branch keeps the original string
+// rather than splicing potentially lossy AST output. Each test below verifies
+// both preservation (no corruption) and idempotence.
+// ---------------------------------------------------------------------------
+
+/**
+ * Build an already-canonical document wrapping `body` so we can measure the
+ * formatter's behaviour on the body construct alone, without also triggering
+ * unrelated canonicalization (modal keywords, attr ordering, ULID assignment).
+ *
+ * The constructed doc has:
+ *   - a fixed, pre-assigned `Id:` → no ULID stamp on pass 1
+ *   - no uppercase modals → normalizeModalKeywords is a no-op
+ *   - no extra blank lines → collapseBlankLines is a no-op
+ * so any deviation between `format(doc).output` and `doc` is attributable
+ * exclusively to the AST body step.
+ */
+function makeCanonicalDoc(body: string): string {
+  // Each body line is indented 2 spaces (continuation indent for a top-level
+  // list item). The attr block uses the 6-space trailer indent.
+  const indentedBody = body
+    .split("\n")
+    .map((l) => (l.trim() === "" ? "" : `  ${l}`))
+    .join("\n");
+  return `# Test\n\n- [SRS_BRK_0001] Title\n\n${indentedBody}\n\n      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF\n`;
+}
+
+Deno.test(
+  "format: safe fallback — thematic break body preserved and idempotent",
+  async () => {
+    // `---` is a valid CommonMark thematic break. The AST builder maps it to
+    // an UnknownNode whose render is NOT yet guaranteed byte-identical, so
+    // the mismatch branch must keep the original string.
+    const body = "Paragraph before.\n\n---\n\nParagraph after.";
+    const doc = makeCanonicalDoc(body);
+
+    const pass1 = await runFormat({ "req.md": doc });
+    assertEquals(pass1.code, 0);
+    const out1 = await pass1.readFile("req.md");
+
+    // The thematic break must survive unchanged.
+    assertStringIncludes(
+      out1,
+      "---",
+      `thematic break should be preserved; output:\n${out1}`,
+    );
+
+    // The formatter must be a no-op on an already-canonical document (the
+    // body construct does not affect any formatter pass other than the AST step,
+    // and the safe fallback keeps the original lines).
+    assertEquals(
+      out1,
+      doc,
+      `format should be a no-op on a canonical doc with a thematic-break body; output:\n${out1}`,
+    );
+
+    // Idempotence: second pass must produce identical output.
+    const pass2 = await runFormat({ "req.md": out1 });
+    const out2 = await pass2.readFile("req.md");
+    assertEquals(
+      out1,
+      out2,
+      "format must be idempotent on thematic-break body",
+    );
+  },
+);
+
+Deno.test(
+  "format: safe fallback — hard line break body preserved and idempotent",
+  async () => {
+    // Two trailing spaces before `\n` form a CommonMark hard line break.
+    // The AST round-trip does not yet guarantee preservation of trailing
+    // spaces, so the mismatch branch must keep the original string.
+    const body = "Line one.  \nLine two.";
+    const doc = makeCanonicalDoc(body);
+
+    const pass1 = await runFormat({ "req.md": doc });
+    assertEquals(pass1.code, 0);
+    const out1 = await pass1.readFile("req.md");
+
+    // The two trailing spaces (hard line break marker) must not be stripped.
+    assertEquals(
+      /Line one\. {2}\n/.test(out1),
+      true,
+      `hard line break (two trailing spaces) should be preserved; output:\n${
+        JSON.stringify(out1)
+      }`,
+    );
+
+    assertEquals(
+      out1,
+      doc,
+      `format should be a no-op on a canonical doc with a hard-line-break body; output:\n${out1}`,
+    );
+
+    const pass2 = await runFormat({ "req.md": out1 });
+    const out2 = await pass2.readFile("req.md");
+    assertEquals(
+      out1,
+      out2,
+      "format must be idempotent on hard-line-break body",
+    );
+  },
+);
+
+Deno.test(
+  "format: safe fallback — link reference definition body preserved and idempotent",
+  async () => {
+    // A link reference definition `[id]: url` is valid CommonMark but is not
+    // currently covered by the body-AST builder, so the mismatch branch must
+    // keep the original string, preventing silent deletion.
+    const body = "See [foo] for details.\n\n[foo]: https://example.com";
+    const doc = makeCanonicalDoc(body);
+
+    const pass1 = await runFormat({ "req.md": doc });
+    assertEquals(pass1.code, 0);
+    const out1 = await pass1.readFile("req.md");
+
+    // The link reference definition must survive.
+    assertStringIncludes(
+      out1,
+      "[foo]: https://example.com",
+      `link reference definition should be preserved; output:\n${out1}`,
+    );
+
+    assertEquals(
+      out1,
+      doc,
+      `format should be a no-op on a canonical doc with a link-ref-def body; output:\n${out1}`,
+    );
+
+    const pass2 = await runFormat({ "req.md": out1 });
+    const out2 = await pass2.readFile("req.md");
+    assertEquals(
+      out1,
+      out2,
+      "format must be idempotent on link-ref-def body",
+    );
+  },
+);
+
+Deno.test(
+  "format: safe fallback — setext heading inside body preserved and idempotent (§5.4 no-loss)",
+  async () => {
+    // A setext heading (underline style) is a valid Markdown construct. It is
+    // an MSL-B040 validation error (headings inside entry bodies are not allowed
+    // by the spec) but the FORMATTER must still NOT destroy it — §5.4 guarantees
+    // no loss of information. The safe fallback keeps the original string.
+    const body = "Subheading\n----------\n\nBody paragraph.";
+    const doc = makeCanonicalDoc(body);
+
+    const pass1 = await runFormat({ "req.md": doc });
+    assertEquals(pass1.code, 0);
+    const out1 = await pass1.readFile("req.md");
+
+    // The setext underline must survive.
+    assertStringIncludes(
+      out1,
+      "----------",
+      `setext heading underline should be preserved; output:\n${out1}`,
+    );
+    assertStringIncludes(
+      out1,
+      "Subheading",
+      `setext heading text should be preserved; output:\n${out1}`,
+    );
+
+    assertEquals(
+      out1,
+      doc,
+      `format should be a no-op on a canonical doc with a setext-heading body; output:\n${out1}`,
+    );
+
+    const pass2 = await runFormat({ "req.md": out1 });
+    const out2 = await pass2.readFile("req.md");
+    assertEquals(
+      out1,
+      out2,
+      "format must be idempotent on setext-heading body",
+    );
+  },
+);
+
+// ---------------------------------------------------------------------------
 // Summary
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
PR 4 of 7 — the formatter cutover (user-approved **Option A: safe conditional fallback**).

Canonicalization (`normalizeModalKeywords`/`collapseBlankLines`/…) is **kept and unchanged**. After canonicalization, each entry body is routed through `render(buildBodyAst(body))`:
- `render(build(body)) === body` (the gate-covered majority) → splice the AST output: **the AST is the load-bearing emission path** (byte-identical by construction).
- `!==` (valid constructs the build/render inverse doesn't yet cover — thematic breaks, hard line breaks, link reference definitions, setext headings) → **keep the proven string body** (safe fallback: zero corruption, no throw, graceful degradation; PR 5/6 + future hardening close the gap).

Net: output is **byte-identical to the pre-PR4 string path for every input**; idempotent. `Entry.body` unchanged; localized to `formatter/mod.ts`.

A critical safety-inversion (the initial impl silently spliced *lossy* AST output for uncovered constructs, deleting `---` etc.) was caught by review and corrected to the safe fallback above, with empirical parity tests.

Reviewed via subagent-driven-development: spec/safety ✅ (23 empirical assertions incl. byte-parity with pre-PR4 for all 4 dangerous constructs; no throw/silent-rewrite), code-quality ✅ (approved). **Follow-up (tracked for PR 5):** extract `emitBodyViaAst` + body-geometry helpers into `formatter/ast_pass.ts` (formatter/mod.ts growing).

## Test Plan
- [x] Equivalence gate green, zero exclusions; format_test +5 (4 dangerous-construct preservation+idempotence, 1 AST-routed canonicalization) 
- [x] just check — 1162 passed, 0 failed; byte-identical & idempotent

🤖 Generated with [Claude Code](https://claude.com/claude-code)
