### PR TITLE
feat(core): MSL-B044 + MSL-C072 on the body AST (Path A PR 6)

### DIFF
--- a/packages/markspec/core/config/mod.ts
+++ b/packages/markspec/core/config/mod.ts
@@ -8,6 +8,8 @@
 import { parse as parseYaml } from "@std/yaml";
 import { dirname, join, resolve } from "@std/path";
 import {
+  type CaptionConventions,
+  type CaptionPosition,
   ConfigError,
   type ConfigFieldError,
   DEFAULT_PROJECT_CONFIG,
@@ -211,6 +213,66 @@ export function parseProjectConfig(
     }
   }
 
+  // caption-conventions: optional mapping of keyword → "above" | "below"
+  let captionConventions: CaptionConventions =
+    DEFAULT_PROJECT_CONFIG.captionConventions;
+  const captionConventionsKey = "caption-conventions";
+  if (
+    obj[captionConventionsKey] !== undefined &&
+    obj[captionConventionsKey] !== null
+  ) {
+    const raw = obj[captionConventionsKey];
+    if (typeof raw !== "object" || Array.isArray(raw)) {
+      errors.push({
+        field: captionConventionsKey,
+        message: `expected a mapping of caption-keyword: above|below, got ${
+          Array.isArray(raw) ? "array" : typeof raw
+        }`,
+        line: findLineNumber(yaml, captionConventionsKey),
+      });
+    } else {
+      const rawMap = raw as Record<string, unknown>;
+      const VALID_KEYWORDS = new Set([
+        "Figure",
+        "Table",
+        "Listing",
+        "Feature",
+        "Equation",
+        "List",
+      ]);
+      const parsed: Record<string, CaptionPosition> = {};
+      let badKey: string | undefined;
+      const captionErrsBefore = errors.length;
+      for (const [kw, pos] of Object.entries(rawMap)) {
+        if (!VALID_KEYWORDS.has(kw)) {
+          badKey = kw;
+          break;
+        }
+        if (pos !== "above" && pos !== "below") {
+          errors.push({
+            field: `${captionConventionsKey}.${kw}`,
+            message: `expected "above" or "below", got ${JSON.stringify(pos)}`,
+            line: findLineNumber(yaml, captionConventionsKey),
+          });
+          continue;
+        }
+        parsed[kw] = pos as CaptionPosition;
+      }
+      if (badKey !== undefined) {
+        errors.push({
+          field: `${captionConventionsKey}.${badKey}`,
+          message: `unknown caption keyword '${badKey}'; valid keywords: ${
+            [...VALID_KEYWORDS].join(", ")
+          }`,
+          line: findLineNumber(yaml, captionConventionsKey),
+        });
+      }
+      if (errors.length === captionErrsBefore) {
+        captionConventions = parsed;
+      }
+    }
+  }
+
   if (errors.length > 0) {
     throw new ConfigError(filePath, errors);
   }
@@ -221,6 +283,7 @@ export function parseProjectConfig(
     labels,
     parents,
     parentFallback,
+    captionConventions,
   };
 }
 

--- a/packages/markspec/core/mod.ts
+++ b/packages/markspec/core/mod.ts
@@ -20,6 +20,8 @@ export {
 export type {
   Attribute,
   Caption,
+  CaptionConventions,
+  CaptionPosition,
   ConfigFieldError,
   Diagnostic,
   Directive,

--- a/packages/markspec/core/mod_test.ts
+++ b/packages/markspec/core/mod_test.ts
@@ -73,6 +73,7 @@ Deno.test("model types are constructible", () => {
     labels: ["ASIL-B"],
     parents: [],
     parentFallback: REFHUB_URL,
+    captionConventions: {},
   };
   assertEquals(config.name, "test-project");
 });

--- a/packages/markspec/core/model/mod.ts
+++ b/packages/markspec/core/model/mod.ts
@@ -392,6 +392,33 @@ export interface Diagnostic {
 /** Default RefHub URL used as implicit fallback for parent registries. */
 export const REFHUB_URL = "https://driftsys.github.io/refhub";
 
+/**
+ * Caption-position convention for a specific caption keyword.
+ * `"above"` — caption must appear above its block.
+ * `"below"` — caption must appear below its block.
+ */
+export type CaptionPosition = "above" | "below";
+
+/**
+ * Per-keyword caption-position conventions.
+ *
+ * Keys are caption keywords (e.g. `"Figure"`, `"Table"`, `"Listing"`,
+ * `"Feature"`, `"Equation"`, `"List"`). A missing key means no
+ * convention is configured for that keyword — MSL-C072 is inactive for
+ * unconfigured keywords.
+ *
+ * Authored in `project.yaml` under `caption-conventions:`:
+ *
+ * ```yaml
+ * caption-conventions:
+ *   Figure: below
+ *   Table: above
+ * ```
+ */
+export type CaptionConventions = Readonly<
+  Partial<Record<string, CaptionPosition>>
+>;
+
 /** MarkSpec project configuration from `project.yaml`. */
 export interface ProjectConfig {
   /** Project name (e.g., `io.driftsys.markspec`). */
@@ -404,6 +431,13 @@ export interface ProjectConfig {
   readonly parents: readonly string[];
   /** Fallback registry URL when parents don't resolve a reference. */
   readonly parentFallback: string;
+  /**
+   * Per-keyword caption-position conventions (spec §4.7 MSL-C072).
+   * When a key is present, the validator emits MSL-C072 if a caption
+   * of that keyword appears on the wrong side of its block. An empty
+   * or absent map means all keywords are unconstrained.
+   */
+  readonly captionConventions: CaptionConventions;
 }
 
 /** Default configuration used when no `project.yaml` is found. */
@@ -413,6 +447,7 @@ export const DEFAULT_PROJECT_CONFIG: ProjectConfig = {
   labels: [],
   parents: [],
   parentFallback: REFHUB_URL,
+  captionConventions: {},
 };
 
 // ---------------------------------------------------------------------------

--- a/packages/markspec/core/validator/caption_convention.ts
+++ b/packages/markspec/core/validator/caption_convention.ts
@@ -1,0 +1,68 @@
+/**
+ * @module core/validator/caption_convention
+ *
+ * MSL-C072 validator — caption position violates project-configured
+ * convention (docs/specs/markspec-core-data-model.md §4.7).
+ *
+ * When `project.yaml` carries a `caption-conventions` map, each caption
+ * whose `position` disagrees with the configured position for its keyword
+ * fires MSL-C072 (warning). Keywords not present in the map are
+ * unconstrained and this validator is silent for them.
+ *
+ * If no conventions are configured (the map is empty or absent) the
+ * validator emits no diagnostics — the rule is inactive.
+ *
+ * This is an AST-only check: `CaptionNode.position` is set by the builder
+ * (`core/ast/build.ts`) from the source order of the caption relative to
+ * its captionable block.
+ */
+
+import type { CaptionConventions, Diagnostic, Entry } from "../model/mod.ts";
+
+/**
+ * Validate caption positions against the project-configured conventions.
+ *
+ * @param entry - The entry whose body AST is scanned for captions.
+ * @param conventions - The configured position conventions from
+ *   `ProjectConfig.captionConventions`. An empty record means no
+ *   conventions are set and the function returns immediately.
+ */
+export function validateCaptionConvention(
+  entry: Entry,
+  conventions: CaptionConventions,
+): readonly Diagnostic[] {
+  // Fast-path: no conventions configured → rule inactive.
+  if (Object.keys(conventions).length === 0) return [];
+
+  const blocks = entry.bodyAst ?? [];
+  const diagnostics: Diagnostic[] = [];
+
+  for (const block of blocks) {
+    if (block.kind !== "caption") continue;
+
+    const expected = conventions[block.keyword];
+    // No convention configured for this keyword → skip.
+    if (expected === undefined) continue;
+
+    // Convention is satisfied → no diagnostic.
+    if (block.position === expected) continue;
+
+    const fileLine = entry.location.line + block.range.start.line;
+
+    diagnostics.push({
+      code: "MSL-C072",
+      severity: "warning",
+      message:
+        `${entry.displayId}: ${block.keyword}: caption appears ${block.position} ` +
+        `its block but the project convention requires it to be ${expected} ` +
+        `(spec §4.7; configure under 'caption-conventions' in project.yaml)`,
+      location: {
+        file: entry.location.file,
+        line: fileLine,
+        column: 1,
+      },
+    });
+  }
+
+  return diagnostics;
+}

--- a/packages/markspec/core/validator/caption_convention_test.ts
+++ b/packages/markspec/core/validator/caption_convention_test.ts
@@ -1,0 +1,163 @@
+/**
+ * @module core/validator/caption_convention_test
+ *
+ * Unit tests for the MSL-C072 validator (caption position vs
+ * project-configured convention).
+ *
+ * TDD: RED → GREEN per code.
+ */
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import type { CaptionConventions, Entry } from "../model/mod.ts";
+import { buildBodyAst } from "../ast/build.ts";
+import { validateCaptionConvention } from "./caption_convention.ts";
+
+function makeEntry(displayId: string, body: string): Entry {
+  return {
+    displayId,
+    title: "Test entry",
+    body,
+    bodyAst: buildBodyAst(body),
+    rawAttributes: [],
+    id: undefined,
+    shape: "identified",
+    location: { file: "test.md", line: 10, column: 1 },
+    source: "markdown",
+    typedAttributes: new Map(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Positive cases — MSL-C072 should fire
+// ---------------------------------------------------------------------------
+
+Deno.test("validateCaptionConvention: Figure below but convention=above → MSL-C072", () => {
+  // Caption below the figure, but convention requires above.
+  const body = [
+    "![Brake diagram](brake.svg)",
+    "",
+    "Figure: Brake pressure diagram",
+  ].join("\n");
+  const conventions: CaptionConventions = { Figure: "above" };
+  const entry = makeEntry("REQ-001", body);
+  const diags = validateCaptionConvention(entry, conventions);
+  const c072 = diags.filter((d) => d.code === "MSL-C072");
+  assertEquals(c072.length, 1, `expected 1 MSL-C072, got ${c072.length}`);
+  assertEquals(c072[0].severity, "warning");
+  assertStringIncludes(c072[0].message, "Figure");
+  assertStringIncludes(c072[0].message, "below");
+  assertStringIncludes(c072[0].message, "above");
+});
+
+Deno.test("validateCaptionConvention: Table above but convention=below → MSL-C072", () => {
+  // Caption above the table, but convention requires below.
+  const body = [
+    "Table: System requirements overview",
+    "",
+    "| Req | Description |",
+    "| --- | ----------- |",
+    "| R1  | Sensor input |",
+  ].join("\n");
+  const conventions: CaptionConventions = { Table: "below" };
+  const entry = makeEntry("REQ-002", body);
+  const diags = validateCaptionConvention(entry, conventions);
+  const c072 = diags.filter((d) => d.code === "MSL-C072");
+  assertEquals(c072.length, 1, `expected 1 MSL-C072, got ${c072.length}`);
+  assertEquals(c072[0].severity, "warning");
+  assertStringIncludes(c072[0].message, "Table");
+});
+
+Deno.test("validateCaptionConvention: multiple violations → multiple MSL-C072", () => {
+  // Two figures both below, convention says above for Figure.
+  const body = [
+    "![Diagram 1](a.svg)",
+    "",
+    "Figure: Diagram one",
+    "",
+    "More text.",
+    "",
+    "![Diagram 2](b.svg)",
+    "",
+    "Figure: Diagram two",
+  ].join("\n");
+  const conventions: CaptionConventions = { Figure: "above" };
+  const entry = makeEntry("REQ-003", body);
+  const diags = validateCaptionConvention(entry, conventions);
+  const c072 = diags.filter((d) => d.code === "MSL-C072");
+  assertEquals(
+    c072.length,
+    2,
+    `expected 2 MSL-C072, got ${c072.length}; diags: ${JSON.stringify(diags)}`,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Negative cases — MSL-C072 should NOT fire
+// ---------------------------------------------------------------------------
+
+Deno.test("validateCaptionConvention: Figure below and convention=below → no MSL-C072", () => {
+  const body = [
+    "![Brake diagram](brake.svg)",
+    "",
+    "Figure: Brake pressure diagram",
+  ].join("\n");
+  const conventions: CaptionConventions = { Figure: "below" };
+  const entry = makeEntry("REQ-004", body);
+  const diags = validateCaptionConvention(entry, conventions);
+  assertEquals(diags.filter((d) => d.code === "MSL-C072").length, 0);
+});
+
+Deno.test("validateCaptionConvention: Figure above and convention=above → no MSL-C072", () => {
+  const body = [
+    "Figure: Brake pressure diagram",
+    "",
+    "![Brake diagram](brake.svg)",
+  ].join("\n");
+  const conventions: CaptionConventions = { Figure: "above" };
+  const entry = makeEntry("REQ-005", body);
+  const diags = validateCaptionConvention(entry, conventions);
+  assertEquals(diags.filter((d) => d.code === "MSL-C072").length, 0);
+});
+
+Deno.test("validateCaptionConvention: empty conventions → no MSL-C072", () => {
+  const body = [
+    "![Brake diagram](brake.svg)",
+    "",
+    "Figure: Brake pressure diagram",
+  ].join("\n");
+  const conventions: CaptionConventions = {};
+  const entry = makeEntry("REQ-006", body);
+  const diags = validateCaptionConvention(entry, conventions);
+  assertEquals(diags.filter((d) => d.code === "MSL-C072").length, 0);
+});
+
+Deno.test("validateCaptionConvention: Figure keyword not in conventions → no MSL-C072", () => {
+  // Only Table is configured, Figure is unconstrained.
+  const body = [
+    "![Brake diagram](brake.svg)",
+    "",
+    "Figure: Brake pressure diagram",
+  ].join("\n");
+  const conventions: CaptionConventions = { Table: "above" };
+  const entry = makeEntry("REQ-007", body);
+  const diags = validateCaptionConvention(entry, conventions);
+  assertEquals(diags.filter((d) => d.code === "MSL-C072").length, 0);
+});
+
+Deno.test("validateCaptionConvention: no bodyAst → no MSL-C072", () => {
+  const entry: Entry = {
+    displayId: "REQ-008",
+    title: "Test",
+    body: "Figure: Caption\n\n![x](y.svg)",
+    bodyAst: undefined,
+    rawAttributes: [],
+    id: undefined,
+    shape: "identified",
+    location: { file: "test.md", line: 1, column: 1 },
+    source: "markdown",
+    typedAttributes: new Map(),
+  };
+  const conventions: CaptionConventions = { Figure: "below" };
+  const diags = validateCaptionConvention(entry, conventions);
+  assertEquals(diags.filter((d) => d.code === "MSL-C072").length, 0);
+});

--- a/packages/markspec/core/validator/feature_ac.ts
+++ b/packages/markspec/core/validator/feature_ac.ts
@@ -1,0 +1,113 @@
+/**
+ * @module core/validator/feature_ac
+ *
+ * MSL-B044 validator — entry body contains both a Feature (Gherkin)
+ * block and a separate list labelled "Acceptance criteria" (the
+ * alternative form). Only one canonical form is required; having both
+ * is redundant and indicates an inconsistency the author should resolve.
+ *
+ * Detection heuristic (spec §4.5 "MSL-B044"):
+ *   - The entry body contains at least one `FeatureNode`.
+ *   - The entry body also contains a `ListNode` that is introduced by
+ *     a `ParagraphNode` (or is headed by text in a paragraph) whose
+ *     text matches "acceptance criteria" case-insensitively — i.e., a
+ *     paragraph immediately preceding a list whose prose trims to
+ *     "acceptance criteria" (or starts with it), OR a paragraph
+ *     immediately following the list that reads like a label, OR the
+ *     first item text of the list begins with "Acceptance criteria".
+ *
+ * This is an AST-only check; no external dependency.
+ */
+
+import type { Diagnostic, Entry } from "../model/mod.ts";
+import type { BodyBlock } from "../ast/nodes.ts";
+
+/** Case-insensitive match for "acceptance criteria" anywhere in text. */
+const ACCEPTANCE_CRITERIA_RE = /acceptance\s+criteria/i;
+
+/**
+ * Determine whether a body block appears to label an "Acceptance
+ * criteria" list — either the block itself is a paragraph whose text
+ * matches, or it is a list whose first item text matches.
+ */
+function isAcceptanceCriteriaLabel(block: BodyBlock): boolean {
+  if (block.kind === "paragraph") {
+    return ACCEPTANCE_CRITERIA_RE.test(block.content.text);
+  }
+  if (block.kind === "list") {
+    // Check first list item's first paragraph for the label.
+    const firstItem = block.items[0];
+    if (firstItem) {
+      for (const sub of firstItem.blocks) {
+        if (
+          sub.kind === "paragraph" &&
+          ACCEPTANCE_CRITERIA_RE.test(sub.content.text)
+        ) {
+          return true;
+        }
+      }
+    }
+  }
+  return false;
+}
+
+/**
+ * Check if there is an "Acceptance criteria" list in the body.
+ *
+ * Strategies (in priority order):
+ * 1. A `ListNode` is preceded by a `ParagraphNode` whose text matches
+ *    "acceptance criteria".
+ * 2. A `ListNode` is followed by a `ParagraphNode` whose text matches
+ *    "acceptance criteria".
+ * 3. A `ListNode`'s first item paragraph text matches.
+ */
+function hasAcceptanceCriteriaList(blocks: readonly BodyBlock[]): boolean {
+  for (let i = 0; i < blocks.length; i++) {
+    const block = blocks[i];
+    if (block.kind !== "list") continue;
+
+    // Strategy 1: preceding paragraph is the label
+    if (i > 0 && isAcceptanceCriteriaLabel(blocks[i - 1])) return true;
+    // Strategy 2: following paragraph is the label
+    if (
+      i + 1 < blocks.length && isAcceptanceCriteriaLabel(blocks[i + 1])
+    ) return true;
+    // Strategy 3: first list item text is the label
+    if (isAcceptanceCriteriaLabel(block)) return true;
+  }
+  return false;
+}
+
+/**
+ * Validate that an entry's body does not contain both a Feature block
+ * (Gherkin) and a separate "Acceptance criteria" list. Emits MSL-B044
+ * (warning) when both are present.
+ */
+export function validateFeatureAc(entry: Entry): readonly Diagnostic[] {
+  const blocks = entry.bodyAst ?? [];
+
+  // Quick exit: need at least one FeatureNode.
+  const featureBlock = blocks.find((b) => b.kind === "feature");
+  if (!featureBlock) return [];
+
+  // Now check for an "Acceptance criteria" list.
+  if (!hasAcceptanceCriteriaList(blocks)) return [];
+
+  const fileLine = entry.location.line + featureBlock.range.start.line;
+
+  return [
+    {
+      code: "MSL-B044",
+      severity: "warning",
+      message:
+        `${entry.displayId}: body contains both a Feature (Gherkin) block ` +
+        `and a separate "Acceptance criteria" list — use one canonical form ` +
+        `(Feature block preferred per spec §4.5)`,
+      location: {
+        file: entry.location.file,
+        line: fileLine,
+        column: 1,
+      },
+    },
+  ];
+}

--- a/packages/markspec/core/validator/feature_ac_test.ts
+++ b/packages/markspec/core/validator/feature_ac_test.ts
@@ -1,0 +1,196 @@
+/**
+ * @module core/validator/feature_ac_test
+ *
+ * Unit tests for the MSL-B044 validator (Feature block + Acceptance
+ * criteria list collision).
+ *
+ * TDD: RED → GREEN per code.
+ */
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import type { Entry } from "../model/mod.ts";
+import { buildBodyAst } from "../ast/build.ts";
+import { validateFeatureAc } from "./feature_ac.ts";
+
+function makeEntry(displayId: string, body: string): Entry {
+  return {
+    displayId,
+    title: "Test entry",
+    body,
+    bodyAst: buildBodyAst(body),
+    rawAttributes: [],
+    id: undefined,
+    shape: "identified",
+    location: { file: "test.md", line: 10, column: 1 },
+    source: "markdown",
+    typedAttributes: new Map(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Positive cases — MSL-B044 should fire
+// ---------------------------------------------------------------------------
+
+Deno.test("validateFeatureAc: Feature + AC list (paragraph label before) → MSL-B044", () => {
+  const body = [
+    "The system shall handle emergency braking.",
+    "",
+    "```gherkin",
+    "Feature: Emergency braking",
+    "  Scenario: Collision avoidance",
+    "    Given the vehicle is moving at 60 km/h",
+    "    When an obstacle is detected at 30 m",
+    "    Then emergency braking is applied",
+    "```",
+    "",
+    "Acceptance criteria",
+    "",
+    "- The vehicle stops within the required distance",
+    "- No false activations occur",
+  ].join("\n");
+  const entry = makeEntry("REQ-001", body);
+  const diags = validateFeatureAc(entry);
+  const b044 = diags.filter((d) => d.code === "MSL-B044");
+  assertEquals(b044.length, 1, `expected 1 MSL-B044, got ${b044.length}`);
+  assertEquals(b044[0].severity, "warning");
+  assertStringIncludes(b044[0].message, "Feature");
+  assertStringIncludes(b044[0].message, "Acceptance criteria");
+});
+
+Deno.test("validateFeatureAc: Feature + AC list (case-insensitive label) → MSL-B044", () => {
+  const body = [
+    "Body prose.",
+    "",
+    "```gherkin",
+    "Feature: Braking",
+    "  Scenario: Stop",
+    "    Given moving",
+    "    Then stopped",
+    "```",
+    "",
+    "ACCEPTANCE CRITERIA",
+    "",
+    "- Criterion one",
+    "- Criterion two",
+  ].join("\n");
+  const entry = makeEntry("REQ-002", body);
+  const diags = validateFeatureAc(entry);
+  assertEquals(diags.filter((d) => d.code === "MSL-B044").length, 1);
+});
+
+Deno.test("validateFeatureAc: Feature + AC list (label follows list) → MSL-B044", () => {
+  const body = [
+    "Body prose.",
+    "",
+    "```gherkin",
+    "Feature: Braking",
+    "  Scenario: Stop",
+    "    Given moving",
+    "    Then stopped",
+    "```",
+    "",
+    "- Criterion one",
+    "- Criterion two",
+    "",
+    "Acceptance Criteria for the requirement above.",
+  ].join("\n");
+  const entry = makeEntry("REQ-003", body);
+  const diags = validateFeatureAc(entry);
+  assertEquals(diags.filter((d) => d.code === "MSL-B044").length, 1);
+});
+
+// ---------------------------------------------------------------------------
+// Negative cases — MSL-B044 should NOT fire
+// ---------------------------------------------------------------------------
+
+Deno.test("validateFeatureAc: Feature only, no AC list → no MSL-B044", () => {
+  const body = [
+    "Body prose.",
+    "",
+    "```gherkin",
+    "Feature: Emergency braking",
+    "  Scenario: Collision avoidance",
+    "    Given moving",
+    "    Then stopped",
+    "```",
+  ].join("\n");
+  const entry = makeEntry("REQ-004", body);
+  const diags = validateFeatureAc(entry);
+  assertEquals(diags.filter((d) => d.code === "MSL-B044").length, 0);
+});
+
+Deno.test("validateFeatureAc: AC list only, no Feature → no MSL-B044", () => {
+  const body = [
+    "Acceptance criteria",
+    "",
+    "- Criterion one",
+    "- Criterion two",
+  ].join("\n");
+  const entry = makeEntry("REQ-005", body);
+  const diags = validateFeatureAc(entry);
+  assertEquals(diags.filter((d) => d.code === "MSL-B044").length, 0);
+});
+
+Deno.test("validateFeatureAc: plain list without AC label → no MSL-B044", () => {
+  const body = [
+    "Body prose.",
+    "",
+    "```gherkin",
+    "Feature: Emergency braking",
+    "  Scenario: Stop",
+    "    Given moving",
+    "    Then stopped",
+    "```",
+    "",
+    "Implementation notes",
+    "",
+    "- Note one",
+    "- Note two",
+  ].join("\n");
+  const entry = makeEntry("REQ-006", body);
+  const diags = validateFeatureAc(entry);
+  assertEquals(diags.filter((d) => d.code === "MSL-B044").length, 0);
+});
+
+Deno.test("validateFeatureAc: Feature + list whose first item begins with 'Acceptance criteria' (Strategy 3 only) → MSL-B044", () => {
+  // No separate label paragraph — Strategy 1 and Strategy 2 cannot match.
+  // Only Strategy 3 (first list item text starts with "Acceptance criteria")
+  // can trigger the diagnostic.
+  const body = [
+    "Body prose.",
+    "",
+    "```gherkin",
+    "Feature: Emergency braking",
+    "  Scenario: Collision avoidance",
+    "    Given the vehicle is moving at 60 km/h",
+    "    When an obstacle is detected at 30 m",
+    "    Then emergency braking is applied",
+    "```",
+    "",
+    "- Acceptance criteria: vehicle stops within distance",
+    "- No false activations occur",
+  ].join("\n");
+  const entry = makeEntry("REQ-008", body);
+  const diags = validateFeatureAc(entry);
+  const b044 = diags.filter((d) => d.code === "MSL-B044");
+  assertEquals(b044.length, 1, `expected 1 MSL-B044, got ${b044.length}`);
+  assertEquals(b044[0].severity, "warning");
+  assertStringIncludes(b044[0].message, "Acceptance criteria");
+});
+
+Deno.test("validateFeatureAc: no bodyAst → no MSL-B044", () => {
+  const entry: Entry = {
+    displayId: "REQ-007",
+    title: "Test",
+    body: "```gherkin\nFeature: X\n```\n\nAcceptance criteria\n\n- A",
+    bodyAst: undefined,
+    rawAttributes: [],
+    id: undefined,
+    shape: "identified",
+    location: { file: "test.md", line: 1, column: 1 },
+    source: "markdown",
+    typedAttributes: new Map(),
+  };
+  const diags = validateFeatureAc(entry);
+  assertEquals(diags.filter((d) => d.code === "MSL-B044").length, 0);
+});

--- a/packages/markspec/core/validator/pipeline.ts
+++ b/packages/markspec/core/validator/pipeline.ts
@@ -8,7 +8,12 @@
  * and Stage 4 (traceability rules — {@linkcode validateTraceabilityForEntry}).
  */
 
-import type { Diagnostic, EffectiveProfile, Entry } from "../model/mod.ts";
+import type {
+  CaptionConventions,
+  Diagnostic,
+  EffectiveProfile,
+  Entry,
+} from "../model/mod.ts";
 import { validate } from "./mod.ts";
 import {
   classifyEntriesStage,
@@ -24,6 +29,8 @@ import { validateTraceTargetTypes } from "./trace_types.ts";
 import { effectiveScope, validateAttributesForEntry } from "./attributes.ts";
 import { normalizeListValues } from "./normalize.ts";
 import { validateTraceabilityForEntry } from "./traceability.ts";
+import { validateFeatureAc } from "./feature_ac.ts";
+import { validateCaptionConvention } from "./caption_convention.ts";
 
 /** Result of running the full validator pipeline. */
 export interface PipelineResult {
@@ -43,10 +50,16 @@ export interface PipelineResult {
  *
  * When `profile` is `null`, entries pass through unchanged (no `type`
  * assignments).
+ *
+ * @param captionConventions - Optional project-configured caption-position
+ *   conventions (from `ProjectConfig.captionConventions`). When supplied
+ *   and non-empty, MSL-C072 is checked for each entry. Defaults to no
+ *   conventions (rule inactive).
  */
 export function runPipeline(
   entries: readonly Entry[],
   profile: EffectiveProfile | null,
+  captionConventions: CaptionConventions = {},
 ): PipelineResult {
   const diagnostics: Diagnostic[] = [];
 
@@ -75,7 +88,9 @@ export function runPipeline(
     diagnostics.push(...validateCoreTypeAttribute(entry, profile));
     diagnostics.push(...inferTypeFromDisplayIdShape(entry));
     diagnostics.push(...validateCaptions(entry));
+    diagnostics.push(...validateCaptionConvention(entry, captionConventions));
     diagnostics.push(...validateBodyBlocks(entry));
+    diagnostics.push(...validateFeatureAc(entry));
     diagnostics.push(...validatePerTypeAttributes(entry));
     diagnostics.push(...validateModalKeywords(entry));
   }

--- a/packages/markspec/main.ts
+++ b/packages/markspec/main.ts
@@ -10,7 +10,12 @@
 
 import { Command } from "@cliffy/command";
 import { ConfigError, VERSION } from "./core/mod.ts";
-import type { CompileResult, ProfileChain, ReadFile } from "./core/mod.ts";
+import type {
+  CaptionConventions,
+  CompileResult,
+  ProfileChain,
+  ReadFile,
+} from "./core/mod.ts";
 import type { BookStructure, Chapter } from "./book/mod.ts";
 
 /** Print "not yet implemented" to stderr and exit 1. */
@@ -648,11 +653,23 @@ const cli = new Command()
         Deno.exit(1);
       }
 
-      const { discoverProjectRoot } = await import("./core/mod.ts");
+      const { discoverProjectRoot, loadConfig } = await import("./core/mod.ts");
       const projectRoot = await discoverProjectRoot(Deno.cwd(), readFile);
       const chain = projectRoot !== undefined
         ? await loadActiveProfile(projectRoot)
         : null;
+
+      // Load project config for config-driven rules (e.g. MSL-C072
+      // caption-position convention). Absent config → defaults (rules inactive).
+      let captionConventions: CaptionConventions = {};
+      if (projectRoot !== undefined) {
+        try {
+          const configResult = await loadConfig(projectRoot, readFile);
+          if (configResult) {
+            captionConventions = configResult.config.captionConventions;
+          }
+        } catch { /* config load failure is non-fatal for validate */ }
+      }
 
       const { parseFile, runPipeline } = await import("./core/mod.ts");
 
@@ -669,7 +686,11 @@ const cli = new Command()
         allEntries.push(...result.entries);
       }
 
-      const result = runPipeline(allEntries, chain?.effective ?? null);
+      const result = runPipeline(
+        allEntries,
+        chain?.effective ?? null,
+        captionConventions,
+      );
 
       // Apply --strict: promote warnings to errors.
       const diagnostics = options.strict
@@ -1188,13 +1209,24 @@ const cli = new Command()
       Deno.exit(0);
     }
 
-    const { discoverProjectRoot, format, parseFile, runPipeline } =
+    const { discoverProjectRoot, format, loadConfig, parseFile, runPipeline } =
       await import("./core/mod.ts");
 
     const projectRoot = await discoverProjectRoot(Deno.cwd(), readFile);
     const chain = projectRoot !== undefined
       ? await loadActiveProfile(projectRoot)
       : null;
+
+    // Load caption conventions for MSL-C072.
+    let hookCaptionConventions: CaptionConventions = {};
+    if (projectRoot !== undefined) {
+      try {
+        const configResult = await loadConfig(projectRoot, readFile);
+        if (configResult) {
+          hookCaptionConventions = configResult.config.captionConventions;
+        }
+      } catch { /* non-fatal */ }
+    }
 
     let hadError = false;
     const allEntries = [];
@@ -1227,7 +1259,11 @@ const cli = new Command()
     }
 
     if (!hadError) {
-      const result = runPipeline(allEntries, chain?.effective ?? null);
+      const result = runPipeline(
+        allEntries,
+        chain?.effective ?? null,
+        hookCaptionConventions,
+      );
       for (const d of result.diagnostics) {
         const loc = d.location ? `${d.location.file}:${d.location.line}` : "";
         console.error(`${d.severity}[${d.code}]: ${loc} ${d.message}`);

--- a/packages/markspec/render/mod_test.ts
+++ b/packages/markspec/render/mod_test.ts
@@ -22,6 +22,7 @@ function testConfig(): ProjectConfig {
     labels: [],
     parents: [],
     parentFallback: "",
+    captionConventions: {},
   };
 }
 

--- a/packages/markspec/render/mustache/mod_test.ts
+++ b/packages/markspec/render/mustache/mod_test.ts
@@ -24,6 +24,7 @@ function makeConfig(
     labels: [],
     parents: [],
     parentFallback: "",
+    captionConventions: {},
     ...overrides,
   };
 }

--- a/tests/e2e/validate_test.ts
+++ b/tests/e2e/validate_test.ts
@@ -1814,3 +1814,183 @@ Deno.test("validate: no files exits 1", async () => {
   assertEquals(code, 1);
   assertStringIncludes(stderr, "no files specified");
 });
+
+// ---------------------------------------------------------------------------
+// MSL-B044 — Feature block + Acceptance criteria list collision (warning)
+// ---------------------------------------------------------------------------
+
+Deno.test("validate: MSL-B044 fires when Feature + AC list present", async () => {
+  const { code, stderr } = await markspec(["validate", "req.md"], {
+    files: {
+      "req.md": `# Requirements
+
+- [REQ-001] Emergency braking feature
+
+  The system shall apply emergency braking.
+
+  \`\`\`gherkin
+  Feature: Emergency braking
+    Scenario: Collision avoidance
+      Given the vehicle is moving at 60 km/h
+      When an obstacle is detected at 30 m
+      Then emergency braking is applied
+  \`\`\`
+
+  Acceptance criteria
+
+  - The vehicle stops within the required distance
+  - No false activations occur
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+`,
+    },
+  });
+  // MSL-B044 is a warning → exit 2
+  assertEquals(
+    code,
+    2,
+    `expected exit 2 (warning), got ${code}; stderr: ${stderr}`,
+  );
+  assertStringIncludes(stderr, "MSL-B044");
+  assertStringIncludes(stderr, "Acceptance criteria");
+});
+
+Deno.test("validate: MSL-B044 does not fire for Feature only (no AC list)", async () => {
+  const { code: _code, stderr } = await markspec(["validate", "req.md"], {
+    files: {
+      "req.md": `# Requirements
+
+- [REQ-001] Emergency braking feature
+
+  The system shall apply emergency braking.
+
+  \`\`\`gherkin
+  Feature: Emergency braking
+    Scenario: Collision avoidance
+      Given the vehicle is moving
+      Then braking is applied
+  \`\`\`
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+`,
+    },
+  });
+  // Warning from MSL-M061 (no modal keyword — but "shall" is present above)
+  // Let's check MSL-B044 is absent
+  assertEquals(
+    stderr.includes("MSL-B044"),
+    false,
+    `MSL-B044 should not fire; stderr: ${stderr}`,
+  );
+});
+
+Deno.test("validate: MSL-B044 does not fire for AC list only (no Feature)", async () => {
+  const { code: _code, stderr } = await markspec(["validate", "req.md"], {
+    files: {
+      "req.md": `# Requirements
+
+- [REQ-001] Emergency braking requirement
+
+  The system shall apply emergency braking.
+
+  Acceptance criteria
+
+  - The vehicle stops within the required distance
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+`,
+    },
+  });
+  assertEquals(
+    stderr.includes("MSL-B044"),
+    false,
+    `MSL-B044 should not fire; stderr: ${stderr}`,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// MSL-C072 — caption position violates project-configured convention (warning)
+// ---------------------------------------------------------------------------
+
+Deno.test("validate: MSL-C072 fires when Figure caption is below but convention=above", async () => {
+  const { code, stderr } = await markspec(["validate", "req.md"], {
+    files: {
+      "project.yaml": `name: test-project
+caption-conventions:
+  Figure: above
+`,
+      "req.md": `# Requirements
+
+- [REQ-001] System diagram requirement
+
+  See the brake diagram below.
+
+  ![Brake diagram](brake.svg)
+
+  Figure: Brake pressure schematic
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+`,
+    },
+  });
+  // MSL-C072 is a warning → exit 2
+  assertEquals(
+    code,
+    2,
+    `expected exit 2 (warning), got ${code}; stderr: ${stderr}`,
+  );
+  assertStringIncludes(stderr, "MSL-C072");
+  assertStringIncludes(stderr, "Figure");
+});
+
+Deno.test("validate: MSL-C072 does not fire when Figure caption is below and convention=below", async () => {
+  const { code: _code, stderr } = await markspec(["validate", "req.md"], {
+    files: {
+      "project.yaml": `name: test-project
+caption-conventions:
+  Figure: below
+`,
+      "req.md": `# Requirements
+
+- [REQ-001] System diagram requirement
+
+  See the brake diagram below.
+
+  ![Brake diagram](brake.svg)
+
+  Figure: Brake pressure schematic
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+`,
+    },
+  });
+  assertEquals(
+    stderr.includes("MSL-C072"),
+    false,
+    `MSL-C072 should not fire when convention matches; stderr: ${stderr}`,
+  );
+});
+
+Deno.test("validate: MSL-C072 does not fire when no caption-conventions configured", async () => {
+  const { code: _code, stderr } = await markspec(["validate", "req.md"], {
+    files: {
+      "req.md": `# Requirements
+
+- [REQ-001] System diagram requirement
+
+  See the brake diagram below.
+
+  ![Brake diagram](brake.svg)
+
+  Figure: Brake pressure schematic
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+`,
+    },
+  });
+  assertEquals(
+    stderr.includes("MSL-C072"),
+    false,
+    `MSL-C072 should not fire without project config; stderr: ${stderr}`,
+  );
+});


### PR DESCRIPTION
## Summary
PR 6 of 7 — implements **two** of the four AST-gated diagnostics the canonical body-AST unlocks:

- **MSL-B044** (warning) — entry body has both a Feature (Gherkin) block and a separate "Acceptance criteria" list (one canonical form, Feature, preferred). `core/validator/feature_ac.ts`.
- **MSL-C072** (warning) — `CaptionNode.position` violates the project-configured caption convention. `core/validator/caption_convention.ts` + new optional `ProjectConfig.captionConventions` (default `{}` ⇒ rule inactive; fully backward-compatible); threaded through `validate`/`hook`.

**MSL-M050/M051 are deferred-by-dependency, NOT implemented.** Their resolution chain is "normative per ADR-005 §Part 2", which is the unlanded nextgen content-model ADR; ADR-005 on `main` is CLI architecture and no in-project entity-resolution model is specified anywhere. Per user decision, the implementer correctly refused to invent resolution semantics. **PR 7 records this via ADR** (reclassifying the review finding defect → deferred) alongside the ADR-012 bounded-exception amendment + ADR-014.

Additive: new diagnostics only; full existing suite green & unchanged; equivalence gate untouched. Reviewed via subagent-driven-development: spec ✅ (B044+C072 correct, additive, M050/M051 cleanly absent, backward-compatible), code-quality ✅ (after minor fixes: Strategy-3 test, doc-ref, type precision, config-guard clarity).

Tracked follow-up: dedup the caption-keyword list (config `VALID_KEYWORDS` vs `captions.ts CAPTION_KEYWORDS`).

## Test Plan
- [x] just check — 1206 passed, 0 failed; equivalence gate green; deno check clean
- [x] B044 fires on Feature+AC-list (3 detection strategies incl. first-item), not on either alone; C072 inactive without config, fires/clears per convention; warnings → validate exit 2; existing fixtures emit no new C072 noise

🤖 Generated with [Claude Code](https://claude.com/claude-code)
