### PR TITLE
fix(core): surface caption-conventions config errors; correct ADR-014; pin Path A invariants

### DIFF
--- a/docs/architecture/adr-014-canonical-body-ast.md
+++ b/docs/architecture/adr-014-canonical-body-ast.md
@@ -77,10 +77,29 @@ decisions, not left implicit in code comments.
 - The formatter cutover is safe by construction (gate-proven where the AST is
   load-bearing; proven string path everywhere else).
 
-### What shifts for existing code (not yet implemented)
+### What shifts for existing code
 
-- Nothing in shipped behaviour. Output is byte-identical to pre-refactor for
-  every input; all existing diagnostics unchanged.
+- **Formatter output is byte-identical to pre-refactor for every input.** The
+  fallback guard (`render(buildBodyAst(body)) === body` ? emit via AST : keep
+  original string) ensures no document is modified in any way it was not already
+  modified by the pre-refactor formatter. This statement is verified and
+  correct.
+- **Two diagnostics changed intentionally in the validator migration (PR #340).
+  The "all existing diagnostics unchanged" claim in the original draft of this
+  section was false and is corrected here:**
+  - **MSL-B042** now emits one diagnostic per task-list _block_ (one per
+    `ListNode` with `hasTaskItems: true`) rather than one per task-list _item_
+    line. For a body containing a 3-item task list: was 3 diagnostics, now 1.
+    This is **accepted as intentional** — the AST-based approach is structurally
+    cleaner, the error/exit code is unchanged, and the new behaviour is pinned
+    by a regression test (see PR #341 follow-up).
+  - **MSL-M060** now fires on _any_ non-canonical-case modal keyword (e.g.
+    title-case `Should`, `Shall`) rather than only on fully-uppercase forms
+    (`SHOULD`, `SHALL`). This is a behaviour broadening that is arguably more
+    spec-correct but was shipped unlabelled. Its warning message still says "is
+    uppercase" even for title-case forms, which is inaccurate. This is recorded
+    as **known tracked debt** — not fixed in this follow-up (see "Known debt"
+    under Out-of-scope below).
 - Future work inherits two defined obligations: widen the build/render inverse
   toward totality (shrinking the string-fallback set), and specify the
   entity-resolution model that unblocks M050/M051.
@@ -127,3 +146,9 @@ decisions, not left implicit in code comments.
 - Extracting `emitBodyViaAst` + body-geometry helpers out of `formatter/mod.ts`
   into a focused module (tracked code-quality follow-up).
 - The broader `MSL-P/I/M/F` scheme migration (still ADR-012's deferred phase).
+- **Known debt — MSL-M060:** The validator migration (PR #340) broadened M060's
+  trigger beyond all-uppercase modals to any non-canonical-case form (including
+  title-case `Should`, `Shall`). Its warning message still reads "is uppercase"
+  for forms that are merely title-case, not fully uppercase — the wording is
+  inaccurate. Both the trigger broadening and the message inaccuracy are tracked
+  debt; neither is addressed in this ADR or its follow-up PR.

--- a/packages/markspec/core/validator/body_blocks_test.ts
+++ b/packages/markspec/core/validator/body_blocks_test.ts
@@ -84,6 +84,36 @@ Deno.test("validateBodyBlocks: normal list (no tasks) — no MSL-B042", () => {
 });
 
 // ---------------------------------------------------------------------------
+// MSL-B042: Path A / ADR-014 intentional behaviour change — one diag per
+// task-list BLOCK, not one per item.
+//
+// Pre-Path-A (line-scanner): a 3-item task list emitted 3 MSL-B042 diagnostics,
+// one per item line.  Post-Path-A (AST-based, PR #340): the validator fires
+// once per ListNode with hasTaskItems=true, so the same 3-item list emits
+// EXACTLY ONE MSL-B042.  This was accepted as intentional in ADR-014.
+// This test pins that accepted behaviour.  If someone reverts the validator to
+// per-item line-scanning this test will fail — that is the intended guard.
+// ---------------------------------------------------------------------------
+
+Deno.test("validateBodyBlocks: 3-item task list emits exactly ONE MSL-B042 (ADR-014 Path A intentional change)", () => {
+  const body = [
+    "Body text.",
+    "",
+    "- [ ] First task item",
+    "- [x] Second task item",
+    "- [ ] Third task item",
+    "",
+  ].join("\n");
+  const entry = makeEntry("REQ-001", body);
+  const b042 = validateBodyBlocks(entry).filter((d) => d.code === "MSL-B042");
+  assertEquals(
+    b042.length,
+    1,
+    "Path A AST migration (ADR-014): a multi-item task list must emit exactly 1 MSL-B042, not one per item",
+  );
+});
+
+// ---------------------------------------------------------------------------
 // MSL-B043 — raw HTML
 // ---------------------------------------------------------------------------
 

--- a/packages/markspec/main.ts
+++ b/packages/markspec/main.ts
@@ -661,6 +661,8 @@ const cli = new Command()
 
       // Load project config for config-driven rules (e.g. MSL-C072
       // caption-position convention). Absent config → defaults (rules inactive).
+      // A malformed config (ConfigError) IS surfaced — a bad caption-conventions
+      // block silently disabling MSL-C072 would be invisible debt (M-1 fix).
       let captionConventions: CaptionConventions = {};
       if (projectRoot !== undefined) {
         try {
@@ -668,7 +670,15 @@ const cli = new Command()
           if (configResult) {
             captionConventions = configResult.config.captionConventions;
           }
-        } catch { /* config load failure is non-fatal for validate */ }
+        } catch (err) {
+          if (err instanceof ConfigError) {
+            console.error(`error: ${err.message}`);
+            Deno.exit(1);
+          }
+          // Other unexpected errors (I/O, etc.) remain non-fatal — the rule
+          // simply stays inactive; the file-missing path already returns undefined
+          // from readFile and never throws.
+        }
       }
 
       const { parseFile, runPipeline } = await import("./core/mod.ts");
@@ -1217,7 +1227,9 @@ const cli = new Command()
       ? await loadActiveProfile(projectRoot)
       : null;
 
-    // Load caption conventions for MSL-C072.
+    // Load caption conventions for MSL-C072.  A malformed config (ConfigError)
+    // IS surfaced — same as the validate command (M-1 fix).  Absent config stays
+    // non-fatal; the rule simply stays inactive.
     let hookCaptionConventions: CaptionConventions = {};
     if (projectRoot !== undefined) {
       try {
@@ -1225,7 +1237,13 @@ const cli = new Command()
         if (configResult) {
           hookCaptionConventions = configResult.config.captionConventions;
         }
-      } catch { /* non-fatal */ }
+      } catch (err) {
+        if (err instanceof ConfigError) {
+          console.error(`error: ${err.message}`);
+          Deno.exit(1);
+        }
+        // Other unexpected errors remain non-fatal.
+      }
     }
 
     let hadError = false;

--- a/tests/e2e/config_test.ts
+++ b/tests/e2e/config_test.ts
@@ -51,3 +51,71 @@ Deno.test("invalid project.yaml produces actionable error on compile", async () 
   assertStringIncludes(stderr, "invalid project.yaml");
   assertStringIncludes(stderr, "name");
 });
+
+// ---------------------------------------------------------------------------
+// M-1 fix: malformed caption-conventions surfaces instead of being swallowed
+//
+// Pre-fix: a bad caption-conventions block in project.yaml was silently
+// swallowed by `catch { /* non-fatal */ }` in the validate and hook commands,
+// silently disabling MSL-C072 with no message.
+//
+// Post-fix: a ConfigError thrown by loadConfig IS surfaced to stderr and the
+// command exits 1.  A *missing* config or absent project.yaml still stays
+// non-fatal (the rule just stays inactive — no false error).
+// ---------------------------------------------------------------------------
+
+const VALID_REQ = `# Test
+
+- [REQ-001] A requirement
+
+  Body text.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+`;
+
+Deno.test("validate: malformed caption-conventions in project.yaml surfaces error (M-1 fix)", async () => {
+  // "unknown-keyword" is not a valid caption keyword; loadConfig throws
+  // ConfigError.  The validate command must surface it rather than silently
+  // continuing with MSL-C072 disabled.
+  const { code, stderr } = await markspec(["validate", "req.md"], {
+    files: {
+      "project.yaml":
+        "name: test-project\ncaption-conventions:\n  unknown-keyword: above\n",
+      "req.md": VALID_REQ,
+    },
+  });
+  assertEquals(code, 1, `expected exit 1, got ${code}; stderr:\n${stderr}`);
+  assertStringIncludes(
+    stderr,
+    "error:",
+    "expected an error message on stderr for malformed caption-conventions",
+  );
+});
+
+Deno.test("validate: absent project.yaml still works silently — no false error (M-1 regression guard)", async () => {
+  // No project.yaml: validate must still succeed for a valid file and
+  // must NOT emit any caption-conventions error.  This is the non-fatal
+  // path that must remain unchanged by the M-1 fix.
+  const { code, stderr } = await markspec(["validate", "req.md"], {
+    files: {
+      "req.md": VALID_REQ,
+    },
+  });
+  assertEquals(code, 0, `expected exit 0, got ${code}; stderr:\n${stderr}`);
+  assertEquals(
+    stderr.includes("caption"),
+    false,
+    `expected no caption-conventions mention in stderr; got:\n${stderr}`,
+  );
+});
+
+Deno.test("validate: well-formed caption-conventions in project.yaml succeeds silently", async () => {
+  const { code, stderr } = await markspec(["validate", "req.md"], {
+    files: {
+      "project.yaml":
+        "name: test-project\ncaption-conventions:\n  Figure: above\n",
+      "req.md": VALID_REQ,
+    },
+  });
+  assertEquals(code, 0, `expected exit 0, got ${code}; stderr:\n${stderr}`);
+});

--- a/tests/e2e/format_test.ts
+++ b/tests/e2e/format_test.ts
@@ -772,3 +772,69 @@ Deno.test("format: reports summary to stderr", async () => {
   assertStringIncludes(stderr, "file(s) formatted");
   assertStringIncludes(stderr, "total)");
 });
+
+// ---------------------------------------------------------------------------
+// Formatter fallback guard — regression test (ADR-014 §Decision-2)
+//
+// The formatter's emitBodyViaAst() uses a safe conditional fallback:
+//   render(buildBodyAst(body)) === body  →  emit via AST
+//   otherwise                           →  keep original string body
+//
+// The build/render inverse is NOT total over valid Markdown.  Bodies that
+// contain constructs not yet covered by the equivalence gate (hard line
+// breaks, setext headings, link-reference definitions, thematic breaks, …)
+// do not round-trip and MUST be left byte-identical by the formatter.
+//
+// This test uses a hard line break (`line  \nline`) — verified to NOT
+// round-trip: render(buildBodyAst("Line one  \nLine two")) returns
+// "Line oneLine two" (the two trailing spaces and newline are lost).
+//
+// If someone removes the fallback guard in emitBodyViaAst(), the formatter
+// will corrupt hard-line-break bodies (stripping the trailing spaces +
+// newline) and this test will fail.  That is the INTENDED guard.
+// ---------------------------------------------------------------------------
+
+Deno.test(
+  "format: entry body with hard line break is preserved byte-identically (fallback guard — ADR-014 §Decision-2)",
+  async () => {
+    // The body contains a hard line break: two trailing spaces before \n.
+    // render(buildBodyAst(body)) !== body for this construct, so the
+    // formatter MUST take the string-fallback path, leaving it untouched.
+    const input = [
+      "# Test",
+      "",
+      "- [REQ-001] Hard-line-break requirement",
+      "",
+      "  This sentence ends here.  ",
+      "  This continues on the next line.",
+      "",
+      "      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF",
+      "",
+    ].join("\n");
+
+    const pass1 = await runFormat({ "req.md": input });
+    assertEquals(
+      pass1.code,
+      0,
+      `format should succeed on a hard-line-break body; stderr: ${pass1.stderr}`,
+    );
+
+    const out1 = await pass1.readFile("req.md");
+
+    // The hard line break (two trailing spaces before newline) must be intact.
+    assertEquals(
+      out1.includes("This sentence ends here.  \n"),
+      true,
+      `formatter must preserve the hard line break (two trailing spaces) byte-identically; got:\n${out1}`,
+    );
+
+    // Idempotency: a second pass must not touch the already-canonical file.
+    const pass2 = await runFormat({ "req.md": out1 });
+    const out2 = await pass2.readFile("req.md");
+    assertEquals(
+      out1,
+      out2,
+      "format must be idempotent on a body containing a hard line break",
+    );
+  },
+);


### PR DESCRIPTION
## Summary
Acts on the holistic Path A review.

- **M-1 fix:** `validate`/`hook` no longer silently swallow a malformed `caption-conventions` config (which silently disabled MSL-C072). A `ConfigError` is now surfaced + exit 1, matching the `requireProjectConfig` pattern. **Verified invariant:** no `project.yaml` / no `caption-conventions` stays silent & byte-identical to base for both commands; only an actually-malformed config surfaces.
- **ADR-014 corrected:** its "all existing diagnostics unchanged" claim was false. Now records MSL-B042 (one-per-task-list-block) as an accepted intentional change, and MSL-M060 (trigger broadened beyond all-uppercase + inaccurate "is uppercase" message for title-case) as **tracked debt, deliberately not fixed here** (per decision). The true formatter-output-byte-identical statement is preserved.
- **Regression pins:** MSL-B042 one-per-task-list; the formatter fallback guard (a hard-line-break body must round-trip byte-identically via the string path — fails if the anti-corruption `continue` guard is removed).

Additive tests only; existing suite unchanged. Reviewed: spec/correctness ✅ (M-1 invariant independently verified live vs base; ADR honest; pins genuine; scope clean).

## Test Plan
- [x] just check — 1211 passed, 0 failed; equivalence gate green; deno check clean
- [x] M-1: no-config & no-caption-conventions silent (both validate+hook); malformed → exit 1 — verified against base `2bd1a63`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
