### PR TITLE
docs(spec): profile schema & listing directives (Prompt 2)

### DIFF
--- a/docs/specs/markspec-listing-directives.md
+++ b/docs/specs/markspec-listing-directives.md
@@ -1,0 +1,561 @@
+# MarkSpec — Listing Directives
+
+Status: Draft (Prompt 2 of the next-gen refactor)\
+Date: 2026-05-16\
+Scope: The three parallel listing-document directives — `markspec:references`,
+`markspec:glossary`, `markspec:components` — at the **data level**: grammar,
+component Id-scheme parsers, validation\
+Builds on: [markspec-core-data-model.md](markspec-core-data-model.md) (Prompt 1
+output), [markspec-profile-schema.md](markspec-profile-schema.md) (companion —
+Component type vocabulary, `term`→`Definition` binding), ADR-006 (listing
+directives), ADR-003 (information & traceability model — §Part 6 URI scheme
+map), ADR-001 (Markdown format — heading structure)
+
+This spec freezes the **directive grammar**, the **glossary heading-shape
+grammar** (distinct from the Entry/Reference shapes), the **exact per-scheme
+parsers** for Component `Id:` values, and the **per-directive validation** rules
+(empty-listing and missing-directive behaviour).
+
+### Out of scope (rendering — Prompt 3 / Prompt 4)
+
+ADR-006 §Context is explicit, and the Prompt-2 brief restates it: **book /
+renderer behaviour is not specified here.** Out of scope:
+
+- Suffix-chapter ordering and placement (bibliography / glossary / BOM as back
+  matter).
+- Anchor generation, slugging, and intra-book cross-reference resolution between
+  listings and entries.
+- Numbering, sort order presentation, column layout of the rendered BOM table.
+
+This spec defines only what the **parser and validator** must accept and report.
+Rendering consumes that model in Prompt 3 (toolchain) / Prompt 4 (user docs).
+
+---
+
+## 0. Terminology
+
+Inherits [markspec-core-data-model.md §0](markspec-core-data-model.md) and
+[markspec-profile-schema.md §0](markspec-profile-schema.md). Adds:
+
+| Term                    | Meaning                                                                                                                  |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| **listing directive**   | One of `markspec:references` / `markspec:glossary` / `markspec:components` (ADR-006 §Decision).                          |
+| **listing document**    | A Markdown file carrying a listing directive (explicitly or by filename trigger).                                        |
+| **glossary shape**      | The heading-based document structure (H1/H2/H3) that is **not** an entry — §4. Distinct from Authored/Reference shapes.  |
+| **component Id scheme** | A URI scheme MarkSpec recognizes for a Component-type Reference `Id:` (purl, mfg, gtin, cpe, urn:system, urn:tool) — §5. |
+
+---
+
+## 1. The three parallel directives
+
+ADR-006 §Decision fixes three patterns — **uniform in trigger and lifecycle,
+distinct in grammar**:
+
+| Pattern        | Filename        | Directive             | Lists                       | Underlying model                                                              |
+| -------------- | --------------- | --------------------- | --------------------------- | ----------------------------------------------------------------------------- |
+| **References** | `references.md` | `markspec:references` | External published works    | Reference-shape entries; `Type:` resolves to Specification / Component        |
+| **Glossary**   | `glossary.md`   | `markspec:glossary`   | Domain vocabulary, acronyms | **Not entries** — glossary heading shape (§4) → core `Definition` items       |
+| **Components** | `components.md` | `markspec:components` | System components (BOM)     | Reference-shape (typically) or Authored Component-type entries; Id schemes §5 |
+
+They are **siblings, not variants** (ADR-006 §Context): the glossary's grammar
+is heading-based, not the trailers-bearing entry block — §4 specifies it
+separately and the spec does not unify the three.
+
+**Cross-references to the companion spec:**
+
+- The Component types a `markspec:components` listing admits
+  (`SoftwareComponent`, `HardwareComponent`, `SoftwareInterface`,
+  `HardwareInterface`, and profile subtypes such as `dependency`, `ecu`) are
+  core types per core-data-model §1.3; profile subtyping is
+  [markspec-profile-schema.md §3/§4](markspec-profile-schema.md).
+- The glossary produces core `Definition` items (core-data-model §1.3 / ADR-003
+  §Part 2 "Definition"); the default profile's `term`→`Definition` binding is
+  [markspec-profile-schema.md §7.1](markspec-profile-schema.md).
+- A profile's per-type `id-schemes:` hint
+  ([markspec-profile-schema.md §4.5](markspec-profile-schema.md)) is validated
+  against the parsers in §5 of this spec.
+
+---
+
+## 2. Directive placement and triggering
+
+### 2.1 Filename trigger vs explicit directive
+
+ADR-006 §Decision: "Filename triggers the directive automatically; the explicit
+directive is needed only when the file uses a different name."
+
+- **Filename trigger.** A file whose basename (case-insensitive, extension
+  stripped) is exactly `references`, `glossary`, or `components` is treated as
+  carrying the corresponding directive, with no comment required.
+- **Explicit directive.** Any file may carry an HTML-comment directive to opt in
+  under a different name (ADR-006 §File organization — split files like
+  `hardware-components.md`):
+
+  ```text
+  <!-- markspec:components -->
+  <!-- markspec:references -->
+  <!-- markspec:glossary -->
+  ```
+
+  The directive comment is the only raw-HTML form permitted outside an entry
+  body (core-data-model §2.4.1 `MSL-B043` exempts `<!-- markspec:* -->`).
+
+### 2.2 File-level vs block-level placement
+
+- **File-level (canonical).** The directive (filename or comment) governs the
+  **entire file**. A file-level directive comment, when present, MUST appear
+  before the first entry / first H2 group (for glossary). This is the only
+  placement ADR-006 specifies and the canonical form.
+- **Block-level.** ADR-006 does not define a sub-file directive scope. This spec
+  **does not introduce one**: a listing file is wholly one listing kind. Mixing
+  (e.g. a `markspec:components` block inside a requirements document) is **not**
+  supported — the directive is file-level only. Rationale: a single-kind file
+  matches the split-file organization ADR-006 §File organization already
+  provides (`hardware-components.md`, `software-components.md`), and per-block
+  directives would reintroduce the heterogeneous-document smell ADR-006 §Context
+  rejects. (See §7 Open Question 1.)
+
+### 2.3 Conflicting / duplicate directives
+
+| Situation                                                                           | Behaviour                                                                                                                               |
+| ----------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| Filename `references.md` **and** an explicit `<!-- markspec:references -->` (agree) | Accepted; the explicit comment is redundant but not an error (`MSL-L010` info, "redundant directive").                                  |
+| Filename `glossary.md` but explicit `<!-- markspec:components -->` (disagree)       | Error `MSL-L011`: directive conflicts with filename trigger. The explicit directive does **not** silently win — the author resolves it. |
+| Two different explicit directives in one file                                       | Error `MSL-L012`: multiple listing directives in one file. A listing file is one kind (§2.2).                                           |
+| No filename trigger and no explicit directive                                       | Not a listing document — see §6.4 (missing-directive behaviour). Not an error in itself.                                                |
+
+The `MSL-L…` code category is introduced by this spec — see §6.5 options
+analysis for why a new category rather than reusing `MSL-A…`/`MSL-R…`.
+
+---
+
+## 3. References listing
+
+### 3.1 Model
+
+A `markspec:references` document contains **Reference-shape entries**
+(core-data-model §1.2 — `Id:` is a scheme-qualified URI). Their `Type:` resolves
+(core-data-model §1.3.1) to **Specification** (standards, papers, regulations,
+RFCs) or **Component** (packaged dependencies cited bibliographically). This is
+the entry block of core-data-model §2, unchanged — the references listing adds
+**no new grammar**; it is a _placement + validation_ convention over ordinary
+Reference entries.
+
+Already specified by core-data-model §2 (entry grammar), §1.5 (`Reference-url` /
+`Reference-document` core attributes), and the published spec §2.3 (ADR-006
+§References). This section only fixes the listing-level validation (§6.1).
+
+### 3.2 Relationship to `References:`
+
+An entry elsewhere citing a work via the universal `References:` citation
+attribute (core-data-model §1.4) points at a Reference entry that **should**
+live in a references listing. A `References:` locator citing a slug absent from
+any in-scope Reference entry is `MSL-R085` (core-data-model §4.8) — unchanged;
+the references listing is the conventional home that makes such citations
+resolve.
+
+---
+
+## 4. Glossary heading-shape grammar
+
+### 4.1 Why it is not the entry model
+
+ADR-006 §Glossary: glossary entries are "**Not part of the entry model** — uses
+the heading-based structure from ADR-001 (H1 title, H2 letter groups, H3 terms,
+body is the definition, cross-references via Markdown link references at end of
+file)." Distinct because (ADR-006 §Glossary): a heading + paragraph is enough;
+glossary terms are not trace targets; mixing terms with bibliographic references
+clutters both.
+
+A glossary document therefore uses **headings**, which the entry body model
+explicitly **forbids inside an entry** (core-data-model §2.4.1 `MSL-B040`). The
+glossary shape lives at the _document_ level, not inside any entry — the two
+never collide. Each glossary term produces one core **`Definition`** Item
+(core-data-model §1.3; ADR-003 §Part 2 "Definition"), so glossary terms still
+participate in the information model (citable via `{{def.<slug>}}` and
+`References:`), without being Authored/Reference entries.
+
+### 4.2 Grammar (EBNF, normative)
+
+```ebnf
+GlossaryDoc      = [ DirectiveComment ] Title FrontProse?
+                   LetterGroup+ LinkRefBlock? ;
+
+Title            = "#" SP TitleText NL BlankLine ;          (* exactly one H1 *)
+
+FrontProse       = { ParagraphBlock } ;                     (* optional intro *)
+
+LetterGroup      = "##" SP GroupHeading NL BlankLine
+                   TermDef+ ;
+
+GroupHeading     = /[^\n]+/ ;        (* conventionally a single letter "A".."Z"
+                                        or "0–9"/"Symbols"; not enforced *)
+
+TermDef          = "###" SP Term NL BlankLine
+                   Definition
+                   BlankLine ;
+
+Term             = /[^\n]+/ ;        (* the term as displayed *)
+
+Definition       = DefinitionBlock { BlankLine DefinitionBlock } ;
+
+DefinitionBlock  = Paragraph | List | Table | Code | Math
+                 | Note | Blockquote | DefinitionList ;     (* see 4.4 *)
+
+LinkRefBlock     = { LinkRefDefinition } ;                  (* end of file *)
+LinkRefDefinition= "[" LinkLabel "]:" SP URLorSlug [ SP Title ] NL ;
+
+DirectiveComment = "<!--" SP "markspec:glossary" SP "-->" NL BlankLine ;
+SP               = " " ;
+NL               = "\n" ;
+BlankLine        = NL ;
+```
+
+Normative rules:
+
+- **R4-a — one H1.** Exactly one H1 (the glossary title). Zero or ≥2 →
+  `MSL-L020` (error).
+- **R4-b — H2 = group.** Every term lives under an H2 group. An H3 with no
+  preceding H2 in the file is `MSL-L021` (error). The H2 text is conventionally
+  a letter bucket but the grammar does not constrain it (rendering/sorting is
+  out of scope — §Out of scope).
+- **R4-c — H3 = term.** Each H3 is one term. The H3 text is the **display
+  term**. The term **slug** (the identity used by `{{def.<slug>}}` resolution
+  and `References:`, ADR-010 §6 / core-data-model §1.4) is derived
+  deterministically: lowercase; trim; collapse internal whitespace runs to a
+  single `-`; drop every character outside `[a-z0-9._/-]` (the display-ID token
+  grammar of core-data-model §1.7 / §2.5.2). Two H3s deriving the same slug (in
+  scope) → `MSL-L022` (error, duplicate term).
+- **R4-d — body = definition.** The blocks between an H3 and the next H3/H2/EOF
+  are the definition. An empty definition (no block) → `MSL-L023` (warning — a
+  defined-but-empty term is a smell, not malformed).
+- **R4-e — depth.** Headings deeper than H3 (`####`+) inside a glossary document
+  are `MSL-L024` (error): the glossary shape is exactly three levels.
+- **R4-f — link references at end.** Collected link-reference definitions
+  (`[label]: target`) are permitted only **after the last term**, as a trailing
+  block (ADR-006 §Glossary "cross-references via Markdown link references at end
+  of file"). A link-reference definition interleaved between terms is `MSL-L025`
+  (warning — CommonMark still resolves it, but it violates the convention).
+
+### 4.3 Mapping to the `Definition` Item
+
+Each `TermDef` yields one `Definition` Item (core-data-model §1.3 / ADR-003
+§Part 2):
+
+| `Definition` attribute (ADR-003 §Part 2) | Source in the glossary shape                                                                                                      |
+| ---------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `Id`                                     | A ULID assigned by `markspec fmt` (Authored-equivalent; glossary terms are project-owned). The slug (R4-c) is the display handle. |
+| `type`                                   | `Definition` (fixed for the glossary shape).                                                                                      |
+| `Content`                                | The H3 term text + definition blocks.                                                                                             |
+| `Aliases`                                | Optional — see R4-g.                                                                                                              |
+| `See-also`                               | Optional — derived from intra-glossary link references targeting other term slugs.                                                |
+
+- **R4-g — aliases.** A parenthetical acronym in the H3 (e.g.
+  `### Automotive Safety Integrity Level (ASIL)`) contributes the parenthetical
+  token as an `Aliases` value **and** an additional resolvable slug. This is a
+  convenience; profiles needing richer acronym modelling extend `Definition`
+  ([markspec-profile-schema.md §3](markspec-profile-schema.md); ADR-010 §6
+  "Profiles that need a richer glossary model … extend `term`").
+- The `Id:` for glossary terms is assigned, not authored: glossary documents
+  carry **no trailers block** (they are not entries). `fmt` maintains a sidecar
+  identity binding (mechanism deferred to Prompt 3 — the _data_ rule here is
+  only that a term's identity is its slug + an assigned ULID, stable across
+  renames per core-data-model §1.2 properties).
+
+### 4.4 Definition body blocks
+
+A definition admits the **prose-bearing subset** of the closed body-block
+catalogue (core-data-model §2.4): `Paragraph`, `List`, `Table`, `Code`, `Math`,
+`Note`, `Blockquote`, `DefinitionList`. Excluded: `Figure` and `Feature` — a
+glossary definition is textual; a figure or a Gherkin scenario in a glossary is
+`MSL-L026` (warning). Inline markers (modal keywords, `$Identifier` entity
+references — core-data-model §2.5) are recognized inside definition prose
+exactly as in entry bodies.
+
+### 4.5 Options analysis — glossary grammar
+
+| Decision                                                   | Alternative                                                      | Why rejected                                                                                                                                                                                                                   |
+| ---------------------------------------------------------- | ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Heading shape (H1/H2/H3), not the entry block (**chosen**) | Model glossary terms as Authored entries with `Type: Definition` | ADR-006 §Glossary explicitly rejects this: a heading + paragraph is enough; a trailers block per term is ceremony. Headings are forbidden in entry bodies (core-data-model §2.4.1) so the two shapes cannot be unified anyway. |
+| Slug derived from H3 text deterministically (R4-c)         | Require an explicit slug per term (e.g. `{#asil}` attribute)     | Adds authoring ceremony to the simplest document type; deterministic derivation matches the renumberable-display-ID model (core-data-model §1.7) and the published `[[term-slug]]` convention (ADR-010 §6).                    |
+| H2 unconstrained text (R4-b)                               | Enforce single-letter A–Z buckets                                | Bucketing is a _rendering/sort_ concern (explicitly out of scope — §Out of scope). The parser should not reject `## Symbols` or `## 0–9`.                                                                                      |
+| Three levels exactly (R4-e)                                | Allow nested sub-terms (H4)                                      | ADR-006 fixes "H3 terms"; sub-terms are a richer-glossary feature ADR-010 §6 delegates to profile extension, not the base shape.                                                                                               |
+
+---
+
+## 5. Component Id schemes — exact parsers
+
+For a Component-type entry in a `markspec:components` listing (or anywhere a
+Component Reference appears), the `Id:` value is a scheme-qualified URI
+(core-data-model §1.2). ADR-006 §Component Id schemes + ADR-003 §Part 6 fix the
+recognized schemes. This section gives the **exact parser** for each. Each
+parser either **accepts** (and yields the structured components below, feeding
+type inference per core-data-model §1.3.1 step 5 / ADR-003 §Part 6) or
+**rejects** with the cited diagnostic.
+
+A value that is a well-formed RFC 3986 URI but matches **none** of the schemes
+below is still a valid Reference `Id:` (core-data-model §1.2) — it simply gets
+no component-scheme classification (`MSL-L030` info: "unrecognized component Id
+scheme; classified by fallback"). Scheme matching is **longest-declared-prefix
+wins**, with profile-declared schemes taking precedence over the core set for
+the prefixes they cover
+([markspec-profile-schema.md §6](markspec-profile-schema.md); ADR-003 §Part 6
+"Profile extension").
+
+### 5.1 `pkg:` — Package URL (purl)
+
+**Authoritative grammar:** the Package-URL (purl) specification,
+`github.com/package-url/purl-spec` (the `PURL-SPECIFICATION.rst` ABNF). MarkSpec
+**does not redefine** purl; it adopts the upstream grammar by reference
+(Prompt-2 constraint — "purl has its own grammar; reuse it"). The canonical purl
+string is:
+
+```text
+pkg:type/namespace/name@version?qualifiers#subpath
+```
+
+MarkSpec-relevant rules (a thin profile over the upstream spec — the upstream
+spec is normative for anything not stated here):
+
+- **P5.1-a.** `scheme` MUST be the literal `pkg` (lowercase). Else not a purl;
+  fall through to other schemes.
+- **P5.1-b.** `type` and `name` are REQUIRED; `namespace`, `version`,
+  `qualifiers`, `subpath` are OPTIONAL — per the upstream spec. A missing
+  required component → `MSL-L031` (error, "malformed purl: <reason>"), message
+  quoting the upstream rule violated.
+- **P5.1-c.** Percent-decoding, canonical lowercasing of `type`, and
+  type-specific normalization (e.g. `pkg:golang` case rules) follow the upstream
+  spec verbatim. MarkSpec performs no normalization the upstream spec does not
+  mandate (preserves the round-trip / determinism contract, core-data-model §5).
+- **P5.1-d — type → Item type.** The `pkg:` `type` segment maps to a core Item
+  type per ADR-003 §Part 6 "Core scheme map"
+  (`pkg:cargo|npm|maven|pypi|go|nuget|deno|swift` → `SoftwareComponent`;
+  `pkg:hw|device` → `HardwareComponent`; `pkg:firmware` → `SoftwareComponent`; a
+  purl carrying a `#<symbol-path>` subpath → `SoftwareUnit`). Profiles extend
+  the map ([markspec-profile-schema.md §6](markspec-profile-schema.md)). An
+  unmapped `pkg:` type is accepted (valid purl) and classified `Component`
+  (abstract fallback, core-data-model §1.3.1) with `MSL-L030` info.
+
+`pkg:` is the strongest convention (ADR-006 §Component Id schemes — SPDX,
+CycloneDX, GitHub Dependency Graph). It is the recommended scheme for every
+software dependency.
+
+### 5.2 `mfg:vendor:partno` — manufacturer part
+
+A MarkSpec-local convention (ADR-006 §Component Id schemes — "informal but
+readable"; no upstream standard). Grammar (ABNF, normative; this spec owns it):
+
+```abnf
+mfg-id     = "mfg:" vendor ":" partno
+vendor     = token
+partno     = token *( ":" token )      ; partno MAY contain colons
+token      = 1*( ALPHA / DIGIT / "-" / "." / "_" )
+```
+
+- **P5.2-a.** Exactly the literal prefix `mfg:`, then a non-empty `vendor`, then
+  `:`, then a non-empty `partno`. `partno` MAY itself contain `:` (vendor part
+  numbers do); the **first** `:` after `mfg:` ends the vendor, the remainder
+  (which may contain further `:`) is the part number.
+- **P5.2-b.** A missing `vendor` or `partno`, or a character outside `token`, is
+  `MSL-L032` (error, "malformed mfg id").
+- **P5.2-c — type.** Maps to `HardwareComponent` (ADR-003 §Part 6 — the
+  `urn:<vendor>:<part-number>` row generalizes; `mfg:` is the readable form).
+  Refined to `HardwareUnit` if the entry carries `Footprint`/`Value`
+  (core-data-model §1.3.1 step 6 discriminating attributes).
+
+### 5.3 `gtin:` — GS1 Global Trade Item Number
+
+**Authoritative grammar:** GS1 General Specifications (GTIN). MarkSpec adopts it
+by reference. Grammar (the MarkSpec-validated subset):
+
+```abnf
+gtin-id    = "gtin:" 1*DIGIT          ; 8, 12, 13, or 14 digits
+```
+
+- **P5.3-a.** After `gtin:`, exactly 8, 12, 13, or 14 decimal digits
+  (GTIN-8/12/13/14). Any other length → `MSL-L033` (error, "gtin: expected
+  8/12/13/14 digits").
+- **P5.3-b.** The final digit is the GS1 mod-10 check digit. MarkSpec verifies
+  it (GS1 standard check-digit algorithm); a failed check digit is `MSL-L034`
+  (error, "gtin: check digit mismatch"). The algorithm is cited, not reproduced
+  (GS1 General Specifications §7.9 "Check digit calculation").
+- **P5.3-c — type.** `HardwareComponent` (cataloged part — ADR-006 §Component Id
+  schemes "canonical for cataloged parts").
+
+### 5.4 `cpe:` — Common Platform Enumeration
+
+**Authoritative grammar:** NIST IR 7695 (CPE 2.3 Naming Specification),
+Formatted-String binding. MarkSpec adopts it by reference and validates the
+formatted-string form:
+
+```text
+cpe:2.3:part:vendor:product:version:update:edition:language:sw_edition:target_sw:target_hw:other
+```
+
+- **P5.4-a.** MUST begin `cpe:2.3:` then exactly **11** colon-separated
+  components (`part` … `other`), per NIST IR 7695 §6.2. The legacy URI binding
+  (`cpe:/…`, CPE 2.2) is **rejected** with `MSL-L035` (error, "cpe: use 2.3
+  formatted-string binding") — a single canonical form (core-data-model §3.1
+  determinism rationale).
+- **P5.4-b.** `part` MUST be one of `a` (application), `o` (OS), `h` (hardware);
+  else `MSL-L036` (error). Component escaping/quoting follows NIST IR 7695 §6.2
+  verbatim.
+- **P5.4-c — type.** `part: h` → `HardwareComponent`; `part: a`/`o` →
+  `SoftwareComponent` (ADR-006 §Component Id schemes — "cpe: exists for
+  platforms"; ADR-003 §Part 6 fallback to Component when ambiguous).
+
+### 5.5 `urn:system:` and `urn:tool:`
+
+URN forms (RFC 8141 URN syntax) for, respectively, an external system the
+project integrates with and a development tool. ADR-006 treats these as trivial;
+this spec fixes the ABNF (MarkSpec owns these NID-like conventions):
+
+```abnf
+system-id  = "urn:system:" segment *( ":" segment )
+tool-id    = "urn:tool:"   segment *( ":" segment )
+segment    = 1*( ALPHA / DIGIT / "-" / "." / "_" )
+```
+
+- **P5.5-a.** Non-empty after the prefix; each `segment` non-empty; characters
+  restricted to `segment`. Violations → `MSL-L037` (error).
+- **P5.5-b — type.** `urn:system:` → `Component` (external system; abstract
+  fallback unless a profile maps it more specifically — ADR-003 §Part 6
+  `urn:system:` row → Component / HardwareComponent per profile). `urn:tool:` →
+  `SoftwareComponent` (development tool — ADR-003 §Part 6 "Development tool
+  `urn:tool:`"). A profile may remap either prefix
+  ([markspec-profile-schema.md §6](markspec-profile-schema.md)).
+
+### 5.6 Scheme summary
+
+| Scheme        | Grammar owner               | MarkSpec parser § | Default Item type (pre-profile)       |
+| ------------- | --------------------------- | ----------------- | ------------------------------------- |
+| `pkg:`        | purl spec (by reference)    | §5.1              | per type segment (ADR-003 §Part 6)    |
+| `mfg:`        | this spec (ABNF)            | §5.2              | HardwareComponent                     |
+| `gtin:`       | GS1 Gen. Specs (by ref.)    | §5.3              | HardwareComponent                     |
+| `cpe:`        | NIST IR 7695 (by reference) | §5.4              | HardwareComponent / SoftwareComponent |
+| `urn:system:` | this spec (ABNF)            | §5.5              | Component                             |
+| `urn:tool:`   | this spec (ABNF)            | §5.5              | SoftwareComponent                     |
+
+### 5.7 Options analysis — Id-scheme parsing
+
+| Decision                                          | Alternative                                   | Why rejected                                                                                                                                                                                                                                                                                    |
+| ------------------------------------------------- | --------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Adopt purl / CPE / GTIN by reference (**chosen**) | Re-specify each grammar inline in this spec   | The Prompt-2 brief is explicit ("Component Id schemes have authoritative upstream specs. … Don't reinvent"). Reproducing them invites drift and licensing review; referencing the canonical spec is the only maintainable choice.                                                               |
+| Reject CPE 2.2 URI binding (P5.4-a)               | Accept both 2.2 and 2.3 bindings              | Two canonical forms for one identity violate the single-canonical-form principle (core-data-model §3.1) and complicate matching. 2.3 is the current NIST binding.                                                                                                                               |
+| `mfg:` first-colon-splits-vendor (P5.2-a)         | Disallow `:` in part numbers                  | Real manufacturer part numbers contain `:`; forbidding it makes the scheme unusable for its purpose. The fixed `mfg:vendor:` prefix makes the split unambiguous.                                                                                                                                |
+| New `MSL-L…` category for listing diagnostics     | Reuse `MSL-A…` (attributes) / `MSL-R…` (refs) | Listing/scheme errors are neither trailer-attribute nor cross-reference resolution failures; folding them into `A`/`R` blurs the category meaning core-data-model §4 fixes. A dedicated category keeps diagnostics greppable and lets profiles promote listing rules independently. (See §6.5.) |
+
+---
+
+## 6. Per-directive validation
+
+### 6.1 References listing
+
+- Every block-level item MUST be a Reference-shape entry (core-data-model §1.2).
+  An Authored entry (ULID `Id:`) in a references listing → `MSL-L040` (warning —
+  likely misplaced; a project-owned artifact is not a bibliographic reference,
+  but the entry itself is well-formed).
+- Each entry's resolved `Type:` SHOULD be `Specification` or `Component`
+  (ADR-006 §References). A resolved `Unit` in a references listing → `MSL-L041`
+  (warning).
+- `Reference-document` / `Reference-url` are core attributes (core-data-model
+  §1.5) and are **not required** by the listing (a bare URN-only reference is
+  valid).
+
+### 6.2 Glossary listing
+
+- The file MUST satisfy the §4.2 grammar; violations are the `MSL-L02x` codes in
+  §4.2.
+- A glossary file MUST NOT contain entry blocks (`- [ID] …` with a trailers
+  block). An entry in a glossary file → `MSL-L042` (error — the glossary is not
+  the entry model; ADR-006 §Glossary).
+
+### 6.3 Components listing
+
+- Every item MUST resolve to a Component-family `Type:`
+  (`Component`/`SoftwareComponent`/`HardwareComponent`/`SoftwareInterface`/`HardwareInterface`
+  or a profile subtype of one — core-data-model §1.3;
+  [markspec-profile-schema.md §3](markspec-profile-schema.md)). A non-Component
+  type in a components listing → `MSL-L043` (error).
+- A Reference-shape component's `Id:` MUST parse under some §5 scheme **or** be
+  a valid RFC 3986 URI (the `MSL-L030` info fallback applies; not an error —
+  ADR-006 §Component Id schemes allows "any scheme that satisfies RFC 3986").
+- An Authored-shape component (project-owned crate / in-house ECU — ADR-006
+  §Components "may include Entry-authored Components") is valid; its `Id:` is a
+  ULID and §5 does not apply.
+
+### 6.4 Empty-listing and missing-directive behaviour
+
+| Situation                                                                                  | Behaviour                                                                                                                                                                                                                                                                                                                           |
+| ------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Listing document present, **zero** items (no entries / no terms)                           | `MSL-L050` **info**, not error: an empty `references.md`/`components.md`/`glossary.md` is a valid placeholder (a new project legitimately has none). Rendering (out of scope) decides whether to emit an empty chapter.                                                                                                             |
+| Listing document with only front prose, no items                                           | Same as above (`MSL-L050`).                                                                                                                                                                                                                                                                                                         |
+| A `References:` / `{{def.<slug>}}` citation with **no** listing document anywhere in scope | Not a listing error. Resolution falls to the existing core codes: `MSL-R085` (unresolved `References:` slug, core-data-model §4.8) / the `Definition`-resolution warning. The listing is conventional, not mandatory — its absence degrades to ordinary unresolved-reference diagnostics, never a hard "missing directive" failure. |
+| A file that _looks_ like a listing (e.g. `glossary.md`) but is empty / malformed           | Filename trigger still applies; §4 / §6.2 validation runs and reports. The trigger is structural, not opt-in.                                                                                                                                                                                                                       |
+
+**Missing-directive principle:** the listing directives are an **organizational
+convention**, not a precondition for validation. Their absence never escalates a
+reference/definition resolution issue beyond the core code that already covers
+it (core-data-model §4.8). This keeps a profile-free, listing-free project valid
+(ADR-009 §10 core-only mode).
+
+### 6.5 Diagnostic category — `MSL-L…`
+
+This spec introduces the `MSL-L` (Listing) category, extending the
+core-data-model §4 namespace (which reserves `P/I/T/A/B/M/C/R/F`). `L` is
+**additive** and does not alter any core code. Codes used here:
+`MSL-L010`–`L012` (directive placement, §2.3), `L020`–`L026` (glossary grammar,
+§4), `L030`–`L037` (Id schemes, §5), `L040`–`L043` (per-directive content,
+§6.1–6.3), `L050` (empty listing, §6.4). Severity follows the core model
+(core-data-model §4.10): errors are malformed listings; warnings are smells;
+info is advisory. Profiles may promote any `MSL-L` warning/info to error
+([markspec-profile-schema.md §4.3](markspec-profile-schema.md); core-data-model
+§4.10) and may not demote an `MSL-L` error.
+
+---
+
+## 7. Open questions
+
+Capped at five (Prompt-2 constraint).
+
+1. **Block-level directive scope.** §2.2 forbids sub-file directive scoping and
+   relies on ADR-006's split-file organization instead. A monorepo with one
+   `components.md` per package may still want a single aggregated file with
+   per-section scoping. Is the file-level-only restriction permanent, or does a
+   future ADR carve a block-level directive (and how would it interact with
+   core-data-model §2.4.1 `MSL-B043` raw-HTML rules)?
+2. **Glossary identity persistence.** §4.3 says a glossary term's identity is
+   its slug + an assigned ULID, stable across renames, with `fmt` maintaining a
+   sidecar binding — but the sidecar mechanism is deferred to Prompt 3. What is
+   the on-disk form, and does a renamed H3 (slug change) preserve the ULID the
+   way a renamed display ID does for entries (core-data-model §1.2)?
+3. **`See-also` derivation (R4 table).** §4.3 derives `Definition.See-also` from
+   intra-glossary link references. The exact rule (which `[label]: target` forms
+   count, how a target slug is matched) is sketched, not pinned. Should
+   `See-also` be author-explicit instead of derived?
+4. **purl `qualifiers` and identity.** §5.1 adopts purl verbatim, but purl
+   `qualifiers` (e.g. `?repository_url=…`) can make two strings denote the same
+   artifact. Does MarkSpec treat purl identity as the canonical-normalized form
+   (so `Id:` dedup, core-data-model §4.2 `MSL-I007`, sees them as equal), and is
+   that normalization in scope for Prompt 3?
+5. **Profile-supplied component schemes vs §5 parsers.** §5 fixes parsers for
+   six schemes; [markspec-profile-schema.md §6](markspec-profile-schema.md) lets
+   profiles add scheme→type mappings. A profile can map a _prefix_ but cannot
+   supply a _parser/validator_ for it (that is hook territory, ADR-012). Until
+   hooks land, is "prefix mapping without structural validation" sufficient for
+   compliance profiles, or do common hardware schemes (e.g. IEC 61360) need
+   first-class parsers here?
+
+---
+
+## Annex — Cross-reference summary
+
+| Section here                | Source                                                                                                               |
+| --------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| §1 Three directives         | ADR-006 §Decision; core-data-model §1.2/§1.3                                                                         |
+| §2 Placement / triggering   | ADR-006 §Decision/§File organization; core-data-model §2.4.1                                                         |
+| §3 References listing       | core-data-model §1.2/§1.5/§2/§4.8; ADR-006 §References                                                               |
+| §4 Glossary heading shape   | ADR-006 §Glossary; ADR-001 §heading structure; core-data-model §1.3/§2.4.1; ADR-003 §Part 2 "Definition"; ADR-010 §6 |
+| §5 Component Id schemes     | ADR-006 §Component Id schemes; ADR-003 §Part 6; purl spec; NIST IR 7695; GS1 Gen. Specs; RFC 8141; RFC 3986          |
+| §6 Per-directive validation | ADR-006 §Consequences; core-data-model §4.8/§4.10; ADR-009 §10                                                       |
+| §1/§5/§6 profile cross-refs | [markspec-profile-schema.md](markspec-profile-schema.md) §3/§4.5/§6/§7.1                                             |

--- a/docs/specs/markspec-profile-schema.md
+++ b/docs/specs/markspec-profile-schema.md
@@ -1,0 +1,781 @@
+# MarkSpec — Profile Schema
+
+Status: Draft (Prompt 2 of the next-gen refactor)\
+Date: 2026-05-16\
+Scope: MarkSpec profile layer — how profiles declare concrete types, inherit the
+core taxonomy, stack via `extends:`, and pin compatibility\
+Builds on: [markspec-core-data-model.md](markspec-core-data-model.md) (Prompt 1
+output — the frozen core model), ADR-003 (information & traceability model),
+ADR-004 (authoring model), ADR-008 (profile system — distribution and
+extends-chain mechanics), ADR-009 (core / profile boundary), ADR-010 (default
+profile)
+
+This spec is the build target for the Prompt-2 profile-schema implementation. It
+freezes the **profile manifest schema**, the **inheritance rule** that binds
+profile-declared concrete types to the core's built-in taxonomy, the
+**`extends:` stacking and conflict-resolution rules**, the **type-inference
+precedence** a profile participates in, the **default profile contents**, and
+the **versioning / compatibility** contract. It does not specify listing
+directives ([markspec-listing-directives.md](markspec-listing-directives.md)),
+the toolchain wiring (Prompt 3), or end-user documentation (Prompt 4).
+
+The companion file
+[markspec-listing-directives.md](markspec-listing-directives.md) depends on this
+one for the Component type vocabulary and the `term` → `Definition` binding;
+cross-references are flagged inline.
+
+---
+
+## 0. Terminology
+
+This spec inherits the terminology of
+[markspec-core-data-model.md §0](markspec-core-data-model.md) verbatim
+(**entry**, **Entry**, **Authored**, **Reference**, **Item**, **shape**,
+**type**, **attribute**, **trailers**) and adds:
+
+| Term                    | Meaning in this spec                                                                                                                                    |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **profile**             | A distributable, versioned package declaring concrete types, attributes, relations, and rules. ADR-008 §1.                                              |
+| **manifest**            | The `markspec.yaml` file at a profile's root: manifest fields (identity, distribution) + the `profile:` content subtree. ADR-008 §4.                    |
+| **core type**           | One of the 4 abstract (`Item`, `Specification`, `Component`, `Unit`) or 15 concrete built-in types frozen by core-data-model §1.3. Reserved (MSL-A040). |
+| **profile type**        | A concrete type a profile declares by `extends:`-ing a core type or another profile type. Lowercase-with-hyphens by convention (ADR-004 §Part 2).       |
+| **chain**               | The linear `extends:` inheritance path of profiles: default → compliance → org → team → project. ADR-008 §5; ADR-009 §11.                               |
+| **tier**                | One profile in the chain.                                                                                                                               |
+| **effective profile**   | The single merged view produced by collapsing the chain per §5. What the validator / compiler consume.                                                  |
+| **core schema version** | The contract-surface version of core-data-model.md a profile pins against (§8). Distinct from a profile's own `version:`.                               |
+
+---
+
+## 1. Reconciliation stance (authoritative)
+
+The profile layer sits on a fault line between two ADR generations:
+
+- **ADR-008 / ADR-009 / ADR-010** (the profile system as first drafted) frame
+  the core as carrying _no type vocabulary_ — every type, including
+  `requirement`, is profile-declared; the manifest keys each type by a `shape:`
+  (`identified` / `referenced`); the bundled default profile (ADR-010 §2) ships
+  four types (`requirement`, `note`, `term`, `reference`).
+- **core-data-model.md** (Prompt 1, merged) supersedes that framing per its §1.3
+  reconciliation note: the **15 concrete types are core**, with the abstract
+  parents (`Specification` / `Component` / `Unit` / `Item`) serving as
+  direct-instantiation fallbacks _and_ as roots for profile subtypes; §4.4
+  `MSL-A040` reserves the 15-type vocabulary against profile shadowing.
+
+This spec resolves the fault line as follows, and the resolution is normative
+for `main` after the refactor (per `nextgen/README.md` §Spec authority — the
+nextgen ADRs and each prompt's output spec are authoritative for `main` once the
+refactor lands):
+
+1. **The core taxonomy is authoritative.** Profiles do not _declare_ the base
+   vocabulary; they **extend** it. core-data-model §1.3 / §1.6 govern; ADR-008
+   §4 "Profile schema" and §6 "Type enforcement", and ADR-010 §2 "Type
+   vocabulary", are superseded where they conflict. Annex B enumerates the exact
+   deltas.
+2. **ADR-008 retains distribution mechanics unchanged.** Package layout (§1),
+   distribution channels (§2), consumer binding (§3), the `extends:` _chain_
+   resolution and vendoring (§5), CLI surface (§9), and the hooks slot (§10) of
+   ADR-008 stand. This spec only redefines what goes _inside_ the `profile:`
+   content subtree.
+3. **Shape leaves the manifest.** Under the orthogonal two-layer model
+   (core-data-model §1.1) shape is decided by the `Id:` value format alone and
+   is independent of type. ADR-008's per-type `shape:` key is therefore not
+   meaningful — a `requirement` may be Authored (a ULID-identified spec) or
+   Reference (a cited standard whose `Type:` resolves to `Requirement`, ADR-004
+   §Part 3). The manifest replaces per-type `shape:` with per-type `extends:`
+   (§3).
+
+**Options analysis — reconciliation stance.**
+
+| Alternative                                                                                                     | Rejected because                                                                                                                                                                                                                                   |
+| --------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Purely additive (keep ADR-008 §4 verbatim, add inheritance as new optional keys, keep ADR-010's 4-type default) | Leaves the 15-type-core vs 4-type-default contradiction unresolved; core-data-model §1.6 already states profiles _extend_ the 15 core types, so a 4-type independent default is incoherent.                                                        |
+| Defer the reconciliation to an open question                                                                    | The manifest schema is the build target of this prompt; an unresolved core/profile boundary makes the schema unimplementable. core-data-model §6 caps open questions for exactly this reason — forks that block the build are decided, not parked. |
+| Authoritative redefine + supersession annex (**chosen**)                                                        | Matches the nextgen spec-authority rule and core-data-model §1.3; the only stance that yields a coherent, implementable manifest. Cost: an explicit deltas annex (Annex B) — accepted.                                                             |
+
+---
+
+## 2. Manifest format, location, discovery
+
+### 2.1 Package and manifest
+
+A profile is the directory shape ADR-008 §1 fixes:
+
+```text
+<profile-id>/
+├── markspec.yaml        # manifest + declarative content (authoritative)
+├── hooks/               # optional — deferred to ADR-012
+└── README.md            # recommended
+```
+
+`markspec.yaml` has two regions (ADR-008 §4): **manifest fields** (identity,
+versioning, distribution, compatibility) and the **`profile:` content subtree**
+(the part this spec redefines). Region boundary:
+
+```yaml
+# ── Manifest fields ───────────────────────────────────────────────
+id: "@markspec/profile-aspice-4"
+version: 1.2.0
+description: ASPICE 4.0 software engineering profile
+license: MIT
+extends: "npm:@markspec/profile-default@^1.0"   # one parent, ADR-008 §5
+markspec-schema: "1"                              # core schema pin, §8
+
+# ── Content subtree (participates in extends merge, §5) ────────────
+profile:
+  attributes: []          # universal-scope attribute declarations
+  labels: []              # well-known label values
+  types: {}               # concrete-type declarations, §3 / §4
+  documents:              # ADR-007 / ADR-008 §4 "document types"
+    types: []
+    frontMatter: []
+```
+
+The fixed key set inside `profile:` is **`attributes`**, **`labels`**,
+**`types`**, **`documents`**. Any other key under `profile:` is a profile-load
+error (`PROFILE-LOAD-002`, carried from the ADR-008 implementation). Three
+ADR-008 keys are **removed** (Annex B): the per-shape scopes `identified:` and
+`referenced:` (shape is not a profile concept, §1.3) and the universal
+`required:` list (subsumed by per-attribute `required:` and per-type
+`required:`, §4.2).
+
+### 2.2 Location, discovery, binding
+
+Unchanged from ADR-008 §3 and ADR-010 §1:
+
+- A consumer project lists active profiles in `.markspec.yaml` (`profiles:`). At
+  most one content-bearing chain (ADR-008 §3); any number of hook-only profiles.
+- The **default profile** (§7) is bundled in the binary and registered as the
+  implicit bottom of the chain unless `default-profile: false` is set in
+  `.markspec.yaml` (ADR-010 §1).
+- `markspec profile add <spec>` vendors a resolved profile into `profiles/<id>/`
+  and pins the version in `.markspec.yaml` (ADR-008 §2 "Vendoring"). Vendored
+  profiles are committed.
+- Discovery walks up from the working directory to find `.markspec.yaml`
+  alongside `project.yaml` (core-data-model is silent on discovery; this matches
+  the shipped `core/config` + `core/profile` loader behaviour and is unchanged).
+
+**Core-only mode** (no profile, `default-profile: false` and empty `profiles:`)
+remains valid (ADR-009 §10): the 15-type core taxonomy and core hygiene
+(`MSL-I*`, `MSL-R080`) still apply; only profile-declared types, relations, and
+promoted-to-error rules are dormant.
+
+---
+
+## 3. Declaring concrete types and inheritance to the core
+
+### 3.1 The `extends:` rule
+
+Every profile type is declared as a keyed entry under `profile.types:` and
+**must** declare a single `extends:` target naming the type it specializes:
+
+```yaml
+profile:
+  types:
+    software-requirement:
+      extends: Requirement              # a core concrete type
+      display-id-pattern: "SRS_{scope}_{n:04d}"
+    stakeholder-requirement:
+      extends: Requirement
+      display-id-pattern: "STK_{scope}_{n:04d}"
+    hazard:
+      extends: Risk                     # core concrete type
+    ecu:
+      extends: HardwareComponent        # core concrete type
+    safety-requirement:
+      extends: software-requirement     # another *profile* type (same chain)
+```
+
+Rules (ADR-003 §Part 7 "Profiles cannot remove or replace core types … Only
+extend"; ADR-004 §Part 2 "Inheritance is declared in the profile manifest"):
+
+- **R3.1-a.** `extends:` is **required** for every profile type. A type with no
+  parent has no place in the taxonomy and inherits no attributes or relations.
+  Omitting it is a profile-load error (`PROFILE-TYPE-001`, new).
+- **R3.1-b.** The `extends:` target is resolved against the union of (1) the 19
+  core type names (4 abstract + 15 concrete, core-data-model §1.3) and (2) every
+  profile type in the _same effective profile_ (§5). Resolution is by name over
+  that union, not by declaration order — acyclicity and the root-at-core
+  requirement (R3.1-c) make order irrelevant. An unresolved target is
+  `PROFILE-TYPE-002` (new, error).
+- **R3.1-c.** The inheritance graph must be acyclic and must root at a core
+  type. A cycle, or a chain that never reaches a core type, is
+  `PROFILE-TYPE-003` (new, error).
+- **R3.1-d.** A profile type **may not** be named identically to any core type
+  (the 19 reserved names). That is shadowing, not extension — `MSL-A040` /
+  `PROFILE-TYPE-004` (core-data-model §4.4 reserves the vocabulary).
+- **R3.1-e.** Shape is **not** declared. An entry's shape is the `Id:`-format
+  decision of core-data-model §1.2 and is orthogonal to its `Type:`. A profile
+  type is usable by both shapes unless a profile rule (§4.3) restricts it.
+
+The resolved abstract ancestor (`Specification` / `Component` / `Unit` / `Item`)
+of every type — core or profile — is what core validation rules operate on
+(direction of `Derived-from`, applicability of `Realizes`, the per-relation
+target columns of ADR-003 §Part 2). This is ADR-004 §Part 2 "Tooling resolves
+any concrete `Type:` value to its abstract parent".
+
+### 3.2 Options analysis — inheritance declaration
+
+| Decision                                   | Alternative                                                     | Why rejected                                                                                                                                                                                                                                            |
+| ------------------------------------------ | --------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Per-type `extends:` naming the parent type | Keep ADR-008 per-type `shape:` (identified/referenced)          | `shape:` is obsolete under the orthogonal model (§1.3): a profile type can be authored or cited. Keeping it forces the contradiction core-data-model §1.1 removes, and gives no inheritance edge to the 15-type taxonomy core-data-model §1.6 requires. |
+| Per-type `extends:`                        | Separate `abstract-parent:` (only the 4 abstract roots allowed) | Forbids `SRS extends Requirement` / `Hazard extends Risk` — the exact multi-level subtyping ADR-003 §Part 7 enumerates. Collapsing every profile type onto an abstract root loses the concrete core attributes (e.g. `Test.Verifies`).                  |
+| Per-type `extends:`                        | Infer the parent from `display-id-pattern:` prefix only         | Reference-shape and slug-keyed profile types have no numeric display-ID pattern (core-data-model §1.7); inference would leave them parentless. Explicit `extends:` is the single declaration that works for every type.                                 |
+| `extends:` required (R3.1-a)               | Default missing `extends:` to `Item`                            | Silent reparenting to the permissive fallback hides author error and yields a type with no inherited trace attributes. An explicit required edge is auditable — the compliance-review property ADR-008 §Context demands.                                |
+
+---
+
+## 4. Per-concrete-type declarations
+
+A `profile.types.<name>` entry recognizes this fixed key set (superseding
+ADR-008's per-type key set — Annex B):
+
+| Key                              | Meaning                                                                                              |
+| -------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `extends`                        | Parent type (§3). Required.                                                                          |
+| `description`                    | Human-readable summary. Optional.                                                                    |
+| `display-id-pattern`             | Template (ADR-009 §5 grammar): literal prefix + `{n}`/`{n:0Nd}` + optional `{scope}`. Optional.      |
+| `display-id-pattern-enforcement` | `off` \| `warn` \| `error`. Default `warn`. ADR-008 §6; ADR-010 §5.                                  |
+| `required`                       | List of attribute names that must be present on entries of this type. §4.2.                          |
+| `attributes`                     | Per-type attribute declarations (extend the inherited set). §4.1.                                    |
+| `traceability`                   | Map keyed by link-attribute name; per-relation `target` / `cardinality` / `required`. ADR-008 §7.    |
+| `body`                           | Allowed / required body-block constraint over the closed catalogue. §4.4.                            |
+| `color`                          | Render bucket hint (carried from the shipped implementation; consumed by render, out of scope here). |
+
+Any other per-type key is `PROFILE-TYPE-005` (new, error). The ADR-008 per-type
+`shape:` key is **removed** (§1.3 / Annex B).
+
+### 4.1 Attributes — inherited, optional, required
+
+A type's effective attribute set is the **union** of:
+
+1. The universal attributes (core-data-model §1.4) and, for Reference-shape
+   entries, the promoted Reference attributes (core-data-model §1.5).
+2. The core attributes of every type on the `extends:` chain up to the abstract
+   root (core-data-model §1.6 / ADR-003 §Part 2 — e.g. `software-requirement`
+   inherits `Requirement` ⊂ `Specification`: `Derived-from`, `Satisfies`,
+   `Allocated-to`).
+3. The profile `attributes:` declared on this type and on every ancestor profile
+   type.
+
+Each profile attribute declaration uses the ADR-008 §4 attribute schema (`name`,
+`type`, `required`, `cardinality`, `values`, `inverse`) unchanged. The
+default-cardinality inference (ADR-008 §4 "default cardinality" — singular types
+→ `0..1`, list types → `0..N`) is unchanged.
+
+**Inherited attributes may be tightened, never relaxed** (§5 merge rule applied
+within a single profile across the `extends:` edge): a profile type may mark an
+inherited optional attribute `required`, narrow an inherited `enum`'s `values`,
+or tighten an inherited `cardinality`. It may not widen any of these, nor remove
+an inherited attribute (ADR-003 §Part 7; ADR-008 §5 constraint-field rule).
+
+### 4.2 `required`
+
+`required:` at the type scope and `required: true` at the attribute scope both
+promote an attribute's lower cardinality bound (`0..1`→`1..1`, `0..N`→`1..N`),
+exactly as ADR-008 §4 "default cardinality" specifies. The ADR-008 _universal_
+`profile.required:` list is removed (Annex B): an attribute that must be present
+on every entry is declared `required: true` on the universal `attributes:` entry
+instead. This removes the only ADR-008 path by which `required` could name an
+attribute not declared in scope.
+
+### 4.3 Validation rules a profile may add
+
+Per ADR-003 §Part 7 and core-data-model §4.10, a profile may add — and only
+_add_ — validation:
+
+- Required attributes / required relations on its types.
+- Tighter cardinality than the inherited / core default.
+- Type-compatibility constraints (e.g. an ASIL-D `Requirement` may not be
+  `Realizes`-d by a QM `Component`).
+- Display-ID format enforcement (`display-id-pattern-enforcement: error`).
+- Promotion of any core `warning`/`info` to `error` (core-data-model §4.10).
+- A per-type _shape restriction_: an optional `shape:` **constraint** (not the
+  removed declaration key) under a profile rule that an entry of this type must
+  be Authored or must be Reference — e.g. `dependency` entries must be
+  Reference. Violations are profile-defined errors. This is opt-in policy, not
+  the ADR-008 structural key.
+
+A profile **may not** demote a core `error`, remove a core type/relation, or
+relax an inherited constraint (ADR-009 §profile-extension; core-data-model
+§4.10; ADR-003 §Part 7). Attempting any is a profile-load error
+(`PROFILE-MERGE-010`, new).
+
+### 4.4 Allowed body blocks
+
+The body-block catalogue is **closed** at the core level (core-data-model §2.4 —
+ten block types) and a profile cannot extend it (core-data-model §5.4: a new
+block type requires an ADR amendment, not a profile). A profile may _constrain_
+which of the ten a type admits, via an optional `body:` key:
+
+```yaml
+types:
+  contract:
+    extends: Contract
+    body:
+      require: [Code]        # a Contract entry's body must contain a Code block
+      forbid:  [Feature]     # … and must not contain a Gherkin Feature block
+```
+
+`require:` / `forbid:` name body-AST node types from core-data-model §2.4.
+Unknown node names are `PROFILE-TYPE-006` (new, error). A violated `require:` /
+`forbid:` is a profile-defined error on the entry. Profiles cannot _add_ block
+types (`PROFILE-TYPE-007`, new, error) — the catalogue is core-frozen.
+
+### 4.5 Id-scheme hints
+
+For Reference-shape types, a profile may declare which URI schemes are expected,
+feeding type inference (§6) and listing validation
+([markspec-listing-directives.md §5](markspec-listing-directives.md)):
+
+```yaml
+types:
+  dependency:
+    extends: SoftwareComponent
+    id-schemes: ["pkg:cargo", "pkg:npm"]   # purl, listing-directives §5
+  hardware-part:
+    extends: HardwareComponent
+    id-schemes: ["mfg:", "gtin:", "urn:system:"]
+```
+
+`id-schemes:` is advisory at the profile layer (a non-matching `Id:` scheme is a
+`warning`, not an error, unless the profile promotes it). The authoritative
+scheme→type map is ADR-003 §Part 6 plus profile extensions (§6). The exact
+per-scheme parsers live in
+[markspec-listing-directives.md §5](markspec-listing-directives.md) — this spec
+references them; it does not duplicate the grammars.
+
+---
+
+## 5. `extends:` stacking and conflict resolution
+
+The chain (default → compliance → org → team → project) is resolved by ADR-008
+§5 unchanged: a profile names at most one `extends:` parent; the resolved chain
+is linear; the **effective profile** is the per-field merge of all tiers.
+
+### 5.1 Merge rules (ADR-008 §5, restated for the typed model)
+
+| Field category                                                                                 | Rule                                                                                                                      |
+| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| List-additive (`attributes`, `labels`, `types`, `traceability` entries)                        | Union across tiers. Same-named declarations must be _compatible_ (§5.3).                                                  |
+| Constraint fields (`cardinality`, `enum` values, `required`, `display-id-pattern-enforcement`) | Child may tighten; child may not relax. Relaxation is `PROFILE-MERGE-010` (error) at profile load.                        |
+| `traceability.target` matchers                                                                 | Child's target set must be a subset of the parent's. Introducing a target outside the parent's set is a relaxation error. |
+
+Scope precedence within one tier is unchanged (ADR-008 §5):
+`profile.* (universal) ⊂ inherited core/profile type ⊂ profile.types.<name>.*`.
+
+### 5.2 Attribute-name collision policy (resolves core-data-model §6 OpenQ5)
+
+core-data-model §6 Open Question 5 — "are profile attribute names namespaced by
+their declaring profile, or is the trailer-key space global?" — is **resolved
+here: the trailer-key namespace is flat and global.**
+
+- Trailers are git-trailers (core-data-model §2.3 / ADR-002 §Part 1).
+  git-trailer keys are a single flat namespace by construction; per-profile
+  prefixing (`aspice:ASIL`) would break `git interpret-trailers`, grep-ability,
+  and ADR-009 §6 "attribute spelling is stable across profiles".
+- Therefore two tiers (or a profile type and a core type) declaring the **same
+  attribute name** must declare it **compatibly** (§5.3). A compatible
+  re-declaration merges (constraints take the tightest). An **incompatible**
+  re-declaration is a profile-load error `PROFILE-MERGE-011` (new): _"attribute
+  `X` redeclared with incompatible {type|cardinality-family|inverse}"_.
+- A profile attribute name equal to a **core-reserved** name (`Id`, the
+  per-core- type attribute set of core-data-model §1.4–1.6, the 19 type names)
+  is `MSL-A040` (core-data-model §4.4) — reserved, unshadowable, regardless of
+  compatibility.
+
+**Options analysis — collision policy.**
+
+| Alternative                                             | Rejected because                                                                                                                                                            |
+| ------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Flat global namespace, compatible-or-error (**chosen**) | Matches git-trailer reality and ADR-009 §6; ADR-008 §5 already says "same-named attribute in multiple tiers requires compatible definitions" — this names the failure code. |
+| Per-profile namespacing (`profile:Attr`)                | Breaks git-trailer tooling and the stable-spelling contract; authors would write profile-qualified keys in source, defeating the plain-text-in-Git goal.                    |
+| Per-type namespacing only                               | Two profile types under different parents could still both reach the same entry via inheritance; the collision resurfaces at the entry. Doesn't actually scope.             |
+| Last-tier-wins                                          | The exact "not last one wins" failure the Prompt-2 context calls out; silently drops a parent's stricter definition — a compliance-audit hole.                              |
+
+### 5.3 The four stacking cases (Prompt 2 A, cases a–d)
+
+Resolved by applying §5.1 + §5.2:
+
+**(a) Same type name, different abstract parent.** Two tiers declare
+`type: audit-record`, one `extends: Record`, one `extends: Risk`. The abstract
+ancestors differ (`Specification` either way here, but consider
+`extends: Record` vs `extends: Component`). This is a **structural
+incompatibility**, not a tighten — there is no single parent. Error
+`PROFILE-MERGE-012` (new): _"type `T` redeclared with conflicting `extends:`
+(`P1` vs `P2`)"_. Resolution requires the child profile to pick one parent
+explicitly; the chain does not guess.
+
+**(b) Same type name, additive attribute sets.** Two tiers declare
+`type: requirement-x` with disjoint `attributes:`. Merge = union (§5.1
+list-additive). Both attribute sets apply. No diagnostic. Same-named attributes
+within the union follow §5.2.
+
+**(c) Same type name, conflicting `required:` sets.** Tier-1 marks attribute `A`
+required on `T`; tier-2 (child) does not mention `A`. `required` is a constraint
+field and **monotone-tightening**: the union of required sets applies (`A` stays
+required). A child can _add_ to `required:`; it cannot drop a parent's required
+attribute (that is relaxation → `PROFILE-MERGE-010`). "Conflicting" required
+sets therefore _don't_ conflict — they accumulate. The only error case is a
+child attempting to _un-require_ (e.g. declaring `A` with an explicitly wider
+cardinality), which §5.1 already rejects.
+
+**(d) Same `display-id-pattern`, different concrete types.** Tier-1
+`requirement` and tier-2 `safety-requirement` both compile to a pattern matching
+`SRS_*`. At parse time an `SRS_…` entry now matches two patterns. This is
+**not** a profile-load error (the patterns are individually valid); it is a
+_per-entry_ type-inference ambiguity, resolved by §6: tooling emits
+`MSL-T021`/an ambiguity warning and the author disambiguates with an explicit
+`Type:` (core-data-model §1.3.1 step 1 always wins; ADR-009 §5 "Ambiguity and
+diagnostics"). A profile that wants the patterns mutually exclusive must make
+them non-overlapping; the schema does not forbid overlap because legitimate
+subtype refinement (`SRS_SAFETY_*` ⊂ `SRS_*`) needs it.
+
+### 5.4 Generated inverses across the chain
+
+Generated inverses (core-data-model §1.6 / ADR-003 §Part 3) are computed by the
+compiler from the forward relation's `inverse:` declaration; they are never
+authored and never merged as authored attributes. A child profile may add a
+forward relation whose inverse name collides with an inherited inverse — that is
+a §5.2 collision on the _generated_ key and is `PROFILE-MERGE-011` (the inverse
+name participates in the same flat namespace).
+
+---
+
+## 6. Type-inference precedence (resolves core-data-model §6 OpenQ2)
+
+core-data-model §1.3.1 fixes the 8-step resolution chain; §6 Open Question 2
+asks how profile step 2 (`display-id-pattern`) races profile/core step 5 (URI
+scheme map) and whether the answer is profile-author-controllable. **Resolved
+here:**
+
+1. **Step 2 is Authored-only.** A `display-id-pattern` compiles to a recognizer
+   over the _display ID_ of an **Authored** entry (ULID `Id:`). A Reference
+   entry's display ID is a slug (core-data-model §1.7) and does **not** feed
+   step 2. Step 5 (URI scheme map) applies **only** to Reference entries. The
+   two steps are shape-disjoint and never race for the same entry — closing the
+   first half of OpenQ2.
+2. **Profile URI-scheme mappings beat the core map, for covered prefixes only.**
+   A profile may declare additional scheme→type mappings (ADR-003 §Part 6
+   "Profile extension"). For a given Reference `Id:`, the **longest matching
+   declared prefix wins**; profile-declared prefixes take precedence over the
+   core map (ADR-003 §Part 6) _only for the prefixes they cover_; the core map
+   (ADR-003 §Part 6 "Core scheme map") is the universal fallback. Two profile
+   tiers mapping the same prefix to different types is a §5.2-class incompatible
+   redeclaration → `PROFILE-MERGE-013` (new).
+3. **Explicit `Type:` always wins** (core-data-model §1.3.1 step 1). This is the
+   profile-author- and entry-author-controllable escape hatch OpenQ2 asks for:
+   when a profile _also_ declares a Reference-shape type with a
+   `display-id-pattern` (a slug-shaped pattern), and that races the URI scheme
+   map, the entry **must** carry an explicit `Type:` or tooling emits `MSL-T021`
+   (late-stage inference) and falls back to the URI scheme map result.
+
+Profiles do not reorder the core chain; they only populate steps 2, 5, and 6
+(document directives). The chain order itself is core-frozen (core-data-model
+§1.3.1).
+
+---
+
+## 7. The default profile
+
+### 7.1 Contents — thin, by construction
+
+Under the 15-type core taxonomy the default profile is **much smaller** than
+ADR-010 §2 describes. The core already provides `Requirement`, `Test`,
+`Contract`, `Record`, `Risk`, the Component/Unit families, and `Definition`
+(core-data-model §1.3). The default profile therefore declares **no new concrete
+types**. It contributes only _bindings and hygiene_ over the core taxonomy:
+
+1. **Display-ID pattern bindings** for the five core Specification prefixes,
+   `display-id-pattern-enforcement: warn` (opinion-light, ADR-010 §5):
+
+   | Core type     | Pattern (suggested, not enforced) |
+   | ------------- | --------------------------------- |
+   | `Requirement` | `REQ-{n:03d}`                     |
+   | `Test`        | `TST-{n:03d}`                     |
+   | `Contract`    | `ICD-{n:03d}`                     |
+   | `Record`      | `REC-{n:03d}`                     |
+   | `Risk`        | `RSK-{n:03d}`                     |
+
+   These are _bindings to core types_, not new types. They make the five
+   core-reserved prefixes (core-data-model §1.7) mintable/recognized out of the
+   box. Enforcement `warn` (not `error`) keeps the default opinion-light
+   (ADR-010 §5).
+2. **RFC 2119 / RFC 8174 hygiene** on `Requirement` (ADR-010 §3): an
+   **informational** diagnostic (`MSL-M061`, core-data-model §4.6) when a
+   `Requirement` entry's body carries no uppercase RFC 2119 keyword.
+   Recommended, not enforced; overridable by `normative-language: none` (ADR-010
+   §3, §7).
+3. **Glossary `term` convenience.** ADR-010's `term` type maps to the core
+   `Definition` type (core-data-model §1.3 / ADR-003 §Part 2 "Definition"). The
+   default profile binds a free-form-slug display-ID rule
+   (`display-id-pattern-enforcement: off`) to `Definition` and declares the
+   `{{def.<slug>}}` prose-resolution convenience (ADR-010 §6). See
+   [markspec-listing-directives.md §4](markspec-listing-directives.md) for the
+   glossary heading-shape grammar that produces `Definition` items.
+4. **Hygiene-rule restatement.** ADR-010 §4's eight hygiene rules are restated
+   at the profile layer for user-facing diagnostic messages. The first five
+   (unique `Id:`, unique display ID, references resolve, well-formed URI for
+   Reference, well-formed ULID for Authored) are core hygiene (core-data-model
+   §4.1–4.8) surfaced with explanatory text — _named, not re-enforced_ (ADR-010
+   §4).
+5. **Optional front-matter keys** `normative-language` and `glossary-scope`
+   (ADR-010 §7) — unchanged, neither required.
+
+### 7.2 What ADR-010's four types become
+
+| ADR-010 §2 type | Disposition under the 15-type core                                                                                                                                                                                                                                                           |
+| --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `requirement`   | **Collapses into** core `Requirement` (core-data-model §1.3). The default profile binds the `REQ-` pattern + RFC 2119 hygiene to it. No new type.                                                                                                                                            |
+| `term`          | **Maps to** core `Definition` (ADR-003 §Part 2). The default profile binds slug display-IDs + `{{def.}}` resolution. No new type.                                                                                                                                                            |
+| `reference`     | **Subsumed by** the Reference _shape_ + the type the `Id:` URI scheme infers (core-data-model §1.5, §1.3.1 step 5). Not a type at all under the orthogonal model.                                                                                                                            |
+| `note`          | **Dropped from the default baseline.** An informational callout that backs no Item is the "Informative entries" item ADR-003 §Open-questions defers. Until that ADR lands, `note` is not a default-profile type; authors needing a stable-ID callout use core `Record` or a project profile. |
+
+### 7.3 Rationale and options analysis
+
+| Decision                                            | Alternative                                                    | Why rejected                                                                                                                                                                                                       |
+| --------------------------------------------------- | -------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Thin default — bindings + hygiene only (**chosen**) | Re-declare ADR-010's 4 types as profile subtypes of core types | `requirement extends Requirement` is a no-op rename; `reference` cannot be a type (it is a shape). Re-declaration adds a vocabulary the core already owns and re-introduces the 15-vs-4 contradiction §1 resolves. |
+| Thin default                                        | Empty default profile (core taxonomy alone)                    | Loses the out-of-box display-ID patterns + RFC 2119 hygiene ADR-010 §Context justifies as the tech-writer first-run experience. The default profile earns its keep purely as bindings.                             |
+| `note` dropped                                      | Keep `note` as a default `extends: Record`                     | A Record is a _logged decision/event with rationale_ (ADR-003 §Part 2) — semantically wrong for a generic callout. Forcing it distorts the taxonomy; deferral (ADR-003 open questions) is honest.                  |
+
+---
+
+## 8. Versioning, compatibility, and schema pinning
+
+### 8.1 Profile version
+
+A profile carries `version: <semver>` (ADR-008 §4). Consumers pin via the
+`.markspec.yaml` specifier range (npm `@^1.2`, git `#<tag>`, local pin recorded
+on `profile add`) — ADR-008 §2/§3 unchanged. `extends:` targets are range-pinned
+identically (ADR-008 §5).
+
+### 8.2 Core schema pin (`markspec-schema:`)
+
+A profile written against this spec depends on a specific **core data-model
+contract surface** — the type vocabulary (core-data-model §1.3), attribute
+catalogue (§1.4–1.6), value types (§1.8), and lint codes (§4). A profile
+declares the core schema it targets with a new manifest field:
+
+```yaml
+markspec-schema: "1"          # major contract version of core-data-model.md
+```
+
+- `markspec-schema:` is a single integer naming the **major** version of the
+  core data-model contract. The Prompt-1 frozen model (core-data-model.md,
+  Status: Draft) is core schema **`1`**. Subsequent breaking changes to the core
+  type vocabulary, reserved names, or lint-code semantics bump it.
+- The MarkSpec binary advertises the core schema version(s) it implements.
+  Loading a profile whose `markspec-schema:` the binary does not implement is a
+  profile-load error `PROFILE-SCHEMA-001` (new): _"profile targets core schema
+  N; this MarkSpec implements {…}"_.
+- Absent `markspec-schema:` → assumed `1` with a `warning`
+  (`PROFILE-SCHEMA-002`, new) recommending an explicit pin. (Warning, not error,
+  so pre-existing ADR-008 manifests still load.)
+- The core schema version is **independent** of the binary's release version and
+  of any profile's `version:`. A profile may track core schema `1` across many
+  of its own releases.
+
+### 8.3 Options analysis — schema pinning
+
+| Decision                             | Alternative                                                | Why rejected                                                                                                                                                                                                                          |
+| ------------------------------------ | ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Dedicated integer `markspec-schema:` | Pin via `extends:` to a versioned bundled default profile  | Couples schema compatibility to the default profile's release cadence; a compliance profile that opts out of the default (`default-profile: false`) would have nothing to pin against.                                                |
+| Dedicated `markspec-schema:`         | An `engines`-style semver range against the binary version | The binary version and the data-model contract version move independently (a binary patch release does not change the model). Pinning to the contract, not the tool, is what compliance review needs.                                 |
+| Integer major only                   | Full semver `markspec-schema: "1.2.0"`                     | The core contract surface is frozen per-prompt and changes only at major boundaries (core-data-model §3.1 determinism contract / §5 round-trip invariants). Minor/patch granularity implies a cadence the frozen model does not have. |
+
+---
+
+## 9. Worked examples
+
+### 9.1 Minimal ASPICE profile (stacked on default)
+
+`@markspec/profile-aspice-4/markspec.yaml`:
+
+```yaml
+id: "@markspec/profile-aspice-4"
+version: 0.1.0
+description: Minimal ASPICE 4.0 software-engineering profile
+license: MIT
+extends: "npm:@markspec/profile-default@^1"
+markspec-schema: "1"
+
+profile:
+  labels: [ASIL-A, ASIL-B, ASIL-C, ASIL-D, QM]
+
+  types:
+    stakeholder-requirement:
+      extends: Requirement
+      display-id-pattern: "STK_{scope}_{n:04d}"
+      display-id-pattern-enforcement: error
+
+    system-requirement:
+      extends: Requirement
+      display-id-pattern: "SYS_{scope}_{n:04d}"
+      display-id-pattern-enforcement: error
+      required: [Derived-from]
+      traceability:
+        Derived-from:
+          target: [stakeholder-requirement]
+          cardinality: 1..N
+          required: true
+
+    software-requirement:
+      extends: Requirement
+      display-id-pattern: "SRS_{scope}_{n:04d}"
+      display-id-pattern-enforcement: error
+      traceability:
+        Derived-from:
+          target: [system-requirement]
+          cardinality: 1..N
+          required: true
+
+    software-unit-test:
+      extends: Test
+      display-id-pattern: "SWT_{scope}_{n:04d}"
+      traceability:
+        Verifies:
+          target: [software-requirement]
+          cardinality: 1..N
+          required: true
+```
+
+Notes:
+
+- Each type `extends:` a core concrete type (§3.1). No `shape:` (§1.3).
+- `Derived-from` / `Verifies` are **core** Specification/Test attributes
+  (core-data-model §1.6); the profile only tightens their `target` /
+  `cardinality` / `required` (§4.1, §5.1). It declares no new attribute names.
+- Stacked on the default (§7): the default's `REQ-`/`TST-` _warn_ bindings are
+  inherited; ASPICE's typed patterns are stricter (`error`) — a legal tighten
+  (§5.1).
+
+### 9.2 Minimal ISO 26262 profile (stacked on default)
+
+`@markspec/profile-iso-26262/markspec.yaml`:
+
+```yaml
+id: "@markspec/profile-iso-26262"
+version: 0.1.0
+description: Minimal ISO 26262 functional-safety profile
+license: MIT
+extends: "npm:@markspec/profile-default@^1"
+markspec-schema: "1"
+
+profile:
+  attributes:
+    - name: ASIL
+      type: enum
+      values: [A, B, C, D, QM]
+
+  types:
+    hazard:
+      extends: Risk
+      display-id-pattern: "HAZ_{scope}_{n:04d}"
+      display-id-pattern-enforcement: error
+      required: [ASIL]
+      attributes:
+        - name: ASIL
+          type: enum
+          values: [A, B, C, D]        # tightened: QM not valid for a hazard
+      traceability:
+        Mitigated-by:
+          target: [safety-requirement]
+          cardinality: 1..N
+          required: true
+
+    safety-requirement:
+      extends: software-requirement   # extends an ASPICE *profile* type …
+      display-id-pattern: "SAF_{scope}_{n:04d}"
+      required: [ASIL]
+```
+
+Notes:
+
+- `hazard extends Risk` (core), inheriting `Caused-by` / `Mitigated-by`
+  (core-data-model §1.6 / ADR-003 §Part 2 "Risk"); the profile only adds the
+  `ASIL` attribute and tightens trace rules.
+- `ASIL` is declared at universal scope (`enum [A,B,C,D,QM]`) and **tightened**
+  on `hazard` to `[A,B,C,D]` (§4.1 inherited-tighten; §5.1 constraint-narrow).
+  The two declarations share a name and are _compatible_ (§5.2) — same value
+  type, narrowed values.
+- `safety-requirement extends software-requirement` demonstrates a profile type
+  extending another profile type **in the same effective chain** (R3.1-b) — only
+  valid when the ASPICE profile is also in the chain. If ISO 26262 is loaded
+  without ASPICE, `extends: software-requirement` is unresolved
+  (`PROFILE-TYPE-002`). A standalone ISO 26262 profile would instead
+  `extends: Requirement`.
+- Stacking order in `.markspec.yaml`: a project combining both publishes a
+  pre-merged profile (ADR-008 §3 "Projects wanting to combine two domain
+  standards … publish a pre-merged profile") — the consumer does not list ASPICE
+  and ISO 26262 as two independent content chains.
+
+---
+
+## 10. Open questions
+
+Capped at five (Prompt-2 constraint).
+
+1. **`note` / informative entries.** §7.2 drops `note` pending ADR-003's
+   deferred "Informative entries" decision. Until that ADR lands, projects
+   needing a stable-ID non-Item callout have no default-profile vehicle. Should
+   the default profile ship a provisional `note` binding (to what core type?),
+   or is the deferral acceptable for Stage 1?
+2. **Pre-merged combined profiles.** ADR-008 §3 mandates a _pre-merged_ profile
+   for ASPICE + ISO 26262 rather than two consumer chains. This spec specifies
+   the merge algebra (§5) but not a `markspec profile merge` authoring command.
+   Is producing the pre-merged artifact a manual authoring task, or does it need
+   tooling (Prompt 3 territory)?
+3. **`id-schemes:` enforcement strength.** §4.5 makes `id-schemes:` advisory
+   (warning). A compliance profile may want a Reference `dependency` whose `Id:`
+   is _not_ a `pkg:` URL to be a hard error. Is per-scheme enforcement mode
+   (`off`/`warn`/`error`, mirroring display-ID enforcement) worth the schema
+   surface, or does the profile express this via an ordinary validation rule?
+4. **Core schema version cadence.** §8.2 defines `markspec-schema:` as an
+   integer major. The trigger for a bump (any reserved-name change? any new lint
+   code? only round-trip-invariant changes?) is not enumerated. Who owns the
+   core schema version registry and its change policy — this spec, an ADR, or
+   Prompt 3's toolchain spec?
+5. **Profile-declared body-block _constraints_ vs the closed catalogue.** §4.4
+   lets a profile `require:`/`forbid:` core block types but not add new ones.
+   Some domains (e.g. a formal-methods profile wanting a `tla` block) will want
+   a new block. Is the closed catalogue (core-data-model §2.4 / §5.4) a hard
+   ADR-amendment boundary forever, or should a future profile-extension ADR
+   carve a controlled block-extension point?
+
+---
+
+## Annex A — Cross-reference summary
+
+| Section here                      | Source                                                                                    |
+| --------------------------------- | ----------------------------------------------------------------------------------------- |
+| §0 Terminology                    | core-data-model §0; ADR-008 §1/§4                                                         |
+| §1 Reconciliation stance          | core-data-model §1.3 reconciliation note; nextgen/README §Spec authority; ADR-003 §Part 1 |
+| §2 Manifest format / discovery    | ADR-008 §1–§4; ADR-010 §1; ADR-009 §10                                                    |
+| §3 `extends:` inheritance         | ADR-003 §Part 7; ADR-004 §Part 2; core-data-model §1.3/§1.6                               |
+| §4 Per-type declarations          | ADR-008 §4/§6/§7; ADR-003 §Part 2/§Part 7; core-data-model §1.6/§2.4/§4.10                |
+| §5 Stacking & conflict resolution | ADR-008 §5/§7; core-data-model §6 OpenQ5; ADR-009 §6/§profile-extension                   |
+| §6 Type-inference precedence      | core-data-model §1.3.1 / §6 OpenQ2; ADR-003 §Part 5/§Part 6; ADR-009 §5                   |
+| §7 Default profile                | ADR-010 §2–§7; core-data-model §1.3; ADR-003 §Part 2/§Open-questions                      |
+| §8 Versioning & schema pin        | ADR-008 §2/§4/§5; core-data-model §3.1/§5                                                 |
+| §9 Worked examples                | ADR-008 §3/§5; ADR-003 §Part 2/§Part 7; core-data-model §1.6                              |
+| §5/§6 listing cross-refs          | [markspec-listing-directives.md](markspec-listing-directives.md) §4/§5                    |
+
+---
+
+## Annex B — Changes from ADR-008 §4/§6 and ADR-010 §2
+
+This spec supersedes the following, per §1 (authoritative for `main` after the
+refactor lands):
+
+| Superseded                                                                                          | Replaced by                                                                                                                                                                                                                 |
+| --------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ADR-008 §4 per-type `shape: identified\|referenced` key                                             | Per-type `extends: <type>` (§3.1). Shape is an `Id:`-format decision, orthogonal to type (core-data-model §1.1).                                                                                                            |
+| ADR-008 §4 per-shape scopes `profile.identified:` / `profile.referenced:`                           | Removed (§2.1). Shape is not a profile scope. Universal + per-type scopes remain.                                                                                                                                           |
+| ADR-008 §4 universal `profile.required:` list                                                       | Removed (§4.2). Use `required: true` on the universal `attributes:` entry.                                                                                                                                                  |
+| ADR-008 §6 "types declared ⇒ every entry must carry a `type:`" enforcement framing                  | Type is now _always_ resolvable via the core chain (core-data-model §1.3.1 — never errors). Profiles tighten via `display-id-pattern-enforcement` and explicit-`Type:` rules (§6), not a global "must declare type" switch. |
+| ADR-010 §2 four default types (`requirement`/`note`/`term`/`reference`)                             | §7.2: `requirement`→core `Requirement`; `term`→core `Definition`; `reference`→Reference shape; `note` dropped (deferred). Default profile declares no new concrete types.                                                   |
+| ADR-010 §2 "Profiles may extend the type catalog but may not shadow these names" (applied to the 4) | Generalized to the 19 core-reserved names (core-data-model §4.4 `MSL-A040`); the default profile adds none.                                                                                                                 |
+
+ADR-008 §§1–3, §5, §7, §9, §10 and ADR-009 in full are **unchanged** and remain
+authoritative for distribution, the `extends:` chain algorithm, traceability
+rule shape, the CLI surface, and the core/profile boundary principle.


### PR DESCRIPTION
## nextgen Prompt 2 — Profile schema & listing directives

Spec-authoring deliverable (no implementation, per the Prompt 2 constraint).
Two product specs in `docs/specs/`, peers of `markspec-core-data-model.md`
(the merged Prompt 1 output). One PR — the two files cross-reference each
other and form one cohesive deliverable.

### `markspec-profile-schema.md`

- **Reconciliation stance (§1, authoritative):** the nextgen 15-type core
  taxonomy is authoritative; ADR-008 retains distribution / `extends` /
  vendoring mechanics; ADR-008 §4/§6 and ADR-010 §2 are superseded where
  they conflict (Annex B enumerates the exact deltas). Matches the nextgen
  spec-authority rule and core-data-model §1.3.
- **`extends:` inheritance (§3):** per-type `extends:` replaces ADR-008's
  per-type `shape:` (shape is an `Id:`-format decision, orthogonal to type).
  Profile types inherit the core taxonomy (`SRS extends Requirement`,
  `hazard extends Risk`). Options analysis included.
- **Stacking & conflict resolution (§5):** the four prompt cases (a–d)
  resolved via ADR-008 §5 + a flat global trailer-key namespace. **Resolves
  core-data-model §6 OpenQ5.**
- **Type-inference precedence (§6):** **resolves core-data-model §6 OpenQ2**
  — `display-id-pattern` is Authored-only; profile URI schemes win only for
  covered prefixes; explicit `Type:` always wins.
- **Thin default profile (§7):** no new concrete types; binds the 5 core
  Specification prefixes + RFC 2119 hygiene + `term`→`Definition`; documents
  what ADR-010's four types become (`note` dropped, deferred).
- **Versioning (§8):** new `markspec-schema:` core-schema pin. **Worked
  ASPICE + ISO 26262 profiles (§9)**, each stacked on default.
- ≤5 open questions; Annex A (cross-refs) + Annex B (supersession deltas).

### `markspec-listing-directives.md`

- Explicit **rendering OUT-OF-SCOPE** banner (chapter ordering, anchors,
  cross-book refs → Prompt 3/4).
- **Glossary heading-shape EBNF (§4):** H1/H2/H3, deterministic slug
  derivation, link-refs-at-end; explicitly *not* the entry model; maps to
  the core `Definition` type.
- **Exact Component Id-scheme parsers (§5):** `pkg:`/purl, `cpe:`, `gtin:`
  adopted *by reference* to the upstream specs (not reinvented, per the
  brief); `mfg:` / `urn:system:` / `urn:tool:` ABNF owned here.
- **Per-directive validation (§6):** empty-listing = info (valid
  placeholder); missing-directive degrades to existing core codes, never a
  hard failure (preserves core-only mode). New `MSL-L` diagnostic category
  with options analysis vs reusing `MSL-A`/`MSL-R`.
- ≤5 open questions + cross-ref annex. Bidirectional cross-refs with the
  profile spec.

### Process

- Prerequisite satisfied: Prompt 1's core model is merged to `main`.
- Executed direct-to-main via `prompt-02-*` branch (consistent with how
  Prompt 1 landed). No tracking issue — for a spec-doc deliverable the
  merged docs are the record (PROCESS.md).
- `just check` gates + pre-commit hook (fmt / dprint / lint / typecheck /
  commit-msg lint) all green at commit time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
