### PR TITLE
docs(spec): toolchain distribution & e2e test strategy (Prompt 3)

### DIFF
--- a/docs/specs/markspec-e2e-test-strategy.md
+++ b/docs/specs/markspec-e2e-test-strategy.md
@@ -1,0 +1,386 @@
+# MarkSpec — E2E Test Strategy
+
+Status: Draft (Prompt 3 of the next-gen refactor)\
+Date: 2026-05-16\
+Scope: The end-to-end test architecture — three latency-gated rings, fixture
+organization, snapshot determinism, the LSP/MCP replay format, the CI matrix,
+and per-ring coverage targets\
+Builds on: [markspec-core-data-model.md](markspec-core-data-model.md) (Prompt 1
+output — §3.1 determinism contract, §5 round-trip invariants, §5.5 round-trip
+test obligations explicitly addressed to "Prompt 3 e2e"),
+[markspec-toolchain-distribution.md](markspec-toolchain-distribution.md) (Prompt
+3 companion — the binary and install surfaces Ring 3 exercises),
+[markspec-profile-schema.md](markspec-profile-schema.md) (Prompt 2),
+[markspec-listing-directives.md](markspec-listing-directives.md) (Prompt 2),
+AGENTS.md §Test conventions
+
+This spec freezes the **test ring model**, **fixture layout on disk**, the
+**snapshot determinism rules**, the **LSP/MCP request-replay format**, the **CI
+matrix**, and **coverage targets per ring**. It does not implement tests
+(Prompt-3 constraint — specs only); the implementation lands when the toolchain
+is refactored against the nextgen model.
+
+It is the companion of
+[markspec-toolchain-distribution.md](markspec-toolchain-distribution.md): Ring 3
+drives the `install` commands and the LSP/MCP entrypoints that spec defines.
+Cross-references are flagged inline.
+
+---
+
+## 0. Terminology
+
+| Term                      | Meaning in this spec                                                                                                              |
+| ------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| **ring**                  | A test tier defined by a latency budget and a trigger cadence (§2). Rings 1–3.                                                    |
+| **golden parse**          | A fixture whose expected parse/format output is committed and asserted byte-for-byte (Ring 1).                                    |
+| **corpus**                | A realistic multi-file project tree fixture exercised through the CLI (Ring 2).                                                   |
+| **replay**                | A recorded JSON-RPC transcript of an LSP or MCP session, re-driven against the server and asserted modulo normalization (Ring 3). |
+| **normalization**         | The deterministic scrub applied to output before snapshot comparison (§5.2).                                                      |
+| **blackbox**              | A test that touches only the CLI binary via `Deno.Command`, importing nothing from `packages/` (AGENTS.md §E2E tests).            |
+| **round-trip obligation** | One of the five test obligations core-data-model §5.5 hands to Prompt 3.                                                          |
+
+---
+
+## 1. Scope and relationship to existing conventions
+
+AGENTS.md §Test conventions already fixes two layers: **unit tests** (colocated
+`<module>_test.ts`, importing the module directly) and **e2e tests** (blackbox
+in `tests/e2e/`, CLI-only via the `markspec()` helper, `assertSnapshot` for
+prose). This spec does **not** replace them — the three rings **organize**
+existing and future tests by latency and cadence so the right tests run at the
+right time. A given test file belongs to exactly one ring (§3).
+
+The current suite (`tests/e2e/*_test.ts` — 30+ files including
+`ast_equivalence_test.ts`, `format_test.ts`, `validate_test.ts`, `mcp_test.ts`,
+`lsp_*_test.ts`, plus colocated unit tests) is the starting population §3 maps
+into rings. No test is deleted by this spec; some are reclassified and the slow
+ones move off the per-commit path.
+
+Out of scope: unit-test design (covered by AGENTS.md), the toolchain install
+mechanics themselves (Prompt 3 companion), and Stage-2 concerns (perf
+benchmarking, fuzzing) — Open Question 5.
+
+---
+
+## 2. The three rings
+
+Latency is the organizing axis (Prompt-3 Context: "E2E tests in three rings,
+gated by latency … they catch different classes of regression"):
+
+| Ring  | Class                           | Budget (whole ring) | Trigger                                     | Catches                                                                                  |
+| ----- | ------------------------------- | ------------------- | ------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| **1** | Golden parse / format / lint    | < 5 s               | every commit (pre-commit hook + every push) | Parser / formatter / lint regressions; round-trip invariant breaks (core-data-model §5). |
+| **2** | Scenario — full CLI pipeline    | < 90 s              | every PR (and every push to a PR branch)    | Cross-subcommand regressions; profile / listing behavior; compile→export→report.         |
+| **3** | Integration — LSP/MCP + install | < 15 min            | nightly + pre-release                       | Protocol regressions; editor/client config-write; install idempotence.                   |
+
+Each ring is a strict superset trigger of the one below in _cadence_ (Ring 1
+runs whenever Ring 2 does; Ring 2 whenever Ring 3 does) but **not** in content —
+they exercise different surfaces and a green Ring 1 says nothing about Ring 3.
+
+### 2.1 Ring 1 — golden parse / format / lint
+
+Pure, in-process, microsecond-to-millisecond assertions. Input fixture → parse →
+AST / formatted output / diagnostic set, asserted byte-for-byte against a
+committed golden. No subprocess, no filesystem beyond reading the fixture. This
+is where core-data-model §3.1 (idempotence, totality, bytewise reproducibility)
+and §5 (round-trip invariants) are enforced. `ast_equivalence_test.ts` is the
+seed of this ring.
+
+### 2.2 Ring 2 — scenario (full CLI pipeline)
+
+Blackbox, subprocess, seconds. Drives the actual binary via the `markspec()`
+helper (AGENTS.md §E2E) against realistic multi-file corpora: `fmt`, `lint`,
+`compile`, `export`, `report`, `book build`, `profile`, the listing directives.
+Asserts exit code, stdout/stderr split (clig.dev), and normalized snapshots. The
+bulk of today's `tests/e2e/*_test.ts` is Ring 2.
+
+### 2.3 Ring 3 — integration (LSP / MCP / install)
+
+Subprocess, stateful protocol sessions, minutes. Replays recorded JSON-RPC
+transcripts (§6) against `markspec lsp` / `markspec mcp`, and exercises
+`markspec lsp install` / `markspec mcp install`
+([markspec-toolchain-distribution.md §4/§5](markspec-toolchain-distribution.md))
+against throwaway config fixtures, asserting the managed-block contract
+(§toolchain 6) including idempotent re-run. `lsp_*_test.ts` / `mcp_test.ts` are
+the seed.
+
+### 2.4 Options analysis — ring count
+
+| Alternative                                    | Rejected because                                                                                                                                                                                      |
+| ---------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Three rings, latency-gated (**chosen**)        | Matches the Prompt-3 Context exactly; each ring has a distinct failure class and a cadence proportional to its cost. The fast ring stays a per-commit gate.                                           |
+| Flat suite (`deno test` everything every time) | The current state. The LSP/MCP replay and install tests are minutes-long; running them per commit makes the inner loop unusable, so they rot or get skipped.                                          |
+| Two rings (fast unit + slow everything)        | Collapses Ring 2 and Ring 3; a 90 s scenario suite and a 15 min integration suite have different cadences (PR vs nightly). Merging them either slows every PR or delays scenario feedback to nightly. |
+| Four+ rings (add a perf ring now)              | Perf/fuzz is Stage 2 (Open Question 5). Adding an empty ring now is speculative structure (YAGNI).                                                                                                    |
+
+---
+
+## 3. Mapping the current suite into rings
+
+| Current file(s)                                                                                | Ring | Rationale                                                                                                                 |
+| ---------------------------------------------------------------------------------------------- | ---- | ------------------------------------------------------------------------------------------------------------------------- |
+| Colocated `core/**/*_test.ts` (parser, formatter, validator)                                   | 1    | In-process, sub-ms; the unit layer AGENTS.md defines, run as the fast gate.                                               |
+| `tests/e2e/ast_equivalence_test.ts`                                                            | 1    | Round-trip / equivalence assertions — core-data-model §5 territory.                                                       |
+| `tests/e2e/format_test.ts`, `validate_test.ts`                                                 | 1+2  | The pure golden cases → Ring 1; the multi-file / project-context cases → Ring 2 (split by whether they spawn the binary). |
+| `tests/e2e/{compile,export,report,book_build,create,insert,next_id,hook,config,query}_test.ts` | 2    | Blackbox full-pipeline scenarios.                                                                                         |
+| `tests/e2e/profile_*_test.ts`                                                                  | 2    | Profile chain / merge / traceability via the CLI — scenario level.                                                        |
+| `tests/e2e/help_test.ts`                                                                       | 2    | Snapshot of `--help`; cheap but blackbox (spawns binary).                                                                 |
+| `tests/e2e/lsp_*_test.ts`, `lsp_helpers.ts`                                                    | 3    | Stateful LSP sessions — minutes, protocol surface.                                                                        |
+| `tests/e2e/mcp_test.ts`                                                                        | 3    | Stateful MCP session — Ring 3.                                                                                            |
+| (new) install fixtures driving `lsp/mcp install`                                               | 3    | Config-write contract ([toolchain §6](markspec-toolchain-distribution.md)).                                               |
+
+The split of `format_test.ts` / `validate_test.ts` is the only reclassification
+that splits a file: pure input→output goldens move to a Ring-1 in-process
+harness; cases that need a project root / profile resolution stay Ring-2
+blackbox. The split criterion is mechanical — _does the case spawn the binary or
+need the filesystem?_ If no → Ring 1.
+
+### 3.1 Round-trip obligations → rings (core-data-model §5.5)
+
+core-data-model §5.5 hands Prompt 3 five obligations. Their ring placement:
+
+| §5.5 obligation                                                               | Ring | Form                                                                        |
+| ----------------------------------------------------------------------------- | ---- | --------------------------------------------------------------------------- |
+| 1. Idempotence over every body-block type, caption type, shape×type combo     | 1    | Golden corpus; assert `fmt(x) == fmt(fmt(x))` byte-identical.               |
+| 2. Stability under attribute reordering (random valid shuffles → same output) | 1    | Property-style: shuffle trailer order, assert canonical output equal.       |
+| 3. Stability under repeatable-value form mixing (CSV vs multi-line → same)    | 1    | Paired fixtures, same expected golden.                                      |
+| 4. ULID stability for `Origin: synthesized` across runs and platforms         | 1+3  | Ring 1: same input → same derived ULID. Ring 3 (nightly matrix): across OS. |
+| 5. Lossless preservation of unknown trailer keys when no profile loaded       | 1    | Core-only-mode golden; assert unknown keys survive verbatim (§5.4).         |
+
+Obligation 4's cross-platform half is the one assertion that needs the Ring-3
+nightly OS matrix (§7); the rest are Ring 1 and gate every commit.
+
+---
+
+## 4. Fixture organization on disk
+
+Extends the existing `tests/fixtures/` (today: `glossary.md`,
+`requirement-block.md`, `traceability-matrix.md`, `in-code-*.{rs,kt}`,
+`profiles/`). New top-level layout, one concern per fixture, deterministic:
+
+```text
+tests/fixtures/
+├── golden/                 ← Ring 1: input + expected output pairs
+│   ├── parse/<name>.md            and  <name>.ast.json
+│   ├── format/<name>.in.md        and  <name>.out.md
+│   ├── lint/<name>.md             and  <name>.diag.json
+│   └── roundtrip/<name>.md        (idempotence / §5.5 obligations 1–3,5)
+├── corpora/                ← Ring 2: realistic multi-file project trees
+│   ├── minimal/                   (default profile, a few entries)
+│   ├── aspice-slice/              (stacked ASPICE profile, profile-schema §9.1)
+│   └── iso-26262-slice/           (stacked ISO 26262, profile-schema §9.2)
+├── replay/                 ← Ring 3: recorded JSON-RPC transcripts
+│   ├── lsp/<scenario>.jsonl
+│   └── mcp/<scenario>.jsonl
+└── install/                ← Ring 3: throwaway editor/client config seeds
+    ├── neovim/  zed/  claude-desktop/  cursor/   (before/after pairs)
+```
+
+Rules:
+
+- **One concern per fixture.** A `format` golden tests one canonical-form rule,
+  not a grab-bag. A reviewer reading the diff sees exactly what changed.
+- **Corpora are realistic.** `aspice-slice` / `iso-26262-slice` are thin slices
+  of `demo-aeb-*` shaped to the worked examples in
+  [markspec-profile-schema.md §9](markspec-profile-schema.md) — they double as
+  the Prompt-4 example project's backing data (cross-cutting; Prompt 4 cites
+  them).
+- **Deterministic content.** No timestamps, no random ULIDs in committed
+  fixtures except where the test _is_ ULID assignment (then
+  `Origin:
+  synthesized` so the ULID is derivable, core-data-model §3.5).
+- `docs/examples/` stays excluded from formatters (CLAUDE.md); fixtures are
+  separate and may be intentionally non-canonical as _inputs_.
+
+---
+
+## 5. Snapshot strategy
+
+### 5.1 Determinism source of truth
+
+Snapshots are sound only because the tool is deterministic. The contract is
+core-data-model §3.1 (idempotence, total function, bytewise reproducibility
+across macOS/Linux/Windows/Deno/Node/WASM) and §5.3. A snapshot test asserts
+that contract; if a snapshot is flaky, the defect is in the tool's determinism
+(core-data-model §3.1 "If two implementations could disagree, the rule is
+under-specified and is a defect"), not in the test — the test is doing its job.
+
+### 5.2 Normalization
+
+Before comparison, output is normalized so the snapshot captures _meaning_, not
+incidental environment:
+
+| Normalized                    | Rule                                                                                                                                                                                             |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Absolute paths                | Rewrite the temp working dir to `<TMP>`; project root to `<ROOT>`. (The `markspec()` helper already temp-dirs.)                                                                                  |
+| Non-synthesized ULIDs         | Redact random Authored ULIDs to `<ULID:n>` (stable per-snapshot ordinal). `Origin: synthesized` ULIDs are **not** redacted — they are deterministic and _are_ the assertion (§3.1 obligation 4). |
+| Timestamps / durations / PIDs | Redact to `<TIME>` / `<PID>` (only ever appear in diagnostics/progress on stderr, never in data output).                                                                                         |
+| Map / object key order        | Emit with keys sorted; the compiler's JSON output is already deterministic (core-data-model §5.3) — sorting is belt-and-braces against serializer drift.                                         |
+| Trailing whitespace / EOL     | Normalize to `\n`; assert no trailing whitespace (it is itself a formatter rule, core-data-model §3.3.5).                                                                                        |
+
+Normalization is **diff-friendly**: one logical record per line, stable field
+order, so a snapshot delta reads as a minimal unified diff (the same property
+the toolchain spec wants for config writes —
+[toolchain §6.5](markspec-toolchain-distribution.md)).
+
+### 5.3 Update discipline
+
+`.snap` files are committed and CI-verified (AGENTS.md §CI).
+`deno test … --
+--update` regenerates them; the diff is reviewed and committed
+consciously (AGENTS.md §E2E "Snapshot assertions"). A snapshot change in a PR is
+a reviewable artifact — an unexplained `.snap` delta is a review red flag, not a
+rubber stamp.
+
+### 5.4 Options analysis — snapshot scope
+
+| Alternative                                           | Rejected because                                                                                                                              |
+| ----------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| Normalized snapshots, determinism-backed (**chosen**) | Captures full output cheaply; soundness rests on the §3.1 contract the tool already owes. Diff-friendly normalization keeps reviews honest.   |
+| Field-level assertions only (no snapshots)            | Verbose, under-asserts (the fields nobody thought to check regress silently). AGENTS.md already mandates `assertSnapshot` for prose surfaces. |
+| Snapshot raw output, no normalization                 | Every temp path / random ULID makes every run differ — snapshots become untestable or get `--update`-spammed until meaningless.               |
+
+---
+
+## 6. LSP / MCP request-replay format
+
+### 6.1 Transcript format
+
+Ring 3 records and replays **newline-delimited JSON** (`.jsonl`), one JSON-RPC
+message per line, prefixed with a direction marker:
+
+```text
+→ {"jsonrpc":"2.0","id":1,"method":"initialize","params":{…}}
+← {"jsonrpc":"2.0","id":1,"result":{"capabilities":{…},"serverInfo":{…}}}
+→ {"jsonrpc":"2.0","method":"textDocument/didOpen","params":{…}}
+← {"jsonrpc":"2.0","method":"textDocument/publishDiagnostics","params":{…}}
+```
+
+- `→` = client→server (driven by the harness). `←` = server→client (expected,
+  asserted modulo §5.2 normalization).
+- Requests are matched by `id`; notifications by `(method, params)` after
+  normalization. Server→client ordering is asserted per-`id`; unordered
+  notifications (e.g. `publishDiagnostics`) are matched as a set within a settle
+  window.
+- Paths/URIs in params are written relative to a `<ROOT>` token at record time
+  so the transcript is portable (same normalization as §5.2).
+- The replayed binary is the **bundled binary**
+  ([toolchain §2](markspec-toolchain-distribution.md)) invoked as `markspec lsp`
+  / `markspec mcp` — Ring 3 tests the shipped artifact, not an in-process
+  server, so it catches the entrypoint wiring `main.ts` does.
+
+### 6.2 Recording
+
+A `--record` mode on the replay harness captures a live session into a
+transcript; the author trims it to the scenario, reviews it, and commits it
+(same discipline as `.snap`, §5.3). Re-recording after an intentional protocol
+change is a reviewed diff.
+
+### 6.3 Options analysis — replay format
+
+| Alternative                                     | Rejected because                                                                                                                   |
+| ----------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| Direction-tagged JSON-RPC `.jsonl` (**chosen**) | It _is_ the wire format — minimal translation, trivially diffable line-by-line, recordable from a real session, language-agnostic. |
+| Structured scenario DSL (custom YAML steps)     | A second grammar to learn and maintain that must be kept faithful to JSON-RPC; drifts from what the editor actually sends.         |
+| Full binary session capture (pcap-style)        | Opaque, unreviewable, non-portable across platforms; defeats the "reviewable artifact" property every other ring upholds.          |
+| Assert only final state (no transcript)         | Misses ordering / intermediate-notification regressions — exactly the protocol class Ring 3 exists to catch.                       |
+
+---
+
+## 7. CI matrix
+
+| Job       | Rings | Trigger                                            | Budget   | Platform(s)                                                                       |
+| --------- | ----- | -------------------------------------------------- | -------- | --------------------------------------------------------------------------------- |
+| `fast`    | 1     | every push (all branches), pre-commit hook locally | < 5 s    | Linux (CI), host (local)                                                          |
+| `pr`      | 1 + 2 | every pull request / PR push                       | < 95 s   | Linux                                                                             |
+| `nightly` | 1+2+3 | scheduled nightly + pre-release tag                | < 17 min | Linux **and** macOS **and** Windows (the §3.1 obligation-4 cross-platform matrix) |
+
+- The existing single CI invocation
+  (`deno test --allow-read --allow-write --allow-run --allow-env --allow-ffi`,
+  AGENTS.md §CI) becomes the **`pr`** job. `fast` is a filtered subset (Ring-1
+  tagged tests only). `nightly` adds Ring 3 and the OS matrix.
+- Test→ring tagging mechanism: a ring tag in the test name or a per-directory
+  convention (`tests/e2e/` Ring 2/3 by file per §3; Ring 1 = colocated unit +
+  the in-process golden harness). The exact tag syntax is an implementation
+  detail (Open Question 2).
+- `nightly` is the **only** job that needs `--allow-run` for the install
+  fixtures and the LSP/MCP subprocess replay at scale; `pr` already has it for
+  the blackbox helper.
+- A red `nightly` blocks a release tag, not the merge that triggered the nightly
+  — Ring 3 regressions are release gates, not PR gates (latency budget
+  rationale, §2).
+
+### 7.1 Options analysis — matrix
+
+| Alternative                           | Rejected because                                                                                                                                       |
+| ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| fast/pr/nightly as above (**chosen**) | Cadence matches cost (§2); cross-platform only where an obligation demands it (§3.1 ob.4), keeping nightly affordable.                                 |
+| Run the OS matrix on every PR         | 3× the PR CI minutes for a guarantee only obligation-4 needs; the determinism contract (§5.1) makes single-platform PR runs sound for everything else. |
+| No nightly; everything on PR          | Pushes Ring 3 (15 min) onto every PR — the inner-loop-killing failure §2.4 rejects.                                                                    |
+
+---
+
+## 8. Coverage targets per ring
+
+Coverage is defined by **surface enumeration**, not a line-percentage number (a
+line target rewards trivial tests; surface enumeration rewards the cases that
+regress):
+
+| Ring | Target (must be exhaustive over the named surface)                                                                                                                                                                                                                                                                                                                                                                                             |
+| ---- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1    | 100% of the five core-data-model §5.5 round-trip obligations; every body-block type (10, core-data-model §2.4); every caption type (6, core-data-model §2.6); every shape × abstract-type combination (core-data-model §1.1); every `MSL-` lint code in core-data-model §4 has at least one positive and one negative golden.                                                                                                                  |
+| 2    | Every implemented CLI subcommand (CLAUDE.md table) with at least one happy-path and one error-path scenario; every listing directive ([markspec-listing-directives.md §6](markspec-listing-directives.md)); a stacked-profile corpus exercising [markspec-profile-schema.md §5](markspec-profile-schema.md) merge cases (a)–(d).                                                                                                               |
+| 3    | Every LSP capability the server advertises (`lsp/server.ts` `InitializeResult.capabilities` — diagnostics, completion, hover, definition, references, document/workspace symbols, rename, folding, highlights, code actions); every MCP tool and resource (`mcp/server.ts`); every first-class install adapter ([markspec-toolchain-distribution.md §4.2/§5.2](markspec-toolchain-distribution.md)) including idempotent re-run and `--print`. |
+
+A new core lint code, body block, LSP capability, MCP tool, or install adapter
+is **not done** until its ring's enumeration includes it — this is the
+regression-proofing contract, enforced by review, not a coverage gate that can
+be gamed.
+
+### 8.1 Options analysis — coverage definition
+
+| Alternative                             | Rejected because                                                                                                            |
+| --------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| Surface enumeration (**chosen**)        | Ties "covered" to the actual contract surfaces (lint codes, capabilities, subcommands); a gap is visible and reviewable.    |
+| Line-coverage percentage gate           | Rewards exercising lines, not asserting behavior; a 90% line target passes with no assertion on the output that matters.    |
+| No explicit target ("write good tests") | Unfalsifiable; the regression classes the rings exist to catch slip through because nobody owns "is the surface complete?". |
+
+---
+
+## 9. Open questions
+
+Capped at five (Prompt-3 constraint).
+
+1. **Ring-1 in-process harness vs blackbox.** §3 splits `format_test.ts` into a
+   Ring-1 in-process harness (imports `core/`) and Ring-2 blackbox. AGENTS.md
+   §E2E says e2e imports _nothing_ from source. Is the Ring-1 golden harness a
+   _unit_-layer construct (colocated, allowed to import `core/`) rather than an
+   e2e one — i.e. does Ring 1 live under `core/**` not `tests/e2e/`?
+2. **Ring tagging mechanism.** §7 defers the concrete tag syntax (test-name
+   prefix? `Deno.test` metadata? directory convention?). Which, and does it need
+   to survive `deno test` filtering portably to Node?
+3. **Corpora vs the Prompt-4 example project.** §4 says `aspice-slice` doubles
+   as Prompt 4's example project. If they diverge (docs need pedagogy, tests
+   need edge cases), do they fork, or does the example project stay a strict
+   superset the corpora subset?
+4. **Replay settle window.** §6.1 matches unordered notifications "within a
+   settle window". What defines the window — a fixed timeout (flaky under CI
+   load) or a quiescence signal from the server (needs a protocol affordance)?
+5. **Stage-2 rings.** Perf/throughput and fuzz/property testing are excluded
+   (§1, §2.4). When Stage 2 adds them, are they Ring 4 / Ring 5, or a separate
+   non-ring track triggered independently of this cadence model?
+
+---
+
+## Annex — Cross-reference summary
+
+| Section here     | Source                                                                                                                                                                              |
+| ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| §1 Conventions   | AGENTS.md §Test conventions; existing `tests/e2e/`                                                                                                                                  |
+| §2 Three rings   | Prompt-3 Context; core-data-model §3.1/§5                                                                                                                                           |
+| §3 Suite mapping | `tests/e2e/*`; core-data-model §5.5 (round-trip obligations addressed to Prompt 3)                                                                                                  |
+| §4 Fixtures      | `tests/fixtures/`; [markspec-profile-schema.md §9](markspec-profile-schema.md); CLAUDE.md (`docs/examples/` exclusion)                                                              |
+| §5 Snapshots     | core-data-model §3.1/§5.3; AGENTS.md §E2E "Snapshot assertions" / §CI                                                                                                               |
+| §6 Replay format | `lsp/server.ts`, `mcp/server.ts`; [markspec-toolchain-distribution.md §2](markspec-toolchain-distribution.md)                                                                       |
+| §7 CI matrix     | AGENTS.md §CI; core-data-model §5.3 (cross-platform); [markspec-toolchain-distribution.md §3.4](markspec-toolchain-distribution.md)                                                 |
+| §8 Coverage      | CLAUDE.md §CLI subcommands; core-data-model §2.4/§2.6/§4/§5.5; `lsp/server.ts`; `mcp/server.ts`; [markspec-toolchain-distribution.md §4.2/§5.2](markspec-toolchain-distribution.md) |

--- a/docs/specs/markspec-toolchain-distribution.md
+++ b/docs/specs/markspec-toolchain-distribution.md
@@ -1,0 +1,390 @@
+# MarkSpec — Toolchain Distribution
+
+Status: Draft (Prompt 3 of the next-gen refactor)\
+Date: 2026-05-16\
+Scope: How the MarkSpec toolchain is packaged and installed — the single binary,
+the `lsp install` / `mcp install` surfaces, version/schema alignment, and
+config-write safety\
+Builds on: [markspec-core-data-model.md](markspec-core-data-model.md) (Prompt 1
+output), [markspec-profile-schema.md](markspec-profile-schema.md) (Prompt 2 —
+`markspec-schema:` core-schema pin), ADR-001 (Markdown format), ADR-003
+(information & traceability model), ADR-004 (authoring model), ADR-005 (CLI
+architecture — subcommand dispatch, single binary), clig.dev (Command Line
+Interface Guidelines)
+
+This spec freezes the **distribution model** (one bundled binary, three
+entrypoints), the **install surfaces** for the LSP and MCP servers
+(`markspec lsp install` / `markspec mcp install`), the **version / schema
+alignment** contract, and the **config-write safety** rules every installer
+obeys. It does not specify the e2e test strategy
+([markspec-e2e-test-strategy.md](markspec-e2e-test-strategy.md)) or the end-user
+documentation (Prompt 4 — `markspec-user-docs.md`, which cites this spec for
+install surface details).
+
+The companion file
+[markspec-e2e-test-strategy.md](markspec-e2e-test-strategy.md) exercises the
+install commands specified here in its Ring 3 integration tests;
+cross-references are flagged inline.
+
+> **ADR-002bis note.** The Prompt-3 brief lists "ADR-002bis" as an input.
+> ADR-002bis does not exist as a separate file (core-data-model §6 Open Question
+> 1). This spec treats ADR-002 §Part 1 and core-data-model §2.3/§3.3 as the
+> authoritative trailers reference, consistent with core-data-model's resolution
+> of the same dangling citation.
+
+---
+
+## 0. Terminology
+
+| Term                    | Meaning in this spec                                                                                                                                 |
+| ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **binary**              | The single `markspec` executable produced by `deno compile packages/markspec/main.ts`.                                                               |
+| **entrypoint**          | One of the three runtime faces of the binary: the CLI, the LSP server (`markspec lsp`), the MCP server (`markspec mcp`).                             |
+| **install surface**     | The `markspec lsp install` / `markspec mcp install` command set that writes editor / client configuration.                                           |
+| **adapter**             | A per-target module that knows one editor's or client's config location, format, and managed-region convention.                                      |
+| **managed block**       | A delimited, idempotent region the installer owns inside an otherwise user-owned config file (§6).                                                   |
+| **core-schema version** | The core-data-model contract version the binary implements (core-data-model §3.1/§5; [markspec-profile-schema.md §8.2](markspec-profile-schema.md)). |
+| **scope**               | Where config is written: `user` (the editor's per-user config) or `workspace` (the project, next to `markspec.yaml`).                                |
+
+---
+
+## 1. Scope and boundaries
+
+In scope: the binary's shape, the `install` command surfaces, what they write
+and how safely, and how versions line up.
+
+Out of scope (and their owners):
+
+- **Editor-extension internals** (the VS Code extension's activation, the LSP
+  client wiring) — that code already exists (`editors/vscode/`); this spec
+  governs only the CLI-side `install` commands and how they interact with it.
+- **Quickstart / "single command to install"** narrative — Prompt 4
+  (`markspec-user-docs.md`) owns the user-facing story and **cites this spec**
+  for the surface.
+- **Profile distribution** (`markspec profile add`, npm/git specifiers) — owned
+  by ADR-008 §2 and [markspec-profile-schema.md §2](markspec-profile-schema.md).
+  This spec covers _toolchain_ distribution, not _profile_ distribution.
+- **Release engineering** (signing, notarization, the GitHub release pipeline) —
+  Stage 2 / out of scope; §3.4 only fixes the version contract the pipeline must
+  honor.
+
+---
+
+## 2. One bundled binary, three entrypoints
+
+### 2.1 Decision
+
+MarkSpec ships **one** executable. The CLI, the LSP server, and the MCP server
+are three entrypoints of the same binary, dispatched by subcommand (ADR-005
+§subcommand dispatch; CLAUDE.md "One compile target — one binary"):
+
+```bash
+deno compile packages/markspec/main.ts   # → markspec   (the only artifact)
+
+markspec <subcommand> …                  # CLI
+markspec lsp                             # LSP server (stdio JSON-RPC)
+markspec mcp                             # MCP server (stdio JSON-RPC)
+```
+
+`lsp/server.ts` and `mcp/server.ts` are dynamically imported by `main.ts` only
+when their subcommand runs (lazy loading — CLAUDE.md "Single binary, lazy
+loading"; `markspec validate` never loads the MCP SDK). There is **no**
+`markspec-lsp` or `markspec-mcp` artifact.
+
+### 2.2 Options analysis — packaging
+
+| Alternative                                          | Rejected because                                                                                                                                                                                                                                 |
+| ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| One bundled binary, subcommand dispatch (**chosen**) | One artifact to download, one version to reason about, zero version-skew between CLI/LSP/MCP. Lazy import keeps cold-start fast (ADR-005). Matches the already-shipped architecture.                                                             |
+| Separate `markspec-lsp` / `markspec-mcp` binaries    | Three artifacts, three version numbers, three PATH entries — the exact version-skew the Prompt-3 Context flags ("Separate binaries create version-skew the user has to debug"). The editor would need to discover and version-match three files. |
+| npm/PyPI wrapper that shells to a runtime            | Reintroduces a runtime dependency (Deno/Node) on the user's machine — defeats the `deno compile` single-file-distribution property. Acceptable later as an _additional_ channel, not the primary artifact.                                       |
+| Editor extension bundles its own server build        | Forks the server: the extension's bundled copy drifts from the CLI the user runs in the terminal. The extension must spawn the _same_ binary the user installed (the current `editors/vscode` design already does this — §4.3).                  |
+
+---
+
+## 3. Version and schema alignment
+
+### 3.1 One release ⇒ one binary ⇒ one core-schema version
+
+Because the three entrypoints are one binary, their versions are **identical by
+construction** — there is no CLI-vs-LSP-vs-MCP version to reconcile. The single
+axis that matters across the toolchain _and_ the profile layer is the
+**core-schema version**.
+
+- The binary embeds, and `markspec --version` reports, both the **release
+  version** (semver of the `markspec` package) and the **core-schema version**
+  (the integer contract version of core-data-model.md it implements —
+  [markspec-profile-schema.md §8.2](markspec-profile-schema.md); core-data-model
+  §3.1 determinism contract / §5 round-trip invariants).
+
+  ```text
+  $ markspec --version
+  markspec 0.5.0 (core-schema 1)
+  ```
+
+- A profile's `markspec-schema:` pin
+  ([markspec-profile-schema.md §8.2](markspec-profile-schema.md)) is checked
+  against the binary's core-schema version at profile load. This spec defines
+  only the _binary side_ of that contract: the binary MUST advertise its
+  core-schema version both on `--version` and in the LSP/MCP handshake (§3.3).
+
+### 3.2 Options analysis — version axes
+
+| Alternative                                                     | Rejected because                                                                                                                                                                                           |
+| --------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Release version + core-schema version, CLI=LSP=MCP (**chosen**) | The only two axes that vary independently (the tool can patch without the data model changing). One binary makes CLI/LSP/MCP version identity free.                                                        |
+| Independent LSP / MCP protocol versions surfaced to the user    | The user never picks an LSP/MCP protocol; the editor negotiates it. Surfacing it as a user-facing version is noise. Protocol capability is negotiated in the handshake (§3.3), not versioned for the user. |
+| Core-schema folded into the release semver major                | Couples the data-model contract to the tool's release cadence; a tooling bugfix that bumps semver would falsely imply a model change. core-data-model §3.1 freezes the model independently of the tool.    |
+
+### 3.3 Skew detection
+
+- **LSP.** The server reports its release + core-schema version in an
+  `initialize` result `serverInfo` extension and as a `markspec/version`
+  notification. A client whose expected core-schema differs SHOULD surface a
+  visible warning (the existing `editors/vscode` status bar is the natural home;
+  the _mechanism_ — version in the handshake — is fixed here, the UI is
+  extension territory).
+- **MCP.** The server advertises the same pair in the MCP `serverInfo` /
+  `initialize` response. An MCP client on a mismatched core-schema MUST be able
+  to detect it from that field.
+- **CLI.** `markspec doctor` (ADR-008 §9) reports binary core-schema vs the
+  active profile's `markspec-schema:` pin and flags a mismatch
+  (`PROFILE-SCHEMA-001`,
+  [markspec-profile-schema.md §8.2](markspec-profile-schema.md)).
+
+### 3.4 Release contract (boundary only)
+
+Release engineering is out of scope, but the version contract it must honor is
+fixed here: a release publishes exactly one binary per platform; all carry the
+same release + core-schema version; the core-schema version changes only at a
+core-data-model major boundary (core-data-model §3.1). The platform set and
+signing are Stage-2 concerns.
+
+---
+
+## 4. LSP install surface
+
+### 4.1 Command
+
+```text
+markspec lsp install --editor=<id> [--scope=user|workspace]
+                      [--print] [--force] [--no-color]
+```
+
+| Flag            | Meaning                                                                                                                                                                        |
+| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `--editor=<id>` | Required. One of the first-class adapter ids (§4.2). An unknown id errors with the list of known ids + a typo suggestion (clig.dev "suggest corrections").                     |
+| `--scope`       | `workspace` (default when a `markspec.yaml`/`.markspec.yaml` is found by walking up, §4.4) or `user`. Explicit flag overrides detection.                                       |
+| `--print`       | Write nothing; print the exact config block to **stdout** and the target path to **stderr** (clig.dev stream split). The universal fallback for any editor without an adapter. |
+| `--force`       | Apply the change without the interactive confirm (and the only way to write in a non-TTY context — §6.4).                                                                      |
+| `--no-color`    | Standard clig.dev color control; `NO_COLOR` env honored identically.                                                                                                           |
+
+### 4.2 First-class editor adapters (v1)
+
+| `--editor` id | Target                                  | Config artifact                                                   |
+| ------------- | --------------------------------------- | ----------------------------------------------------------------- |
+| `vscode`      | VS Code / VS Codium                     | Verifies the MarkSpec extension is the LSP host; see §4.3.        |
+| `neovim`      | Neovim (`nvim-lspconfig` or native LSP) | A Lua managed block in the user's MarkSpec LSP config fragment.   |
+| `zed`         | Zed                                     | A JSON managed region in `settings.json` `lsp` / language server. |
+
+Any other editor: `--print` only (a documented, copyable snippet). Adding an
+adapter later is additive and does not change the command surface (Open Question
+1).
+
+### 4.3 VS Code is extension-hosted
+
+VS Code does not get a config-file write. The shipped `editors/vscode` extension
+is already the LSP host and already spawns the bundled binary
+(`serverOptions.ts` resolves the binary; the extension is "a thin LSP client" —
+`editors/vscode/src/extension.ts`). `markspec lsp install --editor=vscode`
+therefore **verifies and reports**, it does not mutate config:
+
+- Confirms the extension is installed and points at _this_ binary (path +
+  core-schema match, §3.3).
+- On mismatch, prints the remediation (the `markspec.server.path` setting value)
+  rather than silently rewriting user settings.
+
+This keeps the single-binary invariant (§2): the extension must spawn the same
+binary the user installed, never a divergent bundled copy (§2.2 last row).
+
+### 4.4 Workspace detection
+
+`--scope=workspace` resolves the project root by walking up from the working
+directory for `markspec.yaml` / `.markspec.yaml` (the same discovery the profile
+loader uses — [markspec-profile-schema.md §2.2](markspec-profile-schema.md)). No
+project marker found and `--scope` not given explicitly → the installer selects
+`user` scope and says so on stderr (it never silently writes a workspace file
+into a non-project directory — clig.dev "explicit over implicit").
+
+---
+
+## 5. MCP install surface
+
+### 5.1 Command
+
+Symmetrical with §4:
+
+```text
+markspec mcp install --client=<id> [--scope=user|workspace]
+                      [--print] [--force] [--no-color]
+```
+
+### 5.2 First-class client adapters (v1)
+
+| `--client` id    | Target                | Config artifact                                                                       |
+| ---------------- | --------------------- | ------------------------------------------------------------------------------------- |
+| `claude-desktop` | Claude Desktop        | A JSON managed region under `mcpServers` in the Claude Desktop config file.           |
+| `cursor`         | Cursor                | A JSON managed region in the Cursor MCP config.                                       |
+| `vscode`         | VS Code (Copilot/MCP) | Verifies the shipped extension's MCP provider; see §5.3. No `.vscode/mcp.json` write. |
+
+Any other client: `--print` the stdio server definition (`command: markspec`,
+`args: ["mcp"]`) for manual paste.
+
+### 5.3 VS Code MCP is provider-hosted
+
+The shipped extension registers the MCP server via the stable VS Code 1.101+
+`lm.registerMcpServerDefinitionProvider` API (`editors/vscode/src/extension.ts`;
+`mcpDefinition.ts`) — VS Code sees the same binary as the LSP with **no**
+`.vscode/mcp.json`. `markspec mcp install --client=vscode` therefore verifies
+the provider is active and the binary matches (§3.3); it does not write a config
+file (parity with §4.3).
+
+### 5.4 Stdio definition is canonical
+
+Every MCP adapter writes the same logical definition — a stdio server spawning
+`markspec mcp`. The adapter's only per-client knowledge is _where_ and in _what
+serialization_ that definition lives. The definition content is identical across
+clients (the single-binary invariant again).
+
+---
+
+## 6. Config-write safety
+
+The Prompt-3 Context is explicit: "Config-write is destructive by default in
+most tools. The installer must preview every change, never overwrite without
+explicit `--force`, and produce config the user can read and verify." This
+section is normative.
+
+### 6.1 The managed-block model
+
+An installer never owns the user's config file. It owns a single delimited,
+idempotent **managed block** inside it:
+
+- **JSON targets** (Zed, Cursor, Claude Desktop, VS Code-when-applicable): a
+  single object under a stable, namespaced key (e.g. an `markspec` entry inside
+  `mcpServers`/`lsp`), written via structure-preserving edit — sibling keys, key
+  order, comments (JSONC) preserved. Never a whole-file rewrite.
+- **Block-style targets** (Neovim Lua): a fenced region delimited by
+  `-- >>> markspec (managed) >>>` … `-- <<< markspec (managed) <<<`. Content
+  between the fences is owned by the installer; everything else is the user's.
+
+### 6.2 Idempotence
+
+Re-running `install` with the same binary + scope is a **no-op**: the managed
+block is regenerated and compared; if byte-identical, nothing is written and the
+command reports "already up to date" (exit 0). This makes `install` safe to run
+from a provisioning script repeatedly (mirrors the determinism discipline of
+core-data-model §3.1 — same input, same output).
+
+### 6.3 Preview, confirm, backup
+
+Default (TTY, no `--force`):
+
+1. Compute the new managed block; diff it against the current file.
+2. Print the unified diff to **stderr** (clig.dev: diagnostics/preview to
+   stderr; the only thing on stdout is the block itself under `--print`).
+3. Prompt for confirmation. On decline, exit 0 having written nothing.
+4. On accept: write a timestamped sidecar backup
+   (`<config>.markspec-bak-<ISO8601>`) **then** apply the edit. Report both
+   paths on stderr.
+
+`install` is never destructive: the only bytes it changes are inside the managed
+block; the backup makes even that reversible.
+
+### 6.4 Non-TTY behavior (clig.dev)
+
+When stdin is not a TTY (CI, provisioning, piped):
+
+- `--force` present → apply (still writes the backup first). Used by automation.
+- `--force` absent → **error, exit non-zero**, with the remediation message
+  ("re-run with `--force`, or `--print` and apply manually"). A missing
+  confirmation in a non-interactive context is an **error, not a silent
+  default** (clig.dev "No interactive prompts when stdin is not a TTY";
+  AGENTS.md CLI rules). `--print` always works in any context (it writes
+  nothing).
+
+### 6.5 Options analysis — write model
+
+| Alternative                                                                 | Rejected because                                                                                                                                                                                                                          |
+| --------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Managed block, idempotent, preview+backup (**chosen**)                      | Re-runnable, reviewable (the diff is the audit surface — same property ADR-008 §Context wants for profiles), reversible, and minimally invasive. Matches "produce config the user can read and verify".                                   |
+| Whole-file template the installer owns                                      | Destroys user customizations on every run — the exact "destructive by default" failure the Context rejects.                                                                                                                               |
+| Separate dedicated file the installer fully owns (e.g. `markspec.lsp.json`) | Clean ownership, but many targets (Claude Desktop, Zed, Neovim) have a single config file with no include mechanism; a separate file would simply be ignored. Falls back to `--print` for those — strictly worse UX than a managed block. |
+| Blind deep-merge into the target's JSON                                     | Cannot express Neovim Lua or comment-bearing JSONC; merge conflicts resolve silently and unreviewably; no clean removal path. The managed block gives a single region to add, update, or delete atomically.                               |
+
+### 6.6 Uninstall / update
+
+`markspec lsp install --editor=<id> --remove` (and the MCP analogue) deletes
+exactly the managed block (and, for JSON, the namespaced key), leaving the rest
+of the file and a backup. Update is just re-running `install` (§6.2). No
+separate `update` verb (clig.dev: fewer verbs; idempotent install subsumes it).
+
+---
+
+## 7. clig.dev conformance
+
+The install surface follows the project CLI standard (AGENTS.md §"CLI standard:
+clig.dev"; <https://clig.dev/>):
+
+| Rule (clig.dev / AGENTS.md)              | How `install` complies                                                                                                   |
+| ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| stdout = data, stderr = messaging        | `--print` block → stdout; diffs, prompts, paths, progress → stderr.                                                      |
+| Exit codes (0 ok, 1 error, 2 warnings)   | 0 = applied or already-up-to-date or user-declined; 1 = unknown target / write failure / non-TTY without `--force`.      |
+| `-h`/`--help` everywhere, examples first | `markspec lsp install --help` leads with the common invocation, then flags. `markspec help lsp install` works.           |
+| Suggest corrections on typos             | Unknown `--editor`/`--client` id → "did you mean `<closest>`?" + full list.                                              |
+| `NO_COLOR` + `--no-color`                | Diff/preview coloring suppressed; honored identically.                                                                   |
+| No interactive prompts when not a TTY    | §6.4 — error, not prompt; `--force` is the automation path.                                                              |
+| Progress for >1s operations              | Adapter resolution / backup / write are sub-second; if a future adapter is slow it must print a progress line to stderr. |
+| Deterministic, reviewable artifacts      | §6.2 idempotence; the managed block is byte-stable for a given binary + scope.                                           |
+
+---
+
+## 8. Open questions
+
+Capped at five (Prompt-3 constraint).
+
+1. **Adapter growth policy.** v1 ships three LSP + three MCP adapters
+   (§4.2/§5.2). Who owns the criteria for promoting an editor from `--print` to
+   a first-class adapter, and is the adapter set versioned with the binary or
+   independently extensible (a hooks-style contribution, cf. ADR-008 §10)?
+2. **`markspec.yaml` vs `.markspec.yaml` as the workspace marker.** §4.4 treats
+   either as the project root signal, matching the profile loader. If a repo has
+   `project.yaml` but no `.markspec.yaml`, is that still a workspace for
+   install-scope purposes? (Touches
+   [markspec-profile-schema.md §2.2](markspec-profile-schema.md) discovery.)
+3. **Binary self-path resolution.** Adapters must write the path to _this_
+   binary. Under `deno compile` that is `Deno.execPath()`, but a symlinked /
+   PATH-shimmed install may resolve to the shim. Should the installer write the
+   resolved real path, the invoked name (`markspec`, relying on PATH), or make
+   it a flag?
+4. **Backup retention.** §6.3 writes a timestamped backup on every apply.
+   Unbounded backups accumulate. Is pruning (keep last N) in scope for the
+   installer, or left to the user / OS?
+5. **VS Code verify-only vs offer-to-fix.** §4.3/§5.3 make VS Code verify-only.
+   When the extension is absent entirely, should `install` attempt
+   `code --install-extension`, or strictly stay out of the editor's extension
+   manager and only print instructions?
+
+---
+
+## Annex — Cross-reference summary
+
+| Section here                  | Source                                                                                                                         |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| §2 Single binary              | ADR-005 §subcommand dispatch; CLAUDE.md "One compile target"; `packages/markspec/main.ts`                                      |
+| §3 Version / schema alignment | core-data-model §3.1/§5; [markspec-profile-schema.md §8.2](markspec-profile-schema.md); ADR-008 §9                             |
+| §4 LSP install                | `editors/vscode/src/extension.ts`, `serverOptions.ts`; clig.dev; [markspec-profile-schema.md §2.2](markspec-profile-schema.md) |
+| §5 MCP install                | `editors/vscode/src/mcpDefinition.ts`; `packages/markspec/mcp/server.ts`; clig.dev                                             |
+| §6 Config-write safety        | Prompt-3 Context; clig.dev; AGENTS.md §CLI rules; core-data-model §3.1 (determinism analogy)                                   |
+| §7 clig.dev conformance       | <https://clig.dev/>; AGENTS.md §"CLI standard: clig.dev"                                                                       |
+| Ring 3 exercises §4/§5        | [markspec-e2e-test-strategy.md](markspec-e2e-test-strategy.md) §2/§6                                                           |


### PR DESCRIPTION
## nextgen Prompt 3 — Toolchain distribution & E2E test strategy

Spec-authoring deliverable (no implementation, per the Prompt 3 constraint).
Two product specs in `docs/specs/`, peers of `markspec-core-data-model.md`.
One PR — the two files cross-reference each other and form one cohesive
deliverable. Depends on Prompt 1 (merged); parallel with the now-merged
Prompt 2.

### `markspec-toolchain-distribution.md`

- **§2 Single bundled binary:** formalizes/justifies the CLAUDE.md-mandated
  one-artifact, three-entrypoint (CLI/LSP/MCP) model; options analysis
  rejects separate binaries (version-skew, the exact failure the Prompt-3
  Context flags).
- **§3 Version/schema alignment:** one release ⇒ one binary ⇒ one
  core-schema version; `markspec --version` reports both; ties to
  `markspec-profile-schema.md` §8.2 `markspec-schema:` pin; LSP/MCP/CLI
  skew detection.
- **§4/§5 Install surfaces:** `markspec lsp install --editor=` /
  `mcp install --client=` with symmetrical flags and a small first-class
  adapter matrix (LSP: vscode/neovim/zed; MCP: claude-desktop/cursor/
  vscode); `--print` fallback for the rest. VS Code is **verify-only** —
  the shipped extension already hosts the LSP and the stable VS Code 1.101+
  MCP provider, so no config write.
- **§6 Config-write safety:** the **managed-block** model — idempotent
  fenced region, preview-diff by default, `--force` + timestamped backup,
  re-run = no-op, **non-TTY without `--force` = error not prompt**
  (clig.dev). Options analysis vs whole-file / separate-file / deep-merge.
- **§7** full clig.dev conformance table. ≤5 open questions + annex.

### `markspec-e2e-test-strategy.md`

- **§2 Three latency-gated rings:** golden ≤5s (every commit), scenario
  ≤90s (every PR), integration ≤15min (nightly + pre-release). Options
  analysis vs flat / 2-ring / 4-ring.
- **§3 Maps the current 30+ test files into rings** explicitly, plus a
  table placing **core-data-model §5.5's five round-trip obligations**
  (the ones it addresses to "Prompt 3 e2e") into rings.
- **§4** on-disk fixture layout (`golden/ corpora/ replay/ install/`);
  corpora double as Prompt 4's example-project backing.
- **§5 Snapshot determinism** sourced from core-data-model §3.1/§5;
  normalization table (paths, non-synthesized ULIDs redacted but
  synthesized ones *asserted*, key-sort, EOL).
- **§6** direction-tagged JSON-RPC `.jsonl` replay format (options
  analysis vs DSL / pcap / state-only).
- **§7** CI matrix (`fast`/`pr`/`nightly`; OS matrix only where §5.5
  obligation 4 needs it). **§8 coverage by surface enumeration** (every
  lint code / body block / LSP capability / MCP tool / install adapter),
  not a line %. ≤5 open questions + annex.

### Process

- Prerequisite satisfied: Prompt 1 merged; Prompt 2 merged (#345).
- Direct-to-main via `prompt-03-*` branch, consistent with Prompts 1–2.
  No tracking issue — for a spec-doc deliverable the merged docs are the
  record (PROCESS.md).
- `just check` gates + pre-commit hook (fmt / dprint / lint / typecheck /
  commit-msg lint) all green at commit time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
