### PR TITLE
docs(spec): compile output, lockfile, indexing & external sync (Prompt 7)

### DIFF
--- a/docs/specs/markspec-background-indexing.md
+++ b/docs/specs/markspec-background-indexing.md
@@ -1,0 +1,222 @@
+# MarkSpec — Background Indexing
+
+Status: Draft (Prompt 7 of the next-gen refactor — Stage 2)\
+Date: 2026-05-17\
+Scope: the **local-only** index that backs sub-100 ms editor queries — data
+model, storage, modes, concurrency, invalidation, recovery\
+Builds on: core-data-model (Prompt 1 — entry/Item §1, AST §2, inline markers
+§2.5, inverses §1.6, round-trip §5), profile-schema (Prompt 2),
+listing-directives (Prompt 2 — glossary §4, components §5), prose-analysis
+(Prompt 5 — the flagship glossary cross-check consumes this index);
+ADR-001/002/003/004, ADR-006 (caching/staleness §5), ADR-012 (diagnostic codes);
+LSP ground truth: `lsp/workspace.ts` (`WorkspaceIndex`), `lsp/server.ts`,
+`lsp/completions.ts`
+
+One of four sibling Prompt-7 specs
+([compile-output](markspec-compile-output.md), [lockfile](markspec-lockfile.md),
+[external-sync-model](markspec-external-sync-model.md)). **Not unified with
+them** (compile-output §1.2). This spec freezes the local index; it is **not**
+the published `/api/` output (that is the compile-output spec — different
+durability and audience: this is disposable and never published).
+
+---
+
+## 0. Terminology
+
+| Term                 | Meaning in this spec                                                                                                 |
+| -------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| **index**            | `.markspec/index.db` — the local, disposable query accelerator. Never committed, never published.                    |
+| **cold scan**        | Building the index from nothing (no db, or a corrupt one) — full project walk.                                       |
+| **warm incremental** | Updating the index for the files that changed since the last run, only.                                              |
+| **federated read**   | Querying a federated upstream's published `/api/` (compile-output §5) through the local index's resolver, read-only. |
+| **invalidation**     | Deciding which index rows a file change makes stale — the actual hard problem (Prompt-7 Context).                    |
+| **edge**             | A trace relation: authored (from source) or generated inverse (core-data-model §1.6 / ADR-003 §Part 3).              |
+
+---
+
+## 1. Purpose & why it is its own spec
+
+### 1.1 Purpose
+
+The index makes the interactive surfaces fast: **sub-100 ms** `$Identifier`
+resolution (core-data-model §2.5.2), `Derived-from:` / trace-attribute
+completion (`lsp/completions.ts`), and the prose-analysis flagship **glossary
+cross-check** (`xref-glossary-undefined`, prose-analysis §2.8 — it resolves a
+capitalized term against glossary `Definition` items; that lookup must be
+index-backed to hit its <5 ms budget). It is the persistent, scalable
+replacement for the current in-memory `WorkspaceIndex` (`lsp/workspace.ts`),
+which rebuilds the whole project on every server start.
+
+### 1.2 Why a separate spec (anti-unification)
+
+The index is **disposable, local-only, per-keystroke**. The compile output is
+archival/published; the lockfile is committed/slow; the sync log is append-only
+audit. Conflating the per-keystroke cache with the published contract is the
+six-months-elegant / years-cornered mistake the Prompt-7 Context rejects
+(compile-output §1.2 table). The index may share the _schema philosophy_ of the
+optional SQLite mirror (compile-output §4.3) but **not the file**: `index.db` is
+never published; the mirror is never used as the editor's working store.
+
+## 2. Storage — options analysis
+
+| Option                                     | Rejected / chosen because                                                                                                                                                                                                                                                                      |
+| ------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **SQLite (`.markspec/index.db`) — chosen** | The boring correct answer. Embedded, zero-config, single-file, ACID, mature WAL concurrency (§4), and **every editor/CLI/human can inspect it** with ubiquitous tooling if a query is wrong. The interesting problem is invalidation (§5), not storage — SQLite removes storage as a variable. |
+| Tantivy / a full-text engine               | **Rejected.** Optimizes ranked text search; the dominant queries are exact-key point lookups (Id, displayId, edge endpoint) and prefix completion, which a B-tree index serves better and simpler. Adds a large dependency for the wrong query shape.                                          |
+| RocksDB / LMDB (KV store)                  | **Rejected.** Faster raw KV, but no ad-hoc query, no human-inspectable form, and the project would hand-roll the relational queries (edges, glossary joins) SQLite gives for free. Speed it adds is below the budget headroom (§6).                                                            |
+| Custom binary format                       | **Rejected.** Every reason to not invent the compile-output format (compile-output §3) applies double to a format nobody else can open. Maintenance and corruption-recovery burden with no upside over SQLite.                                                                                 |
+| In-memory only (status quo)                | **Rejected at scale.** `WorkspaceIndex` reparses the whole project per server start; the §6 cold budget at 10k entries is unmet without persistence. Kept as the tiny-project fast path (§3.4).                                                                                                |
+
+## 3. Index data model & modes
+
+### 3.1 Tables (logical)
+
+- `entries` — `Id`, `displayId`, resolved `Type` (core-data-model §1.3), shape,
+  title, file/line (`file.*` property, ADR-006), `content_hash`.
+- `edges` — `(from_id, kind, to_id, generated)`: authored relations and
+  generated inverses (core-data-model §1.6 / ADR-003 §Part 3) in one table,
+  `generated` flags which.
+- `glossary` — `Definition` items (slug, term, file) from the glossary
+  heading-shape (listing-directives §4) — backs `xref-glossary-undefined`.
+- `components` — Component-typed entries keyed by their parsed Id scheme
+  (listing-directives §5: `pkg`/`mfg`/`gtin`/`cpe`/`urn:*`).
+- `references` — Reference-shape entries (slug, URI, `Type`) — backs
+  `References:` resolution (`MSL-R085`).
+- `entities` — `$Identifier` symbols (core-data-model §2.5.2) for sub-5 ms
+  resolution.
+
+### 3.2 Modes
+
+- **Cold scan.** No db / corrupt db / schema-version mismatch (§7) → full
+  project walk, parse, populate. Budget §6.
+- **Warm incremental.** Watch / on-demand: only files whose mtime+hash changed
+  (§5) are reparsed; only their rows + the rows their change invalidates (§5.2)
+  are rewritten.
+- **Federated read.** A cross-project target (compile-output §5) is resolved by
+  reading the upstream's published `entries.idx` through a read-through cache
+  table; **read-only**, never written back into the upstream, pinned by the
+  lockfile (lockfile spec §2.2 `[[upstream.registry]]`).
+
+## 4. Concurrency
+
+**Single-writer, many-reader.** One writer process holds the index (SQLite WAL
+mode: readers never block the writer, the writer never blocks readers). The LSP
+server is the canonical writer; CLI (`compile`, `validate`) and MCP open
+**read-only** and, if the index is absent/stale, fall back to a direct parse
+rather than contending for the write lock (correctness without the index is
+always available — §8). A stale read is acceptable for completion/hover (it
+self-heals on the next incremental); it is never acceptable for
+`validate`/`compile`, which therefore do not trust a stale index for a
+correctness verdict (§8 OQ).
+
+## 5. Invalidation — the actual design problem
+
+Storage is solved (§2); **invalidation is where this is won or lost**. If the
+warm path constantly invalidates itself, the cold/warm distinction is
+meaningless.
+
+### 5.1 Change detection
+
+A file is unchanged iff `(mtime, size)` matches **and**, on a cheap mismatch, a
+content `sha256` matches the stored `content_hash`. mtime is the fast gate; the
+hash is the truth (mtime is unreliable across checkout/clone — git touches
+mtimes without changing content; the hash prevents a spurious full reparse of an
+unchanged tree, the classic self-invalidation trap).
+
+### 5.2 Cross-file invalidation
+
+A change is not local when it changes a **resolution target**:
+
+- **Rename / Id change** of an entry → every edge row pointing at the old Id, in
+  any file, is stale (the trace graph is global, core-data-model §1.3).
+  Invalidate the changed file **plus** the reverse-edge closure of the affected
+  Ids (bounded by `edges.to_id` index — not a full rescan).
+- **Glossary change** (a `Definition` added/removed/renamed, listing-directives
+  §4) → every entry whose prose was flagged (or cleared) by
+  `xref-glossary-undefined` against that term is stale (prose-analysis §2.8).
+  Invalidate by the `glossary.slug` → referencing entries reverse map, not the
+  whole project.
+- **Profile change** (`.markspec.yaml` / a resolved profile tier, profile-schema
+  §5) → type inference (core-data-model §1.3.1) can shift for many entries →
+  **cold scan** (a profile change is rare and legitimately global; pretending it
+  is incremental is the self-invalidation trap in the other direction).
+
+The rule: invalidate the **closure of what actually depends on the change**,
+computed from the index's own reverse maps — never "the file" (too little,
+misses cross-file) and never "everything" (too much, kills warm). This closure
+is the spec's core contribution.
+
+## 6. Performance budgets (numbers)
+
+| Operation                           | Budget      | Basis                                                                                                                                            |
+| ----------------------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Cold index, 10 000 entries          | **< 5 s**   | parse-bound; one pass, batched inserts in one transaction.                                                                                       |
+| Warm incremental, per changed entry | **< 50 ms** | reparse one file + rewrite its rows + the §5.2 closure (bounded by reverse-edge index).                                                          |
+| Single-Id query                     | **< 5 ms**  | primary-key/B-tree point lookup; this is the `$Identifier` / completion hot path and the prose-analysis flagship's budget (prose-analysis §5.4). |
+| Glossary cross-check lookup         | **< 5 ms**  | indexed `glossary.slug` lookup — the index exists largely to make this rule viable at scale.                                                     |
+
+Budgets are determinism-friendly: identical project state ⇒ identical index
+content (modulo `properties` observation), so warm == cold result (consistency
+check in CI, §8 OQ).
+
+## 7. Recovery & versioning
+
+- **Corrupt index → rebuild, never block.** A failed integrity check, a
+  truncated WAL, or an unreadable db ⇒ delete `index.db`, cold-scan, log one
+  warning. The index is **disposable by definition**; a corrupt cache must never
+  break `validate`/`compile`/the editor (those always have the source as ground
+  truth — §4).
+- **Schema-version row.** `index.db` stores its own format `schema` integer
+  **and** the `markspec-schema` it was built under. A mismatch on either ⇒
+  treated exactly as corruption ⇒ silent rebuild. No index migration is written
+  — and none is needed (this is _why_ the no-migration-until-1.0 decision
+  (2026-05-17) is free here: the index is regenerated from source in < 5 s, §6).
+  Pre-1.0 format churn costs one cold scan.
+- **Coexistence with `/api/`.** The index is local-only and never published; the
+  compile output is published and never used as the editor store (compile-output
+  §1.2 / §4.3). A project may have both, one, or neither; they never share a
+  file and never invalidate each other.
+
+## 8. Privacy
+
+`index.db` lives under `.markspec/` and is **git-ignored by default** (a
+generated, machine-local cache). It mirrors source content (entries, prose,
+glossary) plus `file.*`/`git.*` properties — all repository-internal. It
+**excludes** `sync.*` external-system state (that is the sync model's cache,
+§sync spec §5, with its own TTL and locality) and any credential. Nothing in the
+index is transmitted; it is never an input to the published `/api/`. A federated
+read caches an upstream's _public_ `/api/` data only.
+
+## 9. Open questions
+
+Capped at five.
+
+1. **Stale-index trust for `validate`/`compile`.** §4 says correctness commands
+   don't trust a stale index. Do they (a) always full-parse (simple, slower CI),
+   (b) trust the index iff a fast whole-project hash matches, or (c)
+   verify-then-use? The CI-time cost of (a) at 100k entries may be unacceptable.
+2. **Watch vs on-demand incremental.** §3.2 warm mode — file-watcher (instant,
+   OS-specific, flaky on network FS) vs lazy on-query staleness check (portable,
+   a small first-query latency). Which is canonical, which optional?
+3. **Federated-read cache lifetime.** §3.2 read-through cache of an upstream
+   `/api/` — TTL like the sync cache (sync spec §5), or pinned strictly by the
+   lockfile hash (lockfile spec §3) and only refreshed on `lock --update`?
+4. **Index sharing across worktrees.** A repo with multiple git worktrees (this
+   project uses them — `.worktrees/`) — one `index.db` per worktree (isolation,
+   N rebuilds) or a shared keyed store (one build, harder invalidation §5)?
+5. **Cross-file invalidation cost ceiling.** §5.2's reverse-edge closure is
+   bounded but a hub entry (compile-output §2 worst case) has a huge reverse
+   set; a rename there is O(huge). Cap the closure and fall back to cold above a
+   threshold, or always pay it?
+
+## Annex — Cross-reference summary
+
+| Section | Source                                                                                                |
+| ------- | ----------------------------------------------------------------------------------------------------- |
+| §1      | core-data-model §2.5 / §2.5.2; `lsp/workspace.ts` / `lsp/completions.ts`; prose-analysis §2.8 / §5.4  |
+| §2      | Prompt-7 Context (SQLite "boring correct"; invalidation is the problem)                               |
+| §3      | core-data-model §1.3 / §1.6; ADR-003 §Part 3; listing-directives §4 / §5; compile-output §5           |
+| §4      | SQLite WAL; AGENTS.md (correctness without cache); §8                                                 |
+| §5      | ADR-006 §5 (caching/staleness); core-data-model §1.3 / §1.3.1; prose-analysis §2.8; profile-schema §5 |
+| §6      | Prompt-7 budgets; prose-analysis §5.4                                                                 |
+| §7      | compile-output §1.2 / §4.3; project decision (no migration until 1.0); profile-schema §8.2            |

--- a/docs/specs/markspec-compile-output.md
+++ b/docs/specs/markspec-compile-output.md
@@ -1,0 +1,296 @@
+# MarkSpec — Compile Output & Registry Protocol
+
+Status: Draft (Prompt 7 of the next-gen refactor — Stage 2)\
+Date: 2026-05-17\
+Scope: the `/api/` output of `markspec compile` — the **shared, publishable**
+artifact; its on-disk shape, size behavior, federation, and schema versioning\
+Builds on: core-data-model (Prompt 1 — entry/Item model §1, AST §2, generated
+inverses §1.6, round-trip §5), profile-schema (Prompt 2 — `markspec-schema:`
+§8.2), listing-directives (Prompt 2 — references §3, component Id schemes §5),
+toolchain-distribution (Prompt 3 — core-schema version on `--version`/handshake
+§3); ADR-001/002/003/004, ADR-006 (property model), ADR-011 (ingestion / SBOM),
+ADR-012 (diagnostic codes)
+
+This is **one of four sibling Prompt-7 specs**
+([markspec-lockfile.md](markspec-lockfile.md),
+[markspec-background-indexing.md](markspec-background-indexing.md),
+[markspec-external-sync-model.md](markspec-external-sync-model.md)). They are
+deliberately **not unified** — see §1.2. This spec freezes the compile-output
+format and the registry protocol; it does not specify the local index (that is
+the indexing spec — different durability, local-only) or the lockfile (different
+audience, different cadence).
+
+---
+
+## 0. Terminology
+
+| Term                        | Meaning in this spec                                                                                                                           |
+| --------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| **compile output**          | The artifact `markspec compile` writes — the project's entries + traceability graph in a consumable form.                                      |
+| **`/api/` layout**          | The on-disk directory the compile output is published as (manifest + addressable entries), servable as static files.                           |
+| **manifest**                | The small, always-JSON root document: schema version, counts, project identity, the index of where entries live, federation links.             |
+| **entry record**            | One compiled entry: its resolved attributes, resolved `Type:`, generated inverse edges, and `properties` (ADR-006).                            |
+| **registry protocol**       | The contract by which one project's `/api/` output is consumed by another (cross-project federation) — manifest shape + resolution rules (§5). |
+| **`markspecSchemaVersion`** | The integer core-schema contract version at the manifest root (= the binary's core-schema, toolchain-distribution §3; profile-schema §8.2).    |
+
+---
+
+## 1. Scope, audience, and why this is its own spec
+
+### 1.1 What the compile output is for
+
+The compile output is the **shared** artifact: it is what a CI job publishes,
+what a downstream project federates against, what a regulator or an auditor is
+handed, what a traceability-matrix renderer consumes. Its defining properties
+are **portability** (static files, no server required), **durability** (it is an
+archival record), and a **stable, versioned schema** (consumers outside this
+repo depend on it).
+
+### 1.2 Why it is a separate spec (the anti-unification constraint)
+
+The Prompt-7 brief is explicit: do **not** unify the four artifacts. The compile
+output, the lockfile, the local index, and the sync log have different
+audiences, cadences, durability, and security postures:
+
+| Artifact                       | Audience                                 | Cadence             | Durability        | Security posture                  |
+| ------------------------------ | ---------------------------------------- | ------------------- | ----------------- | --------------------------------- |
+| **Compile output** (this spec) | downstream projects, auditors, renderers | per CI build        | archival          | published — must not leak secrets |
+| Lockfile                       | the project + CI                         | per upstream change | committed to git  | integrity (hashes)                |
+| Local index                    | the local toolchain                      | per keystroke       | disposable        | local-only, never published       |
+| Sync log                       | the project + audit                      | per sync            | append-only audit | may contain external-system data  |
+
+Unifying them couples a per-keystroke disposable cache to an archival published
+contract — elegant for six months, a corner for years. Each sibling spec
+restates this table from its own side.
+
+### 1.3 In / out of scope
+
+In scope: the `/api/` directory shape, the manifest schema, entry-record
+serialization, size behavior, federation, schema versioning and forward-compat
+rules.
+
+Out of scope: the local index (indexing spec); the lockfile (lockfile spec);
+rendering the output to HTML/PDF (Prompt 3/4 — this is the data the renderer
+consumes); ingestion of foreign formats into entries (ADR-011); the
+`markspec migrate` tool — **there is none** before 1.0 (project decision: no
+migration / backward-compat tooling until 1.0; §7 forward-compat is a post-1.0
+guarantee, §7.3).
+
+---
+
+## 2. Size analysis — the real constraint is parse cost
+
+The crossover where JSON stops being comfortable is not raw byte size; it is
+**parse cost on the consuming end**: every consumer that wants one entry must
+parse the whole blob.
+
+| Project size | Entries                                                                          | Approx. compiled JSON                                                                     | Whole-blob parse (cold, JS `JSON.parse`)                                                                           | Verdict                                                                          |
+| ------------ | -------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------- |
+| small        | 100                                                                              | ~0.3–1 MB                                                                                 | < 20 ms                                                                                                            | JSON-only is fine; nothing to optimize.                                          |
+| medium       | 10 000                                                                           | ~30–80 MB                                                                                 | ~0.5–1.5 s                                                                                                         | JSON-only is uncomfortable: every LSP/CI/render reparses the blob.               |
+| large        | 100 000                                                                          | ~300–800 MB                                                                               | ~6–15 s + multi-GB peak heap                                                                                       | JSON-only is unusable: parse cost dominates, heap blows on 32-bit/CI containers. |
+| worst case   | 100 000 entries, deep `Derived-from` fan-in, every entry with generated inverses | graph edges ≈ O(entries × avg-degree); a single hub entry's reverse-edge list can be 10⁴⁺ | The hub-entry reverse-edge list is the pathological object; it must not force a full re-serialize of the manifest. |                                                                                  |
+
+The conclusion is **not** "abandon JSON". It is **split the manifest from the
+entries**: a small manifest a consumer always parses, plus **individually
+addressable** entry records a consumer parses only the ones it needs.
+
+---
+
+## 3. Options analysis — output format
+
+| Option                                                                               | Parse-cost behavior                                                                                                                      | Rejected / chosen because                                                                                                                                                                                                                                                                              |
+| ------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **1. JSON-only (current `serializeCompileResult`)**                                  | Whole blob parsed for one entry; O(N) for any read.                                                                                      | **Rejected past small.** Fine ≤ ~1k entries; the medium/large rows of §2 make it the bottleneck for every LSP, CI, and renderer. Kept as the small-project degenerate case (§4.4).                                                                                                                     |
+| **2. JSON manifest + NDJSON entries**                                                | Manifest O(1); entries streamable line-by-line; one entry = seek + one line parse with a byte offset.                                    | **Chosen (core).** No dependency, diff-able, greppable, append-friendly, every language streams it. Byte-offset index in the manifest gives O(1) single-entry read. Matches AGENTS.md "deterministic, grep/diff-friendly".                                                                             |
+| **3. JSON manifest + SQLite entries**                                                | Indexed point queries; no parse of unrelated entries.                                                                                    | **Rejected as the published format**; **adopted as an optional mirror** (§4.3). SQLite is a binary that does not diff, is awkward in static hosting / git, and duplicates the **local** index's job (indexing spec). Good as an opt-in consumer convenience, wrong as the canonical archival artifact. |
+| **4. JSON manifest + Parquet entries**                                               | Columnar, excellent for analytic scans over all entries.                                                                                 | **Rejected.** Optimizes the wrong query (full-column analytics) for the dominant access pattern (resolve one entry / one subtree). Adds a heavyweight columnar dependency to every consumer for a use case a report tool can derive. Revisit only if analytics becomes a first-class consumer (§8 OQ). |
+| **5. Hybrid: JSON manifest + NDJSON entries + optional SQLite mirror (recommended)** | Manifest O(1); NDJSON O(1)-per-entry via offset index; SQLite mirror for consumers that want indexed queries without building their own. | **Chosen.** Option 2 is the canonical, always-emitted core; the SQLite mirror (§4.3) is `--with-sqlite`, derived and verifiable, never the source of truth. Numbers, not vibes: §2's parse-cost table is the justification — manifest stays < 100 KB at every size; per-entry read is constant.        |
+
+**Recommendation: option 5.** Canonical = JSON manifest + NDJSON entries (option
+2); `--with-sqlite` adds a derived read-mirror (option 3) for consumers that
+prefer SQL. JSON-only (option 1) is auto-selected for small projects (§4.4)
+because below ~1k entries the split is pure overhead.
+
+---
+
+## 4. The `/api/` layout
+
+### 4.1 Directory shape
+
+```text
+api/
+├── manifest.json            # always JSON, always small (§4.2)
+├── entries.ndjson           # one entry record per line (§4.5)
+├── entries.idx              # byte-offset index: displayId/Id → (offset,length)
+├── edges.ndjson             # generated inverse edges, one per line (§4.6)
+└── entries.sqlite           # OPTIONAL mirror, only with --with-sqlite (§4.3)
+```
+
+Everything under `api/` is static-servable (GitHub/GitLab Pages, an S3 bucket, a
+file path). No server, no runtime. The directory is the protocol.
+
+### 4.2 Manifest (`manifest.json`)
+
+Always JSON, always small (target < 100 KB at 100k entries — it holds no entry
+bodies):
+
+```jsonc
+{
+  "markspecSchemaVersion": 1,          // core-schema integer (toolchain §3; profile-schema §8.2)
+  "generator": { "release": "0.6.0", "coreSchema": 1 },
+  "project": { "name": "...", "root": "urn:markspec:project:<id>" },
+  "counts": { "entries": 10234, "edges": 48120, "byType": { "Requirement": 900, ... } },
+  "entries": { "format": "ndjson", "file": "entries.ndjson", "index": "entries.idx" },
+  "edges": { "format": "ndjson", "file": "edges.ndjson" },
+  "sqliteMirror": null,                // or "entries.sqlite" when --with-sqlite
+  "federation": [ /* §5 */ ],
+  "reserved": {}                       // reserved namespace (§7.2)
+}
+```
+
+Determinism: byte-identical for identical input (core-data-model §5.3 ethos;
+AGENTS.md deterministic artifacts). No timestamps or run metadata in the
+manifest unless `--with-run-metadata` is passed (CLAUDE.md "Deterministic output
+… No timestamps … unless explicitly requested").
+
+### 4.3 Optional SQLite mirror
+
+`markspec compile --with-sqlite` additionally writes `entries.sqlite`: a
+read-only mirror of `entries.ndjson` + `edges.ndjson` with indexes on
+`displayId`, `Id`, `Type`, and edge endpoints. It is **derived** — the manifest
+records its content hash so a consumer can verify it matches the NDJSON, and the
+NDJSON is always authoritative. This deliberately **reuses the schema philosophy
+of, but is not, the local index** (indexing spec): the mirror is published and
+archival; the local `index.db` is disposable and never published. They do not
+share a file.
+
+### 4.4 Small-project degenerate form
+
+Below a threshold (default 1000 entries, `--split-threshold`), `compile` emits a
+single `compiled.json` (the option-1 shape) **and** a manifest that points at it
+(`"entries": { "format": "inline", "file":
+"compiled.json" }`). Consumers branch
+on `entries.format`. Rationale: the split's per-file overhead is not worth it
+below the §2 small row; the manifest indirection keeps consumers uniform.
+
+### 4.5 Entry record (one NDJSON line)
+
+Each line is one JSON object: the resolved entry — `Id`, `displayId`, resolved
+`Type` (core-data-model §1.3), shape, title, authored attributes, body AST
+reference or inline (configurable), `properties` (ADR-006
+`file.*`/`git.*`/`source.*` — **never** `sync.*` here, §6 privacy), and its
+**authored** outbound relations. Lossless for unknown keys (core-data-model
+§5.4). Generated inverses are **not** inlined on the entry — they live in
+`edges.ndjson` (§4.6) so a hub entry's 10⁴ reverse edges (the §2 worst case)
+never bloat the entry record or force a manifest re-serialize.
+
+### 4.6 Edges (`edges.ndjson`)
+
+One line per generated inverse edge (`Superseded-by`, `Verified-by`, every
+ADR-003 §Part 3 inverse — core-data-model §1.6). Separating edges from entries
+makes the worst-case hub entry O(1) to read and lets a consumer that only needs
+forward trace skip the edge file entirely. Edges are generated, never authored
+(core-data-model §4.4 `MSL-A030`), and never round-trip to source.
+
+---
+
+## 5. Cross-project federation via the registry protocol
+
+A ULID/URI is globally unique "across the project and its imported registries"
+(core-data-model §1.3). Federation is how project B resolves a cross-reference
+whose target lives in project A's published `/api/`.
+
+- **`manifest.federation`** lists upstream registries:
+  `{ "id": "<urn:markspec:project:...>", "api": "<url-or-path to their api/>", "markspecSchemaVersion": 1, "pin": "<lockfile ref>" }`.
+- Resolution: a reference target not found locally is resolved against each
+  federated manifest's `entries.idx` (O(1) per upstream), nearest pin first.
+  **The lockfile (lockfile spec) pins which upstream version** — this spec
+  defines the protocol shape; the lockfile defines reproducibility of _which_
+  version (cross-ref: lockfile spec §1, §4).
+- A federated upstream on a different `markspecSchemaVersion` is a **hard**
+  resolution error unless the consumer opts into a documented compatibility
+  window (§7) — versions are a public contract (toolchain-distribution §3 skew
+  detection, same discipline).
+- Federation is **read-only and acyclic**: a manifest may not list a cycle of
+  registries (detected, `MSL-?` registry diagnostic — ADR-012 catalogue; exact
+  code §8 OQ). One-directional like the trace graph itself (AGENTS.md
+  "Dependency flow is strictly one-directional").
+
+The registry protocol is _just these static files + these resolution rules_.
+There is no registry server, no API surface beyond "serve the `api/` directory".
+This keeps federation a property of the artifact, not a new product (the same
+restraint the sync spec applies to connectors).
+
+## 6. Privacy
+
+- `entries.ndjson` carries `file.*`/`git.*`/`source.*` properties (ADR-006) —
+  repository-internal but **not secret**. `git.contributors` is the one
+  PII-adjacent field; it is included only with `--with-contributors` (default
+  off) because a published `/api/` is world-readable.
+- `sync.*` properties (external-system state — ADR-006 §1) are **never** in the
+  compile output. They belong to the local sync model (sync spec) and may carry
+  external-system identifiers; publishing them would leak the integration
+  surface. This is a hard exclusion, enforced at serialization.
+- No credentials, tokens, or `.markspec/sync/**` content ever enter `api/`
+  (cross-ref: sync spec §6, lockfile spec §6).
+
+## 7. Versioning & forward compatibility
+
+### 7.1 Mechanism
+
+`markspecSchemaVersion` (manifest root) is the integer core-schema contract
+version (toolchain-distribution §3.1; profile-schema §8.2 — one shared axis). A
+consumer reads it first and refuses a major it does not implement.
+
+### 7.2 Additive-only & reserved namespaces
+
+Within one `markspecSchemaVersion`, changes are **additive-only**: new manifest
+keys, new entry fields, new edge kinds may appear; existing keys never change
+meaning or type and are never removed. Consumers MUST ignore unknown keys
+(forward-compat). The manifest `reserved` object and any key prefixed `x-` are
+reserved for experimental/extension data and carry no compatibility guarantee.
+
+### 7.3 The compatibility guarantee is post-1.0
+
+**Pre-1.0 there is no cross-version compatibility guarantee and no migration
+tooling** (project decision, 2026-05-17). A `markspecSchemaVersion` bump before
+1.0 may break consumers; the only "upgrade path" is **recompile from source** —
+which is free here, because the compile output is a _derived_ artifact
+(regenerated by `markspec
+compile`, never hand-edited). The additive-only rule
+(§7.2) and any old→new consumer migration become a binding guarantee **at 1.0**.
+This is why the no-migration-tooling decision is consistent with this spec: the
+artifact is disposable-and-regenerable, so it needs no migrator.
+
+## 8. Open questions
+
+Capped at five.
+
+1. **Federation cycle / error diagnostic codes.** §5 needs registry diagnostics
+   (cycle, schema-skew, unreachable upstream). Which ADR-012 category — a new
+   `MSL-?` registry letter, or reuse `MSL-R` (trace)?
+2. **Body AST inline vs by-reference in the entry record.** §4.5 leaves `body`
+   configurable. Default to inline (self-contained record, larger) or
+   by-reference to a separate body store (smaller record, another file to
+   fetch)? Numbers needed at the 100k row.
+3. **Analytics consumer.** Option 4 (Parquet) was rejected for the point-read
+   pattern. If a fleet-level analytics consumer becomes first-class, is a
+   Parquet _export_ (alongside, not replacing, NDJSON) warranted, or is that a
+   report-tool concern?
+4. **Federation auth for non-public upstreams.** §5 assumes a world-readable
+   `api/`. A private upstream needs an auth story; is that in scope here or
+   strictly a hosting concern (like the sync spec keeps auth in connectors)?
+5. **`entries.idx` format.** A JSON map vs a fixed-width binary offset table vs
+   a sorted text file. Trade memory vs parse vs diffability; which is canonical?
+
+## Annex — Cross-reference summary
+
+| Section | Source                                                                                    |
+| ------- | ----------------------------------------------------------------------------------------- |
+| §1.2    | Prompt-7 anti-unification constraint; sibling specs (lockfile / indexing / sync) §1       |
+| §2 size | core-data-model §1 (entry/Item), §1.6 (inverses); empirical parse-cost reasoning          |
+| §4.5/6  | core-data-model §1.3 / §1.6 / §5.4; ADR-006 (`file/git/source/sync` properties)           |
+| §5      | core-data-model §1.3 ("imported registries"); ADR-011 (ingestion); lockfile spec §1/§4    |
+| §6      | ADR-006 §1; sync spec §6; lockfile spec §6                                                |
+| §7      | toolchain-distribution §3; profile-schema §8.2; project decision (no migration until 1.0) |

--- a/docs/specs/markspec-external-sync-model.md
+++ b/docs/specs/markspec-external-sync-model.md
@@ -1,0 +1,265 @@
+# MarkSpec — External Sync Model
+
+Status: Draft (Prompt 7 of the next-gen refactor — Stage 2)\
+Scope: the **common data model** for syncing entries with external systems
+(Jira, DOORS, Jama, Codebeamer, PLM, …) — **not** any per-tool connector\
+Date: 2026-05-17\
+Builds on: core-data-model (Prompt 1 — `External-id` §1.4, value types §1.8,
+generated provenance §1.6), profile-schema (Prompt 2), lockfile (Prompt 7 —
+locked-attribute pinning), background-indexing (Prompt 7 — `sync.*` excluded
+from the index); ADR-002 (`External-id`, `sync` properties), ADR-006 (property
+model — `sync.*` §1, sync connector model §4, caching §5), ADR-011 (ingestion),
+ADR-012 (diagnostic codes)
+
+One of four sibling Prompt-7 specs
+([compile-output](markspec-compile-output.md), [lockfile](markspec-lockfile.md),
+[background-indexing](markspec-background-indexing.md)). **Not unified with
+them** (compile-output §1.2). This spec freezes the _common_ sync data model.
+**Per-tool connectors are out of scope — each is its own ADR** (ADR-006
+§Out-of-scope). If this line blurs, MarkSpec becomes a sync framework, which is
+a different product (Prompt-7 Context).
+
+---
+
+## 0. Terminology
+
+| Term                 | Meaning in this spec                                                                                                                       |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| **external system**  | A requirements/ALM/PLM tool the project mirrors entries to/from (Jira, DOORS, Jama, Codebeamer, PLM, a ReqIF export).                      |
+| **connector**        | The per-system implementation (API calls, field maps, auth). **Out of scope here**; each connector is a separate ADR.                      |
+| **`External-id`**    | The core universal attribute binding an entry to its identifier(s) in external systems (core-data-model §1.4; value type `external-id`).   |
+| **mapping file**     | `.markspec/sync/<system>.yaml` — the project-authored schema binding MarkSpec attributes ↔ external fields (§3). The connector's contract. |
+| **locked attribute** | An attribute that, while the entry is bound to an external system, is owned upstream and read-only locally (§4).                           |
+| **sync log**         | `.markspec/sync/<system>/log.ndjson` — the append-only audit trail of sync operations (§7).                                                |
+
+---
+
+## 1. Scope — ruthless core/connector split
+
+Per the Prompt-7 Context, the line is drawn hard:
+
+| **Core (this spec owns)**                 | **Connector (separate ADR per tool)**             |
+| ----------------------------------------- | ------------------------------------------------- |
+| `External-id` attribute semantics (§2)    | Every per-tool API call                           |
+| Sync directions & their model (§2.3)      | Every field-value transformation                  |
+| `mapping.yaml` **schema** (§3)            | The concrete field map _content_ for a given tool |
+| Locked-attribute inference & lint (§4)    | Authentication / credential flows                 |
+| Conflict-resolution **policy** model (§5) | The conflict UI                                   |
+| Cache **shape** & TTL semantics (§6)      | The wire protocol / pagination                    |
+| Audit-log **shape** (§7)                  | Rate limiting, retries, tool quirks               |
+
+A proposal that adds tool-specific knowledge to this spec is rejected by
+construction. **Why a separate spec (anti-unification):** the sync log is
+append-only audit that may carry external-system data (a distinct security
+posture); the compile output is published, the lockfile committed, the index
+disposable (compile-output §1.2 table).
+
+## 2. `External-id` and sync directions
+
+### 2.1 `External-id` semantics
+
+`External-id` is core (core-data-model §1.4), value type `external-id`
+(repeatable, `scheme:value`, core-data-model §1.8 / ADR-002). One entry may bind
+several systems:
+
+```text
+External-id: jira:PROJ-1423
+External-id: doors:/Project/Reqs/REQ-107
+```
+
+The `scheme` selects which `mapping.yaml` / connector applies. `External-id` is
+**authored** (the binding is a project decision); the _state_ of that binding is
+observed as `sync.*` **properties** (`last_synced_at`, `remote_state`,
+`external_source` — ADR-006 §1), never authored, never round-tripped
+(core-data-model §5; ADR-002 properties).
+
+### 2.2 `remote_state` taxonomy
+
+`sync.remote_state` (ADR-006 §4) is fixed here as a closed vocabulary: `ok` ·
+`ahead` (local edits not pushed) · `behind` (upstream edits not pulled) ·
+`conflict` (both sides changed) · `deleted-upstream` · `unreachable` (sync
+attempted, system unavailable) · `unbound` (no live binding). Connectors map
+their tool state into this vocabulary; consumers (lint, matrix, LSP status) read
+only this vocabulary.
+
+### 2.3 Sync directions
+
+| Direction         | Meaning                                                                                | Locked attributes (§4)                         |
+| ----------------- | -------------------------------------------------------------------------------------- | ---------------------------------------------- |
+| **outbound**      | MarkSpec is source of truth; the external system mirrors it.                           | none (local is authoritative)                  |
+| **inbound**       | The external system is source of truth; entries are projected read-only into MarkSpec. | all mapped attributes                          |
+| **bidirectional** | Both author; conflicts possible and resolved per §5.                                   | per-attribute, declared in `mapping.yaml` (§3) |
+
+Direction is declared per system (and optionally per attribute) in the mapping
+file. Inbound entries carry `Origin: synthesized`-class provenance
+(core-data-model §1 / ADR-003 §Part 4) so `fmt`/`compile` know they are
+externally owned.
+
+## 3. Mapping file schema — `.markspec/sync/<system>.yaml`
+
+This spec defines the **schema**; a connector ADR supplies the values.
+
+```yaml
+system: jira                       # scheme used in External-id
+direction: bidirectional           # outbound | inbound | bidirectional (§2.3)
+identity:
+  external-id-scheme: jira         # which External-id scheme binds here
+attributes:                        # MarkSpec attr ↔ external field
+  - markspec: Title
+    external: summary
+    direction: bidirectional
+  - markspec: Derived-from
+    external: customfield_parent
+    direction: outbound
+  - markspec: Labels
+    external: labels
+    locked: true                   # upstream-owned while bound (§4)
+conflict:
+  default: manual                  # §5 — manual | local-wins | remote-wins | newest-wins
+cache:
+  ttl: 15m                         # §6
+```
+
+### 3.1 ReqIF MCP-server approach
+
+For ReqIF (the common DOORS/Jama interchange), a connector ADR will define an
+**MCP server** whose tool an agent calls to _analyze a ReqIF export and emit a
+`mapping.yaml`_. This spec defines **only the `mapping.yaml` schema** the agent
+must produce (above) — **not** the agent prompt, the ReqIF parser, or the MCP
+tool surface (those are the ReqIF connector ADR). The schema is the contract;
+generation of an instance of it is connector territory. (This is the one place
+the brief names a mechanism; the boundary still holds — we own the target
+schema, not the generator.)
+
+### 3.2 Options analysis — mapping file format & location
+
+| Decision                                            | Alternative                       | Why rejected                                                                                                                                                                                                                                                               |
+| --------------------------------------------------- | --------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| YAML at `.markspec/sync/<system>.yaml` (**chosen**) | A `sync:` block in `project.yaml` | Per-system files isolate blast radius, allow per-system git history/ownership, and keep `project.yaml` from becoming an n-system god-object. Mirrors `.markspec/sync/<system>/…` cache+log locality.                                                                       |
+| YAML (**chosen**)                                   | TOML / JSON                       | Authored by humans (and agents emitting human-reviewable config); YAML matches the profile-manifest authoring convention (profile-schema). Distinct from the lockfile (tool-written → TOML, lockfile §2.1) — different author, different choice, deliberately not unified. |
+| One file per system                                 | One file, all systems             | A multi-system god-file conflates security postures (one system's token-scoped fields beside another's) and update cadences — the same anti-unification logic as the four artifacts.                                                                                       |
+
+## 4. Locked-attribute inference
+
+When an entry is bound (`External-id`) under an inbound or per-attribute
+`locked: true` mapping, those attributes are **owned upstream**: editing them
+locally is a defect (the next sync overwrites the edit or creates a spurious
+conflict).
+
+- **Inference.** Locked set = (direction == inbound ⇒ all mapped attributes) ∪
+  (attributes with `locked: true`). Computed from `mapping.yaml` + the entry's
+  `External-id`; no per-tool knowledge.
+- **The lockfile records which** (cross-ref: lockfile spec). `markspec
+  lock`
+  records, per bound entry, the locked-attribute set and the upstream value hash
+  at lock time — so a trace audit can prove a locked attribute was not locally
+  tampered with (lockfile spec §1 framing). The sync model _infers_ the set; the
+  lockfile _pins_ it. Two specs, one fact, no duplication (anti-unification).
+- **Lint flags edits to locked attributes.** A locally modified locked attribute
+  is a diagnostic (ADR-012 catalogue — a `sync`/`MSL-?` locked-edit code; exact
+  code §9 OQ). It is a **warning** locally (the author may be staging an
+  intentional upstream change) and an **error** in CI / `--locked` (parity with
+  lockfile spec §5: integrity guarantees are hard in CI).
+
+## 5. Conflict resolution
+
+A conflict is: local and upstream both changed a mapped attribute since
+`last_synced_at` (detected by comparing hashes against the lockfile's recorded
+upstream hash — §4 / lockfile spec §3, not by trusting timestamps).
+
+- **Policy is configurable; default is `manual`.** Vocabulary: `manual` (default
+  — record the conflict, change nothing, surface it), `local-wins`,
+  `remote-wins`, `newest-wins` (by upstream change timestamp, only where the
+  connector supplies a trustworthy one).
+- `manual` writes a conflict record to the sync log (§7) and sets
+  `sync.remote_state = conflict` (§2.2); it never silently picks a side.
+  Auto-resolution is opt-in per system/attribute in `mapping.yaml`.
+- The **resolution UI is connector/tooling territory**; this spec fixes only the
+  policy vocabulary and that `manual` is the safe default (ADR-006
+  §Out-of-scope: "UI for resolving sync conflicts — tooling concern").
+
+## 6. Caching, generated-attribute provenance, privacy
+
+- **Cache.** `.markspec/sync/<system>/cache/` holds the last fetched upstream
+  snapshot per bound entry, with a per-system `ttl` (§3, default 15m; ADR-006
+  §5). The cache makes offline work and conflict detection possible without
+  re-hitting the API every command. It is **disposable** (rebuilt on next online
+  sync) — like the index (background-indexing §7), unlike the lockfile.
+- **Generated-attribute provenance: local vs external.** A generated inverse
+  (core-data-model §1.6) computed from _local_ edges is `provenance: local`; one
+  whose endpoint is an inbound/external entry is `provenance: external`. Compile
+  output (compile-output §4.6) and the matrix surface this so an auditor
+  distinguishes a locally-derived trace from an upstream-asserted one. The flag
+  is core model; the _value_ comes from the connector.
+- **Privacy — what stays local / logged / cached.** `External-id` (authored, in
+  source) and `sync.*` properties are repository-internal. The **cache** and
+  **log** under `.markspec/sync/` are **git-ignored by default** and **never
+  enter the published `/api/`** (compile-output §6 hard-excludes `sync.*`) **nor
+  the local index** (background-indexing §8 excludes `sync.*`). Credentials live
+  in the environment/connector, **never** in `mapping.yaml`, the cache, the log,
+  or the lockfile (parity across all four specs). External-system payload in the
+  cache/log is the one place tool data lands on disk; it is local, ignored, and
+  TTL-bounded by construction.
+
+## 7. Audit trail — `.markspec/sync/<system>/log.ndjson`
+
+Append-only, one JSON object per sync operation:
+`{ ts, op (push|pull|conflict|resolve), entryId, externalId, direction,
+attrsChanged[], remoteStateBefore, remoteStateAfter, hashBefore,
+hashAfter, actor }`.
+NDJSON because it is append-only and streamable (the same reasoning as
+compile-output entries, different artifact — a sync log is _audit_, not a
+published graph; not unified). It is the evidentiary record for "when did this
+entry diverge from Jira and who reconciled it", the sync-side analogue of the
+lockfile's trace-audit guarantee. Rotation / retention is a tooling concern (§9
+OQ); the **shape** is fixed here.
+
+## 8. Versioning & compatibility
+
+- `mapping.yaml` carries `schema:` (its own format version, independent of
+  `markspec-schema`). A newer mapping schema read by an older binary is a hard
+  error (a half-understood field map silently mis-syncs — the worst failure for
+  a system of record).
+- **Pre-1.0:** the mapping/log/cache formats may change without a migration path
+  (project decision, 2026-05-17 — no migration/back-compat tooling until 1.0).
+  Consistent and cheap because cache + log + inferred locked-set are
+  **regenerable** (re-sync rebuilds the cache; the log is append-only and append
+  continues; only `mapping.yaml` is hand-authored and a format bump is a
+  documented hand-edit, not a tool migration — acceptable pre-1.0). The
+  cross-version guarantee binds at 1.0.
+
+## 9. Open questions
+
+Capped at five.
+
+1. **Locked-edit diagnostic code.** §4 needs a code for "edited a locked
+   attribute". New ADR-012 `sync` category, or reuse `MSL-A` (attribute)? It
+   must be distinguishable from an ordinary attribute error because its CI
+   semantics differ (lockfile-tied).
+2. **`newest-wins` clock trust.** §5 allows timestamp-based resolution only
+   where the connector supplies a trustworthy clock. Is a per-connector "clock
+   trustworthy?" declaration part of the `mapping.yaml` schema (core) or a
+   connector-ADR concern?
+3. **Inbound entries and `fmt`.** §2.3 inbound entries are upstream-owned. Does
+   `fmt` skip them entirely, format-but-not-reorder, or treat them like
+   `Origin: synthesized` (core-data-model §6 OpenQ4 territory)?
+4. **Log retention.** §7 log is append-only and unbounded. Is
+   rotation/compaction in scope for the _model_ (a `maxBytes`/`maxAge` in
+   `mapping.yaml`) or strictly tooling?
+5. **Multi-system binding of one entry.** §2.1 allows several `External-id`s. If
+   two systems both map `Title` bidirectionally and disagree, is that a §5
+   conflict, a configuration error rejected at `mapping.yaml` load, or a
+   documented precedence order?
+
+## Annex — Cross-reference summary
+
+| Section | Source                                                                                        |
+| ------- | --------------------------------------------------------------------------------------------- |
+| §1      | Prompt-7 Context (core/connector split); ADR-006 §Out-of-scope; compile-output §1.2           |
+| §2      | core-data-model §1.4 / §1.6 / §1.8 / §5; ADR-002 (properties); ADR-006 §1 / §4                |
+| §3      | ADR-006 §4 (connector model); ADR-011 (ingestion); profile-schema (YAML authoring convention) |
+| §4      | lockfile spec §1 / §3 / §5; ADR-012; core-data-model §1.6                                     |
+| §5      | ADR-006 §4 / §Out-of-scope; lockfile spec §3                                                  |
+| §6      | ADR-006 §5; compile-output §6; background-indexing §7 / §8; core-data-model §1.6              |
+| §7      | ADR-006 §4; compile-output §4.6 (NDJSON reasoning, distinct artifact)                         |
+| §8      | profile-schema §8.2; project decision (no migration until 1.0)                                |

--- a/docs/specs/markspec-lockfile.md
+++ b/docs/specs/markspec-lockfile.md
@@ -1,0 +1,224 @@
+# MarkSpec — Lockfile
+
+Status: Draft (Prompt 7 of the next-gen refactor — Stage 2)\
+Date: 2026-05-17\
+Scope: `markspec.lock` — pinning **trace audits** to reproducibility across
+upstream change, not binaries\
+Builds on: core-data-model (Prompt 1 — Reference shape §1.2/§1.5, generated
+inverses §1.6, value types §1.8), profile-schema (Prompt 2 — profile version /
+`markspec-schema:` §8.1/§8.2, specifier ranges), listing-directives (Prompt 2 —
+references §3, component Id schemes §5); ADR-002 (Reference entries, value
+types), ADR-006 (`build.*` / `sync.*` properties), ADR-008 (profile
+distribution), ADR-011 (ingestion), ADR-012 (diagnostic codes)
+
+One of four sibling Prompt-7 specs
+([compile-output](markspec-compile-output.md),
+[background-indexing](markspec-background-indexing.md),
+[external-sync-model](markspec-external-sync-model.md)). **Not unified with
+them** (compile-output §1.2 restates why). This spec freezes the lockfile
+format, update mechanics, vendoring, conflict resolution, and security model.
+
+---
+
+## 0. Terminology
+
+| Term                          | Meaning in this spec                                                                                                                     |
+| ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| **lockfile**                  | `markspec.lock` at the project root — the committed record that makes trace audits reproducible.                                         |
+| **upstream**                  | An external resolvable the project depends on: a Reference entry's cited work, a profile, a federated registry (compile-output §5).      |
+| **resolved version**          | The concrete version a fuzzy upstream reference resolved to at lock time (e.g. `ISO-26262-6` → `:ed-2`, a profile range → an exact tag). |
+| **content hash**              | A digest of the resolved upstream's canonical bytes, recorded so a later run can detect upstream drift.                                  |
+| **generated-attribute cache** | The lockfile's record of computed inverse edges (core-data-model §1.6) so a trace audit reproduces without recompiling the world.        |
+| **CI mode**                   | `markspec lock --check` (or any command with `--locked`) — read-only, fails instead of writing.                                          |
+
+---
+
+## 1. What the lockfile is for (and is not)
+
+The lockfile pins **trace audits to reproducibility**, not binaries to builds.
+Git already makes first-party content reproducible; `deno
+compile` already pins
+the toolchain (toolchain-distribution §3). The lockfile exists so a question
+like
+
+> _"What version of ISO 26262 did `REQ-107` cite on 2026-03-15, and has the
+> cited clause changed since?"_
+
+is **answerable and reproducible** months later, across upstream republication.
+That regulator/auditor question is the feature; every mechanism below serves it.
+
+It is therefore **a registry-protocol consumer, not a dependency manager.**
+`Cargo.lock` pins binaries to make builds reproducible; `markspec.lock` pins
+_references_ to make **trace audits** reproducible. The distinction drives every
+decision here.
+
+**Why a separate spec (anti-unification).** The lockfile is committed to git,
+changes only on upstream change (slow cadence), and its security posture is
+_integrity_ (hashes). The compile output is archival/published (different
+audience), the index is disposable per-keystroke (different durability), the
+sync log is append-only audit (different security). See compile-output §1.2.
+
+## 2. Location & format
+
+`markspec.lock` at the project root (beside `project.yaml` / `.markspec.yaml`;
+same discovery as the profile loader, profile-schema §2.2). Committed to git.
+
+### 2.1 Options analysis — TOML vs JSON
+
+| Option            | Rejected / chosen because                                                                                                                                                                                                                                                                              |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| JSON              | **Rejected.** A lockfile is human-reviewed in PRs (an upstream-version bump is a reviewable security event). JSON's no-comments, brace-heavy, diff-noisy form is poor for that. (The _compile output_ is JSON because it is machine-consumed, not reviewed — different audience, compile-output §1.2.) |
+| YAML              | **Rejected.** Significant-whitespace + type-coercion footguns in a security-relevant, machine-written file. profile-schema manifests are YAML because authored by humans; the lockfile is tool-written, human-_read_.                                                                                  |
+| **TOML (chosen)** | Tool-written, human-reviewed: TOML diffs cleanly per table, supports comments (a generated header explaining "do not hand-edit; run `markspec lock`"), is unambiguous to emit deterministically, and is `dprint`-formattable (AGENTS.md). Matches the `Cargo.lock` precedent the §1 framing invokes.   |
+
+The lockfile is **deterministic**: tables and keys in a fixed order,
+byte-identical for identical resolution (core-data-model §5.3 ethos), so a no-op
+`markspec lock` produces a zero diff.
+
+### 2.2 Content
+
+```toml
+# @generated by `markspec lock` — do not hand-edit. Run `markspec lock`.
+schema = 1 # lockfile format version (§7), distinct from markspec-schema
+
+[meta]
+markspec-schema = 1 # core-schema the project resolved against (profile-schema §8.2)
+locked-at = "2026-03-15T09:00:00Z"
+
+[[upstream.reference]] # one per distinct cited Reference (listing-directives §3)
+slug = "ISO-26262-6"
+id = "urn:iso:std:iso:26262:-6:ed-2" # the RESOLVED concrete URI
+resolved = "ed-2"
+hash = "sha256:…" # canonical-bytes digest (§5)
+source = "https://www.iso.org/standard/68383.html" # where it was fetched/verified
+component-scheme = "urn" # listing-directives §5 classification, if any
+
+[[upstream.profile]] # profiles are upstreams too (profile-schema §8.1, ADR-008 §2)
+id = "@org/aspice"
+specifier = "npm:@org/aspice@^1.2" # the fuzzy specifier from .markspec.yaml
+resolved = "1.2.4" # the exact version it locked to
+hash = "sha256:…"
+
+[[upstream.registry]] # federated registries (compile-output §5)
+id = "urn:markspec:project:upstream-platform"
+api = "https://…/api/"
+resolved-manifest-hash = "sha256:…"
+markspec-schema = 1
+
+[generated-cache] # §3 — generated inverse-edge cache
+edges-hash = "sha256:…" # digest of edges.ndjson (compile-output §4.6) at lock time
+```
+
+`Reference` `Id:` values are URIs (core-data-model §1.2); `resolved` captures
+the version segment a fuzzy citation pinned to. Component-typed References
+additionally record the `listing-directives §5` scheme
+(`pkg`/`mfg`/`gtin`/`cpe`/`urn:system`/`urn:tool`) so an SBOM-style audit
+("which `pkg:cargo/serde` version was cited") is answerable.
+
+## 3. Generated-attribute cache
+
+Generated inverses (`Verified-by`, `Superseded-by`, every ADR-003 §Part 3
+inverse — core-data-model §1.6) are never committed to source (`MSL-A030`,
+core-data-model §4.4). But a _trace audit_ needs them, and recomputing the full
+graph to answer one historical question is expensive. The lockfile records the
+**hash** of the generated edge set (compile-output `edges.ndjson` §4.6) at lock
+time — not the edges themselves (that would duplicate the compile output,
+violating anti-unification). A reproduction step recompiles, hashes, and
+compares: identical hash ⇒ the trace graph is bit-for-bit the one the audit saw.
+The cache is _integrity metadata_, not a second copy of the graph.
+
+## 4. Update mechanics
+
+| Command                         | Behavior                                                                                                                                                   |
+| ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `markspec lock`                 | Resolve every upstream, write/refresh `markspec.lock`. Idempotent: re-running with no upstream change is a zero diff.                                      |
+| `markspec lock --check`         | **CI mode.** Resolve, compare to the committed lockfile, **write nothing**; exit non-zero on any drift (new/changed/removed upstream, hash mismatch).      |
+| `markspec lock --update[=<id>]` | Re-resolve all (or one) upstreams to current latest within the specifier range; the explicit "I am intentionally moving the pin" verb.                     |
+| `markspec fmt`                  | **Reads** the lockfile (to surface a stale-pin warning) but **never writes** it. Locking is not a formatting concern (AGENTS.md formatters/linters split). |
+| `markspec compile` / `lsp`      | Read the lockfile to pin federated resolution (compile-output §5); never write it.                                                                         |
+
+Only `markspec lock` (and `--update`) mutate the file. This mirrors the
+`Cargo.lock` discipline: the build reads it, one explicit command writes it.
+
+## 5. Security
+
+- **Hash verification.** Every resolved upstream records a `sha256:` digest of
+  its canonical bytes. On every `lock`/`compile`, MarkSpec re-fetches (or reads
+  the vendor mirror, §6) and re-hashes.
+- **Mismatch = warn locally, refuse in CI.** A hash mismatch (upstream content
+  changed under a pinned version — a tampering or silent-republish signal) is a
+  **warning** in interactive use (the author may legitimately `--update`) and a
+  **hard refusal** (exit non-zero, no proceed) under `--check`/`--locked` CI
+  mode. A regulator's reproducibility guarantee is void if a pinned upstream can
+  change unnoticed.
+- **No secrets in the lockfile.** Auth needed to _fetch_ a private upstream
+  lives in the environment/connector, never in `markspec.lock` (it is committed
+  and world-readable in the repo). The lockfile records _what_ and _its hash_,
+  never _how to authenticate_ (parity with compile-output §6 and sync spec §6).
+- **Privacy.** The lockfile records upstream identities and hashes only — no
+  entry bodies, no `sync.*` data, no PII. It is safe to commit and to include in
+  an audit package.
+
+## 6. Vendoring
+
+`markspec lock --vendor` mirrors every resolved upstream's canonical bytes into
+`.markspec/vendor/<scheme>/<id>/` and records the mirror path in the lockfile.
+Rationale: a regulator audit years later must not depend on `iso.org` still
+serving the same bytes. With a vendor mirror, the hash check (§5) runs against
+the local copy and the audit is self-contained and offline-reproducible.
+`.markspec/vendor/` is git-committed for true archival projects, or
+git-ignored + rebuilt from the lockfile for projects that trust upstream
+availability (project choice; the lockfile is the source of truth either way).
+
+## 7. Versioning & compatibility
+
+- The lockfile carries its **own** `schema` integer (the lockfile _format_
+  version), distinct from `markspec-schema` (the core-data-model contract). They
+  version independently: the lockfile layout can evolve without a core-schema
+  bump and vice-versa.
+- `markspec lock` written by a newer format `schema` is read by an older binary
+  as a **hard error** (not a silent best-effort) — a lockfile half-understood is
+  worse than none for a reproducibility guarantee.
+- **Pre-1.0:** the lockfile _format_ may change without a migration path
+  (project decision, 2026-05-17 — no migration/back-compat tooling until 1.0).
+  This is consistent and low-cost because the lockfile is **regenerable**:
+  `rm markspec.lock && markspec lock --update` rebuilds it from
+  `.markspec.yaml` + the references in source. A format bump's "migration" is
+  one re-lock; no `markspec migrate` is needed. The cross-version-read guarantee
+  binds at 1.0.
+
+## 8. Open questions
+
+Capped at five.
+
+1. **Reference version resolution source.** §2.2 records a `resolved` version
+   for a cited standard, but a `urn:iso:…:ed-2` is only as precise as the author
+   wrote it. Does `lock` attempt to _discover_ the latest edition (needs a
+   per-scheme resolver — registry territory), or only pin exactly what the
+   author cited and hash _that_?
+2. **Hash canonicalization for non-byte-stable upstreams.** An HTTPS page
+   re-rendered server-side changes bytes without changing content. §5's
+   "canonical bytes" needs a per-scheme canonicalization rule (PDF? HTML? purl
+   tarball?) — own it here or defer to a resolver ADR?
+3. **Vendor mirror in git vs not (default).** §6 leaves it a project choice.
+   Should the _default_ be ignore-and-rebuild (lean repo, trusts upstream) or
+   commit (true archival)? The safety-critical default may differ from the
+   general one.
+4. **Lockfile vs compile-output edge hash coupling.** §3 hashes `edges.ndjson`
+   (compile-output §4.6). If compile-output changes its edge serialization, the
+   lock hash churns with no semantic change. Hash a canonical edge _model_
+   instead of the file bytes?
+5. **Profile-pin interaction with `extends:` chains.** profile-schema §5 chains
+   profiles; `lock` pins each tier. Is a transitive `extends:` parent an
+   `[[upstream.profile]]` row of its own, or folded into the child's resolution?
+
+## Annex — Cross-reference summary
+
+| Section | Source                                                                                           |
+| ------- | ------------------------------------------------------------------------------------------------ |
+| §1      | Prompt-7 Context (audit-reproducibility framing); compile-output §1.2 (anti-unification)         |
+| §2.2    | core-data-model §1.2 / §1.5 / §1.8; listing-directives §3 / §5; profile-schema §8.1 / ADR-008 §2 |
+| §3      | core-data-model §1.6 / §4.4 (`MSL-A030`); ADR-003 §Part 3; compile-output §4.6                   |
+| §4      | AGENTS.md (formatters/linters split); `Cargo.lock` precedent                                     |
+| §5/§6   | ADR-006 (`build.*` provenance); compile-output §6; sync spec §6                                  |
+| §7      | profile-schema §8.2; project decision (no migration until 1.0)                                   |


### PR DESCRIPTION
## nextgen Prompt 7 — compile output, lockfile, indexing & external sync

Spec-authoring deliverable (no implementation, per the Stage-2
cross-cutting constraint). **Four** product specs in `docs/specs/`,
deliberately **not unified** (the brief's CRITICAL constraint). Depends
on Prompts 1-2 (merged). **Final Stage-2 prompt** — P6 (migration tool)
and P8 (migration playbook) were dropped per the no-migration /
no-backward-compat-until-1.0 decision.

### The four specs

- **`markspec-compile-output.md`** — the `/api/` shared/published
  artifact. Size analysis at 100 / 10k / 100k entries justified on
  **parse cost** (not byte size); five format options analyzed;
  recommendation = JSON manifest + NDJSON entries + byte-offset index,
  optional derived SQLite mirror. Registry-protocol federation
  (static-files, acyclic, read-only). `markspecSchemaVersion` +
  additive-only forward-compat.
- **`markspec-lockfile.md`** — `markspec.lock` (TOML; options analysis
  vs JSON/YAML). Pins **trace-audit reproducibility** (the regulator
  question), not binaries. Per-upstream resolved version + content hash,
  generated-edge hash cache, `--check` CI mode, `--vendor`, hash-verify
  (warn local / refuse CI).
- **`markspec-background-indexing.md`** — local-only disposable
  `.markspec/index.db` (SQLite; options analysis vs Tantivy/RocksDB/
  custom). The spec's weight is **invalidation** — dependency-closure,
  not file-only or everything. Single-writer/many-reader; budgets as
  numbers (cold < 5 s/10k, incremental < 50 ms, query < 5 ms);
  corrupt → rebuild, never block.
- **`markspec-external-sync-model.md`** — the **common** sync data model
  only; per-tool connectors are explicitly separate ADRs. `External-id`
  semantics, `mapping.yaml` schema, locked-attribute inference
  (lockfile-pinned), conflict policy (default `manual`), NDJSON audit
  log.

### Design stances

- **Anti-unification honored.** Each spec restates the
  audience/cadence/durability/security table from its own side and
  states why it must not merge with the other three. Cross-refs are
  tight and non-duplicating (e.g. locked-attributes: sync *infers*,
  lockfile *pins*).
- **Consistent with no-migration-until-1.0.** Every spec frames
  forward/back-compat as a **post-1.0 guarantee**; pre-1.0 the upgrade
  path is *regenerate*, which is free because all four are derived
  artifacts — the reason the no-migrator decision is internally
  consistent, not a gap.
- Options analysis on every storage/format decision; perf budgets as
  numbers; privacy (local / logged / cached; `sync.*` never published);
  open questions capped at five per file; cites the merged specs +
  ADR-001/002/003/004/006/011/012 without duplicating them.

### Process

- Prerequisites satisfied: Prompts 1-2 merged. Direct-to-main via
  `prompt-07-output-lock-index-sync` branch, consistent with Prompts
  1-5.
- `just build` green (check = lint + test + typecheck, then compile);
  pre-commit gate (fmt / dprint / lint / typecheck / commit-msg lint)
  green at commit time.
- Merging this completes the nextgen Stage 2 spec set on `main`
  (P5 + P7; P6/P8 dropped by decision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
