### PR TITLE
feat(core): implement spec section 4.1/4.2 parser and identity diagnostics (MSL-P0xx/I0xx)

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -33,6 +33,7 @@
     "npm:unified@*": "11.0.5",
     "npm:unified@11": "11.0.5",
     "npm:vscode-languageserver-textdocument@1": "1.0.12",
+    "npm:vscode-languageserver@*": "9.0.1",
     "npm:vscode-languageserver@9": "9.0.1",
     "npm:web-tree-sitter@0.24": "0.24.7"
   },

--- a/packages/markspec/core/ast/normalize_test.ts
+++ b/packages/markspec/core/ast/normalize_test.ts
@@ -48,11 +48,15 @@ Deno.test("normalizeBodyAst: already-canonical body is a no-op", () => {
 });
 
 Deno.test("normalizeBodyAst: modal inside a list item normalized", () => {
-  assertEquals(rt("- The driver SHALL act.\n- Plain item."),
-    "- The driver shall act.\n- Plain item.");
+  assertEquals(
+    rt("- The driver SHALL act.\n- Plain item."),
+    "- The driver shall act.\n- Plain item.",
+  );
 });
 
 Deno.test("normalizeBodyAst: modal inside a definition-list definition normalized", () => {
-  assertEquals(rt("Term\n: The system MUST stop."),
-    "Term\n: The system must stop.");
+  assertEquals(
+    rt("Term\n: The system MUST stop."),
+    "Term\n: The system must stop.",
+  );
 });

--- a/packages/markspec/core/parser/markdown.ts
+++ b/packages/markspec/core/parser/markdown.ts
@@ -9,6 +9,7 @@ import type { Definition, List, ListItem, Paragraph, Text } from "mdast";
 import type { Attribute, Diagnostic, Entry, EntryShape } from "../model/mod.ts";
 import { IDENTITY_KEY, shapeFromIdValue } from "../model/mod.ts";
 import {
+  ATTR_LINE_RE,
   collateAttributes,
   parseAttributes,
   splitBodyAndAttributes,
@@ -40,6 +41,12 @@ const SLUG_RE = /^[A-Za-z]([A-Za-z0-9._/-]*[A-Za-z0-9])?$/;
 
 /** Match `[...]` at the start of a list item paragraph. Captures: [1] = display ID, [2] = title. */
 const ENTRY_START_RE = /^\[([^\]]+)\]\s*(.*)$/;
+
+/** Match `[]` at the start — empty brackets. */
+const EMPTY_BRACKET_RE = /^\[\]\s*(.*)$/;
+
+/** Match `[` at the start without a closing `]` on the same logical content — unterminated. */
+const UNTERMINATED_BRACKET_RE = /^\[[^\]]*$/;
 
 /**
  * Find the `Id:` attribute on an entry. Returns undefined when absent. If
@@ -169,10 +176,35 @@ function extractEntry(
 
   if (firstInline.type === "text") {
     // remark may parse `[ID] Title` as a single text node
-    const match = ENTRY_START_RE.exec((firstInline as Text).value);
+    const textValue = (firstInline as Text).value;
+    const match = ENTRY_START_RE.exec(textValue);
     if (match) {
       displayId = match[1];
       title = match[2].trim();
+    } else if (EMPTY_BRACKET_RE.test(textValue)) {
+      // MSL-P001: bracketed content is empty — `- [] Title`
+      const entryLine = item.position?.start.line ?? 1;
+      diagnostics.push({
+        code: "MSL-P001",
+        severity: "error",
+        message:
+          "list item starts with `[]` but the bracketed content is empty " +
+          "(spec section 4.1)",
+        location: { file, line: entryLine, column: 1 },
+      });
+      return undefined;
+    } else if (UNTERMINATED_BRACKET_RE.test(textValue)) {
+      // MSL-P003: display-ID brackets unterminated (missing `]`)
+      const entryLine = item.position?.start.line ?? 1;
+      diagnostics.push({
+        code: "MSL-P003",
+        severity: "error",
+        message:
+          "display-ID brackets unterminated -- missing `]` before end of " +
+          "title line (spec section 4.1)",
+        location: { file, line: entryLine, column: 1 },
+      });
+      return undefined;
     }
   }
 
@@ -214,11 +246,168 @@ function extractEntry(
   // citation compatibility. Canonical slug never contains `@`.
   if (displayId.startsWith("@")) displayId = displayId.slice(1);
 
+  // MSL-I005: Display ID is empty (after `@` stripping).
+  if (displayId.length === 0) {
+    const entryLine = item.position?.start.line ?? 1;
+    diagnostics.push({
+      code: "MSL-I005",
+      severity: "error",
+      message: "display ID is empty (spec section 4.2)",
+      location: { file, line: entryLine, column: 1 },
+    });
+    return undefined;
+  }
+
+  // MSL-P002: title text missing after `]`. The title capture is empty
+  // and was not populated from subsequent nodes (linkReference path sets
+  // title from rest nodes).
+  if (title !== undefined && title.length === 0) {
+    const entryLine = item.position?.start.line ?? 1;
+    diagnostics.push({
+      code: "MSL-P002",
+      severity: "error",
+      message:
+        `${displayId}: title line missing title text after ']' (spec section 4.1)`,
+      location: { file, line: entryLine, column: 1 },
+    });
+    // Continue parsing — entry is still structurally valid for downstream
+    // validation (MSL-P010 also fires from the validator for empty titles).
+  }
+
   // Extract body content and attributes.
   const bodyContent = extractBodyContent(item, markdown);
   const [body, attrLines] = splitBodyAndAttributes(bodyContent);
   const attributes = parseAttributes(attrLines);
   const bodyAst = buildBodyAst(body);
+
+  const entryLine = item.position?.start.line ?? 1;
+
+  // MSL-P020: trailers block is not the final indented code block.
+  // Detect `Key: Value` lines in the body that likely should be trailers
+  // but are not at the final position (body content follows them).
+  // Exclude caption keywords (Figure:, Table:, etc.) which are legitimate
+  // body content, not misplaced trailer attributes.
+  const CAPTION_KEYWORDS = new Set([
+    "Figure",
+    "Table",
+    "Listing",
+    "Feature",
+    "Equation",
+    "List",
+  ]);
+  if (body.length > 0) {
+    const bodyLines = body.split("\n");
+    let inFencedBlock = false;
+    for (let i = 0; i < bodyLines.length; i++) {
+      const trimmed = bodyLines[i].trim();
+      // Track fenced code blocks (``` or ~~~) to skip their contents
+      if (/^(`{3,}|~{3,})/.test(trimmed)) {
+        inFencedBlock = !inFencedBlock;
+        continue;
+      }
+      if (inFencedBlock) continue;
+      if (!ATTR_LINE_RE.test(trimmed)) continue;
+      // Extract the key portion to check against caption keywords
+      const keyMatch = trimmed.match(/^([A-Z][A-Za-z-]*):/);
+      if (keyMatch && CAPTION_KEYWORDS.has(keyMatch[1])) continue;
+      // Found a Key: Value line in the body — non-final position
+      diagnostics.push({
+        code: "MSL-P020",
+        severity: "error",
+        message:
+          `${displayId}: trailers block is not the final indented code ` +
+          `block of the entry -- content appears after trailer-like ` +
+          `lines (spec section 4.1)`,
+        location: { file, line: entryLine, column: 1 },
+      });
+      break; // One diagnostic per entry is sufficient
+    }
+  }
+
+  // MSL-P021 / MSL-P022: validate trailer lines for syntax correctness.
+  // The trailer block is the final indented code block. Lines within it
+  // should all match `Key: Value` syntax. We check both the parsed
+  // attrLines AND the trailing body lines that might be in a code block
+  // but failed ATTR_LINE_RE (thus stayed in the body).
+  const TRAILER_KEY_RE = /^[A-Za-z][A-Za-z0-9-]*$/;
+  const COLON_SPLIT_RE = /^([^:]+):\s*(.*)$/;
+
+  // Check lines that DID end up in attrLines but might have key issues
+  for (const rawLine of attrLines) {
+    const trimmed = rawLine.trim();
+    if (!trimmed) continue;
+    if (!ATTR_LINE_RE.test(trimmed)) {
+      const colonMatch = COLON_SPLIT_RE.exec(trimmed);
+      if (colonMatch) {
+        const key = colonMatch[1].trim();
+        if (!TRAILER_KEY_RE.test(key)) {
+          diagnostics.push({
+            code: "MSL-P022",
+            severity: "error",
+            message: `${displayId}: trailer key '${key}' contains characters ` +
+              `outside [A-Za-z][A-Za-z0-9-]* (spec section 4.1)`,
+            location: { file, line: entryLine, column: 1 },
+          });
+        } else {
+          diagnostics.push({
+            code: "MSL-P021",
+            severity: "error",
+            message: `${displayId}: trailer line does not match 'Key: Value' ` +
+              `syntax (spec section 4.1): "${trimmed}"`,
+            location: { file, line: entryLine, column: 1 },
+          });
+        }
+      } else {
+        diagnostics.push({
+          code: "MSL-P021",
+          severity: "error",
+          message: `${displayId}: trailer line does not match 'Key: Value' ` +
+            `syntax (spec section 4.1): "${trimmed}"`,
+          location: { file, line: entryLine, column: 1 },
+        });
+      }
+    }
+  }
+
+  // Also scan trailing body lines for suspected misplaced trailers.
+  // If the body's last non-empty lines look like they belong to an
+  // indented code block with colon-separated content that has invalid
+  // keys, emit P022. Lines without colons that appear in what looks
+  // like a trailer block emit P021.
+  if (body.length > 0) {
+    const bodyLines = body.split("\n");
+    // Walk backward from the end of the body to find lines in a trailing
+    // code-block-like region that have colons (suspected trailers).
+    for (let i = bodyLines.length - 1; i >= 0; i--) {
+      const trimmed = bodyLines[i].trim();
+      if (!trimmed) continue; // skip trailing blanks
+      const colonMatch = COLON_SPLIT_RE.exec(trimmed);
+      if (!colonMatch) break; // stop at non-colon line
+      const key = colonMatch[1].trim();
+      if (ATTR_LINE_RE.test(trimmed)) {
+        // Valid attr line in body → already caught by P020
+        continue;
+      }
+      if (!TRAILER_KEY_RE.test(key)) {
+        diagnostics.push({
+          code: "MSL-P022",
+          severity: "error",
+          message: `${displayId}: trailer key '${key}' contains characters ` +
+            `outside [A-Za-z][A-Za-z0-9-]* (spec section 4.1)`,
+          location: { file, line: entryLine, column: 1 },
+        });
+      } else if (colonMatch[2].trim().length === 0) {
+        diagnostics.push({
+          code: "MSL-P021",
+          severity: "error",
+          message: `${displayId}: trailer line does not match 'Key: Value' ` +
+            `syntax (spec section 4.1): "${trimmed}"`,
+          location: { file, line: entryLine, column: 1 },
+        });
+      }
+      break; // one diagnostic per trailing suspect line is sufficient
+    }
+  }
 
   // Detect legacy paragraph + trailing-backslash attribute form and warn.
   if (
@@ -267,6 +456,21 @@ function extractEntry(
   // this field when a profile is loaded.
   const type: string | undefined = undefined;
 
+  // MSL-P030: Authored entry has no body block (title + trailers only).
+  // For Reference shape, body is optional (ADR-002 section Part 3). For Authored,
+  // the body is required. We also emit P030 when the body is empty (all
+  // content was consumed as attributes).
+  if (shape === "Authored" && body.trim().length === 0) {
+    diagnostics.push({
+      code: "MSL-P030",
+      severity: "error",
+      message:
+        `${displayId}: Authored entry has no body block -- entries must ` +
+        `have body content between title and trailers (spec section 4.1)`,
+      location: { file, line: entryLine, column: 1 },
+    });
+  }
+
   // Body requirement: identified entries require a body; referenced entries
   // may omit it. If there's only one child (the title paragraph), admit
   // only referenced entries.
@@ -278,7 +482,7 @@ function extractEntry(
 
   const entryLocation = { file, line, column };
 
-  // Inline `$Identifier` entity references (spec §2.5.2). Resolution
+  // Inline `$Identifier` entity references (spec section 2.5.2). Resolution
   // into the project's entity registry is left to the validator's
   // marker pass; the parser only emits the lexical hits.
   // Pass the already-built bodyAst to avoid a redundant mdast parse.

--- a/packages/markspec/core/validator/mod.ts
+++ b/packages/markspec/core/validator/mod.ts
@@ -83,6 +83,8 @@ function checkStructural(
 
   for (const entry of entries) {
     // MSL-R003: exactly one `Id:` attribute per entry.
+    // Dual-emit: MSL-I002 (Reference missing Id), MSL-I003 (Authored missing
+    // Id), MSL-I004 (multiple Id) — nextgen §4.2 codes alongside legacy.
     const idAttrs = entry.rawAttributes.filter((a) => a.key === IDENTITY_KEY);
     if (idAttrs.length === 0) {
       diagnostics.push({
@@ -91,6 +93,24 @@ function checkStructural(
         message: `${entry.displayId}: missing Id: attribute`,
         location: entry.location,
       });
+      // Dual-emit: shape-specific nextgen code
+      if (entry.shape === "Reference") {
+        diagnostics.push({
+          code: "MSL-I002",
+          severity: "error",
+          message: `${entry.displayId}: Reference-shape entry without Id: ` +
+            `fmt cannot mint URIs (spec section 4.2)`,
+          location: entry.location,
+        });
+      } else {
+        diagnostics.push({
+          code: "MSL-I003",
+          severity: "error",
+          message: `${entry.displayId}: Authored-shape entry without Id: ` +
+            `run fmt to mint a ULID (spec section 4.2)`,
+          location: entry.location,
+        });
+      }
     } else if (idAttrs.length > 1) {
       diagnostics.push({
         code: "MSL-R003",
@@ -99,9 +119,18 @@ function checkStructural(
           `${entry.displayId}: multiple Id: attributes (${idAttrs.length}) — exactly one is required`,
         location: entry.location,
       });
+      // Dual-emit: MSL-I004
+      diagnostics.push({
+        code: "MSL-I004",
+        severity: "error",
+        message: `${entry.displayId}: multiple Id: trailers ` +
+          `(${idAttrs.length}) on the same entry (spec section 4.2)`,
+        location: entry.location,
+      });
     }
 
     // MSL-R004: `Id:` value must be a ULID or a scheme-qualified URI.
+    // Dual-emit: MSL-I001 — nextgen §4.2 code alongside legacy.
     if (idAttrs.length > 0) {
       const value = idAttrs[0].value;
       const isUlid = ULID_RE.test(value);
@@ -112,6 +141,14 @@ function checkStructural(
           severity: "error",
           message:
             `${entry.displayId}: Id: value '${value}' is neither a bare ULID nor a scheme-qualified URI`,
+          location: entry.location,
+        });
+        diagnostics.push({
+          code: "MSL-I001",
+          severity: "error",
+          message:
+            `${entry.displayId}: Id: value '${value}' is neither a ULID ` +
+            `(^[0-9A-HJKMNP-TV-Z]{26}$) nor an RFC 3986 URI (spec section 4.2)`,
           location: entry.location,
         });
       }
@@ -152,6 +189,7 @@ function checkStructural(
     }
 
     // MSL-R006: Display ID unique across all entries.
+    // Dual-emit: MSL-I008 (warning) — nextgen §4.2.
     const existingDisplay = displayIds.get(entry.displayId);
     if (existingDisplay) {
       diagnostics.push({
@@ -161,11 +199,21 @@ function checkStructural(
           `duplicate display ID '${entry.displayId}' (also at ${existingDisplay.location.file}:${existingDisplay.location.line})`,
         location: entry.location,
       });
+      diagnostics.push({
+        code: "MSL-I008",
+        severity: "warning",
+        message: `duplicate display ID '${entry.displayId}' within the same ` +
+          `shape (also at ${existingDisplay.location.file}:` +
+          `${existingDisplay.location.line}) -- cross-references resolve ` +
+          `by Id:, so this is style-only (spec section 4.2)`,
+        location: entry.location,
+      });
     } else {
       displayIds.set(entry.displayId, entry);
     }
 
     // MSL-R005: identity value unique across all entries.
+    // Dual-emit: MSL-I007 — nextgen §4.2.
     if (entry.id) {
       const existingId = ids.get(entry.id);
       if (existingId) {
@@ -174,6 +222,15 @@ function checkStructural(
           severity: "error",
           message:
             `duplicate Id '${entry.id}' (also at ${existingId.location.file}:${existingId.location.line})`,
+          location: entry.location,
+        });
+        diagnostics.push({
+          code: "MSL-I007",
+          severity: "error",
+          message:
+            `duplicate Id: value '${entry.id}' across the project (also ` +
+            `at ${existingId.location.file}:${existingId.location.line}) ` +
+            `(spec section 4.2)`,
           location: entry.location,
         });
       } else {

--- a/packages/markspec/main.ts
+++ b/packages/markspec/main.ts
@@ -13,6 +13,7 @@ import { ConfigError, VERSION } from "./core/mod.ts";
 import type {
   CaptionConventions,
   CompileResult,
+  Diagnostic,
   ProfileChain,
   ReadFile,
 } from "./core/mod.ts";
@@ -684,6 +685,7 @@ const cli = new Command()
       const { parseFile, runPipeline } = await import("./core/mod.ts");
 
       const allEntries = [];
+      const parseDiagnostics: Diagnostic[] = [];
       for (const filePath of files) {
         let content: string;
         try {
@@ -694,6 +696,7 @@ const cli = new Command()
         }
         const result = await parseFile(content, { file: filePath });
         allEntries.push(...result.entries);
+        parseDiagnostics.push(...result.diagnostics);
       }
 
       const result = runPipeline(
@@ -702,12 +705,15 @@ const cli = new Command()
         captionConventions,
       );
 
+      // Merge parse-level diagnostics (MSL-P0xx) with pipeline diagnostics.
+      const allDiagnostics = [...parseDiagnostics, ...result.diagnostics];
+
       // Apply --strict: promote warnings to errors.
       const diagnostics = options.strict
-        ? result.diagnostics.map((d) =>
+        ? allDiagnostics.map((d) =>
           d.severity === "warning" ? { ...d, severity: "error" as const } : d
         )
-        : result.diagnostics;
+        : allDiagnostics;
 
       const hasErrors = diagnostics.some((d) => d.severity === "error");
       const hasWarnings = diagnostics.some((d) => d.severity === "warning");

--- a/tests/e2e/parse_identity_diagnostics_test.ts
+++ b/tests/e2e/parse_identity_diagnostics_test.ts
@@ -1,0 +1,418 @@
+/**
+ * @module tests/e2e/parse_identity_diagnostics_test
+ *
+ * E2E acceptance tests for §4.1 Parse (MSL-P0xx) and §4.2 Identity & Shape
+ * (MSL-I0xx) diagnostic codes from core-data-model.md.
+ *
+ * These tests exercise `markspec validate` as a black-box CLI command.
+ * Each test verifies that the correct diagnostic code surfaces in stderr.
+ */
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { markspec } from "./helpers.ts";
+
+// ===========================================================================
+// §4.1 Parse errors (MSL-P0xx)
+// ===========================================================================
+
+// ---------------------------------------------------------------------------
+// MSL-P001: bracketed content is empty — `- [] Title`
+// ---------------------------------------------------------------------------
+
+Deno.test("validate: empty display-ID brackets → MSL-P001", async () => {
+  const { code, stderr } = await markspec(["validate", "req.md"], {
+    files: {
+      "req.md": `# Test
+
+- [] Empty brackets title
+
+  Body text here.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+`,
+    },
+  });
+  assertEquals(code, 1, `expected exit 1, stderr: ${stderr}`);
+  assertStringIncludes(stderr, "MSL-P001");
+});
+
+// ---------------------------------------------------------------------------
+// MSL-P002: title text missing after `]`
+// ---------------------------------------------------------------------------
+
+Deno.test("validate: no title after display-ID brackets → MSL-P002", async () => {
+  const { code, stderr } = await markspec(["validate", "req.md"], {
+    files: {
+      "req.md": `# Test
+
+- [REQ-001]
+
+  Body text here.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+`,
+    },
+  });
+  assertEquals(code, 1, `expected exit 1, stderr: ${stderr}`);
+  assertStringIncludes(stderr, "MSL-P002");
+});
+
+// ---------------------------------------------------------------------------
+// MSL-P003: unterminated display-ID brackets (missing `]`)
+// ---------------------------------------------------------------------------
+
+Deno.test("validate: unterminated bracket → MSL-P003", async () => {
+  const { code, stderr } = await markspec(["validate", "req.md"], {
+    files: {
+      "req.md": `# Test
+
+- [REQ-001 Unterminated bracket title
+
+  Body text here.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+`,
+    },
+  });
+  assertEquals(code, 1, `expected exit 1, stderr: ${stderr}`);
+  assertStringIncludes(stderr, "MSL-P003");
+});
+
+// ---------------------------------------------------------------------------
+// MSL-P020: trailers block is not the final indented code block
+// ---------------------------------------------------------------------------
+
+Deno.test("validate: trailers not final indented block → MSL-P020", async () => {
+  const { code, stderr } = await markspec(["validate", "req.md"], {
+    files: {
+      "req.md": `# Test
+
+- [REQ-001] Valid title
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+
+  Body text after the trailers block.
+`,
+    },
+  });
+  assertEquals(code, 1, `expected exit 1, stderr: ${stderr}`);
+  assertStringIncludes(stderr, "MSL-P020");
+});
+
+// ---------------------------------------------------------------------------
+// MSL-P021: trailer line does not match `Key: Value` syntax
+// ---------------------------------------------------------------------------
+
+Deno.test("validate: malformed trailer line → MSL-P021", async () => {
+  // A line in what appears to be the trailer region that has no colon-
+  // separated structure. Since `splitBodyAndAttributes` requires matching
+  // ATTR_LINE_RE for inclusion, the malformed line displaces valid trailers
+  // into the body and P020 fires. P021 fires on the trailing colon-like
+  // line that doesn't parse as a valid Key: Value.
+  const { code, stderr } = await markspec(["validate", "req.md"], {
+    files: {
+      "req.md": `# Test
+
+- [REQ-001] Valid title
+
+  Body text.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      not-a-key-value: 
+`,
+    },
+  });
+  assertEquals(code, 1, `expected exit 1, stderr: ${stderr}`);
+  assertStringIncludes(stderr, "MSL-P021");
+});
+
+// ---------------------------------------------------------------------------
+// MSL-P022: trailer key contains invalid characters
+// ---------------------------------------------------------------------------
+
+Deno.test("validate: invalid trailer key chars → MSL-P022", async () => {
+  const { code, stderr } = await markspec(["validate", "req.md"], {
+    files: {
+      "req.md": `# Test
+
+- [REQ-001] Valid title
+
+  Body text.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      Bad_Key: some value
+`,
+    },
+  });
+  assertEquals(code, 1, `expected exit 1, stderr: ${stderr}`);
+  assertStringIncludes(stderr, "MSL-P022");
+});
+
+// ---------------------------------------------------------------------------
+// MSL-P030: Authored entry has no body block
+// ---------------------------------------------------------------------------
+
+Deno.test("validate: Authored entry without body → MSL-P030", async () => {
+  const { code, stderr } = await markspec(["validate", "req.md"], {
+    files: {
+      "req.md": `# Test
+
+- [REQ-001] Title only with trailers
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+`,
+    },
+  });
+  assertEquals(code, 1, `expected exit 1, stderr: ${stderr}`);
+  assertStringIncludes(stderr, "MSL-P030");
+});
+
+Deno.test("validate: Reference entry without body → no MSL-P030 (allowed)", async () => {
+  const { stderr } = await markspec(["validate", "references.md"], {
+    files: {
+      "references.md": `# References
+
+- [iso26262] ISO 26262
+
+      Id: urn:iso:std:iso:26262
+`,
+    },
+  });
+  // MSL-P030 must NOT fire for Reference-shape entries (body is optional).
+  // Other warnings (MSL-T021, MSL-M061) may still be present.
+  assertEquals(
+    stderr.includes("MSL-P030"),
+    false,
+    `MSL-P030 should not fire for Reference entries, got: ${stderr}`,
+  );
+});
+
+// ===========================================================================
+// §4.2 Identity & shape (MSL-I0xx) — dual-emit alongside legacy codes
+// ===========================================================================
+
+// ---------------------------------------------------------------------------
+// MSL-I001 (+ legacy MSL-R004): Id value is neither ULID nor URI
+// ---------------------------------------------------------------------------
+
+Deno.test("validate: invalid Id value → MSL-I001 + MSL-R004", async () => {
+  const { code, stderr } = await markspec(["validate", "req.md"], {
+    files: {
+      "req.md": `# Test
+
+- [REQ-001] Valid title
+
+  Body text.
+
+      Id: not-a-valid-ulid-or-uri
+`,
+    },
+  });
+  assertEquals(code, 1, `expected exit 1, stderr: ${stderr}`);
+  assertStringIncludes(stderr, "MSL-I001");
+  assertStringIncludes(stderr, "MSL-R004");
+});
+
+// ---------------------------------------------------------------------------
+// MSL-I002 (+ legacy MSL-R003): Reference-shape entry without Id
+// ---------------------------------------------------------------------------
+
+Deno.test("validate: Reference entry missing Id → MSL-I002 + MSL-R003", async () => {
+  const { code, stderr } = await markspec(["validate", "references.md"], {
+    files: {
+      "references.md": `# References
+
+- [serde] Serde library
+
+  A serialization framework.
+`,
+    },
+  });
+  assertEquals(code, 1, `expected exit 1, stderr: ${stderr}`);
+  assertStringIncludes(stderr, "MSL-I002");
+  assertStringIncludes(stderr, "MSL-R003");
+});
+
+// ---------------------------------------------------------------------------
+// MSL-I003 (+ legacy MSL-R003): Authored-shape entry without Id
+// ---------------------------------------------------------------------------
+
+Deno.test("validate: Authored entry missing Id → MSL-I003 + MSL-R003", async () => {
+  const { code, stderr } = await markspec(["validate", "req.md"], {
+    files: {
+      "req.md": `# Test
+
+- [REQ-001] Valid title
+
+  Body text.
+
+      Labels: ASIL-B
+`,
+    },
+  });
+  assertEquals(code, 1, `expected exit 1, stderr: ${stderr}`);
+  assertStringIncludes(stderr, "MSL-I003");
+  assertStringIncludes(stderr, "MSL-R003");
+});
+
+// ---------------------------------------------------------------------------
+// MSL-I004 (+ legacy MSL-R003): Multiple Id trailers
+// ---------------------------------------------------------------------------
+
+Deno.test("validate: multiple Id attributes → MSL-I004 + MSL-R003", async () => {
+  const { code, stderr } = await markspec(["validate", "req.md"], {
+    files: {
+      "req.md": `# Test
+
+- [REQ-001] Valid title
+
+  Body text.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEG
+`,
+    },
+  });
+  assertEquals(code, 1, `expected exit 1, stderr: ${stderr}`);
+  assertStringIncludes(stderr, "MSL-I004");
+  assertStringIncludes(stderr, "MSL-R003");
+});
+
+// ---------------------------------------------------------------------------
+// MSL-I005: Display ID is empty
+// ---------------------------------------------------------------------------
+
+Deno.test("validate: empty display ID after @ strip → MSL-I005", async () => {
+  // The `@` prefix is stripped for Pandoc compatibility; if only `@` was in
+  // the brackets, the display ID becomes empty → MSL-I005.
+  const { code, stderr } = await markspec(["validate", "references.md"], {
+    files: {
+      "references.md": `# References
+
+- [@] Title here
+
+  Body text.
+
+      Id: urn:example:test
+`,
+    },
+  });
+  assertEquals(code, 1, `expected exit 1, stderr: ${stderr}`);
+  assertStringIncludes(stderr, "MSL-I005");
+});
+
+Deno.test("validate: empty brackets emits MSL-P001 (not I005)", async () => {
+  // `[]` triggers P001 (parse-level empty bracket), entry is not admitted.
+  const { code, stderr } = await markspec(["validate", "req.md"], {
+    files: {
+      "req.md": `# Test
+
+- [] Title here
+
+  Body text.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+`,
+    },
+  });
+  assertEquals(code, 1, `expected exit 1, stderr: ${stderr}`);
+  assertStringIncludes(stderr, "MSL-P001");
+});
+
+// ---------------------------------------------------------------------------
+// MSL-I007 (+ legacy MSL-R005): Duplicate Id value across project
+// ---------------------------------------------------------------------------
+
+Deno.test("validate: duplicate Id value → MSL-I007 + MSL-R005", async () => {
+  const { code, stderr } = await markspec(["validate", "req.md"], {
+    files: {
+      "req.md": `# Test
+
+- [REQ-001] First entry
+
+  Body text.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+
+- [REQ-002] Second entry with same Id
+
+  Body text.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+`,
+    },
+  });
+  assertEquals(code, 1, `expected exit 1, stderr: ${stderr}`);
+  assertStringIncludes(stderr, "MSL-I007");
+  assertStringIncludes(stderr, "MSL-R005");
+});
+
+// ---------------------------------------------------------------------------
+// MSL-I008 (+ legacy MSL-R006): Duplicate display ID within same shape
+// ---------------------------------------------------------------------------
+
+Deno.test("validate: duplicate display ID → MSL-I008 + MSL-R006", async () => {
+  const { code, stderr } = await markspec(["validate", "req.md"], {
+    files: {
+      "req.md": `# Test
+
+- [REQ-001] First entry
+
+  Body text.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+
+- [REQ-001] Same display ID different content
+
+  Body text.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEG
+`,
+    },
+  });
+  assertEquals(code, 1, `expected exit 1, stderr: ${stderr}`);
+  assertStringIncludes(stderr, "MSL-I008");
+  assertStringIncludes(stderr, "MSL-R006");
+});
+
+// ===========================================================================
+// MSL-I006 — already emitted (regression guard)
+// ===========================================================================
+
+Deno.test("validate: Reference slug violation → MSL-I006 (regression)", async () => {
+  const { code, stderr } = await markspec(["validate", "references.md"], {
+    files: {
+      "references.md": `# References
+
+- [123-bad-slug] Invalid slug starts with digit
+
+  Body text.
+
+      Id: urn:example:bad-slug
+`,
+    },
+  });
+  assertEquals(code, 1, `expected exit 1, stderr: ${stderr}`);
+  assertStringIncludes(stderr, "MSL-I006");
+});
+
+// ===========================================================================
+// MSL-P010 — already emitted (regression guard)
+// ===========================================================================
+
+Deno.test("validate: empty title after trim → MSL-P010 (regression)", async () => {
+  const { code, stderr } = await markspec(["validate", "req.md"], {
+    files: {
+      "req.md": `# Test
+
+- [REQ-001]   
+
+  Body text.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+`,
+    },
+  });
+  assertEquals(code, 1, `expected exit 1, stderr: ${stderr}`);
+  assertStringIncludes(stderr, "MSL-P010");
+});

--- a/tests/e2e/profile_attributes_test.ts
+++ b/tests/e2e/profile_attributes_test.ts
@@ -48,6 +48,8 @@ Deno.test("profile attributes e2e: happy path — all required present, types va
 
 - [REQ-0001] A requirement
 
+  Body text.
+
       Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
       Rationale: Needed for safety
       Count: 42
@@ -73,6 +75,8 @@ Deno.test("profile attributes e2e: missing required → MSL-A001", async () => {
 
 - [REQ-0001] Missing rationale
 
+  Body text.
+
       Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
 `,
     },
@@ -89,6 +93,8 @@ Deno.test("profile attributes e2e: cardinality upper exceeded → MSL-A002", asy
       "req.md": `# Example
 
 - [REQ-0001] Too many owners
+
+  Body text.
 
       Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
       Rationale: needed
@@ -111,6 +117,8 @@ Deno.test("profile attributes e2e: cardinality lower unmet → MSL-A003", async 
 
 - [REQ-0001] Too few owners
 
+  Body text.
+
       Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
       Rationale: needed
       Owners: single
@@ -129,6 +137,8 @@ Deno.test("profile attributes e2e: value-type mismatch → MSL-A004", async () =
 
 - [REQ-0001] Count must be integer
 
+  Body text.
+
       Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
       Rationale: needed
       Count: not-an-integer
@@ -146,6 +156,8 @@ Deno.test("profile attributes e2e: unknown attribute → MSL-A005 warning", asyn
       "req.md": `# Example
 
 - [REQ-0001] Unknown attribute
+
+  Body text.
 
       Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
       Rationale: needed
@@ -169,6 +181,8 @@ Deno.test("profile attributes e2e: enum type-mismatch → MSL-A004 on Status", a
 
 - [REQ-0001] Bad status
 
+  Body text.
+
       Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
       Rationale: needed
       Status: rejected
@@ -186,6 +200,8 @@ Deno.test("profile attributes e2e: no profile → no MSL-A diagnostics (core-onl
       "req.md": `# Example
 
 - [REQ-0001] No profile
+
+  Body text.
 
       Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
 `,

--- a/tests/e2e/profile_git_test.ts
+++ b/tests/e2e/profile_git_test.ts
@@ -11,7 +11,7 @@ import { setupGitFixture } from "./helpers_git.ts";
 const PROJECT_YAML = `name: phase4-e2e\nversion: 0.1.0\n`;
 
 const REQ_MD =
-  `# Example\n\n- [REQ-0001] A requirement\n\n  Id: 01HGW2Q8MNP3RSTVWXYZABCDEF\\\n`;
+  `# Example\n\n- [REQ-0001] A requirement\n\n  Body text.\n\n      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF\n`;
 
 const BASE_PROFILE_YAML = `id: "@acme/phase4-base"
 version: 1.0.0

--- a/tests/e2e/profile_loader_test.ts
+++ b/tests/e2e/profile_loader_test.ts
@@ -15,7 +15,7 @@ const MINIMAL_PROFILE = `id: "@acme/phase2-minimal"\nversion: 0.1.0\n`;
 
 // Minimal markdown file for validate to process.
 const REQ_MD =
-  `# Example\n\n- [NOTE-001] A note\n\n  Id: 01HGW2Q8MNP3RSTVWXYZABCDEF\\\n`;
+  `# Example\n\n- [NOTE-001] A note\n\n  Body text.\n\n      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF\n`;
 
 Deno.test("profile loader e2e: no .markspec.yaml — core-only mode, exit 0", async () => {
   const { code } = await markspec(["validate", "req.md"], {

--- a/tests/e2e/profile_merge_test.ts
+++ b/tests/e2e/profile_merge_test.ts
@@ -50,6 +50,8 @@ const REQ_MD = `# Example
 
 - [REQ-0001] A requirement
 
+  Body text.
+
       Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
 `;
 

--- a/tests/e2e/profile_traceability_test.ts
+++ b/tests/e2e/profile_traceability_test.ts
@@ -41,9 +41,13 @@ Deno.test("traceability e2e: test entry Verifies a requirement → clean", async
 
 - [REQ-0001] A requirement
 
+  Body text.
+
       Id: 01REQ000000000000000000001
 
 - [TEST-0001] A test
+
+  Body text.
 
       Id: 01TEST00000000000000000001
       Verifies: 01REQ000000000000000000001
@@ -63,6 +67,8 @@ Deno.test("traceability e2e: test entry missing Verifies → MSL-L001", async ()
 
 - [TEST-0001] A test with no Verifies
 
+  Body text.
+
       Id: 01TEST00000000000000000001
 `,
     },
@@ -80,17 +86,25 @@ Deno.test("traceability e2e: Verifies too many targets → MSL-L002", async () =
 
 - [REQ-0001] First
 
+  Body text.
+
       Id: 01REQ000000000000000000001
 
 - [REQ-0002] Second
+
+  Body text.
 
       Id: 01REQ000000000000000000002
 
 - [REQ-0003] Third
 
+  Body text.
+
       Id: 01REQ000000000000000000003
 
 - [TEST-0001] A test
+
+  Body text.
 
       Id: 01TEST00000000000000000001
       Verifies: 01REQ000000000000000000001
@@ -111,9 +125,13 @@ Deno.test("traceability e2e: Verifies points at a non-requirement → MSL-L004",
 
 - [TEST-0002] Another test
 
+  Body text.
+
       Id: 01TEST00000000000000000002
 
 - [TEST-0001] A test verifying the wrong type
+
+  Body text.
 
       Id: 01TEST00000000000000000001
       Verifies: 01TEST00000000000000000002
@@ -133,13 +151,19 @@ Deno.test("traceability e2e: comma-separated Verifies is split by Stage 2.5", as
 
 - [REQ-0001] First
 
+  Body text.
+
       Id: 01REQ000000000000000000001
 
 - [REQ-0002] Second
 
+  Body text.
+
       Id: 01REQ000000000000000000002
 
 - [TEST-0001] A test verifying two reqs via CSV syntax
+
+  Body text.
 
       Id: 01TEST00000000000000000001
       Verifies: 01REQ000000000000000000001, 01REQ000000000000000000002
@@ -160,6 +184,8 @@ Deno.test("traceability e2e: no profile → Stage 4 silent", async () => {
       "doc.md": `# Example
 
 - [TEST-0001] A test
+
+  Body text.
 
       Id: 01TEST00000000000000000001
 `,

--- a/tests/e2e/profile_types_test.ts
+++ b/tests/e2e/profile_types_test.ts
@@ -34,6 +34,8 @@ Deno.test("profile types e2e: entry matching REQ pattern classifies cleanly", as
 
 - [REQ-0001] A requirement
 
+  Body text.
+
       Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
 `,
     },
@@ -53,6 +55,8 @@ Deno.test("profile types e2e: un-classified entry emits MSL-T003", async () => {
 
 - [FOO-001] An entry with no matching type
 
+  Body text.
+
       Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
 `,
     },
@@ -71,6 +75,8 @@ Deno.test("profile types e2e: explicit Type: attribute overrides display-ID infe
 
 - [FOO-001] Explicitly typed as note
 
+  Body text.
+
       Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
       Type: note
 `,
@@ -88,6 +94,8 @@ Deno.test("profile types e2e: explicit Type: unknown value emits MSL-T001", asyn
       "req.md": `# Example
 
 - [REQ-0001] Unknown type
+
+  Body text.
 
       Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
       Type: bogus
@@ -108,6 +116,8 @@ Deno.test("profile types e2e: pattern-enforcement=error + mismatch emits MSL-T00
 
 - [FOO-001] Requirement via explicit Type: but wrong display-ID form
 
+  Body text.
+
       Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
       Type: requirement
 `,
@@ -124,6 +134,8 @@ Deno.test("profile types e2e: no .markspec.yaml — core-only mode, no MSL-T dia
       "req.md": `# Example
 
 - [FOO-001] An entry
+
+  Body text.
 
       Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
 `,


### PR DESCRIPTION
## Summary

Implements Slice 2 of the nextgen diagnostic refactor: parser diagnostics (section 4.1) and identity diagnostics (section 4.2) per the MarkSpec language specification.

### What changed

- **Parser diagnostics (MSL-P001-P030):** New diagnostics in core/parser/markdown.ts for malformed entry blocks -- missing display-ID (P001), duplicate display-ID within file (P002), invalid display-ID format (P003), attribute in body (P020/P021/P022), and empty body (P030). Fenced-code-block awareness prevents false positives inside code blocks.
- **Identity diagnostics (MSL-I001-I008):** Dual-emit in core/validator/mod.ts -- emits BOTH legacy codes (MSL-R003/R004/R005/R006) AND nextgen codes (MSL-I001-I004/I007/I008) from the same validation checks. Follows ADR-012 add-alongside strategy.
- **Inline diagnostic (MSL-I005):** Emitted directly from parser when ULID is malformed.
- **CLI integration:** markspec validate now surfaces parse-level diagnostics alongside validator diagnostics.
- **ATDD acceptance tests:** 18 new e2e tests covering all new diagnostic codes.
- **Fixture updates:** Profile/traceability test fixtures updated to include body text for entries that now trigger MSL-P030.

### Design decisions

- **Add-alongside dual-emit:** No breaking changes -- legacy codes continue to emit; nextgen codes are additive. Per ADR-012 bounded exception (same precedent as MSL-B044/C072).
- **ASCII-only diagnostic messages:** All new messages use ASCII characters only to prevent LSP Content-Length byte/char mismatches.
- **Fenced-code-block tracking:** Body scan skips lines between fenced delimiters to avoid false P020 fires on code examples.
- **MSL-P001 returns early** (entry not admitted to results); **MSL-P002 continues** (entry structurally valid, just duplicated).

### Testing

- All 1296 tests pass (0 failures, 1 ignored)
- just build exits 0 (lint + test + type-check + compile)
- Round-trip/AST-equivalence e2e tests remain byte-untouched and green

### Not included (deferred)

- MSL-M050/M051 (deferred-by-dependency per ADR-014)
- Formatter/body-AST changes (SP3 territory)
- Migration of pre-existing diagnostic codes