### PR TITLE
feat(core): profile-schema Tier 2 — extends replaces shape, remove identified/referenced scope

### DIFF
--- a/docs/examples/profiles/aspice-swe-mini/markspec.yaml
+++ b/docs/examples/profiles/aspice-swe-mini/markspec.yaml
@@ -4,6 +4,7 @@
 
 id: "@markspec/profile-aspice-swe-mini"
 version: 0.1.0
+markspec-schema: "1"
 description: Minimal ASPICE SWE vertical (design validation)
 license: MIT
 extends: "npm:@markspec/profile-default@^1.0"
@@ -11,7 +12,7 @@ extends: "npm:@markspec/profile-default@^1.0"
 profile:
 
   # ==========================================================================
-  # Universal — applies to every entry regardless of shape or type
+  # Universal — applies to every entry regardless of type
   # ==========================================================================
   attributes:
     - { name: External-id, type: external-id, cardinality: 0..1 }
@@ -29,33 +30,17 @@ profile:
     - manual
 
   # ==========================================================================
-  # Per-shape defaults (the two core shapes from ADR-009 §1)
-  # ==========================================================================
-  identified:
-    attributes:
-      - { name: Derived-from, type: id-list }
-      - { name: Realized-by,  type: id-list }
-      - { name: Verifies,     type: id-list }
-      - { name: Tests,        type: id-list }
-    traceability:
-      Derived-from: { target: [{ shape: identified }] }
-
-  referenced:
-    attributes:
-      - { name: Reference-url, type: url, cardinality: 0..1 }
-
-  # ==========================================================================
-  # Per-type — each type declares its shape and tightens rules
+  # Per-type — each type declares its core-type extension and tightens rules
   # ==========================================================================
   types:
     stakeholder-requirement:
-      shape: identified
+      extends: Requirement
       color: primary
       description: Stakeholder requirement (SWE.1 input)
       display-id-pattern: "STK_{scope}_{n:04d}"
 
     software-requirement:
-      shape: identified
+      extends: Requirement
       color: primary
       description: Software requirement (SWE.1 output)
       display-id-pattern: "SRS_{scope}_{n:04d}"
@@ -67,7 +52,7 @@ profile:
           required: true
 
     software-element:
-      shape: identified
+      extends: SoftwareComponent
       color: secondary
       description: Software element spec (SWE.2)
       display-id-pattern: "SWE_{scope}_{n:04d}"
@@ -83,7 +68,7 @@ profile:
           required: true
 
     unit:
-      shape: identified
+      extends: SoftwareUnit
       color: tertiary
       description: Source-code unit (function, method, module)
       # display-id-pattern-enforcement: off  # namespace-path IDs
@@ -91,7 +76,7 @@ profile:
         - { name: Element-kind, type: enum, values: [module, class, function, source] }
 
     unit-test:
-      shape: identified
+      extends: Test
       color: danger
       description: Software unit test (SWE.4)
       display-id-pattern: "SWT_{scope}_{n:04d}"
@@ -107,7 +92,7 @@ profile:
           required: true
 
     integration-test:
-      shape: identified
+      extends: Test
       color: danger
       description: Software integration test (SWE.5)
       display-id-pattern: "SIT_{scope}_{n:04d}"
@@ -119,7 +104,7 @@ profile:
           required: true
 
     standard:
-      shape: referenced
+      extends: Specification
       description: External normative standard (ISO, DO, IEC, RFC, …)
 
   # ==========================================================================

--- a/docs/examples/profiles/default/markspec.yaml
+++ b/docs/examples/profiles/default/markspec.yaml
@@ -19,11 +19,6 @@ profile:
     warning: orange
     danger: red
 
-  identified:
-    attributes: []
-  referenced:
-    attributes: []
-
   types: {}
 
   documents:

--- a/packages/markspec/core/compiler/inverses.ts
+++ b/packages/markspec/core/compiler/inverses.ts
@@ -166,17 +166,6 @@ function collectInverseSpecs(profile: EffectiveProfile): InverseSpec[] {
     }
   }
 
-  // Identified shape scope
-  for (const [, entry] of profile.identified.attributes) {
-    if (entry.value.inverse) {
-      specs.push({
-        attrName: entry.value.name,
-        inverse: entry.value.inverse,
-        sourceType: null,
-      });
-    }
-  }
-
   // Type scopes
   for (const [typeName, typeEntry] of profile.types) {
     for (const [, attrEntry] of typeEntry.value.attributes) {

--- a/packages/markspec/core/compiler/inverses_test.ts
+++ b/packages/markspec/core/compiler/inverses_test.ts
@@ -3,7 +3,6 @@ import { generateInverses } from "./inverses.ts";
 import type {
   AttrDecl,
   EffectiveProfile,
-  EffectiveShapeScope,
   EffectiveTypeDef,
   Entry,
   ProvenancedMap,
@@ -53,23 +52,16 @@ function attrDecl(
   };
 }
 
-const emptyShapeScope: EffectiveShapeScope = {
-  required: { value: [], origin: "test-profile" },
-  attributes: new Map(),
-  traceability: new Map(),
-};
-
 function makeProfile(
   typeAttrs: Record<string, Record<string, AttrDecl>> = {},
   universalAttrs: Record<string, AttrDecl> = {},
-  identifiedAttrs: Record<string, AttrDecl> = {},
 ): EffectiveProfile {
   const types = new Map<string, ProvenancedMapEntry<EffectiveTypeDef>>();
   for (const [typeName, attrs] of Object.entries(typeAttrs)) {
     types.set(typeName, {
       value: {
         name: typeName,
-        shape: "Authored",
+        extends: "Item",
         displayIdPattern: { value: undefined, origin: "test-profile" },
         displayIdPatternEnforcement: { value: "off", origin: "test-profile" },
         color: { value: undefined, origin: "test-profile" },
@@ -81,15 +73,9 @@ function makeProfile(
     });
   }
   return {
-    required: { value: [], origin: "test-profile" },
     attributes: pm(universalAttrs),
     labels: { value: [], origin: "test-profile" },
     colors: new Map(),
-    identified: {
-      ...emptyShapeScope,
-      attributes: pm(identifiedAttrs),
-    },
-    referenced: emptyShapeScope,
     types,
     documents: { types: new Map(), frontMatter: new Map() },
   };
@@ -386,16 +372,16 @@ Deno.test("generateInverses: inverse from universal-scope attribute", () => {
   );
 });
 
-Deno.test("generateInverses: inverse from identified-shape-scope attribute", () => {
+Deno.test("generateInverses: inverse from per-type scope attribute", () => {
   const profile = makeProfile(
-    { requirement: {} },
-    {},
     {
-      Satisfies: attrDecl({
-        name: "Satisfies",
-        type: "id-list",
-        inverse: { name: "Satisfied-by", category: "requirement" },
-      }),
+      requirement: {
+        Satisfies: attrDecl({
+          name: "Satisfies",
+          type: "id-list",
+          inverse: { name: "Satisfied-by", category: "requirement" },
+        }),
+      },
     },
   );
 

--- a/packages/markspec/core/model/mod.ts
+++ b/packages/markspec/core/model/mod.ts
@@ -670,7 +670,6 @@ export type {
   Cardinality,
   DocTypeDef,
   EffectiveProfile,
-  EffectiveShapeScope,
   EffectiveTypeDef,
   EnforcementMode,
   InverseDecl,

--- a/packages/markspec/core/model/profile.ts
+++ b/packages/markspec/core/model/profile.ts
@@ -5,8 +5,6 @@
  * schema. Used by the profile loader, merger, and validator.
  */
 
-import type { EntryShape } from "./mod.ts";
-
 // ---------------------------------------------------------------------------
 // Value types (ADR-002 Annex C)
 // ---------------------------------------------------------------------------
@@ -91,7 +89,8 @@ export type EnforcementMode = "off" | "warn" | "error";
 
 export interface TypeDef {
   readonly name: string;
-  readonly shape: EntryShape;
+  /** The core type this profile type extends (e.g., "Requirement", "Test"). */
+  readonly extends: string;
   readonly displayIdPattern?: string;
   readonly displayIdPatternEnforcement: EnforcementMode;
   readonly required: readonly string[];
@@ -143,7 +142,6 @@ export interface ProfileManifest {
   readonly extends?: ProfileSpecifier;
 
   // profile: content section
-  readonly universalRequired: readonly string[];
   readonly universalAttributes: readonly AttrDecl[];
   readonly labels: readonly string[];
 
@@ -154,16 +152,6 @@ export interface ProfileManifest {
    * Empty when the manifest does not declare `profile.colors:`.
    */
   readonly colors: ReadonlyMap<string, string>;
-
-  readonly identified: {
-    readonly required: readonly string[];
-    readonly attributes: readonly AttrDecl[];
-    readonly traceability: ReadonlyMap<string, TraceRule>;
-  };
-  readonly referenced: {
-    readonly required: readonly string[];
-    readonly attributes: readonly AttrDecl[];
-  };
 
   readonly types: ReadonlyMap<string, TypeDef>;
 
@@ -232,19 +220,11 @@ export interface ProvenancedMapEntry<V> {
 /** Map with per-entry provenance. Keys are always strings (attr/type/link names). */
 export type ProvenancedMap<V> = ReadonlyMap<string, ProvenancedMapEntry<V>>;
 
-/** Shape-scope rules after merging (identified or referenced). */
-export interface EffectiveShapeScope {
-  readonly required: ProvenancedValue<readonly string[]>;
-  readonly attributes: ProvenancedMap<AttrDecl>;
-  /** Referenced scope's traceability is always empty (referenced entries don't originate links). */
-  readonly traceability: ProvenancedMap<TraceRule>;
-}
-
 /** Type-scope rules after merging. */
 export interface EffectiveTypeDef {
   readonly name: string;
-  /** Shape is frozen at the type's declaration — never changes across the chain. */
-  readonly shape: EntryShape;
+  /** The core type this profile type extends — frozen at declaration, never changes across the chain. */
+  readonly extends: string;
   readonly displayIdPattern: ProvenancedValue<string | undefined>;
   readonly displayIdPatternEnforcement: ProvenancedValue<EnforcementMode>;
   /** Resolved semantic color-role name, or `undefined` when unset. */
@@ -259,13 +239,10 @@ export interface EffectiveTypeDef {
  * per-rule provenance so a diagnostic can blame the right tier.
  */
 export interface EffectiveProfile {
-  readonly required: ProvenancedValue<readonly string[]>;
   readonly attributes: ProvenancedMap<AttrDecl>;
   readonly labels: ProvenancedValue<readonly string[]>;
   /** Semantic color-role bindings merged across the chain. */
   readonly colors: ProvenancedMap<string>;
-  readonly identified: EffectiveShapeScope;
-  readonly referenced: EffectiveShapeScope;
   readonly types: ProvenancedMap<EffectiveTypeDef>;
   readonly documents: {
     readonly types: ProvenancedMap<DocTypeDef>;

--- a/packages/markspec/core/profile/chain.ts
+++ b/packages/markspec/core/profile/chain.ts
@@ -239,20 +239,9 @@ function buildPlaceholderEffective(
 ): EffectiveProfile {
   const leafOrigin = tiers[tiers.length - 1]?.id ?? "<unknown>";
   return {
-    required: { value: [], origin: leafOrigin },
     attributes: new Map(),
     labels: { value: [], origin: leafOrigin },
     colors: new Map(),
-    identified: {
-      required: { value: [], origin: leafOrigin },
-      attributes: new Map(),
-      traceability: new Map(),
-    },
-    referenced: {
-      required: { value: [], origin: leafOrigin },
-      attributes: new Map(),
-      traceability: new Map(),
-    },
     types: new Map(),
     documents: { types: new Map(), frontMatter: new Map() },
   };

--- a/packages/markspec/core/profile/chain_test.ts
+++ b/packages/markspec/core/profile/chain_test.ts
@@ -191,7 +191,8 @@ Deno.test("loadChain: top-level git specifier routes through resolveGitSpecifier
     "/project",
     "/project",
     mockReadFile({
-      [loc.manifestPath]: `id: "@acme/from-git"\nversion: 1.0.0\nmarkspec-schema: "1"\n`,
+      [loc.manifestPath]:
+        `id: "@acme/from-git"\nversion: 1.0.0\nmarkspec-schema: "1"\n`,
     }),
     { runGit },
   );
@@ -222,7 +223,8 @@ Deno.test("loadChain: git specifier in extends chain is walked", async () => {
       "/project/profiles/child/markspec.yaml":
         `id: "@acme/child"\nversion: 1.0.0\nmarkspec-schema: "1"\n` +
         `extends: "git+${parentSpec.repo}#${parentSpec.tag}"\n`,
-      [parentLoc.manifestPath]: `id: "@acme/git-parent"\nversion: 1.0.0\nmarkspec-schema: "1"\n`,
+      [parentLoc.manifestPath]:
+        `id: "@acme/git-parent"\nversion: 1.0.0\nmarkspec-schema: "1"\n`,
     }),
     { runGit },
   );

--- a/packages/markspec/core/profile/colors_test.ts
+++ b/packages/markspec/core/profile/colors_test.ts
@@ -40,7 +40,7 @@ function makeProfile(
     Object.entries(typeColors).map(([name, color]) => [name, {
       value: {
         name,
-        shape: "Authored" as const,
+        extends: "Item",
         displayIdPattern: { value: undefined, origin: "test" },
         displayIdPatternEnforcement: { value: "off" as const, origin: "test" },
         color: { value: color, origin: "test" },
@@ -52,20 +52,9 @@ function makeProfile(
     }]),
   );
   return {
-    required: { value: [], origin: "test" },
     attributes: new Map(),
     labels: { value: [], origin: "test" },
     colors: colorsMap,
-    identified: {
-      required: { value: [], origin: "test" },
-      attributes: new Map(),
-      traceability: new Map(),
-    },
-    referenced: {
-      required: { value: [], origin: "test" },
-      attributes: new Map(),
-      traceability: new Map(),
-    },
     types: typesMap,
     documents: { types: new Map(), frontMatter: new Map() },
   } as EffectiveProfile;
@@ -172,14 +161,12 @@ profile:
     danger: red
   attributes: []
   labels: []
-  identified: { attributes: [] }
-  referenced: { attributes: [] }
   types:
     requirement:
-      shape: identified
+      extends: Requirement
       color: primary
     test:
-      shape: identified
+      extends: Test
       color: danger
   documents: { types: [], frontMatter: [] }
 `;
@@ -204,11 +191,9 @@ profile:
     primary: teal
   attributes: []
   labels: []
-  identified: { attributes: [] }
-  referenced: { attributes: [] }
   types:
     requirement:
-      shape: identified
+      extends: Requirement
   documents: { types: [], frontMatter: [] }
 `;
   const profile = loadEffective(yaml);
@@ -222,9 +207,9 @@ profile:
   );
 });
 
-Deno.test("integration: referenced-shape type stays uncolored even with color authored", () => {
-  // Manifest will emit MSL-PROFILE-COLOR-001 (warning) — manifest still
-  // loads, merge succeeds, and the renderer must return null.
+Deno.test("integration: referenced-shape entry stays uncolored even with type color declared", () => {
+  // A Reference-shape entry returns null regardless of what color the
+  // type declares — the renderer gates on entry.shape, not the profile.
   const yaml = `
 id: "@acme/profile"
 version: 1.0.0
@@ -233,11 +218,9 @@ profile:
     primary: blue
   attributes: []
   labels: []
-  identified: { attributes: [] }
-  referenced: { attributes: [] }
   types:
     standard:
-      shape: referenced
+      extends: Specification
       color: primary
   documents: { types: [], frontMatter: [] }
 `;

--- a/packages/markspec/core/profile/load.ts
+++ b/packages/markspec/core/profile/load.ts
@@ -140,8 +140,6 @@ function checkReservedRedefinitions(chain: ProfileChain): Diagnostic[] {
   }
 
   checkAttrMap(effective.attributes, "universal");
-  checkAttrMap(effective.identified.attributes, "identified");
-  checkAttrMap(effective.referenced.attributes, "referenced");
   for (const [typeName, typeEntry] of effective.types) {
     checkAttrMap(typeEntry.value.attributes, `type '${typeName}'`);
     if (CORE_TYPES.has(typeName)) {

--- a/packages/markspec/core/profile/manifest.ts
+++ b/packages/markspec/core/profile/manifest.ts
@@ -12,9 +12,9 @@ import {
   type AttrDecl,
   type Cardinality,
   COLOR_NAME_RE,
+  CORE_TYPES,
   type DocTypeDef,
   type EnforcementMode,
-  type EntryShape,
   LIST_VALUE_TYPES,
   PALETTE_HUES,
   type ProfileSpecifier,
@@ -38,25 +38,15 @@ const ALLOWED_ROOT_KEYS = new Set([
 ]);
 
 const ALLOWED_PROFILE_KEYS = new Set([
-  "required",
   "attributes",
   "labels",
   "colors",
-  "identified",
-  "referenced",
   "types",
   "documents",
 ]);
 
-const ALLOWED_IDENTIFIED_KEYS = new Set([
-  "required",
-  "attributes",
-  "traceability",
-]);
-const ALLOWED_REFERENCED_KEYS = new Set(["required", "attributes"]);
-
 const ALLOWED_TYPE_KEYS = new Set([
-  "shape",
+  "extends",
   "description",
   "display-id-pattern",
   "display-id-pattern-enforcement",
@@ -81,37 +71,6 @@ const ALLOWED_ATTR_KEYS = new Set([
 const ALLOWED_INVERSE_KEYS = new Set(["name", "category"]);
 
 const ALLOWED_TRACE_RULE_KEYS = new Set(["target", "cardinality", "required"]);
-
-function parseShapeScope(
-  raw: unknown,
-  allowedKeys: Set<string>,
-  context: string,
-  sourcePath: string,
-  diagnostics: Diagnostic[],
-): Record<string, unknown> | undefined {
-  if (raw === undefined) return {};
-  if (raw == null || typeof raw !== "object" || Array.isArray(raw)) {
-    diagnostics.push({
-      code: "PROFILE-LOAD-003",
-      severity: "error",
-      message: `${context}: must be a mapping`,
-      location: { file: sourcePath, line: 1, column: 1 },
-    });
-    return undefined;
-  }
-  const r = raw as Record<string, unknown>;
-  for (const key of Object.keys(r)) {
-    if (!allowedKeys.has(key)) {
-      diagnostics.push({
-        code: "PROFILE-LOAD-003",
-        severity: "error",
-        message: `${context}: unknown key '${key}'`,
-        location: { file: sourcePath, line: 1, column: 1 },
-      });
-    }
-  }
-  return r;
-}
 
 /** Result of parsing a profile manifest. */
 export interface ParseManifestResult {
@@ -629,38 +588,28 @@ function parseTypeDef(
     }
   }
 
-  // The profile-manifest `shape:` vocabulary is the authored
-  // `identified`/`referenced` surface (profile-schema §1.3 marks it
-  // obsolete — its removal is the profile-schema reconciliation slice,
-  // not this one). Map it one-directionally onto the internal EntryShape.
-  // NOT a backward-compat dual-accept: the new names are deliberately not
-  // accepted in authored YAML.
-  const rawShape = r.shape;
-  const shape: "Authored" | "Reference" | undefined = rawShape === "identified"
-    ? "Authored"
-    : rawShape === "referenced"
-    ? "Reference"
-    : undefined;
-  if (shape === undefined) {
+  const rawExtends = r.extends;
+  if (rawExtends === undefined) {
     diagnostics.push({
-      code: "PROFILE-LOAD-003",
-      severity: "error",
-      message: `${ctx}: 'shape' must be 'identified' or 'referenced'`,
-      location: { file: sourcePath, line: 1, column: 1 },
-    });
-    return undefined;
-  }
-
-  if (shape === "Reference" && r.traceability !== undefined) {
-    diagnostics.push({
-      code: "PROFILE-LOAD-003",
+      code: "PROFILE-TYPE-001",
       severity: "error",
       message:
-        `${ctx}: referenced types cannot declare traceability (referenced entries don't originate links)`,
+        `${ctx}: missing required field 'extends' (must be a core type name)`,
       location: { file: sourcePath, line: 1, column: 1 },
     });
     return undefined;
   }
+  if (typeof rawExtends !== "string" || !CORE_TYPES.has(rawExtends)) {
+    diagnostics.push({
+      code: "PROFILE-TYPE-002",
+      severity: "error",
+      message:
+        `${ctx}: 'extends' value '${rawExtends}' is not a recognised core type`,
+      location: { file: sourcePath, line: 1, column: 1 },
+    });
+    return undefined;
+  }
+  const extendsValue = rawExtends;
 
   let displayIdPattern: string | undefined;
   if (r["display-id-pattern"] !== undefined) {
@@ -704,15 +653,6 @@ function parseTypeDef(
       return undefined;
     }
     color = r.color;
-    if (shape === "Reference") {
-      diagnostics.push({
-        code: "MSL-PROFILE-COLOR-001",
-        severity: "warning",
-        message:
-          `${ctx}: 'color' on a referenced-shape type is ignored at render time`,
-        location: { file: sourcePath, line: 1, column: 1 },
-      });
-    }
   }
 
   const required = parseStringList(
@@ -727,18 +667,16 @@ function parseTypeDef(
     sourcePath,
     diagnostics,
   );
-  const traceability = shape === "Authored"
-    ? parseTraceabilityMap(
-      r.traceability,
-      `${ctx}.traceability`,
-      sourcePath,
-      diagnostics,
-    )
-    : new Map<string, TraceRule>();
+  const traceability = parseTraceabilityMap(
+    r.traceability,
+    `${ctx}.traceability`,
+    sourcePath,
+    diagnostics,
+  );
 
   return {
     name,
-    shape: shape as EntryShape,
+    extends: extendsValue,
     displayIdPattern,
     displayIdPatternEnforcement: enforcement,
     required,
@@ -939,7 +877,8 @@ export function parseManifest(
     diagnostics.push({
       code: "PROFILE-SCHEMA-001",
       severity: "error",
-      message: `profile targets core schema "${rawSchema}"; this MarkSpec implements "1"`,
+      message:
+        `profile targets core schema "${rawSchema}"; this MarkSpec implements "1"`,
       location: { file: sourcePath, line: 1, column: 1 },
     });
     return { manifest: null, diagnostics };
@@ -981,12 +920,6 @@ export function parseManifest(
 
   const profileSection = (rawProfile ?? {}) as Record<string, unknown>;
 
-  const universalRequired = parseStringList(
-    profileSection.required,
-    "profile.required",
-    sourcePath,
-    diagnostics,
-  );
   const universalAttributes = parseAttrList(
     profileSection.attributes,
     "profile.attributes",
@@ -1001,61 +934,6 @@ export function parseManifest(
   );
   const colors = parseColorsMap(
     profileSection.colors,
-    sourcePath,
-    diagnostics,
-  );
-
-  if (diagnostics.length > 0) {
-    return { manifest: null, diagnostics };
-  }
-
-  const idRaw = parseShapeScope(
-    profileSection.identified,
-    ALLOWED_IDENTIFIED_KEYS,
-    "profile.identified",
-    sourcePath,
-    diagnostics,
-  );
-  const refRaw = parseShapeScope(
-    profileSection.referenced,
-    ALLOWED_REFERENCED_KEYS,
-    "profile.referenced",
-    sourcePath,
-    diagnostics,
-  );
-
-  if (idRaw === undefined || refRaw === undefined || diagnostics.length > 0) {
-    return { manifest: null, diagnostics };
-  }
-
-  const identifiedRequired = parseStringList(
-    idRaw.required,
-    "profile.identified.required",
-    sourcePath,
-    diagnostics,
-  );
-  const identifiedAttributes = parseAttrList(
-    idRaw.attributes,
-    "profile.identified.attributes",
-    sourcePath,
-    diagnostics,
-  );
-  const identifiedTraceability = parseTraceabilityMap(
-    idRaw.traceability,
-    "profile.identified.traceability",
-    sourcePath,
-    diagnostics,
-  );
-
-  const referencedRequired = parseStringList(
-    refRaw.required,
-    "profile.referenced.required",
-    sourcePath,
-    diagnostics,
-  );
-  const referencedAttributes = parseAttrList(
-    refRaw.attributes,
-    "profile.referenced.attributes",
     sourcePath,
     diagnostics,
   );
@@ -1099,19 +977,9 @@ export function parseManifest(
       : undefined,
     license: typeof root.license === "string" ? root.license : undefined,
     extends: extendsSpec,
-    universalRequired,
     universalAttributes,
     labels,
     colors,
-    identified: {
-      required: identifiedRequired,
-      attributes: identifiedAttributes,
-      traceability: identifiedTraceability,
-    },
-    referenced: {
-      required: referencedRequired,
-      attributes: referencedAttributes,
-    },
     types: types,
     documents: documents,
   };

--- a/packages/markspec/core/profile/manifest_test.ts
+++ b/packages/markspec/core/profile/manifest_test.ts
@@ -68,7 +68,6 @@ Deno.test("parseManifest: profile section accepts only recognized keys", () => {
 id: "@acme/x"
 version: 1.0.0
 profile:
-  required: []
   nonsense: {}
 `);
   assertEquals(result.manifest, null);
@@ -78,13 +77,12 @@ profile:
   }
 });
 
-Deno.test("parseManifest: universal attributes + required + labels", () => {
+Deno.test("parseManifest: universal attributes + labels", () => {
   const result = parseManifest(`
 id: "@acme/x"
 version: 1.0.0
 markspec-schema: "1"
 profile:
-  required: [Status]
   labels: [DRAFT, INTERNAL]
   attributes:
     - name: Status
@@ -93,7 +91,6 @@ profile:
       required: false
 `);
   assertEquals(result.diagnostics.length, 0);
-  assertEquals(result.manifest?.universalRequired, ["Status"]);
   assertEquals(result.manifest?.labels, ["DRAFT", "INTERNAL"]);
   assertEquals(result.manifest?.universalAttributes.length, 1);
   const attr = result.manifest?.universalAttributes[0];
@@ -129,30 +126,6 @@ profile:
   assertEquals(result.diagnostics[0].code, "PROFILE-LOAD-003");
 });
 
-Deno.test("parseManifest: shape scopes parsed", () => {
-  const result = parseManifest(`
-id: "@acme/x"
-version: 1.0.0
-markspec-schema: "1"
-profile:
-  identified:
-    required: [Rationale]
-    attributes:
-      - name: Rationale
-        type: text
-  referenced:
-    attributes:
-      - name: Description
-        type: text
-`);
-  assertEquals(result.diagnostics.length, 0);
-  assertEquals(result.manifest?.identified.required, ["Rationale"]);
-  assertEquals(result.manifest?.identified.attributes.length, 1);
-  assertEquals(result.manifest?.identified.attributes[0].name, "Rationale");
-  assertEquals(result.manifest?.referenced.attributes.length, 1);
-  assertEquals(result.manifest?.referenced.attributes[0].name, "Description");
-});
-
 Deno.test("parseManifest: referenced.traceability is not a recognized key", () => {
   const result = parseManifest(`
 id: "@acme/x"
@@ -164,30 +137,6 @@ profile:
 `);
   assertEquals(result.manifest, null);
   assertEquals(result.diagnostics[0].code, "PROFILE-LOAD-003");
-});
-
-Deno.test("parseManifest: identified.traceability parsed", () => {
-  const result = parseManifest(`
-id: "@acme/x"
-version: 1.0.0
-markspec-schema: "1"
-profile:
-  identified:
-    traceability:
-      Derived-from:
-        target: [{shape: identified}]
-        cardinality: 0..N
-        required: false
-`);
-  assertEquals(result.diagnostics.length, 0);
-  const trace = result.manifest?.identified.traceability;
-  assertEquals(trace?.size, 1);
-  const rule = trace?.get("Derived-from");
-  assertEquals(rule?.target.length, 1);
-  assertEquals(rule?.target[0], { shape: "Authored" });
-  assertEquals(rule?.required, false);
-  assertEquals(rule?.cardinality?.lower, 0);
-  assertEquals(rule?.cardinality?.upper, Infinity);
 });
 
 Deno.test("parseManifest: traceability rejects bad shape matcher", () => {
@@ -226,7 +175,7 @@ markspec-schema: "1"
 profile:
   types:
     requirement:
-      shape: identified
+      extends: Requirement
       display-id-pattern: "REQ-{n:04d}"
       display-id-pattern-enforcement: error
       required: [Rationale]
@@ -239,13 +188,13 @@ profile:
           cardinality: 1..N
           required: true
     standard:
-      shape: referenced
+      extends: Specification
 `);
   assertEquals(result.diagnostics.length, 0);
   const types = result.manifest?.types;
   assertEquals(types?.size, 2);
   const req = types?.get("requirement");
-  assertEquals(req?.shape, "Authored");
+  assertEquals(req?.extends, "Requirement");
   assertEquals(req?.displayIdPattern, "REQ-{n:04d}");
   assertEquals(req?.displayIdPatternEnforcement, "error");
   assertEquals(req?.required, ["Rationale"]);
@@ -253,50 +202,27 @@ profile:
   const trace = req?.traceability.get("Derived-from");
   assertEquals(trace?.target, ["stakeholder-requirement"]);
   const std = types?.get("standard");
-  assertEquals(std?.shape, "Reference");
+  assertEquals(std?.extends, "Specification");
   assertEquals(std?.displayIdPatternEnforcement, "off");
 });
 
-Deno.test("parseManifest: type must declare shape", () => {
-  const result = parseManifest(`
-id: "@acme/x"
-version: 1.0.0
-profile:
-  types:
-    requirement:
-      attributes: []
-`);
-  assertEquals(result.manifest, null);
-  assertEquals(result.diagnostics[0].code, "PROFILE-LOAD-003");
-});
-
-Deno.test("parseManifest: type with bad shape errors", () => {
-  const result = parseManifest(`
-id: "@acme/x"
-version: 1.0.0
-profile:
-  types:
-    thing:
-      shape: sideways
-`);
-  assertEquals(result.manifest, null);
-  assertEquals(result.diagnostics[0].code, "PROFILE-LOAD-003");
-});
-
-Deno.test("parseManifest: referenced type with traceability errors", () => {
+Deno.test("parseManifest: Specification-extending type with traceability is valid in Tier 2", () => {
   const result = parseManifest(`
 id: "@acme/x"
 version: 1.0.0
 profile:
   types:
     standard:
-      shape: referenced
+      extends: Specification
       traceability:
         Something:
           target: [other]
 `);
-  assertEquals(result.manifest, null);
-  assertEquals(result.diagnostics[0].code, "PROFILE-LOAD-003");
+  assertExists(result.manifest);
+  assertEquals(
+    result.diagnostics.filter((d) => d.severity === "error"),
+    [],
+  );
 });
 
 Deno.test("parseManifest: documents section parsed", () => {
@@ -421,7 +347,7 @@ markspec-schema: "1"
 profile:
   types:
     test:
-      shape: identified
+      extends: Requirement
       attributes:
         - name: Verifies
           type: id-list
@@ -442,7 +368,7 @@ version: 1.0.0
 profile:
   types:
     x:
-      shape: identified
+      extends: Requirement
       attributes:
         - name: Foo
           type: text
@@ -461,7 +387,7 @@ version: 1.0.0
 profile:
   types:
     x:
-      shape: identified
+      extends: Requirement
       attributes:
         - name: Link
           type: id-list
@@ -486,10 +412,7 @@ Deno.test("parseManifest: complete fixture parses without diagnostics", async ()
   assertEquals(m.id, "@acme/profile-complete");
   assertEquals(m.version, "1.2.3");
   assertEquals(m.extends, { kind: "local", path: "./base" });
-  assertEquals(m.universalRequired, ["Status"]);
   assertEquals(m.universalAttributes.length, 1);
-  assertEquals(m.identified.traceability.get("Derived-from")?.target.length, 1);
-  assertEquals(m.referenced.attributes[0].name, "Description");
   assertEquals(m.types.size, 3);
   assertEquals(m.types.get("test")?.attributes[0].inverse?.name, "Verified-by");
   assertEquals(m.documents.types.length, 2);
@@ -526,7 +449,7 @@ version: 1.0.0
 profile:
   types:
     x:
-      shape: identified
+      extends: Requirement
       attributes:
         - name: Link
           type: id-list
@@ -559,7 +482,7 @@ version: 1.0.0
 profile:
   types:
     x:
-      shape: identified
+      extends: Requirement
       attributes:
         - name: Link
           type: id-list
@@ -577,11 +500,13 @@ Deno.test("parseManifest: unknown key on trace rule errors", () => {
 id: "@acme/x"
 version: 1.0.0
 profile:
-  identified:
-    traceability:
-      Bad:
-        target: [{shape: identified}]
-        garbage: 1
+  types:
+    req:
+      extends: Requirement
+      traceability:
+        Bad:
+          target: [stakeholder-req]
+          garbage: 1
 `);
   assertEquals(result.manifest, null);
   assertEquals(result.diagnostics[0].code, "PROFILE-LOAD-003");
@@ -613,8 +538,6 @@ profile:
     accent: red
   attributes: []
   labels: []
-  identified: { attributes: [] }
-  referenced: { attributes: [] }
   types: {}
   documents: { types: [], frontMatter: [] }
 `;
@@ -637,8 +560,6 @@ profile:
     primary: indigo
   attributes: []
   labels: []
-  identified: { attributes: [] }
-  referenced: { attributes: [] }
   types: {}
   documents: { types: [], frontMatter: [] }
 `;
@@ -659,8 +580,6 @@ profile:
     "Primary": blue
   attributes: []
   labels: []
-  identified: { attributes: [] }
-  referenced: { attributes: [] }
   types: {}
   documents: { types: [], frontMatter: [] }
 `;
@@ -681,11 +600,9 @@ profile:
     primary: blue
   attributes: []
   labels: []
-  identified: { attributes: [] }
-  referenced: { attributes: [] }
   types:
     requirement:
-      shape: identified
+      extends: Requirement
       color: primary
   documents: { types: [], frontMatter: [] }
 `;
@@ -700,7 +617,7 @@ profile:
   assertEquals(reqType.color, "primary");
 });
 
-Deno.test("parseManifest: color on referenced type emits MSL-PROFILE-COLOR-001 warning", () => {
+Deno.test("parseManifest: Specification-extending type with color loads cleanly in Tier 2 (no MSL-PROFILE-COLOR-001)", () => {
   const yaml = `
 id: test
 version: 1.0.0
@@ -709,21 +626,18 @@ profile:
     primary: blue
   attributes: []
   labels: []
-  identified: { attributes: [] }
-  referenced: { attributes: [] }
   types:
     standard:
-      shape: referenced
+      extends: Specification
       color: primary
   documents: { types: [], frontMatter: [] }
 `;
   const result = parseManifest(yaml, "test.yaml");
-  const warn = result.diagnostics.find((d) =>
+  // MSL-PROFILE-COLOR-001 (color on referenced type) was removed in Tier 2.
+  const color001 = result.diagnostics.find((d) =>
     d.code === "MSL-PROFILE-COLOR-001"
   );
-  assertExists(warn);
-  assertEquals(warn.severity, "warning");
-  // Manifest still loads — warning, not error.
+  assertEquals(color001, undefined);
   assertExists(result.manifest);
 });
 
@@ -775,23 +689,142 @@ markspec-schema: "1"
 profile:
   attributes: []
   labels: []
-  identified: { attributes: [] }
-  referenced: { attributes: [] }
   types:
     req:
-      shape: identified
+      extends: Requirement
       display-id-pattern: "REQ-{n:04d}"
       unknown-per-type-key: bad
   documents: { types: [], frontMatter: [] }
 `;
   const result = parseManifest(yaml);
-  const type005 = result.diagnostics.find((d) =>
-    d.code === "PROFILE-TYPE-005"
-  );
+  const type005 = result.diagnostics.find((d) => d.code === "PROFILE-TYPE-005");
   assertExists(type005);
   assertEquals(type005.severity, "error");
   const load003 = result.diagnostics.find((d) =>
     d.code === "PROFILE-LOAD-003" && d.message.includes("unknown-per-type-key")
   );
   assertEquals(load003, undefined);
+});
+
+// ─── Tier 2: extends: replaces shape:, scope sections removed ────────────────
+
+Deno.test("parseManifest (Tier 2): missing extends: in type emits PROFILE-TYPE-001", () => {
+  const yaml = `
+id: test
+version: 1.0.0
+markspec-schema: "1"
+profile:
+  types:
+    req:
+      display-id-pattern: "REQ-{n:04d}"
+`;
+  const result = parseManifest(yaml);
+  const d = result.diagnostics.find((d) => d.code === "PROFILE-TYPE-001");
+  assertExists(d);
+  assertEquals(d.severity, "error");
+  assertEquals(result.manifest, null);
+});
+
+Deno.test("parseManifest (Tier 2): extends: pointing to unknown core type emits PROFILE-TYPE-002", () => {
+  const yaml = `
+id: test
+version: 1.0.0
+markspec-schema: "1"
+profile:
+  types:
+    req:
+      extends: NotAType
+      display-id-pattern: "REQ-{n:04d}"
+`;
+  const result = parseManifest(yaml);
+  const d = result.diagnostics.find((d) => d.code === "PROFILE-TYPE-002");
+  assertExists(d);
+  assertEquals(d.severity, "error");
+  assertEquals(result.manifest, null);
+});
+
+Deno.test("parseManifest (Tier 2): extends: with valid core type is accepted", () => {
+  const yaml = `
+id: test
+version: 1.0.0
+markspec-schema: "1"
+profile:
+  types:
+    req:
+      extends: Requirement
+      display-id-pattern: "REQ-{n:04d}"
+`;
+  const result = parseManifest(yaml);
+  assertEquals(result.diagnostics.filter((d) => d.severity === "error"), []);
+  assertExists(result.manifest);
+  const req = result.manifest!.types.get("req");
+  assertExists(req);
+  assertEquals(req.extends, "Requirement");
+});
+
+Deno.test("parseManifest (Tier 2): identified: at profile root is unknown key", () => {
+  const yaml = `
+id: test
+version: 1.0.0
+markspec-schema: "1"
+profile:
+  identified:
+    attributes: []
+`;
+  const result = parseManifest(yaml);
+  const d = result.diagnostics.find(
+    (d) => d.code === "PROFILE-LOAD-003" && d.message.includes("'identified'"),
+  );
+  assertExists(d);
+  assertEquals(d.severity, "error");
+});
+
+Deno.test("parseManifest (Tier 2): referenced: at profile root is unknown key", () => {
+  const yaml = `
+id: test
+version: 1.0.0
+markspec-schema: "1"
+profile:
+  referenced:
+    attributes: []
+`;
+  const result = parseManifest(yaml);
+  const d = result.diagnostics.find(
+    (d) => d.code === "PROFILE-LOAD-003" && d.message.includes("'referenced'"),
+  );
+  assertExists(d);
+  assertEquals(d.severity, "error");
+});
+
+Deno.test("parseManifest (Tier 2): required: at profile root is unknown key", () => {
+  const yaml = `
+id: test
+version: 1.0.0
+markspec-schema: "1"
+profile:
+  required: [Status]
+`;
+  const result = parseManifest(yaml);
+  const d = result.diagnostics.find(
+    (d) => d.code === "PROFILE-LOAD-003" && d.message.includes("'required'"),
+  );
+  assertExists(d);
+  assertEquals(d.severity, "error");
+});
+
+Deno.test("parseManifest (Tier 2): shape: in type def is unknown key (PROFILE-TYPE-005)", () => {
+  const yaml = `
+id: test
+version: 1.0.0
+markspec-schema: "1"
+profile:
+  types:
+    req:
+      extends: Requirement
+      shape: Authored
+`;
+  const result = parseManifest(yaml);
+  const d = result.diagnostics.find((d) => d.code === "PROFILE-TYPE-005");
+  assertExists(d);
+  assertEquals(d.severity, "error");
 });

--- a/packages/markspec/core/profile/merge.ts
+++ b/packages/markspec/core/profile/merge.ts
@@ -13,12 +13,10 @@ import type {
   Diagnostic,
   DocTypeDef,
   EffectiveProfile,
-  EffectiveShapeScope,
   EffectiveTypeDef,
   LoadedProfile,
   ProfileChain,
   ProfileId,
-  ProfileManifest,
   ProvenancedMap,
   ProvenancedMapEntry,
   ProvenancedValue,
@@ -104,7 +102,6 @@ function foldTier(
   const m = tier.manifest;
 
   // Universal additive.
-  const required = unionList(base.required, m.universalRequired, origin);
   const labels = unionList(base.labels, m.labels, origin);
   const attributes = unionAttrMap(
     base.attributes,
@@ -116,41 +113,6 @@ function foldTier(
   // Colors map: last-write-wins per key, additive across tiers.
   const colors = unionColorsMap(base.colors, m.colors, origin);
 
-  // Shape scopes — same additive pattern.
-  const identified: EffectiveShapeScope = {
-    required: unionList(
-      base.identified.required,
-      m.identified.required,
-      origin,
-    ),
-    attributes: unionAttrMap(
-      base.identified.attributes,
-      m.identified.attributes,
-      origin,
-      diagnostics,
-    ),
-    traceability: unionTraceMap(
-      base.identified.traceability,
-      m.identified.traceability,
-      origin,
-      diagnostics,
-    ),
-  };
-  const referenced: EffectiveShapeScope = {
-    required: unionList(
-      base.referenced.required,
-      m.referenced.required,
-      origin,
-    ),
-    attributes: unionAttrMap(
-      base.referenced.attributes,
-      m.referenced.attributes,
-      origin,
-      diagnostics,
-    ),
-    traceability: base.referenced.traceability, // always empty
-  };
-
   // Types — add new types, fold existing ones.
   const types = new Map(base.types);
   for (const [name, td] of m.types) {
@@ -159,7 +121,7 @@ function foldTier(
       // Fresh type contributed by this tier.
       const eff: EffectiveTypeDef = {
         name,
-        shape: td.shape,
+        extends: td.extends,
         displayIdPattern: { value: td.displayIdPattern, origin },
         displayIdPatternEnforcement: {
           value: td.displayIdPatternEnforcement,
@@ -201,12 +163,9 @@ function foldTier(
   );
 
   const result: EffectiveProfile = {
-    required,
     attributes,
     labels,
     colors,
-    identified,
-    referenced,
     types,
     documents: {
       types: docTypes,
@@ -352,6 +311,7 @@ function tightenAttr(
       "type",
       `${parent.type} (${existing.origin})`,
       `${child.type} (${childOrigin})`,
+      "PROFILE-MERGE-011",
     ));
     return undefined;
   }
@@ -436,13 +396,14 @@ function tightenType(
   const name = child.name;
   const effExisting = existing.value;
 
-  // Shape must match.
-  if (effExisting.shape !== child.shape) {
+  // extends: must match — conflicting core-type targets is a merge error.
+  if (effExisting.extends !== child.extends) {
     diagnostics.push(mergeRelaxation(
       `type '${name}'`,
-      "shape",
-      `${effExisting.shape} (${existing.origin})`,
-      `${child.shape} (${childOrigin})`,
+      "extends",
+      `${effExisting.extends} (${existing.origin})`,
+      `${child.extends} (${childOrigin})`,
+      "PROFILE-MERGE-012",
     ));
     return undefined;
   }
@@ -516,7 +477,7 @@ function tightenType(
 
   const merged: EffectiveTypeDef = {
     name,
-    shape: effExisting.shape,
+    extends: effExisting.extends,
     displayIdPattern,
     displayIdPatternEnforcement: enforcement,
     color,
@@ -536,9 +497,10 @@ function mergeRelaxation(
   field: string,
   parentView: string,
   childView: string,
+  code: string = "PROFILE-MERGE-010",
 ): Diagnostic {
   return {
-    code: "PROFILE-MERGE-001",
+    code,
     severity: "error",
     message:
       `${subject}: field '${field}' relaxed by child (parent: ${parentView}, child: ${childView})`,
@@ -690,16 +652,9 @@ function seedFromTier(tier: LoadedProfile): EffectiveProfile {
   const m = tier.manifest;
 
   return {
-    required: { value: m.universalRequired, origin },
     attributes: mapFromAttrList(m.universalAttributes, origin),
     labels: { value: m.labels, origin },
     colors: mapFromColors(m.colors, origin),
-    identified: buildShapeScope(m.identified, origin),
-    referenced: {
-      required: { value: m.referenced.required, origin },
-      attributes: mapFromAttrList(m.referenced.attributes, origin),
-      traceability: new Map(),
-    },
     types: mapFromTypes(m.types, origin),
     documents: {
       types: mapFromDocTypes(m.documents.types, origin),
@@ -717,17 +672,6 @@ function mapFromColors(
     out.set(name, { value: hue, origin });
   }
   return out;
-}
-
-function buildShapeScope(
-  raw: ProfileManifest["identified"],
-  origin: ProfileId,
-): EffectiveShapeScope {
-  return {
-    required: { value: raw.required, origin },
-    attributes: mapFromAttrList(raw.attributes, origin),
-    traceability: mapFromTrace(raw.traceability, origin),
-  };
 }
 
 function mapFromAttrList(
@@ -760,7 +704,7 @@ function mapFromTypes(
   for (const [name, td] of types) {
     const eff: EffectiveTypeDef = {
       name,
-      shape: td.shape,
+      extends: td.extends,
       displayIdPattern: { value: td.displayIdPattern, origin },
       displayIdPatternEnforcement: {
         value: td.displayIdPatternEnforcement,

--- a/packages/markspec/core/profile/merge_test.ts
+++ b/packages/markspec/core/profile/merge_test.ts
@@ -32,20 +32,9 @@ function singleTierChain(yaml: string): ProfileChain {
   return {
     tiers: [tier],
     effective: {
-      required: { value: [], origin: tier.id },
       attributes: new Map(),
       labels: { value: [], origin: tier.id },
       colors: new Map(),
-      identified: {
-        required: { value: [], origin: tier.id },
-        attributes: new Map(),
-        traceability: new Map(),
-      },
-      referenced: {
-        required: { value: [], origin: tier.id },
-        attributes: new Map(),
-        traceability: new Map(),
-      },
       types: new Map(),
       documents: { types: new Map(), frontMatter: new Map() },
     },
@@ -59,14 +48,9 @@ Deno.test("mergeChain: single-tier empty profile produces empty effective profil
   const result = mergeChain(chain);
   assertEquals(result.diagnostics, []);
   const eff = result.effective!;
-  assertEquals(eff.required.value, []);
-  assertEquals(eff.required.origin, "@acme/single");
   assertEquals(eff.labels.value, []);
   assertEquals(eff.attributes.size, 0);
   assertEquals(eff.types.size, 0);
-  assertEquals(eff.identified.attributes.size, 0);
-  assertEquals(eff.identified.traceability.size, 0);
-  assertEquals(eff.referenced.attributes.size, 0);
   assertEquals(eff.documents.types.size, 0);
   assertEquals(eff.documents.frontMatter.size, 0);
 });
@@ -76,7 +60,6 @@ Deno.test("mergeChain: single-tier with universal attribute", () => {
 id: "@acme/single"
 version: 1.0.0
 profile:
-  required: [Status]
   attributes:
     - name: Status
       type: enum
@@ -85,8 +68,6 @@ profile:
   const result = mergeChain(chain);
   assertEquals(result.diagnostics, []);
   const eff = result.effective!;
-  assertEquals(eff.required.value, ["Status"]);
-  assertEquals(eff.required.origin, "@acme/single");
   assertEquals(eff.attributes.size, 1);
   const statusEntry = eff.attributes.get("Status")!;
   assertEquals(statusEntry.origin, "@acme/single");
@@ -101,7 +82,7 @@ version: 1.0.0
 profile:
   types:
     requirement:
-      shape: identified
+      extends: Requirement
       display-id-pattern: "REQ-{n:04d}"
       display-id-pattern-enforcement: warn
       required: [Rationale]
@@ -113,7 +94,7 @@ profile:
   assertEquals(result.diagnostics, []);
   const req = result.effective!.types.get("requirement")!;
   assertEquals(req.origin, "@acme/single");
-  assertEquals(req.value.shape, "Authored");
+  assertEquals(req.value.extends, "Requirement");
   assertEquals(req.value.displayIdPattern.value, "REQ-{n:04d}");
   assertEquals(req.value.displayIdPattern.origin, "@acme/single");
   assertEquals(req.value.displayIdPatternEnforcement.value, "warn");
@@ -148,20 +129,9 @@ function multiTierChain(yamls: readonly string[]): ProfileChain {
   return {
     tiers,
     effective: {
-      required: { value: [], origin: tiers[0].id },
       attributes: new Map(),
       labels: { value: [], origin: tiers[0].id },
       colors: new Map(),
-      identified: {
-        required: { value: [], origin: tiers[0].id },
-        attributes: new Map(),
-        traceability: new Map(),
-      },
-      referenced: {
-        required: { value: [], origin: tiers[0].id },
-        attributes: new Map(),
-        traceability: new Map(),
-      },
       types: new Map(),
       documents: { types: new Map(), frontMatter: new Map() },
     },
@@ -197,38 +167,6 @@ profile:
   assertEquals(eff.attributes.get("Owner")?.origin, "@acme/child");
 });
 
-Deno.test("mergeChain: additive — required is union", () => {
-  const chain = multiTierChain([
-    `
-id: "@acme/parent"
-version: 1.0.0
-profile:
-  required: [Status]
-  attributes:
-    - name: Status
-      type: enum
-      values: [draft, approved]
-`,
-    `
-id: "@acme/child"
-version: 1.0.0
-extends: "../parent"
-profile:
-  required: [Owner]
-  attributes:
-    - name: Owner
-      type: text
-`,
-  ]);
-  const result = mergeChain(chain);
-  assertEquals(result.diagnostics, []);
-  const eff = result.effective!;
-  // Order: parent entries come first, child's additions appended.
-  assertEquals(eff.required.value, ["Status", "Owner"]);
-  // required.origin points at the leaf child since it last modified the list.
-  assertEquals(eff.required.origin, "@acme/child");
-});
-
 Deno.test("mergeChain: additive — labels are union, deduplicated", () => {
   const chain = multiTierChain([
     `
@@ -259,7 +197,7 @@ version: 1.0.0
 profile:
   types:
     requirement:
-      shape: identified
+      extends: Requirement
 `,
     `
 id: "@acme/child"
@@ -268,7 +206,7 @@ extends: "../parent"
 profile:
   types:
     test:
-      shape: identified
+      extends: Requirement
 `,
   ]);
   const result = mergeChain(chain);
@@ -287,7 +225,7 @@ version: 1.0.0
 profile:
   types:
     requirement:
-      shape: identified
+      extends: Requirement
       attributes:
         - name: Rationale
           type: text
@@ -299,7 +237,7 @@ extends: "../parent"
 profile:
   types:
     requirement:
-      shape: identified
+      extends: Requirement
       attributes:
         - name: Owner
           type: text
@@ -321,7 +259,7 @@ version: 1.0.0
 profile:
   types:
     requirement:
-      shape: identified
+      extends: Requirement
       traceability:
         Derived-from:
           target: [{shape: identified}]
@@ -333,7 +271,7 @@ extends: "../parent"
 profile:
   types:
     requirement:
-      shape: identified
+      extends: Requirement
       traceability:
         Allocates-to:
           target: [{shape: identified}]
@@ -376,7 +314,7 @@ profile:
   assertEquals(tags.origin, "@acme/child");
 });
 
-Deno.test("mergeChain: relax — child widens cardinality emits PROFILE-MERGE-001", () => {
+Deno.test("mergeChain: relax — child widens cardinality emits PROFILE-MERGE-010", () => {
   const chain = multiTierChain([
     `
 id: "@acme/parent"
@@ -400,7 +338,7 @@ profile:
   ]);
   const result = mergeChain(chain);
   assertEquals(result.effective, null);
-  assertEquals(result.diagnostics[0].code, "PROFILE-MERGE-001");
+  assertEquals(result.diagnostics[0].code, "PROFILE-MERGE-010");
   const msg = result.diagnostics[0].message;
   if (!msg.includes("Tags") || !msg.includes("cardinality")) {
     throw new Error(`diagnostic message missing context: ${msg}`);
@@ -435,7 +373,7 @@ profile:
   assertEquals(status.value.values, ["draft", "approved"]);
 });
 
-Deno.test("mergeChain: relax — child adds enum value not in parent emits PROFILE-MERGE-001", () => {
+Deno.test("mergeChain: relax — child adds enum value not in parent emits PROFILE-MERGE-010", () => {
   const chain = multiTierChain([
     `
 id: "@acme/parent"
@@ -459,7 +397,7 @@ profile:
   ]);
   const result = mergeChain(chain);
   assertEquals(result.effective, null);
-  assertEquals(result.diagnostics[0].code, "PROFILE-MERGE-001");
+  assertEquals(result.diagnostics[0].code, "PROFILE-MERGE-010");
 });
 
 Deno.test("mergeChain: tighten — child sets required:true", () => {
@@ -489,7 +427,7 @@ profile:
   assertEquals(rationale.value.required, true);
 });
 
-Deno.test("mergeChain: relax — child sets required:false when parent had true", () => {
+Deno.test("mergeChain: relax — child sets required:false when parent had true emits PROFILE-MERGE-010", () => {
   const chain = multiTierChain([
     `
 id: "@acme/parent"
@@ -513,10 +451,10 @@ profile:
   ]);
   const result = mergeChain(chain);
   assertEquals(result.effective, null);
-  assertEquals(result.diagnostics[0].code, "PROFILE-MERGE-001");
+  assertEquals(result.diagnostics[0].code, "PROFILE-MERGE-010");
 });
 
-Deno.test("mergeChain: type mismatch — child changes attr type emits PROFILE-MERGE-001", () => {
+Deno.test("mergeChain: type mismatch — child changes attr type emits PROFILE-MERGE-011", () => {
   const chain = multiTierChain([
     `
 id: "@acme/parent"
@@ -538,10 +476,10 @@ profile:
   ]);
   const result = mergeChain(chain);
   assertEquals(result.effective, null);
-  assertEquals(result.diagnostics[0].code, "PROFILE-MERGE-001");
+  assertEquals(result.diagnostics[0].code, "PROFILE-MERGE-011");
 });
 
-Deno.test("mergeChain: type shape mismatch across tiers emits PROFILE-MERGE-001", () => {
+Deno.test("mergeChain: type extends mismatch across tiers emits PROFILE-MERGE-012", () => {
   const chain = multiTierChain([
     `
 id: "@acme/parent"
@@ -549,7 +487,7 @@ version: 1.0.0
 profile:
   types:
     thing:
-      shape: identified
+      extends: Requirement
 `,
     `
 id: "@acme/child"
@@ -558,19 +496,19 @@ extends: "../parent"
 profile:
   types:
     thing:
-      shape: referenced
+      extends: Test
 `,
   ]);
   const result = mergeChain(chain);
   assertEquals(result.effective, null);
-  assertEquals(result.diagnostics[0].code, "PROFILE-MERGE-001");
+  assertEquals(result.diagnostics[0].code, "PROFILE-MERGE-012");
   const msg = result.diagnostics[0].message;
-  if (!msg.includes("shape")) {
-    throw new Error(`expected 'shape' in message, got: ${msg}`);
+  if (!msg.includes("extends")) {
+    throw new Error(`expected 'extends' in message, got: ${msg}`);
   }
 });
 
-Deno.test("mergeChain: display-id-pattern differs between tiers emits PROFILE-MERGE-001", () => {
+Deno.test("mergeChain: display-id-pattern differs between tiers emits PROFILE-MERGE-010", () => {
   const chain = multiTierChain([
     `
 id: "@acme/parent"
@@ -578,7 +516,7 @@ version: 1.0.0
 profile:
   types:
     requirement:
-      shape: identified
+      extends: Requirement
       display-id-pattern: "REQ-{n:04d}"
 `,
     `
@@ -588,13 +526,13 @@ extends: "../parent"
 profile:
   types:
     requirement:
-      shape: identified
+      extends: Requirement
       display-id-pattern: "REQ-{n:06d}"
 `,
   ]);
   const result = mergeChain(chain);
   assertEquals(result.effective, null);
-  assertEquals(result.diagnostics[0].code, "PROFILE-MERGE-001");
+  assertEquals(result.diagnostics[0].code, "PROFILE-MERGE-010");
   const msg = result.diagnostics[0].message;
   if (!msg.includes("display-id-pattern")) {
     throw new Error(`expected 'display-id-pattern' in message, got: ${msg}`);
@@ -609,7 +547,7 @@ version: 1.0.0
 profile:
   types:
     requirement:
-      shape: identified
+      extends: Requirement
 `,
     `
 id: "@acme/child"
@@ -618,7 +556,7 @@ extends: "../parent"
 profile:
   types:
     requirement:
-      shape: identified
+      extends: Requirement
       display-id-pattern: "REQ-{n:04d}"
 `,
   ]);
@@ -637,7 +575,7 @@ version: 1.0.0
 profile:
   types:
     requirement:
-      shape: identified
+      extends: Requirement
       display-id-pattern: "REQ-{n:04d}"
       display-id-pattern-enforcement: warn
 `,
@@ -648,7 +586,7 @@ extends: "../parent"
 profile:
   types:
     requirement:
-      shape: identified
+      extends: Requirement
       display-id-pattern: "REQ-{n:04d}"
       display-id-pattern-enforcement: error
 `,
@@ -659,7 +597,7 @@ profile:
   assertEquals(req.displayIdPatternEnforcement.value, "error");
 });
 
-Deno.test("mergeChain: enforcement loosening error → warn emits PROFILE-MERGE-001", () => {
+Deno.test("mergeChain: enforcement loosening error → warn emits PROFILE-MERGE-010", () => {
   const chain = multiTierChain([
     `
 id: "@acme/parent"
@@ -667,7 +605,7 @@ version: 1.0.0
 profile:
   types:
     requirement:
-      shape: identified
+      extends: Requirement
       display-id-pattern: "REQ-{n:04d}"
       display-id-pattern-enforcement: error
 `,
@@ -678,14 +616,14 @@ extends: "../parent"
 profile:
   types:
     requirement:
-      shape: identified
+      extends: Requirement
       display-id-pattern: "REQ-{n:04d}"
       display-id-pattern-enforcement: warn
 `,
   ]);
   const result = mergeChain(chain);
   assertEquals(result.effective, null);
-  assertEquals(result.diagnostics[0].code, "PROFILE-MERGE-001");
+  assertEquals(result.diagnostics[0].code, "PROFILE-MERGE-010");
 });
 
 Deno.test("mergeChain: traceability target narrows valid subset", () => {
@@ -696,7 +634,7 @@ version: 1.0.0
 profile:
   types:
     requirement:
-      shape: identified
+      extends: Requirement
       traceability:
         Derived-from:
           target: [stakeholder-req, system-req]
@@ -708,7 +646,7 @@ extends: "../parent"
 profile:
   types:
     requirement:
-      shape: identified
+      extends: Requirement
       traceability:
         Derived-from:
           target: [stakeholder-req]
@@ -730,7 +668,7 @@ version: 1.0.0
 profile:
   types:
     requirement:
-      shape: identified
+      extends: Requirement
       traceability:
         Derived-from:
           target: [stakeholder-req]
@@ -742,66 +680,10 @@ extends: "../parent"
 profile:
   types:
     requirement:
-      shape: identified
+      extends: Requirement
       traceability:
         Derived-from:
           target: [stakeholder-req, system-req]
-`,
-  ]);
-  const result = mergeChain(chain);
-  assertEquals(result.effective, null);
-  assertEquals(result.diagnostics[0].code, "PROFILE-MERGE-002");
-});
-
-Deno.test("mergeChain: child narrows shape matcher to specific type is allowed", () => {
-  const chain = multiTierChain([
-    `
-id: "@acme/parent"
-version: 1.0.0
-profile:
-  identified:
-    traceability:
-      Derived-from:
-        target: [{shape: identified}]
-`,
-    `
-id: "@acme/child"
-version: 1.0.0
-extends: "../parent"
-profile:
-  identified:
-    traceability:
-      Derived-from:
-        target: [stakeholder-req]
-`,
-  ]);
-  const result = mergeChain(chain);
-  assertEquals(result.diagnostics, []);
-  const trace = result.effective!.identified.traceability
-    .get("Derived-from")!;
-  assertEquals(trace.value.target, ["stakeholder-req"]);
-});
-
-Deno.test("mergeChain: child adds shape matcher not in parent emits PROFILE-MERGE-002", () => {
-  const chain = multiTierChain([
-    `
-id: "@acme/parent"
-version: 1.0.0
-profile:
-  identified:
-    traceability:
-      Derived-from:
-        target: [{shape: identified}]
-`,
-    `
-id: "@acme/child"
-version: 1.0.0
-extends: "../parent"
-profile:
-  identified:
-    traceability:
-      Derived-from:
-        target: [{shape: identified}, {shape: referenced}]
 `,
   ]);
   const result = mergeChain(chain);
@@ -817,7 +699,7 @@ version: 1.0.0
 profile:
   types:
     requirement:
-      shape: identified
+      extends: Requirement
       traceability:
         Derived-from:
           target: [stakeholder-req]
@@ -830,7 +712,7 @@ extends: "../parent"
 profile:
   types:
     requirement:
-      shape: identified
+      extends: Requirement
       traceability:
         Derived-from:
           target: [stakeholder-req]
@@ -889,7 +771,7 @@ profile:
     primary: blue
   types:
     requirement:
-      shape: identified
+      extends: Requirement
       color: primary
 `);
   const result = mergeChain(chain);
@@ -908,7 +790,7 @@ profile:
     primary: blue
   types:
     requirement:
-      shape: identified
+      extends: Requirement
       color: missing
 `);
   const result = mergeChain(chain);
@@ -936,7 +818,7 @@ extends: "../parent"
 profile:
   types:
     requirement:
-      shape: identified
+      extends: Requirement
       color: primary
 `,
   ]);
@@ -958,7 +840,7 @@ version: 1.0.0
 profile:
   types:
     requirement:
-      shape: identified
+      extends: Requirement
       color: primary
 `,
     `
@@ -989,7 +871,7 @@ profile:
     new: blue
   types:
     requirement:
-      shape: identified
+      extends: Requirement
       color: new
 `,
     `
@@ -999,7 +881,7 @@ extends: "../parent"
 profile:
   types:
     requirement:
-      shape: identified
+      extends: Requirement
       color: new
 `,
   ]);
@@ -1008,4 +890,101 @@ profile:
   const t = result.effective!.types.get("requirement")!;
   assertEquals(t.value.color.value, "new");
   assertEquals(t.value.color.origin, "@acme/child");
+});
+
+// ─── Tier 2: MERGE code reclassification ─────────────────────────────────────
+
+Deno.test("mergeChain (Tier 2): cardinality relaxation emits PROFILE-MERGE-010", () => {
+  const chain = multiTierChain([
+    `
+id: "@acme/parent"
+version: 1.0.0
+profile:
+  attributes:
+    - name: Status
+      type: enum
+      required: true
+      cardinality: "1..1"
+      values: [Open, Closed]
+  types:
+    req:
+      extends: Requirement
+      display-id-pattern: "REQ-{n:04d}"
+`,
+    `
+id: "@acme/child"
+version: 1.0.0
+extends: "../parent"
+profile:
+  attributes:
+    - name: Status
+      type: enum
+      cardinality: "0..1"
+      values: [Open]
+  types:
+    req:
+      extends: Requirement
+`,
+  ]);
+  const result = mergeChain(chain);
+  assertEquals(result.diagnostics.length, 1);
+  assertEquals(result.diagnostics[0].code, "PROFILE-MERGE-010");
+});
+
+Deno.test("mergeChain (Tier 2): attribute type mismatch emits PROFILE-MERGE-011", () => {
+  const chain = multiTierChain([
+    `
+id: "@acme/parent"
+version: 1.0.0
+profile:
+  attributes:
+    - name: Ref
+      type: id
+  types:
+    req:
+      extends: Requirement
+      display-id-pattern: "REQ-{n:04d}"
+`,
+    `
+id: "@acme/child"
+version: 1.0.0
+extends: "../parent"
+profile:
+  attributes:
+    - name: Ref
+      type: text
+  types:
+    req:
+      extends: Requirement
+`,
+  ]);
+  const result = mergeChain(chain);
+  assertEquals(result.diagnostics.length, 1);
+  assertEquals(result.diagnostics[0].code, "PROFILE-MERGE-011");
+});
+
+Deno.test("mergeChain (Tier 2): conflicting extends: targets emits PROFILE-MERGE-012", () => {
+  const chain = multiTierChain([
+    `
+id: "@acme/parent"
+version: 1.0.0
+profile:
+  types:
+    req:
+      extends: Requirement
+      display-id-pattern: "REQ-{n:04d}"
+`,
+    `
+id: "@acme/child"
+version: 1.0.0
+extends: "../parent"
+profile:
+  types:
+    req:
+      extends: Test
+`,
+  ]);
+  const result = mergeChain(chain);
+  assertEquals(result.diagnostics.length, 1);
+  assertEquals(result.diagnostics[0].code, "PROFILE-MERGE-012");
 });

--- a/packages/markspec/core/profile/strawman_test.ts
+++ b/packages/markspec/core/profile/strawman_test.ts
@@ -114,12 +114,12 @@ Deno.test("strawman: software-requirement has Derived-from traceability rule", a
   assertEquals(derivedFrom.value.required, true);
 });
 
-Deno.test("strawman: standard type has referenced shape", async () => {
+Deno.test("strawman: standard type extends Specification", async () => {
   const result = await loadStrawmanChain();
   assertExists(result.chain);
   const standard = result.chain.effective.types.get("standard");
   assertExists(standard);
-  assertEquals(standard.value.shape, "Reference");
+  assertEquals(standard.value.extends, "Specification");
 });
 
 Deno.test("strawman: per-type color resolves through merged colors map", async () => {

--- a/packages/markspec/core/validator/attributes.ts
+++ b/packages/markspec/core/validator/attributes.ts
@@ -29,10 +29,10 @@ const CORE_RESERVED_KEYS: ReadonlySet<string> = new Set([
 
 /**
  * Effective attribute declarations and required list for an entry, derived
- * from the profile's universal, shape, and (when classified) type scopes.
+ * from the profile's universal and (when classified) type scopes.
  *
  * Scope layering (outer → inner):
- *   universal → shape.identified/referenced → types.<T>
+ *   universal → types.<T>
  *
  * Name collisions: inner scope wins. Required lists are concatenated in
  * scope order (universal first, type last) preserving duplicates across
@@ -45,7 +45,7 @@ export interface EffectiveAttrScope {
 
 /**
  * Compute the effective attribute scope for a given entry against the
- * profile. Uses universal + shape scope always; adds type scope only when
+ * profile. Uses universal scope always; adds type scope only when
  * `entry.type` is set and the type is declared in the profile.
  */
 export function effectiveScope(
@@ -56,18 +56,8 @@ export function effectiveScope(
   const attributes = new Map<string, AttrDecl>();
 
   // Universal scope.
-  required.push(...profile.required.value);
   for (const [name, attrEntry] of profile.attributes) {
     attributes.set(name, attrEntry.value);
-  }
-
-  // Shape scope.
-  const shapeScope = entry.shape === "Authored"
-    ? profile.identified
-    : profile.referenced;
-  required.push(...shapeScope.required.value);
-  for (const [name, e] of shapeScope.attributes) {
-    attributes.set(name, e.value);
   }
 
   // Type scope (only when classified).
@@ -85,14 +75,6 @@ export function effectiveScope(
   // names that aren't explicitly declared as attributes. A trace rule IS an
   // id-list attribute by definition — profile authors shouldn't have to
   // declare it in both places.
-  const shapeTrace = entry.shape === "Authored"
-    ? profile.identified.traceability
-    : profile.referenced.traceability;
-  for (const [name] of shapeTrace) {
-    if (!attributes.has(name)) {
-      attributes.set(name, synthesizedLinkAttr(name));
-    }
-  }
   if (entry.type !== undefined) {
     const typeEntry = profile.types.get(entry.type);
     if (typeEntry !== undefined) {

--- a/packages/markspec/core/validator/attributes_test.ts
+++ b/packages/markspec/core/validator/attributes_test.ts
@@ -9,7 +9,6 @@ import { effectiveScope, validateAttributesForEntry } from "./attributes.ts";
 import type {
   AttrDecl,
   EffectiveProfile,
-  EffectiveShapeScope,
   EffectiveTypeDef,
   Entry,
   EntryShape,
@@ -26,20 +25,8 @@ function provAttrs(
   return out;
 }
 
-function shapeScope(opts: {
-  required?: readonly string[];
-  attributes?: readonly AttrDecl[];
-}): EffectiveShapeScope {
-  return {
-    required: { value: opts.required ?? [], origin: ORIGIN },
-    attributes: provAttrs(opts.attributes ?? []),
-    traceability: new Map(),
-  };
-}
-
 function typeDef(opts: {
   name: string;
-  shape: EntryShape;
   required?: readonly string[];
   attributes?: readonly AttrDecl[];
 }): ProvenancedMapEntry<EffectiveTypeDef> {
@@ -47,7 +34,7 @@ function typeDef(opts: {
     origin: ORIGIN,
     value: {
       name: opts.name,
-      shape: opts.shape,
+      extends: "Requirement",
       displayIdPattern: { value: undefined, origin: ORIGIN },
       displayIdPatternEnforcement: { value: "off", origin: ORIGIN },
       color: { value: undefined, origin: ORIGIN },
@@ -59,21 +46,15 @@ function typeDef(opts: {
 }
 
 function profile(opts: {
-  universalRequired?: readonly string[];
   universalAttrs?: readonly AttrDecl[];
-  identified?: EffectiveShapeScope;
-  referenced?: EffectiveShapeScope;
   types?: ReadonlyArray<ProvenancedMapEntry<EffectiveTypeDef>>;
 }): EffectiveProfile {
   const typesMap = new Map<string, ProvenancedMapEntry<EffectiveTypeDef>>();
   for (const t of opts.types ?? []) typesMap.set(t.value.name, t);
   return {
-    required: { value: opts.universalRequired ?? [], origin: ORIGIN },
     attributes: provAttrs(opts.universalAttrs ?? []),
     labels: { value: [], origin: ORIGIN },
     colors: new Map(),
-    identified: opts.identified ?? shapeScope({}),
-    referenced: opts.referenced ?? shapeScope({}),
     types: typesMap,
     documents: { types: new Map(), frontMatter: new Map() },
   };
@@ -129,54 +110,45 @@ const notesAttr: AttrDecl = {
 
 Deno.test("effectiveScope: universal only", () => {
   const p = profile({
-    universalRequired: ["Status"],
     universalAttrs: [statusAttr],
   });
   const e = entry({ shape: "Authored" });
   const scope = effectiveScope(e, p);
-  assertEquals(scope.required, ["Status"]);
+  assertEquals(scope.required, []);
   assertEquals(scope.attributes.size, 1);
   assertEquals(scope.attributes.get("Status"), statusAttr);
 });
 
-Deno.test("effectiveScope: universal + identified shape for identified entry", () => {
+Deno.test("effectiveScope: Authored entry without type uses only universal scope", () => {
   const p = profile({
     universalAttrs: [statusAttr],
-    identified: shapeScope({
-      required: ["Rationale"],
+    types: [typeDef({
+      name: "requirement",
       attributes: [textAttr],
-    }),
-    referenced: shapeScope({
-      attributes: [notesAttr],
-    }),
+    })],
   });
   const e = entry({ shape: "Authored" });
   const scope = effectiveScope(e, p);
-  assertEquals(scope.required, ["Rationale"]);
-  assertEquals(scope.attributes.size, 2);
+  assertEquals(scope.required, []);
+  assertEquals(scope.attributes.size, 1);
   assertEquals(scope.attributes.has("Status"), true);
-  assertEquals(scope.attributes.has("Rationale"), true);
-  assertEquals(scope.attributes.has("Notes"), false);
+  assertEquals(scope.attributes.has("Rationale"), false);
 });
 
-Deno.test("effectiveScope: universal + referenced shape for referenced entry", () => {
+Deno.test("effectiveScope: Reference entry without type uses only universal scope", () => {
   const p = profile({
     universalAttrs: [statusAttr],
-    identified: shapeScope({
-      attributes: [textAttr],
-    }),
-    referenced: shapeScope({
-      required: ["Notes"],
+    types: [typeDef({
+      name: "requirement",
       attributes: [notesAttr],
-    }),
+    })],
   });
   const e = entry({ shape: "Reference" });
   const scope = effectiveScope(e, p);
-  assertEquals(scope.required, ["Notes"]);
-  assertEquals(scope.attributes.size, 2);
+  assertEquals(scope.required, []);
+  assertEquals(scope.attributes.size, 1);
   assertEquals(scope.attributes.has("Status"), true);
-  assertEquals(scope.attributes.has("Notes"), true);
-  assertEquals(scope.attributes.has("Rationale"), false);
+  assertEquals(scope.attributes.has("Notes"), false);
 });
 
 Deno.test("effectiveScope: classified entry adds type-specific scope", () => {
@@ -189,10 +161,8 @@ Deno.test("effectiveScope: classified entry adds type-specific scope", () => {
   };
   const p = profile({
     universalAttrs: [statusAttr],
-    identified: shapeScope({ attributes: [textAttr] }),
     types: [typeDef({
       name: "requirement",
-      shape: "Authored",
       required: ["ASIL"],
       attributes: [asilAttr],
     })],
@@ -200,11 +170,11 @@ Deno.test("effectiveScope: classified entry adds type-specific scope", () => {
   const e = entry({ shape: "Authored", type: "requirement" });
   const scope = effectiveScope(e, p);
   assertEquals(scope.required, ["ASIL"]);
-  assertEquals(scope.attributes.size, 3);
+  assertEquals(scope.attributes.size, 2);
   assertEquals(scope.attributes.has("ASIL"), true);
 });
 
-Deno.test("effectiveScope: un-classified entry uses only universal + shape", () => {
+Deno.test("effectiveScope: un-classified entry uses only universal scope", () => {
   const asilAttr: AttrDecl = {
     name: "ASIL",
     type: "enum",
@@ -214,30 +184,22 @@ Deno.test("effectiveScope: un-classified entry uses only universal + shape", () 
   };
   const p = profile({
     universalAttrs: [statusAttr],
-    identified: shapeScope({ attributes: [textAttr] }),
     types: [typeDef({
       name: "requirement",
-      shape: "Authored",
       attributes: [asilAttr],
     })],
   });
   const e = entry({ shape: "Authored" });
   const scope = effectiveScope(e, p);
-  assertEquals(scope.attributes.size, 2);
+  assertEquals(scope.attributes.size, 1);
   assertEquals(scope.attributes.has("ASIL"), false);
 });
 
-Deno.test("effectiveScope: required lists concatenated in scope order", () => {
+Deno.test("effectiveScope: required comes from type scope only", () => {
   const p = profile({
-    universalRequired: ["Status"],
     universalAttrs: [statusAttr],
-    identified: shapeScope({
-      required: ["Rationale"],
-      attributes: [textAttr],
-    }),
     types: [typeDef({
       name: "requirement",
-      shape: "Authored",
       required: ["ASIL"],
       attributes: [{
         name: "ASIL",
@@ -250,11 +212,11 @@ Deno.test("effectiveScope: required lists concatenated in scope order", () => {
   });
   const e = entry({ shape: "Authored", type: "requirement" });
   const scope = effectiveScope(e, p);
-  assertEquals(scope.required, ["Status", "Rationale", "ASIL"]);
+  assertEquals(scope.required, ["ASIL"]);
 });
 
-Deno.test("effectiveScope: type-scope attr wins over shape-scope attr on name collision", () => {
-  const shapeStatus: AttrDecl = {
+Deno.test("effectiveScope: type-scope attr wins over universal attr on name collision", () => {
+  const universalStatus: AttrDecl = {
     name: "Status",
     type: "text",
     required: false,
@@ -268,10 +230,9 @@ Deno.test("effectiveScope: type-scope attr wins over shape-scope attr on name co
     values: ["draft", "approved"],
   };
   const p = profile({
-    identified: shapeScope({ attributes: [shapeStatus] }),
+    universalAttrs: [universalStatus],
     types: [typeDef({
       name: "requirement",
-      shape: "Authored",
       attributes: [typeStatus],
     })],
   });
@@ -282,10 +243,14 @@ Deno.test("effectiveScope: type-scope attr wins over shape-scope attr on name co
 
 Deno.test("validateAttributesForEntry: required missing → MSL-A001", () => {
   const p = profile({
-    universalRequired: ["Status"],
     universalAttrs: [statusAttr],
+    types: [typeDef({
+      name: "requirement",
+      required: ["Status"],
+      attributes: [statusAttr],
+    })],
   });
-  const e = entry({ shape: "Authored", attrs: {} });
+  const e = entry({ shape: "Authored", type: "requirement", attrs: {} });
   const diags = validateAttributesForEntry(e, p);
   const a001 = diags.find((d) => d.code === "MSL-A001");
   if (!a001) {
@@ -298,11 +263,16 @@ Deno.test("validateAttributesForEntry: required missing → MSL-A001", () => {
 
 Deno.test("validateAttributesForEntry: required present → no MSL-A001", () => {
   const p = profile({
-    universalRequired: ["Status"],
     universalAttrs: [statusAttr],
+    types: [typeDef({
+      name: "requirement",
+      required: ["Status"],
+      attributes: [statusAttr],
+    })],
   });
   const e = entry({
     shape: "Authored",
+    type: "requirement",
     attrs: { Status: ["draft"] },
   });
   const diags = validateAttributesForEntry(e, p);
@@ -458,26 +428,29 @@ Deno.test("effectiveScope: trace rule without explicit attribute declaration syn
     required: true,
   };
   const p: EffectiveProfile = {
-    required: { value: [], origin },
     attributes: new Map(),
     labels: { value: [], origin },
     colors: new Map(),
-    identified: {
-      required: { value: [], origin },
-      attributes: new Map(),
-      traceability: new Map([
-        ["Verifies", { value: traceRule, origin }],
-      ]),
-    },
-    referenced: {
-      required: { value: [], origin },
-      attributes: new Map(),
-      traceability: new Map(),
-    },
-    types: new Map(),
+    types: new Map([
+      ["requirement", {
+        origin,
+        value: {
+          name: "requirement",
+          extends: "Requirement",
+          displayIdPattern: { value: undefined, origin },
+          displayIdPatternEnforcement: { value: "off", origin },
+          color: { value: undefined, origin },
+          required: { value: [], origin },
+          attributes: new Map(),
+          traceability: new Map([
+            ["Verifies", { value: traceRule, origin }],
+          ]),
+        },
+      }],
+    ]),
     documents: { types: new Map(), frontMatter: new Map() },
   };
-  const e = entry({ shape: "Authored" });
+  const e = entry({ shape: "Authored", type: "requirement" });
   const scope = effectiveScope(e, p);
   const verifies = scope.attributes.get("Verifies");
   if (!verifies) throw new Error("expected synthesized Verifies attribute");
@@ -487,8 +460,9 @@ Deno.test("effectiveScope: trace rule without explicit attribute declaration syn
 });
 
 Deno.test("effectiveScope: explicit attribute declaration wins over trace-rule synthesis", () => {
-  // If the profile declares both the attribute AND the trace rule,
-  // the explicit attr wins (not synthesized).
+  // If the profile declares the attribute explicitly at universal scope AND the
+  // type has a trace rule for the same key, the explicit attr wins — synthesis
+  // only fires when the key is not already in the scope map.
   const origin = ORIGIN;
   const explicitAttr: AttrDecl = {
     name: "Verifies",
@@ -502,28 +476,31 @@ Deno.test("effectiveScope: explicit attribute declaration wins over trace-rule s
     required: false,
   };
   const p: EffectiveProfile = {
-    required: { value: [], origin },
     attributes: new Map([
       ["Verifies", { value: explicitAttr, origin }],
     ]),
     labels: { value: [], origin },
     colors: new Map(),
-    identified: {
-      required: { value: [], origin },
-      attributes: new Map(),
-      traceability: new Map([
-        ["Verifies", { value: traceRule, origin }],
-      ]),
-    },
-    referenced: {
-      required: { value: [], origin },
-      attributes: new Map(),
-      traceability: new Map(),
-    },
-    types: new Map(),
+    types: new Map([
+      ["requirement", {
+        origin,
+        value: {
+          name: "requirement",
+          extends: "Requirement",
+          displayIdPattern: { value: undefined, origin },
+          displayIdPatternEnforcement: { value: "off", origin },
+          color: { value: undefined, origin },
+          required: { value: [], origin },
+          attributes: new Map(),
+          traceability: new Map([
+            ["Verifies", { value: traceRule, origin }],
+          ]),
+        },
+      }],
+    ]),
     documents: { types: new Map(), frontMatter: new Map() },
   };
-  const e = entry({ shape: "Authored" });
+  const e = entry({ shape: "Authored", type: "requirement" });
   const scope = effectiveScope(e, p);
   assertEquals(scope.attributes.get("Verifies"), explicitAttr);
 });

--- a/packages/markspec/core/validator/normalize_test.ts
+++ b/packages/markspec/core/validator/normalize_test.ts
@@ -28,20 +28,9 @@ function profile(opts: {
   universalAttrs?: readonly AttrDecl[];
 }): EffectiveProfile {
   return {
-    required: { value: [], origin: ORIGIN },
     attributes: provAttrs(opts.universalAttrs ?? []),
     labels: { value: [], origin: ORIGIN },
     colors: new Map(),
-    identified: {
-      required: { value: [], origin: ORIGIN },
-      attributes: new Map(),
-      traceability: new Map(),
-    },
-    referenced: {
-      required: { value: [], origin: ORIGIN },
-      attributes: new Map(),
-      traceability: new Map(),
-    },
     types: new Map(),
     documents: { types: new Map(), frontMatter: new Map() },
   };
@@ -199,25 +188,14 @@ Deno.test("normalizeListValues: entry with no typedAttributes is returned as-is"
 Deno.test("normalizeListValues: type-scope declarations are considered", () => {
   const origin = ORIGIN;
   const p: EffectiveProfile = {
-    required: { value: [], origin },
     attributes: new Map(),
     labels: { value: [], origin },
     colors: new Map(),
-    identified: {
-      required: { value: [], origin },
-      attributes: new Map(),
-      traceability: new Map(),
-    },
-    referenced: {
-      required: { value: [], origin },
-      attributes: new Map(),
-      traceability: new Map(),
-    },
     types: new Map([
       ["requirement", {
         value: {
           name: "requirement",
-          shape: "Authored",
+          extends: "Requirement",
           displayIdPattern: { value: undefined, origin },
           displayIdPatternEnforcement: { value: "off", origin },
           color: { value: undefined, origin },

--- a/packages/markspec/core/validator/pipeline.ts
+++ b/packages/markspec/core/validator/pipeline.ts
@@ -177,8 +177,5 @@ function collectAllProfileAttributes(
     // so Stage 1's MSL-R010 doesn't flag them before Stage 2 classifies.
     for (const name of typeEntry.value.traceability.keys()) out.add(name);
   }
-  // Shape-level trace rule link names too.
-  for (const name of profile.identified.traceability.keys()) out.add(name);
-  for (const name of profile.referenced.traceability.keys()) out.add(name);
   return out;
 }

--- a/packages/markspec/core/validator/pipeline_test.ts
+++ b/packages/markspec/core/validator/pipeline_test.ts
@@ -45,7 +45,7 @@ function buildProfileWithRequirement(): EffectiveProfile {
   const reqType: ProvenancedMapEntry<EffectiveTypeDef> = {
     value: {
       name: "requirement",
-      shape: "Authored",
+      extends: "Requirement",
       displayIdPattern: { value: "REQ-{n:04d}", origin },
       displayIdPatternEnforcement: { value: "off", origin },
       color: { value: undefined, origin },
@@ -56,20 +56,9 @@ function buildProfileWithRequirement(): EffectiveProfile {
     origin,
   };
   return {
-    required: { value: [], origin },
     attributes: new Map(),
     labels: { value: [], origin },
     colors: new Map(),
-    identified: {
-      required: { value: [], origin },
-      attributes: new Map(),
-      traceability: new Map(),
-    },
-    referenced: {
-      required: { value: [], origin },
-      attributes: new Map(),
-      traceability: new Map(),
-    },
     types: new Map([["requirement", reqType]]),
     documents: { types: new Map(), frontMatter: new Map() },
   };
@@ -148,7 +137,7 @@ Deno.test("runPipeline: Stage 3 checks attributes of classified entries", () => 
     origin,
     value: {
       name: "requirement",
-      shape: "Authored",
+      extends: "Requirement",
       displayIdPattern: { value: "REQ-{n:04d}", origin },
       displayIdPatternEnforcement: { value: "off", origin },
       color: { value: undefined, origin },
@@ -160,20 +149,9 @@ Deno.test("runPipeline: Stage 3 checks attributes of classified entries", () => 
     },
   };
   const profile: EffectiveProfile = {
-    required: { value: [], origin },
     attributes: new Map(),
     labels: { value: [], origin },
     colors: new Map(),
-    identified: {
-      required: { value: [], origin },
-      attributes: new Map(),
-      traceability: new Map(),
-    },
-    referenced: {
-      required: { value: [], origin },
-      attributes: new Map(),
-      traceability: new Map(),
-    },
     types: new Map([["requirement", reqType]]),
     documents: { types: new Map(), frontMatter: new Map() },
   };
@@ -214,20 +192,9 @@ Deno.test("runPipeline: MSL-R010 suppressed for profile-declared attributes", ()
     cardinality: { lower: 0, upper: 1 },
   };
   const profile: EffectiveProfile = {
-    required: { value: [], origin },
     attributes: new Map([["Rationale", { value: rationaleAttr, origin }]]),
     labels: { value: [], origin },
     colors: new Map(),
-    identified: {
-      required: { value: [], origin },
-      attributes: new Map(),
-      traceability: new Map(),
-    },
-    referenced: {
-      required: { value: [], origin },
-      attributes: new Map(),
-      traceability: new Map(),
-    },
     types: new Map(),
     documents: { types: new Map(), frontMatter: new Map() },
   };
@@ -262,20 +229,9 @@ Deno.test("runPipeline: MSL-R010 suppressed for profile-declared attributes", ()
 Deno.test("runPipeline: profile with zero types runs Stage 2 permissively", () => {
   const origin = "@test/p";
   const profile: EffectiveProfile = {
-    required: { value: [], origin },
     attributes: new Map(),
     labels: { value: [], origin },
     colors: new Map(),
-    identified: {
-      required: { value: [], origin },
-      attributes: new Map(),
-      traceability: new Map(),
-    },
-    referenced: {
-      required: { value: [], origin },
-      attributes: new Map(),
-      traceability: new Map(),
-    },
     types: new Map(),
     documents: { types: new Map(), frontMatter: new Map() },
   };
@@ -299,7 +255,7 @@ Deno.test("runPipeline: Stage 4 catches required link missing", () => {
     origin,
     value: {
       name: "test",
-      shape: "Authored",
+      extends: "Requirement",
       displayIdPattern: { value: "TEST-{n:04d}", origin },
       displayIdPatternEnforcement: { value: "off", origin },
       color: { value: undefined, origin },
@@ -311,20 +267,9 @@ Deno.test("runPipeline: Stage 4 catches required link missing", () => {
     },
   };
   const profile: EffectiveProfile = {
-    required: { value: [], origin },
     attributes: new Map(),
     labels: { value: [], origin },
     colors: new Map(),
-    identified: {
-      required: { value: [], origin },
-      attributes: new Map(),
-      traceability: new Map(),
-    },
-    referenced: {
-      required: { value: [], origin },
-      attributes: new Map(),
-      traceability: new Map(),
-    },
     types: new Map([["test", reqType]]),
     documents: { types: new Map(), frontMatter: new Map() },
   };
@@ -364,22 +309,11 @@ Deno.test("runPipeline: Stage 2.5 normalization splits comma-separated id-list v
     cardinality: { lower: 0, upper: Infinity },
   };
   const profile: EffectiveProfile = {
-    required: { value: [], origin },
     attributes: new Map([
       ["Verifies", { value: verifiesAttr, origin }],
     ]),
     labels: { value: [], origin },
     colors: new Map(),
-    identified: {
-      required: { value: [], origin },
-      attributes: new Map(),
-      traceability: new Map(),
-    },
-    referenced: {
-      required: { value: [], origin },
-      attributes: new Map(),
-      traceability: new Map(),
-    },
     types: new Map(),
     documents: { types: new Map(), frontMatter: new Map() },
   };

--- a/packages/markspec/core/validator/traceability.ts
+++ b/packages/markspec/core/validator/traceability.ts
@@ -24,11 +24,10 @@ import type {
 } from "../model/mod.ts";
 
 /**
- * Effective trace rules for an entry: union of identified-shape-scope rules
- * and (when classified) type-scope rules. Type-scope rules win on
- * link-attribute-name collision.
+ * Effective trace rules for an entry: type-scope rules only.
+ * Type-scope rules are applied only when the entry is classified.
  *
- * Referenced entries always return an empty map.
+ * Reference entries (shape !== "Authored") always return an empty map.
  */
 export function effectiveTraceRules(
   entry: Entry,
@@ -36,11 +35,6 @@ export function effectiveTraceRules(
 ): ReadonlyMap<string, TraceRule> {
   const out = new Map<string, TraceRule>();
   if (entry.shape !== "Authored") return out;
-
-  // Shape scope.
-  for (const [name, ruleEntry] of profile.identified.traceability) {
-    out.set(name, ruleEntry.value);
-  }
 
   // Type scope (only when classified AND type is declared in the profile).
   if (entry.type !== undefined) {

--- a/packages/markspec/core/validator/traceability_test.ts
+++ b/packages/markspec/core/validator/traceability_test.ts
@@ -12,7 +12,6 @@ import {
 } from "./traceability.ts";
 import type {
   EffectiveProfile,
-  EffectiveShapeScope,
   EffectiveTypeDef,
   Entry,
   EntryShape,
@@ -32,26 +31,15 @@ function traceMap(
   return out;
 }
 
-function shapeScope(opts: {
-  traceability?: Record<string, TraceRule>;
-}): EffectiveShapeScope {
-  return {
-    required: { value: [], origin: ORIGIN },
-    attributes: new Map(),
-    traceability: traceMap(opts.traceability ?? {}),
-  };
-}
-
 function typeDef(opts: {
   name: string;
-  shape: EntryShape;
   traceability?: Record<string, TraceRule>;
 }): ProvenancedMapEntry<EffectiveTypeDef> {
   return {
     origin: ORIGIN,
     value: {
       name: opts.name,
-      shape: opts.shape,
+      extends: "Requirement",
       displayIdPattern: { value: undefined, origin: ORIGIN },
       displayIdPatternEnforcement: { value: "off", origin: ORIGIN },
       color: { value: undefined, origin: ORIGIN },
@@ -63,19 +51,14 @@ function typeDef(opts: {
 }
 
 function profile(opts: {
-  identified?: EffectiveShapeScope;
-  referenced?: EffectiveShapeScope;
   types?: ReadonlyArray<ProvenancedMapEntry<EffectiveTypeDef>>;
 }): EffectiveProfile {
   const typesMap = new Map<string, ProvenancedMapEntry<EffectiveTypeDef>>();
   for (const t of opts.types ?? []) typesMap.set(t.value.name, t);
   return {
-    required: { value: [], origin: ORIGIN },
     attributes: new Map(),
     labels: { value: [], origin: ORIGIN },
     colors: new Map(),
-    identified: opts.identified ?? shapeScope({}),
-    referenced: opts.referenced ?? shapeScope({}),
     types: typesMap,
     documents: { types: new Map(), frontMatter: new Map() },
   };
@@ -108,38 +91,36 @@ const verifiesRule: TraceRule = {
   required: true,
 };
 
-Deno.test("effectiveTraceRules: identified shape scope only", () => {
+Deno.test("effectiveTraceRules: classified entry gets type-scope rules", () => {
   const p = profile({
-    identified: shapeScope({
+    types: [typeDef({
+      name: "test",
       traceability: { "Derived-from": derivedFromRule },
-    }),
+    })],
   });
-  const e = entry({ shape: "Authored" });
+  const e = entry({ shape: "Authored", type: "test" });
   const rules = effectiveTraceRules(e, p);
   assertEquals(rules.size, 1);
   assertEquals(rules.get("Derived-from"), derivedFromRule);
 });
 
-Deno.test("effectiveTraceRules: referenced entry always returns empty map", () => {
+Deno.test("effectiveTraceRules: Reference entry always returns empty map", () => {
   const p = profile({
-    identified: shapeScope({
+    types: [typeDef({
+      name: "citation",
       traceability: { "Derived-from": derivedFromRule },
-    }),
+    })],
   });
   const e = entry({ shape: "Reference" });
   const rules = effectiveTraceRules(e, p);
   assertEquals(rules.size, 0);
 });
 
-Deno.test("effectiveTraceRules: classified entry adds type-scope rules", () => {
+Deno.test("effectiveTraceRules: classified entry gets all type rules", () => {
   const p = profile({
-    identified: shapeScope({
-      traceability: { "Derived-from": derivedFromRule },
-    }),
     types: [typeDef({
       name: "test",
-      shape: "Authored",
-      traceability: { Verifies: verifiesRule },
+      traceability: { Verifies: verifiesRule, "Derived-from": derivedFromRule },
     })],
   });
   const e = entry({ shape: "Authored", type: "test" });
@@ -149,37 +130,29 @@ Deno.test("effectiveTraceRules: classified entry adds type-scope rules", () => {
   assertEquals(rules.get("Verifies"), verifiesRule);
 });
 
-Deno.test("effectiveTraceRules: un-classified entry uses only shape scope", () => {
+Deno.test("effectiveTraceRules: un-classified Authored entry returns empty map", () => {
+  // Tier 2: no shape scope — unclassified entries get no traceability rules.
   const p = profile({
-    identified: shapeScope({
-      traceability: { "Derived-from": derivedFromRule },
-    }),
     types: [typeDef({
       name: "test",
-      shape: "Authored",
       traceability: { Verifies: verifiesRule },
     })],
   });
   const e = entry({ shape: "Authored" });
   const rules = effectiveTraceRules(e, p);
-  assertEquals(rules.size, 1);
+  assertEquals(rules.size, 0);
   assertEquals(rules.has("Verifies"), false);
-  assertEquals(rules.has("Derived-from"), true);
 });
 
-Deno.test("effectiveTraceRules: type scope wins on link-name collision", () => {
+Deno.test("effectiveTraceRules: type rules are used for classified entry", () => {
   const tightRule: TraceRule = {
     target: ["stakeholder-requirement"],
     cardinality: { lower: 1, upper: Infinity },
     required: true,
   };
   const p = profile({
-    identified: shapeScope({
-      traceability: { "Derived-from": derivedFromRule },
-    }),
     types: [typeDef({
       name: "requirement",
-      shape: "Authored",
       traceability: { "Derived-from": tightRule },
     })],
   });
@@ -188,16 +161,17 @@ Deno.test("effectiveTraceRules: type scope wins on link-name collision", () => {
   assertEquals(rules.get("Derived-from"), tightRule);
 });
 
-Deno.test("effectiveTraceRules: classified entry with unknown type falls back to shape scope", () => {
+Deno.test("effectiveTraceRules: classified with unknown type returns empty map", () => {
+  // Tier 2: no shape scope fallback — unknown type → no rules.
   const p = profile({
-    identified: shapeScope({
+    types: [typeDef({
+      name: "test",
       traceability: { "Derived-from": derivedFromRule },
-    }),
+    })],
   });
   const e = entry({ shape: "Authored", type: "not-in-profile" });
   const rules = effectiveTraceRules(e, p);
-  assertEquals(rules.size, 1);
-  assertEquals(rules.get("Derived-from"), derivedFromRule);
+  assertEquals(rules.size, 0);
 });
 
 function targetEntry(opts: {
@@ -320,7 +294,9 @@ Deno.test("validateTraceabilityForEntry: required link missing → MSL-L001", ()
     required: true,
   };
   const p = profile({
-    identified: shapeScope({ traceability: { Verifies: requiredRule } }),
+    types: [
+      typeDef({ name: "test", traceability: { Verifies: requiredRule } }),
+    ],
   });
   const e = entryWithAttrs({ shape: "Authored", type: "test" });
   const graph = graphOf([e]);
@@ -347,7 +323,9 @@ Deno.test("validateTraceabilityForEntry: required link present → no MSL-L001",
     required: true,
   };
   const p = profile({
-    identified: shapeScope({ traceability: { Verifies: requiredRule } }),
+    types: [
+      typeDef({ name: "test", traceability: { Verifies: requiredRule } }),
+    ],
   });
   const e = entryWithAttrs({
     shape: "Authored",
@@ -368,7 +346,7 @@ Deno.test("validateTraceabilityForEntry: upper cardinality exceeded → MSL-L002
     required: false,
   };
   const p = profile({
-    identified: shapeScope({ traceability: { Verifies: rule } }),
+    types: [typeDef({ name: "test", traceability: { Verifies: rule } })],
   });
   const target1 = entryWithAttrs({
     id: "01T1T1T1T1T1T1T1T1T1T1T1T1",
@@ -400,7 +378,7 @@ Deno.test("validateTraceabilityForEntry: lower cardinality unmet → MSL-L003", 
     required: false,
   };
   const p = profile({
-    identified: shapeScope({ traceability: { Verifies: rule } }),
+    types: [typeDef({ name: "test", traceability: { Verifies: rule } })],
   });
   const target1 = entryWithAttrs({
     id: "01T1T1T1T1T1T1T1T1T1T1T1T1",
@@ -427,7 +405,7 @@ Deno.test("validateTraceabilityForEntry: required missing does not double-emit w
     required: true,
   };
   const p = profile({
-    identified: shapeScope({ traceability: { Verifies: rule } }),
+    types: [typeDef({ name: "test", traceability: { Verifies: rule } })],
   });
   const e = entryWithAttrs({ shape: "Authored", type: "test" });
   const graph = graphOf([e]);
@@ -447,7 +425,7 @@ Deno.test("validateTraceabilityForEntry: target type matches → no MSL-L004", (
     required: false,
   };
   const p = profile({
-    identified: shapeScope({ traceability: { Verifies: rule } }),
+    types: [typeDef({ name: "test", traceability: { Verifies: rule } })],
   });
   const target = entryWithAttrs({
     id: "01T1T1T1T1T1T1T1T1T1T1T1T1",
@@ -472,7 +450,7 @@ Deno.test("validateTraceabilityForEntry: target type mismatch → MSL-L004", () 
     required: false,
   };
   const p = profile({
-    identified: shapeScope({ traceability: { Verifies: rule } }),
+    types: [typeDef({ name: "test", traceability: { Verifies: rule } })],
   });
   const wrongTarget = entryWithAttrs({
     id: "01T1T1T1T1T1T1T1T1T1T1T1T1",
@@ -505,7 +483,7 @@ Deno.test("validateTraceabilityForEntry: shape matcher accepts any identified ta
     required: false,
   };
   const p = profile({
-    identified: shapeScope({ traceability: { Derived: rule } }),
+    types: [typeDef({ name: "test", traceability: { Derived: rule } })],
   });
   const target = entryWithAttrs({
     id: "01T1T1T1T1T1T1T1T1T1T1T1T1",
@@ -529,7 +507,7 @@ Deno.test("validateTraceabilityForEntry: target not in graph is silently skipped
     required: false,
   };
   const p = profile({
-    identified: shapeScope({ traceability: { Verifies: rule } }),
+    types: [typeDef({ name: "test", traceability: { Verifies: rule } })],
   });
   const e = entryWithAttrs({
     shape: "Authored",
@@ -548,7 +526,7 @@ Deno.test("validateTraceabilityForEntry: one valid + one invalid target → sing
     required: false,
   };
   const p = profile({
-    identified: shapeScope({ traceability: { Verifies: rule } }),
+    types: [typeDef({ name: "test", traceability: { Verifies: rule } })],
   });
   const good = entryWithAttrs({
     id: "01GOOD0000000000000000000",
@@ -578,14 +556,14 @@ Deno.test("validateTraceabilityForEntry: one valid + one invalid target → sing
 
 // Scope gating
 
-Deno.test("validateTraceabilityForEntry: referenced entries are skipped entirely", () => {
+Deno.test("validateTraceabilityForEntry: Reference entries are skipped entirely", () => {
   const rule: TraceRule = {
     target: ["requirement"],
     cardinality: { lower: 1, upper: Infinity },
     required: true,
   };
   const p = profile({
-    identified: shapeScope({ traceability: { Verifies: rule } }),
+    types: [typeDef({ name: "citation", traceability: { Verifies: rule } })],
   });
   const e = entryWithAttrs({ shape: "Reference", type: "citation" });
   const graph = graphOf([e]);
@@ -593,20 +571,19 @@ Deno.test("validateTraceabilityForEntry: referenced entries are skipped entirely
   assertEquals(diags, []);
 });
 
-Deno.test("validateTraceabilityForEntry: un-classified entry uses shape-scope rules only", () => {
+Deno.test("validateTraceabilityForEntry: un-classified Authored entry gets no rules", () => {
+  // Tier 2: only type-scope rules exist. An un-classified entry has no type,
+  // so no traceability rules apply → no diagnostics.
   const rule: TraceRule = {
     target: [{ shape: "Authored" }],
     cardinality: { lower: 0, upper: Infinity },
     required: true,
   };
   const p = profile({
-    identified: shapeScope({ traceability: { Link: rule } }),
+    types: [typeDef({ name: "test", traceability: { Link: rule } })],
   });
   const e = entryWithAttrs({ shape: "Authored" });
   const graph = graphOf([e]);
   const diags = validateTraceabilityForEntry(e, p, graph);
-  const l001 = diags.find((d) => d.code === "MSL-L001");
-  if (!l001) {
-    throw new Error(`expected MSL-L001, got: ${diags.map((d) => d.code)}`);
-  }
+  assertEquals(diags, []);
 });

--- a/packages/markspec/core/validator/types.ts
+++ b/packages/markspec/core/validator/types.ts
@@ -195,7 +195,6 @@ export function classifyEntry(
   if (entry.shape !== "Authored") return { type: undefined, diagnostics };
   const matches: string[] = [];
   for (const [typeName, typeEntry] of profile.types) {
-    if (typeEntry.value.shape !== entry.shape) continue;
     const pattern = typeEntry.value.displayIdPattern.value;
     if (pattern === undefined) continue;
     const regex = compileDisplayIdPattern(pattern);

--- a/packages/markspec/core/validator/types_test.ts
+++ b/packages/markspec/core/validator/types_test.ts
@@ -39,7 +39,6 @@ function buildEntry(opts: {
 
 function buildType(opts: {
   name: string;
-  shape: EntryShape;
   displayIdPattern?: string;
   enforcement?: "off" | "warn" | "error";
 }): ProvenancedMapEntry<EffectiveTypeDef> {
@@ -47,7 +46,7 @@ function buildType(opts: {
   return {
     value: {
       name: opts.name,
-      shape: opts.shape,
+      extends: "Requirement",
       displayIdPattern: { value: opts.displayIdPattern, origin },
       displayIdPatternEnforcement: {
         value: opts.enforcement ?? "off",
@@ -69,20 +68,9 @@ function buildProfile(
   const typesMap = new Map<string, ProvenancedMapEntry<EffectiveTypeDef>>();
   for (const t of types) typesMap.set(t.value.name, t);
   return {
-    required: { value: [], origin },
     attributes: new Map(),
     labels: { value: [], origin },
     colors: new Map(),
-    identified: {
-      required: { value: [], origin },
-      attributes: new Map(),
-      traceability: new Map(),
-    },
-    referenced: {
-      required: { value: [], origin },
-      attributes: new Map(),
-      traceability: new Map(),
-    },
     types: typesMap,
     documents: { types: new Map(), frontMatter: new Map() },
   };
@@ -92,7 +80,6 @@ Deno.test("classifyEntry: unique pattern match classifies entry", () => {
   const profile = buildProfile([
     buildType({
       name: "requirement",
-      shape: "Authored",
       displayIdPattern: "REQ-{n:04d}",
     }),
   ]);
@@ -106,7 +93,6 @@ Deno.test("classifyEntry: no match + strict mode emits MSL-T003", () => {
   const profile = buildProfile([
     buildType({
       name: "requirement",
-      shape: "Authored",
       displayIdPattern: "REQ-{n:04d}",
     }),
   ]);
@@ -120,12 +106,10 @@ Deno.test("classifyEntry: ambiguous match emits MSL-T002", () => {
   const profile = buildProfile([
     buildType({
       name: "requirement",
-      shape: "Authored",
       displayIdPattern: "REQ-{n}",
     }),
     buildType({
       name: "req-extended",
-      shape: "Authored",
       displayIdPattern: "REQ-{n:04d}",
     }),
   ]);
@@ -135,17 +119,17 @@ Deno.test("classifyEntry: ambiguous match emits MSL-T002", () => {
   assertEquals(result.diagnostics[0].code, "MSL-T002");
 });
 
-Deno.test("classifyEntry: only types with matching shape are considered", () => {
+Deno.test("classifyEntry: all types participate in pattern match regardless of extends", () => {
+  // Tier 2: types no longer have a 'shape' field; all participate in pattern
+  // matching. Only the entry's own shape guards classification (Authored only).
   const profile = buildProfile([
     buildType({
       name: "requirement",
-      shape: "Authored",
       displayIdPattern: "REQ-{n:04d}",
     }),
     buildType({
       name: "citation",
-      shape: "Reference",
-      displayIdPattern: "REQ-{n:04d}",
+      displayIdPattern: "CIT-{n:04d}",
     }),
   ]);
   const entry = buildEntry({ displayId: "REQ-0001", shape: "Authored" });
@@ -158,7 +142,6 @@ Deno.test("classifyEntry: explicit Type: trailer used when present", () => {
   const profile = buildProfile([
     buildType({
       name: "requirement",
-      shape: "Authored",
       displayIdPattern: "REQ-{n:04d}",
     }),
   ]);
@@ -174,7 +157,7 @@ Deno.test("classifyEntry: explicit Type: trailer used when present", () => {
 
 Deno.test("classifyEntry: explicit Type: unknown value emits MSL-T001", () => {
   const profile = buildProfile([
-    buildType({ name: "requirement", shape: "Authored" }),
+    buildType({ name: "requirement" }),
   ]);
   const entry = buildEntry({
     displayId: "REQ-0001",
@@ -190,12 +173,10 @@ Deno.test("classifyEntry: explicit Type: overrides pattern inference", () => {
   const profile = buildProfile([
     buildType({
       name: "requirement",
-      shape: "Authored",
       displayIdPattern: "REQ-{n}",
     }),
     buildType({
       name: "note",
-      shape: "Authored",
       displayIdPattern: "NOTE-{n}",
     }),
   ]);
@@ -219,7 +200,7 @@ Deno.test("classifyEntry: permissive (empty types map) never emits MSL-T003", ()
 
 Deno.test("classifyEntry: type without pattern doesn't participate in pattern match", () => {
   const profile = buildProfile([
-    buildType({ name: "generic", shape: "Authored" }),
+    buildType({ name: "generic" }),
   ]);
   const entry = buildEntry({ displayId: "FOO-001", shape: "Authored" });
   const result = classifyEntry(entry, profile);
@@ -231,7 +212,6 @@ Deno.test("classifyEntriesStage: sets entry.type on successful classification", 
   const profile = buildProfile([
     buildType({
       name: "requirement",
-      shape: "Authored",
       displayIdPattern: "REQ-{n:04d}",
     }),
   ]);
@@ -259,7 +239,6 @@ Deno.test("classifyEntriesStage: accumulates diagnostics across entries", () => 
   const profile = buildProfile([
     buildType({
       name: "requirement",
-      shape: "Authored",
       displayIdPattern: "REQ-{n:04d}",
     }),
   ]);
@@ -277,7 +256,6 @@ Deno.test("classifyEntriesStage: MSL-T004 warn when enforcement=warn and pattern
   const profile = buildProfile([
     buildType({
       name: "requirement",
-      shape: "Authored",
       displayIdPattern: "REQ-{n:04d}",
       enforcement: "warn",
     }),
@@ -304,7 +282,6 @@ Deno.test("classifyEntriesStage: MSL-T004 error when enforcement=error", () => {
   const profile = buildProfile([
     buildType({
       name: "requirement",
-      shape: "Authored",
       displayIdPattern: "REQ-{n:04d}",
       enforcement: "error",
     }),
@@ -330,7 +307,6 @@ Deno.test("classifyEntriesStage: no MSL-T004 when enforcement=off", () => {
   const profile = buildProfile([
     buildType({
       name: "requirement",
-      shape: "Authored",
       displayIdPattern: "REQ-{n:04d}",
       enforcement: "off",
     }),
@@ -351,7 +327,6 @@ Deno.test("classifyEntriesStage: pattern-matched classification is never MSL-T00
   const profile = buildProfile([
     buildType({
       name: "requirement",
-      shape: "Authored",
       displayIdPattern: "REQ-{n:04d}",
       enforcement: "error",
     }),
@@ -372,7 +347,6 @@ Deno.test("classifyEntry: Reference-shape entry is NOT classified by display-id-
   const profile = buildProfile([
     buildType({
       name: "external-ref",
-      shape: "Reference",
       displayIdPattern: "EXT-{n:04d}",
     }),
   ]);

--- a/packages/markspec/main.ts
+++ b/packages/markspec/main.ts
@@ -395,13 +395,7 @@ profile:
   attributes: []
   labels: []
 
-  # Per-shape scope
-  identified:
-    attributes: []
-  referenced:
-    attributes: []
-
-  # Per-type scope
+  # Per-type scope (use extends: to link to a core type, e.g. extends: Requirement)
   types: {}
 
   # Document scope

--- a/packages/markspec/mcp/resources/profile.ts
+++ b/packages/markspec/mcp/resources/profile.ts
@@ -19,7 +19,7 @@ import type {
 /** Per-type distillation. */
 export interface ProfileTypeView {
   readonly name: string;
-  readonly shape: string;
+  readonly extends: string;
   readonly displayIdPattern: string | undefined;
   readonly color: string | undefined;
   readonly requiredAttributes: readonly string[];
@@ -59,24 +59,19 @@ export function buildProfileView(
     description: t.manifest.description ?? "",
   }));
 
-  const universalRequired = [...eff.required.value];
+  const universalRequired: string[] = [];
   const universalAllowed = [...eff.attributes.keys()];
 
   const types: ProfileTypeView[] = [];
   for (const [name, entry] of eff.types) {
     const tdef: EffectiveTypeDef = entry.value;
-    const shape = tdef.shape;
-    const shapeScope = shape === "Authored" ? eff.identified : eff.referenced;
 
     const allowed = new Set<string>([
       ...tdef.attributes.keys(),
-      ...shapeScope.attributes.keys(),
       ...eff.attributes.keys(),
     ]);
     const required = new Set<string>([
       ...tdef.required.value,
-      ...shapeScope.required.value,
-      ...eff.required.value,
     ]);
     for (const r of required) allowed.delete(r);
 
@@ -95,7 +90,7 @@ export function buildProfileView(
 
     types.push({
       name,
-      shape,
+      extends: tdef.extends,
       displayIdPattern: tdef.displayIdPattern.value,
       color: tdef.color.value,
       requiredAttributes: [...required],
@@ -152,7 +147,7 @@ export function renderProfile(view: ProfileView | null): string {
       if (t.displayIdPattern) {
         lines.push(`- **Display-ID pattern**: \`${t.displayIdPattern}\``);
       }
-      lines.push(`- **Shape**: ${t.shape}`);
+      lines.push(`- **Extends**: ${t.extends}`);
       if (t.color) lines.push(`- **Color**: ${t.color}`);
       if (t.requiredAttributes.length > 0) {
         lines.push(

--- a/packages/markspec/mcp/resources/profile_test.ts
+++ b/packages/markspec/mcp/resources/profile_test.ts
@@ -30,7 +30,7 @@ Deno.test("renderProfile: includes active profile id and version", () => {
     types: [
       {
         name: "stakeholder-requirement",
-        shape: "Authored",
+        extends: "Requirement",
         displayIdPattern: "STK_{DOMAIN}_{NNNN}",
         color: "blue",
         requiredAttributes: ["Id"],

--- a/tests/e2e/create_test.ts
+++ b/tests/e2e/create_test.ts
@@ -16,7 +16,7 @@ version: 0.1.0
 profile:
   types:
     requirement:
-      shape: identified
+      extends: Requirement
       display-id-pattern: "REQ-{n:04d}"
 `;
 

--- a/tests/e2e/insert_test.ts
+++ b/tests/e2e/insert_test.ts
@@ -15,7 +15,7 @@ version: 0.1.0
 profile:
   types:
     requirement:
-      shape: identified
+      extends: Requirement
       display-id-pattern: "REQ-{n:04d}"
 `;
 

--- a/tests/e2e/next_id_test.ts
+++ b/tests/e2e/next_id_test.ts
@@ -16,10 +16,10 @@ version: 0.1.0
 profile:
   types:
     requirement:
-      shape: identified
+      extends: Requirement
       display-id-pattern: "REQ-{n:04d}"
     note:
-      shape: identified
+      extends: Item
       display-id-pattern: "NOTE-{n:03d}"
 `;
 

--- a/tests/e2e/profile_attributes_test.ts
+++ b/tests/e2e/profile_attributes_test.ts
@@ -19,7 +19,7 @@ profile:
       values: [draft, approved]
   types:
     requirement:
-      shape: identified
+      extends: Requirement
       display-id-pattern: "REQ-{n:04d}"
       required: [Rationale]
       attributes:

--- a/tests/e2e/profile_git_test.ts
+++ b/tests/e2e/profile_git_test.ts
@@ -18,7 +18,7 @@ version: 1.0.0
 profile:
   types:
     requirement:
-      shape: identified
+      extends: Requirement
       display-id-pattern: "REQ-{n:04d}"
 `;
 

--- a/tests/e2e/profile_inverses_test.ts
+++ b/tests/e2e/profile_inverses_test.ts
@@ -15,10 +15,10 @@ version: 0.1.0
 profile:
   types:
     requirement:
-      shape: identified
+      extends: Requirement
       display-id-pattern: "REQ-{n:04d}"
     test:
-      shape: identified
+      extends: Test
       display-id-pattern: "TEST-{n:04d}"
       attributes:
         - name: Verifies

--- a/tests/e2e/profile_loader_test.ts
+++ b/tests/e2e/profile_loader_test.ts
@@ -131,7 +131,7 @@ version: 0.1.0
 profile:
   types:
     Requirement:
-      shape: identified
+      extends: Item
 `;
   const { code, stderr } = await markspec(["validate", "req.md"], {
     files: {
@@ -191,7 +191,8 @@ Deno.test("profile loader e2e: markspec-schema absent → PROFILE-SCHEMA-002 war
 });
 
 Deno.test('profile loader e2e: markspec-schema: "2" → PROFILE-SCHEMA-001 error, exit 1', async () => {
-  const profile = `id: "@acme/wrong-pin"\nversion: 0.1.0\nmarkspec-schema: "2"\n`;
+  const profile =
+    `id: "@acme/wrong-pin"\nversion: 0.1.0\nmarkspec-schema: "2"\n`;
   const { code, stderr } = await markspec(["validate", "req.md"], {
     files: {
       "project.yaml": PROJECT_YAML,

--- a/tests/e2e/profile_merge_test.ts
+++ b/tests/e2e/profile_merge_test.ts
@@ -18,7 +18,7 @@ profile:
       values: [draft, approved, deprecated]
   types:
     requirement:
-      shape: identified
+      extends: Requirement
       display-id-pattern: "REQ-{n:04d}"
 `;
 
@@ -32,7 +32,7 @@ profile:
       values: [draft, approved]
   types:
     requirement:
-      shape: identified
+      extends: Requirement
       display-id-pattern: "REQ-{n:04d}"
 `;
 
@@ -72,7 +72,7 @@ Deno.test("profile merge e2e: valid two-tier chain loads cleanly", async () => {
   assertEquals(lines, []);
 });
 
-Deno.test("profile merge e2e: relaxation in child fails with PROFILE-MERGE-001", async () => {
+Deno.test("profile merge e2e: relaxation in child fails with PROFILE-MERGE-010", async () => {
   const { code, stderr } = await markspec(["validate", "req.md"], {
     files: {
       "project.yaml": PROJECT_YAML,
@@ -83,7 +83,7 @@ Deno.test("profile merge e2e: relaxation in child fails with PROFILE-MERGE-001",
     },
   });
   assertEquals(code, 1);
-  assertStringIncludes(stderr, "PROFILE-MERGE-001");
+  assertStringIncludes(stderr, "PROFILE-MERGE-010");
 });
 
 Deno.test("profile merge e2e: direct extends cycle fails with PROFILE-LOAD-004", async () => {

--- a/tests/e2e/profile_traceability_test.ts
+++ b/tests/e2e/profile_traceability_test.ts
@@ -15,10 +15,10 @@ version: 0.1.0
 profile:
   types:
     requirement:
-      shape: identified
+      extends: Requirement
       display-id-pattern: "REQ-{n:04d}"
     test:
-      shape: identified
+      extends: Test
       display-id-pattern: "TEST-{n:04d}"
       traceability:
         Verifies:

--- a/tests/e2e/profile_types_test.ts
+++ b/tests/e2e/profile_types_test.ts
@@ -15,11 +15,11 @@ version: 0.1.0
 profile:
   types:
     requirement:
-      shape: identified
+      extends: Requirement
       display-id-pattern: "REQ-{n:04d}"
       display-id-pattern-enforcement: error
     note:
-      shape: identified
+      extends: Item
       display-id-pattern: "NOTE-{n:03d}"
       display-id-pattern-enforcement: off
 `;

--- a/tests/fixtures/profiles/phase1/complete.yaml
+++ b/tests/fixtures/profiles/phase1/complete.yaml
@@ -5,31 +5,15 @@ description: A complete fixture exercising every Phase 1 parser feature
 license: MIT
 extends: "./base"
 profile:
-  required: [Status]
   labels: [DRAFT, INTERNAL]
   attributes:
     - name: Status
       type: enum
       values: [draft, approved, deprecated]
       required: false
-  identified:
-    required: [Rationale]
-    attributes:
-      - name: Rationale
-        type: text
-    traceability:
-      Derived-from:
-        target: [{ shape: identified }]
-        cardinality: 0..N
-        required: false
-  referenced:
-    required: []
-    attributes:
-      - name: Description
-        type: text
   types:
     requirement:
-      shape: identified
+      extends: Requirement
       display-id-pattern: "REQ-{n:04d}"
       display-id-pattern-enforcement: warn
       required: [Rationale]
@@ -43,7 +27,7 @@ profile:
           cardinality: 1..N
           required: true
     test:
-      shape: identified
+      extends: Requirement
       display-id-pattern: "TEST-{n:04d}"
       attributes:
         - name: Verifies
@@ -52,7 +36,7 @@ profile:
             name: Verified-by
             category: requirement
     standard:
-      shape: referenced
+      extends: Specification
   documents:
     types:
       - id: requirements-doc

--- a/tests/fixtures/profiles/phase2/minimal/markspec.yaml
+++ b/tests/fixtures/profiles/phase2/minimal/markspec.yaml
@@ -4,5 +4,5 @@ description: Minimal profile used by Phase 2 e2e tests
 profile:
   types:
     note:
-      shape: identified
+      extends: Requirement
       display-id-pattern: "NOTE-{n:03d}"

--- a/tests/fixtures/profiles/phase3/base/markspec.yaml
+++ b/tests/fixtures/profiles/phase3/base/markspec.yaml
@@ -8,7 +8,7 @@ profile:
       values: [draft, approved, deprecated]
   types:
     requirement:
-      shape: identified
+      extends: Requirement
       display-id-pattern: "REQ-{n:04d}"
       display-id-pattern-enforcement: warn
       attributes:

--- a/tests/fixtures/profiles/phase3/child-valid/markspec.yaml
+++ b/tests/fixtures/profiles/phase3/child-valid/markspec.yaml
@@ -9,7 +9,7 @@ profile:
       values: [draft, approved] # narrowed
   types:
     requirement:
-      shape: identified
+      extends: Requirement
       display-id-pattern: "REQ-{n:04d}"
       display-id-pattern-enforcement: error # tightened
       traceability:

--- a/tests/fixtures/profiles/phase5/typed/markspec.yaml
+++ b/tests/fixtures/profiles/phase5/typed/markspec.yaml
@@ -4,10 +4,10 @@ description: Phase 5 e2e — profile with typed entries
 profile:
   types:
     requirement:
-      shape: identified
+      extends: Requirement
       display-id-pattern: "REQ-{n:04d}"
       display-id-pattern-enforcement: error
     note:
-      shape: identified
+      extends: Requirement
       display-id-pattern: "NOTE-{n:03d}"
       display-id-pattern-enforcement: off

--- a/tests/fixtures/profiles/phase6/attributed/markspec.yaml
+++ b/tests/fixtures/profiles/phase6/attributed/markspec.yaml
@@ -8,7 +8,7 @@ profile:
       values: [draft, approved]
   types:
     requirement:
-      shape: identified
+      extends: Requirement
       display-id-pattern: "REQ-{n:04d}"
       required: [Rationale]
       attributes:

--- a/tests/fixtures/profiles/phase7/traceable/markspec.yaml
+++ b/tests/fixtures/profiles/phase7/traceable/markspec.yaml
@@ -4,10 +4,10 @@ description: Phase 7 e2e — profile with traceability rules
 profile:
   types:
     requirement:
-      shape: identified
+      extends: Requirement
       display-id-pattern: "REQ-{n:04d}"
     test:
-      shape: identified
+      extends: Requirement
       display-id-pattern: "TEST-{n:04d}"
       traceability:
         Verifies:


### PR DESCRIPTION
## Summary

- **Breaking schema change**: type declarations now use `extends: <CoreTypeName>` instead of `shape: identified/referenced`. The `identified:`, `referenced:`, and `required:` scope sections are removed from profile manifests.
- `EffectiveTypeDef`: `shape` field replaced by `extends: string` (required); `PROFILE-TYPE-001` fires on missing `extends`
- `EffectiveProfile`: `required`, `identified`, `referenced` fields removed entirely; `EffectiveShapeScope` type removed
- Diagnostic codes renamed: `PROFILE-MERGE-010/011/012` replace `PROFILE-MERGE-001/002/003`
- `MSL-PROFILE-COLOR-001` removed — coloring a `Specification`-extending type is now valid
- Reference-family traceability constraint removed — `extends: Specification` + traceability is valid in Tier 2
- All test fixtures, unit tests, and e2e tests updated to the new `extends:` syntax

## Test plan

- [x] `just build` passes — 1308 tests, 0 failures
- [x] `manifest_test.ts` updated: Tier 1 constraint tests replaced with Tier 2-correct assertions
- [x] All e2e profile tests updated: `shape: identified/referenced` → `extends: Requirement/Test/Item/Specification`
- [x] `profile_merge_test.ts`: `PROFILE-MERGE-001` → `PROFILE-MERGE-010`
- [x] Fixture YAML files in `tests/fixtures/profiles/` updated to new syntax

🤖 Generated with [Claude Code](https://claude.com/claude-code)