### PR TITLE
fix(mcp): add SHA256 content-hash gate to project staleness check

### DIFF
--- a/packages/markspec/mcp/project.ts
+++ b/packages/markspec/mcp/project.ts
@@ -61,10 +61,45 @@ export interface ProjectEnv {
   walk(root: string): AsyncIterable<string>;
 }
 
-/** Per-tracked-file mtime snapshot. */
+/** Per-tracked-file mtime + content-hash snapshot. */
 interface TrackedFile {
   path: string;
   mtime: number;
+  /** SHA-256 hex digest of file content. `undefined` → no hash stored (treat as stale on mtime change). */
+  contentHash?: string;
+}
+
+/** Compute SHA-256 hex digest of UTF-8 text using the Web Crypto global. */
+async function sha256(content: string): Promise<string> {
+  const data = new TextEncoder().encode(content);
+  const buf = await globalThis.crypto.subtle.digest("SHA-256", data);
+  const bytes = new Uint8Array(buf);
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+/**
+ * Two-step staleness gate for a single file.
+ *
+ * - **Fast gate**: if `currentMtime === storedMtime`, the file is unchanged → not stale.
+ *   `readContent` is never called.
+ * - **Truth gate**: if mtime changed, compute the content hash. If `storedHash` is
+ *   `undefined` (no hash recorded yet), treat as stale. Otherwise compare hashes —
+ *   content-identical files (e.g. after `git checkout`) are not stale.
+ *
+ * Exported for unit testing.
+ */
+export async function checkFileStaleness(
+  storedMtime: number,
+  storedHash: string | undefined,
+  currentMtime: number,
+  readContent: () => Promise<string | undefined>,
+): Promise<boolean> {
+  if (currentMtime === storedMtime) return false; // fast path
+  if (!storedHash) return true; // no stored hash → always stale
+  const content = await readContent();
+  if (content === undefined) return true; // file gone
+  const currentHash = await sha256(content);
+  return currentHash !== storedHash;
 }
 
 /** Handler signature for invalidation subscribers. */
@@ -193,12 +228,16 @@ export async function createProject(env: ProjectEnv): Promise<Project> {
         profile: profileChain?.effective ?? undefined,
       });
 
-      // Snapshot mtimes for next invalidation check.
+      // Snapshot mtime + SHA256 hash for the next invalidation check.
       const snapshot: TrackedFile[] = [];
       for (const path of paths) {
         try {
           const { mtime } = await env.stat(path);
-          snapshot.push({ path, mtime });
+          const content = await env.readFile(path);
+          const contentHash = content !== undefined
+            ? await sha256(content)
+            : undefined;
+          snapshot.push({ path, mtime, contentHash });
         } catch {
           // File disappeared during compile — ignore.
         }
@@ -237,11 +276,17 @@ export async function createProject(env: ProjectEnv): Promise<Project> {
   /** Detect any change in the tracked file set since the last compile. */
   async function isStale(): Promise<boolean> {
     if (!projectRoot) return false;
-    // 1) Any tracked file with newer mtime, or missing?
+    // 1) Any tracked file that is stale (mtime fast path → SHA256 truth gate)?
     for (const t of tracked) {
       try {
         const { mtime } = await env.stat(t.path);
-        if (mtime !== t.mtime) return true;
+        const stale = await checkFileStaleness(
+          t.mtime,
+          t.contentHash,
+          mtime,
+          () => env.readFile(t.path),
+        );
+        if (stale) return true;
       } catch {
         return true; // file disappeared
       }

--- a/packages/markspec/mcp/project_test.ts
+++ b/packages/markspec/mcp/project_test.ts
@@ -7,7 +7,11 @@
  */
 
 import { assertEquals, assertExists, assertRejects } from "@std/assert";
-import { createProject, type ProjectEnv } from "./project.ts";
+import {
+  checkFileStaleness,
+  createProject,
+  type ProjectEnv,
+} from "./project.ts";
 
 /** Build a ProjectEnv that serves a fixed file map. */
 function makeEnv(files: Record<string, { content: string; mtime: number }>): {
@@ -199,4 +203,82 @@ Deno.test("subscribeInvalidation: fires handlers after recompile", async () => {
   await proj.getCompiled();
 
   assertEquals(fired, 2);
+});
+
+// ---------------------------------------------------------------------------
+// SHA256 content-hash gate tests
+// ---------------------------------------------------------------------------
+
+/** Compute SHA-256 hex using the same Web Crypto global the production code uses. */
+async function testSha256(content: string): Promise<string> {
+  const data = new TextEncoder().encode(content);
+  const buf = await globalThis.crypto.subtle.digest("SHA-256", data);
+  const bytes = new Uint8Array(buf);
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+Deno.test("checkFileStaleness: same content, mtime bumped → NOT stale", async () => {
+  const storedHash = await testSha256(REQ_DOC);
+
+  const result = await checkFileStaleness(
+    1,
+    storedHash,
+    2, // mtime changed
+    () => Promise.resolve(REQ_DOC), // same content
+  );
+  assertEquals(result, false);
+});
+
+Deno.test("checkFileStaleness: different content, mtime bumped → stale", async () => {
+  const storedHash = await testSha256(REQ_DOC);
+
+  const result = await checkFileStaleness(
+    1,
+    storedHash,
+    2, // mtime changed
+    () => Promise.resolve(REQ_DOC + "\n# extra content"), // different
+  );
+  assertEquals(result, true);
+});
+
+Deno.test("checkFileStaleness: same mtime → NOT stale (fast path, no read)", async () => {
+  let readCalled = false;
+  const result = await checkFileStaleness(
+    1,
+    "somehash",
+    1, // mtime unchanged
+    () => {
+      readCalled = true;
+      return Promise.resolve(REQ_DOC);
+    },
+  );
+  assertEquals(result, false);
+  assertEquals(readCalled, false, "readContent must not be called on mtime fast path");
+});
+
+Deno.test("checkFileStaleness: no stored hash → stale", async () => {
+  const result = await checkFileStaleness(
+    1,
+    undefined, // no stored hash (first run / legacy cache)
+    2, // mtime changed
+    () => Promise.resolve(REQ_DOC),
+  );
+  assertEquals(result, true);
+});
+
+Deno.test("getCompiled: same content, mtime bumped → NOT stale (SHA256 gate)", async () => {
+  const { env, bumpMtime } = makeEnv({
+    "/proj/project.yaml": { content: PROJECT_YAML, mtime: 1 },
+    "/proj/req.md": { content: REQ_DOC, mtime: 1 },
+  });
+  const proj = await createProject(env);
+  const r1 = await proj.getCompiled();
+  assertEquals(r1.entries.size, 1);
+
+  // Bump mtime but keep same content (simulates `git checkout` touching mtime).
+  bumpMtime("/proj/req.md", REQ_DOC, Date.now() + 1000);
+
+  const r2 = await proj.getCompiled();
+  assertEquals(r2.entries.size, 1);
+  assertEquals(r2, r1, "cached result returned — no recompile triggered");
 });

--- a/packages/markspec/mcp/project_test.ts
+++ b/packages/markspec/mcp/project_test.ts
@@ -253,7 +253,11 @@ Deno.test("checkFileStaleness: same mtime → NOT stale (fast path, no read)", a
     },
   );
   assertEquals(result, false);
-  assertEquals(readCalled, false, "readContent must not be called on mtime fast path");
+  assertEquals(
+    readCalled,
+    false,
+    "readContent must not be called on mtime fast path",
+  );
 });
 
 Deno.test("checkFileStaleness: no stored hash → stale", async () => {

--- a/tests/e2e/mcp_test.ts
+++ b/tests/e2e/mcp_test.ts
@@ -353,3 +353,33 @@ Deno.test("mcp: file edit + markspec_refresh fires resources/updated", async () 
     await Deno.remove(cwd, { recursive: true });
   }
 });
+
+Deno.test("mcp: touching a file without changing content does not break results", async () => {
+  const { proc, cwd } = await setup();
+  try {
+    // Warm up the cache.
+    const r1 = await proc.request("tools/call", {
+      name: "entry_search",
+      arguments: { query: "collision" },
+    });
+    // deno-lint-ignore no-explicit-any
+    const c1 = (r1.result as any).content as Array<{ text: string }>;
+    assertStringIncludes(c1[0].text, "STK_E2E_0001");
+
+    // Touch the file: write same content back → mtime bumped, hash unchanged.
+    const content = await Deno.readTextFile(`${cwd}/req.md`);
+    await Deno.writeTextFile(`${cwd}/req.md`, content);
+
+    // SHA256 gate: next search should still return the same entry.
+    const r2 = await proc.request("tools/call", {
+      name: "entry_search",
+      arguments: { query: "collision" },
+    });
+    // deno-lint-ignore no-explicit-any
+    const c2 = (r2.result as any).content as Array<{ text: string }>;
+    assertStringIncludes(c2[0].text, "STK_E2E_0001");
+  } finally {
+    await proc.close();
+    await Deno.remove(cwd, { recursive: true });
+  }
+});


### PR DESCRIPTION
## Summary

- Adds a two-step staleness gate to `mcp/project.ts`: mtime fast-path (no I/O) followed by SHA-256 hash comparison only when mtime differs
- Eliminates spurious full recompiles after `git checkout` or any filesystem operation that bumps mtime without changing content
- Stores `contentHash` alongside `mtime` in the `TrackedFile` snapshot; uses `globalThis.crypto.subtle` (Web Crypto, no new deps)
- Exports `checkFileStaleness()` as a thin testable helper; adds 5 unit tests + 1 e2e test

## Test plan

- [x] `just build` passes (lint + 1444 tests + type-check + binary compile)
- [x] Unit: `checkFileStaleness` — same content/bumped mtime → not stale, different content → stale, same mtime → fast-path (no read), no stored hash → stale
- [x] Unit: `getCompiled` — same content, bumped mtime → cached result returned (no recompile)
- [x] E2E: touch file without changing content → `entry_search` still returns correct result

🤖 Generated with [Claude Code](https://claude.ai/claude-code)