### PR TITLE
feat(core): prose-analysis PA-1 — lint subcommand, MSL-Q lexicon/struct/suppression rules

### DIFF
--- a/packages/markspec/core/lint/mod.ts
+++ b/packages/markspec/core/lint/mod.ts
@@ -1,0 +1,10 @@
+/**
+ * @module core/lint
+ *
+ * Prose-analysis lint pipeline barrel. Exports the public API for the
+ * markspec lint subcommand and LSP integration.
+ */
+
+export type { LintDiagnostic } from "./types.ts";
+export { isProseScope, runLint } from "./runner.ts";
+export type { LintOptions, LintResult } from "./runner.ts";

--- a/packages/markspec/core/lint/rules/lexicon.ts
+++ b/packages/markspec/core/lint/rules/lexicon.ts
@@ -1,0 +1,269 @@
+/**
+ * @module core/lint/rules/lexicon
+ *
+ * Six INCOSE GtWR lexicon rules for PA-1. All operate by scanning
+ * InlineContent.text in prose-bearing AST blocks for canonical
+ * word/phrase matches. No sentence segmentation needed.
+ *
+ * Rules:
+ *   MSL-Q302  incose-r7-vague-term         (warn, score 3)
+ *   MSL-Q303  incose-r8-escape-clause      (warn, score 3)
+ *   MSL-Q304  incose-r9-open-ended         (info, score 1)
+ *   MSL-Q305  incose-r10-superfluous-inf   (info, score 1)
+ *   MSL-Q310  incose-r26-absolute          (info, score 1)
+ *   MSL-Q313  incose-r16-not               (info, score 1)
+ */
+
+import type { BodyBlock } from "../../ast/nodes.ts";
+import type { Entry, Severity, SourceLocation } from "../../model/mod.ts";
+import type { LintDiagnostic } from "../types.ts";
+
+// ---------------------------------------------------------------------------
+// Word/phrase lists (INCOSE GtWR canonical sets)
+// ---------------------------------------------------------------------------
+
+const Q302_TERMS = [
+  "some",
+  "several",
+  "many",
+  "few",
+  "a number of",
+  "approximate",
+  "approximately",
+  "adequate",
+  "adequately",
+  "sufficient",
+  "sufficiently",
+  "reasonable",
+  "reasonably",
+  "efficient",
+  "efficiently",
+  "appropriate",
+  "appropriately",
+  "effective",
+  "effectively",
+  "as needed",
+  "as required",
+];
+
+const Q303_TERMS = [
+  "as appropriate",
+  "as required",
+  "where possible",
+  "if practicable",
+  "if possible",
+  "to the extent possible",
+  "to the extent necessary",
+  "where applicable",
+  "to the extent practicable",
+];
+
+const Q304_TERMS = [
+  "including but not limited to",
+  "etc.",
+  "et cetera",
+  "and so on",
+  "and/or",
+];
+
+const Q305_TERMS = [
+  "be able to",
+  "be capable of",
+  "be designed to",
+  "be required to",
+  "to enable",
+  "to allow",
+  "in order to",
+];
+
+const Q310_TERMS = [
+  "100%",
+  "all of",
+  "every",
+  "all the",
+  "always",
+  "never",
+  "none",
+  "no instance",
+  "complete",
+  "completely",
+  "entire",
+  "entirely",
+];
+
+// ---------------------------------------------------------------------------
+// Rule definitions
+// ---------------------------------------------------------------------------
+
+interface LexiconRule {
+  readonly code: string;
+  readonly slug: string;
+  readonly severity: Severity;
+  readonly scoreContribution: number;
+  readonly terms: readonly string[];
+  /** When true, use whole-word boundary matching instead of substring. */
+  readonly wholeWord: boolean;
+}
+
+const LEXICON_RULES: readonly LexiconRule[] = [
+  {
+    code: "MSL-Q302",
+    slug: "incose-r7-vague-term",
+    severity: "warning",
+    scoreContribution: 3,
+    terms: Q302_TERMS,
+    wholeWord: false,
+  },
+  {
+    code: "MSL-Q303",
+    slug: "incose-r8-escape-clause",
+    severity: "warning",
+    scoreContribution: 3,
+    terms: Q303_TERMS,
+    wholeWord: false,
+  },
+  {
+    code: "MSL-Q304",
+    slug: "incose-r9-open-ended",
+    severity: "info",
+    scoreContribution: 1,
+    terms: Q304_TERMS,
+    wholeWord: false,
+  },
+  {
+    code: "MSL-Q305",
+    slug: "incose-r10-superfluous-infinitive",
+    severity: "info",
+    scoreContribution: 1,
+    terms: Q305_TERMS,
+    wholeWord: false,
+  },
+  {
+    code: "MSL-Q310",
+    slug: "incose-r26-absolute",
+    severity: "info",
+    scoreContribution: 1,
+    terms: Q310_TERMS,
+    wholeWord: false,
+  },
+];
+
+// Q313 uses whole-word boundary matching — "not" must not match "note", "notation"
+const Q313_RULE: LexiconRule = {
+  code: "MSL-Q313",
+  slug: "incose-r16-not",
+  severity: "info",
+  scoreContribution: 1,
+  terms: ["not"],
+  wholeWord: true,
+};
+
+// ---------------------------------------------------------------------------
+// Text extraction from AST blocks
+// ---------------------------------------------------------------------------
+
+/** Extract all InlineContent.text strings from prose-bearing AST blocks.
+ * Walks Paragraph, Note, and List (recursively) per the PA-1 scope.
+ * Skips Table, Code, Feature, Math, Blockquote, etc. */
+function extractTexts(blocks: readonly BodyBlock[]): string[] {
+  const texts: string[] = [];
+  for (const block of blocks) {
+    if (block.kind === "paragraph") {
+      texts.push(block.content.text);
+    } else if (block.kind === "note") {
+      texts.push(block.content.text);
+    } else if (block.kind === "list") {
+      for (const item of block.items) {
+        texts.push(...extractTexts(item.blocks));
+      }
+    }
+    // Table, Blockquote, Code, Feature, Math, Caption, Unknown: skip
+  }
+  return texts;
+}
+
+// ---------------------------------------------------------------------------
+// Match helpers
+// ---------------------------------------------------------------------------
+
+/** Case-insensitive substring scan — returns true if any term found. */
+function containsTerm(text: string, term: string): boolean {
+  return text.toLowerCase().includes(term.toLowerCase());
+}
+
+/** Whole-word, case-insensitive match using word boundaries. */
+function containsWholeWord(text: string, word: string): boolean {
+  // Build a regex with word boundaries around the term.
+  // Escape any regex metacharacters in the word (unlikely for "not" but safe).
+  const escaped = word.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const re = new RegExp(`\\b${escaped}\\b`, "i");
+  return re.test(text);
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/** Run all six lexicon rules on an entry's prose AST blocks.
+ * Returns one LintDiagnostic per matching term per rule (one per rule
+ * per entry — first match only, to avoid flooding). */
+export function runLexiconRules(entry: Entry): LintDiagnostic[] {
+  const blocks = entry.bodyAst ?? [];
+  const texts = extractTexts(blocks);
+  if (texts.length === 0) return [];
+
+  const out: LintDiagnostic[] = [];
+  const location: SourceLocation = entry.location;
+
+  for (const rule of LEXICON_RULES) {
+    let fired = false;
+    for (const text of texts) {
+      if (fired) break;
+      for (const term of rule.terms) {
+        if (containsTerm(text, term)) {
+          out.push({
+            code: rule.code,
+            slug: rule.slug,
+            severity: rule.severity,
+            scoreContribution: rule.scoreContribution,
+            group: "incose",
+            message: `${rule.slug}: '${term}' found in entry body`,
+            location,
+          });
+          fired = true;
+          break;
+        }
+      }
+    }
+  }
+
+  // Q313: whole-word "not"
+  let q313Fired = false;
+  for (const text of texts) {
+    if (q313Fired) break;
+    if (containsWholeWord(text, "not")) {
+      out.push({
+        code: Q313_RULE.code,
+        slug: Q313_RULE.slug,
+        severity: Q313_RULE.severity,
+        scoreContribution: Q313_RULE.scoreContribution,
+        group: "incose",
+        message: `${Q313_RULE.slug}: 'not' found in entry body`,
+        location,
+      });
+      q313Fired = true;
+    }
+  }
+
+  return out;
+}
+
+/** Exported for test/diagnostic use: the set of rule codes this module emits. */
+export const LEXICON_RULE_CODES: ReadonlySet<string> = new Set([
+  "MSL-Q302",
+  "MSL-Q303",
+  "MSL-Q304",
+  "MSL-Q305",
+  "MSL-Q310",
+  "MSL-Q313",
+]);

--- a/packages/markspec/core/lint/rules/lexicon_test.ts
+++ b/packages/markspec/core/lint/rules/lexicon_test.ts
@@ -17,7 +17,10 @@ function makeParagraph(text: string): BodyBlock {
   return {
     kind: "paragraph",
     content: { text, markers: [] },
-    range: { start: { line: 1, column: 1 }, end: { line: 1, column: text.length } },
+    range: {
+      start: { line: 1, column: 1 },
+      end: { line: 1, column: text.length },
+    },
   };
 }
 
@@ -49,22 +52,30 @@ function makeEntry(text: string): Entry {
 // ---------------------------------------------------------------------------
 
 Deno.test("lexicon Q302: fires for 'some'", () => {
-  const diags = runLexiconRules(makeEntry("The system shall use some mechanism."));
+  const diags = runLexiconRules(
+    makeEntry("The system shall use some mechanism."),
+  );
   assertEquals(diags.some((d) => d.code === "MSL-Q302"), true);
 });
 
 Deno.test("lexicon Q302: fires for 'several'", () => {
-  const diags = runLexiconRules(makeEntry("The system handles several sensors."));
+  const diags = runLexiconRules(
+    makeEntry("The system handles several sensors."),
+  );
   assertEquals(diags.some((d) => d.code === "MSL-Q302"), true);
 });
 
 Deno.test("lexicon Q302: fires for 'adequate'", () => {
-  const diags = runLexiconRules(makeEntry("The system shall provide adequate cooling."));
+  const diags = runLexiconRules(
+    makeEntry("The system shall provide adequate cooling."),
+  );
   assertEquals(diags.some((d) => d.code === "MSL-Q302"), true);
 });
 
 Deno.test("lexicon Q302: does not fire on clean text", () => {
-  const diags = runLexiconRules(makeEntry("The system shall process all input data within 100ms."));
+  const diags = runLexiconRules(
+    makeEntry("The system shall process all input data within 100ms."),
+  );
   assertEquals(diags.some((d) => d.code === "MSL-Q302"), false);
 });
 
@@ -78,22 +89,30 @@ Deno.test("lexicon Q302: is case-insensitive ('Some' fires)", () => {
 // ---------------------------------------------------------------------------
 
 Deno.test("lexicon Q303: fires for 'as appropriate'", () => {
-  const diags = runLexiconRules(makeEntry("The system shall respond as appropriate."));
+  const diags = runLexiconRules(
+    makeEntry("The system shall respond as appropriate."),
+  );
   assertEquals(diags.some((d) => d.code === "MSL-Q303"), true);
 });
 
 Deno.test("lexicon Q303: fires for 'where possible'", () => {
-  const diags = runLexiconRules(makeEntry("The system shall retry where possible."));
+  const diags = runLexiconRules(
+    makeEntry("The system shall retry where possible."),
+  );
   assertEquals(diags.some((d) => d.code === "MSL-Q303"), true);
 });
 
 Deno.test("lexicon Q303: fires for 'if practicable'", () => {
-  const diags = runLexiconRules(makeEntry("The system shall log events if practicable."));
+  const diags = runLexiconRules(
+    makeEntry("The system shall log events if practicable."),
+  );
   assertEquals(diags.some((d) => d.code === "MSL-Q303"), true);
 });
 
 Deno.test("lexicon Q303: does not fire on clean text", () => {
-  const diags = runLexiconRules(makeEntry("The system shall always respond within 100ms."));
+  const diags = runLexiconRules(
+    makeEntry("The system shall always respond within 100ms."),
+  );
   assertEquals(diags.some((d) => d.code === "MSL-Q303"), false);
 });
 
@@ -102,12 +121,16 @@ Deno.test("lexicon Q303: does not fire on clean text", () => {
 // ---------------------------------------------------------------------------
 
 Deno.test("lexicon Q304: fires for 'etc.'", () => {
-  const diags = runLexiconRules(makeEntry("The system handles sensors, actuators, etc."));
+  const diags = runLexiconRules(
+    makeEntry("The system handles sensors, actuators, etc."),
+  );
   assertEquals(diags.some((d) => d.code === "MSL-Q304"), true);
 });
 
 Deno.test("lexicon Q304: fires for 'and/or'", () => {
-  const diags = runLexiconRules(makeEntry("The system shall start and/or stop on command."));
+  const diags = runLexiconRules(
+    makeEntry("The system shall start and/or stop on command."),
+  );
   assertEquals(diags.some((d) => d.code === "MSL-Q304"), true);
 });
 
@@ -119,7 +142,9 @@ Deno.test("lexicon Q304: fires for 'including but not limited to'", () => {
 });
 
 Deno.test("lexicon Q304: does not fire on clean text", () => {
-  const diags = runLexiconRules(makeEntry("The system shall handle sensor input."));
+  const diags = runLexiconRules(
+    makeEntry("The system shall handle sensor input."),
+  );
   assertEquals(diags.some((d) => d.code === "MSL-Q304"), false);
 });
 
@@ -128,17 +153,23 @@ Deno.test("lexicon Q304: does not fire on clean text", () => {
 // ---------------------------------------------------------------------------
 
 Deno.test("lexicon Q305: fires for 'be able to'", () => {
-  const diags = runLexiconRules(makeEntry("The system shall be able to process data."));
+  const diags = runLexiconRules(
+    makeEntry("The system shall be able to process data."),
+  );
   assertEquals(diags.some((d) => d.code === "MSL-Q305"), true);
 });
 
 Deno.test("lexicon Q305: fires for 'be capable of'", () => {
-  const diags = runLexiconRules(makeEntry("The system shall be capable of handling 100 requests."));
+  const diags = runLexiconRules(
+    makeEntry("The system shall be capable of handling 100 requests."),
+  );
   assertEquals(diags.some((d) => d.code === "MSL-Q305"), true);
 });
 
 Deno.test("lexicon Q305: fires for 'in order to'", () => {
-  const diags = runLexiconRules(makeEntry("In order to start, the system shall check the clock."));
+  const diags = runLexiconRules(
+    makeEntry("In order to start, the system shall check the clock."),
+  );
   assertEquals(diags.some((d) => d.code === "MSL-Q305"), true);
 });
 
@@ -152,22 +183,30 @@ Deno.test("lexicon Q305: does not fire on clean text", () => {
 // ---------------------------------------------------------------------------
 
 Deno.test("lexicon Q310: fires for 'always'", () => {
-  const diags = runLexiconRules(makeEntry("The system shall always respond within 100ms."));
+  const diags = runLexiconRules(
+    makeEntry("The system shall always respond within 100ms."),
+  );
   assertEquals(diags.some((d) => d.code === "MSL-Q310"), true);
 });
 
 Deno.test("lexicon Q310: fires for 'never'", () => {
-  const diags = runLexiconRules(makeEntry("The system shall never drop a safety message."));
+  const diags = runLexiconRules(
+    makeEntry("The system shall never drop a safety message."),
+  );
   assertEquals(diags.some((d) => d.code === "MSL-Q310"), true);
 });
 
 Deno.test("lexicon Q310: fires for 'complete'", () => {
-  const diags = runLexiconRules(makeEntry("The system shall provide complete coverage."));
+  const diags = runLexiconRules(
+    makeEntry("The system shall provide complete coverage."),
+  );
   assertEquals(diags.some((d) => d.code === "MSL-Q310"), true);
 });
 
 Deno.test("lexicon Q310: does not fire on clean text", () => {
-  const diags = runLexiconRules(makeEntry("The system shall respond within 100ms."));
+  const diags = runLexiconRules(
+    makeEntry("The system shall respond within 100ms."),
+  );
   assertEquals(diags.some((d) => d.code === "MSL-Q310"), false);
 });
 
@@ -176,17 +215,23 @@ Deno.test("lexicon Q310: does not fire on clean text", () => {
 // ---------------------------------------------------------------------------
 
 Deno.test("lexicon Q313: fires for standalone 'not'", () => {
-  const diags = runLexiconRules(makeEntry("The system shall not exceed the memory limit."));
+  const diags = runLexiconRules(
+    makeEntry("The system shall not exceed the memory limit."),
+  );
   assertEquals(diags.some((d) => d.code === "MSL-Q313"), true);
 });
 
 Deno.test("lexicon Q313: does not fire on clean text without 'not'", () => {
-  const diags = runLexiconRules(makeEntry("The system shall process all data."));
+  const diags = runLexiconRules(
+    makeEntry("The system shall process all data."),
+  );
   assertEquals(diags.some((d) => d.code === "MSL-Q313"), false);
 });
 
 Deno.test("lexicon Q313: 'not' does not match 'note'", () => {
-  const diags = runLexiconRules(makeEntry("Note: the system shall process sensor data."));
+  const diags = runLexiconRules(
+    makeEntry("Note: the system shall process sensor data."),
+  );
   assertEquals(diags.some((d) => d.code === "MSL-Q313"), false);
 });
 

--- a/packages/markspec/core/lint/rules/lexicon_test.ts
+++ b/packages/markspec/core/lint/rules/lexicon_test.ts
@@ -1,0 +1,196 @@
+/**
+ * @module core/lint/rules/lexicon_test
+ *
+ * Unit tests for the six INCOSE lexicon rules (MSL-Q302–Q305, Q310, Q313).
+ */
+
+import { assertEquals } from "@std/assert";
+import type { BodyBlock } from "../../ast/nodes.ts";
+import type { Entry } from "../../model/mod.ts";
+import { runLexiconRules } from "./lexicon.ts";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeParagraph(text: string): BodyBlock {
+  return {
+    kind: "paragraph",
+    content: { text, markers: [] },
+    range: { start: { line: 1, column: 1 }, end: { line: 1, column: text.length } },
+  };
+}
+
+function makeEntry(text: string): Entry {
+  const bodyAst: BodyBlock[] = [makeParagraph(text)];
+  return {
+    displayId: "REQ-001",
+    title: "Test entry with body",
+    body: text,
+    bodyAst,
+    rawAttributes: [
+      { key: "Id", value: "01HGW2Q8MNP3RSTVWXYZABCDEF" },
+      { key: "Type", value: "Requirement" },
+    ],
+    typedAttributes: new Map([
+      ["Id", ["01HGW2Q8MNP3RSTVWXYZABCDEF"]],
+      ["Type", ["Requirement"]],
+    ]),
+    id: "01HGW2Q8MNP3RSTVWXYZABCDEF",
+    type: "Requirement",
+    shape: "Authored",
+    location: { file: "test.md", line: 1, column: 1 },
+    source: "markdown",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// MSL-Q302: vague terms (incose-r7-vague-term)
+// ---------------------------------------------------------------------------
+
+Deno.test("lexicon Q302: fires for 'some'", () => {
+  const diags = runLexiconRules(makeEntry("The system shall use some mechanism."));
+  assertEquals(diags.some((d) => d.code === "MSL-Q302"), true);
+});
+
+Deno.test("lexicon Q302: fires for 'several'", () => {
+  const diags = runLexiconRules(makeEntry("The system handles several sensors."));
+  assertEquals(diags.some((d) => d.code === "MSL-Q302"), true);
+});
+
+Deno.test("lexicon Q302: fires for 'adequate'", () => {
+  const diags = runLexiconRules(makeEntry("The system shall provide adequate cooling."));
+  assertEquals(diags.some((d) => d.code === "MSL-Q302"), true);
+});
+
+Deno.test("lexicon Q302: does not fire on clean text", () => {
+  const diags = runLexiconRules(makeEntry("The system shall process all input data within 100ms."));
+  assertEquals(diags.some((d) => d.code === "MSL-Q302"), false);
+});
+
+Deno.test("lexicon Q302: is case-insensitive ('Some' fires)", () => {
+  const diags = runLexiconRules(makeEntry("Some data shall be processed."));
+  assertEquals(diags.some((d) => d.code === "MSL-Q302"), true);
+});
+
+// ---------------------------------------------------------------------------
+// MSL-Q303: escape clauses (incose-r8-escape-clause)
+// ---------------------------------------------------------------------------
+
+Deno.test("lexicon Q303: fires for 'as appropriate'", () => {
+  const diags = runLexiconRules(makeEntry("The system shall respond as appropriate."));
+  assertEquals(diags.some((d) => d.code === "MSL-Q303"), true);
+});
+
+Deno.test("lexicon Q303: fires for 'where possible'", () => {
+  const diags = runLexiconRules(makeEntry("The system shall retry where possible."));
+  assertEquals(diags.some((d) => d.code === "MSL-Q303"), true);
+});
+
+Deno.test("lexicon Q303: fires for 'if practicable'", () => {
+  const diags = runLexiconRules(makeEntry("The system shall log events if practicable."));
+  assertEquals(diags.some((d) => d.code === "MSL-Q303"), true);
+});
+
+Deno.test("lexicon Q303: does not fire on clean text", () => {
+  const diags = runLexiconRules(makeEntry("The system shall always respond within 100ms."));
+  assertEquals(diags.some((d) => d.code === "MSL-Q303"), false);
+});
+
+// ---------------------------------------------------------------------------
+// MSL-Q304: open-ended (incose-r9-open-ended)
+// ---------------------------------------------------------------------------
+
+Deno.test("lexicon Q304: fires for 'etc.'", () => {
+  const diags = runLexiconRules(makeEntry("The system handles sensors, actuators, etc."));
+  assertEquals(diags.some((d) => d.code === "MSL-Q304"), true);
+});
+
+Deno.test("lexicon Q304: fires for 'and/or'", () => {
+  const diags = runLexiconRules(makeEntry("The system shall start and/or stop on command."));
+  assertEquals(diags.some((d) => d.code === "MSL-Q304"), true);
+});
+
+Deno.test("lexicon Q304: fires for 'including but not limited to'", () => {
+  const diags = runLexiconRules(
+    makeEntry("Inputs including but not limited to sensors are accepted."),
+  );
+  assertEquals(diags.some((d) => d.code === "MSL-Q304"), true);
+});
+
+Deno.test("lexicon Q304: does not fire on clean text", () => {
+  const diags = runLexiconRules(makeEntry("The system shall handle sensor input."));
+  assertEquals(diags.some((d) => d.code === "MSL-Q304"), false);
+});
+
+// ---------------------------------------------------------------------------
+// MSL-Q305: superfluous infinitive (incose-r10-superfluous-infinitive)
+// ---------------------------------------------------------------------------
+
+Deno.test("lexicon Q305: fires for 'be able to'", () => {
+  const diags = runLexiconRules(makeEntry("The system shall be able to process data."));
+  assertEquals(diags.some((d) => d.code === "MSL-Q305"), true);
+});
+
+Deno.test("lexicon Q305: fires for 'be capable of'", () => {
+  const diags = runLexiconRules(makeEntry("The system shall be capable of handling 100 requests."));
+  assertEquals(diags.some((d) => d.code === "MSL-Q305"), true);
+});
+
+Deno.test("lexicon Q305: fires for 'in order to'", () => {
+  const diags = runLexiconRules(makeEntry("In order to start, the system shall check the clock."));
+  assertEquals(diags.some((d) => d.code === "MSL-Q305"), true);
+});
+
+Deno.test("lexicon Q305: does not fire on clean text", () => {
+  const diags = runLexiconRules(makeEntry("The system shall process data."));
+  assertEquals(diags.some((d) => d.code === "MSL-Q305"), false);
+});
+
+// ---------------------------------------------------------------------------
+// MSL-Q310: absolute terms (incose-r26-absolute)
+// ---------------------------------------------------------------------------
+
+Deno.test("lexicon Q310: fires for 'always'", () => {
+  const diags = runLexiconRules(makeEntry("The system shall always respond within 100ms."));
+  assertEquals(diags.some((d) => d.code === "MSL-Q310"), true);
+});
+
+Deno.test("lexicon Q310: fires for 'never'", () => {
+  const diags = runLexiconRules(makeEntry("The system shall never drop a safety message."));
+  assertEquals(diags.some((d) => d.code === "MSL-Q310"), true);
+});
+
+Deno.test("lexicon Q310: fires for 'complete'", () => {
+  const diags = runLexiconRules(makeEntry("The system shall provide complete coverage."));
+  assertEquals(diags.some((d) => d.code === "MSL-Q310"), true);
+});
+
+Deno.test("lexicon Q310: does not fire on clean text", () => {
+  const diags = runLexiconRules(makeEntry("The system shall respond within 100ms."));
+  assertEquals(diags.some((d) => d.code === "MSL-Q310"), false);
+});
+
+// ---------------------------------------------------------------------------
+// MSL-Q313: negation (incose-r16-not)
+// ---------------------------------------------------------------------------
+
+Deno.test("lexicon Q313: fires for standalone 'not'", () => {
+  const diags = runLexiconRules(makeEntry("The system shall not exceed the memory limit."));
+  assertEquals(diags.some((d) => d.code === "MSL-Q313"), true);
+});
+
+Deno.test("lexicon Q313: does not fire on clean text without 'not'", () => {
+  const diags = runLexiconRules(makeEntry("The system shall process all data."));
+  assertEquals(diags.some((d) => d.code === "MSL-Q313"), false);
+});
+
+Deno.test("lexicon Q313: 'not' does not match 'note'", () => {
+  const diags = runLexiconRules(makeEntry("Note: the system shall process sensor data."));
+  assertEquals(diags.some((d) => d.code === "MSL-Q313"), false);
+});
+
+Deno.test("lexicon Q313: 'not' does not match 'notation'", () => {
+  const diags = runLexiconRules(makeEntry("The notation shall follow EBNF."));
+  assertEquals(diags.some((d) => d.code === "MSL-Q313"), false);
+});

--- a/packages/markspec/core/lint/rules/struct.ts
+++ b/packages/markspec/core/lint/rules/struct.ts
@@ -1,0 +1,64 @@
+/**
+ * @module core/lint/rules/struct
+ *
+ * Two structural prose-quality rules for PA-1:
+ *   MSL-Q400  struct-title-length   (info, score 1)
+ *   MSL-Q401  struct-body-length    (info, score 1)
+ *
+ * Thresholds are hard-coded defaults; profile-level configuration
+ * (prose.struct.title.minLength / maxLength, etc.) is wired in PA-2.
+ */
+
+import type { Entry, SourceLocation } from "../../model/mod.ts";
+import type { LintDiagnostic } from "../types.ts";
+
+// TODO(PA-2): wire these from prose.struct profile config
+const TITLE_MIN_LENGTH = 3;
+const TITLE_MAX_LENGTH = 120;
+const BODY_MIN_WORDS = 5;
+const BODY_MAX_WORDS = 500;
+
+/** Run MSL-Q400 and MSL-Q401 on an entry. */
+export function runStructRules(entry: Entry): LintDiagnostic[] {
+  const out: LintDiagnostic[] = [];
+  const location: SourceLocation = entry.location;
+
+  // MSL-Q400: title length
+  const titleLen = entry.title.length;
+  if (titleLen < TITLE_MIN_LENGTH || titleLen > TITLE_MAX_LENGTH) {
+    const dir = titleLen < TITLE_MIN_LENGTH ? "too short" : "too long";
+    out.push({
+      code: "MSL-Q400",
+      slug: "struct-title-length",
+      severity: "info",
+      scoreContribution: 1,
+      group: "struct",
+      message: `struct-title-length: title is ${dir} (${titleLen} chars; expected ${TITLE_MIN_LENGTH}–${TITLE_MAX_LENGTH})`,
+      location,
+    });
+  }
+
+  // MSL-Q401: body word count — split entry.body on whitespace
+  const words = entry.body.split(/\s+/).filter((w) => w.length > 0);
+  const wordCount = words.length;
+  if (wordCount < BODY_MIN_WORDS || wordCount > BODY_MAX_WORDS) {
+    const dir = wordCount < BODY_MIN_WORDS ? "too short" : "too long";
+    out.push({
+      code: "MSL-Q401",
+      slug: "struct-body-length",
+      severity: "info",
+      scoreContribution: 1,
+      group: "struct",
+      message: `struct-body-length: body is ${dir} (${wordCount} words; expected ${BODY_MIN_WORDS}–${BODY_MAX_WORDS})`,
+      location,
+    });
+  }
+
+  return out;
+}
+
+/** Exported rule codes for suppression validation. */
+export const STRUCT_RULE_CODES: ReadonlySet<string> = new Set([
+  "MSL-Q400",
+  "MSL-Q401",
+]);

--- a/packages/markspec/core/lint/rules/struct.ts
+++ b/packages/markspec/core/lint/rules/struct.ts
@@ -33,7 +33,8 @@ export function runStructRules(entry: Entry): LintDiagnostic[] {
       severity: "info",
       scoreContribution: 1,
       group: "struct",
-      message: `struct-title-length: title is ${dir} (${titleLen} chars; expected ${TITLE_MIN_LENGTH}–${TITLE_MAX_LENGTH})`,
+      message:
+        `struct-title-length: title is ${dir} (${titleLen} chars; expected ${TITLE_MIN_LENGTH}–${TITLE_MAX_LENGTH})`,
       location,
     });
   }
@@ -49,7 +50,8 @@ export function runStructRules(entry: Entry): LintDiagnostic[] {
       severity: "info",
       scoreContribution: 1,
       group: "struct",
-      message: `struct-body-length: body is ${dir} (${wordCount} words; expected ${BODY_MIN_WORDS}–${BODY_MAX_WORDS})`,
+      message:
+        `struct-body-length: body is ${dir} (${wordCount} words; expected ${BODY_MIN_WORDS}–${BODY_MAX_WORDS})`,
       location,
     });
   }

--- a/packages/markspec/core/lint/rules/suppression.ts
+++ b/packages/markspec/core/lint/rules/suppression.ts
@@ -59,7 +59,8 @@ export function runSuppressionRules(entry: Entry): LintDiagnostic[] {
       severity: "warning",
       scoreContribution: 3,
       group: "disable",
-      message: "disable-without-rationale: 'Markspec-disable' requires a companion 'Rationale' attribute",
+      message:
+        "disable-without-rationale: 'Markspec-disable' requires a companion 'Rationale' attribute",
       location,
     });
   }
@@ -74,7 +75,8 @@ export function runSuppressionRules(entry: Entry): LintDiagnostic[] {
         severity: "warning",
         scoreContribution: 3,
         group: "disable",
-        message: `disable-unknown-rule: '${token}' is not a known lint rule code`,
+        message:
+          `disable-unknown-rule: '${token}' is not a known lint rule code`,
         location,
       });
     }

--- a/packages/markspec/core/lint/rules/suppression.ts
+++ b/packages/markspec/core/lint/rules/suppression.ts
@@ -1,0 +1,84 @@
+/**
+ * @module core/lint/rules/suppression
+ *
+ * Two suppression-hygiene rules for PA-1:
+ *   MSL-Q900  disable-without-rationale  (warn, score 3)
+ *   MSL-Q901  disable-unknown-rule       (warn, score 3)
+ *
+ * These run on every Authored entry (not just in-scope ones) because
+ * suppression hygiene applies to any entry that uses Markspec-disable.
+ */
+
+import type { Entry, SourceLocation } from "../../model/mod.ts";
+import type { LintDiagnostic } from "../types.ts";
+import { LEXICON_RULE_CODES } from "./lexicon.ts";
+import { STRUCT_RULE_CODES } from "./struct.ts";
+
+/** All rule codes shipped in PA-1. MSL-Q900/Q901 are self-referential. */
+export const PA1_KNOWN_RULE_CODES: ReadonlySet<string> = new Set([
+  ...LEXICON_RULE_CODES,
+  ...STRUCT_RULE_CODES,
+  "MSL-Q900",
+  "MSL-Q901",
+]);
+
+/** Parse the Markspec-disable attribute value into individual rule tokens. */
+export function parseDisableValue(value: string): string[] {
+  return value.split(",").map((t) => t.trim()).filter((t) => t.length > 0);
+}
+
+/** Return the Markspec-disable attribute value, or undefined. */
+function getDisableValue(entry: Entry): string | undefined {
+  for (const attr of entry.rawAttributes) {
+    if (attr.key === "Markspec-disable") return attr.value;
+  }
+  return undefined;
+}
+
+/** Return whether the entry has a non-empty Rationale attribute. */
+function hasRationale(entry: Entry): boolean {
+  for (const attr of entry.rawAttributes) {
+    if (attr.key === "Rationale" && attr.value.trim().length > 0) return true;
+  }
+  return false;
+}
+
+/** Run MSL-Q900 and MSL-Q901 on an entry. Safe to call on all Authored entries. */
+export function runSuppressionRules(entry: Entry): LintDiagnostic[] {
+  const out: LintDiagnostic[] = [];
+  const location: SourceLocation = entry.location;
+
+  const disableValue = getDisableValue(entry);
+  if (disableValue === undefined) return out;
+
+  // MSL-Q900: disable without rationale
+  if (!hasRationale(entry)) {
+    out.push({
+      code: "MSL-Q900",
+      slug: "disable-without-rationale",
+      severity: "warning",
+      scoreContribution: 3,
+      group: "disable",
+      message: "disable-without-rationale: 'Markspec-disable' requires a companion 'Rationale' attribute",
+      location,
+    });
+  }
+
+  // MSL-Q901: disable-unknown-rule — check each token in the list
+  const tokens = parseDisableValue(disableValue);
+  for (const token of tokens) {
+    if (!PA1_KNOWN_RULE_CODES.has(token)) {
+      out.push({
+        code: "MSL-Q901",
+        slug: "disable-unknown-rule",
+        severity: "warning",
+        scoreContribution: 3,
+        group: "disable",
+        message: `disable-unknown-rule: '${token}' is not a known lint rule code`,
+        location,
+      });
+    }
+  }
+
+  return out;
+}

--- a/packages/markspec/core/lint/runner.ts
+++ b/packages/markspec/core/lint/runner.ts
@@ -1,0 +1,133 @@
+/**
+ * @module core/lint/runner
+ *
+ * Lint pipeline entry point. Filters entries to in-scope prose targets,
+ * runs lexicon and structural rules, runs suppression hygiene on all
+ * Authored entries, applies suppression, and returns the final diagnostics.
+ */
+
+import type { Entry } from "../model/mod.ts";
+import { CORE_TYPE_HIERARCHY } from "../model/mod.ts";
+import { resolvedCoreType } from "../validator/type_resolution.ts";
+import type { LintDiagnostic } from "./types.ts";
+import { runLexiconRules } from "./rules/lexicon.ts";
+import { runStructRules } from "./rules/struct.ts";
+import { parseDisableValue, runSuppressionRules } from "./rules/suppression.ts";
+
+// ---------------------------------------------------------------------------
+// In-scope predicate
+// ---------------------------------------------------------------------------
+
+/** Walk the CORE_TYPE_HIERARCHY parent chain to check ancestry. */
+function isSpecificationDescendant(typeName: string): boolean {
+  let cursor: string | null = typeName;
+  while (cursor !== null) {
+    if (cursor === "Specification") return true;
+    cursor = CORE_TYPE_HIERARCHY[cursor]?.parent ?? null;
+  }
+  return false;
+}
+
+/**
+ * Returns true when prose-analysis rules should run on this entry.
+ *
+ * In-scope: Authored shape AND resolved core type is Specification or
+ * a direct subtype (Requirement, Test, Contract, Record, Risk).
+ * Reference-shape entries are always excluded.
+ */
+export function isProseScope(entry: Entry): boolean {
+  if (entry.shape === "Reference") return false;
+  const coreType = resolvedCoreType(entry);
+  if (!coreType) return false;
+  return isSpecificationDescendant(coreType);
+}
+
+// ---------------------------------------------------------------------------
+// Pipeline types
+// ---------------------------------------------------------------------------
+
+export interface LintOptions {
+  readonly entries: readonly Entry[];
+}
+
+export interface LintResult {
+  readonly diagnostics: readonly LintDiagnostic[];
+}
+
+// ---------------------------------------------------------------------------
+// Suppression application
+// ---------------------------------------------------------------------------
+
+/** Parse the Markspec-disable list for an entry into a Set of codes/slugs. */
+function disabledCodes(entry: Entry): ReadonlySet<string> {
+  for (const attr of entry.rawAttributes) {
+    if (attr.key === "Markspec-disable") {
+      return new Set(parseDisableValue(attr.value));
+    }
+  }
+  return new Set();
+}
+
+/** Return whether the entry has a non-empty Rationale attribute. */
+function hasRationale(entry: Entry): boolean {
+  for (const attr of entry.rawAttributes) {
+    if (attr.key === "Rationale" && attr.value.trim().length > 0) return true;
+  }
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// runLint
+// ---------------------------------------------------------------------------
+
+/**
+ * Run the PA-1 lint pipeline on a set of entries.
+ *
+ * Pipeline:
+ *   1. Filter to in-scope entries (Specification subtypes, Authored shape).
+ *   2. Run lexicon rules on each in-scope entry's prose blocks.
+ *   3. Run structural rules on each in-scope entry.
+ *   4. Run suppression hygiene on ALL Authored entries.
+ *   5. Apply suppression: drop in-scope diagnostics where the entry's
+ *      Markspec-disable list includes the rule's code and the entry
+ *      has a Rationale. Suppression-hygiene diagnostics (Q900/Q901)
+ *      are never suppressed.
+ *   6. Return remaining diagnostics.
+ */
+export function runLint(options: LintOptions): LintResult {
+  const { entries } = options;
+
+  // Step 1–3: collect diagnostics keyed by entry
+  const inScopeDiags = new Map<Entry, LintDiagnostic[]>();
+  for (const entry of entries) {
+    if (!isProseScope(entry)) continue;
+    const diags: LintDiagnostic[] = [];
+    diags.push(...runLexiconRules(entry));
+    diags.push(...runStructRules(entry));
+    inScopeDiags.set(entry, diags);
+  }
+
+  // Step 4: suppression hygiene on all Authored entries
+  const hygieneDiags: LintDiagnostic[] = [];
+  for (const entry of entries) {
+    if (entry.shape !== "Authored") continue;
+    hygieneDiags.push(...runSuppressionRules(entry));
+  }
+
+  // Step 5: apply suppression to in-scope diagnostics
+  const out: LintDiagnostic[] = [];
+  for (const [entry, diags] of inScopeDiags) {
+    const disabled = disabledCodes(entry);
+    const entryHasRationale = hasRationale(entry);
+    for (const diag of diags) {
+      // Suppression requires both a matching code AND a Rationale.
+      if (entryHasRationale && disabled.has(diag.code)) continue;
+      out.push(diag);
+    }
+  }
+
+  // Step 6: append hygiene diagnostics (never suppressed)
+  out.push(...hygieneDiags);
+
+  return { diagnostics: out };
+}

--- a/packages/markspec/core/lint/runner_test.ts
+++ b/packages/markspec/core/lint/runner_test.ts
@@ -1,0 +1,287 @@
+/**
+ * @module core/lint/runner_test
+ *
+ * Unit tests for the lint runner: isProseScope predicate and runLint pipeline.
+ */
+
+import { assertEquals } from "@std/assert";
+import type { Entry } from "../model/mod.ts";
+import { isProseScope, runLint } from "./runner.ts";
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function makeEntry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    displayId: "REQ-001",
+    title: "Test requirement title",
+    body: "The system shall process data correctly.",
+    bodyAst: [
+      {
+        kind: "paragraph",
+        content: { text: "The system shall process data correctly.", markers: [] },
+        range: {
+          start: { line: 1, column: 1 },
+          end: { line: 1, column: 40 },
+        },
+      },
+    ],
+    rawAttributes: [
+      { key: "Id", value: "01HGW2Q8MNP3RSTVWXYZABCDEF" },
+      { key: "Type", value: "Requirement" },
+    ],
+    typedAttributes: new Map([
+      ["Id", ["01HGW2Q8MNP3RSTVWXYZABCDEF"]],
+      ["Type", ["Requirement"]],
+    ]),
+    id: "01HGW2Q8MNP3RSTVWXYZABCDEF",
+    type: "Requirement",
+    shape: "Authored",
+    location: { file: "test.md", line: 1, column: 1 },
+    source: "markdown",
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// isProseScope
+// ---------------------------------------------------------------------------
+
+Deno.test("isProseScope: Requirement-typed authored entry is in-scope", () => {
+  const entry = makeEntry({ type: "Requirement" });
+  assertEquals(isProseScope(entry), true);
+});
+
+Deno.test("isProseScope: Specification-typed entry is in-scope", () => {
+  const entry = makeEntry({
+    type: "Specification",
+    rawAttributes: [
+      { key: "Id", value: "01HGW2Q8MNP3RSTVWXYZABCDEF" },
+      { key: "Type", value: "Specification" },
+    ],
+    typedAttributes: new Map([
+      ["Id", ["01HGW2Q8MNP3RSTVWXYZABCDEF"]],
+      ["Type", ["Specification"]],
+    ]),
+  });
+  assertEquals(isProseScope(entry), true);
+});
+
+Deno.test("isProseScope: Reference-shape entry is out-of-scope", () => {
+  const entry = makeEntry({
+    shape: "Reference",
+    id: "urn:example:123",
+    rawAttributes: [{ key: "Id", value: "urn:example:123" }],
+    typedAttributes: new Map([["Id", ["urn:example:123"]]]),
+    type: undefined,
+  });
+  assertEquals(isProseScope(entry), false);
+});
+
+Deno.test("isProseScope: Component-typed entry is out-of-scope", () => {
+  const entry = makeEntry({
+    displayId: "COMP-001",
+    type: "Component",
+    rawAttributes: [
+      { key: "Id", value: "01HGW2Q8MNP3RSTVWXYZABCDEF" },
+      { key: "Type", value: "Component" },
+    ],
+    typedAttributes: new Map([
+      ["Id", ["01HGW2Q8MNP3RSTVWXYZABCDEF"]],
+      ["Type", ["Component"]],
+    ]),
+  });
+  assertEquals(isProseScope(entry), false);
+});
+
+// ---------------------------------------------------------------------------
+// Lexicon rules (via runLint)
+// ---------------------------------------------------------------------------
+
+Deno.test("runLint: MSL-Q302 fires for 'some' in body", () => {
+  const text = "The system should use some processing mechanism.";
+  const entry = makeEntry({
+    body: text,
+    bodyAst: [
+      {
+        kind: "paragraph",
+        content: { text, markers: [] },
+        range: { start: { line: 1, column: 1 }, end: { line: 1, column: text.length } },
+      },
+    ],
+  });
+  const result = runLint({ entries: [entry] });
+  const codes = result.diagnostics.map((d) => d.code);
+  assertEquals(codes.includes("MSL-Q302"), true);
+});
+
+Deno.test("runLint: MSL-Q303 fires for 'as appropriate' in body", () => {
+  const text = "The system shall operate as appropriate for the situation.";
+  const entry = makeEntry({
+    body: text,
+    bodyAst: [
+      {
+        kind: "paragraph",
+        content: { text, markers: [] },
+        range: { start: { line: 1, column: 1 }, end: { line: 1, column: text.length } },
+      },
+    ],
+  });
+  const result = runLint({ entries: [entry] });
+  const codes = result.diagnostics.map((d) => d.code);
+  assertEquals(codes.includes("MSL-Q303"), true);
+});
+
+// ---------------------------------------------------------------------------
+// Structural rules (via runLint)
+// ---------------------------------------------------------------------------
+
+Deno.test("runLint: MSL-Q400 fires when title is too short (< 3 chars)", () => {
+  const entry = makeEntry({ title: "Hi" });
+  const result = runLint({ entries: [entry] });
+  const codes = result.diagnostics.map((d) => d.code);
+  assertEquals(codes.includes("MSL-Q400"), true);
+});
+
+Deno.test("runLint: MSL-Q401 fires when body has fewer than 5 words", () => {
+  const text = "Too short body.";
+  const entry = makeEntry({
+    body: text,
+    bodyAst: [
+      {
+        kind: "paragraph",
+        content: { text, markers: [] },
+        range: { start: { line: 1, column: 1 }, end: { line: 1, column: text.length } },
+      },
+    ],
+  });
+  const result = runLint({ entries: [entry] });
+  const codes = result.diagnostics.map((d) => d.code);
+  assertEquals(codes.includes("MSL-Q401"), true);
+});
+
+// ---------------------------------------------------------------------------
+// Suppression hygiene rules (via runLint)
+// ---------------------------------------------------------------------------
+
+Deno.test("runLint: MSL-Q900 fires when Markspec-disable present but no Rationale", () => {
+  const entry = makeEntry({
+    rawAttributes: [
+      { key: "Id", value: "01HGW2Q8MNP3RSTVWXYZABCDEF" },
+      { key: "Type", value: "Requirement" },
+      { key: "Markspec-disable", value: "MSL-Q302" },
+    ],
+    typedAttributes: new Map([
+      ["Id", ["01HGW2Q8MNP3RSTVWXYZABCDEF"]],
+      ["Type", ["Requirement"]],
+      ["Markspec-disable", ["MSL-Q302"]],
+    ]),
+  });
+  const result = runLint({ entries: [entry] });
+  const codes = result.diagnostics.map((d) => d.code);
+  assertEquals(codes.includes("MSL-Q900"), true);
+});
+
+Deno.test("runLint: MSL-Q901 fires when Markspec-disable lists unknown rule code", () => {
+  const entry = makeEntry({
+    rawAttributes: [
+      { key: "Id", value: "01HGW2Q8MNP3RSTVWXYZABCDEF" },
+      { key: "Type", value: "Requirement" },
+      { key: "Markspec-disable", value: "MSL-ZZZZ" },
+      { key: "Rationale", value: "Accepted for this specific entry." },
+    ],
+    typedAttributes: new Map([
+      ["Id", ["01HGW2Q8MNP3RSTVWXYZABCDEF"]],
+      ["Type", ["Requirement"]],
+      ["Markspec-disable", ["MSL-ZZZZ"]],
+      ["Rationale", ["Accepted for this specific entry."]],
+    ]),
+  });
+  const result = runLint({ entries: [entry] });
+  const codes = result.diagnostics.map((d) => d.code);
+  assertEquals(codes.includes("MSL-Q901"), true);
+});
+
+// ---------------------------------------------------------------------------
+// Suppression: valid disable drops the matched rule
+// ---------------------------------------------------------------------------
+
+Deno.test("runLint: valid Markspec-disable suppresses MSL-Q302", () => {
+  const text = "The system should use some processing mechanism.";
+  const entry = makeEntry({
+    body: text,
+    bodyAst: [
+      {
+        kind: "paragraph",
+        content: { text, markers: [] },
+        range: { start: { line: 1, column: 1 }, end: { line: 1, column: text.length } },
+      },
+    ],
+    rawAttributes: [
+      { key: "Id", value: "01HGW2Q8MNP3RSTVWXYZABCDEF" },
+      { key: "Type", value: "Requirement" },
+      { key: "Markspec-disable", value: "MSL-Q302" },
+      { key: "Rationale", value: "Reviewed and accepted." },
+    ],
+    typedAttributes: new Map([
+      ["Id", ["01HGW2Q8MNP3RSTVWXYZABCDEF"]],
+      ["Type", ["Requirement"]],
+      ["Markspec-disable", ["MSL-Q302"]],
+      ["Rationale", ["Reviewed and accepted."]],
+    ]),
+  });
+  const result = runLint({ entries: [entry] });
+  const codes = result.diagnostics.map((d) => d.code);
+  assertEquals(codes.includes("MSL-Q302"), false);
+});
+
+// ---------------------------------------------------------------------------
+// Diagnostics carry slug + group + scoreContribution
+// ---------------------------------------------------------------------------
+
+Deno.test("runLint: diagnostics include slug, group, scoreContribution fields", () => {
+  const text = "The system should use some processing mechanism.";
+  const entry = makeEntry({
+    body: text,
+    bodyAst: [
+      {
+        kind: "paragraph",
+        content: { text, markers: [] },
+        range: { start: { line: 1, column: 1 }, end: { line: 1, column: text.length } },
+      },
+    ],
+  });
+  const result = runLint({ entries: [entry] });
+  const q302 = result.diagnostics.find((d) => d.code === "MSL-Q302");
+  assertEquals(q302 !== undefined, true);
+  // deno-lint-ignore no-explicit-any
+  const d = q302 as any;
+  assertEquals(typeof d.slug, "string");
+  assertEquals(typeof d.group, "string");
+  assertEquals(typeof d.scoreContribution, "number");
+});
+
+// ---------------------------------------------------------------------------
+// Determinism
+// ---------------------------------------------------------------------------
+
+Deno.test("runLint: output is deterministic for same input", () => {
+  const text = "The system should use some processing as appropriate.";
+  const entry = makeEntry({
+    body: text,
+    bodyAst: [
+      {
+        kind: "paragraph",
+        content: { text, markers: [] },
+        range: { start: { line: 1, column: 1 }, end: { line: 1, column: text.length } },
+      },
+    ],
+  });
+  const r1 = runLint({ entries: [entry] });
+  const r2 = runLint({ entries: [entry] });
+  assertEquals(
+    r1.diagnostics.map((d) => d.code),
+    r2.diagnostics.map((d) => d.code),
+  );
+});

--- a/packages/markspec/core/lint/runner_test.ts
+++ b/packages/markspec/core/lint/runner_test.ts
@@ -20,7 +20,10 @@ function makeEntry(overrides: Partial<Entry> = {}): Entry {
     bodyAst: [
       {
         kind: "paragraph",
-        content: { text: "The system shall process data correctly.", markers: [] },
+        content: {
+          text: "The system shall process data correctly.",
+          markers: [],
+        },
         range: {
           start: { line: 1, column: 1 },
           end: { line: 1, column: 40 },
@@ -107,7 +110,10 @@ Deno.test("runLint: MSL-Q302 fires for 'some' in body", () => {
       {
         kind: "paragraph",
         content: { text, markers: [] },
-        range: { start: { line: 1, column: 1 }, end: { line: 1, column: text.length } },
+        range: {
+          start: { line: 1, column: 1 },
+          end: { line: 1, column: text.length },
+        },
       },
     ],
   });
@@ -124,7 +130,10 @@ Deno.test("runLint: MSL-Q303 fires for 'as appropriate' in body", () => {
       {
         kind: "paragraph",
         content: { text, markers: [] },
-        range: { start: { line: 1, column: 1 }, end: { line: 1, column: text.length } },
+        range: {
+          start: { line: 1, column: 1 },
+          end: { line: 1, column: text.length },
+        },
       },
     ],
   });
@@ -152,7 +161,10 @@ Deno.test("runLint: MSL-Q401 fires when body has fewer than 5 words", () => {
       {
         kind: "paragraph",
         content: { text, markers: [] },
-        range: { start: { line: 1, column: 1 }, end: { line: 1, column: text.length } },
+        range: {
+          start: { line: 1, column: 1 },
+          end: { line: 1, column: text.length },
+        },
       },
     ],
   });
@@ -215,7 +227,10 @@ Deno.test("runLint: valid Markspec-disable suppresses MSL-Q302", () => {
       {
         kind: "paragraph",
         content: { text, markers: [] },
-        range: { start: { line: 1, column: 1 }, end: { line: 1, column: text.length } },
+        range: {
+          start: { line: 1, column: 1 },
+          end: { line: 1, column: text.length },
+        },
       },
     ],
     rawAttributes: [
@@ -248,7 +263,10 @@ Deno.test("runLint: diagnostics include slug, group, scoreContribution fields", 
       {
         kind: "paragraph",
         content: { text, markers: [] },
-        range: { start: { line: 1, column: 1 }, end: { line: 1, column: text.length } },
+        range: {
+          start: { line: 1, column: 1 },
+          end: { line: 1, column: text.length },
+        },
       },
     ],
   });
@@ -274,7 +292,10 @@ Deno.test("runLint: output is deterministic for same input", () => {
       {
         kind: "paragraph",
         content: { text, markers: [] },
-        range: { start: { line: 1, column: 1 }, end: { line: 1, column: text.length } },
+        range: {
+          start: { line: 1, column: 1 },
+          end: { line: 1, column: text.length },
+        },
       },
     ],
   });

--- a/packages/markspec/core/lint/types.ts
+++ b/packages/markspec/core/lint/types.ts
@@ -1,0 +1,20 @@
+/**
+ * @module core/lint/types
+ *
+ * LintDiagnostic — prose-quality diagnostic type, extending the core
+ * Diagnostic interface with slug, group, and score metadata. Kept
+ * separate from core Diagnostic to prevent slug/group fields from
+ * leaking into validate/compile JSON output, which has a stable schema.
+ */
+
+import type { Diagnostic } from "../model/mod.ts";
+
+/** A prose-quality diagnostic with slug and group metadata. */
+export interface LintDiagnostic extends Diagnostic {
+  /** Human-readable rule slug, e.g. "incose-r7-vague-term". */
+  readonly slug: string;
+  /** Rule group: "ears" | "modal" | "incose" | "struct" | "xref" | "disable". */
+  readonly group: "ears" | "modal" | "incose" | "struct" | "xref" | "disable";
+  /** Entry-level score contribution for this firing. */
+  readonly scoreContribution: number;
+}

--- a/packages/markspec/core/mod.ts
+++ b/packages/markspec/core/mod.ts
@@ -209,3 +209,7 @@ export type {
   ReportKind,
   ReportOptions,
 } from "./reporter/mod.ts";
+
+// Lint (prose-analysis)
+export { isProseScope, runLint } from "./lint/mod.ts";
+export type { LintDiagnostic, LintOptions, LintResult } from "./lint/mod.ts";

--- a/packages/markspec/core/model/attributes.ts
+++ b/packages/markspec/core/model/attributes.ts
@@ -261,6 +261,23 @@ export const ATTRIBUTE_CATALOG: readonly AttributeSpec[] = [
     shapes: BOTH_SHAPES,
     required: false,
   },
+
+  // Prose-analysis suppression (spec §MSL-Q900/Q901). Authored on any entry
+  // to silence specific lint rule codes; requires a companion Rationale:.
+  {
+    key: "Markspec-disable",
+    type: "text",
+    origin: "authored",
+    shapes: BOTH_SHAPES,
+    required: false,
+  },
+  {
+    key: "Rationale",
+    type: "text",
+    origin: "authored",
+    shapes: BOTH_SHAPES,
+    required: false,
+  },
 ];
 
 /** Canonical Title-Case attribute keys the core recognizes. */

--- a/packages/markspec/lsp/diagnostics.ts
+++ b/packages/markspec/lsp/diagnostics.ts
@@ -65,7 +65,10 @@ export function toLspDiagnostic(diagnostic: CoreDiagnostic): LspDiagnostic {
     message: diagnostic.message,
   };
   if (diagnostic.code.startsWith("MSL-Q")) {
-    return { ...base, codeDescription: { href: buildRuleDocUrl(diagnostic.code) } };
+    return {
+      ...base,
+      codeDescription: { href: buildRuleDocUrl(diagnostic.code) },
+    };
   }
   return base;
 }

--- a/packages/markspec/lsp/diagnostics.ts
+++ b/packages/markspec/lsp/diagnostics.ts
@@ -23,6 +23,8 @@ export interface LspDiagnostic {
   readonly source: string;
   readonly code: string;
   readonly message: string;
+  /** Link to rule documentation, populated for MSL-Q codes. */
+  readonly codeDescription?: { readonly href: string };
 }
 
 /** Map MarkSpec severity to LSP DiagnosticSeverity numeric values. */
@@ -44,10 +46,15 @@ export function toLspSeverity(severity: Severity): number {
  * the same line with a large character value — the editor will clamp to
  * end-of-line, producing an underline from the start position to EOL.
  */
+/** Build a rule documentation URL for MSL-Q lint codes. */
+function buildRuleDocUrl(code: string): string {
+  return `https://markspec.dev/lint/rules/${code.toLowerCase()}`;
+}
+
 export function toLspDiagnostic(diagnostic: CoreDiagnostic): LspDiagnostic {
   const line = diagnostic.location ? diagnostic.location.line - 1 : 0;
   const character = diagnostic.location ? diagnostic.location.column - 1 : 0;
-  return {
+  const base: LspDiagnostic = {
     range: {
       start: { line, character },
       end: { line, character: Number.MAX_SAFE_INTEGER },
@@ -57,6 +64,10 @@ export function toLspDiagnostic(diagnostic: CoreDiagnostic): LspDiagnostic {
     code: diagnostic.code,
     message: diagnostic.message,
   };
+  if (diagnostic.code.startsWith("MSL-Q")) {
+    return { ...base, codeDescription: { href: buildRuleDocUrl(diagnostic.code) } };
+  }
+  return base;
 }
 
 /**

--- a/packages/markspec/main.ts
+++ b/packages/markspec/main.ts
@@ -1289,6 +1289,51 @@ const cli = new Command()
       }
     },
   )
+  .command("lint <paths...:string>")
+  .description(
+    "Run prose-quality rules on entries (lexicon, structural, suppression hygiene)",
+  )
+  .option(
+    "--format <format:string>",
+    "Output format (json|text)",
+    { default: "text" },
+  )
+  .option("--strict", "Promote warnings to errors")
+  .action(
+    async (
+      options: { format?: string; strict?: boolean },
+      ...paths: string[]
+    ) => {
+      const { result } = await compileProject(paths);
+      const { runLint } = await import("./core/mod.ts");
+      const lintResult = runLint({ entries: [...result.entries.values()] });
+
+      let diagnostics = [...lintResult.diagnostics];
+      if (options.strict) {
+        diagnostics = diagnostics.map((d) =>
+          d.severity === "warning" ? { ...d, severity: "error" as const } : d
+        );
+      }
+
+      const hasErrors = diagnostics.some((d) => d.severity === "error");
+      const hasWarnings = diagnostics.some((d) => d.severity === "warning");
+
+      if (options.format === "json") {
+        console.log(JSON.stringify(diagnostics, null, 2));
+      } else {
+        for (const d of diagnostics) {
+          const loc = d.location ? `${d.location.file}:${d.location.line}` : "";
+          console.error(`${d.severity}[${d.code}]: ${loc} ${d.message}`);
+        }
+      }
+
+      if (hasErrors) {
+        Deno.exit(1);
+      } else if (hasWarnings) {
+        Deno.exit(2);
+      }
+    },
+  )
   .command("hook [...files:string]")
   .description("Run format --check + validate as a pre-commit hook")
   .action(async (_options: Record<string, unknown>, ...files: string[]) => {

--- a/tests/e2e/lint_test.ts
+++ b/tests/e2e/lint_test.ts
@@ -1,0 +1,140 @@
+/**
+ * @module tests/e2e/lint_test
+ *
+ * Blackbox E2E tests for `markspec lint`. Runs the CLI binary against
+ * fixture files and asserts exit codes, stdout, and stderr.
+ */
+
+import { assertEquals } from "@std/assert";
+import { markspec } from "./helpers.ts";
+
+// ---------------------------------------------------------------------------
+// Shared fixtures
+// ---------------------------------------------------------------------------
+
+const PROJECT_YAML = `name: test-project
+version: 0.0.1
+`;
+
+/** A clean requirement with no lint issues. */
+const CLEAN_FIXTURE = `- [REQ-001] System shall process sensor data within 100 milliseconds
+
+  The system shall receive sensor readings from all active channels and
+  process each reading within the required latency budget for real-time
+  control operation.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      Type: Requirement
+`;
+
+/** A fixture that triggers Q302 ('some') and Q303 ('as appropriate'). */
+const VAGUE_FIXTURE = `- [REQ-001] System shall handle sensor data
+
+  The system shall use some requirements that should be adequate for
+  the task and respond as appropriate to each situation.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      Type: Requirement
+`;
+
+/** A fixture with a title that is too short (< 3 chars). */
+const SHORT_TITLE_FIXTURE = `- [REQ-001] Hi
+
+  The system shall receive sensor readings from all active channels and
+  process each reading within the required latency budget for real-time
+  control operation.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      Type: Requirement
+`;
+
+// ---------------------------------------------------------------------------
+// 1. Clean fixture exits 0 with valid JSON array output
+// ---------------------------------------------------------------------------
+
+Deno.test("lint: clean fixture exits 0 and stdout is valid JSON array", async () => {
+  const { code, stdout } = await markspec(
+    ["lint", "--format", "json", "req.md"],
+    { files: { "project.yaml": PROJECT_YAML, "req.md": CLEAN_FIXTURE } },
+  );
+  assertEquals(code, 0);
+  const parsed = JSON.parse(stdout);
+  assertEquals(Array.isArray(parsed), true);
+});
+
+// ---------------------------------------------------------------------------
+// 2. Vague fixture triggers MSL-Q302 and MSL-Q303
+// ---------------------------------------------------------------------------
+
+Deno.test("lint: vague fixture triggers MSL-Q302 and MSL-Q303", async () => {
+  const { code, stdout } = await markspec(
+    ["lint", "--format", "json", "req.md"],
+    { files: { "project.yaml": PROJECT_YAML, "req.md": VAGUE_FIXTURE } },
+  );
+  // Exit 2 = warnings present
+  assertEquals(code, 2);
+  const diags = JSON.parse(stdout) as Array<{ code: string }>;
+  assertEquals(diags.some((d) => d.code === "MSL-Q302"), true);
+  assertEquals(diags.some((d) => d.code === "MSL-Q303"), true);
+});
+
+// ---------------------------------------------------------------------------
+// 3. Short title triggers MSL-Q400
+// ---------------------------------------------------------------------------
+
+Deno.test("lint: entry with title < 3 chars triggers MSL-Q400", async () => {
+  const { stdout } = await markspec(
+    ["lint", "--format", "json", "req.md"],
+    { files: { "project.yaml": PROJECT_YAML, "req.md": SHORT_TITLE_FIXTURE } },
+  );
+  // Q400 is info-severity so exit is 0, but the diagnostic appears in JSON
+  const diags = JSON.parse(stdout) as Array<{ code: string }>;
+  assertEquals(diags.some((d) => d.code === "MSL-Q400"), true);
+});
+
+// ---------------------------------------------------------------------------
+// 4. --strict promotes warnings to errors → exits 1
+// ---------------------------------------------------------------------------
+
+Deno.test("lint: --strict promotes warnings to errors (exits 1)", async () => {
+  const { code } = await markspec(
+    ["lint", "--format", "json", "--strict", "req.md"],
+    { files: { "project.yaml": PROJECT_YAML, "req.md": VAGUE_FIXTURE } },
+  );
+  assertEquals(code, 1);
+});
+
+// ---------------------------------------------------------------------------
+// 5. JSON output includes slug and group fields
+// ---------------------------------------------------------------------------
+
+Deno.test("lint: JSON output includes slug, group, scoreContribution", async () => {
+  const { code, stdout } = await markspec(
+    ["lint", "--format", "json", "req.md"],
+    { files: { "project.yaml": PROJECT_YAML, "req.md": VAGUE_FIXTURE } },
+  );
+  assertEquals(code, 2);
+  const diags = JSON.parse(stdout) as Array<
+    { code: string; slug: string; group: string; scoreContribution: number }
+  >;
+  const q302 = diags.find((d) => d.code === "MSL-Q302");
+  assertEquals(q302 !== undefined, true);
+  assertEquals(typeof q302!.slug, "string");
+  assertEquals(typeof q302!.group, "string");
+  assertEquals(typeof q302!.scoreContribution, "number");
+});
+
+// ---------------------------------------------------------------------------
+// 6. Regression: markspec validate output unchanged (no MSL-Q codes in validate)
+// ---------------------------------------------------------------------------
+
+Deno.test("lint: markspec validate does not emit MSL-Q codes", async () => {
+  const { code, stderr } = await markspec(
+    ["validate", "req.md"],
+    { files: { "req.md": VAGUE_FIXTURE } },
+  );
+  // validate should exit 0 (no structural errors in the fixture)
+  assertEquals(code, 0);
+  // No MSL-Q codes in validate output
+  assertEquals(stderr.includes("MSL-Q"), false);
+});

--- a/tests/e2e/lint_test.ts
+++ b/tests/e2e/lint_test.ts
@@ -17,7 +17,8 @@ version: 0.0.1
 `;
 
 /** A clean requirement with no lint issues. */
-const CLEAN_FIXTURE = `- [REQ-001] System shall process sensor data within 100 milliseconds
+const CLEAN_FIXTURE =
+  `- [REQ-001] System shall process sensor data within 100 milliseconds
 
   The system shall receive sensor readings from all active channels and
   process each reading within the required latency budget for real-time


### PR DESCRIPTION
## Summary

- Implements the `markspec lint` subcommand (PA-1 of the prose-analysis spec)
- Adds `LintDiagnostic` supertype (`slug`, `group`, `scoreContribution`) — kept separate from core `Diagnostic` to prevent leaking into validate/compile JSON output
- Ships 10 MSL-Q rules: 6 INCOSE lexicon rules (Q302–Q305, Q310, Q313), 2 structural rules (Q400 title length, Q401 body word count), 2 suppression-hygiene rules (Q900 disable-without-rationale, Q901 disable-unknown-rule)
- `Markspec-disable:` + `Rationale:` added to attribute catalog
- LSP `codeDescription.href` populated for MSL-Q codes
- 38 unit tests + 6 e2e tests; all 1482 tests pass; `just build` green
- Hard invariant maintained: `markspec validate` output unchanged

## Test plan

- [x] `just build` passes (lint + test + typecheck + compile)
- [x] Unit tests: `core/lint/runner_test.ts` (13 tests), `core/lint/rules/lexicon_test.ts` (25 tests)
- [x] E2E tests: `tests/e2e/lint_test.ts` (6 tests including regression: validate output unchanged)
- [x] Q302/Q303 fire on vague fixtures; Q400 fires on short title; suppression drops matched rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)