### PR TITLE
feat(core): toolchain Tier 1 — CORE_SCHEMA_VERSION, LSP serverInfo, completions

### DIFF
--- a/docs/guide/quickstart.md
+++ b/docs/guide/quickstart.md
@@ -5,21 +5,35 @@ install to a rendered HTML book with entry blocks and a traceability link.
 
 ## Step 1 — Install (2 min)
 
-Install MarkSpec globally from JSR:
+### Pre-compiled binary (recommended)
+
+Downloads a self-contained binary — no Deno or Node.js required at runtime:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/driftsys/markspec/main/install.sh | sh
+```
+
+The installer detects your platform (macOS or Linux), downloads the release
+binary, verifies the SHA256 checksum, and places it in `~/.local/bin`. Add that
+directory to your `PATH` if it is not already there.
+
+### Deno runtime (for Deno developers)
+
+If you already have Deno installed and want to run MarkSpec from source:
 
 ```sh
 deno install -g jsr:@driftsys/markspec
 ```
 
-Verify the install:
+If `markspec` is not found after install, add `~/.deno/bin` to your `PATH`.
+
+> **Run without installing:** `deno run jsr:@driftsys/markspec --help`
+
+### Verify the install
 
 ```sh
 markspec --version
 ```
-
-If `markspec` is not found after install, add `~/.deno/bin` to your `PATH`.
-
-> **Run without installing:** `deno run jsr:@driftsys/markspec --help`
 
 ## Step 2 — Create a project (1 min)
 

--- a/packages/markspec/core/mod.ts
+++ b/packages/markspec/core/mod.ts
@@ -9,6 +9,7 @@
  */
 
 export const VERSION = "0.4.0";
+export const CORE_SCHEMA_VERSION = 1;
 
 // Model types
 export {

--- a/packages/markspec/core/mod_test.ts
+++ b/packages/markspec/core/mod_test.ts
@@ -2,6 +2,7 @@ import { assertEquals, assertMatch } from "@std/assert";
 import {
   compile,
   ConfigError,
+  CORE_SCHEMA_VERSION,
   DEFAULT_PROJECT_CONFIG,
   format,
   parse,
@@ -25,13 +26,18 @@ import type {
 } from "./mod.ts";
 
 // ---------------------------------------------------------------------------
-// VERSION
+// VERSION + CORE_SCHEMA_VERSION
 // ---------------------------------------------------------------------------
 
 Deno.test("version is set", () => {
   // Don't pin to a literal — the bump tooling rewrites this on every
   // release. Assert the shape (semver-ish) instead.
   assertMatch(VERSION, /^\d+\.\d+\.\d+(-[\w.]+)?$/);
+});
+
+Deno.test("CORE_SCHEMA_VERSION is exported and equals 1", () => {
+  assertEquals(typeof CORE_SCHEMA_VERSION, "number");
+  assertEquals(CORE_SCHEMA_VERSION, 1);
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/markspec/lsp/server.ts
+++ b/packages/markspec/lsp/server.ts
@@ -29,6 +29,7 @@ import {
 import { TextDocument } from "vscode-languageserver-textdocument";
 import process from "node:process";
 import {
+  CORE_SCHEMA_VERSION,
   DEFAULT_PROJECT_CONFIG,
   type Diagnostic as CoreDiagnostic,
   discoverProjectRoot,
@@ -36,6 +37,7 @@ import {
   loadConfig,
   loadProfileForCommand,
   type ProjectConfig,
+  VERSION,
 } from "../core/mod.ts";
 import { WorkspaceIndex } from "./workspace.ts";
 import { groupDiagnosticsByFile, toLspDiagnostic } from "./diagnostics.ts";
@@ -66,8 +68,6 @@ import {
 } from "./context.ts";
 import { debounce, pathToUri, uriToPath } from "./util.ts";
 import { debugLog } from "./debug_log.ts";
-
-export const VERSION = "0.4.0";
 
 // ---------------------------------------------------------------------------
 // Connection and document manager
@@ -247,6 +247,10 @@ connection.onInitialize(
         documentHighlightProvider: true,
         codeActionProvider: { codeActionKinds: ["quickfix"] },
       },
+      serverInfo: {
+        name: "markspec",
+        version: `${VERSION} (core-schema ${CORE_SCHEMA_VERSION})`,
+      },
     };
   },
 );
@@ -295,6 +299,11 @@ connection.onInitialized(async () => {
     connection.sendNotification("markspec/indexed", {
       files: files.length,
       entries: index.getAllEntries().length,
+    });
+
+    connection.sendNotification("markspec/version", {
+      release: VERSION,
+      coreSchemaVersion: CORE_SCHEMA_VERSION,
     });
   } catch (err) {
     connection.console.error(`Indexing failed: ${err}`);

--- a/packages/markspec/main.ts
+++ b/packages/markspec/main.ts
@@ -9,7 +9,8 @@
  */
 
 import { Command } from "@cliffy/command";
-import { ConfigError, VERSION } from "./core/mod.ts";
+import { CompletionsCommand } from "@cliffy/command/completions";
+import { ConfigError, CORE_SCHEMA_VERSION, VERSION } from "./core/mod.ts";
 import type {
   CaptionConventions,
   CompileResult,
@@ -558,7 +559,7 @@ const deckCmd = new Command()
 
 const cli = new Command()
   .name("markspec")
-  .version(VERSION)
+  .version(`${VERSION} (core-schema ${CORE_SCHEMA_VERSION})`)
   .description(
     "Markdown flavor and toolchain for traceable industrial documentation",
   )
@@ -1454,8 +1455,10 @@ const cli = new Command()
   .command("version")
   .description("Print version")
   .action(() => {
-    console.log(`markspec ${VERSION}`);
+    console.log(`markspec ${VERSION} (core-schema ${CORE_SCHEMA_VERSION})`);
   })
+  // Shell completions (bash, zsh, fish)
+  .command("completions", new CompletionsCommand())
   // Help subcommand: enables `markspec help show`, etc. (clig.dev)
   .command("help [...command:string]")
   .description("Show help for a command")

--- a/packages/markspec/mcp/server.ts
+++ b/packages/markspec/mcp/server.ts
@@ -12,7 +12,7 @@
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import process from "node:process";
-import { VERSION } from "../core/mod.ts";
+import { CORE_SCHEMA_VERSION, VERSION } from "../core/mod.ts";
 import { createProject, defaultEnv } from "./project.ts";
 import { registerResources } from "./resources/mod.ts";
 import { registerTools } from "./tools/mod.ts";
@@ -52,7 +52,11 @@ All resource bodies are Markdown with cross-references as markspec:// URIs you c
  */
 export async function startServer(): Promise<void> {
   const server = new Server(
-    { name: "markspec", version: VERSION },
+    {
+      name: "markspec",
+      version: VERSION,
+      coreSchemaVersion: CORE_SCHEMA_VERSION,
+    },
     {
       capabilities: {
         resources: { subscribe: true, listChanged: true },

--- a/tests/e2e/version_test.ts
+++ b/tests/e2e/version_test.ts
@@ -1,0 +1,26 @@
+import { assertEquals, assertMatch, assertStringIncludes } from "@std/assert";
+import { markspec } from "./helpers.ts";
+
+Deno.test("--version includes core-schema component", async () => {
+  const { code, stdout } = await markspec(["--version"]);
+  assertEquals(code, 0);
+  assertMatch(stdout, /\d+\.\d+\.\d+ \(core-schema \d+\)/);
+});
+
+Deno.test("version subcommand includes core-schema component", async () => {
+  const { code, stdout } = await markspec(["version"]);
+  assertEquals(code, 0);
+  assertMatch(stdout, /markspec \d+\.\d+\.\d+ \(core-schema \d+\)/m);
+});
+
+Deno.test("completions bash exits 0 and outputs bash script", async () => {
+  const { code, stdout } = await markspec(["completions", "bash"]);
+  assertEquals(code, 0);
+  assertStringIncludes(stdout, "markspec");
+});
+
+Deno.test("completions zsh exits 0 and outputs zsh script", async () => {
+  const { code, stdout } = await markspec(["completions", "zsh"]);
+  assertEquals(code, 0);
+  assertStringIncludes(stdout, "#compdef");
+});


### PR DESCRIPTION
## Summary

- Add `CORE_SCHEMA_VERSION = 1` to `core/mod.ts`; export from the public barrel
- `markspec --version` / `markspec version` now output `X.Y.Z (core-schema 1)`
- LSP `initialize` response gains `serverInfo` + `markspec/version` notification after indexing
- MCP `Server` constructor extended with `coreSchemaVersion: 1`
- `markspec completions bash|zsh|fish` enabled via Cliffy `CompletionsCommand`
- `docs/guide/quickstart.md` documents both install paths (pre-compiled binary + Deno/JSR)

## Test Plan

- [x] New unit test: `CORE_SCHEMA_VERSION` is exported from `core/mod.ts` and equals `1`
- [x] New e2e tests: `--version` and `version` match `\d+\.\d+\.\d+ \(core-schema \d+\)`, `completions bash` / `completions zsh` exit 0 with expected output
- [x] All 1443 tests pass (`just build` green)
- [x] `deno lint` and `dprint check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)