### PR TITLE
feat(skills): add markspec-core upskill bundle

### DIFF
--- a/docs/superpowers/specs/2026-05-19-markspec-skills-design.md
+++ b/docs/superpowers/specs/2026-05-19-markspec-skills-design.md
@@ -1,0 +1,307 @@
+# MarkSpec Skills Bundle Design
+
+**Date:** 2026-05-19
+**Status:** Draft
+
+---
+
+## Overview
+
+This spec defines how AI-assistance content (rules, skills) is authored, distributed, and
+extended for MarkSpec consumer projects using the **upskill** toolchain. It answers two
+questions:
+
+1. What skills and rules should ship with MarkSpec for teams authoring traceable docs?
+2. How does the skill set extend automatically when a project extends a profile?
+
+**Scope:** consumer-facing only. Skills for teams using MarkSpec to author compliance
+documentation, not for developing the MarkSpec toolchain itself.
+
+---
+
+## Architecture & Artifact Layout
+
+Three artifact families, one binding rule.
+
+### `markspec-core` bundle
+
+Profile-agnostic MarkSpec literacy. Lives as an upskill SSOT in the markspec repo, which
+doubles as an upskill source registry (`skills-src/REGISTRY.md` declares the registry identity
+per upskill format-spec §3.8). Every profile bundle `requires:` it (directly or transitively).
+
+```text
+markspec/
+└── skills-src/
+    ├── REGISTRY.md
+    ├── markspec-core-rules/
+    │   └── RULE.md                      ← id-integrity + format-before-commit + prose-quality
+    ├── markspec-entry-authoring/
+    │   └── SKILL.md
+    ├── markspec-write-loop/
+    │   └── SKILL.md
+    ├── markspec-diagnostics/
+    │   └── SKILL.md
+    ├── markspec-requirement-style/
+    │   └── SKILL.md
+    ├── markspec-ears/
+    │   └── SKILL.md
+    ├── markspec-gherkin/
+    │   └── SKILL.md
+    ├── markspec-profile-bundle-authoring/
+    │   └── SKILL.md
+    └── markspec-core.bundle.md
+```
+
+### Per-profile bundle
+
+Co-located in the profile package, in a `skills/` slot sibling to ADR-008 §10's reserved
+`hooks/`:
+
+```text
+<profile-id>/
+├── markspec.yaml                        ← extends: "npm:@markspec/profile-default@^1.0"
+├── hooks/                               ← ADR-008 §10 (deferred)
+├── skills/
+│   ├── <profile-id>.bundle.md           ← requires: derived from extends:
+│   ├── <profile-id>-rules/
+│   │   └── RULE.md                      ← profile-specific always-on rules
+│   └── <skill-name>/
+│       └── SKILL.md
+└── README.md
+```
+
+### The binding rule
+
+> A profile's bundle `requires:` entry mirrors the profile's `extends:` field.
+> `extends: X` → the bundle `requires:` X's bundle.
+> The default profile's bundle `requires: [markspec-core]`.
+> Every profile bundle transitively pulls `markspec-core`.
+
+The bundle `requires:` chain is a structural shadow of the profile `extends:` chain:
+
+```
+public-domain (e.g. aspice-4)
+  requires: profile-default
+    requires: markspec-core
+```
+
+mirrors:
+
+```
+aspice-4 markspec.yaml
+  extends: profile-default
+    extends: (none — root)
+```
+
+A consumer runs `upskill add <registry>:<id>.bundle.md`. upskill's transitive `requires:`
+resolution (format-spec §3.7) walks the chain and unions every tier's skills — the same
+closure markspec's loader computes for profile vocabulary.
+
+**SSOT vs consumer split is preserved.** Profile repos hold SSOT (`skills/` items). Consumer
+projects only ever get generated `.claude/` `.github/` `.agents/` outputs via `upskill add`,
+recorded in `.upskill-lock.json`.
+
+---
+
+## Binding Mechanism
+
+No code generates the bundle skeleton. The binding is enforced by a skill, a template, and a
+recipe — not by the markspec CLI.
+
+### Template
+
+A `skills/_template.bundle.md` committed alongside the default profile:
+
+```yaml
+---
+schema: 1
+name: <profile-id>        # match markspec.yaml `id:`, strip @scope/ prefix
+description: <one line>
+license: <SPDX>
+
+items:
+  rules:
+    # - <rule-name>       # one entry per skills/<rule-name>/RULE.md
+  skills:
+    # - <skill-name>      # one entry per skills/<skill-name>/SKILL.md
+  agents: []
+
+requires:
+  # Mirror your profile's `extends:` — one entry per parent profile's bundle.
+  # Example:
+  #   markspec.yaml has:   extends: "npm:@markspec/profile-default@^1.0"
+  #   Bundle requires:     - { name: "profile-default" }
+  #
+  # The default profile's bundle already requires markspec-core, so the full
+  # literacy chain is inherited without listing it explicitly.
+  - { name: "<parent-profile-bundle-name>" }
+
+metadata:
+  markspec-profile: "<profile-id>"
+---
+```
+
+### Recipe
+
+A recipe page (`docs/guide/recipes/profile-skills.md`) explains the single invariant:
+
+> **The bundle `requires:` mirrors the profile `extends:` field.** For every `extends:` target
+> in `markspec.yaml`, add a matching `requires:` entry in the bundle manifest. Use the parent
+> profile's bundle `name` — the same `id` from its `markspec.yaml` with the `@scope/`
+> stripped. The extends-chain and the requires-chain stay in lock-step by convention; auditing
+> the pair is a one-line diff.
+
+The recipe also covers:
+
+- where to create `skills/` relative to `markspec.yaml`
+- naming convention: bundle `name` = profile `id` with `@scope/` stripped
+- how to register new `RULE.md` / `SKILL.md` items and add their names to `items.*`
+- the CI grep check (see Verification below)
+
+### `markspec-profile-bundle-authoring` skill
+
+Lives in `markspec-core`. Teaches AI agents (and human authors) the full authoring flow:
+
+1. Locate the profile's `markspec.yaml` and read `extends:`
+2. Create `skills/<profile-id>.bundle.md` from the template
+3. Derive `requires:` from `extends:` (the only field markspec semantics determine)
+4. Create item directories under `skills/` for each rule/skill to author
+5. Write RULE.md / SKILL.md bodies following upskill format-spec §2/§3
+6. Add item names to `items.rules` / `items.skills` in the bundle manifest
+7. Review checklist: bundle name = profile id (sans scope), requires mirrors extends, every
+   item in `items.*` has a corresponding directory
+
+---
+
+## Skill Inventory
+
+### `markspec-core.bundle.md`
+
+```yaml
+items:
+  rules:
+    - markspec-core-rules
+  skills:
+    - markspec-entry-authoring
+    - markspec-write-loop
+    - markspec-diagnostics
+    - markspec-requirement-style
+    - markspec-ears
+    - markspec-gherkin
+    - markspec-profile-bundle-authoring
+requires: []
+```
+
+| Kind | Name | Activation hint |
+|------|------|----------------|
+| rule | `markspec-core-rules` | Three always-on authoring invariants: Id integrity (never hand-stamp Id: or forge a ULID), format before commit (run markspec format or hook before committing), prose quality (single-responsibility, active voice, measurable, no compound requirements) |
+| skill | `markspec-entry-authoring` | Use when writing, editing, or reviewing a MarkSpec entry block — the `- [TYPE_NNNN] Title` format, body, trailer attributes (Id, Type, Satisfies, Labels…) |
+| skill | `markspec-write-loop` | Use when writing entries to files — teaches the `markspec insert → markspec format → markspec validate` canonical agent write path |
+| skill | `markspec-diagnostics` | Use when `markspec validate` output contains MSL- codes — covers code families (P0xx parse, I0xx identity, M0xx modal, A0xx attribute, T0xx type, B0xx body, C0xx caption), severity, and common fixes |
+| skill | `markspec-requirement-style` | Use first when choosing how to write requirement body text — overview of EARS vs Gherkin vs plain prose, selection criteria, pointers to `markspec-ears` and `markspec-gherkin` |
+| skill | `markspec-ears` | Use when writing EARS-style requirements — all five patterns (ubiquitous / event-driven / state-driven / optional / unwanted) with do/don't examples in MarkSpec entry format |
+| skill | `markspec-gherkin` | Use when writing Gherkin acceptance criteria — Given/When/Then structure, Scenario Outline, Background, do/don't examples, and how scenarios map to MarkSpec Verified-by attributes |
+| skill | `markspec-profile-bundle-authoring` | Use when creating or extending a MarkSpec profile's upskill bundle — teaches the `skills/` slot layout, deriving `requires:` from `extends:`, and registering SKILL.md/RULE.md items |
+
+### `profile-default.bundle.md` (illustrative)
+
+```yaml
+items:
+  rules:
+    - profile-default-rules
+  skills:
+    - markspec-modal-language
+requires:
+  # profile-default has no extends: in markspec.yaml (it is the chain root),
+  # so there is no parent to derive requires: from. This is the one entry in
+  # the system that is hand-authored rather than derived from extends:.
+  - { name: "markspec-core" }
+```
+
+| Kind | Name | Activation hint |
+|------|------|----------------|
+| rule | `profile-default-rules` | RFC 2119 modal keywords (shall, should, may, must, will) must appear lowercase — enforces MSL-M060 |
+| skill | `markspec-modal-language` | Use when writing requirement body text — teaches RFC 2119 shall/should/may/must/will distinctions, anti-patterns, and how the validator flags MSL-M0xx violations |
+
+### `profile-aspice-4.bundle.md` (illustrative)
+
+```yaml
+items:
+  rules:
+    - aspice-4-rules
+  skills:
+    - aspice-type-vocabulary
+    - aspice-traceability-topology
+requires:
+  - { name: "profile-default" }    # derived from extends: "npm:@markspec/profile-default@^1"
+```
+
+| Kind | Name | Activation hint |
+|------|------|----------------|
+| rule | `aspice-4-rules` | Every identified entry must carry exactly one ASIL label (ASIL-A through ASIL-D, or QM); mixing levels in one entry is an error |
+| skill | `aspice-type-vocabulary` | Use when creating or classifying entries — teaches the ASPICE 4.0 type hierarchy (STK, SYS, SWE, SIT, SWT), when to use each, and display-ID patterns |
+| skill | `aspice-traceability-topology` | Use when linking requirements or reading coverage — teaches the V-model chain (STK→SYS→SWE via Satisfies, SWE→SIT→SWT via Verified-by) and how to interpret `markspec report traceability` gaps |
+
+---
+
+## Data Flow
+
+```
+Profile author
+  1. Creates profile package: markspec.yaml + skills/ slot
+  2. Invokes markspec-profile-bundle-authoring skill
+       → scaffolds <id>.bundle.md from template
+       → derives requires: from markspec.yaml extends:
+  3. Hand-authors RULE.md / SKILL.md bodies under skills/
+  4. Adds item names to items.rules / items.skills in the bundle manifest
+  5. Runs markspec profile publish → profile available via npm/git
+
+Consumer project
+  6. upskill add <registry>:<id>.bundle.md
+  7. upskill resolves requires: transitively across the chain:
+       aspice-4 → profile-default → markspec-core
+  8. upskill generates client outputs:
+       .claude/rules/markspec-core-rules.md
+       .claude/skills/markspec-entry-authoring.md
+       .claude/skills/markspec-ears.md
+       ... (full closure, all tiers)
+       .github/ and .agents/ equivalents
+  9. Consumer commits .upskill-lock.json — locks refs and hashes
+```
+
+Step 2 is the only place where the `extends:` → `requires:` mirror is applied. The skill body
+is the single source of truth for that convention.
+
+---
+
+## Edge Cases
+
+| Case | Handling |
+|------|----------|
+| Profile in chain has no `skills/` slot | upskill reports unresolved `requires:` entry. Recipe doc states: every profile in the chain must ship a bundle; hook-only profiles (no `profile:` content section) are the exception — document in the profile's README that no bundle is provided. |
+| Bundle `name` doesn't match profile `id` | Convention: strip `@scope/` from the profile `id`. Documented in template and recipe. Caught in code review, not by tooling. |
+| `extends:` uses a semver range, `requires:` has no version pin | Intentional. `requires:` names the parent bundle without a version constraint, letting upskill resolve to whatever the consumer has installed. Recipe advises this default; pinning is opt-in for stricter environments. |
+| Consumer project uses no profile (markspec-core only) | `upskill add markspec:markspec-core.bundle.md`. Valid — no requires chain needed. |
+
+---
+
+## Verification
+
+No code to unit-test. Verification is:
+
+- `upskill lint --strict` on every bundle manifest and item body (format-spec conformance,
+  description length, required fields). Run in CI for `skills-src/` in the markspec repo and
+  for `skills/` in each profile package.
+- A one-liner CI grep asserts the extends→requires mirror for each profile package:
+
+  ```bash
+  # Illustrative — handles npm: and git: specifiers. Local specifiers (./path)
+  # require different parsing; see recipe doc for the complete check.
+  EXTENDS=$(grep '^extends:' markspec.yaml \
+    | sed 's/.*@\([^@/]*\)\/.*/\1/; s/.*\///; s/@.*//')
+  grep -q "name: \"$EXTENDS\"" skills/*.bundle.md || exit 1
+  ```
+
+- **Acceptance criterion:** a profile author following the recipe and the
+  `markspec-profile-bundle-authoring` skill can produce a `upskill add`-installable bundle
+  in one session, with the full chain resolving correctly.

--- a/docs/superpowers/specs/2026-05-19-markspec-skills-design.md
+++ b/docs/superpowers/specs/2026-05-19-markspec-skills-design.md
@@ -1,21 +1,21 @@
 # MarkSpec Skills Bundle Design
 
-**Date:** 2026-05-19
-**Status:** Draft
+**Date:** 2026-05-19 **Status:** Draft
 
 ---
 
 ## Overview
 
-This spec defines how AI-assistance content (rules, skills) is authored, distributed, and
-extended for MarkSpec consumer projects using the **upskill** toolchain. It answers two
-questions:
+This spec defines how AI-assistance content (rules, skills) is authored,
+distributed, and extended for MarkSpec consumer projects using the **upskill**
+toolchain. It answers two questions:
 
-1. What skills and rules should ship with MarkSpec for teams authoring traceable docs?
+1. What skills and rules should ship with MarkSpec for teams authoring traceable
+   docs?
 2. How does the skill set extend automatically when a project extends a profile?
 
-**Scope:** consumer-facing only. Skills for teams using MarkSpec to author compliance
-documentation, not for developing the MarkSpec toolchain itself.
+**Scope:** consumer-facing only. Skills for teams using MarkSpec to author
+compliance documentation, not for developing the MarkSpec toolchain itself.
 
 ---
 
@@ -25,13 +25,14 @@ Three artifact families, one binding rule.
 
 ### `markspec-core` bundle
 
-Profile-agnostic MarkSpec literacy. Lives as an upskill SSOT in the markspec repo, which
-doubles as an upskill source registry (`skills-src/REGISTRY.md` declares the registry identity
-per upskill format-spec §3.8). Every profile bundle `requires:` it (directly or transitively).
+Profile-agnostic MarkSpec literacy. Lives as an upskill SSOT in the markspec
+repo, which doubles as an upskill source registry (`skills/REGISTRY.md` declares
+the registry identity per upskill format-spec §3.8). Every profile bundle
+`requires:` it (directly or transitively).
 
 ```text
 markspec/
-└── skills-src/
+└── skills/
     ├── REGISTRY.md
     ├── markspec-core-rules/
     │   └── RULE.md                      ← id-integrity + format-before-commit + prose-quality
@@ -54,8 +55,8 @@ markspec/
 
 ### Per-profile bundle
 
-Co-located in the profile package, in a `skills/` slot sibling to ADR-008 §10's reserved
-`hooks/`:
+Co-located in the profile package, in a `skills/` slot sibling to ADR-008 §10's
+reserved `hooks/`:
 
 ```text
 <profile-id>/
@@ -73,11 +74,12 @@ Co-located in the profile package, in a `skills/` slot sibling to ADR-008 §10's
 ### The binding rule
 
 > A profile's bundle `requires:` entry mirrors the profile's `extends:` field.
-> `extends: X` → the bundle `requires:` X's bundle.
-> The default profile's bundle `requires: [markspec-core]`.
-> Every profile bundle transitively pulls `markspec-core`.
+> `extends: X` → the bundle `requires:` X's bundle. The default profile's bundle
+> `requires: [markspec-core]`. Every profile bundle transitively pulls
+> `markspec-core`.
 
-The bundle `requires:` chain is a structural shadow of the profile `extends:` chain:
+The bundle `requires:` chain is a structural shadow of the profile `extends:`
+chain:
 
 ```
 public-domain (e.g. aspice-4)
@@ -93,20 +95,21 @@ aspice-4 markspec.yaml
     extends: (none — root)
 ```
 
-A consumer runs `upskill add <registry>:<id>.bundle.md`. upskill's transitive `requires:`
-resolution (format-spec §3.7) walks the chain and unions every tier's skills — the same
-closure markspec's loader computes for profile vocabulary.
+A consumer runs `upskill add <registry>:<id>.bundle.md`. upskill's transitive
+`requires:` resolution (format-spec §3.7) walks the chain and unions every
+tier's skills — the same closure markspec's loader computes for profile
+vocabulary.
 
-**SSOT vs consumer split is preserved.** Profile repos hold SSOT (`skills/` items). Consumer
-projects only ever get generated `.claude/` `.github/` `.agents/` outputs via `upskill add`,
-recorded in `.upskill-lock.json`.
+**SSOT vs consumer split is preserved.** Profile repos hold SSOT (`skills/`
+items). Consumer projects only ever get generated `.claude/` `.github/`
+`.agents/` outputs via `upskill add`, recorded in `.upskill-lock.json`.
 
 ---
 
 ## Binding Mechanism
 
-No code generates the bundle skeleton. The binding is enforced by a skill, a template, and a
-recipe — not by the markspec CLI.
+No code generates the bundle skeleton. The binding is enforced by a skill, a
+template, and a recipe — not by the markspec CLI.
 
 ### Template
 
@@ -143,33 +146,38 @@ metadata:
 
 ### Recipe
 
-A recipe page (`docs/guide/recipes/profile-skills.md`) explains the single invariant:
+A recipe page (`docs/guide/recipes/profile-skills.md`) explains the single
+invariant:
 
-> **The bundle `requires:` mirrors the profile `extends:` field.** For every `extends:` target
-> in `markspec.yaml`, add a matching `requires:` entry in the bundle manifest. Use the parent
-> profile's bundle `name` — the same `id` from its `markspec.yaml` with the `@scope/`
-> stripped. The extends-chain and the requires-chain stay in lock-step by convention; auditing
-> the pair is a one-line diff.
+> **The bundle `requires:` mirrors the profile `extends:` field.** For every
+> `extends:` target in `markspec.yaml`, add a matching `requires:` entry in the
+> bundle manifest. Use the parent profile's bundle `name` — the same `id` from
+> its `markspec.yaml` with the `@scope/` stripped. The extends-chain and the
+> requires-chain stay in lock-step by convention; auditing the pair is a
+> one-line diff.
 
 The recipe also covers:
 
 - where to create `skills/` relative to `markspec.yaml`
 - naming convention: bundle `name` = profile `id` with `@scope/` stripped
-- how to register new `RULE.md` / `SKILL.md` items and add their names to `items.*`
+- how to register new `RULE.md` / `SKILL.md` items and add their names to
+  `items.*`
 - the CI grep check (see Verification below)
 
 ### `markspec-profile-bundle-authoring` skill
 
-Lives in `markspec-core`. Teaches AI agents (and human authors) the full authoring flow:
+Lives in `markspec-core`. Teaches AI agents (and human authors) the full
+authoring flow:
 
 1. Locate the profile's `markspec.yaml` and read `extends:`
 2. Create `skills/<profile-id>.bundle.md` from the template
-3. Derive `requires:` from `extends:` (the only field markspec semantics determine)
+3. Derive `requires:` from `extends:` (the only field markspec semantics
+   determine)
 4. Create item directories under `skills/` for each rule/skill to author
 5. Write RULE.md / SKILL.md bodies following upskill format-spec §2/§3
 6. Add item names to `items.rules` / `items.skills` in the bundle manifest
-7. Review checklist: bundle name = profile id (sans scope), requires mirrors extends, every
-   item in `items.*` has a corresponding directory
+7. Review checklist: bundle name = profile id (sans scope), requires mirrors
+   extends, every item in `items.*` has a corresponding directory
 
 ---
 
@@ -192,16 +200,16 @@ items:
 requires: []
 ```
 
-| Kind | Name | Activation hint |
-|------|------|----------------|
-| rule | `markspec-core-rules` | Three always-on authoring invariants: Id integrity (never hand-stamp Id: or forge a ULID), format before commit (run markspec format or hook before committing), prose quality (single-responsibility, active voice, measurable, no compound requirements) |
-| skill | `markspec-entry-authoring` | Use when writing, editing, or reviewing a MarkSpec entry block — the `- [TYPE_NNNN] Title` format, body, trailer attributes (Id, Type, Satisfies, Labels…) |
-| skill | `markspec-write-loop` | Use when writing entries to files — teaches the `markspec insert → markspec format → markspec validate` canonical agent write path |
-| skill | `markspec-diagnostics` | Use when `markspec validate` output contains MSL- codes — covers code families (P0xx parse, I0xx identity, M0xx modal, A0xx attribute, T0xx type, B0xx body, C0xx caption), severity, and common fixes |
-| skill | `markspec-requirement-style` | Use first when choosing how to write requirement body text — overview of EARS vs Gherkin vs plain prose, selection criteria, pointers to `markspec-ears` and `markspec-gherkin` |
-| skill | `markspec-ears` | Use when writing EARS-style requirements — all five patterns (ubiquitous / event-driven / state-driven / optional / unwanted) with do/don't examples in MarkSpec entry format |
-| skill | `markspec-gherkin` | Use when writing Gherkin acceptance criteria — Given/When/Then structure, Scenario Outline, Background, do/don't examples, and how scenarios map to MarkSpec Verified-by attributes |
-| skill | `markspec-profile-bundle-authoring` | Use when creating or extending a MarkSpec profile's upskill bundle — teaches the `skills/` slot layout, deriving `requires:` from `extends:`, and registering SKILL.md/RULE.md items |
+| Kind  | Name                                | Activation hint                                                                                                                                                                                                                                            |
+| ----- | ----------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| rule  | `markspec-core-rules`               | Three always-on authoring invariants: Id integrity (never hand-stamp Id: or forge a ULID), format before commit (run markspec format or hook before committing), prose quality (single-responsibility, active voice, measurable, no compound requirements) |
+| skill | `markspec-entry-authoring`          | Use when writing, editing, or reviewing a MarkSpec entry block — the `- [TYPE_NNNN] Title` format, body, trailer attributes (Id, Type, Satisfies, Labels…)                                                                                                 |
+| skill | `markspec-write-loop`               | Use when writing entries to files — teaches the `markspec insert → markspec format → markspec validate` canonical agent write path                                                                                                                         |
+| skill | `markspec-diagnostics`              | Use when `markspec validate` output contains MSL- codes — covers code families (P0xx parse, I0xx identity, M0xx modal, A0xx attribute, T0xx type, B0xx body, C0xx caption), severity, and common fixes                                                     |
+| skill | `markspec-requirement-style`        | Use first when choosing how to write requirement body text — overview of EARS vs Gherkin vs plain prose, selection criteria, pointers to `markspec-ears` and `markspec-gherkin`                                                                            |
+| skill | `markspec-ears`                     | Use when writing EARS-style requirements — all five patterns (ubiquitous / event-driven / state-driven / optional / unwanted) with do/don't examples in MarkSpec entry format                                                                              |
+| skill | `markspec-gherkin`                  | Use when writing Gherkin acceptance criteria — Given/When/Then structure, Scenario Outline, Background, do/don't examples, and how scenarios map to MarkSpec Verified-by attributes                                                                        |
+| skill | `markspec-profile-bundle-authoring` | Use when creating or extending a MarkSpec profile's upskill bundle — teaches the `skills/` slot layout, deriving `requires:` from `extends:`, and registering SKILL.md/RULE.md items                                                                       |
 
 ### `profile-default.bundle.md` (illustrative)
 
@@ -218,9 +226,9 @@ requires:
   - { name: "markspec-core" }
 ```
 
-| Kind | Name | Activation hint |
-|------|------|----------------|
-| rule | `profile-default-rules` | RFC 2119 modal keywords (shall, should, may, must, will) must appear lowercase — enforces MSL-M060 |
+| Kind  | Name                      | Activation hint                                                                                                                                                   |
+| ----- | ------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| rule  | `profile-default-rules`   | RFC 2119 modal keywords (shall, should, may, must, will) must appear lowercase — enforces MSL-M060                                                                |
 | skill | `markspec-modal-language` | Use when writing requirement body text — teaches RFC 2119 shall/should/may/must/will distinctions, anti-patterns, and how the validator flags MSL-M0xx violations |
 
 ### `profile-aspice-4.bundle.md` (illustrative)
@@ -236,10 +244,10 @@ requires:
   - { name: "profile-default" }    # derived from extends: "npm:@markspec/profile-default@^1"
 ```
 
-| Kind | Name | Activation hint |
-|------|------|----------------|
-| rule | `aspice-4-rules` | Every identified entry must carry exactly one ASIL label (ASIL-A through ASIL-D, or QM); mixing levels in one entry is an error |
-| skill | `aspice-type-vocabulary` | Use when creating or classifying entries — teaches the ASPICE 4.0 type hierarchy (STK, SYS, SWE, SIT, SWT), when to use each, and display-ID patterns |
+| Kind  | Name                           | Activation hint                                                                                                                                                                                 |
+| ----- | ------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| rule  | `aspice-4-rules`               | Every identified entry must carry exactly one ASIL label (ASIL-A through ASIL-D, or QM); mixing levels in one entry is an error                                                                 |
+| skill | `aspice-type-vocabulary`       | Use when creating or classifying entries — teaches the ASPICE 4.0 type hierarchy (STK, SYS, SWE, SIT, SWT), when to use each, and display-ID patterns                                           |
 | skill | `aspice-traceability-topology` | Use when linking requirements or reading coverage — teaches the V-model chain (STK→SYS→SWE via Satisfies, SWE→SIT→SWT via Verified-by) and how to interpret `markspec report traceability` gaps |
 
 ---
@@ -269,19 +277,19 @@ Consumer project
   9. Consumer commits .upskill-lock.json — locks refs and hashes
 ```
 
-Step 2 is the only place where the `extends:` → `requires:` mirror is applied. The skill body
-is the single source of truth for that convention.
+Step 2 is the only place where the `extends:` → `requires:` mirror is applied.
+The skill body is the single source of truth for that convention.
 
 ---
 
 ## Edge Cases
 
-| Case | Handling |
-|------|----------|
-| Profile in chain has no `skills/` slot | upskill reports unresolved `requires:` entry. Recipe doc states: every profile in the chain must ship a bundle; hook-only profiles (no `profile:` content section) are the exception — document in the profile's README that no bundle is provided. |
-| Bundle `name` doesn't match profile `id` | Convention: strip `@scope/` from the profile `id`. Documented in template and recipe. Caught in code review, not by tooling. |
-| `extends:` uses a semver range, `requires:` has no version pin | Intentional. `requires:` names the parent bundle without a version constraint, letting upskill resolve to whatever the consumer has installed. Recipe advises this default; pinning is opt-in for stricter environments. |
-| Consumer project uses no profile (markspec-core only) | `upskill add markspec:markspec-core.bundle.md`. Valid — no requires chain needed. |
+| Case                                                           | Handling                                                                                                                                                                                                                                            |
+| -------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Profile in chain has no `skills/` slot                         | upskill reports unresolved `requires:` entry. Recipe doc states: every profile in the chain must ship a bundle; hook-only profiles (no `profile:` content section) are the exception — document in the profile's README that no bundle is provided. |
+| Bundle `name` doesn't match profile `id`                       | Convention: strip `@scope/` from the profile `id`. Documented in template and recipe. Caught in code review, not by tooling.                                                                                                                        |
+| `extends:` uses a semver range, `requires:` has no version pin | Intentional. `requires:` names the parent bundle without a version constraint, letting upskill resolve to whatever the consumer has installed. Recipe advises this default; pinning is opt-in for stricter environments.                            |
+| Consumer project uses no profile (markspec-core only)          | `upskill add markspec:markspec-core.bundle.md`. Valid — no requires chain needed.                                                                                                                                                                   |
 
 ---
 
@@ -289,10 +297,11 @@ is the single source of truth for that convention.
 
 No code to unit-test. Verification is:
 
-- `upskill lint --strict` on every bundle manifest and item body (format-spec conformance,
-  description length, required fields). Run in CI for `skills-src/` in the markspec repo and
-  for `skills/` in each profile package.
-- A one-liner CI grep asserts the extends→requires mirror for each profile package:
+- `upskill lint --strict` on every bundle manifest and item body (format-spec
+  conformance, description length, required fields). Run in CI for `skills/` in
+  the markspec repo and for `skills/` in each profile package.
+- A one-liner CI grep asserts the extends→requires mirror for each profile
+  package:
 
   ```bash
   # Illustrative — handles npm: and git: specifiers. Local specifiers (./path)
@@ -303,5 +312,6 @@ No code to unit-test. Verification is:
   ```
 
 - **Acceptance criterion:** a profile author following the recipe and the
-  `markspec-profile-bundle-authoring` skill can produce a `upskill add`-installable bundle
-  in one session, with the full chain resolving correctly.
+  `markspec-profile-bundle-authoring` skill can produce a
+  `upskill add`-installable bundle in one session, with the full chain resolving
+  correctly.

--- a/packages/markspec/lsp/server.ts
+++ b/packages/markspec/lsp/server.ts
@@ -687,6 +687,7 @@ async function* walkDirectory(dir: string): AsyncGenerator<string> {
     "target",
     "dist",
     "build",
+    "skills", // upskill SSOT — not MarkSpec requirement documents
   ]);
   try {
     for await (const entry of Deno.readDir(dir)) {

--- a/skills/REGISTRY.md
+++ b/skills/REGISTRY.md
@@ -1,0 +1,19 @@
+---
+schema: 1
+name: markspec
+description: Core rules and skills for teams authoring traceable documentation with MarkSpec
+maintainer: driftsys
+homepage: https://github.com/driftsys/markspec
+---
+
+# MarkSpec skill registry
+
+Core AI-assistance content for MarkSpec consumer projects. Provides entry
+authoring literacy, the canonical agent write loop, diagnostic guidance,
+requirement writing patterns (EARS, Gherkin), and profile bundle authoring.
+
+Install the full core bundle:
+
+```bash
+upskill add markspec:markspec-core.bundle.md
+```

--- a/skills/markspec-core-rules/RULE.md
+++ b/skills/markspec-core-rules/RULE.md
@@ -1,0 +1,50 @@
+---
+schema: 1
+name: markspec-core-rules
+description: Always-on MarkSpec authoring invariants for any project using MarkSpec entry blocks
+---
+
+## Id integrity
+
+Never hand-write an `Id:` value or forge a ULID. The `Id:` trailer attribute is
+stamped automatically by `markspec format` and `markspec insert`. A hand-written
+ULID is invalid — it will not have the correct timestamp prefix and will fail
+validation.
+
+**Never do this:**
+
+```markdown
+Id: 01HANDWRITTENULID000000000
+```
+
+**Do this instead:** leave `Id:` absent; run `markspec format <file>` to stamp
+it.
+
+## Format before commit
+
+Run `markspec format <file>` (or `markspec hook <file>`) before committing any
+Markdown file that contains MarkSpec entry blocks. The formatter:
+
+- stamps missing `Id:` ULIDs
+- normalises trailer indentation to 6 spaces
+- adds missing trailing backslashes on multi-line attribute values
+
+Committing unformatted files causes the pre-commit hook to fail and creates
+noisy format-only diff commits.
+
+## Prose quality
+
+Every requirement body must satisfy all of the following. Violating any one
+makes the requirement unverifiable and untraceable.
+
+- **Single responsibility** — one entry expresses one requirement. Never join
+  two requirements with "and", "as well as", or a semicolon.
+- **Active voice** — "The system shall compute X", not "X shall be computed by
+  the system".
+- **Measurable** — include units, thresholds, and tolerances. "within 200 ms",
+  "less than 12 kN", "≥ 99.9 %". Bare adjectives ("fast", "reliable",
+  "user-friendly") are forbidden.
+- **Unambiguous** — no pronoun references ("it", "this"), no undefined
+  abbreviations, no vague quantifiers ("several", "appropriate", "sufficient").
+- **Independently verifiable** — a tester must be able to pass or fail the
+  requirement without consulting the author.

--- a/skills/markspec-core.bundle.md
+++ b/skills/markspec-core.bundle.md
@@ -1,7 +1,10 @@
 ---
 schema: 1
 name: markspec-core
-description: Profile-agnostic MarkSpec literacy — entry authoring, write loop, diagnostics, requirement writing patterns (EARS/Gherkin), and profile bundle authoring
+description: >
+  Profile-agnostic MarkSpec literacy — entry authoring, write loop, diagnostics,
+  requirement writing patterns (EARS/Gherkin), prose review, traceability audit,
+  and profile bundle authoring
 license: MIT
 
 items:
@@ -15,11 +18,15 @@ items:
     - markspec-ears
     - markspec-gherkin
     - markspec-profile-bundle-authoring
+    - markspec-prose-review
+  agents:
+    - markspec-scaffold-profile-bundle
+    - markspec-traceability-review
 
 requires: []
 
 metadata:
-  version: "0.1.0"
+  version: "0.2.0"
   author: driftsys
 ---
 
@@ -33,13 +40,16 @@ transitively via the default profile).
 
 ## Contents
 
-| Kind  | Name                                | Purpose                                                                            |
-| ----- | ----------------------------------- | ---------------------------------------------------------------------------------- |
-| rule  | `markspec-core-rules`               | Always-on authoring invariants (Id integrity, format before commit, prose quality) |
-| skill | `markspec-entry-authoring`          | Entry block format and trailer attributes                                          |
-| skill | `markspec-write-loop`               | Canonical insert → format → validate agent write path                              |
-| skill | `markspec-diagnostics`              | Reading and fixing MSL- diagnostic codes                                           |
-| skill | `markspec-requirement-style`        | EARS vs Gherkin vs plain prose selection guide                                     |
-| skill | `markspec-ears`                     | EARS patterns with do/don't examples                                               |
-| skill | `markspec-gherkin`                  | Gherkin Given/When/Then with do/don't examples                                     |
-| skill | `markspec-profile-bundle-authoring` | Creating and extending profile skill bundles                                       |
+| Kind  | Name                                | Purpose                                                                                                 |
+| ----- | ----------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| rule  | `markspec-core-rules`               | Always-on authoring invariants (Id integrity, format before commit, prose quality)                      |
+| skill | `markspec-entry-authoring`          | Entry block format and trailer attributes                                                               |
+| skill | `markspec-write-loop`               | Canonical insert → format → validate agent write path                                                   |
+| skill | `markspec-diagnostics`              | Reading and fixing MSL- diagnostic codes                                                                |
+| skill | `markspec-requirement-style`        | EARS vs Gherkin vs plain prose selection guide                                                          |
+| skill | `markspec-ears`                     | EARS patterns with do/don't examples                                                                    |
+| skill | `markspec-gherkin`                  | Gherkin Given/When/Then with do/don't examples                                                          |
+| skill | `markspec-profile-bundle-authoring` | Creating and extending profile skill bundles                                                            |
+| skill | `markspec-prose-review`             | Entry-by-entry prose quality checklist (single-responsibility, measurability, EARS/Gherkin correctness) |
+| agent | `markspec-scaffold-profile-bundle`  | Reads markspec.yaml and scaffolds the skills/ bundle manifest automatically                             |
+| agent | `markspec-traceability-review`      | Audits the corpus for missing derivations, untested requirements, and orphaned entries                  |

--- a/skills/markspec-core.bundle.md
+++ b/skills/markspec-core.bundle.md
@@ -1,0 +1,45 @@
+---
+schema: 1
+name: markspec-core
+description: Profile-agnostic MarkSpec literacy — entry authoring, write loop, diagnostics, requirement writing patterns (EARS/Gherkin), and profile bundle authoring
+license: MIT
+
+items:
+  rules:
+    - markspec-core-rules
+  skills:
+    - markspec-entry-authoring
+    - markspec-write-loop
+    - markspec-diagnostics
+    - markspec-requirement-style
+    - markspec-ears
+    - markspec-gherkin
+    - markspec-profile-bundle-authoring
+
+requires: []
+
+metadata:
+  version: "0.1.0"
+  author: driftsys
+---
+
+# markspec-core
+
+Baseline rules and skills for any project using MarkSpec to author traceable
+industrial documentation. Profile-agnostic: works with any profile chain.
+
+Every profile bundle should `requires: [{ name: "markspec-core" }]` (directly or
+transitively via the default profile).
+
+## Contents
+
+| Kind  | Name                                | Purpose                                                                            |
+| ----- | ----------------------------------- | ---------------------------------------------------------------------------------- |
+| rule  | `markspec-core-rules`               | Always-on authoring invariants (Id integrity, format before commit, prose quality) |
+| skill | `markspec-entry-authoring`          | Entry block format and trailer attributes                                          |
+| skill | `markspec-write-loop`               | Canonical insert → format → validate agent write path                              |
+| skill | `markspec-diagnostics`              | Reading and fixing MSL- diagnostic codes                                           |
+| skill | `markspec-requirement-style`        | EARS vs Gherkin vs plain prose selection guide                                     |
+| skill | `markspec-ears`                     | EARS patterns with do/don't examples                                               |
+| skill | `markspec-gherkin`                  | Gherkin Given/When/Then with do/don't examples                                     |
+| skill | `markspec-profile-bundle-authoring` | Creating and extending profile skill bundles                                       |

--- a/skills/markspec-diagnostics/SKILL.md
+++ b/skills/markspec-diagnostics/SKILL.md
@@ -1,0 +1,115 @@
+---
+schema: 1
+name: markspec-diagnostics
+description: >
+  Use when `markspec validate` or `markspec hook` output contains MSL- codes —
+  covers all diagnostic families (P0xx parse, I0xx identity, M0xx modal, A0xx
+  attribute, T0xx type, B0xx body, C0xx caption), severity levels, and
+  common fixes.
+---
+
+# markspec-diagnostics
+
+## Overview
+
+Every MarkSpec diagnostic has the form `severity[MSL-Xnnn]: file:line message`.
+The code family (`X`) identifies the rule category. Fix errors first; warnings
+are style or convention violations that don't block validation.
+
+## Severity
+
+| Severity  | Exit code | Meaning                                        |
+| --------- | --------- | ---------------------------------------------- |
+| `error`   | 1         | Must fix before commit or CI passes            |
+| `warning` | 2         | Should fix; passes CI unless `--strict` is set |
+| `info`    | 0         | Informational; safe to leave                   |
+
+## Code families
+
+### P0xx — Parse
+
+Emitted while reading the Markdown AST. The entry block could not be
+interpreted.
+
+| Code     | Message pattern                            | Fix                                                                                      |
+| -------- | ------------------------------------------ | ---------------------------------------------------------------------------------------- |
+| MSL-P010 | Malformed entry header                     | Verify `- [TYPE_NNNN] Title` format: hyphen, space, brackets, space-separated display ID |
+| MSL-P020 | Display ID does not match expected pattern | Check the profile's declared type pattern; prefix and digit width must match exactly     |
+
+### I0xx — Identity
+
+Emitted during identity validation (uniqueness, ULID format).
+
+| Code     | Message pattern      | Fix                                                                                           |
+| -------- | -------------------- | --------------------------------------------------------------------------------------------- |
+| MSL-I010 | Duplicate display ID | Two entries share the same display ID; delete or renumber one                                 |
+| MSL-I020 | Duplicate ULID       | Two entries share the same `Id:` ULID; delete the hand-written copy and run `markspec format` |
+| MSL-I030 | Malformed ULID       | The `Id:` value is not a valid ULID; delete it and run `markspec format`                      |
+
+### M0xx — Modal language
+
+Emitted when RFC 2119 modal keyword usage violates profile rules (e.g.
+profile-default requires lowercase shall/should/may/must/will).
+
+| Code     | Message pattern         | Fix                                             |
+| -------- | ----------------------- | ----------------------------------------------- |
+| MSL-M050 | Missing modal keyword   | Body must contain at least one RFC 2119 keyword |
+| MSL-M051 | Ambiguous modal keyword | Body uses multiple levels without justification |
+| MSL-M060 | Uppercase modal keyword | Lowercase the keyword: `SHALL` → `shall`        |
+
+### A0xx — Attribute
+
+Emitted for trailer attribute violations.
+
+| Code     | Message pattern                       | Fix                                                               |
+| -------- | ------------------------------------- | ----------------------------------------------------------------- |
+| MSL-A010 | Unknown attribute key                 | Remove or correct the key; check profile's allowed attribute list |
+| MSL-A011 | Citation attribute in CSV form        | Rewrite `Satisfies: A, B` as two separate lines                   |
+| MSL-A012 | Repeatable attribute with empty value | Remove the empty trailer line                                     |
+| MSL-A013 | Single-cardinality attribute repeated | Keep the first occurrence; delete duplicates                      |
+| MSL-A030 | Generated attribute present in source | `Id:` was hand-stamped; delete it and run `markspec format`       |
+
+### T0xx — Type
+
+Emitted for `Type:` attribute value violations.
+
+| Code     | Message pattern          | Fix                                                                          |
+| -------- | ------------------------ | ---------------------------------------------------------------------------- |
+| MSL-T010 | Missing required `Type:` | Add a `Type: <name>` trailer; see profile for declared types                 |
+| MSL-T020 | Unknown type value       | Check the profile's declared types; the validator suggests the closest match |
+
+### B0xx — Body
+
+Emitted for body-text content violations.
+
+| Code     | Message pattern              | Fix                                                                                             |
+| -------- | ---------------------------- | ----------------------------------------------------------------------------------------------- |
+| MSL-B010 | Empty body                   | Add requirement prose between the header line and the trailer block                             |
+| MSL-B044 | Body AST equivalence failure | Body contains Markdown the formatter cannot round-trip safely; simplify or escape the construct |
+
+### C0xx — Caption
+
+Emitted for figure/table caption convention violations.
+
+| Code     | Message pattern  | Fix                                                                                                      |
+| -------- | ---------------- | -------------------------------------------------------------------------------------------------------- |
+| MSL-C072 | Caption position | Move the caption above or below the figure/table as the project's `caption-conventions` setting requires |
+
+## Reading the output
+
+```
+error[MSL-I010]: docs/requirements.md:42 duplicate display ID: SWE_0007
+warning[MSL-M060]: docs/requirements.md:17 modal keyword 'SHALL' must be lowercase
+```
+
+Column numbers are 1-based. The `markspec validate --format json` flag emits
+machine-readable output for programmatic consumption.
+
+## Fixing in bulk
+
+```bash
+markspec validate docs/ --format json | jq '.[] | select(.code == "MSL-M060")'
+```
+
+The LSP server surfaces all diagnostics as editor squiggles and offers quick-fix
+code actions for MSL-M060, MSL-A030, MSL-T020, MSL-A013, MSL-A011, and MSL-A012.

--- a/skills/markspec-ears/SKILL.md
+++ b/skills/markspec-ears/SKILL.md
@@ -1,0 +1,202 @@
+---
+schema: 1
+name: markspec-ears
+description: >
+  Use when writing EARS-style requirements — all five patterns (ubiquitous,
+  event-driven, state-driven, optional, unwanted) with do/don't examples in
+  MarkSpec entry format.
+---
+
+# markspec-ears
+
+## Overview
+
+EARS (Easy Approach to Requirements Syntax) produces unambiguous,
+single-sentence requirements by forcing authors to make the trigger and
+condition explicit. Every EARS sentence begins with a structural keyword that
+signals the pattern.
+
+## The five patterns
+
+### 1. Ubiquitous — always active, no trigger
+
+Use for properties that hold in all system states.
+
+**Template:** _"The `<subject>` shall `<action>`."_
+
+**Do:**
+
+```markdown
+- [SWE_0010] Log every sensor reading
+
+  The data logger shall record each sensor sample with a UTC timestamp accurate
+  to within 1 ms.
+
+      Id:
+      Type: requirement
+      Satisfies: SYS_0003
+```
+
+**Don't:**
+
+```markdown
+- [SWE_0010] Log sensor readings
+
+  Sensor data should be logged.
+```
+
+Why bad: "should" is ambiguous (RFC 2119 recommendation, not obligation); body
+lacks timestamp precision.
+
+---
+
+### 2. Event-driven — triggered by a discrete event
+
+Use when the system must react to something that happens.
+
+**Template:** _"When `<event>`, the `<subject>` shall `<action>`."_
+
+**Do:**
+
+```markdown
+- [SWE_0020] React to ignition-off event
+
+  When the ignition signal transitions from HIGH to LOW, the power management
+  module shall initiate a controlled shutdown sequence within 500 ms.
+
+      Id:
+      Type: requirement
+      Satisfies: SYS_0008
+```
+
+**Don't:**
+
+```markdown
+- [SWE_0020] Shutdown on ignition off
+
+  The system should handle ignition off and shut down.
+```
+
+Why bad: no measurable time bound; "should" is not mandatory.
+
+---
+
+### 3. State-driven — active only while in a particular state
+
+Use when the system must behave differently in a persistent mode.
+
+**Template:** _"While `<state>`, the `<subject>` shall `<action>`."_
+
+**Do:**
+
+```markdown
+- [SWE_0030] Limit torque in degraded mode
+
+  While the torque sensor reports a fault, the drive controller shall limit
+  output torque to no more than 50 % of nominal.
+
+      Id:
+      Type: requirement
+      Satisfies: SYS_0015
+      Labels: ASIL-B
+```
+
+**Don't:**
+
+```markdown
+- [SWE_0030] Degraded mode torque
+
+  In degraded mode the system limits torque appropriately.
+```
+
+Why bad: "appropriately" is unmeasurable; no percentage or absolute limit given.
+
+---
+
+### 4. Optional — conditional on a feature or configuration
+
+Use when a capability is not universally present.
+
+**Template:** _"Where `<feature or condition>` is enabled, the `<subject>` shall
+`<action>`."_
+
+**Do:**
+
+```markdown
+- [SWE_0040] Display speed in mph when locale is US
+
+  Where the user's locale setting is "en-US", the instrument cluster shall
+  display vehicle speed in miles per hour rounded to the nearest integer.
+
+      Id:
+      Type: requirement
+      Satisfies: STK_0002
+```
+
+**Don't:**
+
+```markdown
+- [SWE_0040] MPH display
+
+  US users see mph.
+```
+
+Why bad: not a requirement sentence; "US users" is ambiguous (locale vs.
+nationality); rounding convention absent.
+
+---
+
+### 5. Unwanted behaviour — fault or error response
+
+Use when the system must detect and respond to an abnormal condition.
+
+**Template:** _"If `<unwanted condition>`, the `<subject>` shall `<response>`
+within `<time>`."_
+
+**Do:**
+
+```markdown
+- [SWE_0050] Handle CAN bus timeout
+
+  If no valid CAN frame is received on the safety bus within 100 ms, the safety
+  monitor shall assert the brake request signal and set diagnostic code 0x4A
+  within 10 ms of timeout detection.
+
+      Id:
+      Type: requirement
+      Satisfies: SYS_0022
+      Labels: ASIL-D
+```
+
+**Don't:**
+
+```markdown
+- [SWE_0050] CAN timeout
+
+  The system handles CAN timeouts gracefully.
+```
+
+Why bad: "gracefully" is not measurable; no time bound on detection or response;
+no diagnostic output specified.
+
+---
+
+## Pattern selection cheat sheet
+
+| Trigger            | Pattern            | Opening keyword              |
+| ------------------ | ------------------ | ---------------------------- |
+| Always true        | Ubiquitous         | _(none — starts with "The")_ |
+| Event occurs       | Event-driven       | **When**                     |
+| System is in state | State-driven       | **While**                    |
+| Feature is present | Optional           | **Where**                    |
+| Fault / error      | Unwanted behaviour | **If**                       |
+
+## Combining patterns
+
+State + event is allowed:
+
+_"While braking, when the ABS module signals wheel lock, the brake controller
+shall reduce hydraulic pressure by 30 % within 20 ms."_
+
+Do not combine more than two patterns in one sentence. If a third condition is
+needed, split into two entries.

--- a/skills/markspec-entry-authoring/SKILL.md
+++ b/skills/markspec-entry-authoring/SKILL.md
@@ -1,0 +1,102 @@
+---
+schema: 1
+name: markspec-entry-authoring
+description: >
+  Use when writing, editing, or reviewing a MarkSpec entry block — the
+  `- [TYPE_NNNN] Title` list-item format, body prose, and trailer attributes
+  (Id, Type, Satisfies, Labels, Verified-by, and other trace keys).
+---
+
+# markspec-entry-authoring
+
+## Overview
+
+A MarkSpec entry block is a Markdown list item with a structured header, body
+prose, and an indented trailer section. Two shapes exist:
+
+- **Authored** — has an `Id:` trailer (a ULID); the system owns this block and
+  stamps its ID.
+- **Reference** — no `Id:` trailer; a pointer to an external or higher-level
+  requirement.
+
+## Block anatomy
+
+```markdown
+- [TYPE_NNNN] Title text
+
+  Body prose — one or more paragraphs. Plain Markdown is allowed.
+
+      Id: 01JEMX9GZXYZ0000000000000A
+      Type: requirement
+      Satisfies: STK_0001
+      Labels: ASIL-B, safety-critical
+```
+
+| Part            | Rule                                                                                                                     |
+| --------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `- [TYPE_NNNN]` | Hyphen + space + display ID in brackets. ID is `PREFIX_NNNN` where prefix is UPPER_SNAKE and NNNN is zero-padded digits. |
+| Title           | Free text on the same line, after the closing `]`.                                                                       |
+| Body            | Indented 2 spaces. One blank line above and below separates it from header/trailer.                                      |
+| Trailer         | Indented **6 spaces** exactly. Each attribute on its own line: `Key: value`.                                             |
+
+## Display ID conventions
+
+- Prefix comes from the active profile's type declaration (e.g. `STK_`, `SWE_`).
+- Numbers are zero-padded to a fixed width set by the profile (typically 4
+  digits).
+- Use `markspec next-id <type> <files...>` to read the next safe number.
+- Use `markspec insert <type> <file>` to scaffold a full block with a valid ID.
+- **Never invent a ULID by hand.** Leave `Id:` absent and run
+  `markspec format <file>` to stamp it.
+
+## Core trailer attributes
+
+| Attribute       | Cardinality | Purpose                                                               |
+| --------------- | ----------- | --------------------------------------------------------------------- |
+| `Id:`           | 0–1         | ULID. Stamped by `markspec format`. Present on Authored entries only. |
+| `Type:`         | 0–1         | Declared type name from the active profile.                           |
+| `Satisfies:`    | 0–N         | Upstream display IDs this entry satisfies (one per line).             |
+| `Derived-from:` | 0–N         | Source entries for derived requirements.                              |
+| `Verified-by:`  | 0–N         | Test or acceptance-criteria entries that verify this one.             |
+| `Tests:`        | 0–N         | Reverse of Verified-by — the entry being tested.                      |
+| `Labels:`       | 0–N         | Free-form tags: ASIL level, domain, review state.                     |
+| `References:`   | 0–N         | Informational links — does not create a traceability link.            |
+
+Multi-value attributes repeat the key on separate lines:
+
+```markdown
+Satisfies: STK_0001 Satisfies: STK_0007
+```
+
+## Authored vs Reference
+
+**Authored** — has `Id:`:
+
+```markdown
+- [SWE_0012] Debounce raw sensor inputs
+
+  The software shall debounce each sensor channel with a 5 ms sliding window.
+
+      Id: 01JEMX9GZXYZ0000000000000A
+      Type: requirement
+      Satisfies: SYS_0004
+      Labels: ASIL-B
+```
+
+**Reference** — no `Id:` (external or upstream requirement):
+
+```markdown
+- [STK_0001] Vehicle shall stop before collision
+
+  Stakeholder requirement — traced from customer specification §3.1.
+```
+
+## Common mistakes
+
+| Mistake                                  | Fix                                                        |
+| ---------------------------------------- | ---------------------------------------------------------- |
+| Hand-stamping `Id:`                      | Remove it; run `markspec format`                           |
+| Wrong indent on trailers                 | Must be 6 spaces — not 4, not a tab                        |
+| Compound requirement ("and…")            | Split into two separate entries                            |
+| Bare adjective body ("fast", "reliable") | Add units and thresholds                                   |
+| Displaying `${ULID}` literally           | You copied an unformatted scaffold — run `markspec format` |

--- a/skills/markspec-gherkin/SKILL.md
+++ b/skills/markspec-gherkin/SKILL.md
@@ -1,0 +1,171 @@
+---
+schema: 1
+name: markspec-gherkin
+description: >
+  Use when writing Gherkin acceptance criteria — Given/When/Then structure,
+  Scenario Outline, Background, do/don't examples in MarkSpec entry format,
+  and how scenarios map to the `Verified-by:` attribute.
+---
+
+# markspec-gherkin
+
+## Overview
+
+Gherkin encodes acceptance criteria as concrete examples. A MarkSpec entry body
+can contain one or more Gherkin scenarios in a fenced code block. The entry's
+`Verified-by:` trailer links the requirement to the test entry that implements
+the scenario.
+
+## Basic structure
+
+An entry with Gherkin scenarios looks like this (outer block shows the full
+MarkSpec entry; the inner `gherkin` block holds the scenarios):
+
+```text
+- [SWE_0060] Speed display rounds to nearest integer
+
+  The instrument cluster shall display vehicle speed rounded to the nearest
+  integer value in the configured unit.
+
+  ` ` `gherkin
+  Scenario: Round half-up
+    Given vehicle speed is 42.5 km/h
+    When the cluster updates the display
+    Then the displayed value is 43 km/h
+
+  Scenario: Exact integer
+    Given vehicle speed is 100.0 km/h
+    When the cluster updates the display
+    Then the displayed value is 100 km/h
+  ` ` `
+
+      Id:
+      Type: requirement
+      Satisfies: STK_0002
+      Verified-by: SWT_0060
+```
+
+_(Remove the spaces in `` ` above — they are present only to prevent nesting
+issues in documentation.)_
+
+### Rules
+
+- The `Given` clause sets pre-conditions — system state before the action.
+- The `When` clause describes one triggering action.
+- The `Then` clause states the expected observable outcome.
+- Each `And` / `But` line extends the nearest `Given`, `When`, or `Then`.
+- Keep each step to one observable fact. Multiple assertions → multiple `Then`
+  lines, not a compound sentence.
+
+---
+
+## Do / Don't examples
+
+**Do — concrete values, one action, one outcome:**
+
+```gherkin
+Scenario: Reject out-of-range input
+  Given the brake pressure sensor reads 250 bar
+  When the safety monitor evaluates the reading
+  Then the safety monitor shall assert the sensor-fault flag
+  And the safety monitor shall set DTC 0x4A within 10 ms
+```
+
+**Don't — vague state, compound action, unmeasurable outcome:**
+
+```gherkin
+Scenario: Bad sensor
+  Given the sensor is broken
+  When something happens
+  Then the system handles it appropriately
+```
+
+Why bad: "broken" is undefined; "something happens" is not a single trigger;
+"handles it appropriately" is not verifiable.
+
+---
+
+## Scenario Outline — parameterised examples
+
+Use when the same flow applies to multiple input/output pairs.
+
+```gherkin
+Scenario Outline: Convert speed to locale unit
+  Given vehicle speed is <speed_kmh> km/h
+  And the active locale is <locale>
+  When the cluster updates the display
+  Then the displayed value is <display_value> <unit>
+
+  Examples:
+    | speed_kmh | locale | display_value | unit |
+    | 100       | en-US  | 62            | mph  |
+    | 100       | en-GB  | 62            | mph  |
+    | 100       | fr-FR  | 100           | km/h |
+```
+
+---
+
+## Background — shared pre-conditions
+
+Use `Background` when every scenario in a feature shares the same setup.
+
+```gherkin
+Background:
+  Given the vehicle ignition is ON
+  And the CAN bus is operational
+
+Scenario: Normal speed display
+  When vehicle speed is 80 km/h
+  Then the cluster displays 80 km/h
+```
+
+Keep `Background` short (≤ 3 steps). Complex shared state signals that the
+scenarios belong in separate entries.
+
+---
+
+## Linking requirements to tests via `Verified-by:`
+
+A requirement entry carries `Verified-by: <test-entry-display-ID>`. The test
+entry is a separate MarkSpec entry that implements the scenario.
+
+**Requirement entry:**
+
+```markdown
+- [SWE_0060] Speed display rounds to nearest integer
+
+  …gherkin scenarios…
+
+      Id: 01JEMX9GZXYZ0000000000000A
+      Type: requirement
+      Satisfies: STK_0002
+      Verified-by: SWT_0060
+```
+
+**Test entry (colocated in source or test file):**
+
+```markdown
+- [SWT_0060] Verify speed rounding
+
+  Integration test exercising the cluster display module against the scenarios
+  in SWE_0060.
+
+      Id: 01JEMXBHZXYZ0000000000000B
+      Type: test
+      Tests: SWE_0060
+```
+
+The `Tests:` attribute on the test entry is the reverse link;
+`markspec report traceability` uses both to compute coverage.
+
+---
+
+## Common mistakes
+
+| Mistake                                 | Fix                                                     |
+| --------------------------------------- | ------------------------------------------------------- |
+| Multiple `When` steps                   | Split into separate scenarios — one action per scenario |
+| "it", "this", "the thing" in steps      | Name the subject explicitly in each step                |
+| Implementation detail in `Given`        | Describe observable state, not code internals           |
+| Missing `Verified-by:` on requirement   | Add the link so the traceability report shows coverage  |
+| Duplicate scenario name within an entry | Names must be unique — the validator flags duplicates   |

--- a/skills/markspec-profile-bundle-authoring/SKILL.md
+++ b/skills/markspec-profile-bundle-authoring/SKILL.md
@@ -1,0 +1,179 @@
+---
+schema: 1
+name: markspec-profile-bundle-authoring
+description: >
+  Use when creating or extending a MarkSpec profile's upskill bundle — teaches
+  the `skills/` slot layout, deriving `requires:` from the profile's `extends:`
+  field, and registering SKILL.md / RULE.md items in the bundle manifest.
+---
+
+# markspec-profile-bundle-authoring
+
+## Overview
+
+Every MarkSpec profile that ships AI-assistance content needs a `skills/` slot
+and a bundle manifest. The bundle `requires:` chain must structurally mirror the
+profile `extends:` chain — one `requires:` entry per parent profile bundle.
+
+**Core invariant:**
+
+> `extends: X` in `markspec.yaml` → `requires: [{name: "X-without-scope"}]` in
+> the bundle manifest.
+
+## Directory layout
+
+```text
+<profile-dir>/
+├── markspec.yaml              ← profile manifest (extends:, types:, etc.)
+├── skills/
+│   ├── <profile-id>.bundle.md ← bundle manifest
+│   ├── <profile-id>-rules/
+│   │   └── RULE.md            ← always-on authoring rules
+│   └── <skill-name>/
+│       └── SKILL.md           ← one skill per concept
+└── README.md
+```
+
+The `skills/` slot is a sibling of `hooks/`. It contains only source items;
+consumers never write to it — they get generated outputs via `upskill add`.
+
+## Step-by-step authoring flow
+
+### 1. Read the profile's `extends:`
+
+```bash
+grep '^extends:' markspec.yaml
+# e.g.: extends: "npm:@markspec/profile-default@^1.0"
+```
+
+### 2. Derive the bundle name and `requires:`
+
+Strip the `@scope/` prefix and the version range from the parent specifier:
+
+| `extends:` value                       | `requires:` name                                       |
+| -------------------------------------- | ------------------------------------------------------ |
+| `"npm:@markspec/profile-default@^1.0"` | `"profile-default"`                                    |
+| `"npm:@acme/aspice-4@^2"`              | `"aspice-4"`                                           |
+| `"./path/to/parent"`                   | `"parent-bundle-name"` _(from parent's `name:` field)_ |
+| _(no extends — chain root)_            | `"markspec-core"` _(hand-authored)_                    |
+
+The bundle's own `name:` = the profile's `id:` with `@scope/` stripped.
+
+### 3. Create the bundle manifest
+
+```yaml
+---
+schema: 1
+name: <profile-id>          # profile id with @scope/ stripped
+description: <one line>
+license: <SPDX>
+
+items:
+  rules:
+    # - <rule-name>         # one entry per skills/<rule-name>/RULE.md
+  skills:
+    # - <skill-name>        # one entry per skills/<skill-name>/SKILL.md
+  agents: []
+
+requires:
+  - { name: "<parent-bundle-name>" }   # derived from extends: above
+
+metadata:
+  markspec-profile: "<profile-id>"
+---
+```
+
+### 4. Author RULE.md items
+
+Create `skills/<rule-name>/RULE.md`:
+
+```markdown
+---
+schema: 1
+name: <rule-name>
+description: Always-on authoring invariant for <profile> projects
+---
+
+## Rule title
+
+Rule body — be specific about what authors must/must not do and why.
+```
+
+Then add `- <rule-name>` under `items.rules` in the bundle manifest.
+
+### 5. Author SKILL.md items
+
+Create `skills/<skill-name>/SKILL.md`. Follow `markspec-core` skill conventions:
+
+- `description:` starts with "Use when…", describes triggering conditions only.
+- Body ≤ 500 lines.
+- No time-sensitive content (versions, PR numbers).
+
+Then add `- <skill-name>` under `items.skills` in the bundle manifest.
+
+### 6. Review checklist
+
+- [ ] Bundle `name:` matches profile `id:` with `@scope/` stripped.
+- [ ] `requires:` mirrors `extends:` — one entry per parent.
+- [ ] Every name listed in `items.rules` has a `skills/<name>/RULE.md`.
+- [ ] Every name listed in `items.skills` has a `skills/<name>/SKILL.md`.
+- [ ] `description:` fields are ≤ 1024 characters.
+
+## Example — illustrative profile
+
+`markspec.yaml`:
+
+```yaml
+id: "aspice-4"
+version: "0.1.0"
+extends: "npm:@markspec/profile-default@^1.0"
+```
+
+`skills/aspice-4.bundle.md`:
+
+```yaml
+---
+schema: 1
+name: aspice-4
+description: ASPICE 4.0 authoring rules and skills for MarkSpec projects
+license: MIT
+
+items:
+  rules:
+    - aspice-4-rules
+  skills:
+    - aspice-type-vocabulary
+    - aspice-traceability-topology
+
+requires:
+  - { name: "profile-default" }   # derived from extends: @markspec/profile-default
+
+metadata:
+  markspec-profile: "aspice-4"
+---
+```
+
+## Chain resolution
+
+A consumer running `upskill add <registry>:aspice-4.bundle.md` gets all three
+tiers of skills automatically via transitive `requires:` resolution:
+
+```
+aspice-4
+  → profile-default
+      → markspec-core
+```
+
+This mirrors the profile `extends:` chain exactly.
+
+## CI verification
+
+A one-liner asserts the mirror invariant for npm/git specifiers:
+
+```bash
+EXTENDS=$(grep '^extends:' markspec.yaml \
+  | sed 's/.*@\([^@/]*\)\/.*/\1/; s/.*\///; s/@.*//')
+grep -q "name: \"$EXTENDS\"" skills/*.bundle.md || exit 1
+```
+
+Add this to your profile package's CI pipeline.

--- a/skills/markspec-prose-review/SKILL.md
+++ b/skills/markspec-prose-review/SKILL.md
@@ -1,0 +1,119 @@
+---
+schema: 1
+name: markspec-prose-review
+description: >
+  Use when reviewing MarkSpec entry bodies for prose quality — checks
+  single-responsibility, active voice, measurability, ambiguity, EARS pattern
+  correctness, and Gherkin scenario completeness.
+---
+
+# markspec-prose-review
+
+## Overview
+
+Apply this checklist to each entry body under review. Work entry-by-entry.
+Report each finding with the entry's display ID, the violated criterion, and a
+concrete rewrite suggestion.
+
+## Checklist
+
+### 1. Single responsibility
+
+- [ ] The body expresses exactly one requirement.
+- [ ] No "and", "as well as", or semicolons joining two distinct obligations.
+
+**Flag:** "The system shall compute X and log Y." → split into two entries.
+
+---
+
+### 2. Active voice
+
+- [ ] Subject performs the action: "The `<module>` shall `<verb>`…"
+- [ ] No passive constructions: "shall be computed by", "is handled", "will be
+  provided".
+
+**Flag:** "The brake pressure shall be monitored by the safety module." →
+"The safety module shall monitor the brake pressure."
+
+---
+
+### 3. Measurability
+
+- [ ] Every performance claim has a unit and a numeric threshold or tolerance.
+- [ ] No bare adjectives: "fast", "reliable", "accurate", "sufficient",
+  "appropriate", "user-friendly".
+- [ ] Time bounds use SI units or ms/s: "within 200 ms", not "quickly".
+- [ ] Percentages are explicit: "≥ 99.9 %", not "high availability".
+
+**Flag:** "The system shall respond rapidly." → "The system shall respond within
+200 ms of receiving the request."
+
+---
+
+### 4. Unambiguity
+
+- [ ] No pronoun references without clear antecedents: "it", "this", "they",
+  "the aforementioned".
+- [ ] All abbreviations are defined in a glossary or expanded on first use.
+- [ ] No vague quantifiers: "several", "a number of", "some", "many".
+- [ ] Modal keywords are lowercase RFC 2119: `shall` (mandatory), `should`
+  (recommended), `may` (optional). No bare "will" or "must".
+
+**Flag:** "It shall process them within the defined timeout." → name the subject
+and define both referents explicitly.
+
+---
+
+### 5. Independent verifiability
+
+- [ ] A tester unfamiliar with the author can write a pass/fail test from this
+  entry alone.
+- [ ] No implicit context required ("as described in the design doc", "per
+  §3.2").
+- [ ] The acceptance condition is observable, not internal: "the system shall
+  assert the fault flag on CAN bus 0x1A0" not "the system shall detect the
+  fault internally".
+
+---
+
+### 6. EARS correctness (if EARS style is used)
+
+- [ ] Exactly one EARS keyword opens the sentence: When / While / Where / If /
+  _(none for ubiquitous)_.
+- [ ] Event-driven: "When `<single discrete event>`, the `<subject>` shall…"
+  — trigger is a single observable event, not a state.
+- [ ] State-driven: "While `<persistent state>`, the `<subject>` shall…" —
+  condition is a mode or state, not an event.
+- [ ] Optional: "Where `<feature>` is enabled, the `<subject>` shall…" — gated
+  on a configuration flag or variant, not a runtime event.
+- [ ] Unwanted: "If `<fault/condition>`, the `<subject>` shall `<response>`
+  within `<time>`." — response time is mandatory.
+- [ ] No more than two patterns combined in one sentence.
+
+---
+
+### 7. Gherkin correctness (if Gherkin style is used)
+
+- [ ] Each scenario has exactly one `When` step (one triggering action).
+- [ ] `Given` describes observable pre-conditions, not implementation setup.
+- [ ] `Then` assertions are independently verifiable outcomes, not internal
+  state.
+- [ ] No pronoun references across steps ("it", "the result").
+- [ ] `Verified-by:` trailer on the requirement entry links to the test entry
+  that implements these scenarios.
+
+---
+
+## Reporting format
+
+For each finding:
+
+```
+[DISPLAY_ID] <criterion violated>
+  Found:   "<verbatim offending text>"
+  Issue:   <one-sentence explanation>
+  Suggest: "<concrete rewrite>"
+```
+
+Summarise at the end: total entries reviewed, findings by criterion, entries
+with no findings.

--- a/skills/markspec-prose-review/SKILL.md
+++ b/skills/markspec-prose-review/SKILL.md
@@ -30,10 +30,10 @@ concrete rewrite suggestion.
 
 - [ ] Subject performs the action: "The `<module>` shall `<verb>`…"
 - [ ] No passive constructions: "shall be computed by", "is handled", "will be
-  provided".
+      provided".
 
-**Flag:** "The brake pressure shall be monitored by the safety module." →
-"The safety module shall monitor the brake pressure."
+**Flag:** "The brake pressure shall be monitored by the safety module." → "The
+safety module shall monitor the brake pressure."
 
 ---
 
@@ -41,7 +41,7 @@ concrete rewrite suggestion.
 
 - [ ] Every performance claim has a unit and a numeric threshold or tolerance.
 - [ ] No bare adjectives: "fast", "reliable", "accurate", "sufficient",
-  "appropriate", "user-friendly".
+      "appropriate", "user-friendly".
 - [ ] Time bounds use SI units or ms/s: "within 200 ms", not "quickly".
 - [ ] Percentages are explicit: "≥ 99.9 %", not "high availability".
 
@@ -53,11 +53,11 @@ concrete rewrite suggestion.
 ### 4. Unambiguity
 
 - [ ] No pronoun references without clear antecedents: "it", "this", "they",
-  "the aforementioned".
+      "the aforementioned".
 - [ ] All abbreviations are defined in a glossary or expanded on first use.
 - [ ] No vague quantifiers: "several", "a number of", "some", "many".
 - [ ] Modal keywords are lowercase RFC 2119: `shall` (mandatory), `should`
-  (recommended), `may` (optional). No bare "will" or "must".
+      (recommended), `may` (optional). No bare "will" or "must".
 
 **Flag:** "It shall process them within the defined timeout." → name the subject
 and define both referents explicitly.
@@ -67,27 +67,27 @@ and define both referents explicitly.
 ### 5. Independent verifiability
 
 - [ ] A tester unfamiliar with the author can write a pass/fail test from this
-  entry alone.
+      entry alone.
 - [ ] No implicit context required ("as described in the design doc", "per
-  §3.2").
+      §3.2").
 - [ ] The acceptance condition is observable, not internal: "the system shall
-  assert the fault flag on CAN bus 0x1A0" not "the system shall detect the
-  fault internally".
+      assert the fault flag on CAN bus 0x1A0" not "the system shall detect the
+      fault internally".
 
 ---
 
 ### 6. EARS correctness (if EARS style is used)
 
 - [ ] Exactly one EARS keyword opens the sentence: When / While / Where / If /
-  _(none for ubiquitous)_.
-- [ ] Event-driven: "When `<single discrete event>`, the `<subject>` shall…"
-  — trigger is a single observable event, not a state.
+      _(none for ubiquitous)_.
+- [ ] Event-driven: "When `<single discrete event>`, the `<subject>` shall…" —
+      trigger is a single observable event, not a state.
 - [ ] State-driven: "While `<persistent state>`, the `<subject>` shall…" —
-  condition is a mode or state, not an event.
+      condition is a mode or state, not an event.
 - [ ] Optional: "Where `<feature>` is enabled, the `<subject>` shall…" — gated
-  on a configuration flag or variant, not a runtime event.
+      on a configuration flag or variant, not a runtime event.
 - [ ] Unwanted: "If `<fault/condition>`, the `<subject>` shall `<response>`
-  within `<time>`." — response time is mandatory.
+      within `<time>`." — response time is mandatory.
 - [ ] No more than two patterns combined in one sentence.
 
 ---
@@ -97,10 +97,10 @@ and define both referents explicitly.
 - [ ] Each scenario has exactly one `When` step (one triggering action).
 - [ ] `Given` describes observable pre-conditions, not implementation setup.
 - [ ] `Then` assertions are independently verifiable outcomes, not internal
-  state.
+      state.
 - [ ] No pronoun references across steps ("it", "the result").
 - [ ] `Verified-by:` trailer on the requirement entry links to the test entry
-  that implements these scenarios.
+      that implements these scenarios.
 
 ---
 

--- a/skills/markspec-requirement-style/SKILL.md
+++ b/skills/markspec-requirement-style/SKILL.md
@@ -1,0 +1,91 @@
+---
+schema: 1
+name: markspec-requirement-style
+description: >
+  Use when choosing how to write requirement body text — overview of EARS vs
+  Gherkin vs plain prose, selection criteria, and pointers to the
+  `markspec-ears` and `markspec-gherkin` deep-dive skills.
+---
+
+# markspec-requirement-style
+
+## Overview
+
+A MarkSpec entry body can be written in plain prose, EARS syntax, or Gherkin
+scenario format. The choice depends on the nature of the requirement and who
+will verify it. Consistency within a document section matters more than
+following a single style across all entries.
+
+## Selection guide
+
+```
+Is the requirement testable by running a scenario (UI, API, integration)?
+  YES → Gherkin (Given/When/Then)  →  markspec-gherkin
+
+Is it a functional rule with a clear trigger or condition?
+  YES → EARS pattern               →  markspec-ears
+
+Is it a hardware spec, safety goal, or non-functional property?
+  → Plain prose with RFC 2119 modal (shall/should/may)
+```
+
+## At a glance
+
+| Style       | Best for                                                               | Verified by               |
+| ----------- | ---------------------------------------------------------------------- | ------------------------- |
+| EARS        | System-level functional rules with triggers and states                 | Integration or unit test  |
+| Gherkin     | Acceptance criteria that a tester can run step by step                 | Acceptance or system test |
+| Plain prose | Non-functional requirements, safety goals, hardware specs, STK entries | Review, analysis, or V&V  |
+
+## EARS patterns
+
+EARS (Easy Approach to Requirements Syntax) produces unambiguous,
+single-sentence requirements with a defined trigger. Five patterns cover most
+cases:
+
+- **Ubiquitous** — always true, no trigger: _"The system shall…"_
+- **Event-driven** — triggered by an event: _"When X, the system shall Y."_
+- **State-driven** — active while in a state: _"While P, the system shall Q."_
+- **Optional** — gated by a feature: _"Where feature F is enabled, the system
+  shall…"_
+- **Unwanted behaviour** — fault response: _"If E occurs, the system shall W
+  within T."_
+
+See `markspec-ears` for do/don't examples of each pattern.
+
+## Gherkin scenarios
+
+Gherkin expresses acceptance criteria as executable examples:
+
+```gherkin
+Given <context>
+When <action>
+Then <expected outcome>
+```
+
+Each scenario maps to a MarkSpec entry. The `Verified-by:` trailer links the
+requirement entry to the test entry that implements the scenario.
+
+See `markspec-gherkin` for do/don't examples, Scenario Outline, and Background.
+
+## Plain prose rules
+
+Plain prose entries must still satisfy the prose-quality invariants from
+`markspec-core-rules`:
+
+- **Single responsibility** — one entry, one requirement.
+- **Active voice** — "The system shall…", not "…shall be done by the system".
+- **Measurable** — units, thresholds, tolerances. No bare adjectives.
+- **Unambiguous** — no pronoun references, no undefined abbreviations.
+- **Independently verifiable** — a tester can pass or fail it without the
+  author.
+
+## Mixing styles
+
+EARS and Gherkin are not mutually exclusive across a document. A common split:
+
+- STK entries → plain prose (stakeholder language)
+- SYS / SWE entries → EARS (precise functional rules)
+- Acceptance entries → Gherkin (executable scenarios)
+
+Do not mix styles within a single entry body.

--- a/skills/markspec-scaffold-profile-bundle/AGENT.md
+++ b/skills/markspec-scaffold-profile-bundle/AGENT.md
@@ -1,0 +1,83 @@
+---
+schema: 1
+name: markspec-scaffold-profile-bundle
+description: >
+  Use when creating a new MarkSpec profile package that needs an upskill bundle
+  — reads the profile's markspec.yaml, derives the bundle manifest from the
+  extends: field, and scaffolds the skills/ directory structure.
+license: MIT
+mode: subagent
+model: sonnet
+tools:
+  - read
+  - write
+  - bash
+preload-skills:
+  - markspec-profile-bundle-authoring
+metadata:
+  version: "0.1.0"
+  author: driftsys
+---
+
+## Scaffold a MarkSpec profile bundle
+
+You are scaffolding the upskill `skills/` slot for a MarkSpec profile package.
+When invoked, the user will provide the path to the profile directory (or you
+are already working inside it).
+
+### Steps
+
+1. **Read `markspec.yaml`** in the profile directory. Extract:
+   - `id:` — the profile identifier (may have an `@scope/` prefix)
+   - `extends:` — the parent profile specifier (may be absent for chain roots)
+
+2. **Derive the bundle name** — strip the `@scope/` prefix from `id:`:
+   - `"@markspec/profile-default"` → `"profile-default"`
+   - `"aspice-4"` → `"aspice-4"`
+
+3. **Derive `requires:`** from `extends:`:
+   - `extends: "npm:@markspec/profile-default@^1.0"` → `requires: [{name: "profile-default"}]`
+   - `extends: "npm:@acme/foo@^2"` → `requires: [{name: "foo"}]`
+   - `extends: "./path/to/parent"` → read the parent's `markspec.yaml` `id:` and strip its scope
+   - No `extends:` (chain root) → `requires: [{name: "markspec-core"}]`
+
+4. **Create `skills/` directory** if it does not exist.
+
+5. **Write `skills/<bundle-name>.bundle.md`** using this template, substituting
+   the values derived above:
+
+   ```yaml
+   ---
+   schema: 1
+   name: <bundle-name>
+   description: <one-line description — ask the user if not obvious>
+   license: <SPDX — copy from markspec.yaml if present, else ask>
+
+   items:
+     rules: []
+     skills: []
+     agents: []
+
+   requires:
+     - { name: "<parent-bundle-name>" }
+
+   metadata:
+     markspec-profile: "<profile-id>"
+   ---
+   ```
+
+6. **Report what was created.** List the bundle manifest path and the derived
+   `requires:` value. Remind the user to:
+   - Add rule names to `items.rules` and create `skills/<rule-name>/RULE.md`
+     for each profile-specific always-on rule.
+   - Add skill names to `items.skills` and create `skills/<skill-name>/SKILL.md`
+     for each skill they want to ship.
+   - Run `upskill lint --strict skills/` to validate the manifest.
+
+### Invariants to enforce
+
+- Bundle `name:` must equal the profile `id:` with `@scope/` stripped.
+- `requires:` must contain exactly one entry per parent in the `extends:` chain.
+- Do not create RULE.md or SKILL.md stubs — those are the author's job.
+- Do not overwrite an existing `skills/<bundle-name>.bundle.md` without
+  explicit user confirmation.

--- a/skills/markspec-scaffold-profile-bundle/AGENT.md
+++ b/skills/markspec-scaffold-profile-bundle/AGENT.md
@@ -36,9 +36,11 @@ are already working inside it).
    - `"aspice-4"` → `"aspice-4"`
 
 3. **Derive `requires:`** from `extends:`:
-   - `extends: "npm:@markspec/profile-default@^1.0"` → `requires: [{name: "profile-default"}]`
+   - `extends: "npm:@markspec/profile-default@^1.0"` →
+     `requires: [{name: "profile-default"}]`
    - `extends: "npm:@acme/foo@^2"` → `requires: [{name: "foo"}]`
-   - `extends: "./path/to/parent"` → read the parent's `markspec.yaml` `id:` and strip its scope
+   - `extends: "./path/to/parent"` → read the parent's `markspec.yaml` `id:` and
+     strip its scope
    - No `extends:` (chain root) → `requires: [{name: "markspec-core"}]`
 
 4. **Create `skills/` directory** if it does not exist.
@@ -68,8 +70,8 @@ are already working inside it).
 
 6. **Report what was created.** List the bundle manifest path and the derived
    `requires:` value. Remind the user to:
-   - Add rule names to `items.rules` and create `skills/<rule-name>/RULE.md`
-     for each profile-specific always-on rule.
+   - Add rule names to `items.rules` and create `skills/<rule-name>/RULE.md` for
+     each profile-specific always-on rule.
    - Add skill names to `items.skills` and create `skills/<skill-name>/SKILL.md`
      for each skill they want to ship.
    - Run `upskill lint --strict skills/` to validate the manifest.
@@ -79,5 +81,5 @@ are already working inside it).
 - Bundle `name:` must equal the profile `id:` with `@scope/` stripped.
 - `requires:` must contain exactly one entry per parent in the `extends:` chain.
 - Do not create RULE.md or SKILL.md stubs — those are the author's job.
-- Do not overwrite an existing `skills/<bundle-name>.bundle.md` without
-  explicit user confirmation.
+- Do not overwrite an existing `skills/<bundle-name>.bundle.md` without explicit
+  user confirmation.

--- a/skills/markspec-traceability-review/AGENT.md
+++ b/skills/markspec-traceability-review/AGENT.md
@@ -45,12 +45,12 @@ the user will provide one or more file paths or a glob (e.g. `docs/**/*.md`).
 
 3. **Identify gaps.** Classify every entry into one of these states:
 
-   | State | Condition |
-   | ----- | --------- |
-   | **Fully traced** | Has at least one upstream link AND at least one downstream link (or is a leaf type with no downstream expectation) |
-   | **Missing upstream** | No `Satisfies:` / `Derived-from:` link — orphaned from the requirement chain |
-   | **Missing downstream** | No `Verified-by:` / `Tests:` link — untested requirement |
-   | **Isolated** | Neither upstream nor downstream links — completely unconnected |
+   | State                  | Condition                                                                                                          |
+   | ---------------------- | ------------------------------------------------------------------------------------------------------------------ |
+   | **Fully traced**       | Has at least one upstream link AND at least one downstream link (or is a leaf type with no downstream expectation) |
+   | **Missing upstream**   | No `Satisfies:` / `Derived-from:` link — orphaned from the requirement chain                                       |
+   | **Missing downstream** | No `Verified-by:` / `Tests:` link — untested requirement                                                           |
+   | **Isolated**           | Neither upstream nor downstream links — completely unconnected                                                     |
 
    Leaf types (STK entries at the top of the chain) are expected to have no
    upstream link — do not flag them as "missing upstream".
@@ -64,10 +64,10 @@ the user will provide one or more file paths or a glob (e.g. `docs/**/*.md`).
 
 5. **Check for cross-file consistency.**
 
-   Entries referencing a display ID that does not appear in the corpus
-   will already be flagged by `markspec validate` (broken reference diagnostic).
-   Confirm all such errors are present in your Step 1 output and include them
-   in the report.
+   Entries referencing a display ID that does not appear in the corpus will
+   already be flagged by `markspec validate` (broken reference diagnostic).
+   Confirm all such errors are present in your Step 1 output and include them in
+   the report.
 
 6. **Emit the findings report** in this structure:
 

--- a/skills/markspec-traceability-review/AGENT.md
+++ b/skills/markspec-traceability-review/AGENT.md
@@ -1,0 +1,104 @@
+---
+schema: 1
+name: markspec-traceability-review
+description: >
+  Use when auditing a MarkSpec project for traceability gaps, missing
+  derivations, untested requirements, and orphaned entries — runs CLI commands
+  and interprets the coverage and validation output.
+license: MIT
+mode: subagent
+model: sonnet
+tools:
+  - bash
+  - read
+preload-skills:
+  - markspec-diagnostics
+metadata:
+  version: "0.1.0"
+  author: driftsys
+---
+
+## Traceability review
+
+You are auditing a MarkSpec project for traceability completeness. When invoked,
+the user will provide one or more file paths or a glob (e.g. `docs/**/*.md`).
+
+### Steps
+
+1. **Validate the corpus.**
+
+   ```bash
+   markspec validate <paths> --format json
+   ```
+
+   Collect all diagnostics. Note any `error` severity items — these must be
+   fixed before the traceability picture is reliable.
+
+2. **Generate the traceability report.**
+
+   ```bash
+   markspec report traceability <paths> --format json
+   ```
+
+   Parse the JSON output. The report contains entries with their upstream
+   (`Satisfies:`) and downstream (`Verified-by:` / `Tests:`) links.
+
+3. **Identify gaps.** Classify every entry into one of these states:
+
+   | State | Condition |
+   | ----- | --------- |
+   | **Fully traced** | Has at least one upstream link AND at least one downstream link (or is a leaf type with no downstream expectation) |
+   | **Missing upstream** | No `Satisfies:` / `Derived-from:` link — orphaned from the requirement chain |
+   | **Missing downstream** | No `Verified-by:` / `Tests:` link — untested requirement |
+   | **Isolated** | Neither upstream nor downstream links — completely unconnected |
+
+   Leaf types (STK entries at the top of the chain) are expected to have no
+   upstream link — do not flag them as "missing upstream".
+
+4. **Check V-model coverage.**
+
+   For each STK entry, walk downward through the `Satisfies:` reverse chain
+   (entries that satisfy the STK). Report:
+   - STK entries with no downward trace (no SYS/SWE entry satisfies them).
+   - SWE/SRS entries with no test entry (`Verified-by:` absent).
+
+5. **Check for cross-file consistency.**
+
+   Entries referencing a display ID that does not appear in the corpus
+   will already be flagged by `markspec validate` (broken reference diagnostic).
+   Confirm all such errors are present in your Step 1 output and include them
+   in the report.
+
+6. **Emit the findings report** in this structure:
+
+   ```
+   ## Traceability Review — <date>
+
+   ### Summary
+   - Total entries: N
+   - Fully traced: N
+   - Missing upstream: N (list display IDs)
+   - Missing downstream: N (list display IDs)
+   - Isolated: N (list display IDs)
+   - Validation errors: N
+
+   ### V-model gaps
+   <STK entries with no derivation>
+   <SWE/SRS entries with no test>
+
+   ### Validation errors
+   <MSL- code, file, line, message for each error>
+
+   ### Recommended actions
+   1. <highest priority fix>
+   2. …
+   ```
+
+### Constraints
+
+- Do not modify any files. This is a read-only audit.
+- If `markspec` is not on PATH, report that and stop.
+- If the corpus has validation errors, include them in the report but continue
+  the traceability analysis — partial data is still useful.
+- Do not speculate about requirement intent. Report gaps as structural facts,
+  not quality judgements.

--- a/skills/markspec-write-loop/SKILL.md
+++ b/skills/markspec-write-loop/SKILL.md
@@ -1,0 +1,93 @@
+---
+schema: 1
+name: markspec-write-loop
+description: >
+  Use when writing new entries to a MarkSpec file — teaches the canonical
+  `markspec insert → markspec format → markspec validate` agent write path
+  and explains what each step produces.
+---
+
+# markspec-write-loop
+
+## Overview
+
+The canonical agent write path for adding a new entry to a MarkSpec document is
+a three-command sequence. Run each step and check its output before proceeding.
+
+```
+markspec insert <type> <file>
+markspec format <file>
+markspec validate <file>
+```
+
+Never hand-craft a full entry block and paste it. `insert` computes the correct
+display ID from the current corpus; pasting a guessed ID risks a collision.
+
+## Step 1 — Insert
+
+```bash
+markspec insert <type> <file>
+```
+
+Appends a scaffolded entry block to `<file>`. The block contains:
+
+- the next sequential display ID for `<type>` (computed from all entries in the
+  project),
+- a generated ULID in the `Id:` trailer,
+- skeleton `Type:` and `Satisfies:` trailers.
+
+The file is modified in place. Only the new block is appended; existing content
+is never touched.
+
+**Then:** fill in the `Title` and `Body` prose in the editor. Do not touch `Id:`
+or the display ID — the formatter owns them.
+
+## Step 2 — Format
+
+```bash
+markspec format <file>
+```
+
+- Stamps any missing `Id:` ULIDs.
+- Normalises trailer indent to 6 spaces.
+- Adds missing trailing backslashes on multi-line attribute values.
+
+Run this before committing. The pre-commit hook (`markspec hook`) runs the same
+normalisation check and will reject unformatted files.
+
+## Step 3 — Validate
+
+```bash
+markspec validate <file>
+```
+
+Runs file-local and cross-file checks:
+
+- broken `Satisfies:` / `Verified-by:` references,
+- duplicate display IDs or ULIDs,
+- missing `Id:` on Authored entries,
+- MSL- diagnostic codes (see `markspec-diagnostics`).
+
+Exit 0 = clean. Exit 1 = errors. Exit 2 = warnings only.
+
+Fix any errors and repeat until exit 0.
+
+## Quick reference
+
+| Command                              | Touches file?    | When to run                          |
+| ------------------------------------ | ---------------- | ------------------------------------ |
+| `markspec insert <type> <file>`      | Yes — appends    | Start of the write loop              |
+| `markspec format <file>`             | Yes — normalises | After editing, before commit         |
+| `markspec validate <file>`           | No               | After format, check for broken links |
+| `markspec next-id <type> <paths...>` | No               | Read-only ID preview (no insert)     |
+| `markspec create <type> <paths...>`  | No               | Print scaffold to stdout (no write)  |
+| `markspec hook <file>`               | No               | Pre-commit: format-check + validate  |
+
+## Common mistakes
+
+| Mistake                            | Fix                                                                    |
+| ---------------------------------- | ---------------------------------------------------------------------- |
+| Skipping `markspec format`         | The pre-commit hook will reject the file; run format before committing |
+| Running `validate` before `format` | Format first — some diagnostics are caused by malformed indentation    |
+| Guessing the next display ID       | Use `markspec next-id` or `markspec insert`; never guess               |
+| Editing `Id:` by hand              | Leave it alone; `format` stamps it                                     |


### PR DESCRIPTION
## Summary

- Adds `skills/REGISTRY.md` — declares the markspec repo as an upskill source registry
- Adds `skills/markspec-core.bundle.md` — bundle manifest wiring 1 rule + 7 skills
- Adds `skills/markspec-core-rules/RULE.md` — always-on authoring invariants (Id integrity, format before commit, prose quality)
- Adds 7 SKILL.md files covering entry authoring, the agent write loop, diagnostics, EARS patterns, Gherkin acceptance criteria, requirement style selection, and profile bundle authoring

## Design

The bundle `requires:` chain mirrors the profile `extends:` chain (the core invariant documented in the design spec at `docs/superpowers/specs/2026-05-19-markspec-skills-design.md`). Every profile bundle transitively pulls `markspec-core` via its own `requires:` entry.

Binding is enforced by documentation and the `markspec-profile-bundle-authoring` skill — no CLI generation.

## Test plan

- [ ] `upskill lint --strict skills/` passes on all bundle and item files
- [ ] `upskill add markspec:markspec-core.bundle.md` resolves cleanly in a consumer project
- [ ] Each SKILL.md `description:` starts with "Use when…" and is under 1024 chars
- [ ] Every item listed in `markspec-core.bundle.md` has a corresponding directory with a RULE.md or SKILL.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)