### PR TITLE
fix(lsp): serialize file parse, fix URI encoding, add close/open handlers

### DIFF
--- a/packages/markspec/lsp/server.ts
+++ b/packages/markspec/lsp/server.ts
@@ -66,7 +66,12 @@ import {
   isMarkspecFile,
   isSourceFile,
 } from "./context.ts";
-import { debounce, pathToUri, uriToPath } from "./util.ts";
+import {
+  debounce,
+  type DebouncedFunction,
+  pathToUri,
+  uriToPath,
+} from "./util.ts";
 import { debugLog } from "./debug_log.ts";
 
 // ---------------------------------------------------------------------------
@@ -169,6 +174,12 @@ function publishAllDiagnostics(): void {
 
 // Debounced cross-file validation (1000ms)
 const debouncedValidateAll = debounce(publishAllDiagnostics, 1000);
+
+// Per-file debounced parse — serializes rapid edits and prevents stale
+// index writes from concurrent async parse calls (B2).
+const pendingContent = new Map<string, string>();
+// deno-lint-ignore no-explicit-any
+const debouncedFileParses = new Map<string, DebouncedFunction<any>>();
 
 // ---------------------------------------------------------------------------
 // Completions
@@ -316,27 +327,58 @@ connection.onInitialized(async () => {
 // Document sync
 // ---------------------------------------------------------------------------
 
-documents.onDidChangeContent(async (change) => {
+documents.onDidChangeContent((change) => {
   const filePath = uriToPath(change.document.uri);
   if (!isMarkspecFile(filePath)) return;
 
-  // Re-parse the changed file
-  const parseDiags = await index.parseAndUpdateFile(
-    filePath,
-    change.document.getText(),
-  );
+  // Stash latest content so the debounced parse always uses the most
+  // recent snapshot, even if multiple edits arrive before the timer fires.
+  pendingContent.set(filePath, change.document.getText());
 
-  // Publish file-local diagnostics immediately
-  publishFileDiagnostics(filePath, parseDiags);
-
-  // Schedule cross-file validation
-  debouncedValidateAll();
+  let debouncedParse = debouncedFileParses.get(filePath);
+  if (!debouncedParse) {
+    debouncedParse = debounce(async () => {
+      const content = pendingContent.get(filePath);
+      if (content === undefined) return;
+      const parseDiags = await index.parseAndUpdateFile(filePath, content);
+      publishFileDiagnostics(filePath, parseDiags);
+      debouncedValidateAll();
+    }, 50);
+    debouncedFileParses.set(filePath, debouncedParse);
+  }
+  debouncedParse();
 });
 
 documents.onDidSave(() => {
   // Force cross-file validation on save
   debouncedValidateAll.cancel();
   publishAllDiagnostics();
+});
+
+documents.onDidClose((event) => {
+  const filePath = uriToPath(event.document.uri);
+  if (!isMarkspecFile(filePath)) return;
+  // Remove the file from the index and clear its diagnostics so stale
+  // entries don't affect cross-file validation after the buffer closes.
+  index.removeFile(filePath);
+  pendingContent.delete(filePath);
+  debouncedFileParses.delete(filePath);
+  connection.sendDiagnostics({ uri: event.document.uri, diagnostics: [] });
+  debouncedValidateAll();
+});
+
+documents.onDidOpen(async (event) => {
+  const filePath = uriToPath(event.document.uri);
+  if (!isMarkspecFile(filePath)) return;
+  // Index newly opened files immediately so rename and other workspace
+  // operations cover them even before the first edit event fires.
+  if (index.getFilePaths().includes(filePath)) return; // already indexed
+  const parseDiags = await index.parseAndUpdateFile(
+    filePath,
+    event.document.getText(),
+  );
+  publishFileDiagnostics(filePath, parseDiags);
+  debouncedValidateAll();
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/markspec/lsp/util.ts
+++ b/packages/markspec/lsp/util.ts
@@ -15,11 +15,11 @@ export function uriToPath(uri: string): string {
 
 /**
  * Convert a filesystem path to a `file://` URI.
- * Encodes special characters for URI safety.
+ * Uses the URL constructor so valid URI characters like `()`, `@`, `!`
+ * are preserved rather than percent-encoded by `encodeURIComponent`.
  */
 export function pathToUri(path: string): string {
-  const encoded = path.split("/").map(encodeURIComponent).join("/");
-  return `file://${encoded}`;
+  return new URL(`file://${path}`).href;
 }
 
 /** A debounced function with a `cancel()` method. */

--- a/packages/markspec/lsp/util_test.ts
+++ b/packages/markspec/lsp/util_test.ts
@@ -35,6 +35,18 @@ Deno.test("pathToUri: encodes spaces", () => {
   );
 });
 
+Deno.test("pathToUri: preserves valid URI characters like parentheses", () => {
+  assertEquals(
+    pathToUri("/foo/bar(1).md"),
+    "file:///foo/bar(1).md",
+  );
+});
+
+Deno.test("pathToUri/uriToPath round-trip", () => {
+  const path = "/Users/dev/project/foo.md";
+  assertEquals(uriToPath(pathToUri(path)), path);
+});
+
 Deno.test("debounce: calls function after delay", async () => {
   let callCount = 0;
   const fn = debounce(() => {


### PR DESCRIPTION
## Summary
- **B2**: Debounce per-file parse at 50ms to prevent stale index writes under rapid typing
- **B3**: Replace `encodeURIComponent` with `new URL()` in `pathToUri` — fixes LSP feature silently breaking for paths with `()`, `@`, etc.
- **M3**: Add `documents.onDidClose` handler — clears diagnostics and removes stale index entries
- **M4**: Add `documents.onDidOpen` handler — indexes new/unsaved files so rename covers them

## Issues
Closes #368, closes #369, closes #372, closes #373. Part of #366.

## Test plan
- [ ] `pathToUri("/foo/bar(1).md") === "file:///foo/bar(1).md"` (B3)
- [ ] Rapid typing no longer causes flickering diagnostics (B2)
- [ ] Closing a file clears its diagnostics (M3)
- [ ] Rename includes newly opened unsaved files (M4)
- [ ] `just check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)