### PR TITLE
fix(mcp): forceRefresh always recompiles, async handler errors logged

### DIFF
--- a/packages/markspec/mcp/project.ts
+++ b/packages/markspec/mcp/project.ts
@@ -103,7 +103,9 @@ export async function checkFileStaleness(
 }
 
 /** Handler signature for invalidation subscribers. */
-export type InvalidationHandler = (result: CompileResult) => void;
+export type InvalidationHandler = (
+  result: CompileResult,
+) => void | Promise<void>;
 
 /** Project context handle returned by {@linkcode createProject}. */
 export interface Project {
@@ -246,11 +248,20 @@ export async function createProject(env: ProjectEnv): Promise<Project> {
       cached = result;
       // Fire handlers AFTER cache is committed but isolate handler errors so
       // one bad subscriber doesn't break others or abort the compile result.
+      // Async handlers are not awaited — their rejections are caught and logged.
       for (const h of handlers) {
-        try {
-          h(result);
-        } catch {
-          // Handler error — ignore.
+        const maybePromise = (() => {
+          try {
+            return h(result);
+          } catch (err) {
+            console.error(`InvalidationHandler sync error: ${err}`);
+            return undefined;
+          }
+        })();
+        if (maybePromise instanceof Promise) {
+          maybePromise.catch((err) => {
+            console.error(`InvalidationHandler async error: ${err}`);
+          });
         }
       }
       return result;
@@ -342,9 +353,15 @@ export async function createProject(env: ProjectEnv): Promise<Project> {
             "Operations require project context.",
         );
       }
-      // Force-refresh joins an in-flight compile rather than firing a second
-      // one. What matters is that after this resolves, the cache reflects a
-      // fresh compile.
+      // Wait for any in-flight compile to settle so its finally-block can
+      // reset inFlight before we start a fresh one. Then clear the cache so
+      // ensureCompile unconditionally kicks off a new compile.
+      if (inFlight) {
+        try {
+          await inFlight;
+        } catch { /* ignore — errors surface on next getCompiled() */ }
+      }
+      cached = null;
       return await ensureCompile();
     },
     subscribeInvalidation(handler: InvalidationHandler): () => void {


### PR DESCRIPTION
## Summary
- **M5**: `forceRefresh()` now waits for any in-flight compile to settle (so its `finally` block can reset `inFlight`), then clears `cached`, then calls `ensureCompile()` — guaranteeing a fresh compile always runs regardless of race state
- **M6**: `InvalidationHandler` type updated to `(result: CompileResult) => void | Promise<void>`; dispatch loop catches sync errors and attaches `.catch()` to async handlers instead of silently swallowing them

## Issues
Closes #374, closes #375. Part of #366.

## Test plan
- [x] `forceRefresh()` returns a new compile result object distinct from the cached one (existing test `forceRefresh: recompiles even with no changes` covers this)
- [x] Async handler errors are logged to `console.error` rather than silently dropped
- [x] `just check` passes — 1522 tests, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)