### PR TITLE
fix(lint): remove duplicate Q302 term; fix profile barrel exports

### DIFF
--- a/packages/markspec/core/lint/rules/lexicon.ts
+++ b/packages/markspec/core/lint/rules/lexicon.ts
@@ -43,7 +43,7 @@ const Q302_TERMS = [
   "effective",
   "effectively",
   "as needed",
-  "as required",
+  // "as required" belongs exclusively to Q303 (INCOSE R8 escape clause)
 ];
 
 const Q303_TERMS = [

--- a/packages/markspec/core/mod.ts
+++ b/packages/markspec/core/mod.ts
@@ -84,6 +84,7 @@ export {
 export type { LoadConfigResult, ReadFile } from "./config/mod.ts";
 
 export {
+  addProfileSpecifier,
   MARKSPEC_YAML_FILENAME,
   parseMarkspecYaml,
   readMarkspecYaml,

--- a/packages/markspec/core/profile/mod.ts
+++ b/packages/markspec/core/profile/mod.ts
@@ -35,10 +35,9 @@ export type { LoadProfileForCommandResult } from "./load.ts";
 export { mergeChain } from "./merge.ts";
 export type { MergeResult } from "./merge.ts";
 
-export { cacheDir } from "./cache.ts";
-export type { CacheEnv } from "./cache.ts";
-
-export { defaultRunNpm, resolveNpmSpecifier } from "./npm.ts";
-export type { ResolveNpmOptions, RunNpm } from "./npm.ts";
+// cacheDir, CacheEnv, defaultRunNpm, resolveNpmSpecifier, ResolveNpmOptions,
+// and RunNpm are internal implementation details of the NPM resolver — they
+// are not part of the public profile API and are not re-exported from
+// core/mod.ts. Consumers use loadChain / loadProfileForCommand instead.
 
 export { resolveEntryColor } from "./colors.ts";

--- a/packages/markspec/main.ts
+++ b/packages/markspec/main.ts
@@ -497,7 +497,7 @@ profile:
     const { config: _config, projectRoot } = await requireProjectConfig();
 
     // Parse the specifier string to validate format.
-    const { parseMarkspecYaml } = await import("./core/config/markspec.ts");
+    const { parseMarkspecYaml } = await import("./core/mod.ts");
     const testYaml = `profiles:\n  - "${spec}"\n`;
     const parseResult = parseMarkspecYaml(testYaml, "<cli>");
 
@@ -531,7 +531,7 @@ profile:
     }
 
     // Record the specifier in .markspec.yaml.
-    const { addProfileSpecifier } = await import("./core/config/markspec.ts");
+    const { addProfileSpecifier } = await import("./core/mod.ts");
     await addProfileSpecifier(
       spec,
       readFile,


### PR DESCRIPTION
## Summary
- **M8**: Remove "as required" from `Q302_TERMS` — it belongs only in Q303 (escape clause per INCOSE R8); single occurrence now produces one diagnostic instead of two
- **M10**: Audit profile module exports — remove `export` from symbols unused outside `core/` (`cacheDir`, `CacheEnv`, `defaultRunNpm`, `resolveNpmSpecifier`, `ResolveNpmOptions`, `RunNpm`); add `addProfileSpecifier` to `core/mod.ts` barrel; fix `main.ts` direct imports from `core/config/markspec.ts` to go through `core/mod.ts`

## Issues
Closes #377, closes #379. Part of #366.

## Test plan
- [ ] Entry body with "as required" produces exactly one diagnostic (Q303, not Q302 + Q303)
- [ ] No code outside `core/` imports directly from `core/profile/` internals or `core/config/` internals (all now barrel-routed through `core/mod.ts`)
- [ ] `just check` passes (1522 tests, lint clean, type-check clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)