### PR TITLE
fix(compiler): SerializedEntry type, all edges in streaming, hyphen-aware scope filter

### DIFF
--- a/packages/markspec/core/compiler/manifest.ts
+++ b/packages/markspec/core/compiler/manifest.ts
@@ -69,10 +69,6 @@ export function buildManifest(
     byType[typeName] = (byType[typeName] ?? 0) + 1;
   }
 
-  const generatedEdgeCount = result.links.filter(
-    (l) => l.origin === "generated",
-  ).length;
-
   return {
     markspecSchemaVersion: 1,
     generator: {
@@ -85,7 +81,7 @@ export function buildManifest(
     },
     counts: {
       entries: result.entries.size,
-      edges: streaming ? generatedEdgeCount : result.links.length,
+      edges: result.links.length,
       byType,
     },
     entries: streaming

--- a/packages/markspec/core/compiler/mod.ts
+++ b/packages/markspec/core/compiler/mod.ts
@@ -234,7 +234,7 @@ function buildAdjacency(
 
 // Re-export serialization helper.
 export { serializeCompileResult } from "./schema.ts";
-export type { SerializedCompileResult } from "./schema.ts";
+export type { SerializedCompileResult, SerializedEntry } from "./schema.ts";
 
 // Re-export inverse generation.
 export { generateInverses } from "./inverses.ts";

--- a/packages/markspec/core/compiler/ndjson_writer.ts
+++ b/packages/markspec/core/compiler/ndjson_writer.ts
@@ -5,7 +5,7 @@
  *
  * Three pure, Deno-free functions — callers perform the actual file I/O:
  *   - {@linkcode buildEntriesNdjson}: entries sorted by displayId
- *   - {@linkcode buildEdgesNdjson}: generated-only links
+ *   - {@linkcode buildEdgesNdjson}: all links (authored + generated)
  *   - {@linkcode indexToJson}: compact byte-offset index JSON
  */
 
@@ -78,15 +78,19 @@ export function indexToJson(
 /**
  * Build the `edges.ndjson` byte stream.
  *
- * Only links with `origin === "generated"` are written. Each line is a
- * compact JSON object with `from`, `to`, and `kind` only — `origin` and
- * `location` are derivable and not persisted.
+ * All links (both authored and generated) are written. Each line is a
+ * compact JSON object with `from`, `to`, `kind`, and `origin` — the
+ * `location` field is omitted as it is not needed for interchange.
  */
 export function buildEdgesNdjson(links: readonly Link[]): Uint8Array {
   const chunks: Uint8Array[] = [];
   for (const link of links) {
-    if (link.origin !== "generated") continue;
-    const record = { from: link.from, to: link.to, kind: link.kind };
+    const record = {
+      from: link.from,
+      to: link.to,
+      kind: link.kind,
+      origin: link.origin,
+    };
     chunks.push(enc.encode(JSON.stringify(record) + "\n"));
   }
   return concat(chunks);

--- a/packages/markspec/core/compiler/ndjson_writer_test.ts
+++ b/packages/markspec/core/compiler/ndjson_writer_test.ts
@@ -186,7 +186,7 @@ Deno.test("indexToJson: keys are sorted lexicographically", () => {
 // buildEdgesNdjson
 // ---------------------------------------------------------------------------
 
-Deno.test("buildEdgesNdjson: writes only generated links, not authored", () => {
+Deno.test("buildEdgesNdjson: writes all links (authored and generated)", () => {
   const links: Link[] = [
     makeAuthoredLink("A_0001", "B_0001"),
     makeGeneratedLink("B_0001", "A_0001"),
@@ -195,33 +195,49 @@ Deno.test("buildEdgesNdjson: writes only generated links, not authored", () => {
   const ndjson = buildEdgesNdjson(links);
   const text = new TextDecoder().decode(ndjson);
   const lines = text.split("\n").filter((l) => l.length > 0);
-  assertEquals(lines.length, 1);
-  const edge = JSON.parse(lines[0]);
-  assertEquals(edge.from, "B_0001");
-  assertEquals(edge.to, "A_0001");
+  assertEquals(lines.length, 3);
 });
 
-Deno.test("buildEdgesNdjson: edge records have from, to, kind only", () => {
+Deno.test("buildEdgesNdjson: edge records have from, to, kind, origin", () => {
   const links: Link[] = [makeGeneratedLink("X_0001", "Y_0001")];
   const ndjson = buildEdgesNdjson(links);
   const text = new TextDecoder().decode(ndjson);
   const edge = JSON.parse(text.trim());
-  assertEquals(Object.keys(edge).sort(), ["from", "kind", "to"]);
+  assertEquals(Object.keys(edge).sort(), ["from", "kind", "origin", "to"]);
 });
 
-Deno.test("buildEdgesNdjson: empty result when no generated links", () => {
+Deno.test("buildEdgesNdjson: authored link preserves origin undefined", () => {
   const links: Link[] = [
     makeAuthoredLink("A_0001", "B_0001"),
   ];
   const ndjson = buildEdgesNdjson(links);
   const text = new TextDecoder().decode(ndjson);
+  const edge = JSON.parse(text.trim());
+  assertEquals(edge.from, "A_0001");
+  assertEquals(edge.to, "B_0001");
+  // authored links have no origin field — JSON.stringify omits undefined
+  assertEquals(edge.origin, undefined);
+});
+
+Deno.test("buildEdgesNdjson: generated link preserves origin field", () => {
+  const links: Link[] = [makeGeneratedLink("B_0001", "A_0001")];
+  const ndjson = buildEdgesNdjson(links);
+  const text = new TextDecoder().decode(ndjson);
+  const edge = JSON.parse(text.trim());
+  assertEquals(edge.origin, "generated");
+});
+
+Deno.test("buildEdgesNdjson: empty result when no links", () => {
+  const links: Link[] = [];
+  const ndjson = buildEdgesNdjson(links);
+  const text = new TextDecoder().decode(ndjson);
   assertEquals(text.trim(), "");
 });
 
-Deno.test("buildEdgesNdjson: multiple generated links each on own line", () => {
+Deno.test("buildEdgesNdjson: multiple links each on own line", () => {
   const links: Link[] = [
     makeGeneratedLink("B_0001", "A_0001"),
-    makeGeneratedLink("C_0001", "A_0001"),
+    makeAuthoredLink("C_0001", "A_0001"),
   ];
   const ndjson = buildEdgesNdjson(links);
   const text = new TextDecoder().decode(ndjson);

--- a/packages/markspec/core/compiler/schema.ts
+++ b/packages/markspec/core/compiler/schema.ts
@@ -10,6 +10,17 @@ import type { CompileResult } from "./mod.ts";
 import type { Diagnostic, Entry, Link } from "../model/mod.ts";
 
 /**
+ * JSON-serializable form of {@linkcode Entry}.
+ *
+ * Identical to `Entry` except `typedAttributes` is a plain
+ * `Record<string, readonly string[]>` instead of a `ReadonlyMap` — Maps are
+ * not JSON-serializable. All other fields are passed through unchanged.
+ */
+export type SerializedEntry = Omit<Entry, "typedAttributes"> & {
+  readonly typedAttributes?: Record<string, readonly string[]>;
+};
+
+/**
  * Serialized form of {@linkcode CompileResult}.
  *
  * All `ReadonlyMap` fields are converted to plain objects keyed by display ID.
@@ -17,7 +28,7 @@ import type { Diagnostic, Entry, Link } from "../model/mod.ts";
  */
 export interface SerializedCompileResult {
   /** Entries keyed by display ID. */
-  readonly entries: Record<string, Entry>;
+  readonly entries: Record<string, SerializedEntry>;
   /** All traceability links. */
   readonly links: readonly Link[];
   /** Outgoing links per entry (entry -> targets). */
@@ -40,9 +51,8 @@ export interface SerializedCompileResult {
 export function serializeCompileResult(
   result: CompileResult,
 ): SerializedCompileResult {
-  const rawEntries = Object.fromEntries(result.entries);
-  const entries: Record<string, Entry> = {};
-  for (const [key, entry] of Object.entries(rawEntries)) {
+  const entries: Record<string, SerializedEntry> = {};
+  for (const [key, entry] of result.entries) {
     entries[key] = serializeEntry(entry);
   }
   return {
@@ -55,27 +65,29 @@ export function serializeCompileResult(
 }
 
 /**
- * Convert an {@linkcode Entry} to a JSON-safe form by replacing
- * `typedAttributes` (a `ReadonlyMap`) with a plain object, and stripping
- * `properties.sync` (privacy rule — never publish connector state).
+ * Convert an {@linkcode Entry} to a JSON-safe {@linkcode SerializedEntry} by
+ * replacing `typedAttributes` (a `ReadonlyMap`) with a plain
+ * `Record<string, readonly string[]>`, and stripping `properties.sync`
+ * (privacy rule — never publish connector state).
  */
-export function serializeEntry(entry: Entry): Entry {
-  let result: Entry = entry;
+export function serializeEntry(entry: Entry): SerializedEntry {
+  // Replace the ReadonlyMap with a plain Record when populated; omit when empty
+  // so JSON output stays compact.
+  const typedAttributes: Record<string, readonly string[]> | undefined =
+    entry.typedAttributes && entry.typedAttributes.size > 0
+      ? Object.fromEntries(entry.typedAttributes)
+      : undefined;
 
-  if (entry.typedAttributes && entry.typedAttributes.size > 0) {
-    const typedObj = Object.fromEntries(entry.typedAttributes);
-    result = {
-      ...result,
-      typedAttributes: typedObj as unknown as Entry["typedAttributes"],
-    };
+  // Strip properties.sync (connector state must not be published).
+  let properties = entry.properties;
+  if (properties?.sync !== undefined) {
+    const { sync: _sync, ...rest } = properties;
+    properties = Object.keys(rest).length > 0 ? rest : undefined;
   }
 
-  if (result.properties?.sync !== undefined) {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { sync: _sync, ...rest } = result.properties;
-    const strippedProperties = Object.keys(rest).length > 0 ? rest : undefined;
-    result = { ...result, properties: strippedProperties };
-  }
-
-  return result;
+  return {
+    ...entry,
+    typedAttributes,
+    properties,
+  };
 }

--- a/packages/markspec/core/compiler/schema_test.ts
+++ b/packages/markspec/core/compiler/schema_test.ts
@@ -1,5 +1,6 @@
 import { assertEquals } from "@std/assert";
 import { serializeCompileResult } from "./schema.ts";
+import type { SerializedEntry } from "./schema.ts";
 import type { CompileResult } from "./mod.ts";
 import type { Entry, Link } from "../model/mod.ts";
 
@@ -79,11 +80,11 @@ Deno.test("serializeCompileResult: entries keyed by displayId", () => {
     "SRS_BRK_0002",
   ]);
   assertEquals(
-    (serialized.entries["SRS_BRK_0001"] as Entry).displayId,
+    serialized.entries["SRS_BRK_0001"].displayId,
     "SRS_BRK_0001",
   );
   assertEquals(
-    (serialized.entries["SRS_BRK_0002"] as Entry).displayId,
+    serialized.entries["SRS_BRK_0002"].displayId,
     "SRS_BRK_0002",
   );
 });
@@ -170,7 +171,7 @@ Deno.test("serializeCompileResult: strips sync.* from entry properties", () => {
   };
 
   const serialized = serializeCompileResult(result);
-  const serializedEntry = serialized.entries["STK_0001"] as Entry;
+  const serializedEntry: SerializedEntry = serialized.entries["STK_0001"];
 
   // sync.* must be absent
   assertEquals(serializedEntry.properties?.sync, undefined);
@@ -195,7 +196,7 @@ Deno.test("serializeCompileResult: drops properties entirely when sync is the on
   };
 
   const serialized = serializeCompileResult(result);
-  const serializedEntry = serialized.entries["STK_0002"] as Entry;
+  const serializedEntry: SerializedEntry = serialized.entries["STK_0002"];
 
   assertEquals(serializedEntry.properties, undefined);
 });

--- a/packages/markspec/core/mod.ts
+++ b/packages/markspec/core/mod.ts
@@ -186,6 +186,7 @@ export type {
   CompileResult,
   GenerateInversesResult,
   SerializedCompileResult,
+  SerializedEntry,
 } from "./compiler/mod.ts";
 export { buildManifest } from "./compiler/manifest.ts";
 export type {

--- a/packages/markspec/core/reporter/mod.ts
+++ b/packages/markspec/core/reporter/mod.ts
@@ -57,8 +57,8 @@ function filterEntries(
   if (scope) {
     const scopeUpper = scope.toUpperCase();
     entries = entries.filter((e) => {
-      const parts = e.displayId.split("_");
-      return parts.length >= 2 && parts[1] === scopeUpper;
+      const parts = e.displayId.split(/[_-]/);
+      return parts.some((p) => p === scopeUpper);
     });
   }
 


### PR DESCRIPTION
## Summary
- **M1**: Introduce `SerializedEntry` type so `serializeEntry` return type matches its actual shape — eliminates `as unknown as` cast
- **M2**: Fix streaming mode to include all links (authored + generated) in `edges.ndjson` — no more silent data loss
- **M7**: Fix `--scope` filter to split on both `_` and `-` and match any segment — supports hyphenated display IDs

## Issues
Closes #370, closes #371, closes #376. Part of #366.

## Test plan
- [x] `serializeEntry` return type is `SerializedEntry`, no `as unknown as` (M1)
- [x] Updated `schema_test.ts` to use `SerializedEntry` instead of casting to `Entry`
- [x] Streaming compile output `edges.ndjson` contains authored links in addition to generated links (M2)
- [x] Updated `ndjson_writer_test.ts` to reflect the new all-links behavior
- [x] `--scope BRK` now matches `SRS-BRK-0001` format IDs (M7)
- [x] `just check` passes (1524 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)