### PR TITLE
feat(core): populate file.* properties on compiled entries

### DIFF
--- a/packages/markspec/core/compiler/mod.ts
+++ b/packages/markspec/core/compiler/mod.ts
@@ -26,6 +26,14 @@ export interface CompileOptions {
   readonly readFile: (path: string) => Promise<string>;
   /** Active profile for inverse attribute generation. Optional — when absent, inverses are skipped. */
   readonly profile?: EffectiveProfile;
+  /**
+   * Optional. Called once per source file to obtain its mtime.
+   * Returns undefined when stat is unavailable (remote, test mock, etc.).
+   * When absent, `entry.properties.file.mtime` is left undefined.
+   */
+  readonly statFile?: (
+    path: string,
+  ) => Promise<{ mtime: Date | null } | undefined>;
 }
 
 /** Compiled project output with resolved traceability graph. */
@@ -76,7 +84,23 @@ export async function compile(
       continue;
     }
     const result = await parseFile(content, { file: filePath });
-    allEntries.push(...result.entries);
+    const stat = options.statFile
+      ? await options.statFile(filePath)
+      : undefined;
+    const mtimeStr = stat?.mtime ? stat.mtime.toISOString() : undefined;
+    const annotatedEntries = result.entries.map((entry) => ({
+      ...entry,
+      properties: {
+        ...entry.properties,
+        file: {
+          path: filePath,
+          line: entry.location.line,
+          column: entry.location.column,
+          mtime: mtimeStr,
+        },
+      },
+    }));
+    allEntries.push(...annotatedEntries);
     parseDiagnostics.push(...result.diagnostics);
     if (result.document) documents.set(filePath, result.document);
   }

--- a/packages/markspec/core/compiler/mod_test.ts
+++ b/packages/markspec/core/compiler/mod_test.ts
@@ -297,3 +297,48 @@ Deno.test("compile: no front matter → document absent", async () => {
   const result = await compile(["req.md"], { readFile: reader(files) });
   assertEquals(result.documents.has("req.md"), false);
 });
+
+// ---------------------------------------------------------------------------
+// file.* properties population
+// ---------------------------------------------------------------------------
+
+const FIXTURE_MD = `- [REQ-001] Title
+
+  Body.
+
+      Id: ${ULID_A}
+`;
+
+Deno.test("compile: properties.file.path set when statFile provided", async () => {
+  const files = { "req.md": FIXTURE_MD };
+  const fakeMtime = new Date("2026-05-19T10:23:00.000Z");
+  const result = await compile(["req.md"], {
+    readFile: reader(files),
+    statFile: () => Promise.resolve({ mtime: fakeMtime }),
+  });
+  const entry = result.entries.get("REQ-001");
+  assertExists(entry);
+  assertEquals(entry.properties?.file?.path, "req.md");
+  assertEquals(entry.properties?.file?.mtime, "2026-05-19T10:23:00.000Z");
+});
+
+Deno.test("compile: properties.file.path set without statFile; mtime absent", async () => {
+  const files = { "req.md": FIXTURE_MD };
+  const result = await compile(["req.md"], { readFile: reader(files) });
+  const entry = result.entries.get("REQ-001");
+  assertExists(entry);
+  assertEquals(entry.properties?.file?.path, "req.md");
+  assertEquals(entry.properties?.file?.mtime, undefined);
+});
+
+Deno.test("compile: statFile returning undefined → mtime absent, no crash", async () => {
+  const files = { "req.md": FIXTURE_MD };
+  const result = await compile(["req.md"], {
+    readFile: reader(files),
+    statFile: () => Promise.resolve(undefined),
+  });
+  const entry = result.entries.get("REQ-001");
+  assertExists(entry);
+  assertEquals(entry.properties?.file?.path, "req.md");
+  assertEquals(entry.properties?.file?.mtime, undefined);
+});

--- a/packages/markspec/core/model/mod.ts
+++ b/packages/markspec/core/model/mod.ts
@@ -264,6 +264,8 @@ export interface EntryProperties {
     readonly path: string;
     readonly line?: number;
     readonly column?: number;
+    /** ISO 8601 last-modified timestamp from the filesystem. */
+    readonly mtime?: string;
   };
   /** Version-control observations. */
   readonly git?: {

--- a/packages/markspec/main.ts
+++ b/packages/markspec/main.ts
@@ -104,6 +104,8 @@ async function compileProject(
   const result = await compile(paths, {
     readFile: (p) => Deno.readTextFile(p),
     profile: chain?.effective ?? undefined,
+    statFile: (p) =>
+      Deno.stat(p).then((s) => ({ mtime: s.mtime })).catch(() => undefined),
   });
 
   for (const diag of result.diagnostics) {
@@ -199,6 +201,8 @@ const bookCmd = new Command()
     const compiled = await compile([...files.keys()], {
       readFile: (p) => Deno.readTextFile(p),
       profile: bookChain?.effective ?? undefined,
+      statFile: (p) =>
+        Deno.stat(p).then((s) => ({ mtime: s.mtime })).catch(() => undefined),
     });
 
     const result = buildBook(structure, {

--- a/tests/e2e/compile_properties_test.ts
+++ b/tests/e2e/compile_properties_test.ts
@@ -1,0 +1,53 @@
+/**
+ * @module tests/e2e/compile_properties_test
+ *
+ * E2E tests for `properties.file.*` population on compiled entries.
+ * Verifies that every compiled entry carries its source file path and
+ * last-modified timestamp when compiled via the CLI.
+ */
+
+import { assertEquals, assertMatch } from "@std/assert";
+import { markspec } from "./helpers.ts";
+
+const PROJECT_YAML = `name: test-project\nversion: 0.1.0\n`;
+
+const SAMPLE_MD = `- [STK_0001] The system shall be fast
+
+  Body text.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+`;
+
+Deno.test("compile: properties.file.path present in --format json output", async () => {
+  const { code, stdout } = await markspec(
+    ["compile", "--format", "json", "req.md"],
+    { files: { "project.yaml": PROJECT_YAML, "req.md": SAMPLE_MD } },
+  );
+  assertEquals(code, 0);
+  const parsed = JSON.parse(stdout);
+  const entry = parsed.entries["STK_0001"];
+  assertEquals(typeof entry.properties?.file?.path, "string");
+});
+
+Deno.test("compile: properties.file.mtime is a valid ISO 8601 timestamp", async () => {
+  const { code, stdout } = await markspec(
+    ["compile", "--format", "json", "req.md"],
+    { files: { "project.yaml": PROJECT_YAML, "req.md": SAMPLE_MD } },
+  );
+  assertEquals(code, 0);
+  const parsed = JSON.parse(stdout);
+  const mtime = parsed.entries["STK_0001"]?.properties?.file?.mtime;
+  assertMatch(mtime, /^\d{4}-\d{2}-\d{2}T/);
+});
+
+Deno.test("export json: properties.file.* fields present in output", async () => {
+  const { code, stdout } = await markspec(
+    ["export", "json", "req.md"],
+    { files: { "project.yaml": PROJECT_YAML, "req.md": SAMPLE_MD } },
+  );
+  assertEquals(code, 0);
+  const parsed = JSON.parse(stdout);
+  const entry = parsed.entries["STK_0001"];
+  assertEquals(typeof entry.properties?.file?.path, "string");
+  assertMatch(entry.properties?.file?.mtime, /^\d{4}-\d{2}-\d{2}T/);
+});

--- a/tests/e2e/export_test.ts
+++ b/tests/e2e/export_test.ts
@@ -10,6 +10,28 @@ import { assertEquals, assertStringIncludes } from "@std/assert";
 import { parse as parseYaml } from "@std/yaml";
 import { markspec } from "./helpers.ts";
 
+/** Strip `properties.file.mtime` from every entry so cross-run comparisons
+ * aren't sensitive to filesystem timestamps from separate temp dirs. */
+function stripMtime(result: Record<string, unknown>): Record<string, unknown> {
+  const entries = result.entries as Record<string, Record<string, unknown>>;
+  const stripped: Record<string, Record<string, unknown>> = {};
+  for (const [id, entry] of Object.entries(entries)) {
+    const props = entry.properties as
+      | Record<string, Record<string, unknown>>
+      | undefined;
+    if (props?.file) {
+      const { mtime: _mtime, ...fileRest } = props.file;
+      stripped[id] = {
+        ...entry,
+        properties: { ...props, file: fileRest },
+      };
+    } else {
+      stripped[id] = entry;
+    }
+  }
+  return { ...result, entries: stripped };
+}
+
 const PROJECT_YAML = `name: phase5-e2e\nversion: 0.1.0\n`;
 
 const SAMPLE_MD = `# Example
@@ -114,9 +136,12 @@ Deno.test("export json: matches the compile --format json output", async () => {
   );
   assertEquals(exportRun.code, 0);
   assertEquals(compileRun.code, 0);
+  // Strip properties.file.mtime before comparing — both commands stat the
+  // same files but in separate temp dirs created at different times, so
+  // mtime values differ between invocations. The structural graph is what matters.
   assertEquals(
-    JSON.parse(exportRun.stdout),
-    JSON.parse(compileRun.stdout),
+    stripMtime(JSON.parse(exportRun.stdout)),
+    stripMtime(JSON.parse(compileRun.stdout)),
     "export json and compile --format json should produce identical output",
   );
 });


### PR DESCRIPTION
## Summary

- Adds `mtime?: string` (ISO 8601) to `EntryProperties.file` in `core/model/mod.ts`
- Adds optional `statFile` callback to `CompileOptions` — keeps the compiler Node-safe (no `Deno.*` in library code); library callers that omit it compile identically to before
- Annotates every parsed entry with `properties.file.{ path, line, column, mtime }` during Phase 1 of `compile()`; properties survive classification and inverse-generation spreads unchanged
- Wires `Deno.stat()` at both `compile()` call sites in `main.ts` (`compileProject` helper + `book build` path) so every CLI invocation populates mtime
- Fixes one pre-existing e2e test (`export json: matches the compile --format json output`) that compared two separate-process outputs — now strips `mtime` before structural comparison since separate temp dirs produce different timestamps

## Test Plan

- [x] 3 new unit tests in `core/compiler/mod_test.ts`: `statFile` provided → path + mtime set; absent → path set, mtime undefined; `statFile` returns undefined → no crash
- [x] 3 new e2e tests in `tests/e2e/compile_properties_test.ts`: `compile --format json` has `properties.file.path`; `mtime` matches ISO 8601 pattern; `export json` has both fields
- [x] `just build` green — 1529 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)