### PR TITLE
perf(core/lsp): fix O(n²) parser, double-parse formatter, sequential reads, incremental index

### DIFF
--- a/packages/markspec/core/compiler/mod.ts
+++ b/packages/markspec/core/compiler/mod.ts
@@ -53,6 +53,32 @@ export interface CompileResult {
 }
 
 /**
+ * Semaphore for bounded concurrency — limits simultaneous file reads to
+ * avoid exhausting OS file-descriptor limits on large projects.
+ *
+ * Private to this module; not exported.
+ */
+class Semaphore {
+  private queue: Array<() => void> = [];
+  constructor(private maxConcurrent: number) {}
+  async acquire(): Promise<void> {
+    if (this.maxConcurrent > 0) {
+      this.maxConcurrent--;
+      return;
+    }
+    await new Promise<void>((resolve) => this.queue.push(resolve));
+  }
+  release(): void {
+    const next = this.queue.shift();
+    if (next) {
+      next();
+    } else {
+      this.maxConcurrent++;
+    }
+  }
+}
+
+/**
  * Compile MarkSpec files from the given paths into a resolved
  * traceability graph.
  *
@@ -69,40 +95,72 @@ export async function compile(
   const parseDiagnostics: Diagnostic[] = [];
   const documents = new Map<string, Document>();
 
-  // Phase 1: Read and parse all files.
-  for (const filePath of paths) {
-    let content: string;
-    try {
-      content = await read(filePath);
-    } catch {
-      parseDiagnostics.push({
-        code: "MSL-E000",
-        severity: "error",
-        message: `failed to read file: ${filePath}`,
-        location: undefined,
-      });
-      continue;
-    }
-    const result = await parseFile(content, { file: filePath });
-    const stat = options.statFile
-      ? await options.statFile(filePath)
-      : undefined;
-    const mtimeStr = stat?.mtime ? stat.mtime.toISOString() : undefined;
-    const annotatedEntries = result.entries.map((entry) => ({
-      ...entry,
-      properties: {
-        ...entry.properties,
-        file: {
-          path: filePath,
-          line: entry.location.line,
-          column: entry.location.column,
-          mtime: mtimeStr,
-        },
-      },
-    }));
-    allEntries.push(...annotatedEntries);
-    parseDiagnostics.push(...result.diagnostics);
-    if (result.document) documents.set(filePath, result.document);
+  // Phase 1: Read and parse all files with bounded concurrency (16 slots).
+  // Using Promise.all avoids sequential I/O latency on large projects while
+  // the semaphore prevents exhausting OS file-descriptor limits.
+  const sem = new Semaphore(16);
+
+  type FileResult = {
+    filePath: string;
+    entries: Entry[];
+    diagnostics: Diagnostic[];
+    document: Document | undefined;
+  } | null;
+
+  const fileResults = await Promise.all(
+    [...paths].map(async (filePath): Promise<FileResult> => {
+      await sem.acquire();
+      try {
+        let content: string;
+        try {
+          content = await read(filePath);
+        } catch {
+          return {
+            filePath,
+            entries: [],
+            diagnostics: [{
+              code: "MSL-E000",
+              severity: "error",
+              message: `failed to read file: ${filePath}`,
+              location: undefined,
+            }],
+            document: undefined,
+          };
+        }
+        const result = await parseFile(content, { file: filePath });
+        const stat = options.statFile
+          ? await options.statFile(filePath)
+          : undefined;
+        const mtimeStr = stat?.mtime ? stat.mtime.toISOString() : undefined;
+        const annotatedEntries = result.entries.map((entry) => ({
+          ...entry,
+          properties: {
+            ...entry.properties,
+            file: {
+              path: filePath,
+              line: entry.location.line,
+              column: entry.location.column,
+              mtime: mtimeStr,
+            },
+          },
+        }));
+        return {
+          filePath,
+          entries: annotatedEntries,
+          diagnostics: [...result.diagnostics],
+          document: result.document,
+        };
+      } finally {
+        sem.release();
+      }
+    }),
+  );
+
+  for (const res of fileResults) {
+    if (!res) continue;
+    allEntries.push(...res.entries);
+    parseDiagnostics.push(...res.diagnostics);
+    if (res.document) documents.set(res.filePath, res.document);
   }
 
   // Phase 2: Validate all entries.

--- a/packages/markspec/core/formatter/mod.ts
+++ b/packages/markspec/core/formatter/mod.ts
@@ -231,10 +231,21 @@ function emitBodyViaAst(
   lines: string[],
   file: string,
   diagnostics: Diagnostic[],
+  cachedEntries: Entry[] | undefined,
 ): boolean {
-  // Diagnostics from this re-parse are intentionally discarded: the
-  // input is already canonical (post-collapse) output.
-  const { entries } = parseMarkdown(lines.join("\n"), { file });
+  // When the caller supplies pre-parsed entries whose line numbers are still
+  // valid in `lines` (i.e., no line-count-changing operations occurred before
+  // this call), skip the re-parse entirely — the common hot path for files
+  // that are already in canonical form. When the caller passes undefined the
+  // re-parse is performed as before.
+  let entries: Entry[];
+  if (cachedEntries !== undefined) {
+    entries = cachedEntries;
+  } else {
+    // Diagnostics from this re-parse are intentionally discarded: the
+    // input is already canonical (post-collapse) output.
+    ({ entries } = parseMarkdown(lines.join("\n"), { file }));
+  }
   if (entries.length === 0) return false;
 
   let bodyChanged = false;
@@ -469,10 +480,22 @@ export function format(
   // load-bearing body-emission path AND the body modal-keyword pass
   // (the pre-parse whole-body string pass was removed above). It
   // returns whether any body was rewritten so `changed` stays accurate
-  // for `--check`. emitBodyViaAst re-parses collapsedLines to get
-  // post-collapse entry positions, scoped only to the body segment
-  // (title/trailer/front-matter are untouched).
-  if (emitBodyViaAst(collapsedLines, file, diagnostics)) changed = true;
+  // for `--check`.
+  //
+  // D6 optimization: when neither attribute-block splicing nor blank-line
+  // collapse altered any line positions, the first-parse entry line numbers
+  // are still valid in `collapsedLines` — pass the cached entries so
+  // emitBodyViaAst skips its re-parse (the hot path for already-formatted
+  // files). When `changed` is true, any splicing or collapse may have
+  // shifted positions, so pass undefined to trigger the normal re-parse.
+  if (
+    emitBodyViaAst(
+      collapsedLines,
+      file,
+      diagnostics,
+      changed ? undefined : entries,
+    )
+  ) changed = true;
 
   const formattedBody = collapsedLines.join("\n");
 

--- a/packages/markspec/core/parser/markdown.ts
+++ b/packages/markspec/core/parser/markdown.ts
@@ -95,6 +95,10 @@ export function parseMarkdown(
   const entries: Entry[] = [];
   const diagnostics: Diagnostic[] = [];
 
+  // Pre-split once so every extractBodyContent call shares the same array
+  // instead of re-splitting for each list item (O(N×L) → O(N+L)).
+  const markdownLines = markdown.split("\n");
+
   // Collect link definition identifiers for shortcut reference exclusion.
   const definitions = new Set(
     tree.children
@@ -112,7 +116,7 @@ export function parseMarkdown(
     for (const item of list.children) {
       const entry = extractEntry(
         item,
-        markdown,
+        markdownLines,
         file,
         definitions,
         isReferencesDoc,
@@ -147,7 +151,7 @@ function detectReferencesDocument(
  */
 function extractEntry(
   item: ListItem,
-  markdown: string,
+  markdownLines: string[],
   file: string,
   definitions: Set<string>,
   isReferencesDoc: boolean,
@@ -275,7 +279,7 @@ function extractEntry(
   }
 
   // Extract body content and attributes.
-  const bodyContent = extractBodyContent(item, markdown);
+  const bodyContent = extractBodyContent(item, markdownLines);
   const [body, attrLines] = splitBodyAndAttributes(bodyContent);
   const attributes = parseAttributes(attrLines);
   const bodyAst = buildBodyAst(body);
@@ -516,12 +520,11 @@ function extractEntry(
  * which contains the display ID and title).
  *
  * Reconstructs the text content from the source markdown using position info.
+ * Accepts a pre-split lines array to avoid redundant splits across entries.
  */
-function extractBodyContent(item: ListItem, markdown: string): string {
+function extractBodyContent(item: ListItem, lines: string[]): string {
   const children = item.children.slice(1); // Skip title paragraph
   if (!children.length) return "";
-
-  const lines = markdown.split("\n");
 
   // Get the range from the second child's start to the last child's end
   const startLine = children[0].position?.start.line;

--- a/packages/markspec/lsp/workspace.ts
+++ b/packages/markspec/lsp/workspace.ts
@@ -18,9 +18,11 @@ export interface DisplayIdEntry {
 /**
  * In-memory index of all parsed entries, keyed by file path.
  *
- * Maintains both per-file storage (for incremental updates) and global
- * lookup indexes (rebuilt on every mutation). The index is the single
- * source of truth for the LSP's view of the project.
+ * Maintains both per-file storage (for incremental updates) and a global
+ * display-ID lookup index updated incrementally on every mutation. Updating
+ * a single file touches only that file's entries in the global index —
+ * O(old + new) rather than O(all entries) — so LSP responsiveness is
+ * maintained on large projects.
  */
 export class WorkspaceIndex {
   /** Per-file entry storage. Key is the file path. */
@@ -34,20 +36,80 @@ export class WorkspaceIndex {
   // -----------------------------------------------------------------------
 
   /**
-   * Replace all entries for a file and rebuild global indexes.
+   * Replace all entries for a file and update global indexes incrementally.
    *
    * Call this after re-parsing a file. Pass an empty array to clear a
    * file's entries without removing it from tracking.
+   *
+   * Instead of rebuilding the entire `byDisplayId` map (O(all entries)),
+   * this removes only the old entries for `filePath` and inserts the new
+   * ones — O(old + new) rather than O(total).
    */
   updateFile(filePath: string, entries: Entry[]): void {
+    // Remove old entries for this file from the global index.
+    const oldEntries = this.fileEntries.get(filePath);
+    if (oldEntries) {
+      for (const entry of oldEntries) {
+        // Only remove if this file is still the authoritative source for
+        // this display ID (first-entry-wins invariant: another file may
+        // have claimed the same ID while this file's entries were stale).
+        if (this.byDisplayId.get(entry.displayId)?.location.file === filePath) {
+          this.byDisplayId.delete(entry.displayId);
+          // Promote a survivor from another file so duplicate-ID entries
+          // declared in other files remain reachable after this file loses
+          // ownership. Without promotion, removing STK_001 from file A
+          // would leave byDisplayId with no entry for STK_001 even though
+          // file B still declares it.
+          for (const [otherPath, otherEntries] of this.fileEntries) {
+            if (otherPath === filePath) continue;
+            const survivor = otherEntries.find(
+              (e) => e.displayId === entry.displayId,
+            );
+            if (survivor) {
+              this.byDisplayId.set(entry.displayId, survivor);
+              break; // first-entry-wins; stop after first match
+            }
+          }
+        }
+      }
+    }
+
+    // Store the new entries.
     this.fileEntries.set(filePath, entries);
-    this.rebuildGlobalIndexes();
+
+    // Add new entries — first entry wins for duplicate display IDs.
+    for (const entry of entries) {
+      if (!this.byDisplayId.has(entry.displayId)) {
+        this.byDisplayId.set(entry.displayId, entry);
+      }
+    }
   }
 
   /** Remove a file and its entries from the index entirely. */
   removeFile(filePath: string): void {
+    const oldEntries = this.fileEntries.get(filePath);
     this.fileEntries.delete(filePath);
-    this.rebuildGlobalIndexes();
+    if (!oldEntries) return;
+
+    // Incrementally remove deleted entries from the global index.
+    // fileEntries no longer contains filePath at this point (deleted above),
+    // so the survivor scan correctly skips the removed file.
+    for (const entry of oldEntries) {
+      if (this.byDisplayId.get(entry.displayId)?.location.file === filePath) {
+        this.byDisplayId.delete(entry.displayId);
+        // Promote a survivor from another file so duplicate-ID entries
+        // declared in other files remain reachable after this file is closed.
+        for (const [, otherEntries] of this.fileEntries) {
+          const survivor = otherEntries.find(
+            (e) => e.displayId === entry.displayId,
+          );
+          if (survivor) {
+            this.byDisplayId.set(entry.displayId, survivor);
+            break; // first-entry-wins; stop after first match
+          }
+        }
+      }
+    }
   }
 
   // -----------------------------------------------------------------------
@@ -153,7 +215,13 @@ export class WorkspaceIndex {
   // Internal
   // -----------------------------------------------------------------------
 
-  /** Rebuild all global indexes from per-file storage. */
+  /**
+   * Rebuild all global indexes from per-file storage.
+   *
+   * Not called from `updateFile` or `removeFile` — those use the
+   * incremental path. Retained for potential future use (e.g., a
+   * full reindex after a bulk rename).
+   */
   private rebuildGlobalIndexes(): void {
     this.byDisplayId.clear();
     for (const entries of this.fileEntries.values()) {

--- a/packages/markspec/lsp/workspace_test.ts
+++ b/packages/markspec/lsp/workspace_test.ts
@@ -124,3 +124,45 @@ Deno.test("WorkspaceIndex: getNextDisplayIdNumber returns 1 for empty prefix", (
   const index = new WorkspaceIndex();
   assertEquals(index.getNextDisplayIdNumber("STK_AEB_"), 1);
 });
+
+Deno.test("WorkspaceIndex: updateFile promotes survivor when owner loses a display ID", () => {
+  const index = new WorkspaceIndex();
+
+  // Index both files — a.md wins the display ID (indexed first).
+  index.updateFile("a.md", [entry("STK_0001", { file: "a.md" })]);
+  index.updateFile("b.md", [entry("STK_0001", { file: "b.md" })]);
+
+  assertEquals(
+    index.getEntryByDisplayId("STK_0001")?.location.file,
+    "a.md",
+  );
+
+  // Update file A to remove STK_0001 — file B's entry should be promoted.
+  index.updateFile("a.md", []);
+
+  assertEquals(
+    index.getEntryByDisplayId("STK_0001")?.location.file,
+    "b.md",
+  );
+});
+
+Deno.test("WorkspaceIndex: removeFile promotes survivor when removed file owned a display ID", () => {
+  const index = new WorkspaceIndex();
+
+  // Index both files — a.md wins the display ID (indexed first).
+  index.updateFile("a.md", [entry("STK_0001", { file: "a.md" })]);
+  index.updateFile("b.md", [entry("STK_0001", { file: "b.md" })]);
+
+  assertEquals(
+    index.getEntryByDisplayId("STK_0001")?.location.file,
+    "a.md",
+  );
+
+  // Remove file A entirely — file B's entry should be promoted.
+  index.removeFile("a.md");
+
+  assertEquals(
+    index.getEntryByDisplayId("STK_0001")?.location.file,
+    "b.md",
+  );
+});


### PR DESCRIPTION
## Summary

Resolves #381 from Debt Epic #366 — four performance fixes with real user-latency impact.

**D5 — O(N×L) body extraction** (`core/parser/markdown.ts`): `parseMarkdown` pre-splits the file into a `lines: string[]` array once, then passes it into `extractBodyContent` for each entry. Eliminates an O(N×L) `document.split("\n")` call inside the per-entry loop.

**D6 — Double-parse in formatter** (`core/formatter/mod.ts`): `format()` now passes the first-parse entries as `cachedEntries` into `emitBodyViaAst` when the file is already in canonical form. The second `parseMarkdown` call is eliminated on the hot path (already-formatted files).

**D8 — Sequential compiler file reads** (`core/compiler/mod.ts`): The sequential `for...of` / `await readFile` loop is replaced with `Promise.all` over a private `Semaphore(16)`. Compiler reads up to 16 files concurrently.

**D7 — O(n) LSP index rebuild** (`lsp/workspace.ts`): `updateFile` and `removeFile` no longer call `rebuildGlobalIndexes()`. They incrementally update `byDisplayId`, with survivor-promotion when an owner file loses a display ID (preserves first-entry-wins across files). Regression tests added for the duplicate-ID-across-files scenario.

## Test plan

- [x] `just check` passes (lint + 1567 tests + type-check)
- [x] `deno fmt --check` passes
- [x] `dprint check` passes
- [x] New tests: `WorkspaceIndex: updateFile promotes survivor`, `WorkspaceIndex: removeFile promotes survivor`

🤖 Generated with [Claude Code](https://claude.com/claude-code)