### PR TITLE
refactor(core): brand DisplayId/Ulid types, type ast/build.ts, open LinkKind

### DIFF
--- a/packages/markspec/cli/commands/context_cmd.ts
+++ b/packages/markspec/cli/commands/context_cmd.ts
@@ -7,6 +7,7 @@
  */
 
 import { Command } from "@cliffy/command";
+import { type DisplayId, makeDisplayId } from "../../core/mod.ts";
 import { compileProject } from "../helpers.ts";
 
 export const contextCmd = new Command()
@@ -23,7 +24,8 @@ export const contextCmd = new Command()
       ...paths: string[]
     ) => {
       const { result, chain: _profileChain } = await compileProject(paths);
-      const entry = result.entries.get(id);
+      const startId = makeDisplayId(id);
+      const entry = result.entries.get(startId);
 
       if (!entry) {
         console.error(`error: entry not found: ${id}`);
@@ -34,15 +36,15 @@ export const contextCmd = new Command()
       const chain: Array<{ displayId: string; title: string; depth: number }> =
         [];
       const visited = new Set<string>();
-      let currentIds = [id];
+      let currentIds: DisplayId[] = [startId];
       let depth = 0;
 
       // Add the starting entry at depth 0.
       chain.push({ displayId: entry.displayId, title: entry.title, depth: 0 });
-      visited.add(id);
+      visited.add(startId);
 
       while (depth < options.depth && currentIds.length > 0) {
-        const nextIds: string[] = [];
+        const nextIds: DisplayId[] = [];
         for (const currentId of currentIds) {
           const links = result.forward.get(currentId) ?? [];
           for (const link of links) {

--- a/packages/markspec/cli/commands/dependents.ts
+++ b/packages/markspec/cli/commands/dependents.ts
@@ -5,6 +5,7 @@
  */
 
 import { Command } from "@cliffy/command";
+import { makeDisplayId } from "../../core/mod.ts";
 import { compileProject } from "../helpers.ts";
 
 export const dependentsCmd = new Command()
@@ -16,14 +17,15 @@ export const dependentsCmd = new Command()
   .action(
     async (options: { format?: string }, id: string, ...paths: string[]) => {
       const { result, chain: _chain } = await compileProject(paths);
-      const entry = result.entries.get(id);
+      const displayId = makeDisplayId(id);
+      const entry = result.entries.get(displayId);
 
       if (!entry) {
         console.error(`error: entry not found: ${id}`);
         Deno.exit(1);
       }
 
-      const reverseLinks = result.reverse.get(id) ?? [];
+      const reverseLinks = result.reverse.get(displayId) ?? [];
 
       if (options.format === "json") {
         const output = reverseLinks.map((link) => ({

--- a/packages/markspec/cli/commands/show.ts
+++ b/packages/markspec/cli/commands/show.ts
@@ -5,6 +5,7 @@
  */
 
 import { Command } from "@cliffy/command";
+import { makeDisplayId } from "../../core/mod.ts";
 import { compileProject } from "../helpers.ts";
 
 export const showCmd = new Command()
@@ -16,15 +17,16 @@ export const showCmd = new Command()
   .action(
     async (options: { format?: string }, id: string, ...paths: string[]) => {
       const { result, chain: _chain } = await compileProject(paths);
-      const entry = result.entries.get(id);
+      const displayId = makeDisplayId(id);
+      const entry = result.entries.get(displayId);
 
       if (!entry) {
         console.error(`error: entry not found: ${id}`);
         Deno.exit(1);
       }
 
-      const forwardLinks = result.forward.get(id) ?? [];
-      const reverseLinks = result.reverse.get(id) ?? [];
+      const forwardLinks = result.forward.get(displayId) ?? [];
+      const reverseLinks = result.reverse.get(displayId) ?? [];
 
       if (options.format === "json") {
         const output = {

--- a/packages/markspec/core/ast/build.ts
+++ b/packages/markspec/core/ast/build.ts
@@ -13,7 +13,17 @@
  * This module is pure library code: no `Deno.*` APIs.
  */
 
-import type { Root } from "mdast";
+import type {
+  Blockquote,
+  List,
+  ListItem,
+  Nodes,
+  Root,
+  RootContent,
+  Table,
+  TableCell,
+  TableRow,
+} from "mdast";
 import { processor } from "../parser/remark.ts";
 import { classifyConvention } from "../parser/entity_refs.ts";
 import type {
@@ -353,15 +363,14 @@ function splitVerbatimDeflist(
 // mdast text extraction helper
 // ---------------------------------------------------------------------------
 
-// deno-lint-ignore no-explicit-any
-function extractMdastText(node: any): string {
+function extractMdastText(node: Nodes | undefined): string {
   if (!node) return "";
   // Inline code nodes carry their value without delimiters in mdast;
   // re-add the backtick delimiters so the round-trip is byte-identical.
   if (node.type === "inlineCode") return `\`${node.value}\``;
-  if (typeof node.value === "string") return node.value;
-  if (Array.isArray(node.children)) {
-    return node.children.map(extractMdastText).join("");
+  if ("value" in node && typeof node.value === "string") return node.value;
+  if ("children" in node) {
+    return node.children.map((c) => extractMdastText(c as Nodes)).join("");
   }
   return "";
 }
@@ -447,8 +456,7 @@ function deQuote(rawBlockquote: string): string {
 // Main builder — mdast node → BodyBlock
 // ---------------------------------------------------------------------------
 
-// deno-lint-ignore no-explicit-any
-function mapMdastNode(node: any, body: string): BodyBlock {
+function mapMdastNode(node: RootContent, body: string): BodyBlock {
   const range = positionToRange(node.position);
 
   switch (node.type) {
@@ -535,18 +543,16 @@ function mapMdastNode(node: any, body: string): BodyBlock {
     }
 
     case "list": {
+      const listNode = node as List;
       // Detect GFM task-list items (remark-gfm sets `checked` to true/false).
-      // deno-lint-ignore no-explicit-any
-      const hasTaskItems = node.children.some((item: any) =>
+      const hasTaskItems = listNode.children.some((item: ListItem) =>
         item.checked != null
       );
-      const items: ListItemNode[] = node.children.map(
-        // deno-lint-ignore no-explicit-any
-        (item: any): ListItemNode => {
+      const items: ListItemNode[] = listNode.children.map(
+        (item: ListItem): ListItemNode => {
           const itemRange = positionToRange(item.position);
           const subBlocks: BodyBlock[] = (item.children ?? []).map(
-            // deno-lint-ignore no-explicit-any
-            (child: any) => mapMdastNode(child, body),
+            (child) => mapMdastNode(child as RootContent, body),
           );
           return {
             blocks: subBlocks,
@@ -558,8 +564,8 @@ function mapMdastNode(node: any, body: string): BodyBlock {
       );
       return {
         kind: "list",
-        ordered: node.ordered ?? false,
-        spread: node.spread ?? false,
+        ordered: listNode.ordered ?? false,
+        spread: listNode.spread ?? false,
         items,
         ...(hasTaskItems ? { hasTaskItems: true } : {}),
         range,
@@ -567,15 +573,18 @@ function mapMdastNode(node: any, body: string): BodyBlock {
     }
 
     case "table": {
-      // deno-lint-ignore no-explicit-any
-      const rows: (readonly InlineContent[])[] = node.children.map((row: any) =>
-        // deno-lint-ignore no-explicit-any
-        (row.children ?? []).map((cell: any) => {
-          const cellText = extractMdastText(cell);
-          const cellRange = positionToRange(cell.position);
-          // stored == recognition (table cells render via TableNode.raw; Task 5 confirms)
-          return inlineContent(cellText, cellText, cellRange);
-        })
+      const tableNode = node as Table;
+      const rows: (readonly InlineContent[])[] = tableNode.children.map(
+        (row: TableRow) =>
+          row.children.map((cell: TableCell) => {
+            // TableCell children are PhrasingContent ⊂ RootContent ⊂ Nodes.
+            const cellText = cell.children
+              .map((c) => extractMdastText(c as unknown as Nodes))
+              .join("");
+            const cellRange = positionToRange(cell.position);
+            // stored == recognition (table cells render via TableNode.raw; Task 5 confirms)
+            return inlineContent(cellText, cellText, cellRange);
+          }),
       );
       const [header = [], ...dataRows] = rows;
       const raw = verbatimSlice(body, node.position);
@@ -606,11 +615,12 @@ function mapMdastNode(node: any, body: string): BodyBlock {
     }
 
     case "blockquote": {
-      const verbatim = deQuote(verbatimSlice(body, node.position));
-      const firstChild = node.children?.[0];
+      const bqNode = node as Blockquote;
+      const verbatim = deQuote(verbatimSlice(body, bqNode.position));
+      const firstChild = bqNode.children?.[0];
 
       if (firstChild?.type === "paragraph") {
-        const paraText = extractMdastText(firstChild);
+        const paraText = extractMdastText(firstChild as unknown as Nodes);
         const admonMatch = ADMONITION_FIRST_LINE_RE.exec(paraText.trim());
         if (admonMatch) {
           const kind = admonMatch[1] as AdmonitionKind;
@@ -618,10 +628,9 @@ function mapMdastNode(node: any, body: string): BodyBlock {
           // Flattened recognition text (unchanged from prior behaviour):
           // marker-stripped first paragraph + remaining paragraphs.
           const rest = paraText.replace(ADMONITION_FIRST_LINE_RE, "").trim();
-          const otherText = node.children
+          const otherText = bqNode.children
             .slice(1)
-            // deno-lint-ignore no-explicit-any
-            .map((c: any) => extractMdastText(c))
+            .map((c) => extractMdastText(c as unknown as Nodes))
             .join("\n\n");
           const flattened = [rest, otherText].filter(Boolean).join("\n\n");
 
@@ -653,9 +662,8 @@ function mapMdastNode(node: any, body: string): BodyBlock {
         }
       }
 
-      const bqFlattened = node.children
-        // deno-lint-ignore no-explicit-any
-        .map((c: any) => extractMdastText(c))
+      const bqFlattened = bqNode.children
+        .map((c) => extractMdastText(c as unknown as Nodes))
         .join("\n\n");
       return {
         kind: "blockquote",
@@ -671,10 +679,7 @@ function mapMdastNode(node: any, body: string): BodyBlock {
       // without re-scanning the body string.
       type SubKind = "heading" | "thematic-break" | "html" | undefined;
       let subkind: SubKind;
-      if (
-        node.type === "heading" ||
-        node.type === "setextHeading"
-      ) {
+      if (node.type === "heading") {
         subkind = "heading";
       } else if (node.type === "thematicBreak") {
         subkind = "thematic-break";

--- a/packages/markspec/core/compiler/inverses_test.ts
+++ b/packages/markspec/core/compiler/inverses_test.ts
@@ -1,5 +1,6 @@
 import { assertEquals } from "@std/assert";
 import { generateInverses } from "./inverses.ts";
+import { makeDisplayId } from "../model/mod.ts";
 import type {
   AttrDecl,
   EffectiveProfile,
@@ -16,7 +17,9 @@ import type {
 const LOC = { file: "test.md", line: 1, column: 1 } as const;
 
 function entry(
-  overrides: Partial<Entry> & { displayId: string },
+  { displayId, ...overrides }: Partial<Omit<Entry, "displayId">> & {
+    displayId: string;
+  },
 ): Entry {
   return {
     title: "",
@@ -27,6 +30,7 @@ function entry(
     source: "markdown",
     typedAttributes: new Map(),
     ...overrides,
+    displayId: makeDisplayId(displayId),
   };
 }
 

--- a/packages/markspec/core/compiler/link_target_test.ts
+++ b/packages/markspec/core/compiler/link_target_test.ts
@@ -1,5 +1,6 @@
 import { assertEquals } from "@std/assert";
 import { checkLinkTargets } from "./link_target.ts";
+import { makeDisplayId } from "../model/mod.ts";
 import type { DisplayId, Entry, Link, SourceLocation } from "../model/mod.ts";
 
 const LOC: SourceLocation = { file: "test.md", line: 1, column: 1 };
@@ -12,7 +13,7 @@ function makeEntry(
   } = {},
 ): Entry {
   return {
-    displayId,
+    displayId: makeDisplayId(displayId),
     title: displayId,
     body: "",
     rawAttributes: opts.rawAttributes ?? [],
@@ -24,13 +25,18 @@ function makeEntry(
 }
 
 function makeLink(from: string, to: string): Link {
-  return { from, to, kind: "satisfies", location: LOC };
+  return {
+    from: makeDisplayId(from),
+    to: makeDisplayId(to),
+    kind: "satisfies",
+    location: LOC,
+  };
 }
 
 Deno.test("checkLinkTargets: active target produces no diagnostic", () => {
   const entries = new Map<DisplayId, Entry>([
-    ["REQ-001", makeEntry("REQ-001")],
-    ["REQ-002", makeEntry("REQ-002")],
+    [makeDisplayId("REQ-001"), makeEntry("REQ-001")],
+    [makeDisplayId("REQ-002"), makeEntry("REQ-002")],
   ]);
   const links = [makeLink("REQ-002", "REQ-001")];
   const diagnostics = checkLinkTargets(entries, links);
@@ -40,12 +46,12 @@ Deno.test("checkLinkTargets: active target produces no diagnostic", () => {
 Deno.test("checkLinkTargets: DRAFT target produces info", () => {
   const entries = new Map<DisplayId, Entry>([
     [
-      "REQ-001",
+      makeDisplayId("REQ-001"),
       makeEntry("REQ-001", {
         typedAttributes: new Map([["Labels", ["DRAFT"]]]),
       }),
     ],
-    ["REQ-002", makeEntry("REQ-002")],
+    [makeDisplayId("REQ-002"), makeEntry("REQ-002")],
   ]);
   const links = [makeLink("REQ-002", "REQ-001")];
   const diagnostics = checkLinkTargets(entries, links);
@@ -57,12 +63,12 @@ Deno.test("checkLinkTargets: DRAFT target produces info", () => {
 Deno.test("checkLinkTargets: Deprecated target produces warning", () => {
   const entries = new Map<DisplayId, Entry>([
     [
-      "REQ-001",
+      makeDisplayId("REQ-001"),
       makeEntry("REQ-001", {
         rawAttributes: [{ key: "Deprecated", value: "replaced by REQ-003" }],
       }),
     ],
-    ["REQ-002", makeEntry("REQ-002")],
+    [makeDisplayId("REQ-002"), makeEntry("REQ-002")],
   ]);
   const links = [makeLink("REQ-002", "REQ-001")];
   const diagnostics = checkLinkTargets(entries, links);
@@ -74,12 +80,12 @@ Deno.test("checkLinkTargets: Deprecated target produces warning", () => {
 Deno.test("checkLinkTargets: Superseded-by target produces warning", () => {
   const entries = new Map<DisplayId, Entry>([
     [
-      "REQ-001",
+      makeDisplayId("REQ-001"),
       makeEntry("REQ-001", {
         typedAttributes: new Map([["Superseded-by", ["REQ-003"]]]),
       }),
     ],
-    ["REQ-002", makeEntry("REQ-002")],
+    [makeDisplayId("REQ-002"), makeEntry("REQ-002")],
   ]);
   const links = [makeLink("REQ-002", "REQ-001")];
   const diagnostics = checkLinkTargets(entries, links);
@@ -90,7 +96,7 @@ Deno.test("checkLinkTargets: Superseded-by target produces warning", () => {
 
 Deno.test("checkLinkTargets: unresolved target is skipped (handled by MSL-T005)", () => {
   const entries = new Map<DisplayId, Entry>([
-    ["REQ-002", makeEntry("REQ-002")],
+    [makeDisplayId("REQ-002"), makeEntry("REQ-002")],
   ]);
   const links = [makeLink("REQ-002", "NONEXISTENT")];
   const diagnostics = checkLinkTargets(entries, links);

--- a/packages/markspec/core/compiler/manifest_test.ts
+++ b/packages/markspec/core/compiler/manifest_test.ts
@@ -1,11 +1,12 @@
 import { assertEquals, assertExists } from "@std/assert";
 import { buildManifest } from "./manifest.ts";
+import { makeDisplayId } from "../model/mod.ts";
 import type { CompileResult } from "./mod.ts";
-import type { Entry, Link, ProjectConfig } from "../model/mod.ts";
+import type { DisplayId, Entry, Link, ProjectConfig } from "../model/mod.ts";
 
 function makeEntry(displayId: string, type?: string): Entry {
   return {
-    displayId,
+    displayId: makeDisplayId(displayId),
     title: `Title for ${displayId}`,
     body: "",
     rawAttributes: [],
@@ -20,8 +21,8 @@ function makeEntry(displayId: string, type?: string): Entry {
 
 function makeLink(from: string, to: string): Link {
   return {
-    from,
-    to,
+    from: makeDisplayId(from),
+    to: makeDisplayId(to),
     kind: "satisfies",
     location: { file: "test.md", line: 1, column: 1 },
   };
@@ -41,8 +42,8 @@ function makeResult(
   links: Link[],
 ): CompileResult {
   const entryMap = new Map(entries.map((e) => [e.displayId, e]));
-  const forward = new Map<string, Link[]>();
-  const reverse = new Map<string, Link[]>();
+  const forward = new Map<DisplayId, Link[]>();
+  const reverse = new Map<DisplayId, Link[]>();
   for (const link of links) {
     if (!forward.has(link.from)) forward.set(link.from, []);
     forward.get(link.from)!.push(link);

--- a/packages/markspec/core/compiler/mod.ts
+++ b/packages/markspec/core/compiler/mod.ts
@@ -14,6 +14,7 @@ import type {
   Link,
   SourceLocation,
 } from "../model/mod.ts";
+import { makeDisplayId } from "../model/mod.ts";
 import { parseFile } from "../parser/mod.ts";
 import { classifyEntriesStage, validate } from "../validator/mod.ts";
 import { ATTR_TO_LINK_KIND } from "./constants.ts";
@@ -261,7 +262,7 @@ function extractLinksFromAttribute(
     // Format: "ID §section" — extract ID part only.
     const idPart = value.split(/\s/)[0];
     if (idPart) {
-      return [{ from, to: idPart, kind, location }];
+      return [{ from, to: makeDisplayId(idPart), kind, location }];
     }
     return [];
   }
@@ -271,7 +272,7 @@ function extractLinksFromAttribute(
     .split(",")
     .map((s) => s.trim())
     .filter((s) => s.length > 0)
-    .map((to) => ({ from, to, kind, location }));
+    .map((to) => ({ from, to: makeDisplayId(to), kind, location }));
 }
 
 /** Build an adjacency map from links using a key selector. */

--- a/packages/markspec/core/compiler/mod_test.ts
+++ b/packages/markspec/core/compiler/mod_test.ts
@@ -7,6 +7,7 @@
 
 import { assertEquals, assertExists } from "@std/assert";
 import { compile } from "./mod.ts";
+import { makeDisplayId } from "../model/mod.ts";
 
 const ULID_A = "01HGW2Q8MNP3RSTVWXYZABCDEF";
 const ULID_B = "01HGW2Q8MNP3RSTVWXYZABCDEG";
@@ -38,7 +39,7 @@ Deno.test("compile: extracts entries from a single file", async () => {
   };
   const result = await compile(["req.md"], { readFile: reader(files) });
   assertEquals(result.entries.size, 1);
-  const entry = result.entries.get("REQ-001");
+  const entry = result.entries.get(makeDisplayId("REQ-001"));
   assertExists(entry);
   assertEquals(entry.shape, "Authored");
   assertEquals(entry.id, ULID_A);
@@ -61,8 +62,8 @@ Deno.test("compile: merges entries across multiple files", async () => {
   };
   const result = await compile(["a.md", "b.md"], { readFile: reader(files) });
   assertEquals(result.entries.size, 2);
-  assertExists(result.entries.get("REQ-001"));
-  assertExists(result.entries.get("REQ-002"));
+  assertExists(result.entries.get(makeDisplayId("REQ-001")));
+  assertExists(result.entries.get(makeDisplayId("REQ-002")));
 });
 
 Deno.test("compile: mixed identified + referenced entries", async () => {
@@ -81,8 +82,11 @@ Deno.test("compile: mixed identified + referenced entries", async () => {
   const result = await compile(["requirements.md", "references.md"], {
     readFile: reader(files),
   });
-  assertEquals(result.entries.get("REQ-001")?.shape, "Authored");
-  assertEquals(result.entries.get("ISO-26262-6")?.shape, "Reference");
+  assertEquals(result.entries.get(makeDisplayId("REQ-001"))?.shape, "Authored");
+  assertEquals(
+    result.entries.get(makeDisplayId("ISO-26262-6"))?.shape,
+    "Reference",
+  );
 });
 
 Deno.test("compile: missing file emits MSL-E000 error", async () => {
@@ -193,7 +197,7 @@ Deno.test("compile: forward map carries outgoing links per entry", async () => {
 `,
   };
   const result = await compile(["req.md"], { readFile: reader(files) });
-  const out = result.forward.get("REQ-002") ?? [];
+  const out = result.forward.get(makeDisplayId("REQ-002")) ?? [];
   assertEquals(out.length, 1);
   assertEquals(out[0].kind, "supersedes");
 });
@@ -215,7 +219,7 @@ Deno.test("compile: reverse map carries incoming links per target", async () => 
 `,
   };
   const result = await compile(["req.md"], { readFile: reader(files) });
-  const incoming = result.reverse.get("REQ-001") ?? [];
+  const incoming = result.reverse.get(makeDisplayId("REQ-001")) ?? [];
   assertEquals(incoming.length, 1);
   assertEquals(incoming[0].from, "REQ-002");
 });
@@ -316,7 +320,7 @@ Deno.test("compile: properties.file.path set when statFile provided", async () =
     readFile: reader(files),
     statFile: () => Promise.resolve({ mtime: fakeMtime }),
   });
-  const entry = result.entries.get("REQ-001");
+  const entry = result.entries.get(makeDisplayId("REQ-001"));
   assertExists(entry);
   assertEquals(entry.properties?.file?.path, "req.md");
   assertEquals(entry.properties?.file?.mtime, "2026-05-19T10:23:00.000Z");
@@ -325,7 +329,7 @@ Deno.test("compile: properties.file.path set when statFile provided", async () =
 Deno.test("compile: properties.file.path set without statFile; mtime absent", async () => {
   const files = { "req.md": FIXTURE_MD };
   const result = await compile(["req.md"], { readFile: reader(files) });
-  const entry = result.entries.get("REQ-001");
+  const entry = result.entries.get(makeDisplayId("REQ-001"));
   assertExists(entry);
   assertEquals(entry.properties?.file?.path, "req.md");
   assertEquals(entry.properties?.file?.mtime, undefined);
@@ -337,7 +341,7 @@ Deno.test("compile: statFile returning undefined → mtime absent, no crash", as
     readFile: reader(files),
     statFile: () => Promise.resolve(undefined),
   });
-  const entry = result.entries.get("REQ-001");
+  const entry = result.entries.get(makeDisplayId("REQ-001"));
   assertExists(entry);
   assertEquals(entry.properties?.file?.path, "req.md");
   assertEquals(entry.properties?.file?.mtime, undefined);

--- a/packages/markspec/core/compiler/ndjson_writer_test.ts
+++ b/packages/markspec/core/compiler/ndjson_writer_test.ts
@@ -6,6 +6,7 @@
 
 import { assertEquals, assertGreater } from "@std/assert";
 import type { Entry, Link } from "../model/mod.ts";
+import { makeDisplayId } from "../model/mod.ts";
 import {
   buildEdgesNdjson,
   buildEntriesNdjson,
@@ -18,7 +19,7 @@ import {
 
 function makeEntry(displayId: string, body = "Body."): Entry {
   return {
-    displayId,
+    displayId: makeDisplayId(displayId),
     title: `Title ${displayId}`,
     body,
     rawAttributes: [],
@@ -31,8 +32,8 @@ function makeEntry(displayId: string, body = "Body."): Entry {
 
 function makeAuthoredLink(from: string, to: string): Link {
   return {
-    from,
-    to,
+    from: makeDisplayId(from),
+    to: makeDisplayId(to),
     kind: "satisfies",
     location: { file: "test.md", line: 1, column: 1 },
   };
@@ -40,8 +41,8 @@ function makeAuthoredLink(from: string, to: string): Link {
 
 function makeGeneratedLink(from: string, to: string): Link {
   return {
-    from,
-    to,
+    from: makeDisplayId(from),
+    to: makeDisplayId(to),
     kind: "satisfies",
     location: { file: "test.md", line: 1, column: 1 },
     origin: "generated",
@@ -54,9 +55,9 @@ function makeGeneratedLink(from: string, to: string): Link {
 
 Deno.test("buildEntriesNdjson: 3 entries produce 3 newline-terminated lines", () => {
   const entries = new Map([
-    ["C_0001", makeEntry("C_0001")],
-    ["A_0001", makeEntry("A_0001")],
-    ["B_0001", makeEntry("B_0001")],
+    [makeDisplayId("C_0001"), makeEntry("C_0001")],
+    [makeDisplayId("A_0001"), makeEntry("A_0001")],
+    [makeDisplayId("B_0001"), makeEntry("B_0001")],
   ]);
   const { ndjson } = buildEntriesNdjson(entries);
   const text = new TextDecoder().decode(ndjson);
@@ -68,8 +69,8 @@ Deno.test("buildEntriesNdjson: 3 entries produce 3 newline-terminated lines", ()
 
 Deno.test("buildEntriesNdjson: each line is valid JSON with correct displayId", () => {
   const entries = new Map([
-    ["STK_0001", makeEntry("STK_0001")],
-    ["STK_0002", makeEntry("STK_0002")],
+    [makeDisplayId("STK_0001"), makeEntry("STK_0001")],
+    [makeDisplayId("STK_0002"), makeEntry("STK_0002")],
   ]);
   const { ndjson } = buildEntriesNdjson(entries);
   const text = new TextDecoder().decode(ndjson);
@@ -81,9 +82,9 @@ Deno.test("buildEntriesNdjson: each line is valid JSON with correct displayId", 
 
 Deno.test("buildEntriesNdjson: lines are sorted by displayId", () => {
   const entries = new Map([
-    ["C_0003", makeEntry("C_0003")],
-    ["A_0001", makeEntry("A_0001")],
-    ["B_0002", makeEntry("B_0002")],
+    [makeDisplayId("C_0003"), makeEntry("C_0003")],
+    [makeDisplayId("A_0001"), makeEntry("A_0001")],
+    [makeDisplayId("B_0002"), makeEntry("B_0002")],
   ]);
   const { ndjson } = buildEntriesNdjson(entries);
   const text = new TextDecoder().decode(ndjson);
@@ -94,19 +95,22 @@ Deno.test("buildEntriesNdjson: lines are sorted by displayId", () => {
 
 Deno.test("buildEntriesNdjson: index has correct byte offsets and lengths", () => {
   const entries = new Map([
-    ["B_0001", makeEntry("B_0001")],
-    ["A_0001", makeEntry("A_0001")],
+    [makeDisplayId("B_0001"), makeEntry("B_0001")],
+    [makeDisplayId("A_0001"), makeEntry("A_0001")],
   ]);
   const { ndjson, index } = buildEntriesNdjson(entries);
 
   assertEquals(index.size, 2);
-  assertGreater(index.get("A_0001")!.length, 0);
-  assertGreater(index.get("B_0001")!.length, 0);
+  assertGreater(index.get(makeDisplayId("A_0001"))!.length, 0);
+  assertGreater(index.get(makeDisplayId("B_0001"))!.length, 0);
 
   // A_0001 comes first (sorted), so its offset is 0
-  assertEquals(index.get("A_0001")!.offset, 0);
+  assertEquals(index.get(makeDisplayId("A_0001"))!.offset, 0);
   // B_0001 offset is A's length
-  assertEquals(index.get("B_0001")!.offset, index.get("A_0001")!.length);
+  assertEquals(
+    index.get(makeDisplayId("B_0001"))!.offset,
+    index.get(makeDisplayId("A_0001"))!.length,
+  );
 
   // Verify seek-and-compare: read the bytes at the declared position and
   // confirm they match the original line.
@@ -121,10 +125,10 @@ Deno.test("buildEntriesNdjson: index has correct byte offsets and lengths", () =
 Deno.test("buildEntriesNdjson: byte lengths use UTF-8 encoding, not JS string .length", () => {
   // "😀" is 4 bytes in UTF-8 but 2 code units in JS (surrogate pair).
   const entries = new Map([
-    ["X_0001", makeEntry("X_0001", "Body with emoji 😀")],
+    [makeDisplayId("X_0001"), makeEntry("X_0001", "Body with emoji 😀")],
   ]);
   const { ndjson, index } = buildEntriesNdjson(entries);
-  const { offset, length } = index.get("X_0001")!;
+  const { offset, length } = index.get(makeDisplayId("X_0001"))!;
   const slice = ndjson.slice(offset, offset + length);
   const decoded = new TextDecoder().decode(slice);
   const parsed = JSON.parse(decoded);
@@ -139,14 +143,14 @@ Deno.test("buildEntriesNdjson: byte lengths use UTF-8 encoding, not JS string .l
 
 Deno.test("buildEntriesNdjson: output is byte-identical regardless of Map insertion order", () => {
   const a = new Map([
-    ["C_0001", makeEntry("C_0001")],
-    ["A_0001", makeEntry("A_0001")],
-    ["B_0001", makeEntry("B_0001")],
+    [makeDisplayId("C_0001"), makeEntry("C_0001")],
+    [makeDisplayId("A_0001"), makeEntry("A_0001")],
+    [makeDisplayId("B_0001"), makeEntry("B_0001")],
   ]);
   const b = new Map([
-    ["A_0001", makeEntry("A_0001")],
-    ["B_0001", makeEntry("B_0001")],
-    ["C_0001", makeEntry("C_0001")],
+    [makeDisplayId("A_0001"), makeEntry("A_0001")],
+    [makeDisplayId("B_0001"), makeEntry("B_0001")],
+    [makeDisplayId("C_0001"), makeEntry("C_0001")],
   ]);
   const { ndjson: na } = buildEntriesNdjson(a);
   const { ndjson: nb } = buildEntriesNdjson(b);
@@ -159,8 +163,8 @@ Deno.test("buildEntriesNdjson: output is byte-identical regardless of Map insert
 
 Deno.test("indexToJson: produces compact single-line JSON", () => {
   const index = new Map([
-    ["B_0001", { offset: 100, length: 50 }],
-    ["A_0001", { offset: 0, length: 100 }],
+    [makeDisplayId("B_0001"), { offset: 100, length: 50 }],
+    [makeDisplayId("A_0001"), { offset: 0, length: 100 }],
   ]);
   const json = indexToJson(index);
   // Must be parseable
@@ -173,9 +177,9 @@ Deno.test("indexToJson: produces compact single-line JSON", () => {
 
 Deno.test("indexToJson: keys are sorted lexicographically", () => {
   const index = new Map([
-    ["Z_0001", { offset: 200, length: 30 }],
-    ["A_0001", { offset: 0, length: 100 }],
-    ["M_0001", { offset: 100, length: 100 }],
+    [makeDisplayId("Z_0001"), { offset: 200, length: 30 }],
+    [makeDisplayId("A_0001"), { offset: 0, length: 100 }],
+    [makeDisplayId("M_0001"), { offset: 100, length: 100 }],
   ]);
   const json = indexToJson(index);
   const keys = Object.keys(JSON.parse(json));

--- a/packages/markspec/core/compiler/schema_test.ts
+++ b/packages/markspec/core/compiler/schema_test.ts
@@ -2,12 +2,13 @@ import { assertEquals } from "@std/assert";
 import { serializeCompileResult } from "./schema.ts";
 import type { SerializedEntry } from "./schema.ts";
 import type { CompileResult } from "./mod.ts";
-import type { Entry, Link } from "../model/mod.ts";
+import type { DisplayId, Entry, Link } from "../model/mod.ts";
+import { makeDisplayId } from "../model/mod.ts";
 
 /** Build a minimal Entry for testing. */
 function makeEntry(displayId: string): Entry {
   return {
-    displayId,
+    displayId: makeDisplayId(displayId),
     title: `Title for ${displayId}`,
     body: "",
     rawAttributes: [],
@@ -22,8 +23,8 @@ function makeEntry(displayId: string): Entry {
 /** Build a minimal Link for testing. */
 function makeLink(from: string, to: string): Link {
   return {
-    from,
-    to,
+    from: makeDisplayId(from),
+    to: makeDisplayId(to),
     kind: "satisfies",
     location: { file: "test.md", line: 1, column: 1 },
   };
@@ -33,8 +34,12 @@ Deno.test("serializeCompileResult: converts Maps to plain objects", () => {
   const entry = makeEntry("SRS_BRK_0001");
   const entries = new Map([[entry.displayId, entry]]);
   const link = makeLink("SRS_BRK_0001", "SYS_BRK_0042");
-  const forward = new Map([["SRS_BRK_0001", [link]]]);
-  const reverse = new Map([["SYS_BRK_0042", [link]]]);
+  const forward = new Map<DisplayId, Link[]>([[makeDisplayId("SRS_BRK_0001"), [
+    link,
+  ]]]);
+  const reverse = new Map<DisplayId, Link[]>([[makeDisplayId("SYS_BRK_0042"), [
+    link,
+  ]]]);
 
   const result: CompileResult = {
     entries,
@@ -114,8 +119,12 @@ Deno.test("serializeCompileResult: round-trip via JSON.parse", () => {
   const result: CompileResult = {
     entries: new Map([[entry.displayId, entry]]),
     links: [link],
-    forward: new Map([["SRS_BRK_0001", [link]]]),
-    reverse: new Map([["SYS_BRK_0042", [link]]]),
+    forward: new Map<DisplayId, Link[]>([[makeDisplayId("SRS_BRK_0001"), [
+      link,
+    ]]]),
+    reverse: new Map<DisplayId, Link[]>([[makeDisplayId("SYS_BRK_0042"), [
+      link,
+    ]]]),
     documents: new Map(),
     diagnostics: [
       {

--- a/packages/markspec/core/lint/rules/lexicon_test.ts
+++ b/packages/markspec/core/lint/rules/lexicon_test.ts
@@ -7,6 +7,7 @@
 import { assertEquals } from "@std/assert";
 import type { BodyBlock } from "../../ast/nodes.ts";
 import type { Entry } from "../../model/mod.ts";
+import { makeDisplayId } from "../../model/mod.ts";
 import { runLexiconRules } from "./lexicon.ts";
 
 // ---------------------------------------------------------------------------
@@ -27,7 +28,7 @@ function makeParagraph(text: string): BodyBlock {
 function makeEntry(text: string): Entry {
   const bodyAst: BodyBlock[] = [makeParagraph(text)];
   return {
-    displayId: "REQ-001",
+    displayId: makeDisplayId("REQ-001"),
     title: "Test entry with body",
     body: text,
     bodyAst,

--- a/packages/markspec/core/lint/runner_test.ts
+++ b/packages/markspec/core/lint/runner_test.ts
@@ -6,15 +6,20 @@
 
 import { assertEquals } from "@std/assert";
 import type { Entry } from "../model/mod.ts";
+import { makeDisplayId } from "../model/mod.ts";
 import { isProseScope, runLint } from "./runner.ts";
 
 // ---------------------------------------------------------------------------
 // Test helpers
 // ---------------------------------------------------------------------------
 
-function makeEntry(overrides: Partial<Entry> = {}): Entry {
+function makeEntry(
+  { displayId, ...overrides }: Partial<Omit<Entry, "displayId">> & {
+    displayId?: string;
+  } = {},
+): Entry {
   return {
-    displayId: "REQ-001",
+    displayId: makeDisplayId(displayId ?? "REQ-001"),
     title: "Test requirement title",
     body: "The system shall process data correctly.",
     bodyAst: [

--- a/packages/markspec/core/mod.ts
+++ b/packages/markspec/core/mod.ts
@@ -15,6 +15,7 @@ export const CORE_SCHEMA_VERSION = 1;
 export {
   ConfigError,
   DEFAULT_PROJECT_CONFIG,
+  KNOWN_LINK_KINDS,
   PALETTE_HUES,
   REFHUB_URL,
 } from "./model/mod.ts";

--- a/packages/markspec/core/mod.ts
+++ b/packages/markspec/core/mod.ts
@@ -16,6 +16,8 @@ export {
   ConfigError,
   DEFAULT_PROJECT_CONFIG,
   KNOWN_LINK_KINDS,
+  makeDisplayId,
+  makeUlid,
   PALETTE_HUES,
   REFHUB_URL,
 } from "./model/mod.ts";

--- a/packages/markspec/core/mod_test.ts
+++ b/packages/markspec/core/mod_test.ts
@@ -5,6 +5,7 @@ import {
   CORE_SCHEMA_VERSION,
   DEFAULT_PROJECT_CONFIG,
   format,
+  makeDisplayId,
   parse,
   REFHUB_URL,
   report,
@@ -60,7 +61,7 @@ Deno.test("model types are constructible", () => {
   assertEquals(diag.severity, "error");
 
   const entry: Entry = {
-    displayId: "SRS_BRK_0001",
+    displayId: makeDisplayId("SRS_BRK_0001"),
     title: "Sensor debouncing",
     body: "The sensor driver shall debounce raw inputs.",
     rawAttributes: [attr],

--- a/packages/markspec/core/model/mod.ts
+++ b/packages/markspec/core/model/mod.ts
@@ -564,23 +564,32 @@ export interface EntityRef {
  * Kind of directional link between entries — relation name lifted from the
  * source attribute.
  *
- * The core bakes in only `supersedes` (universal retirement). All other
- * relation names listed here are conventions recognized by shipped profile
- * packages; in a profile-aware pipeline, link kinds come from the active
- * profile's `traceability:` declarations rather than this closed union.
+ * Open `string` so profile-declared relation names (e.g., from a profile's
+ * `traceability:` declarations) can be used without changing core. The
+ * canonical built-in kinds are enumerated in {@linkcode KNOWN_LINK_KINDS}.
  */
-export type LinkKind =
-  | "satisfies"
-  | "derived-from"
-  | "references"
-  | "allocated-to"
-  | "realizes"
-  | "verifies"
-  | "tests"
-  | "depends-on"
-  | "part-of"
-  | "generated-from"
-  | "supersedes";
+export type LinkKind = string;
+
+/**
+ * Built-in link kinds recognized by the core compiler and shipped profiles.
+ *
+ * Consumers that need to validate or enumerate the core-defined relation
+ * vocabulary should use this constant rather than hard-coding string literals.
+ * Profile-declared kinds extend this set at runtime.
+ */
+export const KNOWN_LINK_KINDS: readonly string[] = [
+  "satisfies",
+  "derived-from",
+  "references",
+  "allocated-to",
+  "realizes",
+  "verifies",
+  "tests",
+  "depends-on",
+  "part-of",
+  "generated-from",
+  "supersedes",
+] as const;
 
 /** A directional link between two entries in the traceability graph. */
 export interface Link {

--- a/packages/markspec/core/model/mod.ts
+++ b/packages/markspec/core/model/mod.ts
@@ -47,8 +47,21 @@ export { inferTypeFromDiscriminatingAttr } from "./discriminating_attr.ts";
  * For referenced entries the display ID is a slug (pandoc/BibTeX cite-key
  * convention, e.g., `ISO-26262-6`, `serde`, `smith2021`). The leading `@`
  * in `[@slug]` is accepted as Pandoc sugar and stripped during parsing.
+ *
+ * Branded so a `Ulid` cannot be accidentally passed where a `DisplayId`
+ * is expected, and vice versa. Use {@linkcode makeDisplayId} to construct.
  */
-export type DisplayId = string;
+export type DisplayId = string & { readonly __brand: "DisplayId" };
+
+/**
+ * Cast a plain string to a branded `DisplayId`.
+ *
+ * This is a zero-cost assertion — no validation is performed. The caller
+ * asserts that `s` is a syntactically valid display ID.
+ */
+export function makeDisplayId(s: string): DisplayId {
+  return s as DisplayId;
+}
 
 // ---------------------------------------------------------------------------
 // ULID
@@ -59,8 +72,22 @@ export type DisplayId = string;
  *
  * Used as the `Id:` attribute value for identified entries. Assigned by
  * tooling, never hand-authored, immutable once assigned.
+ *
+ * Branded so a `DisplayId` cannot be accidentally passed where a `Ulid`
+ * is expected, and vice versa. Use {@linkcode makeUlid} to construct.
  */
-export type Ulid = string;
+export type Ulid = string & { readonly __brand: "Ulid" };
+
+/**
+ * Cast a plain string to a branded `Ulid`.
+ *
+ * This is a zero-cost assertion — no validation is performed. The caller
+ * asserts that `s` is a syntactically valid 26-character Crockford base32
+ * ULID.
+ */
+export function makeUlid(s: string): Ulid {
+  return s as Ulid;
+}
 
 // ---------------------------------------------------------------------------
 // Source location

--- a/packages/markspec/core/parser/markdown.ts
+++ b/packages/markspec/core/parser/markdown.ts
@@ -7,7 +7,7 @@
 
 import type { Definition, List, ListItem, Paragraph, Text } from "mdast";
 import type { Attribute, Diagnostic, Entry, EntryShape } from "../model/mod.ts";
-import { IDENTITY_KEY, shapeFromIdValue } from "../model/mod.ts";
+import { IDENTITY_KEY, makeDisplayId, shapeFromIdValue } from "../model/mod.ts";
 import {
   ATTR_LINE_RE,
   collateAttributes,
@@ -498,7 +498,7 @@ function extractEntry(
   }, bodyAst);
 
   return {
-    displayId,
+    displayId: makeDisplayId(displayId),
     title: title ?? "",
     body,
     bodyAst,

--- a/packages/markspec/core/profile/colors_test.ts
+++ b/packages/markspec/core/profile/colors_test.ts
@@ -6,11 +6,12 @@
 import { assertEquals } from "@std/assert";
 import { resolveEntryColor } from "./colors.ts";
 import type { EffectiveProfile, Entry } from "../model/mod.ts";
+import { makeDisplayId } from "../model/mod.ts";
 
 function makeIdentifiedEntry(type: string | undefined): Entry {
   return {
     shape: "Authored",
-    displayId: "TST_AAA_0001",
+    displayId: makeDisplayId("TST_AAA_0001"),
     title: "t",
     body: "",
     rawAttributes: [],

--- a/packages/markspec/core/validator/attributes_test.ts
+++ b/packages/markspec/core/validator/attributes_test.ts
@@ -14,6 +14,7 @@ import type {
   EntryShape,
   ProvenancedMapEntry,
 } from "../model/mod.ts";
+import { makeDisplayId } from "../model/mod.ts";
 
 const ORIGIN = "@test/p";
 
@@ -75,7 +76,7 @@ function entry(opts: {
     for (const v of vs) attributes.push({ key: k, value: v });
   }
   return {
-    displayId: "X-001",
+    displayId: makeDisplayId("X-001"),
     title: "",
     body: "",
     id: "01HGW2Q8MNP3RSTVWXYZABCDEF",

--- a/packages/markspec/core/validator/body_blocks_test.ts
+++ b/packages/markspec/core/validator/body_blocks_test.ts
@@ -9,12 +9,13 @@
 
 import { assertEquals } from "@std/assert";
 import type { Entry } from "../model/mod.ts";
+import { makeDisplayId } from "../model/mod.ts";
 import { buildBodyAst } from "../ast/build.ts";
 import { validateBodyBlocks } from "./body_blocks.ts";
 
 function makeEntry(displayId: string, body: string): Entry {
   return {
-    displayId,
+    displayId: makeDisplayId(displayId),
     title: "Test entry",
     body,
     bodyAst: buildBodyAst(body),

--- a/packages/markspec/core/validator/caption_convention_test.ts
+++ b/packages/markspec/core/validator/caption_convention_test.ts
@@ -9,12 +9,13 @@
 
 import { assertEquals, assertStringIncludes } from "@std/assert";
 import type { CaptionConventions, Entry } from "../model/mod.ts";
+import { makeDisplayId } from "../model/mod.ts";
 import { buildBodyAst } from "../ast/build.ts";
 import { validateCaptionConvention } from "./caption_convention.ts";
 
 function makeEntry(displayId: string, body: string): Entry {
   return {
-    displayId,
+    displayId: makeDisplayId(displayId),
     title: "Test entry",
     body,
     bodyAst: buildBodyAst(body),
@@ -146,7 +147,7 @@ Deno.test("validateCaptionConvention: Figure keyword not in conventions → no M
 
 Deno.test("validateCaptionConvention: no bodyAst → no MSL-C072", () => {
   const entry: Entry = {
-    displayId: "REQ-008",
+    displayId: makeDisplayId("REQ-008"),
     title: "Test",
     body: "Figure: Caption\n\n![x](y.svg)",
     bodyAst: undefined,

--- a/packages/markspec/core/validator/captions_test.ts
+++ b/packages/markspec/core/validator/captions_test.ts
@@ -10,12 +10,13 @@
 
 import { assertEquals, assertStringIncludes } from "@std/assert";
 import type { Entry } from "../model/mod.ts";
+import { makeDisplayId } from "../model/mod.ts";
 import { buildBodyAst } from "../ast/build.ts";
 import { validateCaptions } from "./captions.ts";
 
 function makeEntry(displayId: string, body: string): Entry {
   return {
-    displayId,
+    displayId: makeDisplayId(displayId),
     title: "Test entry",
     body,
     bodyAst: buildBodyAst(body),

--- a/packages/markspec/core/validator/feature_ac_test.ts
+++ b/packages/markspec/core/validator/feature_ac_test.ts
@@ -9,12 +9,13 @@
 
 import { assertEquals, assertStringIncludes } from "@std/assert";
 import type { Entry } from "../model/mod.ts";
+import { makeDisplayId } from "../model/mod.ts";
 import { buildBodyAst } from "../ast/build.ts";
 import { validateFeatureAc } from "./feature_ac.ts";
 
 function makeEntry(displayId: string, body: string): Entry {
   return {
-    displayId,
+    displayId: makeDisplayId(displayId),
     title: "Test entry",
     body,
     bodyAst: buildBodyAst(body),
@@ -180,7 +181,7 @@ Deno.test("validateFeatureAc: Feature + list whose first item begins with 'Accep
 
 Deno.test("validateFeatureAc: no bodyAst → no MSL-B044", () => {
   const entry: Entry = {
-    displayId: "REQ-007",
+    displayId: makeDisplayId("REQ-007"),
     title: "Test",
     body: "```gherkin\nFeature: X\n```\n\nAcceptance criteria\n\n- A",
     bodyAst: undefined,

--- a/packages/markspec/core/validator/mod_test.ts
+++ b/packages/markspec/core/validator/mod_test.ts
@@ -8,11 +8,14 @@
 
 import { assertEquals } from "@std/assert";
 import type { Entry } from "../model/mod.ts";
+import { makeDisplayId } from "../model/mod.ts";
 import { validate } from "./mod.ts";
 
-function entry(partial: Partial<Entry> & { displayId: string }): Entry {
+function entry(
+  partial: Partial<Omit<Entry, "displayId">> & { displayId: string },
+): Entry {
   return {
-    displayId: partial.displayId,
+    displayId: makeDisplayId(partial.displayId),
     title: partial.title ?? "Test entry",
     body: partial.body ?? "Body.",
     rawAttributes: partial.rawAttributes ?? [],

--- a/packages/markspec/core/validator/modal_keywords_test.ts
+++ b/packages/markspec/core/validator/modal_keywords_test.ts
@@ -11,6 +11,7 @@
 
 import { assertEquals } from "@std/assert";
 import type { Entry } from "../model/mod.ts";
+import { makeDisplayId } from "../model/mod.ts";
 import { buildBodyAst } from "../ast/build.ts";
 import { validateModalKeywords } from "./modal_keywords.ts";
 
@@ -21,7 +22,7 @@ function makeEntry(
 ): Entry {
   const bodyAst = buildBodyAst(body);
   return {
-    displayId,
+    displayId: makeDisplayId(displayId),
     title: "Test entry",
     body,
     bodyAst,

--- a/packages/markspec/core/validator/normalize_test.ts
+++ b/packages/markspec/core/validator/normalize_test.ts
@@ -13,6 +13,7 @@ import type {
   EntryShape,
   ProvenancedMapEntry,
 } from "../model/mod.ts";
+import { makeDisplayId } from "../model/mod.ts";
 
 const ORIGIN = "@test/p";
 
@@ -47,7 +48,7 @@ function entry(opts: {
     for (const v of vs) attributes.push({ key: k, value: v });
   }
   return {
-    displayId: "X-001",
+    displayId: makeDisplayId("X-001"),
     id: "01HGW2Q8MNP3RSTVWXYZABCDEF",
     shape: opts.shape,
     source: "markdown",

--- a/packages/markspec/core/validator/pipeline_test.ts
+++ b/packages/markspec/core/validator/pipeline_test.ts
@@ -13,6 +13,7 @@ import type {
   EntryShape,
   ProvenancedMapEntry,
 } from "../model/mod.ts";
+import { makeDisplayId } from "../model/mod.ts";
 
 function buildEntry(opts: {
   displayId: string;
@@ -28,7 +29,7 @@ function buildEntry(opts: {
     attributes.push({ key: "Type", value: opts.typeAttribute });
   }
   return {
-    displayId: opts.displayId,
+    displayId: makeDisplayId(opts.displayId),
     title: opts.displayId,
     body: "",
     id: opts.id ?? "01HGW2Q8MNP3RSTVWXYZABCDEF",
@@ -89,7 +90,7 @@ Deno.test("runPipeline: profile present runs Stage 2, entries classified", () =>
 
 Deno.test("runPipeline: Stage 1 error contributes to diagnostics + valid=false", () => {
   const entry: Entry = {
-    displayId: "REQ-0001",
+    displayId: makeDisplayId("REQ-0001"),
     title: "",
     body: "",
     id: "01HGW2Q8MNP3RSTVWXYZABCDEF",
@@ -112,7 +113,7 @@ Deno.test("runPipeline: Stage 1 error contributes to diagnostics + valid=false",
 Deno.test("runPipeline: both stages contribute diagnostics independently", () => {
   const profile = buildProfileWithRequirement();
   const entry: Entry = {
-    displayId: "FOO-001",
+    displayId: makeDisplayId("FOO-001"),
     title: "",
     body: "",
     id: "01HGW2Q8MNP3RSTVWXYZABCDEF",
@@ -166,7 +167,7 @@ Deno.test("runPipeline: Stage 3 checks attributes of classified entries", () => 
 
   // Entry classified as requirement but missing Rationale.
   const e: Entry = {
-    displayId: "REQ-0001",
+    displayId: makeDisplayId("REQ-0001"),
     id: "01HGW2Q8MNP3RSTVWXYZABCDEF",
     shape: "Authored",
     source: "markdown",
@@ -209,7 +210,7 @@ Deno.test("runPipeline: MSL-R010 suppressed for profile-declared attributes", ()
   };
 
   const e: Entry = {
-    displayId: "X-001",
+    displayId: makeDisplayId("X-001"),
     id: "01HGW2Q8MNP3RSTVWXYZABCDEF",
     shape: "Authored",
     source: "markdown",
@@ -288,7 +289,7 @@ Deno.test("runPipeline: Stage 4 catches required link missing", () => {
   };
 
   const e: Entry = {
-    displayId: "TEST-0001",
+    displayId: makeDisplayId("TEST-0001"),
     id: "01HGW2Q8MNP3RSTVWXYZABCDEF",
     shape: "Authored",
     source: "markdown",
@@ -333,7 +334,7 @@ Deno.test("runPipeline: Stage 2.5 normalization splits comma-separated id-list v
   };
 
   const target1: Entry = {
-    displayId: "REQ-0001",
+    displayId: makeDisplayId("REQ-0001"),
     id: "01T1T1T1T1T1T1T1T1T1T1T1T1",
     shape: "Authored",
     source: "markdown",
@@ -344,7 +345,7 @@ Deno.test("runPipeline: Stage 2.5 normalization splits comma-separated id-list v
     location: { file: "t.md", line: 1, column: 1 },
   };
   const target2: Entry = {
-    displayId: "REQ-0002",
+    displayId: makeDisplayId("REQ-0002"),
     id: "01T2T2T2T2T2T2T2T2T2T2T2T2",
     shape: "Authored",
     source: "markdown",
@@ -355,7 +356,7 @@ Deno.test("runPipeline: Stage 2.5 normalization splits comma-separated id-list v
     location: { file: "t.md", line: 1, column: 1 },
   };
   const e: Entry = {
-    displayId: "TEST-0001",
+    displayId: makeDisplayId("TEST-0001"),
     id: "01HGW2Q8MNP3RSTVWXYZABCDEF",
     shape: "Authored",
     source: "markdown",

--- a/packages/markspec/core/validator/trace_types_test.ts
+++ b/packages/markspec/core/validator/trace_types_test.ts
@@ -10,6 +10,7 @@
 import { assertEquals } from "@std/assert";
 import { validateTraceTargetTypes } from "./trace_types.ts";
 import type { Entry } from "../model/mod.ts";
+import { makeDisplayId } from "../model/mod.ts";
 
 const ULID_A = "01HGW2Q8MNP3RSTVWXYZABCDEF";
 const ULID_B = "01HGW2Q8MNP3RSTVWXYZABCDEG";
@@ -22,7 +23,7 @@ function entry(opts: {
 }): Entry {
   const id = opts.id ?? ULID_A;
   return {
-    displayId: opts.displayId,
+    displayId: makeDisplayId(opts.displayId),
     title: "Test",
     body: "Body.",
     rawAttributes: opts.rawAttributes ?? [{ key: "Id", value: id }],

--- a/packages/markspec/core/validator/traceability_test.ts
+++ b/packages/markspec/core/validator/traceability_test.ts
@@ -18,6 +18,7 @@ import type {
   ProvenancedMapEntry,
   TraceRule,
 } from "../model/mod.ts";
+import { makeDisplayId } from "../model/mod.ts";
 
 const ORIGIN = "@test/p";
 
@@ -70,7 +71,7 @@ function profile(opts: {
 
 function entry(opts: { shape: EntryShape; type?: string }): Entry {
   return {
-    displayId: "X-001",
+    displayId: makeDisplayId("X-001"),
     id: "01HGW2Q8MNP3RSTVWXYZABCDEF",
     shape: opts.shape,
     type: opts.type,
@@ -184,7 +185,7 @@ function targetEntry(opts: {
   displayId?: string;
 }): Entry {
   return {
-    displayId: opts.displayId ?? "Y-001",
+    displayId: makeDisplayId(opts.displayId ?? "Y-001"),
     id: "01TARGET02TARGET03TARGET04",
     shape: opts.shape,
     type: opts.type,
@@ -274,7 +275,7 @@ function entryWithAttrs(opts: {
     for (const v of vs) attributes.push({ key: k, value: v });
   }
   return {
-    displayId: opts.displayId ?? "REQ-0001",
+    displayId: makeDisplayId(opts.displayId ?? "REQ-0001"),
     id: opts.id ?? "01HGW2Q8MNP3RSTVWXYZABCDEF",
     shape: opts.shape,
     type: opts.type,

--- a/packages/markspec/core/validator/type_resolution_test.ts
+++ b/packages/markspec/core/validator/type_resolution_test.ts
@@ -15,6 +15,7 @@ import {
   resolvedCoreTypeWithProvenance,
 } from "./type_resolution.ts";
 import type { Entry } from "../model/mod.ts";
+import { makeDisplayId } from "../model/mod.ts";
 
 const ULID = "01HGW2Q8MNP3RSTVWXYZABCDEF";
 
@@ -25,7 +26,7 @@ function makeEntry(opts: {
   id?: string;
 }): Entry {
   return {
-    displayId: "TEST-001",
+    displayId: makeDisplayId("TEST-001"),
     title: "Test entry",
     body: "Body.",
     rawAttributes: opts.attrs,
@@ -159,7 +160,7 @@ Deno.test("resolvedCoreType: step 4 falls back to prefix when no explicit Type a
 
   const reqEntry = {
     ...entry,
-    displayId: "REQ-001",
+    displayId: makeDisplayId("REQ-001"),
   };
   assertEquals(resolvedCoreType(reqEntry), "Requirement");
 });
@@ -208,7 +209,7 @@ Deno.test("resolvedCoreTypeWithProvenance: step 3 — Source: introspection", ()
 Deno.test("resolvedCoreTypeWithProvenance: step 4 — display-ID prefix", () => {
   const entry = {
     ...makeEntry({ attrs: [{ key: "Id", value: ULID }] }),
-    displayId: "REQ-001",
+    displayId: makeDisplayId("REQ-001"),
   };
   assertEquals(
     resolvedCoreTypeWithProvenance(entry),

--- a/packages/markspec/core/validator/types_test.ts
+++ b/packages/markspec/core/validator/types_test.ts
@@ -13,6 +13,7 @@ import type {
   EntryShape,
   ProvenancedMapEntry,
 } from "../model/mod.ts";
+import { makeDisplayId } from "../model/mod.ts";
 
 function buildEntry(opts: {
   displayId: string;
@@ -24,7 +25,7 @@ function buildEntry(opts: {
     ? [{ key: "Type", value: opts.typeAttribute }]
     : [];
   return {
-    displayId: opts.displayId,
+    displayId: makeDisplayId(opts.displayId),
     title: "",
     body: "",
     id: "01HGW2Q8MNP3RSTVWXYZABCDEF",

--- a/packages/markspec/core/validator/types_unit_test.ts
+++ b/packages/markspec/core/validator/types_unit_test.ts
@@ -10,6 +10,7 @@
 import { assertEquals } from "@std/assert";
 import { inferTypeFromDisplayIdShape } from "./types.ts";
 import type { Entry } from "../model/mod.ts";
+import { makeDisplayId } from "../model/mod.ts";
 
 const ULID = "01HGW2Q8MNP3RSTVWXYZABCDEF";
 
@@ -19,7 +20,7 @@ function authoredEntry(opts: {
   rawAttributes?: Array<{ key: string; value: string }>;
 }): Entry {
   return {
-    displayId: opts.displayId,
+    displayId: makeDisplayId(opts.displayId),
     title: "Test entry",
     body: "Body.",
     rawAttributes: opts.rawAttributes ?? [{ key: "Id", value: ULID }],

--- a/packages/markspec/lsp/completions_test.ts
+++ b/packages/markspec/lsp/completions_test.ts
@@ -15,6 +15,7 @@ import {
   isTypeAttributeTrigger,
 } from "./completions.ts";
 import type { DisplayIdEntry } from "./workspace.ts";
+import { makeDisplayId } from "../core/mod.ts";
 
 // --- Trigger detection ---
 
@@ -70,8 +71,8 @@ Deno.test("extractRelationName: extracts 'Derived-from'", () => {
 
 Deno.test("buildIdReferenceItems: returns items for all display IDs", () => {
   const ids: DisplayIdEntry[] = [
-    { displayId: "STK_AEB_0001", title: "Braking" },
-    { displayId: "SAD_AEB_0001", title: "Architecture" },
+    { displayId: makeDisplayId("STK_AEB_0001"), title: "Braking" },
+    { displayId: makeDisplayId("SAD_AEB_0001"), title: "Architecture" },
   ];
   const items = buildIdReferenceItems(ids);
   assertEquals(items.length, 2);

--- a/packages/markspec/lsp/definition_test.ts
+++ b/packages/markspec/lsp/definition_test.ts
@@ -8,11 +8,12 @@
 
 import { assertEquals } from "@std/assert";
 import type { Entry } from "../core/model/mod.ts";
+import { makeDisplayId } from "../core/model/mod.ts";
 import { entryToLspLocation } from "./definition.ts";
 
 function makeEntry(file: string, line: number, column: number): Entry {
   return {
-    displayId: "REQ-001",
+    displayId: makeDisplayId("REQ-001"),
     title: "Test",
     body: "",
     rawAttributes: [{ key: "Id", value: "01HGW2Q8MNP3RSTVWXYZABCDEF" }],

--- a/packages/markspec/lsp/folding_test.ts
+++ b/packages/markspec/lsp/folding_test.ts
@@ -9,11 +9,12 @@
 
 import { assertEquals } from "@std/assert";
 import type { Entry } from "../core/model/mod.ts";
+import { makeDisplayId } from "../core/model/mod.ts";
 import { entriesToFoldingRanges } from "./folding.ts";
 
 function makeEntry(displayId: string, line: number): Entry {
   return {
-    displayId,
+    displayId: makeDisplayId(displayId),
     title: displayId,
     body: "",
     rawAttributes: [{ key: "Id", value: "01HGW2Q8MNP3RSTVWXYZABCDEF" }],

--- a/packages/markspec/lsp/hover_test.ts
+++ b/packages/markspec/lsp/hover_test.ts
@@ -7,6 +7,7 @@
 
 import { assertEquals } from "@std/assert";
 import type { Entry } from "../core/model/mod.ts";
+import { makeDisplayId } from "../core/model/mod.ts";
 import { displayIdAtPosition, formatHoverContent } from "./hover.ts";
 
 const ULID = "01HGW2Q8MNP3RSTVWXYZABCDEF";
@@ -18,7 +19,7 @@ function makeEntry(opts: {
   body?: string;
 }): Entry {
   return {
-    displayId: opts.displayId,
+    displayId: makeDisplayId(opts.displayId),
     title: opts.title,
     body: opts.body ?? "",
     rawAttributes: [{ key: "Id", value: ULID }],

--- a/packages/markspec/lsp/references_test.ts
+++ b/packages/markspec/lsp/references_test.ts
@@ -8,6 +8,7 @@
 
 import { assertEquals } from "@std/assert";
 import type { Entry } from "../core/model/mod.ts";
+import { makeDisplayId } from "../core/model/mod.ts";
 import { findReferencingEntries } from "./references.ts";
 
 function makeEntry(
@@ -16,7 +17,7 @@ function makeEntry(
   line = 1,
 ): Entry {
   return {
-    displayId,
+    displayId: makeDisplayId(displayId),
     title: displayId,
     body: "",
     rawAttributes: attrs.map(([key, value]) => ({ key, value })),

--- a/packages/markspec/lsp/server.ts
+++ b/packages/markspec/lsp/server.ts
@@ -36,6 +36,7 @@ import {
   type EffectiveProfile,
   loadConfig,
   loadProfileForCommand,
+  makeDisplayId,
   type ProjectConfig,
   VERSION,
 } from "../core/mod.ts";
@@ -471,7 +472,7 @@ connection.onHover((params) => {
 
   const id = displayIdAtPosition(line, params.position.character);
   if (!id) return null;
-  const entry = index.getEntryByDisplayId(id);
+  const entry = index.getEntryByDisplayId(makeDisplayId(id));
   if (!entry) return null;
 
   return {
@@ -504,7 +505,7 @@ connection.onDefinition((params) => {
 
   const id = displayIdAtPosition(line, params.position.character);
   if (!id) return null;
-  const entry = index.getEntryByDisplayId(id);
+  const entry = index.getEntryByDisplayId(makeDisplayId(id));
   if (!entry) return null;
 
   return entryToLspLocation(entry);
@@ -539,7 +540,7 @@ connection.onReferences((params) => {
 
   // includeDeclaration: prepend the declaration's location when asked.
   if (params.context?.includeDeclaration) {
-    const decl = index.getEntryByDisplayId(id);
+    const decl = index.getEntryByDisplayId(makeDisplayId(id));
     if (decl) locations.unshift(entryToLspLocation(decl));
   }
 

--- a/packages/markspec/lsp/symbols_test.ts
+++ b/packages/markspec/lsp/symbols_test.ts
@@ -7,6 +7,7 @@
 
 import { assertEquals } from "@std/assert";
 import type { Entry } from "../core/model/mod.ts";
+import { makeDisplayId } from "../core/model/mod.ts";
 import {
   entriesToDocumentSymbols,
   entriesToWorkspaceSymbols,
@@ -22,7 +23,7 @@ function makeEntry(opts: {
   shape?: "Authored" | "Reference";
 }): Entry {
   return {
-    displayId: opts.displayId,
+    displayId: makeDisplayId(opts.displayId),
     title: opts.title,
     body: "",
     rawAttributes: [{ key: "Id", value: "01HGW2Q8MNP3RSTVWXYZABCDEF" }],

--- a/packages/markspec/lsp/workspace_test.ts
+++ b/packages/markspec/lsp/workspace_test.ts
@@ -7,6 +7,7 @@
 import { assertEquals } from "@std/assert";
 import { WorkspaceIndex } from "./workspace.ts";
 import type { Entry, SourceLocation } from "../core/mod.ts";
+import { makeDisplayId } from "../core/mod.ts";
 
 /** Helper to create a minimal identified entry. */
 function entry(
@@ -16,7 +17,7 @@ function entry(
   const file = opts.file ?? "test.md";
   const location: SourceLocation = { file, line: 1, column: 1 };
   return {
-    displayId,
+    displayId: makeDisplayId(displayId),
     title: opts.title ?? displayId,
     body: "",
     rawAttributes: opts.id ? [{ key: "Id", value: opts.id }] : [],
@@ -41,8 +42,14 @@ Deno.test("WorkspaceIndex: updateFile adds entries to index", () => {
   index.updateFile("reqs.md", entries);
 
   assertEquals(index.getAllEntries().length, 2);
-  assertEquals(index.getEntryByDisplayId("STK_AEB_0001")?.title, "Braking");
-  assertEquals(index.getEntryByDisplayId("STK_AEB_0002")?.title, "Steering");
+  assertEquals(
+    index.getEntryByDisplayId(makeDisplayId("STK_AEB_0001"))?.title,
+    "Braking",
+  );
+  assertEquals(
+    index.getEntryByDisplayId(makeDisplayId("STK_AEB_0002"))?.title,
+    "Steering",
+  );
 });
 
 Deno.test("WorkspaceIndex: updateFile replaces entries for same file", () => {
@@ -55,8 +62,11 @@ Deno.test("WorkspaceIndex: updateFile replaces entries for same file", () => {
     entry("STK_003", { file: "reqs.md" }),
   ]);
   assertEquals(index.getAllEntries().length, 2);
-  assertEquals(index.getEntryByDisplayId("STK_001"), undefined);
-  assertEquals(index.getEntryByDisplayId("STK_002")?.displayId, "STK_002");
+  assertEquals(index.getEntryByDisplayId(makeDisplayId("STK_001")), undefined);
+  assertEquals(
+    index.getEntryByDisplayId(makeDisplayId("STK_002"))?.displayId,
+    makeDisplayId("STK_002"),
+  );
 });
 
 Deno.test("WorkspaceIndex: removeFile removes entries", () => {
@@ -67,8 +77,11 @@ Deno.test("WorkspaceIndex: removeFile removes entries", () => {
 
   index.removeFile("a.md");
   assertEquals(index.getAllEntries().length, 1);
-  assertEquals(index.getEntryByDisplayId("STK_001"), undefined);
-  assertEquals(index.getEntryByDisplayId("STK_002")?.displayId, "STK_002");
+  assertEquals(index.getEntryByDisplayId(makeDisplayId("STK_001")), undefined);
+  assertEquals(
+    index.getEntryByDisplayId(makeDisplayId("STK_002"))?.displayId,
+    makeDisplayId("STK_002"),
+  );
 });
 
 Deno.test("WorkspaceIndex: getEntriesForFile returns file-scoped entries", () => {
@@ -77,7 +90,10 @@ Deno.test("WorkspaceIndex: getEntriesForFile returns file-scoped entries", () =>
   index.updateFile("b.md", [entry("STK_002", { file: "b.md" })]);
 
   assertEquals(index.getEntriesForFile("a.md").length, 1);
-  assertEquals(index.getEntriesForFile("a.md")[0].displayId, "STK_001");
+  assertEquals(
+    index.getEntriesForFile("a.md")[0].displayId,
+    makeDisplayId("STK_001"),
+  );
   assertEquals(index.getEntriesForFile("c.md").length, 0);
 });
 
@@ -133,7 +149,7 @@ Deno.test("WorkspaceIndex: updateFile promotes survivor when owner loses a displ
   index.updateFile("b.md", [entry("STK_0001", { file: "b.md" })]);
 
   assertEquals(
-    index.getEntryByDisplayId("STK_0001")?.location.file,
+    index.getEntryByDisplayId(makeDisplayId("STK_0001"))?.location.file,
     "a.md",
   );
 
@@ -141,7 +157,7 @@ Deno.test("WorkspaceIndex: updateFile promotes survivor when owner loses a displ
   index.updateFile("a.md", []);
 
   assertEquals(
-    index.getEntryByDisplayId("STK_0001")?.location.file,
+    index.getEntryByDisplayId(makeDisplayId("STK_0001"))?.location.file,
     "b.md",
   );
 });
@@ -154,7 +170,7 @@ Deno.test("WorkspaceIndex: removeFile promotes survivor when removed file owned 
   index.updateFile("b.md", [entry("STK_0001", { file: "b.md" })]);
 
   assertEquals(
-    index.getEntryByDisplayId("STK_0001")?.location.file,
+    index.getEntryByDisplayId(makeDisplayId("STK_0001"))?.location.file,
     "a.md",
   );
 
@@ -162,7 +178,7 @@ Deno.test("WorkspaceIndex: removeFile promotes survivor when removed file owned 
   index.removeFile("a.md");
 
   assertEquals(
-    index.getEntryByDisplayId("STK_0001")?.location.file,
+    index.getEntryByDisplayId(makeDisplayId("STK_0001"))?.location.file,
     "b.md",
   );
 });

--- a/packages/markspec/mcp/resources/entries_test.ts
+++ b/packages/markspec/mcp/resources/entries_test.ts
@@ -6,11 +6,12 @@
 
 import { assertStringIncludes } from "@std/assert";
 import type { Entry } from "../../core/mod.ts";
+import { makeDisplayId } from "../../core/mod.ts";
 import { renderEntriesIndex } from "./entries.ts";
 
 function mkEntry(displayId: string, title: string, type?: string): Entry {
   return {
-    displayId,
+    displayId: makeDisplayId(displayId),
     title,
     body: "",
     rawAttributes: [],

--- a/packages/markspec/mcp/resources/entry_test.ts
+++ b/packages/markspec/mcp/resources/entry_test.ts
@@ -6,10 +6,11 @@
 
 import { assertEquals, assertStringIncludes } from "@std/assert";
 import type { Entry, Link } from "../../core/mod.ts";
+import { makeDisplayId } from "../../core/mod.ts";
 import { renderEntry } from "./entry.ts";
 
 const ENTRY: Entry = {
-  displayId: "STK_AEB_0001",
+  displayId: makeDisplayId("STK_AEB_0001"),
   title: "Stop on imminent collision",
   body:
     "When the system detects an imminent collision with a stationary object,\nit shall command emergency braking.",
@@ -31,8 +32,8 @@ const ENTRY: Entry = {
 
 const FORWARD: Link[] = [
   {
-    from: "STK_AEB_0001",
-    to: "SYS_AEB_0012",
+    from: makeDisplayId("STK_AEB_0001"),
+    to: makeDisplayId("SYS_AEB_0012"),
     kind: "satisfies",
     location: {
       file: "/proj/docs/product/stakeholder-requirements.md",
@@ -44,8 +45,8 @@ const FORWARD: Link[] = [
 
 const REVERSE: Link[] = [
   {
-    from: "VAL_AEB_0001",
-    to: "STK_AEB_0001",
+    from: makeDisplayId("VAL_AEB_0001"),
+    to: makeDisplayId("STK_AEB_0001"),
     kind: "verifies",
     location: { file: "/proj/tests/val_aeb.rs", line: 12, column: 1 },
   },

--- a/packages/markspec/mcp/resources/mod.ts
+++ b/packages/markspec/mcp/resources/mod.ts
@@ -35,6 +35,7 @@ import {
 } from "./profile.ts";
 import { renderEntriesIndex } from "./entries.ts";
 import { renderEntry } from "./entry.ts";
+import { makeDisplayId } from "../../core/mod.ts";
 
 /** A resource descriptor as returned by resources/list. */
 export interface ResourceDescriptor {
@@ -137,11 +138,12 @@ export async function readResource(
   }
 
   if (isEntryUri(uri)) {
-    const displayId = parseEntryUri(uri)!;
+    const rawDisplayId = parseEntryUri(uri)!;
+    const displayId = makeDisplayId(rawDisplayId);
     const result = await project.getCompiled();
     const entry = result.entries.get(displayId);
     if (!entry) {
-      throw new Error(`entry not found: ${displayId}`);
+      throw new Error(`entry not found: ${rawDisplayId}`);
     }
     const titles = new Map<string, string>();
     for (const [id, e] of result.entries) titles.set(id, e.title);

--- a/packages/markspec/mcp/resources/mod_test.ts
+++ b/packages/markspec/mcp/resources/mod_test.ts
@@ -8,12 +8,18 @@
  */
 
 import { assertEquals, assertRejects, assertStringIncludes } from "@std/assert";
-import type { CompileResult, Entry, ProfileChain } from "../../core/mod.ts";
+import type {
+  CompileResult,
+  DisplayId,
+  Entry,
+  ProfileChain,
+} from "../../core/mod.ts";
+import { makeDisplayId } from "../../core/mod.ts";
 import type { Project } from "../project.ts";
 import { listResourceDescriptors, readResource } from "./mod.ts";
 
 function mkProject(entries: Entry[]): Project {
-  const entriesMap = new Map<string, Entry>();
+  const entriesMap = new Map<DisplayId, Entry>();
   for (const e of entries) entriesMap.set(e.displayId, e);
   const result: CompileResult = {
     entries: entriesMap,
@@ -36,7 +42,7 @@ function mkProject(entries: Entry[]): Project {
 }
 
 const E1: Entry = {
-  displayId: "STK_TEST_0001",
+  displayId: makeDisplayId("STK_TEST_0001"),
   title: "First entry",
   body: "",
   rawAttributes: [],

--- a/packages/markspec/mcp/tools/context.ts
+++ b/packages/markspec/mcp/tools/context.ts
@@ -6,6 +6,7 @@
  */
 
 import type { CompileResult } from "../../core/mod.ts";
+import { makeDisplayId } from "../../core/mod.ts";
 import { entryUri } from "../uri.ts";
 
 /** One entry in the context chain. */
@@ -26,18 +27,19 @@ export function walkContext(
   startId: string,
   maxDepth: number,
 ): ContextNode[] {
-  const start = result.entries.get(startId);
+  const brandedStart = makeDisplayId(startId);
+  const start = result.entries.get(brandedStart);
   if (!start) return [];
 
   const out: ContextNode[] = [
     { displayId: startId, title: start.title, depth: 0 },
   ];
   const visited = new Set<string>([startId]);
-  let frontier: string[] = [startId];
+  let frontier = [brandedStart];
   let depth = 0;
 
   while (depth < maxDepth && frontier.length > 0) {
-    const next: string[] = [];
+    const next: typeof frontier = [];
     for (const id of frontier) {
       const links = result.forward.get(id) ?? [];
       for (const link of links) {

--- a/packages/markspec/mcp/tools/context_test.ts
+++ b/packages/markspec/mcp/tools/context_test.ts
@@ -5,12 +5,13 @@
  */
 
 import { assertEquals, assertStringIncludes } from "@std/assert";
-import type { CompileResult, Entry, Link } from "../../core/mod.ts";
+import type { CompileResult, DisplayId, Entry, Link } from "../../core/mod.ts";
+import { makeDisplayId } from "../../core/mod.ts";
 import { renderContext, walkContext } from "./context.ts";
 
 function mk(displayId: string, title: string): Entry {
   return {
-    displayId,
+    displayId: makeDisplayId(displayId),
     title,
     body: "",
     rawAttributes: [],
@@ -25,17 +26,17 @@ function buildResult(
   entries: Entry[],
   edges: { from: string; to: string; kind: Link["kind"] }[],
 ): CompileResult {
-  const entryMap = new Map<string, Entry>();
+  const entryMap = new Map<DisplayId, Entry>();
   for (const e of entries) entryMap.set(e.displayId, e);
 
   const links: Link[] = edges.map((e) => ({
-    from: e.from,
-    to: e.to,
+    from: makeDisplayId(e.from),
+    to: makeDisplayId(e.to),
     kind: e.kind,
     location: { file: "/x", line: 1, column: 1 },
   }));
 
-  const forward = new Map<string, Link[]>();
+  const forward = new Map<DisplayId, Link[]>();
   for (const link of links) {
     const list = forward.get(link.from) ?? [];
     list.push(link);

--- a/packages/markspec/mcp/tools/search_test.ts
+++ b/packages/markspec/mcp/tools/search_test.ts
@@ -6,11 +6,12 @@
 
 import { assertEquals, assertStringIncludes } from "@std/assert";
 import type { Entry } from "../../core/mod.ts";
+import { makeDisplayId } from "../../core/mod.ts";
 import { renderSearchResults, scoreEntries } from "./search.ts";
 
 function mk(displayId: string, title: string): Entry {
   return {
-    displayId,
+    displayId: makeDisplayId(displayId),
     title,
     body: "",
     rawAttributes: [],

--- a/packages/markspec/render/includes/mod.ts
+++ b/packages/markspec/render/includes/mod.ts
@@ -8,6 +8,7 @@
  */
 
 import type { CompileResult, Diagnostic, Entry } from "../../core/mod.ts";
+import { makeDisplayId } from "../../core/mod.ts";
 
 // ---------------------------------------------------------------------------
 // Public API
@@ -213,7 +214,7 @@ function resolveEntryRef(
   filter: string | undefined,
   options: IncludeOptions,
 ): ResolveResult {
-  const entry = options.compiled.entries.get(ref);
+  const entry = options.compiled.entries.get(makeDisplayId(ref));
 
   if (!entry) {
     return {

--- a/packages/markspec/render/includes/mod_test.ts
+++ b/packages/markspec/render/includes/mod_test.ts
@@ -2,15 +2,20 @@ import { assertEquals } from "@std/assert";
 import { processIncludes } from "./mod.ts";
 import type { IncludeOptions } from "./mod.ts";
 import type { CompileResult, Entry } from "../../core/mod.ts";
+import { makeDisplayId } from "../../core/mod.ts";
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
 /** Build a minimal Entry for testing. */
-function testEntry(overrides: Partial<Entry> = {}): Entry {
+function testEntry(
+  { displayId, ...overrides }: Partial<Omit<Entry, "displayId">> & {
+    displayId?: string;
+  } = {},
+): Entry {
   return {
-    displayId: "SRS_BRK_0001",
+    displayId: makeDisplayId(displayId ?? "SRS_BRK_0001"),
     title: "Sensor debouncing",
     body: "The sensor driver shall debounce raw inputs.",
     rawAttributes: [

--- a/packages/markspec/render/mustache/mod_test.ts
+++ b/packages/markspec/render/mustache/mod_test.ts
@@ -8,6 +8,7 @@ import { assertEquals } from "@std/assert";
 import type { MustacheContext } from "./mod.ts";
 import { resolveMustache } from "./mod.ts";
 import type { CompileResult, Entry, ProjectConfig } from "../../core/mod.ts";
+import { makeDisplayId } from "../../core/mod.ts";
 import type { CaptionRegistry } from "../captions/mod.ts";
 
 // ---------------------------------------------------------------------------
@@ -32,7 +33,7 @@ function makeConfig(
 /** Build a minimal Entry for testing. */
 function makeEntry(displayId: string): Entry {
   return {
-    displayId,
+    displayId: makeDisplayId(displayId),
     title: `Title for ${displayId}`,
     body: "",
     rawAttributes: [],

--- a/packages/markspec/render/styles/mod.ts
+++ b/packages/markspec/render/styles/mod.ts
@@ -10,6 +10,7 @@
  */
 
 import type { CompileResult, Diagnostic } from "../../core/mod.ts";
+import { makeDisplayId } from "../../core/mod.ts";
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -99,7 +100,7 @@ export function styleRequirementBlocks(
 
     // Only transform if the ID is a known entry and matches valid format.
     if (
-      !knownIds.has(displayId) ||
+      !knownIds.has(makeDisplayId(displayId)) ||
       (!TYPED_ID_RE.test(displayId) && !REF_ID_RE.test(displayId))
     ) {
       outputLines.push(lines[i]);

--- a/packages/markspec/render/styles/mod_test.ts
+++ b/packages/markspec/render/styles/mod_test.ts
@@ -6,8 +6,9 @@
 
 import { assertEquals, assertStringIncludes } from "@std/assert";
 import { styleRequirementBlocks } from "./mod.ts";
-import type { CompileResult } from "../../core/mod.ts";
+import type { CompileResult, DisplayId } from "../../core/mod.ts";
 import type { Entry } from "../../core/mod.ts";
+import { makeDisplayId } from "../../core/mod.ts";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -24,10 +25,10 @@ function buildCompiled(
     id?: string;
   }>,
 ): CompileResult {
-  const map = new Map<string, Entry>();
+  const map = new Map<DisplayId, Entry>();
   for (const e of entries) {
     const entry: Entry = {
-      displayId: e.displayId,
+      displayId: makeDisplayId(e.displayId),
       title: e.title,
       body: e.body ?? "",
       rawAttributes: e.attributes ?? [],
@@ -37,7 +38,7 @@ function buildCompiled(
       source: "markdown",
       typedAttributes: new Map(),
     };
-    map.set(e.displayId, entry);
+    map.set(entry.displayId, entry);
   }
   return {
     entries: map,

--- a/packages/markspec/render/typst/template_test.ts
+++ b/packages/markspec/render/typst/template_test.ts
@@ -2,6 +2,7 @@ import { assertStringIncludes } from "@std/assert";
 import { generateTypstDocument } from "./template.ts";
 import type { DocumentMetadata } from "./template.ts";
 import type { Entry } from "../../core/mod.ts";
+import { makeDisplayId } from "../../core/mod.ts";
 
 Deno.test("generateTypstDocument: imports markspec-doc and cmarker", () => {
   const result = generateTypstDocument("Hello world");
@@ -115,9 +116,13 @@ Deno.test("generateTypstDocument: no ms-image binding when imageBasePrefix empty
 // ---------------------------------------------------------------------------
 
 /** Minimal identified entry fixture for template tests. */
-function makeIdentifiedEntry(overrides: Partial<Entry> = {}): Entry {
+function makeIdentifiedEntry(
+  { displayId, ...overrides }: Partial<Omit<Entry, "displayId">> & {
+    displayId?: string;
+  } = {},
+): Entry {
   return {
-    displayId: "STK_0001",
+    displayId: makeDisplayId(displayId ?? "STK_0001"),
     title: "Test requirement",
     body: "The system shall do something.",
     rawAttributes: [],
@@ -131,9 +136,13 @@ function makeIdentifiedEntry(overrides: Partial<Entry> = {}): Entry {
 }
 
 /** Minimal referenced entry fixture. */
-function makeReferencedEntry(overrides: Partial<Entry> = {}): Entry {
+function makeReferencedEntry(
+  { displayId, ...overrides }: Partial<Omit<Entry, "displayId">> & {
+    displayId?: string;
+  } = {},
+): Entry {
   return {
-    displayId: "EXT_0001",
+    displayId: makeDisplayId(displayId ?? "EXT_0001"),
     title: "External reference",
     body: "",
     rawAttributes: [],


### PR DESCRIPTION
## Summary

Resolves #383 from Debt Epic #366 — three type-system improvements, delivered as separate commits.

**D14 — `ast/build.ts` typed mdast nodes** (`refactor(core): type ast/build.ts mdast nodes`):
Imports proper mdast types (`Blockquote`, `List`, `ListItem`, `Nodes`, `Root`, `RootContent`, `Table`, `TableCell`, `TableRow`) and removes all 9 `// deno-lint-ignore no-explicit-any` suppressions. Also removes a dead `"setextHeading"` branch (mdast uses `"heading"` for both ATX and setext).

**D16 — Open `LinkKind`** (`feat(core): open LinkKind for profile extension`):
`LinkKind` changes from a closed literal union to `string`. Adds `KNOWN_LINK_KINDS: readonly string[]` (exported from `core/mod.ts`) for validation use. Unblocks profile-extensible link kinds.

**D15 — Brand `DisplayId` and `Ulid`** (`refactor(core): brand DisplayId and Ulid types`):
- `DisplayId = string & { readonly __brand: "DisplayId" }`
- `Ulid = string & { readonly __brand: "Ulid" }`
- `makeDisplayId(s: string): DisplayId` and `makeUlid(s: string): Ulid` exported from `core/mod.ts`
- All production call sites (parser, compiler, LSP, MCP, CLI) and 50 test files updated

No behavioral change — 1567 tests pass.

## Test plan

- [x] `just check` passes (lint + 1567 tests + type-check)
- [x] `deno fmt --check` passes
- [x] `dprint check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)