### PR TITLE
feat(core): bundled default profile auto-registration + opt-out

### DIFF
--- a/docs/architecture/adr-010-default-profile.md
+++ b/docs/architecture/adr-010-default-profile.md
@@ -1,5 +1,12 @@
 # ADR-010: Default Profile — RFC 2119 Hygiene and Generic Types
 
+> **Status note (2026-05-19):** The bundling + auto-registration mechanism and
+> the `default-profile: false` opt-out shipped as a mechanism-only slice. The §2
+> four-type vocabulary is superseded by the 15-type core taxonomy; the bundled
+> default is the thin identity profile of profile-schema §7. §7.1 display-ID
+> pattern bindings, RFC 2119 hygiene (`MSL-M061`), and the `{{def.}}` glossary
+> remain deferred (they need a core-type-binding schema construct).
+
 ## Context
 
 ADR-009 moves the four-family taxonomy out of the core into the profile layer

--- a/docs/examples/profiles/aspice-swe-mini/markspec.yaml
+++ b/docs/examples/profiles/aspice-swe-mini/markspec.yaml
@@ -7,7 +7,6 @@ version: 0.1.0
 markspec-schema: "1"
 description: Minimal ASPICE SWE vertical (design validation)
 license: MIT
-extends: "npm:@markspec/profile-default@^1.0"
 
 profile:
 

--- a/docs/spec/internal/markspec-profile-schema.md
+++ b/docs/spec/internal/markspec-profile-schema.md
@@ -491,6 +491,16 @@ Profiles do not reorder the core chain; they only populate steps 2, 5, and 6
 
 ## 7. The default profile
 
+> **Implementation status (2026-05-19):** §2.2 bundling + auto-registration
+>
+> - `default-profile: false` opt-out shipped (identity/minimal manifest). §7.1
+>   pattern bindings, §7 RFC 2119 hygiene, and the glossary `{{def.}}` binding
+>   remain deferred — blocked on a core-type-binding construct. CLI
+>   `profile show`/`doctor` and the MCP `markspec://profile` resource headline
+>   the leaf (user) profile; `profile show` additionally prints the full
+>   root→leaf chain while the MCP resource lists strict ancestors under
+>   **Inherits** — this presentation difference is intentional.
+
 ### 7.1 Contents — thin, by construction
 
 Under the 15-type core taxonomy the default profile is **much smaller** than

--- a/docs/superpowers/plans/2026-05-19-bundled-default-profile.md
+++ b/docs/superpowers/plans/2026-05-19-bundled-default-profile.md
@@ -1,0 +1,1357 @@
+# Bundled Default Profile Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bundle the default profile into the binary and auto-register it as the
+implicit root of the `extends:` chain, with a `default-profile: false` opt-out,
+so consumers never write `extends: npm:@markspec/profile-default`.
+
+**Architecture:** A new embedded string constant holds a minimal identity
+manifest. A new `ProfileSpecifier` variant `{ kind: "builtin" }` resolves to
+that constant with no I/O. `loadChain` splices the builtin as the implicit root
+when a chain's top tier declares no `extends:` and `bundledDefault` is enabled;
+`loadProfileForCommand` enables it unless `.markspec.yaml` sets
+`default-profile: false`. `profile show` / `doctor` present the leaf tier (not
+the builtin root) as the headline.
+
+**Tech Stack:** Deno, TypeScript (strict), `@std/assert`, `@std/yaml`. Tests are
+colocated `*_test.ts` (unit) and `tests/e2e/*_test.ts` (blackbox via the
+`markspec()` helper).
+
+**Spec:**
+[docs/superpowers/specs/2026-05-19-bundled-default-profile-design.md](../specs/2026-05-19-bundled-default-profile-design.md)
+
+**Conventions:**
+
+- Production code under `packages/markspec/core/` must use **no `Deno.*` APIs**
+  (Node-compat rule). Tests may use `Deno.*`.
+- Conventional Commits with a git-std-allowed scope: one of
+  `auto, repo, ci, spec, core, cli, lsp, mcp, render, book, deck, docs, deps, release`.
+  `core` covers anything under `packages/markspec/core/`; `cli` covers
+  `packages/markspec/main.ts`; `docs` covers documentation.
+- Run `deno fmt` (TS) before each commit. `deno fmt --check` and `dprint check`
+  are separate CI gates.
+- Unit test command:
+  `deno test packages/markspec/core/profile/ packages/markspec/core/config/`
+- E2E test command:
+  `deno test --allow-read --allow-write --allow-run --allow-env --allow-ffi tests/e2e/`
+
+---
+
+## File Structure
+
+| File                                                                                    | Responsibility                                                                            | Action             |
+| --------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- | ------------------ |
+| `packages/markspec/core/profile/default_profile.ts`                                     | The embedded manifest string + builtin specifier + source-path sentinel                   | Create             |
+| `packages/markspec/core/profile/default_profile_test.ts`                                | Asserts the embedded manifest parses & merges clean                                       | Create             |
+| `packages/markspec/core/model/profile.ts`                                               | Add `{ kind: "builtin" }` to `ProfileSpecifier`                                           | Modify             |
+| `packages/markspec/core/profile/chain.ts`                                               | Builtin resolver branch, `specifierKey`/`stringifySpec` branches, `bundledDefault` splice | Modify             |
+| `packages/markspec/core/profile/chain_test.ts`                                          | Splice behaviour cases                                                                    | Modify (add tests) |
+| `packages/markspec/core/config/markspec.ts`                                             | `default-profile` key: allowlist, type, parse                                             | Modify             |
+| `packages/markspec/core/config/markspec_test.ts`                                        | `default-profile` parsing + round-trip                                                    | Modify (add tests) |
+| `packages/markspec/core/profile/load.ts`                                                | Wire builtin-only / spliced chain into `loadProfileForCommand`                            | Modify             |
+| `packages/markspec/core/profile/load_test.ts`                                           | Rewrite core-only-mode tests; add opt-out tests                                           | Modify             |
+| `packages/markspec/core/profile/strawman_test.ts`                                       | Drop the local-default rewrite hack; use real auto-registration                           | Modify             |
+| `docs/examples/profiles/aspice-swe-mini/markspec.yaml`                                  | Remove `extends: npm:@markspec/profile-default@^1.0`                                      | Modify             |
+| `packages/markspec/main.ts`                                                             | `profile show` / `doctor` present the leaf tier, list the chain                           | Modify             |
+| `tests/e2e/profile_doctor_test.ts`                                                      | Opt-out keeps "no profile"; add builtin-shown tests; tier count 1→2                       | Modify             |
+| `tests/e2e/profile_test.ts`                                                             | `profile show --format json`: assert leaf tier                                            | Modify             |
+| `docs/architecture/adr-010-default-profile.md`, `docs/specs/markspec-profile-schema.md` | One-line status note                                                                      | Modify             |
+
+---
+
+## Task 1: Embedded default-profile constant + `builtin` specifier variant
+
+**Files:**
+
+- Create: `packages/markspec/core/profile/default_profile.ts`
+- Create: `packages/markspec/core/profile/default_profile_test.ts`
+- Modify: `packages/markspec/core/model/profile.ts` (`ProfileSpecifier` union)
+- Modify: `packages/markspec/core/profile/chain.ts` (`specifierKey`,
+  `stringifySpec` exhaustiveness branches only)
+
+- [ ] **Step 1: Add the `builtin` variant to the `ProfileSpecifier` union**
+
+In `packages/markspec/core/model/profile.ts`, the union currently ends with the
+`npm` member. Replace:
+
+```typescript
+| {
+  readonly kind: "npm";
+  readonly scope?: string;
+  readonly name: string;
+  readonly range: string;
+};
+```
+
+with:
+
+```typescript
+| {
+  readonly kind: "npm";
+  readonly scope?: string;
+  readonly name: string;
+  readonly range: string;
+}
+| { readonly kind: "builtin" };
+```
+
+- [ ] **Step 2: Create the embedded manifest module**
+
+Create `packages/markspec/core/profile/default_profile.ts`:
+
+```typescript
+/**
+ * @module core/profile/default_profile
+ *
+ * The bundled default profile (profile-schema §7 / §2.2). It ships as an
+ * embedded string constant — never a file on disk — so it survives
+ * `deno compile` and runs under Node without I/O. It is auto-registered as
+ * the implicit root of the `extends:` chain unless `default-profile: false`
+ * is set in `.markspec.yaml`.
+ *
+ * Scope (mechanism only): a minimal identity profile — stable id + the
+ * default colour roles, no types, no rules. The profile-schema §7.1
+ * display-ID pattern bindings, RFC 2119 hygiene, and `{{def.}}` glossary
+ * are deferred (they need a core-type-binding schema construct).
+ */
+
+import type { ProfileSpecifier } from "../model/mod.ts";
+
+/** Specifier that resolves to the embedded default profile. */
+export const BUILTIN_DEFAULT_SPECIFIER: ProfileSpecifier = { kind: "builtin" };
+
+/**
+ * Synthetic source path used for the embedded manifest in diagnostics and
+ * tier bookkeeping. Not a real filesystem path.
+ */
+export const BUILTIN_DEFAULT_SOURCE_PATH = "<bundled:@markspec/profile-default>";
+
+/** The embedded default-profile manifest, authored as YAML. */
+export const DEFAULT_PROFILE_MANIFEST = `id: "@markspec/profile-default"
+version: 1.0.0
+markspec-schema: "1"
+description: Baseline MarkSpec profile
+license: MIT
+profile:
+  attributes: []
+  labels: []
+  colors:
+    primary: blue
+    secondary: teal
+    tertiary: cyan
+    accent: purple
+    muted: grey
+    warning: orange
+    danger: red
+  types: {}
+  documents:
+    types: []
+    frontMatter: []
+`;
+```
+
+- [ ] **Step 3: Add `builtin` branches to `specifierKey` and `stringifySpec`**
+
+These two functions end with `const _exhaustive: never = spec;`. Adding the
+union member breaks that exhaustiveness check until each handles `builtin`. In
+`packages/markspec/core/profile/chain.ts`:
+
+In `specifierKey`, immediately before `const _exhaustive: never = spec;`, add:
+
+```typescript
+if (spec.kind === "builtin") {
+  return "builtin:@markspec/profile-default";
+}
+```
+
+In `stringifySpec`, immediately before `const _exhaustive: never = spec;`, add:
+
+```typescript
+if (spec.kind === "builtin") {
+  return "@markspec/profile-default (bundled)";
+}
+```
+
+- [ ] **Step 4: Write the failing test**
+
+Create `packages/markspec/core/profile/default_profile_test.ts`:
+
+```typescript
+/**
+ * @module core/profile/default_profile_test
+ *
+ * The embedded default-profile manifest must parse and merge cleanly as a
+ * lone tier — it ships in the binary and a malformed constant would break
+ * every project that does not opt out.
+ */
+
+import { assertEquals, assertExists } from "@std/assert";
+import {
+  BUILTIN_DEFAULT_SOURCE_PATH,
+  DEFAULT_PROFILE_MANIFEST,
+} from "./default_profile.ts";
+import { parseManifest } from "./manifest.ts";
+import { loadChain } from "./chain.ts";
+import { BUILTIN_DEFAULT_SPECIFIER } from "./default_profile.ts";
+
+Deno.test("default profile manifest parses with zero error diagnostics", () => {
+  const result = parseManifest(
+    DEFAULT_PROFILE_MANIFEST,
+    BUILTIN_DEFAULT_SOURCE_PATH,
+  );
+  assertExists(result.manifest);
+  assertEquals(result.manifest.id, "@markspec/profile-default");
+  const errors = result.diagnostics.filter((d) => d.severity === "error");
+  assertEquals(errors, []);
+  // markspec-schema is pinned, so PROFILE-SCHEMA-002 must not fire.
+  const schemaMiss = result.diagnostics.filter((d) =>
+    d.code === "PROFILE-SCHEMA-002"
+  );
+  assertEquals(schemaMiss, []);
+});
+
+Deno.test("builtin specifier resolves to a lone one-tier chain", async () => {
+  const readFile = (): Promise<string | undefined> =>
+    Promise.resolve(undefined);
+  const result = await loadChain(
+    BUILTIN_DEFAULT_SPECIFIER,
+    "/project",
+    "/project",
+    readFile,
+    { bundledDefault: true },
+  );
+  assertEquals(
+    result.diagnostics.filter((d) => d.severity === "error"),
+    [],
+  );
+  assertExists(result.chain);
+  assertEquals(result.chain.tiers.length, 1);
+  assertEquals(result.chain.tiers[0].id, "@markspec/profile-default");
+});
+```
+
+- [ ] **Step 5: Run the test to verify the first test passes and the second
+      fails**
+
+Run: `deno test packages/markspec/core/profile/default_profile_test.ts`
+Expected: `default profile manifest parses…` PASSES;
+`builtin specifier resolves…` FAILS (the `bundledDefault` option and the builtin
+resolver branch do not exist yet — a type error on `{ bundledDefault: true }` or
+a resolver fall-through to local). This failure is implemented in Task 2.
+
+- [ ] **Step 6: Run type-check**
+
+Run: `deno check packages/markspec/core/mod.ts packages/markspec/main.ts`
+Expected: PASS (the union member is handled by `specifierKey`/`stringifySpec`;
+the builtin resolver fall-through compiles because the loadChain dispatch is an
+`if/else`, not a `never` switch).
+
+- [ ] **Step 7: Commit**
+
+```bash
+deno fmt packages/markspec/core/profile/default_profile.ts packages/markspec/core/profile/default_profile_test.ts packages/markspec/core/model/profile.ts packages/markspec/core/profile/chain.ts
+git add packages/markspec/core/profile/default_profile.ts packages/markspec/core/profile/default_profile_test.ts packages/markspec/core/model/profile.ts packages/markspec/core/profile/chain.ts
+git commit -m "feat(core): add embedded default-profile manifest and builtin specifier
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: `loadChain` — builtin resolver + `bundledDefault` splice
+
+**Files:**
+
+- Modify: `packages/markspec/core/profile/chain.ts`
+- Test: `packages/markspec/core/profile/chain_test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `packages/markspec/core/profile/chain_test.ts`:
+
+```typescript
+import {
+  BUILTIN_DEFAULT_SPECIFIER,
+} from "./default_profile.ts";
+
+Deno.test("loadChain: bundledDefault splices builtin as root of an extends-less leaf", async () => {
+  const result = await loadChain(
+    { kind: "local", path: "./profiles/custom" },
+    "/project",
+    "/project",
+    mockReadFile({
+      "/project/profiles/custom/markspec.yaml":
+        `id: "@acme/custom"\nversion: 1.0.0\nmarkspec-schema: "1"\n`,
+    }),
+    { bundledDefault: true },
+  );
+  assertEquals(result.diagnostics, []);
+  assertEquals(result.chain?.tiers.length, 2);
+  assertEquals(result.chain?.tiers[0].id, "@markspec/profile-default");
+  assertEquals(result.chain?.tiers[1].id, "@acme/custom");
+});
+
+Deno.test("loadChain: bundledDefault disabled does not splice", async () => {
+  const result = await loadChain(
+    { kind: "local", path: "./profiles/custom" },
+    "/project",
+    "/project",
+    mockReadFile({
+      "/project/profiles/custom/markspec.yaml":
+        `id: "@acme/custom"\nversion: 1.0.0\nmarkspec-schema: "1"\n`,
+    }),
+    { bundledDefault: false },
+  );
+  assertEquals(result.chain?.tiers.length, 1);
+  assertEquals(result.chain?.tiers[0].id, "@acme/custom");
+});
+
+Deno.test("loadChain: builtin leaf with bundledDefault yields exactly one tier (no self-splice)", async () => {
+  const result = await loadChain(
+    BUILTIN_DEFAULT_SPECIFIER,
+    "/project",
+    "/project",
+    mockReadFile({}),
+    { bundledDefault: true },
+  );
+  assertEquals(
+    result.diagnostics.filter((d) => d.severity === "error"),
+    [],
+  );
+  assertEquals(result.chain?.tiers.length, 1);
+  assertEquals(result.chain?.tiers[0].id, "@markspec/profile-default");
+});
+
+Deno.test("loadChain: builtin spliced below a multi-tier local chain", async () => {
+  const result = await loadChain(
+    { kind: "local", path: "./profiles/leaf" },
+    "/project",
+    "/project",
+    mockReadFile({
+      "/project/profiles/leaf/markspec.yaml":
+        `id: "@acme/leaf"\nversion: 1.0.0\nmarkspec-schema: "1"\nextends: "../root"\n`,
+      "/project/profiles/root/markspec.yaml":
+        `id: "@acme/root"\nversion: 1.0.0\nmarkspec-schema: "1"\n`,
+    }),
+    { bundledDefault: true },
+  );
+  assertEquals(result.diagnostics, []);
+  assertEquals(result.chain?.tiers.length, 3);
+  assertEquals(result.chain?.tiers[0].id, "@markspec/profile-default");
+  assertEquals(result.chain?.tiers[1].id, "@acme/root");
+  assertEquals(result.chain?.tiers[2].id, "@acme/leaf");
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `deno test packages/markspec/core/profile/chain_test.ts` Expected: the four
+new tests FAIL — `LoadChainOptions` has no `bundledDefault`, so
+`{ bundledDefault: true }` is a type error and no splice happens.
+
+- [ ] **Step 3: Add `bundledDefault` to `LoadChainOptions`**
+
+In `packages/markspec/core/profile/chain.ts`, replace:
+
+```typescript
+/** Options accepted by {@linkcode loadChain}. */
+export interface LoadChainOptions {
+  readonly runGit?: RunGit;
+  readonly appendFile?: AppendFile;
+}
+```
+
+with:
+
+```typescript
+/** Options accepted by {@linkcode loadChain}. */
+export interface LoadChainOptions {
+  readonly runGit?: RunGit;
+  readonly appendFile?: AppendFile;
+  /**
+   * When true, the bundled default profile is spliced as the implicit
+   * root of the chain (the ultimate `extends:` parent of any tier that
+   * declares none). Default false — only `loadProfileForCommand` enables
+   * it, so direct `loadChain` callers (e.g. `profile add` validation)
+   * keep core-only behaviour.
+   */
+  readonly bundledDefault?: boolean;
+}
+```
+
+- [ ] **Step 4: Add the import**
+
+In `packages/markspec/core/profile/chain.ts`, after the existing
+`import { mergeChain } from "./merge.ts";` line, add:
+
+```typescript
+import {
+  BUILTIN_DEFAULT_SOURCE_PATH,
+  BUILTIN_DEFAULT_SPECIFIER,
+  DEFAULT_PROFILE_MANIFEST,
+} from "./default_profile.ts";
+```
+
+- [ ] **Step 5: Add the builtin resolver branch**
+
+In `loadChain`, the resolver dispatch currently reads:
+
+```typescript
+} else if (cursorSpec.kind === "npm") {
+  const { resolveNpmSpecifier } = await import("./npm.ts");
+  const { cacheDir: cacheDirFn } = await import("./cache.ts");
+  resolved = await resolveNpmSpecifier(
+    cursorSpec,
+    diagnostics,
+    {
+      cacheRoot: cacheDirFn(),
+      readFile,
+    },
+  );
+} else {
+  resolved = await resolveLocalSpecifier(
+    cursorSpec,
+    cursorDir,
+    readFile,
+    diagnostics,
+  );
+}
+```
+
+Replace the final `} else {` block so the dispatch becomes:
+
+```typescript
+} else if (cursorSpec.kind === "npm") {
+  const { resolveNpmSpecifier } = await import("./npm.ts");
+  const { cacheDir: cacheDirFn } = await import("./cache.ts");
+  resolved = await resolveNpmSpecifier(
+    cursorSpec,
+    diagnostics,
+    {
+      cacheRoot: cacheDirFn(),
+      readFile,
+    },
+  );
+} else if (cursorSpec.kind === "builtin") {
+  resolved = {
+    rawYaml: DEFAULT_PROFILE_MANIFEST,
+    sourcePath: BUILTIN_DEFAULT_SOURCE_PATH,
+    baseDir: BUILTIN_DEFAULT_SOURCE_PATH,
+  };
+} else {
+  resolved = await resolveLocalSpecifier(
+    cursorSpec,
+    cursorDir,
+    readFile,
+    diagnostics,
+  );
+}
+```
+
+- [ ] **Step 6: Add the splice to the cursor-advance step**
+
+In `loadChain`, replace:
+
+```typescript
+// Advance cursor to the parent, if any.
+if (parsed.manifest.extends !== undefined) {
+  cursorSpec = parsed.manifest.extends;
+  cursorDir = resolved.baseDir;
+} else {
+  cursorSpec = undefined;
+}
+```
+
+with:
+
+```typescript
+// Advance cursor to the parent, if any. When the tier declares no
+// explicit parent, splice the bundled default as the implicit root
+// (once — never below the builtin itself).
+if (parsed.manifest.extends !== undefined) {
+  cursorSpec = parsed.manifest.extends;
+  cursorDir = resolved.baseDir;
+} else if (opts.bundledDefault && cursorSpec.kind !== "builtin") {
+  cursorSpec = BUILTIN_DEFAULT_SPECIFIER;
+  cursorDir = resolved.baseDir;
+} else {
+  cursorSpec = undefined;
+}
+```
+
+- [ ] **Step 7: Run the tests to verify they pass**
+
+Run:
+`deno test packages/markspec/core/profile/chain_test.ts packages/markspec/core/profile/default_profile_test.ts`
+Expected: PASS (all chain_test cases including the four new ones; both
+default_profile_test cases).
+
+- [ ] **Step 8: Commit**
+
+```bash
+deno fmt packages/markspec/core/profile/chain.ts packages/markspec/core/profile/chain_test.ts
+git add packages/markspec/core/profile/chain.ts packages/markspec/core/profile/chain_test.ts
+git commit -m "feat(core): splice bundled default as implicit chain root in loadChain
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: `.markspec.yaml` — `default-profile` opt-out key
+
+**Files:**
+
+- Modify: `packages/markspec/core/config/markspec.ts`
+- Test: `packages/markspec/core/config/markspec_test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `packages/markspec/core/config/markspec_test.ts`:
+
+```typescript
+Deno.test("parseMarkspecYaml: default-profile false parsed", () => {
+  const result = parseMarkspecYaml(
+    "profiles: []\ndefault-profile: false\n",
+    "/p/.markspec.yaml",
+  );
+  assertExists(result.config);
+  assertEquals(result.config.defaultProfile, false);
+  assertEquals(result.diagnostics, []);
+});
+
+Deno.test("parseMarkspecYaml: default-profile true parsed", () => {
+  const result = parseMarkspecYaml(
+    "default-profile: true\n",
+    "/p/.markspec.yaml",
+  );
+  assertExists(result.config);
+  assertEquals(result.config.defaultProfile, true);
+});
+
+Deno.test("parseMarkspecYaml: default-profile absent leaves field undefined", () => {
+  const result = parseMarkspecYaml(
+    "profiles:\n  - ./profiles/x\n",
+    "/p/.markspec.yaml",
+  );
+  assertExists(result.config);
+  assertEquals(result.config.defaultProfile, undefined);
+});
+
+Deno.test("parseMarkspecYaml: non-boolean default-profile emits MARKSPEC-YAML-003", () => {
+  const result = parseMarkspecYaml(
+    'default-profile: "no"\n',
+    "/p/.markspec.yaml",
+  );
+  assertEquals(result.config, null);
+  assertEquals(result.diagnostics[0].code, "MARKSPEC-YAML-003");
+});
+
+Deno.test("addProfileSpecifier: preserves an existing default-profile key", async () => {
+  const store: Record<string, string> = {
+    "/p/.markspec.yaml": "default-profile: false\nprofiles:\n  - ./a\n",
+  };
+  await addProfileSpecifier(
+    "./b",
+    (path: string) => Promise.resolve(store[path]),
+    (path: string, content: string) => {
+      store[path] = content;
+      return Promise.resolve();
+    },
+    "/p",
+  );
+  assertStringIncludes(store["/p/.markspec.yaml"], "default-profile: false");
+  assertStringIncludes(store["/p/.markspec.yaml"], '- "./b"');
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `deno test packages/markspec/core/config/markspec_test.ts` Expected: the
+new tests FAIL — `result.config.defaultProfile` does not exist (type error /
+undefined) and `default-profile` is currently an unknown-key warning, not
+parsed.
+
+- [ ] **Step 3: Allow the key**
+
+In `packages/markspec/core/config/markspec.ts`, replace:
+
+```typescript
+const ALLOWED_MARKSPEC_YAML_KEYS = new Set(["profiles"]);
+```
+
+with:
+
+```typescript
+const ALLOWED_MARKSPEC_YAML_KEYS = new Set(["profiles", "default-profile"]);
+```
+
+- [ ] **Step 4: Add the field to the parsed shape**
+
+Replace:
+
+```typescript
+/** The parsed content of a `.markspec.yaml`. */
+export interface MarkspecYaml {
+  readonly profiles: readonly ProfileSpecifier[];
+}
+```
+
+with:
+
+```typescript
+/** The parsed content of a `.markspec.yaml`. */
+export interface MarkspecYaml {
+  readonly profiles: readonly ProfileSpecifier[];
+  /**
+   * Opt out of the bundled default profile when explicitly `false`.
+   * `undefined` (key absent) means the default is active.
+   */
+  readonly defaultProfile?: boolean;
+}
+```
+
+- [ ] **Step 5: Parse and validate the key**
+
+In `parseMarkspecYaml`, locate the block that ends the specifier loop:
+
+```typescript
+  // If any specifier failed to parse, treat the whole file as invalid.
+  const hasErrors = diagnostics.some((d) => d.severity === "error");
+  if (hasErrors) {
+    return { config: null, diagnostics };
+  }
+
+  return { config: { profiles }, diagnostics };
+```
+
+Replace it with:
+
+```typescript
+  // default-profile: optional boolean opt-out for the bundled default.
+  let defaultProfile: boolean | undefined;
+  const rawDefaultProfile = root["default-profile"];
+  if (rawDefaultProfile !== undefined) {
+    if (typeof rawDefaultProfile !== "boolean") {
+      diagnostics.push({
+        code: "MARKSPEC-YAML-003",
+        severity: "error",
+        message: ".markspec.yaml: 'default-profile' must be a boolean",
+        location: { file: sourcePath, line: 1, column: 1 },
+      });
+      return { config: null, diagnostics };
+    }
+    defaultProfile = rawDefaultProfile;
+  }
+
+  // If any specifier failed to parse, treat the whole file as invalid.
+  const hasErrors = diagnostics.some((d) => d.severity === "error");
+  if (hasErrors) {
+    return { config: null, diagnostics };
+  }
+
+  return { config: { profiles, defaultProfile }, diagnostics };
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `deno test packages/markspec/core/config/markspec_test.ts` Expected: PASS
+(all existing tests plus the five new ones).
+
+- [ ] **Step 7: Commit**
+
+```bash
+deno fmt packages/markspec/core/config/markspec.ts packages/markspec/core/config/markspec_test.ts
+git add packages/markspec/core/config/markspec.ts packages/markspec/core/config/markspec_test.ts
+git commit -m "feat(core): parse default-profile opt-out key in .markspec.yaml
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Wire `loadProfileForCommand`
+
+**Files:**
+
+- Modify: `packages/markspec/core/profile/load.ts`
+- Test: `packages/markspec/core/profile/load_test.ts`
+
+- [ ] **Step 1: Rewrite the affected tests and add opt-out tests**
+
+In `packages/markspec/core/profile/load_test.ts`, replace the test at lines
+15–28 (the two "returns null chain" tests) with:
+
+```typescript
+Deno.test("loadProfileForCommand: no .markspec.yaml yields the bundled default chain", async () => {
+  const result = await loadProfileForCommand("/project", mockReadFile({}));
+  assertEquals(
+    result.diagnostics.filter((d) => d.severity === "error"),
+    [],
+  );
+  assertEquals(result.chain?.tiers.length, 1);
+  assertEquals(result.chain?.tiers[0].id, "@markspec/profile-default");
+});
+
+Deno.test("loadProfileForCommand: empty profiles list yields the bundled default chain", async () => {
+  const result = await loadProfileForCommand(
+    "/project",
+    mockReadFile({ "/project/.markspec.yaml": "profiles: []\n" }),
+  );
+  assertEquals(result.chain?.tiers.length, 1);
+  assertEquals(result.chain?.tiers[0].id, "@markspec/profile-default");
+});
+
+Deno.test("loadProfileForCommand: default-profile false yields core-only (null chain)", async () => {
+  const result = await loadProfileForCommand(
+    "/project",
+    mockReadFile({
+      "/project/.markspec.yaml": "profiles: []\ndefault-profile: false\n",
+    }),
+  );
+  assertEquals(result.chain, null);
+  assertEquals(result.diagnostics, []);
+});
+```
+
+In the same file, replace the test "loadProfileForCommand: single local profile
+loads end-to-end" (lines 30–42) with:
+
+```typescript
+Deno.test("loadProfileForCommand: single local profile is spliced onto the bundled default", async () => {
+  const result = await loadProfileForCommand(
+    "/project",
+    mockReadFile({
+      "/project/.markspec.yaml": `profiles:\n  - ./profiles/custom\n`,
+      "/project/profiles/custom/markspec.yaml":
+        `id: "@acme/custom"\nversion: 1.0.0\nmarkspec-schema: "1"\n`,
+    }),
+  );
+  assertEquals(result.diagnostics, []);
+  assertEquals(result.chain?.tiers.length, 2);
+  assertEquals(result.chain?.tiers[0].id, "@markspec/profile-default");
+  assertEquals(result.chain?.tiers[1].id, "@acme/custom");
+});
+
+Deno.test("loadProfileForCommand: default-profile false keeps a single-tier chain", async () => {
+  const result = await loadProfileForCommand(
+    "/project",
+    mockReadFile({
+      "/project/.markspec.yaml":
+        `default-profile: false\nprofiles:\n  - ./profiles/custom\n`,
+      "/project/profiles/custom/markspec.yaml":
+        `id: "@acme/custom"\nversion: 1.0.0\nmarkspec-schema: "1"\n`,
+    }),
+  );
+  assertEquals(result.diagnostics, []);
+  assertEquals(result.chain?.tiers.length, 1);
+  assertEquals(result.chain?.tiers[0].id, "@acme/custom");
+});
+```
+
+In the same file, replace the test "loadProfileForCommand: unknown key warning
+does not block loading" (lines 68–83) with:
+
+```typescript
+Deno.test("loadProfileForCommand: unknown key warning does not block loading", async () => {
+  const result = await loadProfileForCommand(
+    "/project",
+    mockReadFile({
+      "/project/.markspec.yaml":
+        `profiles:\n  - ./profiles/custom\nbogus: true\n`,
+      "/project/profiles/custom/markspec.yaml":
+        `id: "@acme/custom"\nversion: 1.0.0\nmarkspec-schema: "1"\n`,
+    }),
+  );
+  // Loading succeeded despite the warning; builtin spliced as root.
+  assertEquals(result.chain?.tiers.length, 2);
+  assertEquals(result.chain?.tiers[0].id, "@markspec/profile-default");
+  assertEquals(result.chain?.tiers[1].id, "@acme/custom");
+  const warnings = result.diagnostics.filter((d) => d.code === "MARKSPEC-YAML-001");
+  assertEquals(warnings.length, 1);
+  assertEquals(warnings[0].severity, "warning");
+});
+```
+
+(The tests "multiple profiles emits PROFILE-LOAD-006", ".markspec.yaml YAML
+error surfaces", and "profile load errors propagate" are unchanged — resolution
+fails before any splice, so they still return `chain: null`.)
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `deno test packages/markspec/core/profile/load_test.ts` Expected: the
+rewritten tests FAIL — `loadProfileForCommand` still returns `chain: null` for
+no/empty profiles and a single-tier chain for one profile.
+
+- [ ] **Step 3: Add the import and helper**
+
+In `packages/markspec/core/profile/load.ts`, after
+`import { loadChain } from "./chain.ts";` add:
+
+```typescript
+import { BUILTIN_DEFAULT_SPECIFIER } from "./default_profile.ts";
+```
+
+After the `loadProfileForCommand` function (before
+`const RESERVED_ATTRIBUTE_KEYS`), add:
+
+```typescript
+/**
+ * Build a chain containing only the bundled default profile. Used when no
+ * project profile is declared but the default is not opted out.
+ */
+async function loadBuiltinOnlyChain(
+  projectRoot: string,
+  readFile: ReadFile,
+  diagnostics: Diagnostic[],
+): Promise<LoadProfileForCommandResult> {
+  const chainResult = await loadChain(
+    BUILTIN_DEFAULT_SPECIFIER,
+    projectRoot,
+    projectRoot,
+    readFile,
+    { bundledDefault: true },
+  );
+  diagnostics.push(...chainResult.diagnostics);
+  if (chainResult.chain) {
+    diagnostics.push(...checkReservedRedefinitions(chainResult.chain));
+  }
+  return { chain: chainResult.chain, diagnostics };
+}
+```
+
+- [ ] **Step 4: Wire the four decision points**
+
+In `loadProfileForCommand`, replace:
+
+```typescript
+const rawYaml = await readMarkspecYaml(projectRoot, readFile);
+if (rawYaml === null) {
+  return { chain: null, diagnostics };
+}
+```
+
+with:
+
+```typescript
+const rawYaml = await readMarkspecYaml(projectRoot, readFile);
+if (rawYaml === null) {
+  // No .markspec.yaml — the default is active (no file to opt out in).
+  return await loadBuiltinOnlyChain(projectRoot, readFile, diagnostics);
+}
+```
+
+Then replace:
+
+```typescript
+const { profiles } = parsed.config;
+if (profiles.length === 0) {
+  return { chain: null, diagnostics };
+}
+```
+
+with:
+
+```typescript
+const { profiles, defaultProfile } = parsed.config;
+const bundledDefault = defaultProfile !== false;
+if (profiles.length === 0) {
+  return bundledDefault
+    ? await loadBuiltinOnlyChain(projectRoot, readFile, diagnostics)
+    : { chain: null, diagnostics };
+}
+```
+
+Then replace:
+
+```typescript
+const chainResult = await loadChain(
+  profiles[0],
+  projectRoot,
+  projectRoot,
+  readFile,
+);
+```
+
+with:
+
+```typescript
+const chainResult = await loadChain(
+  profiles[0],
+  projectRoot,
+  projectRoot,
+  readFile,
+  { bundledDefault },
+);
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `deno test packages/markspec/core/profile/load_test.ts` Expected: PASS (all
+tests, including unchanged PROFILE-LOAD-006 / YAML-error / missing-profile
+cases).
+
+- [ ] **Step 6: Run the full profile + config unit suite**
+
+Run: `deno test packages/markspec/core/profile/ packages/markspec/core/config/`
+Expected: PASS except `strawman_test.ts` (fixed in Task 5) — note any strawman
+failures and continue.
+
+- [ ] **Step 7: Commit**
+
+```bash
+deno fmt packages/markspec/core/profile/load.ts packages/markspec/core/profile/load_test.ts
+git add packages/markspec/core/profile/load.ts packages/markspec/core/profile/load_test.ts
+git commit -m "feat(core): activate bundled default profile in loadProfileForCommand
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Rewrite `strawman_test.ts` to use real auto-registration
+
+**Files:**
+
+- Modify: `packages/markspec/core/profile/strawman_test.ts`
+- Modify: `docs/examples/profiles/aspice-swe-mini/markspec.yaml`
+
+- [ ] **Step 1: Remove the explicit `extends:` from the strawman manifest**
+
+In `docs/examples/profiles/aspice-swe-mini/markspec.yaml`, delete the line:
+
+```yaml
+extends: "npm:@markspec/profile-default@^1.0"
+```
+
+The surrounding lines become:
+
+```yaml
+license: MIT
+
+profile:
+```
+
+- [ ] **Step 2: Replace the chain-loading helper**
+
+In `packages/markspec/core/profile/strawman_test.ts`, replace the helper block
+(lines 27–66, the doc comment plus the entire `loadStrawmanChain` function)
+with:
+
+```typescript
+/**
+ * The strawman declares no `extends:`. The bundled default profile is
+ * auto-spliced as the implicit root when `bundledDefault: true`, exactly
+ * as `loadProfileForCommand` does for real projects.
+ */
+async function loadStrawmanChain(): Promise<{
+  chain: ProfileChain | null;
+  diagnostics: readonly { severity: string; code: string; message: string }[];
+}> {
+  const specifier: ProfileSpecifier = {
+    kind: "local",
+    path: "./aspice-swe-mini",
+  };
+  return await loadChain(specifier, PROFILES_DIR, PROFILES_DIR, readFile, {
+    bundledDefault: true,
+  });
+}
+```
+
+- [ ] **Step 3: Verify the assertion tests still describe the right shape**
+
+The remaining tests (`chain resolves with 2 tiers`,
+`effective profile has all 7 types`, `ASIL labels`, `Derived-from`,
+`standard extends Specification`,
+`per-type color resolves through merged colors map`) are unchanged: the embedded
+default is tier 0 with id `@markspec/profile-default` and the same colour roles,
+so `tiers.length === 2`, `tiers[0].id === "@markspec/profile-default"`,
+`tiers[1].id === "@markspec/profile-aspice-swe-mini"`, and
+`colors.get("primary")?.value === "blue"` all still hold. No edits needed to the
+`Deno.test(...)` blocks.
+
+- [ ] **Step 4: Run the strawman tests**
+
+Run: `deno test --allow-read packages/markspec/core/profile/strawman_test.ts`
+Expected: PASS — all six strawman tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+deno fmt packages/markspec/core/profile/strawman_test.ts
+dprint fmt docs/examples/profiles/aspice-swe-mini/markspec.yaml || true
+git add packages/markspec/core/profile/strawman_test.ts docs/examples/profiles/aspice-swe-mini/markspec.yaml
+git commit -m "test(core): strawman uses bundled default auto-registration
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+(`docs/examples/` is excluded from dprint per CLAUDE.md, so the `dprint fmt` is
+a no-op guarded with `|| true`; the manifest edit only deletes a line and needs
+no reformat.)
+
+---
+
+## Task 6: `profile show` / `doctor` present the leaf tier
+
+**Files:**
+
+- Modify: `packages/markspec/main.ts`
+- Test: `tests/e2e/profile_doctor_test.ts`, `tests/e2e/profile_test.ts`
+
+- [ ] **Step 1: Update the e2e expectations (failing tests first)**
+
+In `tests/e2e/profile_doctor_test.ts`, replace the test "profile show: no
+profile prints message" with:
+
+```typescript
+Deno.test("profile show: opted-out project prints no-profile message", async () => {
+  const { code, stderr } = await markspec(["profile", "show"], {
+    files: {
+      "project.yaml": PROJECT_YAML,
+      ".markspec.yaml": "default-profile: false\n",
+    },
+  });
+  assertEquals(code, 0);
+  assertStringIncludes(stderr, "no profile");
+});
+
+Deno.test("profile show: bundled default shown when no .markspec.yaml", async () => {
+  const { code, stdout } = await markspec(["profile", "show"], {
+    files: {
+      "project.yaml": PROJECT_YAML,
+    },
+  });
+  assertEquals(code, 0);
+  assertStringIncludes(stdout, "@markspec/profile-default");
+});
+```
+
+In the same file, replace the test "doctor: no profile still exits 0" with:
+
+```typescript
+Deno.test("doctor: opted-out project still exits 0 with no-profile message", async () => {
+  const { code, stderr } = await markspec(["doctor"], {
+    files: {
+      "project.yaml": PROJECT_YAML,
+      ".markspec.yaml": "default-profile: false\n",
+    },
+  });
+  assertEquals(code, 0);
+  assertStringIncludes(stderr, "no profile");
+});
+
+Deno.test("doctor: bundled default shown when no .markspec.yaml", async () => {
+  const { code, stderr } = await markspec(["doctor"], {
+    files: {
+      "project.yaml": PROJECT_YAML,
+    },
+  });
+  assertEquals(code, 0);
+  assertStringIncludes(stderr, "@markspec/profile-default");
+});
+```
+
+In the same file, in "doctor: --format json outputs structured data", change:
+
+```typescript
+assertEquals(data.profile.tiers, 1);
+```
+
+to:
+
+```typescript
+assertEquals(data.profile.tiers, 2);
+```
+
+In `tests/e2e/profile_test.ts`, in "profile show: --format json outputs
+ProfileOverview schema", change:
+
+```typescript
+assertStringIncludes(data.tiers[0].id, "my-profile");
+```
+
+to:
+
+```typescript
+assertStringIncludes(
+  data.tiers[data.tiers.length - 1].id,
+  "my-profile",
+);
+```
+
+- [ ] **Step 2: Run the e2e tests to verify the relevant ones fail**
+
+Run:
+`deno test --allow-read --allow-write --allow-run --allow-env --allow-ffi tests/e2e/profile_doctor_test.ts tests/e2e/profile_test.ts`
+Expected: the edited tests FAIL — `profile show` still prints
+`Active profile: @markspec/profile-default` for the multi-tier case,
+`data.profile.tiers` is still numerically wrong, and the no-`.markspec.yaml`
+path still says "no profile".
+
+- [ ] **Step 3: Make `profile show` headline the leaf and list the chain**
+
+In `packages/markspec/main.ts`, in the `profile show` action, replace:
+
+```typescript
+const active = overview.tiers[0];
+console.log(`Active profile: ${active.id}@${active.version}`);
+if (active.summary && active.summary !== active.id) {
+  console.log(active.summary);
+}
+console.log("");
+```
+
+with:
+
+```typescript
+const active = overview.tiers[overview.tiers.length - 1];
+console.log(`Active profile: ${active.id}@${active.version}`);
+if (active.summary && active.summary !== active.id) {
+  console.log(active.summary);
+}
+if (overview.tiers.length > 1) {
+  console.log(
+    `Profile chain: ${
+      overview.tiers.map((t) => t.id).join(" → ")
+    }`,
+  );
+}
+console.log("");
+```
+
+- [ ] **Step 4: Make `doctor` headline the leaf**
+
+In the `doctor` action, replace the JSON `profile` object:
+
+```typescript
+profile: chain
+  ? {
+    id: chain.tiers[0].id,
+    version: chain.tiers[0].version,
+    tiers: chain.tiers.length,
+  }
+  : null,
+```
+
+with:
+
+```typescript
+profile: chain
+  ? {
+    id: chain.tiers[chain.tiers.length - 1].id,
+    version: chain.tiers[chain.tiers.length - 1].version,
+    tiers: chain.tiers.length,
+  }
+  : null,
+```
+
+And replace the text branch:
+
+```typescript
+if (chain) {
+  console.error(
+    `Profile: ${chain.tiers[0].id}@${
+      chain.tiers[0].version
+    } (${chain.tiers.length} tier(s))`,
+  );
+} else {
+  console.error("Profile: no profile configured");
+}
+```
+
+with:
+
+```typescript
+if (chain) {
+  const leaf = chain.tiers[chain.tiers.length - 1];
+  console.error(
+    `Profile: ${leaf.id}@${leaf.version} (${chain.tiers.length} tier(s))`,
+  );
+} else {
+  console.error("Profile: no profile configured");
+}
+```
+
+- [ ] **Step 5: Run the e2e tests to verify they pass**
+
+Run:
+`deno test --allow-read --allow-write --allow-run --allow-env --allow-ffi tests/e2e/profile_doctor_test.ts tests/e2e/profile_test.ts`
+Expected: PASS — including "profile show: prints chain info" (`@acme/test`,
+`0.2.0` now appear because the leaf is the headline) and "doctor: clean project
+exits 0".
+
+- [ ] **Step 6: Commit**
+
+```bash
+deno fmt packages/markspec/main.ts tests/e2e/profile_doctor_test.ts tests/e2e/profile_test.ts
+git add packages/markspec/main.ts tests/e2e/profile_doctor_test.ts tests/e2e/profile_test.ts
+git commit -m "fix(cli): profile show/doctor headline the leaf tier, list the chain
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Full-suite reconciliation
+
+**Files:** any test that assumed core-only behaviour for a no-`.markspec.yaml`
+project.
+
+- [ ] **Step 1: Find other no-profile assumptions**
+
+Run:
+
+```bash
+grep -rn "no profile configured\|no profile\|chain, null\|chain: null\|tiers, 1\|tiers.length, 1" packages/markspec/mcp tests/e2e
+```
+
+Expected: review each hit. The MCP profile resource test
+(`packages/markspec/mcp/resources/profile_test.ts`) and any e2e that runs
+`profile show` / `doctor` / `compile` without a `.markspec.yaml` and asserts a
+core-only outcome are the candidates. For each that breaks: if the intent is to
+test core-only, add `".markspec.yaml": "default-profile: false\n"` to its
+fixture; if the intent is to test "some profile active", update the expected
+id/tier count to include `@markspec/profile-default`.
+
+- [ ] **Step 2: Run the entire test suite**
+
+Run: `deno test --allow-read --allow-write --allow-run --allow-env --allow-ffi`
+Expected: enumerate every failure. Most e2e tests pass only `.md` files (no
+`project.yaml`, no `.markspec.yaml`) and run file-locally without loading a
+profile — they are unaffected. Failures should be limited to
+profile/doctor/MCP-profile tests already addressed in Tasks 4–6 plus any found
+in Step 1.
+
+- [ ] **Step 3: Fix each remaining failure**
+
+For each failure, apply the Step 1 rule (opt-out fixture vs. updated
+expectation). Make the minimal change that preserves the test's original intent.
+Do not blanket-update snapshots — there are no `.snap` files in this repo; all
+assertions are behavioural.
+
+- [ ] **Step 4: Re-run the full suite**
+
+Run: `deno test --allow-read --allow-write --allow-run --allow-env --allow-ffi`
+Expected: PASS — 0 failures.
+
+- [ ] **Step 5: Commit**
+
+```bash
+deno fmt
+git add -A
+git commit -m "test(repo): reconcile suite with bundled-default activation
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+(If Step 1–3 found nothing to change, skip this commit.)
+
+---
+
+## Task 8: Status notes, full build, finish
+
+**Files:**
+
+- Modify: `docs/architecture/adr-010-default-profile.md`
+- Modify: `docs/specs/markspec-profile-schema.md`
+
+- [ ] **Step 1: Add an ADR-010 status note**
+
+At the very top of `docs/architecture/adr-010-default-profile.md`, immediately
+after the first `# ADR-010: …` heading line, insert:
+
+```markdown
+> **Status note (2026-05-19):** The bundling + auto-registration mechanism and
+> the `default-profile: false` opt-out shipped as a mechanism-only slice. The §2
+> four-type vocabulary is superseded by the 19-name core taxonomy; the bundled
+> default is the thin identity profile of profile-schema §7. §7.1 display-ID
+> pattern bindings, RFC 2119 hygiene (`MSL-M061`), and the `{{def.}}` glossary
+> remain deferred (they need a core-type-binding schema construct).
+```
+
+- [ ] **Step 2: Add a profile-schema §7 status note**
+
+In `docs/specs/markspec-profile-schema.md`, immediately after the
+`## 7. The default profile` heading line, insert:
+
+```markdown
+> **Implementation status (2026-05-19):** §2.2 bundling + auto-registration
+>
+> - `default-profile: false` opt-out shipped (identity/minimal manifest). §7.1
+>   pattern bindings, §7 RFC 2119 hygiene, and the glossary `{{def.}}` binding
+>   remain deferred — blocked on a core-type-binding construct.
+```
+
+- [ ] **Step 3: Format the docs**
+
+Run:
+`dprint fmt docs/architecture/adr-010-default-profile.md docs/specs/markspec-profile-schema.md`
+Expected: `Formatted` (or already-formatted).
+
+- [ ] **Step 4: Run the full build gate**
+
+Run: `just build` Expected: lint, full test suite, and type-check all pass; the
+binary compiles to `dist/markspec`.
+
+- [ ] **Step 5: Run the two CI format gates `just build` does NOT cover**
+
+Run: `deno fmt --check && dprint check` Expected: both PASS. (Per the project's
+pre-push checklist, `just build` does not run `deno fmt --check`.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docs/architecture/adr-010-default-profile.md docs/specs/markspec-profile-schema.md
+git commit -m "docs(docs): note bundled-default mechanism shipped; §7.1 deferred
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+- [ ] **Step 7: Finish the development branch**
+
+Use the `superpowers:finishing-a-development-branch` skill to present merge / PR
+/ cleanup options to the user. Acceptance criteria to confirm against the spec
+before finishing:
+
+- No `.markspec.yaml` → chain is `[@markspec/profile-default]` (Task 4 test).
+- `default-profile: false` (+ no/empty profiles) → core-only, `chain: null`
+  (Task 4 test).
+- `profiles: [P]`, `P` has no `extends:` → `[@markspec/profile-default, P]`
+  (Task 2 + Task 4 tests).
+- `default-profile:` non-boolean → `MARKSPEC-YAML-003`, `config: null` (Task 3
+  test).
+- `markspec profile add` preserves `default-profile:` (Task 3 test).
+- Embedded manifest parses with no error diagnostics and no `PROFILE-SCHEMA-002`
+  (Task 1 test).
+- `aspice-swe-mini` resolves with `extends:` removed; strawman test no longer
+  rewrites it (Task 5).
+- `profile show` / `doctor` headline the leaf, not the builtin (Task 6).
+- `just build` + `deno fmt --check` + `dprint check` all pass (Task 8 Steps
+  4–5).
+- No `Deno.*` in the added `core/` production files (`default_profile.ts`, edits
+  to `chain.ts` / `load.ts` / `markspec.ts`).
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** Spec §4 approach → Tasks 1–2; §5 manifest → Task 1; §6
+  behaviour matrix → Tasks 2 + 4 (every row has a test); §7 components → Tasks
+  1–4 + 6; §9 error handling → Task 3 (non-boolean) + Task 2 (no self-splice) +
+  unchanged PROFILE-LOAD paths verified in Task 4; §10 testing → Tasks 1–7; §11
+  breaking changes → Tasks 5–7; §12 acceptance criteria → Task 8 Step 7. The
+  leaf-headline UX decision (post-spec clarification) → Task 6.
+- **Placeholder scan:** none — every code step shows full code; every command
+  states expected output.
+- **Type consistency:** `BUILTIN_DEFAULT_SPECIFIER` /
+  `BUILTIN_DEFAULT_SOURCE_PATH` / `DEFAULT_PROFILE_MANIFEST` (Task 1) used
+  verbatim in Tasks 2 & 4. `LoadChainOptions.bundledDefault` (Task 2) consumed
+  in Task 4. `MarkspecYaml.defaultProfile` (Task 3) read in Task 4.
+  `loadBuiltinOnlyChain` defined and called in Task 4 only. `overview.tiers` /
+  `chain.tiers` indexed as `[length - 1]` for the leaf in Task 6, consistent
+  with `introspect.ts` root→leaf ordering.

--- a/docs/superpowers/specs/2026-05-19-bundled-default-profile-design.md
+++ b/docs/superpowers/specs/2026-05-19-bundled-default-profile-design.md
@@ -1,0 +1,252 @@
+# Design — Bundled default profile: auto-registration + opt-out
+
+**Date:** 2026-05-19 **Status:** Approved (brainstorming); pending
+implementation plan **Scope:** Mechanism only — bundle + auto-register the
+default profile as the implicit bottom of the `extends:` chain, with a
+`default-profile: false` opt-out. Identity/minimal manifest contents.
+
+---
+
+## 1. Problem
+
+In-repo profiles such as
+[docs/examples/profiles/aspice-swe-mini/markspec.yaml](../../examples/profiles/aspice-swe-mini/markspec.yaml)
+declare `extends: "npm:@markspec/profile-default@^1.0"`. That is wrong: the
+default profile is specified to be **bundled in the binary** and loaded
+automatically, so a consumer should never name it explicitly.
+
+Today nothing is bundled:
+
+- No bundled default-profile package or embedded constant exists.
+- `loadChain`
+  ([packages/markspec/core/profile/chain.ts](../../../packages/markspec/core/profile/chain.ts))
+  only walks explicit `extends:` pointers — it never injects a default tier.
+- `.markspec.yaml` parsing
+  ([packages/markspec/core/config/markspec.ts](../../../packages/markspec/core/config/markspec.ts))
+  rejects every key except `profiles` (`ALLOWED_MARKSPEC_YAML_KEYS`), so
+  `default-profile: false` is currently a parse error.
+- `@markspec/profile-default` exists only as a **test fixture**;
+  `strawman_test.ts` rewrites `extends: npm:@markspec/profile-default@^1.0` →
+  `extends: "../default"` because nothing is bundled.
+
+This work is recognized and deliberately deferred: the profile-schema Tier 2
+handoff records _"Bundled default profile auto-activation: DEFERRED to a
+follow-up slice."_
+
+## 2. Authoritative design (ADR-010 is partially superseded)
+
+ADR-010 ("the core has no types; the default profile supplies
+`requirement`/`note`/`term`/`reference`") is obsolete: the nextgen refactor
+froze a 19-name core taxonomy (4 abstract + 15 concrete) directly in core
+(`CORE_ABSTRACT_TYPES` / `CORE_CONCRETE_TYPES` in
+[packages/markspec/core/model/mod.ts](../../../packages/markspec/core/model/mod.ts)).
+
+The authoritative current design is
+[markspec-profile-schema.md §7 + §2.2](../../specs/markspec-profile-schema.md):
+
+- §2.2 — the default profile is **bundled in the binary and registered as the
+  implicit bottom of the chain unless `default-profile: false`** is set in
+  `.markspec.yaml`. Core-only mode = `default-profile: false` **and** empty
+  `profiles:`.
+- §7 — under the 19-name core taxonomy the default profile is **thin**: it
+  declares **no new types**. Its intended contents (display-ID pattern bindings,
+  RFC 2119 hygiene, `{{def.<slug>}}` glossary, hygiene-rule restatement, two
+  front-matter keys) are **out of scope here** — see §8.
+
+## 3. Scope decision
+
+**Mechanism only**, with an **identity/minimal manifest**. Rationale:
+
+- The mechanism (bundle + auto-register + opt-out) is the actual fix for the
+  stated problem and is fully implementable today.
+- §7.1's display-ID pattern bindings are **not expressible** in the current
+  profile schema: §3.1 R3.1-d (implemented as `MSL-A040`,
+  [load.ts](../../../packages/markspec/core/profile/load.ts)) makes a profile
+  type named identically to a core type a hard error, and every profile type
+  must `extends:` a parent as a **new** type — there is no "bind a pattern to an
+  existing core type" construct. The five prefixes `REQ/TST/ICD/REC/RSK` are
+  already core-reserved and inferred unconditionally
+  ([core-data-model §1.7](../../specs/markspec-core-data-model.md)). Adding a
+  binding construct is a separate schema slice.
+- RFC 2119 `MSL-M061` and `{{def.}}` glossary were already deferred for the same
+  blocker; §7.1 bindings join them.
+
+## 4. Approach (chosen: synthetic bottom tier from an embedded constant)
+
+A new embedded constant holds the §7-minimal manifest as a **string**. A new
+`ProfileSpecifier` variant `{ kind: "builtin" }` represents it. The default
+becomes the **implicit root of the `extends:` chain**. Injection happens at the
+loader boundary, never in the user's `.markspec.yaml`.
+
+```text
+.markspec.yaml ─▶ loadProfileForCommand
+                     │  parse config (now also reads `default-profile:`)
+                     │  decide leaf specifier + whether builtin is enabled
+                     ▼
+                  loadChain(leaf)
+                     │  walk extends: leaf → … → root
+                     │  when a tier declares no `extends:` AND builtin enabled
+                     │     AND tier is not itself builtin → cursor = {kind:"builtin"}
+                     │  resolver: kind==="builtin" → embedded constant (no I/O)
+                     ▼
+                  mergeChain  →  tiers[0] = @markspec/profile-default
+```
+
+Rejected alternatives: a bundled `.yaml` file (deno-compile + Node-compat
+fragility; needs an embed step anyway) and config-level injection (couples
+"declared" vs "injected", pollutes `markspec profile add` round-tripping and the
+audit trail).
+
+## 5. Bundled manifest contents
+
+Minimal identity profile, embedded as a string constant:
+
+```yaml
+id: "@markspec/profile-default"
+version: 1.0.0
+markspec-schema: "1"        # avoids PROFILE-SCHEMA-002
+description: Baseline MarkSpec profile
+license: MIT
+profile:
+  attributes: []
+  labels: []
+  colors:
+    primary: blue
+    secondary: teal
+    tertiary: cyan
+    accent: purple
+    muted: grey
+    warning: orange
+    danger: red
+  types: {}
+  documents:
+    types: []
+    frontMatter: []
+```
+
+No new types, no rules. It contributes a stable identity to extend and the
+default color buckets. (`markspec-schema: "1"` is included so the bundled
+manifest does not itself trip `PROFILE-SCHEMA-002`.)
+
+## 6. Behaviour matrix (intended behaviour change)
+
+| `.markspec.yaml` state                                        | Before                    | After                                                                  |
+| ------------------------------------------------------------- | ------------------------- | ---------------------------------------------------------------------- |
+| absent                                                        | core-only (`chain: null`) | **default-only chain** (`tiers=[builtin]`)                             |
+| present, empty `profiles:`                                    | core-only                 | **default-only chain**                                                 |
+| `profiles: [P]`, `P` has no `extends:`                        | `chain=[P]`               | `chain=[builtin, P]`                                                   |
+| `profiles: [P]`, `P extends Q`, `Q` has no `extends:`         | `chain=[Q,P]`             | `chain=[builtin, Q, P]` (builtin spliced as the root, below `Q`)       |
+| `profiles: [P]`, `P extends Q`, `Q extends` an npm/git parent | `chain=[…,Q,P]`           | `chain=[…,Q,P]` (unchanged — explicit root already present, no splice) |
+| `default-profile: false`                                      | core-only                 | **core-only (unchanged)**                                              |
+| `profiles: [A,B]`                                             | `PROFILE-LOAD-006`        | `PROFILE-LOAD-006` (unchanged)                                         |
+
+"Core-only mode" now requires explicit `default-profile: false` — exactly per
+profile-schema §2.2. This behaviour change is intended and spec-mandated.
+
+## 7. Components changed
+
+- **`packages/markspec/core/profile/default_profile.ts`** (new) — the manifest
+  string constant + a `BUILTIN_DEFAULT_SOURCE_PATH` sentinel for diagnostics.
+- **`packages/markspec/core/model/profile.ts`** — add `{ kind: "builtin" }` to
+  the `ProfileSpecifier` union (currently line ~149).
+- **`packages/markspec/core/profile/chain.ts`** —
+  - resolver branch for `kind: "builtin"` returning the embedded constant (no
+    `Deno.*`, Node-safe);
+  - `specifierKey` / `stringifySpec` branches for `builtin`;
+  - in the cursor walk, splice the builtin specifier as the implicit root when
+    the current tier declares no `extends:`, builtin is enabled, and the current
+    tier is not itself the builtin (guards against double injection and
+    builtin-extends-builtin).
+- **`packages/markspec/core/config/markspec.ts`** — add `"default-profile"` to
+  `ALLOWED_MARKSPEC_YAML_KEYS`; add `defaultProfile?: boolean` to
+  `MarkspecYaml`; parse it (non-boolean → `.markspec.yaml` diagnostic);
+  `addProfileSpecifier` must preserve the key on round-trip.
+- **`packages/markspec/core/profile/load.ts`** — `loadProfileForCommand` threads
+  `defaultProfile` (default **true**) into the chain decision. The
+  `rawYaml === null` and empty-`profiles:` paths now return the builtin chain
+  instead of `null` unless opted out. MSL-A040 is unaffected (builtin declares
+  nothing reserved).
+- **`packages/markspec/core/mod.ts`** — export only what main.ts / LSP need
+  (expected: nothing beyond existing types; confirm during implementation).
+
+## 8. Out of scope (explicit — separate later slices)
+
+- §7.1 display-ID pattern bindings (`REQ-`/`TST-`/`ICD-`/`REC-`/`RSK-`,
+  `enforcement: warn`) — blocked on a core-type-binding schema construct.
+- RFC 2119 / RFC 8174 hygiene diagnostic `MSL-M061`.
+- Glossary `{{def.<slug>}}` prose resolution bound to core `Definition`.
+- Hygiene-rule restatement at the profile layer.
+- Optional front-matter keys `normative-language` / `glossary-scope`.
+
+## 9. Error handling & edge cases
+
+- The builtin resolver performs no I/O and cannot fail at runtime. A malformed
+  embedded constant is caught by **its own unit test**, never a user path.
+- `default-profile:` non-boolean → a `.markspec.yaml` diagnostic on the same
+  channel as a malformed `profiles:`, `chain: null`, non-zero exit. Fail loud;
+  no silent fallback.
+- `loadChain` cycle/depth guards already cover the spliced root; the builtin has
+  no `extends:` so the walk always terminates.
+- A user profile that _explicitly_ `extends:` an npm `@markspec/profile-default`
+  still resolves via the existing npm path — we do not hijack that specifier; we
+  only **splice** the builtin when there is no explicit parent.
+
+## 10. Testing
+
+- **Unit** —
+  - `default_profile_test.ts`: the embedded constant parses with zero error
+    diagnostics and no `PROFILE-SCHEMA-002`.
+  - `chain_test.ts`: builtin splice for the six §6 matrix rows (including
+    builtin-only, builtin+leaf, builtin spliced under a multi-tier chain,
+    opt-out suppresses splice, no double-injection when leaf already extends a
+    real parent that itself has no parent).
+  - `markspec_test.ts`: `default-profile:` parsing — `true`, `false`, absent
+    (defaults true), non-boolean (diagnostic).
+- **E2E** — `validate` / `profile show` / `doctor` with no `.markspec.yaml` show
+  the default tier; with `default-profile: false` they are core-only; a
+  `profile show` snapshot includes `@markspec/profile-default` as tier 0.
+- **Fixture / snapshot churn (expected, called out)** —
+  - `strawman_test.ts` drops its local-default rewrite scaffold; the chain
+    auto-includes the builtin. Assertions adjust (chain still resolves,
+    `tiers[0].id === "@markspec/profile-default"`, two tiers).
+  - Any `profile show` / `doctor` snapshot gains the default tier.
+
+## 11. Breaking changes & policy
+
+Per `project_no_migration_until_1_0` (no back-compat shims pre-1.0): in-repo
+manifests are changed, not given a compatibility resolver.
+
+- **`docs/examples/profiles/aspice-swe-mini/markspec.yaml`** — remove
+  `extends: "npm:@markspec/profile-default@^1.0"`. The builtin is now the
+  implicit root; the strawman still forms a two-tier chain (builtin →
+  aspice-swe-mini). This is the demonstration of the fix.
+- `packages/markspec/core/config/markspec_test.ts` npm-specifier-**parsing**
+  tests stay (npm specifier syntax remains valid; they assert parsing, not the
+  default mechanism).
+- Documentation follow-ups (out of code scope, noted here): ADR-008,
+  profile-schema prose, and `skills/markspec-*profile-bundle*` still show
+  `extends: npm:@markspec/profile-default` as the idiom — flag for a later docs
+  pass.
+- Add a one-line status note to ADR-010 / profile-schema §7 recording that the
+  mechanism shipped and that §7.1 bindings / RFC 2119 / glossary remain
+  deferred.
+
+## 12. Acceptance criteria
+
+- [ ] No `.markspec.yaml` → active chain is `[@markspec/profile-default]` (not
+      core-only).
+- [ ] `default-profile: false` (+ empty/absent `profiles:`) → core-only, no
+      synthetic tier, behaviour identical to today.
+- [ ] `profiles: [P]` with no `extends:` in `P` → chain
+      `[@markspec/profile-default, P]`.
+- [ ] `default-profile:` accepts only a boolean; any other value emits a
+      `.markspec.yaml` diagnostic and yields `chain: null`.
+- [ ] `markspec profile add` preserves an existing `default-profile:` key on
+      round-trip.
+- [ ] The embedded manifest parses with zero error diagnostics and no
+      `PROFILE-SCHEMA-002`.
+- [ ] `aspice-swe-mini` strawman resolves with the explicit `extends:` removed;
+      `strawman_test.ts` no longer needs the local-default rewrite.
+- [ ] `just build` (lint + test + typecheck + compile) passes;
+      `deno fmt --check` and `dprint check` pass.
+- [ ] Production code added to `core/` uses no `Deno.*` APIs (Node-compat rule).

--- a/packages/markspec/cli/commands/doctor.ts
+++ b/packages/markspec/cli/commands/doctor.ts
@@ -23,6 +23,9 @@ export const doctorCmd = new Command()
       { severity: string; code: string; message: string }
     > = [];
 
+    const leaf = chain ? chain.tiers[chain.tiers.length - 1] : null;
+    const tierCount = chain ? chain.tiers.length : 0;
+
     if (options.format === "json") {
       const output = {
         project: {
@@ -30,11 +33,11 @@ export const doctorCmd = new Command()
           version: config.version,
           root: projectRoot,
         },
-        profile: chain
+        profile: leaf
           ? {
-            id: chain.tiers[0].id,
-            version: chain.tiers[0].version,
-            tiers: chain.tiers.length,
+            id: leaf.id,
+            version: leaf.version,
+            tiers: tierCount,
           }
           : null,
         diagnostics,
@@ -43,11 +46,9 @@ export const doctorCmd = new Command()
     } else {
       console.error(`Project: ${config.name} (${config.version})`);
       console.error(`Root: ${projectRoot}`);
-      if (chain) {
+      if (leaf) {
         console.error(
-          `Profile: ${chain.tiers[0].id}@${
-            chain.tiers[0].version
-          } (${chain.tiers.length} tier(s))`,
+          `Profile: ${leaf.id}@${leaf.version} (${tierCount} tier(s))`,
         );
       } else {
         console.error("Profile: no profile configured");

--- a/packages/markspec/cli/commands/profile.ts
+++ b/packages/markspec/cli/commands/profile.ts
@@ -32,10 +32,15 @@ export const profileCmd = new Command()
       if (!chain) {
         console.error("no profile configured for this project");
       } else {
-        const active = overview.tiers[0];
+        const active = overview.tiers[overview.tiers.length - 1];
         console.log(`Active profile: ${active.id}@${active.version}`);
         if (active.summary && active.summary !== active.id) {
           console.log(active.summary);
+        }
+        if (overview.tiers.length > 1) {
+          console.log(
+            `Profile chain: ${overview.tiers.map((t) => t.id).join(" → ")}`,
+          );
         }
         console.log("");
 

--- a/packages/markspec/core/config/markspec.ts
+++ b/packages/markspec/core/config/markspec.ts
@@ -39,6 +39,11 @@ export async function readMarkspecYaml(
 /** The parsed content of a `.markspec.yaml`. */
 export interface MarkspecYaml {
   readonly profiles: readonly ProfileSpecifier[];
+  /**
+   * Opt out of the bundled default profile when explicitly `false`.
+   * `undefined` (key absent) means the default is active.
+   */
+  readonly defaultProfile?: boolean;
 }
 
 /** Result of parsing a `.markspec.yaml` string. */
@@ -47,7 +52,7 @@ export interface ParseMarkspecYamlResult {
   readonly diagnostics: readonly Diagnostic[];
 }
 
-const ALLOWED_MARKSPEC_YAML_KEYS = new Set(["profiles"]);
+const ALLOWED_MARKSPEC_YAML_KEYS = new Set(["profiles", "default-profile"]);
 
 /**
  * Parse and validate a `.markspec.yaml` string.
@@ -130,13 +135,29 @@ export function parseMarkspecYaml(
     }
   }
 
+  // default-profile: optional boolean opt-out for the bundled default.
+  let defaultProfile: boolean | undefined;
+  const rawDefaultProfile = root["default-profile"];
+  if (rawDefaultProfile !== undefined) {
+    if (typeof rawDefaultProfile !== "boolean") {
+      diagnostics.push({
+        code: "MARKSPEC-YAML-003",
+        severity: "error",
+        message: ".markspec.yaml: 'default-profile' must be a boolean",
+        location: { file: sourcePath, line: 1, column: 1 },
+      });
+      return { config: null, diagnostics };
+    }
+    defaultProfile = rawDefaultProfile;
+  }
+
   // If any specifier failed to parse, treat the whole file as invalid.
   const hasErrors = diagnostics.some((d) => d.severity === "error");
   if (hasErrors) {
     return { config: null, diagnostics };
   }
 
-  return { config: { profiles }, diagnostics };
+  return { config: { profiles, defaultProfile }, diagnostics };
 }
 
 /**

--- a/packages/markspec/core/config/markspec_test.ts
+++ b/packages/markspec/core/config/markspec_test.ts
@@ -250,3 +250,57 @@ Deno.test("addProfileSpecifier: adds profiles key when missing", async () => {
   assertStringIncludes(written, "profiles:");
   assertStringIncludes(written, "./my-profile");
 });
+
+Deno.test("parseMarkspecYaml: default-profile false parsed", () => {
+  const result = parseMarkspecYaml(
+    "profiles: []\ndefault-profile: false\n",
+    "/p/.markspec.yaml",
+  );
+  assertExists(result.config);
+  assertEquals(result.config.defaultProfile, false);
+  assertEquals(result.diagnostics, []);
+});
+
+Deno.test("parseMarkspecYaml: default-profile true parsed", () => {
+  const result = parseMarkspecYaml(
+    "default-profile: true\n",
+    "/p/.markspec.yaml",
+  );
+  assertExists(result.config);
+  assertEquals(result.config.defaultProfile, true);
+});
+
+Deno.test("parseMarkspecYaml: default-profile absent leaves field undefined", () => {
+  const result = parseMarkspecYaml(
+    "profiles:\n  - ./profiles/x\n",
+    "/p/.markspec.yaml",
+  );
+  assertExists(result.config);
+  assertEquals(result.config.defaultProfile, undefined);
+});
+
+Deno.test("parseMarkspecYaml: non-boolean default-profile emits MARKSPEC-YAML-003", () => {
+  const result = parseMarkspecYaml(
+    'default-profile: "no"\n',
+    "/p/.markspec.yaml",
+  );
+  assertEquals(result.config, null);
+  assertEquals(result.diagnostics[0].code, "MARKSPEC-YAML-003");
+});
+
+Deno.test("addProfileSpecifier: preserves an existing default-profile key", async () => {
+  const store: Record<string, string> = {
+    "/p/.markspec.yaml": "default-profile: false\nprofiles:\n  - ./a\n",
+  };
+  await addProfileSpecifier(
+    "./b",
+    (path: string) => Promise.resolve(store[path]),
+    (path: string, content: string) => {
+      store[path] = content;
+      return Promise.resolve();
+    },
+    "/p",
+  );
+  assertStringIncludes(store["/p/.markspec.yaml"], "default-profile: false");
+  assertStringIncludes(store["/p/.markspec.yaml"], '- "./b"');
+});

--- a/packages/markspec/core/model/profile.ts
+++ b/packages/markspec/core/model/profile.ts
@@ -159,7 +159,8 @@ export type ProfileSpecifier =
     readonly scope?: string;
     readonly name: string;
     readonly range: string;
-  };
+  }
+  | { readonly kind: "builtin" };
 
 /** Parsed `markspec.yaml` content — the manifest authored in a profile. */
 export interface ProfileManifest {

--- a/packages/markspec/core/profile/chain.ts
+++ b/packages/markspec/core/profile/chain.ts
@@ -25,6 +25,11 @@ import type { AppendFile, RunGit } from "./git-cache.ts";
 import { parseManifest } from "./manifest.ts";
 import { mergeChain } from "./merge.ts";
 import {
+  BUILTIN_DEFAULT_SOURCE_PATH,
+  BUILTIN_DEFAULT_SPECIFIER,
+  DEFAULT_PROFILE_MANIFEST,
+} from "./default_profile.ts";
+import {
   type ResolvedProfileSource,
   resolveGitSpecifier,
   resolveLocalSpecifier,
@@ -43,6 +48,14 @@ export interface LoadChainResult {
 export interface LoadChainOptions {
   readonly runGit?: RunGit;
   readonly appendFile?: AppendFile;
+  /**
+   * When true, the bundled default profile is spliced as the implicit
+   * root of the chain (the ultimate `extends:` parent of any tier that
+   * declares none). Default false — only `loadProfileForCommand` enables
+   * it, so direct `loadChain` callers (e.g. `profile add` validation)
+   * keep core-only behaviour.
+   */
+  readonly bundledDefault?: boolean;
 }
 
 /**
@@ -121,17 +134,11 @@ export async function loadChain(
         },
       );
     } else if (cursorSpec.kind === "builtin") {
-      // Explicit branch so a builtin specifier returns a clear diagnostic
-      // instead of falling through to the local-path resolver (which would
-      // emit a confusing "no markspec.yaml" error). Replaced by the real
-      // embedded-manifest resolver in a later task.
-      diagnostics.push({
-        code: "PROFILE-LOAD-007",
-        severity: "error",
-        message: "builtin default-profile resolver not yet implemented",
-        location: { file: "<specifier>", line: 1, column: 1 },
-      });
-      return { chain: null, diagnostics };
+      resolved = {
+        rawYaml: DEFAULT_PROFILE_MANIFEST,
+        sourcePath: BUILTIN_DEFAULT_SOURCE_PATH,
+        baseDir: BUILTIN_DEFAULT_SOURCE_PATH,
+      };
     } else {
       resolved = await resolveLocalSpecifier(
         cursorSpec,
@@ -160,9 +167,14 @@ export async function loadChain(
     };
     tiersLeafFirst.push(tier);
 
-    // Advance cursor to the parent, if any.
+    // Advance cursor to the parent, if any. When the tier declares no
+    // explicit parent, splice the bundled default as the implicit root
+    // (once — never below the builtin itself).
     if (parsed.manifest.extends !== undefined) {
       cursorSpec = parsed.manifest.extends;
+      cursorDir = resolved.baseDir;
+    } else if (opts.bundledDefault && cursorSpec.kind !== "builtin") {
+      cursorSpec = BUILTIN_DEFAULT_SPECIFIER;
       cursorDir = resolved.baseDir;
     } else {
       cursorSpec = undefined;

--- a/packages/markspec/core/profile/chain.ts
+++ b/packages/markspec/core/profile/chain.ts
@@ -120,6 +120,18 @@ export async function loadChain(
           readFile,
         },
       );
+    } else if (cursorSpec.kind === "builtin") {
+      // Explicit branch so a builtin specifier returns a clear diagnostic
+      // instead of falling through to the local-path resolver (which would
+      // emit a confusing "no markspec.yaml" error). Replaced by the real
+      // embedded-manifest resolver in a later task.
+      diagnostics.push({
+        code: "PROFILE-LOAD-007",
+        severity: "error",
+        message: "builtin default-profile resolver not yet implemented",
+        location: { file: "<specifier>", line: 1, column: 1 },
+      });
+      return { chain: null, diagnostics };
     } else {
       resolved = await resolveLocalSpecifier(
         cursorSpec,
@@ -208,6 +220,9 @@ function specifierKey(
     const pkg = spec.scope ? `${spec.scope}/${spec.name}` : spec.name;
     return `npm:${pkg}@${spec.range}`;
   }
+  if (spec.kind === "builtin") {
+    return "builtin:@markspec/profile-default";
+  }
   const _exhaustive: never = spec;
   throw new Error(`Unknown specifier kind`);
 }
@@ -223,6 +238,9 @@ function stringifySpec(spec: ProfileSpecifier): string {
   if (spec.kind === "npm") {
     const pkg = spec.scope ? `${spec.scope}/${spec.name}` : spec.name;
     return `npm:${pkg}@${spec.range}`;
+  }
+  if (spec.kind === "builtin") {
+    return "@markspec/profile-default (bundled)";
   }
   const _exhaustive: never = spec;
   throw new Error(`Unknown specifier kind`);

--- a/packages/markspec/core/profile/chain_test.ts
+++ b/packages/markspec/core/profile/chain_test.ts
@@ -8,6 +8,7 @@ import { assertEquals } from "@std/assert";
 import { loadChain } from "./chain.ts";
 import type { RunGit } from "./git-cache.ts";
 import { computeCacheLocation } from "./git-cache.ts";
+import { BUILTIN_DEFAULT_SPECIFIER } from "./default_profile.ts";
 
 function mockReadFile(map: Record<string, string>) {
   return (path: string): Promise<string | undefined> =>
@@ -263,4 +264,72 @@ Deno.test("loadChain: git clone failure propagates PROFILE-LOAD-001", async () =
 
   assertEquals(result.chain, null);
   assertEquals(result.diagnostics[0].code, "PROFILE-LOAD-001");
+});
+
+Deno.test("loadChain: bundledDefault splices builtin as root of an extends-less leaf", async () => {
+  const result = await loadChain(
+    { kind: "local", path: "./profiles/custom" },
+    "/project",
+    "/project",
+    mockReadFile({
+      "/project/profiles/custom/markspec.yaml":
+        `id: "@acme/custom"\nversion: 1.0.0\nmarkspec-schema: "1"\n`,
+    }),
+    { bundledDefault: true },
+  );
+  assertEquals(result.diagnostics, []);
+  assertEquals(result.chain?.tiers.length, 2);
+  assertEquals(result.chain?.tiers[0].id, "@markspec/profile-default");
+  assertEquals(result.chain?.tiers[1].id, "@acme/custom");
+});
+
+Deno.test("loadChain: bundledDefault disabled does not splice", async () => {
+  const result = await loadChain(
+    { kind: "local", path: "./profiles/custom" },
+    "/project",
+    "/project",
+    mockReadFile({
+      "/project/profiles/custom/markspec.yaml":
+        `id: "@acme/custom"\nversion: 1.0.0\nmarkspec-schema: "1"\n`,
+    }),
+    { bundledDefault: false },
+  );
+  assertEquals(result.chain?.tiers.length, 1);
+  assertEquals(result.chain?.tiers[0].id, "@acme/custom");
+});
+
+Deno.test("loadChain: builtin leaf with bundledDefault yields exactly one tier (no self-splice)", async () => {
+  const result = await loadChain(
+    BUILTIN_DEFAULT_SPECIFIER,
+    "/project",
+    "/project",
+    mockReadFile({}),
+    { bundledDefault: true },
+  );
+  assertEquals(
+    result.diagnostics.filter((d) => d.severity === "error"),
+    [],
+  );
+  assertEquals(result.chain?.tiers.length, 1);
+  assertEquals(result.chain?.tiers[0].id, "@markspec/profile-default");
+});
+
+Deno.test("loadChain: builtin spliced below a multi-tier local chain", async () => {
+  const result = await loadChain(
+    { kind: "local", path: "./profiles/leaf" },
+    "/project",
+    "/project",
+    mockReadFile({
+      "/project/profiles/leaf/markspec.yaml":
+        `id: "@acme/leaf"\nversion: 1.0.0\nmarkspec-schema: "1"\nextends: "../root"\n`,
+      "/project/profiles/root/markspec.yaml":
+        `id: "@acme/root"\nversion: 1.0.0\nmarkspec-schema: "1"\n`,
+    }),
+    { bundledDefault: true },
+  );
+  assertEquals(result.diagnostics, []);
+  assertEquals(result.chain?.tiers.length, 3);
+  assertEquals(result.chain?.tiers[0].id, "@markspec/profile-default");
+  assertEquals(result.chain?.tiers[1].id, "@acme/root");
+  assertEquals(result.chain?.tiers[2].id, "@acme/leaf");
 });

--- a/packages/markspec/core/profile/default_profile.ts
+++ b/packages/markspec/core/profile/default_profile.ts
@@ -1,0 +1,49 @@
+/**
+ * @module core/profile/default_profile
+ *
+ * The bundled default profile (profile-schema §7 / §2.2). It ships as an
+ * embedded string constant — never a file on disk — so it survives
+ * `deno compile` and runs under Node without I/O. It is auto-registered as
+ * the implicit root of the `extends:` chain unless `default-profile: false`
+ * is set in `.markspec.yaml`.
+ *
+ * Scope (mechanism only): a minimal identity profile — stable id + the
+ * default colour roles, no types, no rules. The profile-schema §7.1
+ * display-ID pattern bindings, RFC 2119 hygiene, and `{{def.}}` glossary
+ * are deferred (they need a core-type-binding schema construct).
+ */
+
+import type { ProfileSpecifier } from "../model/mod.ts";
+
+/** Specifier that resolves to the embedded default profile. */
+export const BUILTIN_DEFAULT_SPECIFIER: ProfileSpecifier = { kind: "builtin" };
+
+/**
+ * Synthetic source path used for the embedded manifest in diagnostics and
+ * tier bookkeeping. Not a real filesystem path.
+ */
+export const BUILTIN_DEFAULT_SOURCE_PATH =
+  "<bundled:@markspec/profile-default>";
+
+/** The embedded default-profile manifest, authored as YAML. */
+export const DEFAULT_PROFILE_MANIFEST = `id: "@markspec/profile-default"
+version: 1.0.0
+markspec-schema: "1"
+description: Baseline MarkSpec profile
+license: MIT
+profile:
+  attributes: []
+  labels: []
+  colors:
+    primary: blue
+    secondary: teal
+    tertiary: cyan
+    accent: purple
+    muted: grey
+    warning: orange
+    danger: red
+  types: {}
+  documents:
+    types: []
+    frontMatter: []
+`;

--- a/packages/markspec/core/profile/default_profile_test.ts
+++ b/packages/markspec/core/profile/default_profile_test.ts
@@ -1,0 +1,50 @@
+/**
+ * @module core/profile/default_profile_test
+ *
+ * The embedded default-profile manifest must parse and merge cleanly as a
+ * lone tier — it ships in the binary and a malformed constant would break
+ * every project that does not opt out.
+ */
+
+import { assertEquals, assertExists } from "@std/assert";
+import {
+  BUILTIN_DEFAULT_SOURCE_PATH,
+  DEFAULT_PROFILE_MANIFEST,
+} from "./default_profile.ts";
+import { parseManifest } from "./manifest.ts";
+import { loadChain } from "./chain.ts";
+import { BUILTIN_DEFAULT_SPECIFIER } from "./default_profile.ts";
+
+Deno.test("default profile manifest parses with zero error diagnostics", () => {
+  const result = parseManifest(
+    DEFAULT_PROFILE_MANIFEST,
+    BUILTIN_DEFAULT_SOURCE_PATH,
+  );
+  assertExists(result.manifest);
+  assertEquals(result.manifest.id, "@markspec/profile-default");
+  const errors = result.diagnostics.filter((d) => d.severity === "error");
+  assertEquals(errors, []);
+  const schemaMiss = result.diagnostics.filter((d) =>
+    d.code === "PROFILE-SCHEMA-002"
+  );
+  assertEquals(schemaMiss, []);
+});
+
+Deno.test("builtin specifier resolves to a lone one-tier chain", async () => {
+  const readFile = (): Promise<string | undefined> =>
+    Promise.resolve(undefined);
+  const result = await loadChain(
+    BUILTIN_DEFAULT_SPECIFIER,
+    "/project",
+    "/project",
+    readFile,
+    { bundledDefault: true },
+  );
+  assertEquals(
+    result.diagnostics.filter((d) => d.severity === "error"),
+    [],
+  );
+  assertExists(result.chain);
+  assertEquals(result.chain.tiers.length, 1);
+  assertEquals(result.chain.tiers[0].id, "@markspec/profile-default");
+});

--- a/packages/markspec/core/profile/load.ts
+++ b/packages/markspec/core/profile/load.ts
@@ -17,6 +17,7 @@ import type { ReadFile } from "../config/mod.ts";
 import type { Diagnostic, ProfileChain } from "../model/mod.ts";
 import { CORE_TYPES } from "../model/mod.ts";
 import { loadChain } from "./chain.ts";
+import { BUILTIN_DEFAULT_SPECIFIER } from "./default_profile.ts";
 
 /** Result of `loadProfileForCommand`. */
 export interface LoadProfileForCommandResult {
@@ -30,7 +31,9 @@ export interface LoadProfileForCommandResult {
  * Load the active profile chain for the project at `projectRoot`.
  *
  * Discovery: looks for `.markspec.yaml` at the project root (sibling of
- * `project.yaml`). Absent or empty → `chain: null` (core-only mode).
+ * `project.yaml`). Absent or empty → the bundled default profile is the
+ * sole chain tier, unless `.markspec.yaml` sets `default-profile: false`
+ * (then `chain: null`, core-only mode).
  *
  * v1 constraint: at most **one** content-bearing profile per project. Two or
  * more entries in `profiles:` produces `PROFILE-LOAD-006` and no chain.
@@ -43,7 +46,8 @@ export async function loadProfileForCommand(
 
   const rawYaml = await readMarkspecYaml(projectRoot, readFile);
   if (rawYaml === null) {
-    return { chain: null, diagnostics };
+    // No .markspec.yaml — the default is active (no file to opt out in).
+    return await loadBuiltinOnlyChain(projectRoot, readFile, diagnostics);
   }
 
   const sourcePath = join(projectRoot, MARKSPEC_YAML_FILENAME);
@@ -53,9 +57,12 @@ export async function loadProfileForCommand(
     return { chain: null, diagnostics };
   }
 
-  const { profiles } = parsed.config;
+  const { profiles, defaultProfile } = parsed.config;
+  const bundledDefault = defaultProfile !== false;
   if (profiles.length === 0) {
-    return { chain: null, diagnostics };
+    return bundledDefault
+      ? await loadBuiltinOnlyChain(projectRoot, readFile, diagnostics)
+      : { chain: null, diagnostics };
   }
 
   if (profiles.length > 1) {
@@ -74,10 +81,34 @@ export async function loadProfileForCommand(
     projectRoot,
     projectRoot,
     readFile,
+    { bundledDefault },
   );
   diagnostics.push(...chainResult.diagnostics);
 
   // MSL-A040 — profile must not redefine reserved core keys / types.
+  if (chainResult.chain) {
+    diagnostics.push(...checkReservedRedefinitions(chainResult.chain));
+  }
+  return { chain: chainResult.chain, diagnostics };
+}
+
+/**
+ * Build a chain containing only the bundled default profile. Used when no
+ * project profile is declared but the default is not opted out.
+ */
+async function loadBuiltinOnlyChain(
+  projectRoot: string,
+  readFile: ReadFile,
+  diagnostics: Diagnostic[],
+): Promise<LoadProfileForCommandResult> {
+  const chainResult = await loadChain(
+    BUILTIN_DEFAULT_SPECIFIER,
+    projectRoot,
+    projectRoot,
+    readFile,
+    { bundledDefault: true },
+  );
+  diagnostics.push(...chainResult.diagnostics);
   if (chainResult.chain) {
     diagnostics.push(...checkReservedRedefinitions(chainResult.chain));
   }

--- a/packages/markspec/core/profile/load_test.ts
+++ b/packages/markspec/core/profile/load_test.ts
@@ -12,22 +12,39 @@ function mockReadFile(map: Record<string, string>) {
     Promise.resolve(map[path]);
 }
 
-Deno.test("loadProfileForCommand: no .markspec.yaml returns null chain", async () => {
+Deno.test("loadProfileForCommand: no .markspec.yaml yields the bundled default chain", async () => {
   const result = await loadProfileForCommand("/project", mockReadFile({}));
-  assertEquals(result.chain, null);
-  assertEquals(result.diagnostics, []);
+  // Filter to errors: a builtin-only chain routes through mergeChain,
+  // which may legitimately emit non-error (info/warning) diagnostics.
+  assertEquals(
+    result.diagnostics.filter((d) => d.severity === "error"),
+    [],
+  );
+  assertEquals(result.chain?.tiers.length, 1);
+  assertEquals(result.chain?.tiers[0].id, "@markspec/profile-default");
 });
 
-Deno.test("loadProfileForCommand: empty profiles list returns null chain", async () => {
+Deno.test("loadProfileForCommand: empty profiles list yields the bundled default chain", async () => {
   const result = await loadProfileForCommand(
     "/project",
     mockReadFile({ "/project/.markspec.yaml": "profiles: []\n" }),
+  );
+  assertEquals(result.chain?.tiers.length, 1);
+  assertEquals(result.chain?.tiers[0].id, "@markspec/profile-default");
+});
+
+Deno.test("loadProfileForCommand: default-profile false yields core-only (null chain)", async () => {
+  const result = await loadProfileForCommand(
+    "/project",
+    mockReadFile({
+      "/project/.markspec.yaml": "profiles: []\ndefault-profile: false\n",
+    }),
   );
   assertEquals(result.chain, null);
   assertEquals(result.diagnostics, []);
 });
 
-Deno.test("loadProfileForCommand: single local profile loads end-to-end", async () => {
+Deno.test("loadProfileForCommand: single local profile is spliced onto the bundled default", async () => {
   const result = await loadProfileForCommand(
     "/project",
     mockReadFile({
@@ -37,8 +54,40 @@ Deno.test("loadProfileForCommand: single local profile loads end-to-end", async 
     }),
   );
   assertEquals(result.diagnostics, []);
+  assertEquals(result.chain?.tiers.length, 2);
+  assertEquals(result.chain?.tiers[0].id, "@markspec/profile-default");
+  assertEquals(result.chain?.tiers[1].id, "@acme/custom");
+});
+
+Deno.test("loadProfileForCommand: default-profile false keeps a single-tier chain", async () => {
+  const result = await loadProfileForCommand(
+    "/project",
+    mockReadFile({
+      "/project/.markspec.yaml":
+        `default-profile: false\nprofiles:\n  - ./profiles/custom\n`,
+      "/project/profiles/custom/markspec.yaml":
+        `id: "@acme/custom"\nversion: 1.0.0\nmarkspec-schema: "1"\n`,
+    }),
+  );
+  assertEquals(result.diagnostics, []);
   assertEquals(result.chain?.tiers.length, 1);
   assertEquals(result.chain?.tiers[0].id, "@acme/custom");
+});
+
+Deno.test("loadProfileForCommand: explicit default-profile true still splices the bundled default", async () => {
+  const result = await loadProfileForCommand(
+    "/project",
+    mockReadFile({
+      "/project/.markspec.yaml":
+        `default-profile: true\nprofiles:\n  - ./profiles/custom\n`,
+      "/project/profiles/custom/markspec.yaml":
+        `id: "@acme/custom"\nversion: 1.0.0\nmarkspec-schema: "1"\n`,
+    }),
+  );
+  assertEquals(result.diagnostics, []);
+  assertEquals(result.chain?.tiers.length, 2);
+  assertEquals(result.chain?.tiers[0].id, "@markspec/profile-default");
+  assertEquals(result.chain?.tiers[1].id, "@acme/custom");
 });
 
 Deno.test("loadProfileForCommand: multiple profiles emits PROFILE-LOAD-006", async () => {
@@ -75,11 +124,15 @@ Deno.test("loadProfileForCommand: unknown key warning does not block loading", a
         `id: "@acme/custom"\nversion: 1.0.0\nmarkspec-schema: "1"\n`,
     }),
   );
-  // Loading succeeded despite the warning
-  assertEquals(result.chain?.tiers.length, 1);
-  assertEquals(result.diagnostics.length, 1);
-  assertEquals(result.diagnostics[0].code, "MARKSPEC-YAML-001");
-  assertEquals(result.diagnostics[0].severity, "warning");
+  // Loading succeeded despite the warning; builtin spliced as root.
+  assertEquals(result.chain?.tiers.length, 2);
+  assertEquals(result.chain?.tiers[0].id, "@markspec/profile-default");
+  assertEquals(result.chain?.tiers[1].id, "@acme/custom");
+  const warnings = result.diagnostics.filter((d) =>
+    d.code === "MARKSPEC-YAML-001"
+  );
+  assertEquals(warnings.length, 1);
+  assertEquals(warnings[0].severity, "warning");
 });
 
 Deno.test("loadProfileForCommand: profile load errors propagate", async () => {

--- a/packages/markspec/core/profile/strawman_test.ts
+++ b/packages/markspec/core/profile/strawman_test.ts
@@ -25,44 +25,21 @@ const PROFILES_DIR = resolve(
 );
 
 /**
- * The strawman uses `extends: npm:@markspec/profile-default@^1.0`.
- * For testing, we create a modified version that extends the local default.
+ * The strawman declares no `extends:`. The bundled default profile is
+ * auto-spliced as the implicit root when `bundledDefault: true`, exactly
+ * as `loadProfileForCommand` does for real projects.
  */
 async function loadStrawmanChain(): Promise<{
   chain: ProfileChain | null;
   diagnostics: readonly { severity: string; code: string; message: string }[];
 }> {
-  const originalPath = resolve(PROFILES_DIR, "aspice-swe-mini/markspec.yaml");
-  const original = await Deno.readTextFile(originalPath);
-  const rewritten = original.replace(
-    /extends:.*$/m,
-    'extends: "../default"',
-  );
-
-  const tmpDir = await Deno.makeTempDir({ prefix: "markspec-strawman-" });
-  const profileDir = `${tmpDir}/aspice-swe-mini`;
-  const defaultDir = `${tmpDir}/default`;
-
-  await Deno.mkdir(profileDir, { recursive: true });
-  await Deno.mkdir(defaultDir, { recursive: true });
-
-  await Deno.writeTextFile(`${profileDir}/markspec.yaml`, rewritten);
-
-  const defaultManifest = await Deno.readTextFile(
-    resolve(PROFILES_DIR, "default/markspec.yaml"),
-  );
-  await Deno.writeTextFile(`${defaultDir}/markspec.yaml`, defaultManifest);
-
   const specifier: ProfileSpecifier = {
     kind: "local",
     path: "./aspice-swe-mini",
   };
-
-  try {
-    return await loadChain(specifier, tmpDir, tmpDir, readFile);
-  } finally {
-    await Deno.remove(tmpDir, { recursive: true }).catch(() => {});
-  }
+  return await loadChain(specifier, PROFILES_DIR, PROFILES_DIR, readFile, {
+    bundledDefault: true,
+  });
 }
 
 Deno.test("strawman: chain resolves with 2 tiers", async () => {
@@ -127,6 +104,12 @@ Deno.test("strawman: per-type color resolves through merged colors map", async (
   assertExists(result.chain);
   const types = result.chain.effective.types;
   const colors = result.chain.effective.colors;
+
+  // The colour-role → hue values (primary=blue, …) originate from the
+  // bundled default profile (the root tier). These lines confirm the
+  // merge pipeline propagates them into the effective colours map. The
+  // per-type `color.value` assertions below are the meaningful cross-tier
+  // checks: the role name comes from the strawman, its hue from the default.
 
   // Default profile colors are inherited.
   assertEquals(colors.get("primary")?.value, "blue");

--- a/packages/markspec/mcp/resources/profile.ts
+++ b/packages/markspec/mcp/resources/profile.ts
@@ -39,14 +39,15 @@ export function renderProfile(intro: ProfileIntrospection): string {
     return lines.join("\n") + "\n";
   }
 
-  const active = overview.tiers[0];
+  const active = overview.tiers[overview.tiers.length - 1];
   lines.push(`**Active**: ${active.id}@${active.version}`);
   if (active.summary) {
     lines.push("", active.summary);
   }
   if (overview.tiers.length > 1) {
-    const inherits = overview.tiers.slice(1).map((t) => `${t.id}@${t.version}`)
-      .join(", ");
+    const inherits = overview.tiers.slice(0, -1).map((t) =>
+      `${t.id}@${t.version}`
+    ).join(", ");
     lines.push(`**Inherits**: ${inherits}`);
   }
   lines.push("");

--- a/packages/markspec/mcp/resources/profile_test.ts
+++ b/packages/markspec/mcp/resources/profile_test.ts
@@ -93,6 +93,53 @@ profile:
   assertStringIncludes(text, "Lowest ASIL");
 });
 
+Deno.test("renderProfile: two-tier chain shows leaf as Active and root under Inherits", () => {
+  // Build root tier (the bundled default)
+  const rootResult = parseManifest(
+    `id: "@markspec/profile-default"\nversion: 1.0.0\nmarkspec-schema: "1"\nprofile:\n  types: {}\n`,
+    "<root>",
+  );
+  if (!rootResult.manifest) throw new Error("root parse failed");
+  const rootTier: LoadedProfile = {
+    id: rootResult.manifest.id,
+    version: rootResult.manifest.version,
+    specifier: { kind: "local", path: "./root" },
+    manifest: rootResult.manifest,
+    sourcePath: "<root>",
+    baseDir: "/tmp",
+  };
+
+  // Build leaf tier (the user's own profile)
+  const leafResult = parseManifest(
+    `id: "@acme/leaf"\nversion: 0.1.0\nmarkspec-schema: "1"\nprofile:\n  types: {}\n`,
+    "<leaf>",
+  );
+  if (!leafResult.manifest) throw new Error("leaf parse failed");
+  const leafTier: LoadedProfile = {
+    id: leafResult.manifest.id,
+    version: leafResult.manifest.version,
+    specifier: { kind: "local", path: "./leaf" },
+    manifest: leafResult.manifest,
+    sourcePath: "<leaf>",
+    baseDir: "/tmp",
+  };
+
+  const twoTierChain: ProfileChain = {
+    tiers: [rootTier, leafTier],
+    // deno-lint-ignore no-explicit-any
+    effective: null as any,
+  };
+  const merge = mergeChain(twoTierChain);
+  const chain: ProfileChain = {
+    tiers: [rootTier, leafTier],
+    effective: merge.effective!,
+  };
+
+  const text = renderProfile(buildProfileIntrospection(chain));
+  assertStringIncludes(text, "**Active**: @acme/leaf@0.1.0");
+  assertStringIncludes(text, "**Inherits**: @markspec/profile-default@1.0.0");
+});
+
 // Verify buildProfileView is a thin wrapper re-exporting buildProfileIntrospection.
 Deno.test("buildProfileView: wraps buildProfileIntrospection", () => {
   const chain = makeChain(`

--- a/packages/markspec/mcp/tools/mod.ts
+++ b/packages/markspec/mcp/tools/mod.ts
@@ -84,11 +84,11 @@ const HANDLERS: Record<string, ToolHandler> = {
       files,
       project.projectRoot ?? "",
     );
-    const profileLabel = project.profileChain
-      ? `${project.profileChain.tiers[0].id}@${
-        project.profileChain.tiers[0].version
-      }`
+    const leafTier = project.profileChain
+      ? project.profileChain
+        .tiers[project.profileChain.tiers.length - 1]
       : null;
+    const profileLabel = leafTier ? `${leafTier.id}@${leafTier.version}` : null;
     return renderDiagnosticsReport(
       filtered,
       profileLabel,

--- a/packages/markspec/mcp/tools/validate_test.ts
+++ b/packages/markspec/mcp/tools/validate_test.ts
@@ -5,8 +5,18 @@
  */
 
 import { assertEquals, assertStringIncludes } from "@std/assert";
-import type { Diagnostic } from "../../core/mod.ts";
+import { CallToolRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+import type { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { mergeChain, parseManifest } from "../../core/mod.ts";
+import type {
+  CompileResult,
+  Diagnostic,
+  ProfileChain,
+} from "../../core/mod.ts";
+import type { LoadedProfile } from "../../core/model/mod.ts";
+import type { Project } from "../project.ts";
 import { filterDiagnostics, renderDiagnosticsReport } from "./validate.ts";
+import { registerTools } from "./mod.ts";
 
 const ERR: Diagnostic = {
   code: "MSL-R004",
@@ -83,3 +93,115 @@ Deno.test("filterDiagnostics: absolute path match", () => {
   const out = filterDiagnostics([ERR], ["/proj/docs/req.md"], "/proj");
   assertStringIncludes(out.length.toString(), "1");
 });
+
+// ---------------------------------------------------------------------------
+// validate tool: profile label is the LEAF tier, not the bundled-default root
+// ---------------------------------------------------------------------------
+
+/** Build one chain tier from a manifest YAML, mirroring the makeChain
+ * helper in profile_describe_test.ts. */
+function makeTier(yaml: string): LoadedProfile {
+  const result = parseManifest(yaml, "<test>");
+  if (!result.manifest) throw new Error("parse failed");
+  return {
+    id: result.manifest.id,
+    version: result.manifest.version,
+    specifier: { kind: "local", path: "./test" },
+    manifest: result.manifest,
+    sourcePath: "<test>",
+    baseDir: "/tmp",
+  };
+}
+
+/** Assemble a multi-tier ProfileChain (root -> leaf) and merge it.
+ * mergeChain reads only `.tiers`; the placeholder effective is ignored. */
+function makeMultiTierChain(...tiers: LoadedProfile[]): ProfileChain {
+  // deno-lint-ignore no-explicit-any
+  const merge = mergeChain({ tiers, effective: null as any });
+  return { tiers, effective: merge.effective! };
+}
+
+const ROOT_DEFAULT_YAML = `
+id: "@markspec/profile-default"
+version: 1.0.0
+markspec-schema: "1"
+profile:
+  types:
+    requirement:
+      extends: Requirement
+      description: A baseline requirement
+`;
+
+const LEAF_ACME_YAML = `
+id: "@acme/leaf"
+version: 0.1.0
+markspec-schema: "1"
+profile:
+  types:
+    acme-requirement:
+      extends: Requirement
+      description: An ACME requirement
+`;
+
+/** Minimal CompileResult with no diagnostics -- produces the clean report
+ * path `OK All N entries pass validation under <profileLabel>.`. */
+function emptyCompileResult(): CompileResult {
+  return {
+    entries: new Map(),
+    links: [],
+    forward: new Map(),
+    reverse: new Map(),
+    documents: new Map(),
+    diagnostics: [],
+  };
+}
+
+/** Stub Project exposing only what the validate handler reads:
+ * `profileChain`, `projectRoot`, and `getCompiled()`. */
+function stubProject(profileChain: ProfileChain): Project {
+  return {
+    projectRoot: "/proj",
+    config: undefined,
+    profileChain,
+    profile: profileChain.effective,
+    getCompiled: () => Promise.resolve(emptyCompileResult()),
+    forceRefresh: () => Promise.resolve(emptyCompileResult()),
+    subscribeInvalidation: () => () => {},
+  };
+}
+
+/** Invoke the `validate` tool through registerTools + a Server stub that
+ * captures the tools/call handler, returning the rendered report text. */
+async function invokeValidate(project: Project): Promise<string> {
+  // deno-lint-ignore no-explicit-any
+  let callHandler: ((req: any) => Promise<any>) | undefined;
+  const serverStub = {
+    // deno-lint-ignore no-explicit-any
+    setRequestHandler(schema: unknown, handler: (req: any) => Promise<any>) {
+      if (schema === CallToolRequestSchema) callHandler = handler;
+    },
+  } as unknown as Server;
+  registerTools(serverStub, project);
+  if (!callHandler) throw new Error("tools/call handler not registered");
+  const res = await callHandler({
+    params: { name: "validate", arguments: {} },
+  });
+  return res.content[0].text as string;
+}
+
+Deno.test(
+  "validate tool: profile label is the leaf tier, not the bundled default root",
+  async () => {
+    const root = makeTier(ROOT_DEFAULT_YAML);
+    const leaf = makeTier(LEAF_ACME_YAML);
+    const chain = makeMultiTierChain(root, leaf);
+    // Sanity-check the chain is ordered root -> leaf as the loader produces.
+    assertEquals(chain.tiers[0].id, "@markspec/profile-default");
+    assertEquals(chain.tiers[chain.tiers.length - 1].id, "@acme/leaf");
+
+    const report = await invokeValidate(stubProject(chain));
+
+    assertStringIncludes(report, "under @acme/leaf@0.1.0");
+    assertEquals(report.includes("@markspec/profile-default"), false);
+  },
+);

--- a/tests/e2e/profile_doctor_test.ts
+++ b/tests/e2e/profile_doctor_test.ts
@@ -41,19 +41,30 @@ Deno.test("profile show: --format json outputs structured data", async () => {
   assertEquals(code, 0);
   const data = JSON.parse(stdout);
   assertEquals(Array.isArray(data.tiers), true);
-  assertEquals(data.tiers.length, 1);
-  assertEquals(data.tiers[0].id, "@acme/test");
-  assertEquals(data.tiers[0].version, "0.2.0");
+  assertEquals(data.tiers.length, 2);
+  assertEquals(data.tiers[data.tiers.length - 1].id, "@acme/test");
+  assertEquals(data.tiers[data.tiers.length - 1].version, "0.2.0");
 });
 
-Deno.test("profile show: no profile prints message", async () => {
+Deno.test("profile show: opted-out project prints no-profile message", async () => {
   const { code, stderr } = await markspec(["profile", "show"], {
+    files: {
+      "project.yaml": PROJECT_YAML,
+      ".markspec.yaml": "default-profile: false\n",
+    },
+  });
+  assertEquals(code, 0);
+  assertStringIncludes(stderr, "no profile");
+});
+
+Deno.test("profile show: bundled default shown when no .markspec.yaml", async () => {
+  const { code, stdout } = await markspec(["profile", "show"], {
     files: {
       "project.yaml": PROJECT_YAML,
     },
   });
   assertEquals(code, 0);
-  assertStringIncludes(stderr, "no profile");
+  assertStringIncludes(stdout, "@markspec/profile-default");
 });
 
 // ── doctor ───────────────────────────────────────────────────────────
@@ -85,7 +96,7 @@ Deno.test("doctor: --format json outputs structured data", async () => {
   assertEquals(data.project.version, "0.1.0");
   assertEquals(data.profile.id, "@acme/test");
   assertEquals(data.profile.version, "0.2.0");
-  assertEquals(data.profile.tiers, 1);
+  assertEquals(data.profile.tiers, 2);
   assertEquals(Array.isArray(data.diagnostics), true);
 });
 
@@ -108,12 +119,23 @@ Deno.test("doctor: bad .markspec.yaml exits 1", async () => {
   assertStringIncludes(stderr, "MARKSPEC-YAML");
 });
 
-Deno.test("doctor: no profile still exits 0", async () => {
+Deno.test("doctor: opted-out project still exits 0 with no-profile message", async () => {
+  const { code, stderr } = await markspec(["doctor"], {
+    files: {
+      "project.yaml": PROJECT_YAML,
+      ".markspec.yaml": "default-profile: false\n",
+    },
+  });
+  assertEquals(code, 0);
+  assertStringIncludes(stderr, "no profile");
+});
+
+Deno.test("doctor: bundled default shown when no .markspec.yaml", async () => {
   const { code, stderr } = await markspec(["doctor"], {
     files: {
       "project.yaml": PROJECT_YAML,
     },
   });
   assertEquals(code, 0);
-  assertStringIncludes(stderr, "no profile");
+  assertStringIncludes(stderr, "@markspec/profile-default");
 });

--- a/tests/e2e/profile_test.ts
+++ b/tests/e2e/profile_test.ts
@@ -100,7 +100,10 @@ Deno.test(
     assert(Array.isArray(data.tiers), "tiers must be an array");
     assert(Array.isArray(data.elements), "elements must be an array");
     assert(data.tiers.length > 0, "tiers must be non-empty");
-    assertStringIncludes(data.tiers[0].id, "my-profile");
+    assertStringIncludes(
+      data.tiers[data.tiers.length - 1].id,
+      "my-profile",
+    );
   },
 );
 


### PR DESCRIPTION
## Summary

Makes the default profile genuinely **bundled** so consumers never write
`extends: npm:@markspec/profile-default`.

- **Embedded manifest** (`core/profile/default_profile.ts`): the `@markspec/profile-default` identity manifest ships as a string constant (single-binary + Node-safe), reachable via a new `{ kind: "builtin" }` `ProfileSpecifier`.
- **Auto-registration**: `loadChain` splices the bundled default as the **implicit root** of the `extends:` chain; `loadProfileForCommand` activates it for projects with no/empty `.markspec.yaml` and stacks a declared profile on top of it.
- **Opt-out**: `.markspec.yaml` `default-profile: false` ⇒ core-only mode (null chain). Non-boolean ⇒ `MARKSPEC-YAML-003`.
- **Leaf-as-active presentation**: CLI `profile show` / `doctor`, the MCP `markspec://profile` resource, and the MCP `validate` tool now headline the user's **leaf** profile (the bundled default is the root); `profile show` additionally prints the full root→leaf chain.
- Strawman example/test dropped its `extends:`/temp-dir hack and now exercises real auto-registration.
- ADR-010 + profile-schema §7 status notes added.

**Scope:** mechanism only. profile-schema §7.1 display-ID pattern bindings, RFC 2119 hygiene, and `{{def.}}` glossary are **intentionally deferred** (blocked on a core-type-binding schema construct), per the approved design spec. ADR-010's §2 four-type vocabulary is superseded by the 15-type core taxonomy.

**Behaviour change (intended, documented):** a project with no `.markspec.yaml` goes from core-only → bundled-default-active. Core-only now requires explicit `default-profile: false`. Pre-1.0, no back-compat shims (per project policy); in-repo manifests updated rather than shimmed.

Design: `docs/superpowers/specs/2026-05-19-bundled-default-profile-design.md`
Plan: `docs/superpowers/plans/2026-05-19-bundled-default-profile.md`

## Test Plan

- [x] `just build` green (lint + full suite + type-check + compile)
- [x] Full suite **1586 passed / 0 failed** (incl. new tests across `default_profile_test`, `chain_test`, `markspec_test`, `load_test`, `strawman_test`, e2e `profile`/`doctor`, MCP `profile`/`validate`)
- [x] `deno fmt --check` + `dprint check` clean
- [x] No `Deno.*` in added `core/` production files (Node-compat)
- [x] Per-task spec-compliance + code-quality review, plus whole-implementation review
- [ ] Reviewer sanity-check the intended core-only → default-active behaviour change

🤖 Generated with [Claude Code](https://claude.com/claude-code)