### PR TITLE
feat(core): populate git.* properties on compiled entries

### DIFF
--- a/packages/markspec/cli/commands/book.ts
+++ b/packages/markspec/cli/commands/book.ts
@@ -9,6 +9,7 @@ import { Command } from "@cliffy/command";
 import type { BookStructure, Chapter } from "../../book/mod.ts";
 import {
   loadActiveProfile,
+  makeGitFile,
   notImplemented,
   requireProjectConfig,
 } from "../helpers.ts";
@@ -58,6 +59,7 @@ export const bookCmd = new Command()
       profile: bookChain?.effective ?? undefined,
       statFile: (p) =>
         Deno.stat(p).then((s) => ({ mtime: s.mtime })).catch(() => undefined),
+      gitFile: makeGitFile(false),
     });
 
     const result = buildBook(structure, {

--- a/packages/markspec/cli/commands/compile.ts
+++ b/packages/markspec/cli/commands/compile.ts
@@ -22,13 +22,24 @@ export const compileCmd = new Command()
     "Entry count at which to switch to NDJSON streaming output",
     { default: 1000 },
   )
+  .option(
+    "--with-contributors",
+    "Include git contributor names in properties.git (PII-adjacent, ADR-006; off by default)",
+  )
   .arguments("<paths...:string>")
   .action(
     async (
-      _options: { format?: string; output?: string; splitThreshold: number },
+      _options: {
+        format?: string;
+        output?: string;
+        splitThreshold: number;
+        withContributors?: boolean;
+      },
       ...paths: string[]
     ) => {
-      const { result, chain } = await compileProject(paths);
+      const { result, chain } = await compileProject(paths, {
+        withContributors: _options.withContributors,
+      });
 
       if (_options.output) {
         const {

--- a/packages/markspec/cli/helpers.ts
+++ b/packages/markspec/cli/helpers.ts
@@ -83,20 +83,94 @@ export async function loadActiveProfile(projectRoot: string) {
 }
 
 /**
+ * Run `git` with the given args and return non-empty, trimmed stdout
+ * lines. Returns `[]` on any failure (non-zero exit, `git` absent,
+ * permission denied) so callers degrade gracefully instead of throwing.
+ * Keeping git I/O here keeps `core/` Node-safe.
+ */
+async function gitLines(args: string[]): Promise<string[]> {
+  try {
+    const { code, stdout } = await new Deno.Command("git", {
+      args,
+      stdout: "piped",
+      stderr: "null",
+    }).output();
+    if (code !== 0) return [];
+    return new TextDecoder()
+      .decode(stdout)
+      .split("\n")
+      .map((l) => l.trim())
+      .filter((l) => l.length > 0);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Build a `gitFile` callback for {@linkcode compileProject}. Reads a
+ * file's git history with `git log --follow`. `createdAt` is the oldest
+ * commit's author date, `modifiedAt` the newest, `revision` the short
+ * SHA of the most recent commit (git logs newest-first by default).
+ * Contributor names are fetched only when `withContributors` is true
+ * (PII-adjacent, ADR-006); the compiler deduplicates and sorts them. An
+ * untracked file or unavailable `git` yields undefined so
+ * `properties.git` stays unset.
+ */
+export function makeGitFile(withContributors: boolean) {
+  return async (path: string) => {
+    const dates = await gitLines([
+      "log",
+      "--follow",
+      "--format=%aI",
+      "--",
+      path,
+    ]);
+    if (dates.length === 0) return undefined;
+    const modifiedAt = dates[0];
+    const createdAt = dates[dates.length - 1];
+    const revLine = await gitLines([
+      "log",
+      "--follow",
+      "--format=%h",
+      "-1",
+      "--",
+      path,
+    ]);
+    const revision = revLine[0];
+    let contributors: readonly string[] | undefined;
+    if (withContributors) {
+      const names = await gitLines([
+        "log",
+        "--follow",
+        "--format=%aN",
+        "--",
+        path,
+      ]);
+      if (names.length > 0) contributors = names;
+    }
+    return { createdAt, modifiedAt, revision, contributors };
+  };
+}
+
+/**
  * Compile project files and return the result alongside the loaded profile chain.
  * Shared helper for commands that need the compiled graph.
  */
 export async function compileProject(
   paths: string[],
+  opts: { withContributors?: boolean } = {},
 ): Promise<{ result: CompileResult; chain: ProfileChain | null }> {
   const configResult = await requireProjectConfig();
   const chain = await loadActiveProfile(configResult.projectRoot);
   const { compile } = await import("../core/mod.ts");
+  const withContributors = opts.withContributors ?? false;
   const result = await compile(paths, {
     readFile: (p) => Deno.readTextFile(p),
     profile: chain?.effective ?? undefined,
     statFile: (p) =>
       Deno.stat(p).then((s) => ({ mtime: s.mtime })).catch(() => undefined),
+    gitFile: makeGitFile(withContributors),
+    withContributors,
   });
 
   for (const diag of result.diagnostics) {

--- a/packages/markspec/core/compiler/mod.ts
+++ b/packages/markspec/core/compiler/mod.ts
@@ -11,6 +11,7 @@ import type {
   Document,
   EffectiveProfile,
   Entry,
+  EntryProperties,
   Link,
   SourceLocation,
 } from "../model/mod.ts";
@@ -35,6 +36,68 @@ export interface CompileOptions {
   readonly statFile?: (
     path: string,
   ) => Promise<{ mtime: Date | null } | undefined>;
+  /**
+   * Optional. Called once per source file to obtain its version-control
+   * history. Returns undefined when git is unavailable, the file is
+   * untracked, or the host is non-Deno. When absent — or when it returns
+   * undefined — `entry.properties.git` is left undefined.
+   *
+   * The callback keeps git I/O out of `core/` so the compiler stays
+   * Node-safe. Contributor names are PII-adjacent (ADR-006) and only
+   * retained when {@linkcode CompileOptions.withContributors} is true.
+   */
+  readonly gitFile?: (
+    path: string,
+  ) => Promise<
+    {
+      createdAt?: string;
+      modifiedAt?: string;
+      contributors?: readonly string[];
+      revision?: string;
+    } | undefined
+  >;
+  /**
+   * Opt-in retention of `git.contributors`. Default false: contributor
+   * names are dropped even when {@linkcode CompileOptions.gitFile}
+   * returns them, because they are PII-adjacent (ADR-006). When true the
+   * list is deduplicated and sorted for deterministic output.
+   */
+  readonly withContributors?: boolean;
+}
+
+/**
+ * Shape the raw git observations from {@linkcode CompileOptions.gitFile}
+ * into an entry's `properties.git`. Enforces the PII gate (contributors
+ * dropped unless `withContributors`) and makes the contributor list
+ * deterministic (deduplicated + sorted). Returns undefined when there is
+ * no git data, so absent history leaves `properties.git` unset rather
+ * than emitting an empty object.
+ */
+function resolveGit(
+  raw:
+    | {
+      createdAt?: string;
+      modifiedAt?: string;
+      contributors?: readonly string[];
+      revision?: string;
+    }
+    | undefined,
+  withContributors: boolean,
+): NonNullable<EntryProperties["git"]> | undefined {
+  if (!raw) return undefined;
+  const git: {
+    createdAt?: string;
+    modifiedAt?: string;
+    contributors?: readonly string[];
+    revision?: string;
+  } = {};
+  if (raw.createdAt) git.createdAt = raw.createdAt;
+  if (raw.modifiedAt) git.modifiedAt = raw.modifiedAt;
+  if (raw.revision) git.revision = raw.revision;
+  if (withContributors && raw.contributors && raw.contributors.length > 0) {
+    git.contributors = [...new Set(raw.contributors)].sort();
+  }
+  return Object.keys(git).length > 0 ? git : undefined;
 }
 
 /** Compiled project output with resolved traceability graph. */
@@ -133,6 +196,10 @@ export async function compile(
           ? await options.statFile(filePath)
           : undefined;
         const mtimeStr = stat?.mtime ? stat.mtime.toISOString() : undefined;
+        const git = resolveGit(
+          options.gitFile ? await options.gitFile(filePath) : undefined,
+          options.withContributors ?? false,
+        );
         const annotatedEntries = result.entries.map((entry) => ({
           ...entry,
           properties: {
@@ -143,6 +210,7 @@ export async function compile(
               column: entry.location.column,
               mtime: mtimeStr,
             },
+            ...(git ? { git } : {}),
           },
         }));
         return {

--- a/packages/markspec/core/compiler/mod_test.ts
+++ b/packages/markspec/core/compiler/mod_test.ts
@@ -346,3 +346,92 @@ Deno.test("compile: statFile returning undefined → mtime absent, no crash", as
   assertEquals(entry.properties?.file?.path, "req.md");
   assertEquals(entry.properties?.file?.mtime, undefined);
 });
+
+// ---------------------------------------------------------------------------
+// git.* properties population
+// ---------------------------------------------------------------------------
+
+const GIT_FIXTURE_MD = `- [REQ-001] Title
+
+  Body.
+
+      Id: ${ULID_A}
+`;
+
+Deno.test("compile: properties.git populated from gitFile callback", async () => {
+  const files = { "req.md": GIT_FIXTURE_MD };
+  const result = await compile(["req.md"], {
+    readFile: reader(files),
+    gitFile: () =>
+      Promise.resolve({
+        createdAt: "2026-01-02T08:00:00.000Z",
+        modifiedAt: "2026-05-19T10:23:00.000Z",
+        revision: "abc1234",
+      }),
+  });
+  const entry = result.entries.get(makeDisplayId("REQ-001"));
+  assertExists(entry);
+  assertEquals(entry.properties?.git?.createdAt, "2026-01-02T08:00:00.000Z");
+  assertEquals(entry.properties?.git?.modifiedAt, "2026-05-19T10:23:00.000Z");
+  assertEquals(entry.properties?.git?.revision, "abc1234");
+  // contributors are off by default — PII-adjacent (ADR-006).
+  assertEquals(entry.properties?.git?.contributors, undefined);
+});
+
+Deno.test("compile: properties.git absent when no gitFile provided", async () => {
+  const files = { "req.md": GIT_FIXTURE_MD };
+  const result = await compile(["req.md"], { readFile: reader(files) });
+  const entry = result.entries.get(makeDisplayId("REQ-001"));
+  assertExists(entry);
+  assertEquals(entry.properties?.git, undefined);
+});
+
+Deno.test("compile: gitFile returning undefined → git absent, no crash", async () => {
+  const files = { "req.md": GIT_FIXTURE_MD };
+  const result = await compile(["req.md"], {
+    readFile: reader(files),
+    gitFile: () => Promise.resolve(undefined),
+  });
+  const entry = result.entries.get(makeDisplayId("REQ-001"));
+  assertExists(entry);
+  assertEquals(entry.properties?.git, undefined);
+  // file.* still populated — git absence must not disturb other properties.
+  assertEquals(entry.properties?.file?.path, "req.md");
+});
+
+Deno.test("compile: withContributors true → contributors deduped and sorted", async () => {
+  const files = { "req.md": GIT_FIXTURE_MD };
+  const result = await compile(["req.md"], {
+    readFile: reader(files),
+    withContributors: true,
+    gitFile: () =>
+      Promise.resolve({
+        createdAt: "2026-01-02T08:00:00.000Z",
+        modifiedAt: "2026-05-19T10:23:00.000Z",
+        revision: "abc1234",
+        contributors: ["Zoe", "Ada", "Zoe", "Ada", "Bo"],
+      }),
+  });
+  const entry = result.entries.get(makeDisplayId("REQ-001"));
+  assertExists(entry);
+  assertEquals(entry.properties?.git?.contributors, ["Ada", "Bo", "Zoe"]);
+});
+
+Deno.test("compile: withContributors false strips contributors from callback", async () => {
+  const files = { "req.md": GIT_FIXTURE_MD };
+  const result = await compile(["req.md"], {
+    readFile: reader(files),
+    gitFile: () =>
+      Promise.resolve({
+        createdAt: "2026-01-02T08:00:00.000Z",
+        modifiedAt: "2026-05-19T10:23:00.000Z",
+        revision: "abc1234",
+        contributors: ["Ada", "Bo"],
+      }),
+  });
+  const entry = result.entries.get(makeDisplayId("REQ-001"));
+  assertExists(entry);
+  assertEquals(entry.properties?.git?.contributors, undefined);
+  // Non-PII git fields are still populated.
+  assertEquals(entry.properties?.git?.revision, "abc1234");
+});

--- a/packages/markspec/core/model/mod.ts
+++ b/packages/markspec/core/model/mod.ts
@@ -295,11 +295,15 @@ export interface EntryProperties {
     /** ISO 8601 last-modified timestamp from the filesystem. */
     readonly mtime?: string;
   };
-  /** Version-control observations. */
+  /** Version-control observations from the file's git history. */
   readonly git?: {
+    /** ISO 8601 — author date of the first commit that touched the file. */
     readonly createdAt?: string;
+    /** ISO 8601 — author date of the last commit that touched the file. */
     readonly modifiedAt?: string;
+    /** Distinct commit-author names, sorted. PII-adjacent — opt-in only. */
     readonly contributors?: readonly string[];
+    /** Short SHA of the last commit that touched the file. */
     readonly revision?: string;
   };
   /** External connector state. */

--- a/tests/e2e/compile_git_properties_test.ts
+++ b/tests/e2e/compile_git_properties_test.ts
@@ -1,0 +1,228 @@
+/**
+ * @module tests/e2e/compile_git_properties_test
+ *
+ * E2E tests for `properties.git.*` population on compiled entries.
+ *
+ * Two axes:
+ *   - Graceful degradation: outside a git repo (or without run
+ *     permission) the CLI must still exit 0 and simply omit
+ *     `properties.git` — never crash.
+ *   - Present case: inside a real git repo the four git fields are
+ *     populated, and contributor names appear only with
+ *     `--with-contributors`.
+ */
+
+import { assertEquals, assertMatch } from "@std/assert";
+import { markspec } from "./helpers.ts";
+
+const CLI_ENTRY = new URL(
+  "../../packages/markspec/main.ts",
+  import.meta.url,
+).pathname;
+
+const PROJECT_YAML = `name: test-project\nversion: 0.1.0\n`;
+
+const SAMPLE_MD = `- [STK_0001] The system shall be fast
+
+  Body text.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+`;
+
+/** Parent env with GIT_* stripped — keeps spawned git out of any hook env. */
+function safeEnv(): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(Deno.env.toObject())) {
+    if (!k.startsWith("GIT_")) out[k] = v;
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Graceful degradation — temp dir is not a git repository
+// ---------------------------------------------------------------------------
+
+Deno.test("compile: properties.git absent outside a git repo (no run perm)", async () => {
+  const { code, stdout } = await markspec(
+    ["compile", "--format", "json", "req.md"],
+    { files: { "project.yaml": PROJECT_YAML, "req.md": SAMPLE_MD } },
+  );
+  assertEquals(code, 0);
+  const entry = JSON.parse(stdout).entries["STK_0001"];
+  assertEquals(typeof entry.properties?.file?.path, "string");
+  assertEquals(entry.properties?.git, undefined);
+});
+
+Deno.test("compile: properties.git absent outside a git repo (with run perm)", async () => {
+  const { code, stdout } = await markspec(
+    ["compile", "--format", "json", "req.md"],
+    {
+      files: { "project.yaml": PROJECT_YAML, "req.md": SAMPLE_MD },
+      permissions: ["--allow-run"],
+    },
+  );
+  assertEquals(code, 0);
+  const entry = JSON.parse(stdout).entries["STK_0001"];
+  assertEquals(entry.properties?.git, undefined);
+});
+
+Deno.test("compile --output: compiled.json git absent outside a git repo", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    await Deno.writeTextFile(`${dir}/project.yaml`, PROJECT_YAML);
+    await Deno.writeTextFile(`${dir}/req.md`, SAMPLE_MD);
+    const { code } = await new Deno.Command("deno", {
+      args: [
+        "run",
+        "--allow-read",
+        "--allow-write",
+        "--allow-run",
+        CLI_ENTRY,
+        "compile",
+        "--output",
+        "out",
+        "req.md",
+      ],
+      cwd: dir,
+      stdout: "piped",
+      stderr: "piped",
+      clearEnv: true,
+      env: safeEnv(),
+    }).output();
+    assertEquals(code, 0);
+    const compiled = JSON.parse(
+      await Deno.readTextFile(`${dir}/out/compiled.json`),
+    );
+    const entry = compiled.entries["STK_0001"];
+    assertEquals(typeof entry.properties?.file?.path, "string");
+    assertEquals(entry.properties?.git, undefined);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Present case — a real git repository with one committed file
+// ---------------------------------------------------------------------------
+
+/** git init a fresh repo in `dir` and commit project.yaml + req.md. */
+async function initRepo(dir: string): Promise<void> {
+  const run = async (args: string[]) => {
+    const { code, stderr } = await new Deno.Command(args[0], {
+      args: args.slice(1),
+      cwd: dir,
+      stdout: "null",
+      stderr: "piped",
+      clearEnv: true,
+      env: safeEnv(),
+    }).output();
+    if (code !== 0) {
+      throw new Error(
+        `${args.join(" ")} → ${code}: ${new TextDecoder().decode(stderr)}`,
+      );
+    }
+  };
+  await Deno.writeTextFile(`${dir}/project.yaml`, PROJECT_YAML);
+  await Deno.writeTextFile(`${dir}/req.md`, SAMPLE_MD);
+  await run(["git", "init", "-b", "main", dir]);
+  await run(["git", "-C", dir, "config", "user.email", "t@t.test"]);
+  await run(["git", "-C", dir, "config", "user.name", "Test Author"]);
+  await run(["git", "-C", dir, "config", "commit.gpgsign", "false"]);
+  await run(["git", "-C", dir, "add", "."]);
+  await run(["git", "-C", dir, "commit", "-m", "initial"]);
+}
+
+/** Run `markspec compile` inside `dir` with run permission. */
+async function compileIn(
+  dir: string,
+  extraArgs: string[],
+): Promise<{ code: number; stdout: string; stderr: string }> {
+  const r = await new Deno.Command("deno", {
+    args: [
+      "run",
+      "--allow-read",
+      "--allow-write",
+      "--allow-run",
+      CLI_ENTRY,
+      "compile",
+      "--format",
+      "json",
+      ...extraArgs,
+      "req.md",
+    ],
+    cwd: dir,
+    stdout: "piped",
+    stderr: "piped",
+    clearEnv: true,
+    env: safeEnv(),
+  }).output();
+  return {
+    code: r.code,
+    stdout: new TextDecoder().decode(r.stdout),
+    stderr: new TextDecoder().decode(r.stderr),
+  };
+}
+
+Deno.test("compile: properties.git populated inside a git repo", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    await initRepo(dir);
+    const { code, stdout } = await compileIn(dir, []);
+    assertEquals(code, 0);
+    const git = JSON.parse(stdout).entries["STK_0001"].properties?.git;
+    assertMatch(git.createdAt, /^\d{4}-\d{2}-\d{2}T/);
+    assertMatch(git.modifiedAt, /^\d{4}-\d{2}-\d{2}T/);
+    assertMatch(git.revision, /^[0-9a-f]{7,}$/);
+    // contributors are PII-adjacent (ADR-006) — off without the flag.
+    assertEquals(git.contributors, undefined);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("compile --with-contributors: contributor names included", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    await initRepo(dir);
+    const { code, stdout } = await compileIn(dir, ["--with-contributors"]);
+    assertEquals(code, 0);
+    const git = JSON.parse(stdout).entries["STK_0001"].properties?.git;
+    assertEquals(git.contributors, ["Test Author"]);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("compile --output: compiled.json carries git fields in a repo", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    await initRepo(dir);
+    const { code } = await new Deno.Command("deno", {
+      args: [
+        "run",
+        "--allow-read",
+        "--allow-write",
+        "--allow-run",
+        CLI_ENTRY,
+        "compile",
+        "--output",
+        "out",
+        "req.md",
+      ],
+      cwd: dir,
+      stdout: "piped",
+      stderr: "piped",
+      clearEnv: true,
+      env: safeEnv(),
+    }).output();
+    assertEquals(code, 0);
+    const compiled = JSON.parse(
+      await Deno.readTextFile(`${dir}/out/compiled.json`),
+    );
+    const git = compiled.entries["STK_0001"].properties?.git;
+    assertMatch(git.createdAt, /^\d{4}-\d{2}-\d{2}T/);
+    assertMatch(git.revision, /^[0-9a-f]{7,}$/);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});


### PR DESCRIPTION
## Summary

Fills the four `entry.properties.git` fields (`createdAt`, `modifiedAt`, `contributors`, `revision`) that were declared on the model but never populated. Mirrors the `file.*` slice (PR #391).

- **core stays Node-safe**: new optional `CompileOptions.gitFile` callback (analogous to `statFile`) keeps all git I/O out of `core/`. `resolveGit()` centralises the PII gate and makes `contributors` deterministic (dedup + sort). When the callback is absent or returns `undefined`, `properties.git` stays unset.
- **CLI wiring**: real `gitFile` via `git log --follow` wired into the shared `compileProject` helper (covers `compile`, `export`, `show`, `context`, `dependents`, `report`, `insert`, `create`, `next-id`, `lint`, `doc`) and the `book build` path. `markspec compile` gains `--with-contributors` (default off — `git.contributors` is PII-adjacent per ADR-006; a published `/api/` is world-readable, per `docs/specs/markspec-compile-output.md` section 6).
- **Graceful degradation**: `git` not on PATH, untracked file, or no run permission yields `undefined`, never throws.
- **createdAt/modifiedAt semantics**: `createdAt` is the oldest commit author date, `modifiedAt` the newest. `git log` lists newest-first, so these map to the last/first log line respectively. The handoff's "first = createdAt" shorthand assumed `--reverse` ordering; the implementation follows the model's documented intent (first commit gives `createdAt`).

No doc change: `docs/specs/markspec-compile-output.md` section 6 already specs `--with-contributors` and `git.*`; this PR makes the spec true (same precedent as PR #391).

## Test Plan

- [x] Unit (`core/compiler/mod_test.ts`): populate from mock callback; absent without callback; callback returns `undefined` -> git absent, no crash; `withContributors:true` -> deduped + sorted; default false strips contributors even when callback returns them.
- [x] E2E (`tests/e2e/compile_git_properties_test.ts`): graceful degradation (non-git dir, with/without run perm, `--output`); real-git present case (`compile --format json`, `--with-contributors`, `--output` compiled.json).
- [x] `just build` green; `deno fmt --check` + `dprint check` clean; full suite 1579 passed / 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
