### PR TITLE
ci(pages): build Model Reference book so /model/ resolves

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -45,6 +45,9 @@ jobs:
       - name: Build typography book
         run: mdbook build docs/spec/typography
 
+      - name: Build model reference book
+        run: mdbook build docs/spec/model
+
       - name: Build guide book
         run: mdbook build docs/guide
 


### PR DESCRIPTION
## Problem

https://driftsys.github.io/markspec/model/ returns **404**.

PR #398 merged the user-docs-restructure work to `main`: it added the
`docs/spec/model/` mdBook **and** a "Model Reference" card linking to
`model/` in `docs/index.html`, but it never added a build step to
`.github/workflows/pages.yaml`. The 2026-05-19 Pages deploy therefore
published an `index.html` that links to `model/` while `_site/model/`
was never generated — a dead nav card on the live docs site.

Every other nav target (`/spec/`, `/guide/`, `/typography/`, the
cheatsheet) returns 200; only `/model/` 404s.

## Fix

Add the missing `mdbook build docs/spec/model` step alongside the
existing language/typography/guide builds. No other change is needed:

- `docs/spec/model/book.toml` already targets `build-dir = ../../../_site/model`.
- The existing `docs/spec/**` and `.github/workflows/pages.yaml` path
  triggers already cover this change, so merging to `main` redeploys
  Pages with `_site/model/` populated and the 404 clears.

## Verification

`mdbook build docs/spec/model` run locally: exit 0, produces
`_site/model/index.html` (*"Overview – MarkSpec Model Reference"*) plus
all 12 pages (entry-format, types, attributes, relations, profiles,
prose-analysis, annexes, etc.).

CI-only change — no TS/Deno/docs/token code touched; `dprint` does not
format `.github/workflows/*.yaml` so no format gate applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)