### PR TITLE
Port 5 POC fixes from Renault Alliance fork (R010, T024, grouped enums, {scope}, Derived-from)

### DIFF
--- a/packages/markspec/core/compiler/mod.ts
+++ b/packages/markspec/core/compiler/mod.ts
@@ -17,7 +17,11 @@ import type {
 } from "../model/mod.ts";
 import { makeDisplayId } from "../model/mod.ts";
 import { parseFile } from "../parser/mod.ts";
-import { classifyEntriesStage, validate } from "../validator/mod.ts";
+import {
+  classifyEntriesStage,
+  suppressDeclaredAttrR010,
+  validate,
+} from "../validator/mod.ts";
 import { ATTR_TO_LINK_KIND } from "./constants.ts";
 import { generateInverses } from "./inverses.ts";
 import { checkLinkTargets } from "./link_target.ts";
@@ -232,8 +236,16 @@ export async function compile(
     if (res.document) documents.set(res.filePath, res.document);
   }
 
-  // Phase 2: Validate all entries.
+  // Phase 2: Validate all entries. When a profile is loaded, suppress the
+  // core-only MSL-R010 "unknown attribute" warnings for attributes the profile
+  // declares — mirrors runPipeline's Stage 1 so LSP/MCP diagnostics match the
+  // `validate` command instead of flooding the editor with false positives.
   const validationResult = validate(allEntries);
+  const validationDiagnostics = suppressDeclaredAttrR010(
+    validationResult.diagnostics,
+    allEntries,
+    options.profile ?? null,
+  );
 
   // Phase 2.5: Classify entries when a profile is loaded.
   let classifiedEntries: readonly Entry[] = allEntries;
@@ -280,7 +292,7 @@ export async function compile(
 
   const diagnostics = [
     ...parseDiagnostics,
-    ...validationResult.diagnostics,
+    ...validationDiagnostics,
     ...linkTargetDiags,
   ];
 

--- a/packages/markspec/core/compiler/mod.ts
+++ b/packages/markspec/core/compiler/mod.ts
@@ -339,12 +339,14 @@ function extractLinksFromAttribute(
   if (!kind) return [];
 
   if (LOCATOR_BEARING_ATTRS.has(key)) {
-    // Format: "ID §section" — extract ID part only.
-    const idPart = value.split(/\s/)[0];
-    if (idPart) {
-      return [{ from, to: makeDisplayId(idPart), kind, location }];
-    }
-    return [];
+    // Comma-separated targets, each "ID §section": split the list (these
+    // attributes are 0..N), then take the leading ID token of each value,
+    // dropping the optional free-text locator.
+    return value
+      .split(",")
+      .map((s) => s.trim().split(/\s/)[0])
+      .filter((s) => s.length > 0)
+      .map((to) => ({ from, to: makeDisplayId(to), kind, location }));
   }
 
   // Comma-separated targets for id-list attributes.

--- a/packages/markspec/core/compiler/mod_test.ts
+++ b/packages/markspec/core/compiler/mod_test.ts
@@ -8,6 +8,7 @@
 import { assertEquals, assertExists } from "@std/assert";
 import { compile } from "./mod.ts";
 import { makeDisplayId } from "../model/mod.ts";
+import type { EffectiveProfile } from "../model/mod.ts";
 
 const ULID_A = "01HGW2Q8MNP3RSTVWXYZABCDEF";
 const ULID_B = "01HGW2Q8MNP3RSTVWXYZABCDEG";
@@ -434,4 +435,71 @@ Deno.test("compile: withContributors false strips contributors from callback", a
   assertEquals(entry.properties?.git?.contributors, undefined);
   // Non-PII git fields are still populated.
   assertEquals(entry.properties?.git?.revision, "abc1234");
+});
+
+// ---------------------------------------------------------------------------
+// Profile-aware diagnostics (MSL-R010 suppression)
+// ---------------------------------------------------------------------------
+
+/** Minimal profile declaring a single custom `Foo` text attribute. */
+function profileWithFoo(): EffectiveProfile {
+  return {
+    attributes: new Map([[
+      "Foo",
+      {
+        value: {
+          name: "Foo",
+          type: "text" as const,
+          required: false,
+          cardinality: { lower: 0, upper: 1 },
+        },
+        origin: "@test/p",
+      },
+    ]]),
+    labels: new Map(),
+    conventions: new Map(),
+    colors: new Map(),
+    types: new Map(),
+    documents: { types: new Map(), frontMatter: new Map() },
+  };
+}
+
+Deno.test("compile: suppresses MSL-R010 for profile-declared attributes", async () => {
+  const files = {
+    "req.md": `- [REQ-001] Title
+
+  Body.
+
+  Id: ${ULID_A}
+  Foo: hello
+`,
+  };
+  const result = await compile(["req.md"], {
+    readFile: reader(files),
+    profile: profileWithFoo(),
+  });
+  const r010 = result.diagnostics.find((d) => d.code === "MSL-R010");
+  assertEquals(
+    r010,
+    undefined,
+    `expected no MSL-R010 for profile-declared 'Foo', got: ${r010?.message}`,
+  );
+});
+
+Deno.test("compile: still flags MSL-R010 for undeclared attributes", async () => {
+  const files = {
+    "req.md": `- [REQ-001] Title
+
+  Body.
+
+  Id: ${ULID_A}
+  Bogus: nope
+`,
+  };
+  const result = await compile(["req.md"], {
+    readFile: reader(files),
+    profile: profileWithFoo(),
+  });
+  const r010 = result.diagnostics.find((d) => d.code === "MSL-R010");
+  assertExists(r010, "expected MSL-R010 for undeclared 'Bogus'");
 });

--- a/packages/markspec/core/compiler/mod_test.ts
+++ b/packages/markspec/core/compiler/mod_test.ts
@@ -177,6 +177,33 @@ Deno.test("compile: id-list attr value splits into multiple links", async () => 
   assertEquals(sat.map((l) => l.to).sort(), ["REQ-PARENT-A", "REQ-PARENT-B"]);
 });
 
+Deno.test("compile: multi-value Derived-from splits into one link per target", async () => {
+  // Derived-from is locator-bearing ("ID §section") AND 0..N: a comma-separated
+  // list must yield one clean link per target, with no trailing comma and the
+  // per-value locator dropped.
+  const files = {
+    "req.md": `- [REQ-PARENT-A] A
+
+  Id: ${ULID_A}
+
+- [REQ-PARENT-B] B
+
+  Id: ${ULID_B}
+
+- [REQ-CHILD] Child
+
+      Id: ${ULID_C}
+      Derived-from: REQ-PARENT-A §1.1, REQ-PARENT-B §2.3
+`,
+  };
+  const result = await compile(["req.md"], { readFile: reader(files) });
+  const df = result.links.filter((l) => l.kind === "derived-from");
+  assertEquals(df.length, 2);
+  assertEquals(df.map((l) => l.to).sort(), ["REQ-PARENT-A", "REQ-PARENT-B"]);
+  // No target retains the comma separator.
+  assertEquals(df.every((l) => !l.to.includes(",")), true);
+});
+
 // ---------------------------------------------------------------------------
 // Forward / reverse adjacency maps
 // ---------------------------------------------------------------------------

--- a/packages/markspec/core/mod.ts
+++ b/packages/markspec/core/mod.ts
@@ -184,6 +184,7 @@ export {
   matchesAnyTarget,
   normalizeListValues,
   runPipeline,
+  suppressDeclaredAttrR010,
   validate,
   validateAttributesForEntry,
   validateListingDocuments,

--- a/packages/markspec/core/profile/manifest.ts
+++ b/packages/markspec/core/profile/manifest.ts
@@ -230,6 +230,39 @@ function parseCardinality(
   return { lower, upper };
 }
 
+/**
+ * Flatten a (possibly grouped) value list to its leaf value names. Accepts
+ * items that are bare strings, `{name, description?}` objects, or
+ * `{group, description?, values: [...]}` group objects (recursed). Group
+ * labels and descriptions are documentation-only and dropped — markspec
+ * validates against the value names. Returns `null` when any item matches
+ * none of these shapes.
+ */
+function flattenGroupedNames(raw: unknown): string[] | null {
+  if (!Array.isArray(raw)) return null;
+  const out: string[] = [];
+  for (const item of raw) {
+    if (typeof item === "string") {
+      out.push(item);
+      continue;
+    }
+    if (item == null || typeof item !== "object" || Array.isArray(item)) {
+      return null;
+    }
+    const o = item as Record<string, unknown>;
+    if (typeof o.name === "string") {
+      out.push(o.name);
+    } else if (Array.isArray(o.values)) {
+      const nested = flattenGroupedNames(o.values);
+      if (nested === null) return null;
+      out.push(...nested);
+    } else {
+      return null;
+    }
+  }
+  return out;
+}
+
 function parseAttrDecl(
   raw: unknown,
   context: string,
@@ -288,22 +321,19 @@ function parseAttrDecl(
   );
   let values: readonly string[] | undefined;
   if (vtype === "enum") {
-    const rawValues = r.values;
-    if (
-      !Array.isArray(rawValues) ||
-      rawValues.some((v) => typeof v !== "string") ||
-      rawValues.length === 0
-    ) {
+    const flat = flattenGroupedNames(r.values);
+    if (flat === null || flat.length === 0) {
       diagnostics.push({
         code: "PROFILE-LOAD-003",
         severity: "error",
         message:
-          `${context}: enum attribute '${name}' requires a non-empty 'values' list of strings`,
+          `${context}: enum attribute '${name}' requires a non-empty 'values' list ` +
+          `(strings, {name, description?}, or {group, values: [...]})`,
         location: { file: sourcePath, line: 1, column: 1 },
       });
       return undefined;
     }
-    values = rawValues as string[];
+    values = flat;
   }
   let inverse: { name: string; category: string } | undefined;
   if (r.inverse !== undefined) {
@@ -596,22 +626,23 @@ function parseLabelConcerns(
 ): LabelConcern[] {
   if (raw === undefined) return [];
 
-  // Form A: flat sequence of strings → each becomes a flag concern.
+  // Form A: sequence of label names → each becomes a flag concern. Entries
+  // may be bare strings or grouped objects ({group, values: [{name}, ...]});
+  // groups and descriptions are documentation-only and flattened away.
   if (Array.isArray(raw)) {
-    const concerns: LabelConcern[] = [];
-    for (const item of raw) {
-      if (typeof item !== "string") {
-        diagnostics.push({
-          code: "PROFILE-LOAD-003",
-          severity: "error",
-          message: "profile.labels: list form requires all-string entries",
-          location: { file: sourcePath, line: 1, column: 1 },
-        });
-        return [];
-      }
-      concerns.push({ name: item, kind: "flag", values: [] });
+    const names = flattenGroupedNames(raw);
+    if (names === null) {
+      diagnostics.push({
+        code: "PROFILE-LOAD-003",
+        severity: "error",
+        message:
+          "profile.labels: list entries must be strings, {name, description?}, " +
+          "or {group, values: [...]}",
+        location: { file: sourcePath, line: 1, column: 1 },
+      });
+      return [];
     }
-    return concerns;
+    return names.map((name) => ({ name, kind: "flag" as const, values: [] }));
   }
 
   // Form B: mapping — each key is a concern name.

--- a/packages/markspec/core/profile/manifest_test.ts
+++ b/packages/markspec/core/profile/manifest_test.ts
@@ -1000,3 +1000,79 @@ profile:
     true,
   );
 });
+
+Deno.test("parseManifest: enum and label values accept grouped {group, values} format", () => {
+  const yaml = `
+id: "@acme/profile-grouped"
+version: 0.1.0
+markspec-schema: "1"
+profile:
+  attributes:
+    - name: System
+      type: enum
+      description: grouped enum with nested groups
+      values:
+        - group: A
+          description: group a
+          values:
+            - name: S1
+              description: one
+            - name: S2
+        - group: B
+          values:
+            - S3
+    - name: Method
+      type: enum
+      values:
+        - name: Test
+        - name: Review
+  labels:
+    - group: safety
+      description: ISO 26262
+      values:
+        - name: ASIL-A
+        - name: ASIL-B
+    - group: cyber
+      values:
+        - CAL-1
+`;
+  const result = parseManifest(yaml);
+  assertEquals(result.diagnostics, []);
+  const attrs = result.manifest?.universalAttributes ?? [];
+  assertEquals(attrs.find((a) => a.name === "System")?.values, [
+    "S1",
+    "S2",
+    "S3",
+  ]);
+  assertEquals(attrs.find((a) => a.name === "Method")?.values, [
+    "Test",
+    "Review",
+  ]);
+  // Grouped labels flatten to one flag concern per leaf value name.
+  assertEquals(result.manifest?.labels.map((c) => c.name), [
+    "ASIL-A",
+    "ASIL-B",
+    "CAL-1",
+  ]);
+});
+
+Deno.test("parseManifest: malformed grouped values still fail PROFILE-LOAD-003", () => {
+  const yaml = `
+id: "@acme/profile-bad"
+version: 0.1.0
+markspec-schema: "1"
+profile:
+  attributes:
+    - name: System
+      type: enum
+      values:
+        - group: A
+          values:
+            - 42
+`;
+  const result = parseManifest(yaml);
+  assertEquals(
+    result.diagnostics.some((d) => d.code === "PROFILE-LOAD-003"),
+    true,
+  );
+});

--- a/packages/markspec/core/validator/mod.ts
+++ b/packages/markspec/core/validator/mod.ts
@@ -497,7 +497,7 @@ export function findAttr(
   return attrs.find((a) => a.key === key);
 }
 
-export { runPipeline } from "./pipeline.ts";
+export { runPipeline, suppressDeclaredAttrR010 } from "./pipeline.ts";
 export type { PipelineResult } from "./pipeline.ts";
 
 export { validateListingDocuments } from "./listing.ts";

--- a/packages/markspec/core/validator/pattern.ts
+++ b/packages/markspec/core/validator/pattern.ts
@@ -4,27 +4,55 @@
  * Display-ID pattern template → anchored RegExp.
  *
  * Grammar (per ADR-009 §5):
- *   pattern   := literal-prefix placeholder (literal-suffix)?
- *   placeholder := "{n}" | "{n:" PADDING "d}"
- *   PADDING   := "0" digits
+ *   pattern     := segment+ (exactly one counter)
+ *   segment     := literal | counter | named
+ *   counter     := "{n}" | "{n:" PADDING "d}"
+ *   named       := "{" identifier "}"   (e.g. {scope}, {feature})
+ *   PADDING     := "0" digits
+ *
+ * The counter `{n}` is the numeric running index (exactly one required). A
+ * named placeholder such as `{scope}` matches a free alphanumeric segment —
+ * it validates the *shape* `PREFIX_<scope>_<NNNN>` without pinning the scope
+ * to a fixed value, so one profile pattern serves every feature scope.
  *
  * Examples:
- *   REQ-{n}           → ^REQ-(\d+)$
- *   REQ-{n:04d}       → ^REQ-(\d{4})$
- *   STAKE-REQ-{n:06d} → ^STAKE-REQ-(\d{6})$
+ *   REQ-{n}              → ^REQ-(\d+)$
+ *   REQ-{n:04d}          → ^REQ-(\d{4})$
+ *   XREQ_{scope}_{n:04d} → ^XREQ_(?<scope>[A-Za-z0-9]+)_(\d{4})$
  */
 
-const PLACEHOLDER_RE = /\{n(?::(0\d+)d)?\}/;
+// One token: the {n} counter (optionally padded) OR a {named} segment.
+const TOKEN_RE = /\{n(?::(0\d+)d)?\}|\{([A-Za-z][A-Za-z0-9_]*)\}/g;
 
 /**
  * Compile a display-ID pattern template into an anchored RegExp.
  *
- * Throws if the template is missing the `{n}` placeholder or has an invalid
- * padding specifier.
+ * Throws if the template is missing the `{n}` counter, has more than one, or
+ * has an invalid padding specifier.
  */
 export function compileDisplayIdPattern(template: string): RegExp {
-  const match = PLACEHOLDER_RE.exec(template);
-  if (!match) {
+  let regexSource = "^";
+  let lastIndex = 0;
+  let counters = 0;
+  const re = new RegExp(TOKEN_RE);
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(template)) !== null) {
+    regexSource += escapeRegex(template.slice(lastIndex, match.index));
+    const named = match[2];
+    if (named === undefined) {
+      // {n} / {n:0Nd} counter
+      const padding = match[1];
+      regexSource += "(" + (padding ? `\\d{${Number(padding)}}` : `\\d+`) + ")";
+      counters++;
+    } else {
+      // {scope}-style named segment → free alphanumeric capture
+      regexSource += `(?<${named}>[A-Za-z0-9]+)`;
+    }
+    lastIndex = match.index + match[0].length;
+  }
+  regexSource += escapeRegex(template.slice(lastIndex)) + "$";
+
+  if (counters === 0) {
     if (/\{n:[^}]*\}/.test(template)) {
       throw new Error(
         `display-id-pattern '${template}': invalid padding specifier ` +
@@ -35,18 +63,11 @@ export function compileDisplayIdPattern(template: string): RegExp {
       `display-id-pattern '${template}': missing {n} placeholder`,
     );
   }
-
-  const padding = match[1];
-  const placeholderStart = match.index;
-  const placeholderEnd = match.index + match[0].length;
-
-  const prefix = template.slice(0, placeholderStart);
-  const suffix = template.slice(placeholderEnd);
-
-  const digitGroup = padding ? `\\d{${Number(padding)}}` : `\\d+`;
-
-  const regexSource = "^" + escapeRegex(prefix) + "(" + digitGroup + ")" +
-    escapeRegex(suffix) + "$";
+  if (counters > 1) {
+    throw new Error(
+      `display-id-pattern '${template}': multiple {n} counters (expected one)`,
+    );
+  }
   return new RegExp(regexSource);
 }
 

--- a/packages/markspec/core/validator/pattern_test.ts
+++ b/packages/markspec/core/validator/pattern_test.ts
@@ -71,3 +71,24 @@ Deno.test("compileDisplayIdPattern: invalid padding spec throws", () => {
     }
   }
 });
+
+Deno.test("compileDisplayIdPattern: named {scope} segment matches any token", () => {
+  const r = compileDisplayIdPattern("XREQ_{scope}_{n:04d}");
+  assertEquals(r.test("XREQ_IMMER_0010"), true);
+  assertEquals(r.test("XREQ_WELCOME_0001"), true);
+  assertEquals(r.test("XREQ__0010"), false); // empty scope
+  assertEquals(r.test("XREQ_IMMER_10"), false); // wrong padding
+  assertEquals(r.test("XREQ_IMMER_FOO_0010"), false); // extra segment
+});
+
+Deno.test("compileDisplayIdPattern: named segment without {n} still requires a counter", () => {
+  try {
+    compileDisplayIdPattern("XREQ_{scope}");
+    throw new Error("expected compileDisplayIdPattern to throw");
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (!msg.toLowerCase().includes("{n}")) {
+      throw new Error(`expected '{n}' in error message, got: ${msg}`);
+    }
+  }
+});

--- a/packages/markspec/core/validator/per_type_attrs.ts
+++ b/packages/markspec/core/validator/per_type_attrs.ts
@@ -11,7 +11,7 @@
  * `validator/mod.ts`.
  */
 
-import type { Diagnostic, Entry } from "../model/mod.ts";
+import type { Diagnostic, EffectiveProfile, Entry } from "../model/mod.ts";
 import {
   attributesForType,
   CORE_TYPE_SCOPED_ATTRS,
@@ -46,8 +46,9 @@ const UNIVERSAL_KEYS: ReadonlySet<string> = new Set<string>(
  */
 export function validatePerTypeAttributes(
   entry: Entry,
+  profile?: EffectiveProfile,
 ): readonly Diagnostic[] {
-  const type = resolvedCoreType(entry);
+  const type = resolvedCoreType(entry, profile);
   if (type === undefined) {
     const diagnostics: Diagnostic[] = [];
     for (const attr of entry.rawAttributes) {

--- a/packages/markspec/core/validator/pipeline.ts
+++ b/packages/markspec/core/validator/pipeline.ts
@@ -67,18 +67,9 @@ export function runPipeline(
   // warnings for attributes the profile actually declares (Stage 3's scope
   // validates them directly — the core-only R010 check would be noise).
   const stage1 = validate(entries);
-  const profileDeclaredAttrs = profile !== null
-    ? collectAllProfileAttributes(entries, profile)
-    : null;
-  const filteredStage1 = profileDeclaredAttrs === null
-    ? stage1.diagnostics
-    : stage1.diagnostics.filter((d) => {
-      if (d.code !== "MSL-R010") return true;
-      const match = /attribute '([^']+)'/.exec(d.message);
-      if (!match) return true;
-      return !profileDeclaredAttrs.has(match[1]);
-    });
-  diagnostics.push(...filteredStage1);
+  diagnostics.push(
+    ...suppressDeclaredAttrR010(stage1.diagnostics, entries, profile),
+  );
 
   // Stage 1.5 — core type-attribute check. Runs always (core-only mode
   // included) so unknown `Type:` values fail fast regardless of profile.
@@ -148,6 +139,31 @@ export function runPipeline(
 
   const valid = !diagnostics.some((d) => d.severity === "error");
   return { entries: finalEntries, diagnostics, valid };
+}
+
+/**
+ * Drop core Stage 1 `MSL-R010` ("unknown attribute") warnings for attributes
+ * the loaded profile declares — Stage 3 validates those directly, so the
+ * core-only check would be noise. Returns `diagnostics` unchanged when no
+ * profile is loaded.
+ *
+ * Exported so callers that run only Stage 1 (e.g. the compiler's diagnostic
+ * pass) suppress the same false positives the full {@linkcode runPipeline}
+ * does, keeping LSP/MCP diagnostics consistent with the `validate` command.
+ */
+export function suppressDeclaredAttrR010(
+  diagnostics: readonly Diagnostic[],
+  entries: readonly Entry[],
+  profile: EffectiveProfile | null,
+): readonly Diagnostic[] {
+  if (profile === null) return diagnostics;
+  const declared = collectAllProfileAttributes(entries, profile);
+  return diagnostics.filter((d) => {
+    if (d.code !== "MSL-R010") return true;
+    const match = /attribute '([^']+)'/.exec(d.message);
+    if (!match) return true;
+    return !declared.has(match[1]);
+  });
 }
 
 /**

--- a/packages/markspec/core/validator/pipeline.ts
+++ b/packages/markspec/core/validator/pipeline.ts
@@ -91,7 +91,7 @@ export function runPipeline(
     diagnostics.push(...validateCaptionConvention(entry, captionConventions));
     diagnostics.push(...validateBodyBlocks(entry));
     diagnostics.push(...validateFeatureAc(entry));
-    diagnostics.push(...validatePerTypeAttributes(entry));
+    diagnostics.push(...validatePerTypeAttributes(entry, profile ?? undefined));
     diagnostics.push(...validateModalKeywords(entry));
   }
 

--- a/packages/markspec/core/validator/type_resolution.ts
+++ b/packages/markspec/core/validator/type_resolution.ts
@@ -20,7 +20,7 @@
  * `validator/types.ts` (`inferTypeFromDisplayIdShape`).
  */
 
-import type { Entry } from "../model/mod.ts";
+import type { EffectiveProfile, Entry } from "../model/mod.ts";
 import {
   CORE_TYPE_HIERARCHY,
   inferTypeFromDiscriminatingAttr,
@@ -104,6 +104,22 @@ export interface ResolvedTypeWithProvenance {
 }
 
 /**
+ * Map a profile-declared type name to the core type it `extends`. In the
+ * effective (merged) profile every type's `extends` is frozen to a core type
+ * (spec §1.3.1 step 2 / profile schema), so a single lookup — no chain walk —
+ * yields the core parent. Returns `undefined` when no profile is supplied, the
+ * name is not a profile type, or its `extends` is not a known core type.
+ */
+function profileTypeToCore(
+  typeName: string,
+  profile: EffectiveProfile | undefined,
+): string | undefined {
+  if (!profile) return undefined;
+  const core = profile.types.get(typeName)?.value.extends;
+  return core && CORE_TYPE_HIERARCHY[core] ? core : undefined;
+}
+
+/**
  * Resolve an entry's effective core type and report which step of the
  * spec §1.3.1 chain matched. First match wins. Returns `undefined` when
  * no step in {1..6} resolves to a known core type — callers may then
@@ -112,15 +128,21 @@ export interface ResolvedTypeWithProvenance {
  */
 export function resolvedCoreTypeWithProvenance(
   entry: Entry,
+  profile?: EffectiveProfile,
 ): ResolvedTypeWithProvenance | undefined {
-  // Step 1: explicit Type:
+  // Step 1: explicit Type: — a core type directly, or a profile type whose
+  // `extends:` resolves to a core type (frozen at declaration).
   const explicit = explicitType(entry);
-  if (explicit && CORE_TYPE_HIERARCHY[explicit]) {
-    return { type: explicit, step: 1 };
+  if (explicit) {
+    if (CORE_TYPE_HIERARCHY[explicit]) return { type: explicit, step: 1 };
+    const core = profileTypeToCore(explicit, profile);
+    if (core) return { type: core, step: 1 };
   }
-  // Step 2: profile-classified entry.type
-  if (entry.type && CORE_TYPE_HIERARCHY[entry.type]) {
-    return { type: entry.type, step: 2 };
+  // Step 2: profile-classified entry.type — same core/profile resolution.
+  if (entry.type) {
+    if (CORE_TYPE_HIERARCHY[entry.type]) return { type: entry.type, step: 2 };
+    const core = profileTypeToCore(entry.type, profile);
+    if (core) return { type: core, step: 2 };
   }
   // Step 3: Source: introspection
   const source = sourceValue(entry);
@@ -162,6 +184,9 @@ export function resolvedCoreTypeWithProvenance(
  * type. The caller decides whether to skip validation, fall back to a
  * less specific check, or report on the unclassified state.
  */
-export function resolvedCoreType(entry: Entry): string | undefined {
-  return resolvedCoreTypeWithProvenance(entry)?.type;
+export function resolvedCoreType(
+  entry: Entry,
+  profile?: EffectiveProfile,
+): string | undefined {
+  return resolvedCoreTypeWithProvenance(entry, profile)?.type;
 }

--- a/packages/markspec/core/validator/type_resolution_test.ts
+++ b/packages/markspec/core/validator/type_resolution_test.ts
@@ -14,7 +14,12 @@ import {
   resolvedCoreType,
   resolvedCoreTypeWithProvenance,
 } from "./type_resolution.ts";
-import type { Entry } from "../model/mod.ts";
+import type {
+  EffectiveProfile,
+  EffectiveTypeDef,
+  Entry,
+  ProvenancedMapEntry,
+} from "../model/mod.ts";
 import { makeDisplayId } from "../model/mod.ts";
 
 const ULID = "01HGW2Q8MNP3RSTVWXYZABCDEF";
@@ -261,4 +266,56 @@ Deno.test("resolvedCoreTypeWithProvenance: earliest step wins (explicit Type bea
     resolvedCoreTypeWithProvenance(entry),
     { type: "Requirement", step: 1 },
   );
+});
+
+Deno.test("resolvedCoreType: profile type resolves to its core parent via extends", () => {
+  const origin = "@test/p";
+  const sysReq: ProvenancedMapEntry<EffectiveTypeDef> = {
+    value: {
+      name: "system-requirement",
+      extends: "Requirement",
+      displayIdPattern: { value: "FREQ-{n:04d}", origin },
+      displayIdPatternEnforcement: { value: "off", origin },
+      color: { value: undefined, origin },
+      required: { value: [], origin },
+      attributes: new Map(),
+      traceability: new Map(),
+      description: { value: undefined, origin },
+      attrDescriptions: new Map(),
+      relationDescriptions: new Map(),
+    },
+    origin,
+  };
+  const profile: EffectiveProfile = {
+    attributes: new Map(),
+    labels: new Map(),
+    conventions: new Map(),
+    colors: new Map(),
+    types: new Map([["system-requirement", sysReq]]),
+    documents: { types: new Map(), frontMatter: new Map() },
+  };
+
+  // Step 1 — explicit `Type:` naming a profile type.
+  const explicit = makeEntry({
+    attrs: [{ key: "Type", value: "system-requirement" }],
+  });
+  assertEquals(resolvedCoreType(explicit), undefined); // no profile: unresolvable
+  assertEquals(resolvedCoreType(explicit, profile), "Requirement");
+  assertEquals(
+    resolvedCoreTypeWithProvenance(explicit, profile),
+    { type: "Requirement", step: 1 },
+  );
+
+  // Step 2 — profile-classified entry.type.
+  const classified = makeEntry({ attrs: [], type: "system-requirement" });
+  assertEquals(resolvedCoreType(classified), undefined);
+  assertEquals(resolvedCoreType(classified, profile), "Requirement");
+  assertEquals(
+    resolvedCoreTypeWithProvenance(classified, profile),
+    { type: "Requirement", step: 2 },
+  );
+
+  // An unknown profile type (not in the profile) stays unresolved.
+  const unknown = makeEntry({ attrs: [], type: "mystery-type" });
+  assertEquals(resolvedCoreType(unknown, profile), undefined);
 });

--- a/packages/markspec/lsp/server.ts
+++ b/packages/markspec/lsp/server.ts
@@ -150,7 +150,7 @@ function publishFileDiagnostics(
 
 /** Run cross-file validation and publish diagnostics for all files. */
 function publishAllDiagnostics(): void {
-  const allDiags = index.validateAll();
+  const allDiags = index.validateAll(profile ?? null);
   const grouped = groupDiagnosticsByFile(allDiags);
 
   // Send diagnostics for files that have issues

--- a/packages/markspec/lsp/workspace.ts
+++ b/packages/markspec/lsp/workspace.ts
@@ -6,8 +6,13 @@
  * diagnostics, completions, and future go-to-definition.
  */
 
-import type { Diagnostic, DisplayId, Entry } from "../core/mod.ts";
-import { parseFile, validate } from "../core/mod.ts";
+import type {
+  Diagnostic,
+  DisplayId,
+  EffectiveProfile,
+  Entry,
+} from "../core/mod.ts";
+import { parseFile, suppressDeclaredAttrR010, validate } from "../core/mod.ts";
 
 /** A display ID paired with its entry title, for completion items. */
 export interface DisplayIdEntry {
@@ -204,11 +209,15 @@ export class WorkspaceIndex {
   /**
    * Run cross-file validation on all indexed entries.
    * Returns the full set of validation diagnostics.
+   *
+   * When `profile` is supplied, core-only MSL-R010 "unknown attribute"
+   * warnings are suppressed for attributes the profile declares — matching
+   * the `validate` command so the editor doesn't flood with false positives.
    */
-  validateAll(): readonly Diagnostic[] {
+  validateAll(profile: EffectiveProfile | null = null): readonly Diagnostic[] {
     const allEntries = this.getAllEntries();
     const result = validate(allEntries);
-    return result.diagnostics;
+    return suppressDeclaredAttrR010(result.diagnostics, allEntries, profile);
   }
 
   // -----------------------------------------------------------------------

--- a/packages/markspec/lsp/workspace_test.ts
+++ b/packages/markspec/lsp/workspace_test.ts
@@ -6,8 +6,8 @@
 
 import { assertEquals } from "@std/assert";
 import { WorkspaceIndex } from "./workspace.ts";
-import type { Entry, SourceLocation } from "../core/mod.ts";
-import { makeDisplayId } from "../core/mod.ts";
+import type { EffectiveProfile, Entry, SourceLocation } from "../core/mod.ts";
+import { makeDisplayId, parseFile } from "../core/mod.ts";
 
 /** Helper to create a minimal identified entry. */
 function entry(
@@ -181,4 +181,46 @@ Deno.test("WorkspaceIndex: removeFile promotes survivor when removed file owned 
     index.getEntryByDisplayId(makeDisplayId("STK_0001"))?.location.file,
     "b.md",
   );
+});
+
+Deno.test("WorkspaceIndex: validateAll suppresses MSL-R010 for profile-declared attributes", async () => {
+  const ulid = "01HGW2Q8MNP3RSTVWXYZABCDEF";
+  const md = `- [REQ-001] Title
+
+  Body.
+
+  Id: ${ulid}
+  Foo: hello
+`;
+  const parsed = await parseFile(md, { file: "t.md" });
+  const profile: EffectiveProfile = {
+    attributes: new Map([[
+      "Foo",
+      {
+        value: {
+          name: "Foo",
+          type: "text",
+          required: false,
+          cardinality: { lower: 0, upper: 1 },
+        },
+        origin: "@test/p",
+      },
+    ]]),
+    labels: new Map(),
+    conventions: new Map(),
+    colors: new Map(),
+    types: new Map(),
+    documents: { types: new Map(), frontMatter: new Map() },
+  };
+
+  const index = new WorkspaceIndex();
+  index.updateFile("t.md", parsed.entries);
+
+  // Without a profile the core check still flags the unknown attribute.
+  const bare = index.validateAll();
+  assertEquals(bare.some((d) => d.code === "MSL-R010"), true);
+
+  // With the profile loaded, the declared attribute is suppressed.
+  const withProfile = index.validateAll(profile);
+  assertEquals(withProfile.some((d) => d.code === "MSL-R010"), false);
 });


### PR DESCRIPTION
## Summary

Ports the 5 fixes from the Renault Alliance Car partner team's POC MR ([gitlabee !1](https://gitlabee.dt.renault.com/partners/alliance-car/sandbox/vibe/vibe-spec/markspec/-/merge_requests/1)). Each fix is its own commit so they can be reviewed and reverted in isolation.

- **`fix(core)` — R010 false positives in LSP/MCP** ([2a1132d](https://github.com/driftsys/markspec/commit/2a1132d)) — `runPipeline` already suppressed `MSL-R010` for profile-declared attributes; the compiler's `validate()` path (used by LSP/MCP) didn't, so editors flooded with false positives. Extracts the filter into `suppressDeclaredAttrR010()`, re-exports it through `core/mod.ts`, and applies it from `compile()` + `WorkspaceIndex.validateAll()`. Pure refactor + reuse — no semantic change.
- **`fix(core)` — T024 profile types resolving to core via `extends`** ([c3c0ded](https://github.com/driftsys/markspec/commit/c3c0ded)) — `resolvedCoreType` only matched `CORE_TYPE_HIERARCHY` directly, so `Type: system-requirement` (profile type extending `Requirement`) never resolved. Adds a single-step lookup against `profile.types[*].value.extends` (frozen to a core type by profile merging). Step 1 (explicit `Type:`) and Step 2 (`entry.type`) both updated symmetrically. `validatePerTypeAttributes` now accepts the profile.
- **`feat(profile)` — grouped enum and label value lists** ([2a16e6f](https://github.com/driftsys/markspec/commit/2a16e6f)) — Adds `flattenGroupedNames` accepting bare strings, `{name, description?}` objects, and `{group, values: [...]}` (recursing). Used for enum `values:` and the labels list form, giving parity between the two. Group labels/descriptions are documentation-only and dropped — the validation model is unchanged.
- **`feat(validator)` — named `{scope}` segments in display-id patterns** ([48d3567](https://github.com/driftsys/markspec/commit/48d3567)) — Extends the grammar from `prefix {n} suffix?` to `(literal | {n} | {named})+` with exactly one `{n}`. Named segments compile to `(?<name>[A-Za-z0-9]+)` — one pattern serves every scope. Backward-compatible; existing patterns unchanged. **Generation side (`insert` / `next-id`) doesn't know about `{scope}` yet** — validation only.
- **`fix(compiler)` — multi-value `Derived-from` truncated** ([ce4151b](https://github.com/driftsys/markspec/commit/ce4151b)) — Locator-bearing attrs (`Derived-from`, `References`) were extracted with `value.split(/\s/)[0]`, silently dropping all but the first ID. Now splits on `,` first, then takes the leading token of each value — yields one link per target.

## Provenance

All commits are cherry-picked with `-x` from `partner-renault/poc/combined-fixes`. Original author: `philippe.spozio@ampere.cars` (a072372) with Claude Opus 4.7 co-author trailer.

## Test plan

- [x] `just build` passes locally (lint + 1634 tests + typecheck + compile)
- [x] `deno fmt --check` and `dprint check` pass
- [x] New tests cover each fix (compiler R010 suppression, profile type→core resolution, grouped values, `{scope}` pattern, multi-value Derived-from)
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)