### PR TITLE
feat: source-view entry rendering for MarkSpec in VS Code

### DIFF
--- a/docs/examples/entry-rendering.md
+++ b/docs/examples/entry-rendering.md
@@ -15,9 +15,22 @@ attribute is written in source. Cross-reference relation names (`Satisfies`,
   falls below the configurable threshold and the driver has not applied the
   brake pedal.
 
+  ```feature
+  Scenario: Noise spike shorter than debounce window
+    Given a debounce window of 10ms
+    And a stable pressure reading of 500
+    When a spike of 999 occurs for 5ms
+    Then the output shall remain 500
+
+  Scenario: Sustained change longer than debounce window
+    Given a debounce window of 10ms
+    And a stable pressure reading of 500
+    When the reading changes to 600 for 15ms
+    Then the output shall change to 600
+  ```
+
       Id: 01HGW3A2BCD5VWXYZABCDEFGHJ
-      Labels: ASIL-B
-      Labels: safety-critical
+      Labels: ASIL-B, Labels: safety-critical
 
 - [SYS_AEB_0012] Object threat assessment from radar tracks
 
@@ -28,16 +41,16 @@ attribute is written in source. Cross-reference relation names (`Satisfies`,
       Satisfies: STK_AEB_0001
       Labels: ASIL-B
 
+
 - [SWE_BRK_0107] Median filter implementation
 
   The braking ECU shall apply a 5-sample median filter to the raw brake pressure
-  sensor input before processing.
+  sensor input before processing.  $aNiceVariable
+
 
       Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
       Satisfies: SYS_AEB_0012
-      Labels: ASIL-B
-      Labels: real-time
-      Labels: performance
+      Labels: ASIL-B, real-time, performance
 
 Prose between entries renders normally — no left border, no type coloring. The
 visual separation between entries and prose is provided by the admonition border
@@ -142,3 +155,213 @@ URI, and the display ID serves as a pandoc-style slug:
       Id: pkg:cargo/serde@1.0.0
       Labels: dependency
       Labels: open-source
+
+## EARS patterns and modal verbs
+
+Five entries showing the five EARS patterns. The EARS trigger word
+(`When` / `While` / `If` / `Where`) and the modal verb (`shall`,
+`should`, `may`, `must`, `will`) both render as `keyword` tokens —
+strong/bold on every theme. Negated forms like `shall not` highlight
+only the modal.
+
+- [STK_AEB_0010] Continuous self-diagnostics (Ubiquitous)
+
+  The brake system shall perform continuous self-diagnostics whenever the
+  vehicle ignition is on. The vehicle must report any detected anomaly to
+  the driver instrument cluster within 500 ms.
+
+      Id: 01HGW7A1BCDE2VWXYZABCDEFGH
+      Satisfies: STK_AEB_0001
+      Labels: ASIL-B
+
+- [STK_AEB_0011] Brake response on pedal press (Event-driven)
+
+  When the driver presses the brake pedal, the system shall reduce engine
+  torque within 50 ms. When the driver releases the pedal, engine torque
+  may return to the requested level over the next 100 ms.
+
+      Id: 01HGW7B2DEFG3VWXYZABCDEFGH
+      Satisfies: STK_AEB_0001
+      Labels: ASIL-B
+
+- [STK_AEB_0012] Sensor monitoring in autonomous mode (State-driven)
+
+  While the vehicle is in autonomous mode, the system shall continuously
+  monitor sensor health and report degraded sensors. While a sensor is
+  flagged degraded, the decision module should de-weight its contribution
+  to the fusion output.
+
+      Id: 01HGW7C3FGHJ4VWXYZABCDEFGH
+      Satisfies: STK_AEB_0001
+      Labels: ASIL-B
+
+- [STK_AEB_0013] Optional automatic emergency braking (Optional)
+
+  Where automatic emergency braking is enabled by the driver, the system
+  shall compute time-to-collision for each tracked object on every radar
+  frame. Where the driver has disabled the feature, the system will
+  continue object tracking without engaging the brakes.
+
+      Id: 01HGW7D4GHJK5VWXYZABCDEFGH
+      Satisfies: STK_AEB_0001
+      Labels: ASIL-B
+
+- [STK_AEB_0014] Fault recovery (Unwanted)
+
+  If a primary radar fails, then the system shall switch to degraded mode
+  within one diagnostic cycle. The system shall not engage automatic
+  braking while in degraded mode.
+
+      Id: 01HGW7E5HJKL6VWXYZABCDEFGH
+      Satisfies: STK_AEB_0001
+      Labels: ASIL-B
+      Labels: fault-tolerance
+
+## Entity references and code blocks
+
+Entity references use the `$Identifier` syntax — three case conventions
+distinguish their domain:
+
+- `$TypeName` (PascalCase) → type / class reference
+- `$instanceName` (camelCase) → instance / variable reference
+- `$CONSTANT_NAME` (SCREAMING_SNAKE) → constant reference
+
+- [SWE_BRK_0210] Median filter scaffolding
+
+  The braking ECU shall apply $MedianFilter to $rawPressure samples with
+  window size $WINDOW_SIZE. The filtered output feeds $brakeDecision on
+  every cycle.
+
+  ```rust
+  use crate::filter::MedianFilter;
+
+  pub fn filter_pressure(raw: &[f32]) -> Vec<f32> {
+      let filter = MedianFilter::new(5);
+      raw.iter().map(|&x| filter.next(x)).collect()
+  }
+  ```
+
+  Below the code block: $rawPressure and $MedianFilter remain entity
+  refs because the language fence is `rust`, not `feature`.
+
+      Id: 01HGW8F6JKLM7VWXYZABCDEFGH
+      Satisfies: SYS_AEB_0012
+      Labels: ASIL-B
+      Labels: performance
+
+- [SWE_BRK_0211] Gherkin scenarios for the filter
+
+  The implementation shall pass the acceptance criteria expressed as
+  Gherkin scenarios:
+
+  ```feature
+  Feature: Median filter debouncing
+    Background:
+      Given a window size of 5
+
+    Scenario: Spike shorter than the window
+      Given a stable reading of 500
+      When a spike of 999 occurs for 2 samples
+      Then the output shall remain 500
+
+    Scenario Outline: Window size sensitivity
+      Given a window size of <window>
+      When the input changes from 500 to 600 over <samples> samples
+      Then the output shall be <result>
+      Examples:
+        | window | samples | result |
+        | 3      | 1       | 500    |
+        | 3      | 3       | 600    |
+        | 5      | 3       | 500    |
+  ```
+
+      Id: 01HGW8G7KLMN8VWXYZABCDEFGH
+      Verifies: SWE_BRK_0210
+      Labels: integration
+
+## Tables and math
+
+Tables render as standard Markdown tables. Entity references inside
+table cells still get highlighted; the trailer block sits below the
+table and dims as usual.
+
+- [SAD_AEB_0030] AEB decision-module parameters
+
+  The decision module computes braking thresholds from the parameters
+  below. $T_threshold gates the transition from `Low` to `High` threat.
+
+  | Parameter         | Symbol        | Range      | Source            |
+  | ----------------- | ------------- | ---------- | ----------------- |
+  | Closing velocity  | v_c           | 0–120 km/h | $closingVelocity  |
+  | Time-to-collision | T_TTC         | 0–5 s      | $TTC formula      |
+  | Brake threshold   | T_brake       | 0.5–2.0 s  | $BRAKE_THRESHOLD  |
+  | Sensor period     | $samplePeriod | 50 ms      | radar driver      |
+
+  Table: AEB decision-module input parameters.
+
+  The time-to-collision is defined by:
+
+  $$
+  T_{TTC} = \frac{\text{range}}{\text{closing velocity}}
+  $$
+
+  When $T_{TTC}$ falls below $BRAKE_THRESHOLD, the system shall command
+  full braking. The math fence `$$ … $$` is recognised — identifiers
+  inside the fence are not tokenised as entity references. (Inline
+  single-`$` math such as `$T_{TTC}$` is not currently distinguished
+  from entity refs; the body-token AST refactor will address that.)
+
+      Id: 01HGW9H8MNOP9VWXYZABCDEFGH
+      Satisfies: SYS_AEB_0012
+      Labels: design
+
+## Admonitions and blockquotes
+
+GitHub-flavoured Markdown admonitions (`> [!NOTE]`, `> [!TIP]`,
+`> [!IMPORTANT]`, `> [!WARNING]`, `> [!CAUTION]`) and plain
+blockquotes (`> …`) are part of the spec but currently receive no
+LSP-side visual treatment beyond VS Code's built-in Markdown grammar
+(which renders `>` and `[!NOTE]` as muted block-quote chrome). The
+admonition cards you may have seen in PDF / book / preview renderers
+are produced by the Typst / HTML downstreams, not by the source-view
+LSP.
+
+- [SRS_BRK_0220] Sensor watchdog timeout
+
+  The braking ECU shall trigger a watchdog reset if the radar driver
+  publishes no `RadarFrame` for $WATCHDOG_TIMEOUT_MS milliseconds.
+
+  > [!NOTE]
+  > The watchdog timeout must be at least twice the publish period to
+  > avoid false triggers during transient bus contention.
+
+  > [!WARNING]
+  > Disabling the watchdog (via the `--no-watchdog` build flag) is
+  > only permitted on bench rigs; production builds must keep it
+  > enabled.
+
+  > A plain blockquote — no `[!KIND]` marker. The `shall` inside this
+  > quote still gets keyword-tokenised by the body scanner; same for
+  > modal verbs and EARS triggers inside `[!NOTE]` / `[!WARNING]`
+  > content above.
+
+      Id: 01HGWAI9NPRS0VWXYZABCDEFGH
+      Satisfies: SYS_AEB_0012
+      Labels: ASIL-B
+      Labels: fault-tolerance
+
+- [SRS_BRK_0221] Brake actuator interface
+
+  > [!IMPORTANT]
+  > The actuator interface uses CAN frame ID `0x18FF50E5` (J1939
+  > priority 6). The braking ECU shall publish frames at 100 Hz when
+  > a brake demand is active, and may drop the rate to 10 Hz when no
+  > demand is pending.
+
+  The CAN driver delivers each frame to `$BrakeActuator` via the
+  publish-subscribe bus.
+
+      Id: 01HGWAJ0OQRT1VWXYZABCDEFGH
+      Satisfies: SAD_AEB_0001
+      Labels: interface
+

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "markspec-ide",
-  "version": "0.4.0",
+  "version": "0.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "markspec-ide",
-      "version": "0.4.0",
+      "version": "0.5.2",
       "license": "Apache-2.0",
       "dependencies": {
         "vscode-languageclient": "^9.0.1"

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -53,13 +53,21 @@
         },
         "markspec.server.args": {
           "type": "array",
-          "items": { "type": "string" },
-          "default": ["lsp"],
+          "items": {
+            "type": "string"
+          },
+          "default": [
+            "lsp"
+          ],
           "description": "Arguments passed to the markspec binary to start the LSP server."
         },
         "markspec.trace.server": {
           "type": "string",
-          "enum": ["off", "messages", "verbose"],
+          "enum": [
+            "off",
+            "messages",
+            "verbose"
+          ],
           "default": "off",
           "description": "Trace communication between VS Code and the MarkSpec LSP server."
         },
@@ -75,12 +83,188 @@
         },
         "markspec.mcp.args": {
           "type": "array",
-          "items": { "type": "string" },
-          "default": ["mcp"],
+          "items": {
+            "type": "string"
+          },
+          "default": [
+            "mcp"
+          ],
           "description": "Arguments passed to the markspec binary to start the MCP server. Mirrors 'markspec.server.args' but for the MCP subcommand."
         }
       }
-    }
+    },
+    "colors": [
+      {
+        "id": "markspec.label.background",
+        "description": "Background colour for label pills in MarkSpec entries.",
+        "defaults": {
+          "dark": "#0077BB22",
+          "light": "#4477AA1A",
+          "highContrast": "#0077BB33",
+          "highContrastLight": "#4477AA1A"
+        }
+      },
+      {
+        "id": "markspec.label.foreground",
+        "description": "Foreground (text) colour for label pills.",
+        "defaults": {
+          "dark": "editorForeground",
+          "light": "editorForeground",
+          "highContrast": "editorForeground",
+          "highContrastLight": "editorForeground"
+        }
+      },
+      {
+        "id": "markspec.label.border",
+        "description": "Border colour for valid label pills.",
+        "defaults": {
+          "dark": "#0077BB",
+          "light": "#4477AA",
+          "highContrast": "#0077BB",
+          "highContrastLight": "#4477AA"
+        }
+      },
+      {
+        "id": "markspec.label.invalidBorder",
+        "description": "Border colour for label pills whose value is not in the active profile catalog.",
+        "defaults": {
+          "dark": "errorForeground",
+          "light": "errorForeground",
+          "highContrast": "errorForeground",
+          "highContrastLight": "errorForeground"
+        }
+      },
+      {
+        "id": "markspec.admonition.note.border",
+        "description": "Border colour for note admonitions (> [!NOTE]) in MarkSpec entries.",
+        "defaults": {
+          "dark": "#0077BB",
+          "light": "#4477AA",
+          "highContrast": "#0077BB",
+          "highContrastLight": "#4477AA"
+        }
+      },
+      {
+        "id": "markspec.admonition.note.background",
+        "description": "Background tint for note admonitions in MarkSpec entries.",
+        "defaults": {
+          "dark": "#0077BB1A",
+          "light": "#f0f4f8",
+          "highContrast": "#0077BB33",
+          "highContrastLight": "#f0f4f8"
+        }
+      },
+      {
+        "id": "markspec.admonition.tip.border",
+        "description": "Border colour for tip admonitions (> [!TIP]) in MarkSpec entries.",
+        "defaults": {
+          "dark": "#009988",
+          "light": "#228833",
+          "highContrast": "#009988",
+          "highContrastLight": "#228833"
+        }
+      },
+      {
+        "id": "markspec.admonition.tip.background",
+        "description": "Background tint for tip admonitions in MarkSpec entries.",
+        "defaults": {
+          "dark": "#0099881A",
+          "light": "#f0f8f2",
+          "highContrast": "#00998833",
+          "highContrastLight": "#f0f8f2"
+        }
+      },
+      {
+        "id": "markspec.admonition.important.border",
+        "description": "Border colour for important admonitions (> [!IMPORTANT]) in MarkSpec entries.",
+        "defaults": {
+          "dark": "#EE3377",
+          "light": "#AA3377",
+          "highContrast": "#EE3377",
+          "highContrastLight": "#AA3377"
+        }
+      },
+      {
+        "id": "markspec.admonition.important.background",
+        "description": "Background tint for important admonitions in MarkSpec entries.",
+        "defaults": {
+          "dark": "#EE33771A",
+          "light": "#f8f0f6",
+          "highContrast": "#EE337733",
+          "highContrastLight": "#f8f0f6"
+        }
+      },
+      {
+        "id": "markspec.admonition.warning.border",
+        "description": "Border colour for warning admonitions (> [!WARNING]) in MarkSpec entries.",
+        "defaults": {
+          "dark": "#EE7733",
+          "light": "#CCBB44",
+          "highContrast": "#EE7733",
+          "highContrastLight": "#CCBB44"
+        }
+      },
+      {
+        "id": "markspec.admonition.warning.background",
+        "description": "Background tint for warning admonitions in MarkSpec entries.",
+        "defaults": {
+          "dark": "#EE77331A",
+          "light": "#f8f6f0",
+          "highContrast": "#EE773333",
+          "highContrastLight": "#f8f6f0"
+        }
+      },
+      {
+        "id": "markspec.admonition.caution.border",
+        "description": "Border colour for caution admonitions (> [!CAUTION]) in MarkSpec entries.",
+        "defaults": {
+          "dark": "#CC3311",
+          "light": "#EE6677",
+          "highContrast": "#CC3311",
+          "highContrastLight": "#EE6677"
+        }
+      },
+      {
+        "id": "markspec.admonition.caution.background",
+        "description": "Background tint for caution admonitions in MarkSpec entries.",
+        "defaults": {
+          "dark": "#CC33111A",
+          "light": "#f8f0f0",
+          "highContrast": "#CC331133",
+          "highContrastLight": "#f8f0f0"
+        }
+      },
+      {
+        "id": "markspec.admonition.plain.border",
+        "description": "Border colour for plain blockquotes (no [!KIND] marker).",
+        "defaults": {
+          "dark": "editorLineNumber.foreground",
+          "light": "editorLineNumber.foreground",
+          "highContrast": "editorLineNumber.foreground",
+          "highContrastLight": "editorLineNumber.foreground"
+        }
+      },
+      {
+        "id": "markspec.admonition.plain.background",
+        "description": "Background tint for plain blockquotes.",
+        "defaults": {
+          "dark": "#BBBBBB14",
+          "light": "#88888814",
+          "highContrast": "#BBBBBB22",
+          "highContrastLight": "#88888822"
+        }
+      },
+      {
+        "id": "markspec.entry.border",
+        "description": "Colour of the 3px left-bar that marks each MarkSpec entry block.",
+        "defaults": {
+          "dark": "editorIndentGuide.activeBackground",
+          "light": "editorIndentGuide.activeBackground",
+          "highContrast": "editorIndentGuide.activeBackground",
+          "highContrastLight": "editorIndentGuide.activeBackground"
+        }
+      }
+    ]
   },
   "scripts": {
     "compile": "tsc -p tsconfig.json",

--- a/editors/vscode/src/decorations.ts
+++ b/editors/vscode/src/decorations.ts
@@ -1,0 +1,244 @@
+/**
+ * MarkSpec source-view decorations.
+ *
+ * Owns three TextEditorDecorationType instances (trailer dim, valid
+ * label pill, invalid label pill) and refreshes them on demand
+ * against the LSP server's `markspec/entryRanges` response.
+ */
+
+import {
+  type DecorationOptions,
+  type Disposable,
+  MarkdownString,
+  Range,
+  type TextEditor,
+  type TextEditorDecorationType,
+  ThemeColor,
+  window,
+} from "vscode";
+import type { LanguageClient } from "vscode-languageclient/node";
+
+interface LspPosition {
+  line: number;
+  character: number;
+}
+interface LspRange {
+  start: LspPosition;
+  end: LspPosition;
+}
+interface LspLabelRange {
+  range: LspRange;
+  valid: boolean;
+  diagnostic?: string;
+}
+type BlockquoteKind =
+  | "note"
+  | "tip"
+  | "important"
+  | "warning"
+  | "caution"
+  | "plain";
+interface LspBlockquoteRange {
+  range: LspRange;
+  kind: BlockquoteKind;
+  markerRange?: LspRange;
+}
+interface EntryRangesResponse {
+  entries: Array<{
+    entryRange?: LspRange;
+    titleRange: LspRange;
+    trailerDimRanges: LspRange[];
+    labelRanges: LspLabelRange[];
+    blockquoteRanges?: LspBlockquoteRange[];
+  }>;
+}
+
+function toVsRange(r: LspRange): Range {
+  return new Range(
+    r.start.line,
+    r.start.character,
+    r.end.line,
+    r.end.character,
+  );
+}
+
+const BLOCKQUOTE_KINDS: readonly BlockquoteKind[] = [
+  "note",
+  "tip",
+  "important",
+  "warning",
+  "caution",
+  "plain",
+];
+
+/** Admonition kinds that carry a `[!KIND]` marker (everything but plain). */
+const MARKER_KINDS = [
+  "note",
+  "tip",
+  "important",
+  "warning",
+  "caution",
+] as const;
+type MarkerKind = (typeof MARKER_KINDS)[number];
+
+export class DecorationManager implements Disposable {
+  private entryBorder: TextEditorDecorationType;
+  private trailerDim: TextEditorDecorationType;
+  private titleBold: TextEditorDecorationType;
+  private labelPillValid: TextEditorDecorationType;
+  private labelPillInvalid: TextEditorDecorationType;
+  private blockquotes: Map<BlockquoteKind, TextEditorDecorationType>;
+  private markerPills: Map<MarkerKind, TextEditorDecorationType>;
+
+  constructor(private client: LanguageClient) {
+    // 3px left-bar at column 0 spanning every entry line (title
+    // through last trailer line). Materialises the entry boundary
+    // without a background fill so prose colours stay intact.
+    this.entryBorder = window.createTextEditorDecorationType({
+      borderColor: new ThemeColor("markspec.entry.border"),
+      borderStyle: "solid",
+      borderWidth: "0 0 0 3px",
+      isWholeLine: true,
+    });
+    this.trailerDim = window.createTextEditorDecorationType({
+      opacity: "0.6",
+    });
+    // Title gets the same semantic-token colour as the bracketed ID
+    // (both `*.declaration`); bold here provides the visual weight that
+    // sets the title apart from the ID without changing the colour.
+    this.titleBold = window.createTextEditorDecorationType({
+      fontWeight: "bold",
+    });
+    // Label pill decorations: deliberately omit `color` so the label
+    // text keeps its semantic-token color (an `enumMember` token from
+    // semantic_tokens.ts). Forcing a foreground here would fight the
+    // theme and hide the text when the override didn't resolve cleanly.
+    this.labelPillValid = window.createTextEditorDecorationType({
+      backgroundColor: new ThemeColor("markspec.label.background"),
+      borderColor: new ThemeColor("markspec.label.border"),
+      border: "1px solid",
+      borderRadius: "4px",
+    });
+    this.labelPillInvalid = window.createTextEditorDecorationType({
+      backgroundColor: new ThemeColor("markspec.label.background"),
+      borderColor: new ThemeColor("markspec.label.invalidBorder"),
+      border: "1px solid",
+      borderRadius: "4px",
+    });
+    // Blockquote decoration per kind — left-border bar only. No
+    // background fill: the entry-background decoration provides the
+    // card-style tint, and the admonition is identified by the
+    // coloured left bar plus the marker pill on the first line.
+    this.blockquotes = new Map();
+    for (const kind of BLOCKQUOTE_KINDS) {
+      this.blockquotes.set(
+        kind,
+        window.createTextEditorDecorationType({
+          borderColor: new ThemeColor(`markspec.admonition.${kind}.border`),
+          borderStyle: "solid",
+          borderWidth: "0 0 0 3px",
+          isWholeLine: true,
+        }),
+      );
+    }
+    // Marker pill per admonition kind — coloured pill around the
+    // `[!NOTE]` / `[!TIP]` / etc. text on the blockquote's first line,
+    // sharing the same border/background colours as the kind's left
+    // bar and tokens.alerts palette.
+    this.markerPills = new Map();
+    for (const kind of MARKER_KINDS) {
+      this.markerPills.set(
+        kind,
+        window.createTextEditorDecorationType({
+          backgroundColor: new ThemeColor(
+            `markspec.admonition.${kind}.background`,
+          ),
+          borderColor: new ThemeColor(`markspec.admonition.${kind}.border`),
+          border: "1px solid",
+          borderRadius: "4px",
+        }),
+      );
+    }
+  }
+
+  async refresh(editor: TextEditor): Promise<void> {
+    if (editor.document.languageId !== "markdown") return;
+    let result: EntryRangesResponse;
+    try {
+      result = await this.client.sendRequest<EntryRangesResponse>(
+        "markspec/entryRanges",
+        { uri: editor.document.uri.toString() },
+      );
+    } catch {
+      // Server not ready or doesn't support the request — bail silently.
+      return;
+    }
+    const entryBorders: Range[] = [];
+    const dim: Range[] = [];
+    const titleBold: Range[] = [];
+    const validPills: DecorationOptions[] = [];
+    const invalidPills: DecorationOptions[] = [];
+    const blockquoteBuckets = new Map<BlockquoteKind, Range[]>();
+    for (const kind of BLOCKQUOTE_KINDS) blockquoteBuckets.set(kind, []);
+    const markerBuckets = new Map<MarkerKind, Range[]>();
+    for (const kind of MARKER_KINDS) markerBuckets.set(kind, []);
+    for (const e of result.entries) {
+      if (e.entryRange) entryBorders.push(toVsRange(e.entryRange));
+      titleBold.push(toVsRange(e.titleRange));
+      for (const r of e.trailerDimRanges) dim.push(toVsRange(r));
+      for (const l of e.labelRanges) {
+        const opt: DecorationOptions = {
+          range: toVsRange(l.range),
+          hoverMessage: l.diagnostic
+            ? new MarkdownString(l.diagnostic)
+            : undefined,
+        };
+        (l.valid ? validPills : invalidPills).push(opt);
+      }
+      for (const b of e.blockquoteRanges ?? []) {
+        const bucket = blockquoteBuckets.get(b.kind);
+        if (!bucket) continue;
+        // One decoration per blockquote line so the left-border bar
+        // renders on each visual line, not just the first/last.
+        for (
+          let line = b.range.start.line;
+          line <= b.range.end.line;
+          line++
+        ) {
+          if (line < 0 || line >= editor.document.lineCount) continue;
+          bucket.push(new Range(line, 0, line, 0));
+        }
+        if (b.markerRange && b.kind !== "plain") {
+          markerBuckets.get(b.kind as MarkerKind)?.push(
+            toVsRange(b.markerRange),
+          );
+        }
+      }
+    }
+    editor.setDecorations(this.entryBorder, entryBorders);
+    editor.setDecorations(this.trailerDim, dim);
+    editor.setDecorations(this.titleBold, titleBold);
+    editor.setDecorations(this.labelPillValid, validPills);
+    editor.setDecorations(this.labelPillInvalid, invalidPills);
+    for (const kind of BLOCKQUOTE_KINDS) {
+      const type = this.blockquotes.get(kind);
+      const ranges = blockquoteBuckets.get(kind) ?? [];
+      if (type) editor.setDecorations(type, ranges);
+    }
+    for (const kind of MARKER_KINDS) {
+      const type = this.markerPills.get(kind);
+      const ranges = markerBuckets.get(kind) ?? [];
+      if (type) editor.setDecorations(type, ranges);
+    }
+  }
+
+  dispose(): void {
+    this.entryBorder.dispose();
+    this.trailerDim.dispose();
+    this.titleBold.dispose();
+    this.labelPillValid.dispose();
+    this.labelPillInvalid.dispose();
+    for (const type of this.blockquotes.values()) type.dispose();
+    for (const type of this.markerPills.values()) type.dispose();
+  }
+}

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -16,6 +16,7 @@ import {
   lm,
   McpStdioServerDefinition,
   type OutputChannel,
+  type TextDocument,
   Uri,
   window,
   workspace,
@@ -28,6 +29,7 @@ import {
 import { resolveServerOptions } from "./serverOptions";
 import { resolveMcpDefinition } from "./mcpDefinition";
 import { createStatusBar } from "./statusBar";
+import { DecorationManager } from "./decorations";
 
 let client: LanguageClient | undefined;
 let outputChannel: OutputChannel | undefined;
@@ -40,6 +42,17 @@ const MCP_SETTING_KEYS = [
   "markspec.mcp.args",
   "markspec.server.path",
 ];
+
+function debounce<T extends (...args: never[]) => void>(
+  fn: T,
+  delayMs: number,
+): (...args: Parameters<T>) => void {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  return (...args: Parameters<T>) => {
+    if (timer !== undefined) clearTimeout(timer);
+    timer = setTimeout(() => fn(...args), delayMs);
+  };
+}
 
 export function activate(context: ExtensionContext): void {
   const config = workspace.getConfiguration("markspec");
@@ -93,6 +106,34 @@ export function activate(context: ExtensionContext): void {
   client.start();
 
   createStatusBar(context, client);
+
+  const decorations = new DecorationManager(client);
+  context.subscriptions.push(decorations);
+
+  context.subscriptions.push(
+    window.onDidChangeActiveTextEditor((ed) => {
+      if (ed) void decorations.refresh(ed);
+    }),
+  );
+
+  const debouncedRefresh = debounce((doc: TextDocument) => {
+    const ed = window.activeTextEditor;
+    if (ed && ed.document === doc) void decorations.refresh(ed);
+  }, 100);
+  context.subscriptions.push(
+    workspace.onDidChangeTextDocument((ev) => debouncedRefresh(ev.document)),
+  );
+
+  // Refresh after the server finishes initial indexing.
+  client.onNotification("markspec/indexed", () => {
+    const ed = window.activeTextEditor;
+    if (ed) void decorations.refresh(ed);
+  });
+
+  // Initial paint for whatever is open at activation.
+  if (window.activeTextEditor) {
+    void decorations.refresh(window.activeTextEditor);
+  }
 
   registerMcpProvider(context);
 

--- a/editors/vscode/src/serverOptions.test.ts
+++ b/editors/vscode/src/serverOptions.test.ts
@@ -91,6 +91,21 @@ test("resolveServerOptions: debugLogPath sets MARKSPEC_LSP_DEBUG_LOG env", () =>
   );
 });
 
+test("resolveServerOptions: ${workspaceFolder} is expanded in debugLogPath", () => {
+  const opts = resolveServerOptions({
+    extensionPath: EXT_PATH,
+    workspaceFolder: WORKSPACE,
+    configuredServerPath: undefined,
+    configuredServerArgs: undefined,
+    debugLogPath: "${workspaceFolder}/.markspec-lsp.log",
+    platform: "linux",
+  }) as { options: { env: Record<string, string | undefined> } };
+  assert.equal(
+    opts.options.env.MARKSPEC_LSP_DEBUG_LOG,
+    `${WORKSPACE}/.markspec-lsp.log`,
+  );
+});
+
 test("expandVariables: leaves args untouched when workspaceFolder is undefined", () => {
   const result = expandVariables(
     ["${workspaceFolder}/main.ts"],

--- a/editors/vscode/src/serverOptions.ts
+++ b/editors/vscode/src/serverOptions.ts
@@ -34,13 +34,17 @@ export interface ResolveInput {
  * If `configuredServerPath` is set, use it (developer mode). Otherwise fall
  * back to the bundled binary at `<extensionPath>/bin/markspec(.exe)`.
  *
- * `${workspaceFolder}` is substituted in `configuredServerArgs`.
+ * `${workspaceFolder}` is substituted in `configuredServerArgs` and in
+ * `debugLogPath`.
  */
 export function resolveServerOptions(input: ResolveInput): ServerOptions {
   const { command, args } = resolveCommand(input);
   const env = { ...process.env };
   if (input.debugLogPath) {
-    env.MARKSPEC_LSP_DEBUG_LOG = input.debugLogPath;
+    env.MARKSPEC_LSP_DEBUG_LOG = expandVariables(
+      [input.debugLogPath],
+      input.workspaceFolder,
+    )[0];
   }
   return {
     command,

--- a/packages/markspec/lsp/entry_ranges.ts
+++ b/packages/markspec/lsp/entry_ranges.ts
@@ -1,0 +1,403 @@
+/**
+ * @module lsp/entry_ranges
+ *
+ * Build the payload returned by the `markspec/entryRanges` custom
+ * LSP request: per-entry title range, trailer-dim ranges that
+ * exclude embedded display IDs, and label ranges with a validity
+ * flag and optional diagnostic message.
+ *
+ * Pure function — deterministic on its inputs. The server's
+ * request handler is a thin shim that reads the document buffer,
+ * fetches entries from the workspace index, and calls this.
+ *
+ * Range coordinates follow the LSP convention: zero-based line and
+ * character.
+ */
+
+import type { Diagnostic, EffectiveProfile, Entry } from "../core/model/mod.ts";
+import { scanEntryTrailer, type TrailerLine } from "./entry_trailer.ts";
+
+/** LSP `Position`-shaped tuple. */
+export interface Position {
+  readonly line: number;
+  readonly character: number;
+}
+
+/** LSP `Range`-shaped tuple. */
+export interface Range {
+  readonly start: Position;
+  readonly end: Position;
+}
+
+/** One label inside a `Labels:` value, with validity + optional diag. */
+export interface LabelRange {
+  readonly range: Range;
+  readonly valid: boolean;
+  readonly diagnostic?: string;
+}
+
+/**
+ * Admonition / blockquote kind. `plain` is for `> …` runs without an
+ * `[!KIND]` first-line marker; the five named kinds follow the
+ * GitHub-flavoured Markdown alert vocabulary.
+ */
+export type BlockquoteKind =
+  | "note"
+  | "tip"
+  | "important"
+  | "warning"
+  | "caution"
+  | "plain";
+
+/** A contiguous run of `>` -prefixed lines in entry body, classified. */
+export interface BlockquoteRange {
+  readonly range: Range;
+  readonly kind: BlockquoteKind;
+  /**
+   * Range of the `[!KIND]` marker text on the blockquote's first line,
+   * when `kind !== "plain"`. Lets the client highlight just the marker
+   * (e.g., as a coloured pill) instead of the whole block.
+   */
+  readonly markerRange?: Range;
+}
+
+/** Layout info for one entry. */
+export interface EntryRangeInfo {
+  /**
+   * Full entry block — from the title line through the last trailer
+   * line. Used by the client to paint a subtle card-style background
+   * behind the entire entry.
+   */
+  readonly entryRange: Range;
+  readonly titleRange: Range;
+  readonly trailerDimRanges: readonly Range[];
+  readonly labelRanges: readonly LabelRange[];
+  readonly blockquoteRanges: readonly BlockquoteRange[];
+}
+
+/** Response payload for `markspec/entryRanges`. */
+export interface EntryRangesResponse {
+  readonly entries: readonly EntryRangeInfo[];
+}
+
+/**
+ * Title line pattern: `- [DISPLAY_ID] Title text`.
+ *
+ * The ID class mirrors the project's canonical display-ID grammar used
+ * by `entry_trailer.ts` (`DISPLAY_ID_RE`), `semantic_tokens.ts`, and
+ * `hover.ts` (`DISPLAY_ID_TOKEN_RE`): a leading alphanumeric followed
+ * by at least two more characters from the set `[A-Za-z0-9._/-]`. The
+ * `{2,}` quantifier (not `+`) enforces the ≥3-char total length that
+ * those modules also require, so entry-range layout covers every ID the
+ * parser, hover, rename, and references already accept (e.g.
+ * `my-entry`, `my.entry`, `ns/entry`).
+ */
+const TITLE_LINE_RE =
+  /^(\s*-\s+\[)(@?[A-Za-z0-9][A-Za-z0-9._/-]{2,})(\]\s*)(.*)$/;
+
+/**
+ * Build entry-ranges for every entry in `entries`. `diagnostics` is
+ * consulted to attach hover messages to invalid label pills (any
+ * diagnostic whose location lands on a label range becomes that
+ * label's `diagnostic` field).
+ */
+export function buildEntryRanges(
+  entries: readonly Entry[],
+  profile: EffectiveProfile | undefined,
+  diagnostics: readonly Diagnostic[],
+  lines: readonly string[],
+): EntryRangesResponse {
+  const allowedLabels = collectAllowedLabels(profile);
+  const sorted = [...entries].sort(
+    (a, b) => a.location.line - b.location.line,
+  );
+  const out: EntryRangeInfo[] = [];
+
+  for (let i = 0; i < sorted.length; i++) {
+    const entry = sorted[i];
+    const endLineExclusive = i + 1 < sorted.length
+      ? sorted[i + 1].location.line - 1
+      : lines.length;
+    const titleRange = computeTitleRange(entry, lines);
+    if (!titleRange) continue;
+    const trailerLines = scanEntryTrailer(entry, lines, endLineExclusive);
+    const trailerDimRanges = computeDimRanges(trailerLines, lines);
+    const labelRanges = computeLabelRanges(
+      trailerLines,
+      lines,
+      allowedLabels,
+      diagnostics,
+      entry.location.file,
+    );
+    const blockquoteRanges = computeBlockquoteRanges(
+      entry,
+      lines,
+      trailerLines,
+      endLineExclusive,
+    );
+    const entryRange = computeEntryRange(
+      entry,
+      lines,
+      trailerLines,
+      endLineExclusive,
+    );
+    out.push({
+      entryRange,
+      titleRange,
+      trailerDimRanges,
+      labelRanges,
+      blockquoteRanges,
+    });
+  }
+
+  return { entries: out };
+}
+
+function collectAllowedLabels(
+  profile: EffectiveProfile | undefined,
+): Set<string> | undefined {
+  if (!profile) return undefined;
+  const names = new Set<string>();
+  for (const [name] of profile.labels) names.add(name);
+  return names.size > 0 ? names : undefined;
+}
+
+function computeTitleRange(
+  entry: Entry,
+  lines: readonly string[],
+): Range | undefined {
+  const lineIndex = entry.location.line - 1;
+  if (lineIndex < 0 || lineIndex >= lines.length) return undefined;
+  const m = TITLE_LINE_RE.exec(lines[lineIndex]);
+  if (!m) return undefined;
+  const titleStart = m[1].length + m[2].length + m[3].length;
+  const titleEnd = titleStart + m[4].length;
+  return {
+    start: { line: lineIndex, character: titleStart },
+    end: { line: lineIndex, character: titleEnd },
+  };
+}
+
+function computeDimRanges(
+  trailerLines: readonly TrailerLine[],
+  lines: readonly string[],
+): Range[] {
+  const out: Range[] = [];
+  for (const tl of trailerLines) {
+    const line = lines[tl.lineIndex];
+    // Id is the entry's own identity, not a cross-reference — dim the
+    // whole line with no holes (matches semantic_tokens.ts).
+    if (tl.key === "Id") {
+      out.push({
+        start: { line: tl.lineIndex, character: 0 },
+        end: { line: tl.lineIndex, character: line.length },
+      });
+      continue;
+    }
+    // Labels: dim only the key prefix; the label values themselves stay
+    // bright so the pill decoration overlay has legible text inside.
+    if (tl.key === "Labels") {
+      if (tl.valueStart > 0) {
+        out.push({
+          start: { line: tl.lineIndex, character: 0 },
+          end: { line: tl.lineIndex, character: tl.valueStart },
+        });
+      }
+      continue;
+    }
+    // Build dim sub-ranges by removing each idRange from the full line.
+    let cursor = 0;
+    const sortedIds = [...tl.idRanges].sort((a, b) => a.start - b.start);
+    for (const id of sortedIds) {
+      if (id.start > cursor) {
+        out.push({
+          start: { line: tl.lineIndex, character: cursor },
+          end: { line: tl.lineIndex, character: id.start },
+        });
+      }
+      cursor = id.start + id.length;
+    }
+    if (cursor < line.length) {
+      out.push({
+        start: { line: tl.lineIndex, character: cursor },
+        end: { line: tl.lineIndex, character: line.length },
+      });
+    }
+  }
+  return out;
+}
+
+function computeLabelRanges(
+  trailerLines: readonly TrailerLine[],
+  lines: readonly string[],
+  allowedLabels: Set<string> | undefined,
+  diagnostics: readonly Diagnostic[],
+  file: string,
+): LabelRange[] {
+  const out: LabelRange[] = [];
+  for (const tl of trailerLines) {
+    if (tl.key !== "Labels") continue;
+    const line = lines[tl.lineIndex];
+    const value = line.slice(tl.valueStart, tl.valueStart + tl.valueLength);
+    let segStart = 0;
+    for (let i = 0; i <= value.length; i++) {
+      if (i === value.length || value[i] === ",") {
+        const segText = value.slice(segStart, i);
+        const trimmed = segText.trim();
+        if (trimmed.length > 0) {
+          const leading = segText.indexOf(trimmed);
+          const start = tl.valueStart + segStart + leading;
+          const end = start + trimmed.length;
+          const valid = !allowedLabels || allowedLabels.has(trimmed);
+          const diag = !valid
+            ? findDiagnosticAt(diagnostics, file, tl.lineIndex, start, end)
+            : undefined;
+          out.push({
+            range: {
+              start: { line: tl.lineIndex, character: start },
+              end: { line: tl.lineIndex, character: end },
+            },
+            valid,
+            diagnostic: diag,
+          });
+        }
+        segStart = i + 1;
+      }
+    }
+  }
+  return out;
+}
+
+function findDiagnosticAt(
+  diagnostics: readonly Diagnostic[],
+  file: string,
+  lineIndex: number,
+  startChar: number,
+  endChar: number,
+): string | undefined {
+  for (const d of diagnostics) {
+    if (!d.location || d.location.file !== file) continue;
+    const dl = d.location.line - 1;
+    if (dl !== lineIndex) continue;
+    const dc = d.location.column - 1;
+    if (dc >= startChar && dc < endChar) {
+      return d.message;
+    }
+  }
+  return undefined;
+}
+
+/** Pattern matching a blockquote line: optional indent, then `>` then space-or-EOL. */
+const BLOCKQUOTE_LINE_RE = /^\s*>(\s|$)/;
+
+/**
+ * Detect the admonition kind from a blockquote's first line. Returns
+ * the canonical lowercase kind for `> [!NOTE]` / `[!TIP]` /
+ * `[!IMPORTANT]` / `[!WARNING]` / `[!CAUTION]` markers (case-insensitive
+ * marker per GFM spec), or `"plain"` for any other first-line content.
+ */
+const ADMONITION_MARKER_RE =
+  /^\s*>\s*\[!(NOTE|TIP|IMPORTANT|WARNING|CAUTION)\]\s*$/i;
+
+function classifyBlockquoteFirstLine(line: string): BlockquoteKind {
+  const m = ADMONITION_MARKER_RE.exec(line);
+  if (!m) return "plain";
+  return m[1].toLowerCase() as BlockquoteKind;
+}
+
+/**
+ * Locate the `[!KIND]` marker substring on a blockquote's first line.
+ * Returns the marker's start/end columns (covering the `[` through
+ * the `]`) so the client can decorate just that token.
+ */
+function locateMarker(
+  line: string,
+): { start: number; end: number } | undefined {
+  // Match `[!KIND]` in isolation; the surrounding `> ` and trailing
+  // whitespace are bracketed by the broader ADMONITION_MARKER_RE check.
+  const re = /\[!(?:NOTE|TIP|IMPORTANT|WARNING|CAUTION)\]/i;
+  const m = re.exec(line);
+  if (!m) return undefined;
+  return { start: m.index, end: m.index + m[0].length };
+}
+
+/**
+ * Scan entry body for contiguous blockquote runs and classify each by
+ * its admonition marker. Body is bounded by the entry's title and the
+ * first trailer line (so trailer attributes and inter-entry prose are
+ * never classified as blockquotes).
+ */
+function computeBlockquoteRanges(
+  entry: Entry,
+  lines: readonly string[],
+  trailerLines: readonly TrailerLine[],
+  endLineExclusive: number,
+): BlockquoteRange[] {
+  const bodyEndExclusive = trailerLines.length > 0
+    ? trailerLines[0].lineIndex
+    : endLineExclusive;
+  const startIndex = entry.location.line;
+  const out: BlockquoteRange[] = [];
+  let blockStart: number | undefined;
+  let blockKind: BlockquoteKind = "plain";
+  const flushBlock = (endLineIndex: number): void => {
+    if (blockStart === undefined) return;
+    const range: Range = {
+      start: { line: blockStart, character: 0 },
+      end: { line: endLineIndex, character: lines[endLineIndex].length },
+    };
+    let markerRange: Range | undefined;
+    if (blockKind !== "plain") {
+      const marker = locateMarker(lines[blockStart]);
+      if (marker) {
+        markerRange = {
+          start: { line: blockStart, character: marker.start },
+          end: { line: blockStart, character: marker.end },
+        };
+      }
+    }
+    out.push({ range, kind: blockKind, markerRange });
+    blockStart = undefined;
+    blockKind = "plain";
+  };
+  for (let i = startIndex; i < bodyEndExclusive && i < lines.length; i++) {
+    const line = lines[i];
+    const isQuote = BLOCKQUOTE_LINE_RE.test(line);
+    if (isQuote) {
+      if (blockStart === undefined) {
+        blockStart = i;
+        blockKind = classifyBlockquoteFirstLine(line);
+      }
+      continue;
+    }
+    if (blockStart !== undefined) flushBlock(i - 1);
+  }
+  if (blockStart !== undefined) {
+    flushBlock(Math.min(bodyEndExclusive, lines.length) - 1);
+  }
+  return out;
+}
+
+/**
+ * Compute the full entry-block range: title line through last trailer
+ * line. When no trailer exists, the entry is treated as a single-line
+ * block (just the title). Used by the client to paint a card-style
+ * background behind the entire entry.
+ */
+function computeEntryRange(
+  entry: Entry,
+  lines: readonly string[],
+  trailerLines: readonly TrailerLine[],
+  endLineExclusive: number,
+): Range {
+  const startLine = Math.max(0, entry.location.line - 1);
+  const endLine = trailerLines.length > 0
+    ? trailerLines[trailerLines.length - 1].lineIndex
+    : Math.min(endLineExclusive, lines.length) - 1;
+  const safeEndLine = Math.max(startLine, endLine);
+  const endCol = lines[safeEndLine]?.length ?? 0;
+  return {
+    start: { line: startLine, character: 0 },
+    end: { line: safeEndLine, character: endCol },
+  };
+}

--- a/packages/markspec/lsp/entry_ranges_test.ts
+++ b/packages/markspec/lsp/entry_ranges_test.ts
@@ -1,0 +1,277 @@
+/**
+ * @module lsp/entry_ranges_test
+ *
+ * Unit tests for {@linkcode buildEntryRanges} — produces per-entry
+ * layout info (title range, trailer-dim ranges that exclude IDs,
+ * label ranges + validity).
+ */
+
+import { assertEquals } from "@std/assert";
+import type { Diagnostic, EffectiveProfile, Entry } from "../core/model/mod.ts";
+import { makeDisplayId } from "../core/model/mod.ts";
+import { buildEntryRanges } from "./entry_ranges.ts";
+
+function makeEntry(): Entry {
+  return {
+    displayId: makeDisplayId("REQ-001"),
+    title: "Brake response time",
+    body: "",
+    rawAttributes: [
+      { key: "Id", value: "01HGW2Q8MNP3RSTVWXYZABCDEF" },
+      { key: "Satisfies", value: "STK-001, STK-002" },
+      { key: "Labels", value: "ASIL-B, custom-label" },
+    ],
+    typedAttributes: new Map(),
+    shape: "Authored",
+    location: { file: "t.md", line: 1, column: 1 },
+    source: "markdown",
+  };
+}
+
+function makeProfile(allowedLabels: string[]): EffectiveProfile {
+  return {
+    chain: [],
+    labels: new Map(
+      allowedLabels.map((name) => [
+        name,
+        {
+          value: { name, kind: "enum" as const, values: [] },
+          origin: "test",
+        },
+      ]),
+    ),
+  } as unknown as EffectiveProfile;
+}
+
+Deno.test("buildEntryRanges: title range covers the title text", () => {
+  const text = ["- [REQ-001] Brake response time"].join("\n");
+  const result = buildEntryRanges(
+    [makeEntry()],
+    makeProfile([]),
+    [],
+    text.split("\n"),
+  );
+  assertEquals(result.entries.length, 1);
+  const tr = result.entries[0].titleRange;
+  assertEquals(tr.start.line, 0);
+  assertEquals(tr.start.character, 12); // after `- [REQ-001] `
+  assertEquals(tr.end.line, 0);
+  assertEquals(tr.end.character, 31); // end of "Brake response time"
+});
+
+Deno.test("buildEntryRanges: trailerDimRanges exclude embedded display IDs", () => {
+  const text = [
+    "- [REQ-001] Brake response time",
+    "",
+    "      Satisfies: STK-001, STK-002",
+  ].join("\n");
+  const result = buildEntryRanges(
+    [makeEntry()],
+    makeProfile([]),
+    [],
+    text.split("\n"),
+  );
+  const dim = result.entries[0].trailerDimRanges;
+  // For the Satisfies line, dim ranges should cover everything except
+  // the two display IDs. Expected: indent + "Satisfies: ", then ", ",
+  // then trailing nothing → 2 dim ranges on that line.
+  const line2 = dim.filter((r) => r.start.line === 2);
+  assertEquals(line2.length, 2);
+  // First dim chunk covers from column 0 to before "STK-001".
+  assertEquals(line2[0].start.character, 0);
+  assertEquals(line2[0].end.character, 17);
+  // Second dim chunk covers ", " between IDs.
+  assertEquals(line2[1].start.character, 24); // end of STK-001
+  assertEquals(line2[1].end.character, 26); // start of STK-002
+});
+
+Deno.test("buildEntryRanges: labelRanges carry the valid flag", () => {
+  const text = [
+    "- [REQ-001] Brake response time",
+    "",
+    "      Labels: ASIL-B, custom-label",
+  ].join("\n");
+  const result = buildEntryRanges(
+    [makeEntry()],
+    makeProfile(["ASIL-B"]),
+    [],
+    text.split("\n"),
+  );
+  const labels = result.entries[0].labelRanges;
+  assertEquals(labels.length, 2);
+  assertEquals(labels[0].valid, true);
+  assertEquals(labels[1].valid, false);
+});
+
+Deno.test("buildEntryRanges: labelRanges include diagnostic when invalid label has matching diag", () => {
+  const text = [
+    "- [REQ-001] Brake response time",
+    "",
+    "      Labels: custom-label",
+  ].join("\n");
+  const diag: Diagnostic = {
+    code: "MSL-L010",
+    severity: "warning",
+    message: "Unknown label 'custom-label'",
+    location: { file: "t.md", line: 3, column: 21 },
+  };
+  const result = buildEntryRanges(
+    [makeEntry()],
+    makeProfile(["ASIL-B"]),
+    [diag],
+    text.split("\n"),
+  );
+  const labels = result.entries[0].labelRanges;
+  assertEquals(labels[0].valid, false);
+  assertEquals(labels[0].diagnostic, "Unknown label 'custom-label'");
+});
+
+Deno.test("buildEntryRanges: Id line dim range is contiguous", () => {
+  // The ULID in `Id: 01HGW...` satisfies the display-ID grammar so it
+  // gets reported as an idRange by scanEntryTrailer. The Id slot is
+  // the entry's own identity, not a cross-reference — dim it whole.
+  const text = [
+    "- [REQ-001] Brake response time",
+    "",
+    "      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF",
+  ].join("\n");
+  const result = buildEntryRanges(
+    [makeEntry()],
+    makeProfile([]),
+    [],
+    text.split("\n"),
+  );
+  const idLineDim = result.entries[0].trailerDimRanges.filter(
+    (r) => r.start.line === 2,
+  );
+  assertEquals(idLineDim.length, 1);
+  assertEquals(idLineDim[0].start.character, 0);
+  assertEquals(idLineDim[0].end.character, text.split("\n")[2].length);
+});
+
+Deno.test("buildEntryRanges: Labels line dims only the key prefix", () => {
+  // Pill decorations draw on top of label values — those must NOT be
+  // covered by the dim layer or the pill text becomes unreadable.
+  // Dim only up to the value start (indent + "Labels: ").
+  const text = [
+    "- [REQ-001] Brake response time",
+    "",
+    "      Labels: ASIL-B, custom-label",
+  ].join("\n");
+  const result = buildEntryRanges(
+    [makeEntry()],
+    makeProfile(["ASIL-B", "custom-label"]),
+    [],
+    text.split("\n"),
+  );
+  const labelsLineDim = result.entries[0].trailerDimRanges.filter(
+    (r) => r.start.line === 2,
+  );
+  assertEquals(labelsLineDim.length, 1);
+  assertEquals(labelsLineDim[0].start.character, 0);
+  // Value starts at column 14 (6 indent + "Labels:" + 1 space).
+  assertEquals(labelsLineDim[0].end.character, 14);
+});
+
+Deno.test("buildEntryRanges: referenced entry (@-prefix) gets title range", () => {
+  const text = ["- [@ISO-26262-6] ISO 26262 Part 6"].join("\n");
+  const e: Entry = {
+    ...makeEntry(),
+    displayId: makeDisplayId("ISO-26262-6"),
+    title: "ISO 26262 Part 6",
+  };
+  const result = buildEntryRanges([e], makeProfile([]), [], text.split("\n"));
+  assertEquals(result.entries.length, 1);
+  // Title starts after "- [@ISO-26262-6] " — that's 17 characters.
+  assertEquals(result.entries[0].titleRange.start.character, 17);
+});
+
+Deno.test("buildEntryRanges: title with lowercase / dotted display ID still ranges", () => {
+  const text = ["- [my.entry] Dotted title"].join("\n");
+  const e: Entry = {
+    ...makeEntry(),
+    displayId: makeDisplayId("my.entry"),
+    title: "Dotted title",
+  };
+  const result = buildEntryRanges([e], makeProfile([]), [], text.split("\n"));
+  assertEquals(result.entries.length, 1);
+  assertEquals(result.entries[0].titleRange.start.character, 13); // after `- [my.entry] `
+});
+
+Deno.test("buildEntryRanges: classifies admonition blockquotes by [!KIND] marker", () => {
+  const text = [
+    "- [REQ-001] Title",
+    "",
+    "  > [!NOTE]",
+    "  > A note about something.",
+    "",
+    "  > [!WARNING]",
+    "  > Heads up.",
+    "",
+    "  > Plain quote with no marker.",
+    "",
+    "      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF",
+  ].join("\n");
+  const result = buildEntryRanges(
+    [makeEntry()],
+    makeProfile([]),
+    [],
+    text.split("\n"),
+  );
+  const bqs = result.entries[0].blockquoteRanges;
+  assertEquals(bqs.length, 3);
+  assertEquals(bqs[0].kind, "note");
+  assertEquals(bqs[0].range.start.line, 2);
+  assertEquals(bqs[0].range.end.line, 3);
+  assertEquals(bqs[1].kind, "warning");
+  assertEquals(bqs[1].range.start.line, 5);
+  assertEquals(bqs[1].range.end.line, 6);
+  assertEquals(bqs[2].kind, "plain");
+  assertEquals(bqs[2].range.start.line, 8);
+  assertEquals(bqs[2].range.end.line, 8);
+});
+
+Deno.test("buildEntryRanges: blockquote scan stops at trailer (does not include attribute lines)", () => {
+  const text = [
+    "- [REQ-001] Title",
+    "",
+    "  > [!NOTE]",
+    "  > In the body.",
+    "",
+    "      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF",
+    "      Labels: ASIL-B",
+  ].join("\n");
+  const result = buildEntryRanges(
+    [makeEntry()],
+    makeProfile([]),
+    [],
+    text.split("\n"),
+  );
+  const bqs = result.entries[0].blockquoteRanges;
+  assertEquals(bqs.length, 1);
+  assertEquals(bqs[0].kind, "note");
+  // Blockquote ends at line 3 — never spans into trailer (line 5+).
+  assertEquals(bqs[0].range.end.line, 3);
+});
+
+Deno.test("buildEntryRanges: admonition marker is case-insensitive", () => {
+  const text = [
+    "- [REQ-001] Title",
+    "",
+    "  > [!note]",
+    "  > lowercase marker.",
+    "",
+    "  > [!Important]",
+    "  > Title-case marker.",
+  ].join("\n");
+  const result = buildEntryRanges(
+    [makeEntry()],
+    makeProfile([]),
+    [],
+    text.split("\n"),
+  );
+  const bqs = result.entries[0].blockquoteRanges;
+  assertEquals(bqs.length, 2);
+  assertEquals(bqs[0].kind, "note");
+  assertEquals(bqs[1].kind, "important");
+});

--- a/packages/markspec/lsp/entry_trailer.ts
+++ b/packages/markspec/lsp/entry_trailer.ts
@@ -1,0 +1,141 @@
+/**
+ * @module lsp/entry_trailer
+ *
+ * Scan an entry's trailer block in document text. Returns one
+ * `TrailerLine` per attribute line, with the key range, value
+ * range, and any embedded display-ID ranges. Shared by both the
+ * semantic-tokens builder and the entry-ranges builder.
+ *
+ * The scanner walks document lines starting at the entry's
+ * 1-based start line. It identifies trailer lines (≥4 leading
+ * spaces, `Key:` pattern) and stops when it hits the next entry's
+ * title line or when `endLineExclusive` is reached.
+ *
+ * Returned column offsets are 0-based character indices into the
+ * source line, suitable for direct use as LSP positions.
+ */
+
+import type { Entry } from "../core/model/mod.ts";
+
+/** A single attribute line in an entry's trailer block. */
+export interface TrailerLine {
+  /** 0-based line index in the document. */
+  readonly lineIndex: number;
+  /** Attribute key, e.g. `"Id"`, `"Satisfies"`. */
+  readonly key: string;
+  /** 0-based column where the key starts. */
+  readonly keyStart: number;
+  /** Length of the key in characters. */
+  readonly keyLength: number;
+  /** 0-based column where the value starts (after `:` and any leading whitespace). */
+  readonly valueStart: number;
+  /** Length of the value in characters. */
+  readonly valueLength: number;
+  /** Display-ID sub-ranges discovered inside the value (whole-token matches). */
+  readonly idRanges: readonly { start: number; length: number }[];
+}
+
+/** Trailer-line pattern: ≥4 leading spaces, capital-letter Key, optional `-`, colon. */
+const TRAILER_LINE_RE = /^(\s{4,})([A-Z][A-Za-z-]*)\s*:\s*(.*)$/;
+
+/**
+ * Fenced code-block delimiter — opens or closes a fence of `\`\`\`` or
+ * `~~~` (CommonMark allows three or more, with the closer matching the
+ * opener's length and character class). Used to suppress trailer-line
+ * classification for lines inside any fenced code block — an indented
+ * `Key:` line inside, say, a YAML or feature fence is content, not an
+ * entry attribute.
+ */
+const FENCE_DELIM_RE = /^\s*(`{3,}|~{3,})/;
+
+/**
+ * Display-ID token pattern. Mirrors the grammar in `hover.ts` /
+ * `rename.ts`: letters, digits, `._/-`, ≥3 chars, alphanumeric start.
+ * `\b` cannot be used because `.` and `/` are not word characters, so
+ * boundaries are enforced by explicit `ID_CHAR_RE` checks at the match
+ * edges (same approach as `rename.ts`).
+ */
+const DISPLAY_ID_RE = /[A-Za-z0-9][A-Za-z0-9._/-]{2,}/g;
+
+/** Display-ID character set — letters, digits, dot, slash, hyphen, underscore. */
+const ID_CHAR_RE = /[A-Za-z0-9._/-]/;
+
+/**
+ * Walk the trailer of `entry` in `lines` and return per-line info.
+ *
+ * @param entry The parsed entry whose trailer is to be scanned.
+ * @param lines Document text split on `\n`.
+ * @param endLineExclusive 0-based stop line. Pass the next entry's start line
+ *   (0-based) or `lines.length` for the last entry.
+ */
+export function scanEntryTrailer(
+  entry: Entry,
+  lines: readonly string[],
+  endLineExclusive: number,
+): TrailerLine[] {
+  const out: TrailerLine[] = [];
+  const startIndex = entry.location.line - 1;
+  let insideFence = false;
+  for (let i = startIndex; i < endLineExclusive && i < lines.length; i++) {
+    const line = lines[i];
+    if (FENCE_DELIM_RE.test(line)) {
+      insideFence = !insideFence;
+      continue;
+    }
+    if (insideFence) continue;
+    const m = TRAILER_LINE_RE.exec(line);
+    if (!m) continue;
+    const indent = m[1].length;
+    const key = m[2];
+    const colonIndex = line.indexOf(":", indent + key.length);
+    if (colonIndex < 0) continue;
+    let valueStart = colonIndex + 1;
+    while (line[valueStart] === " " || line[valueStart] === "\t") {
+      valueStart += 1;
+    }
+    // Trim trailing whitespace so the reported value length doesn't
+    // run past the last printable character. Otherwise the entry-
+    // ranges dim region and the semantic-token `string` span would
+    // both extend over invisible spaces past EOL.
+    let valueEnd = line.length;
+    while (
+      valueEnd > valueStart &&
+      (line[valueEnd - 1] === " " || line[valueEnd - 1] === "\t")
+    ) {
+      valueEnd -= 1;
+    }
+    const valueLength = valueEnd - valueStart;
+    const valueText = line.slice(valueStart, valueEnd);
+    const idRanges: { start: number; length: number }[] = [];
+    // Note: this matches purely by shape — any 3+ char alphanumeric
+    // token is reported as an ID range, even in free-form values
+    // like `Note: foobar`. Consumers needing key-aware semantics
+    // (only treat as IDs when the key is a trace attribute) must
+    // filter on tl.key themselves. Pre-existing limitation also
+    // present in hover.ts and rename.ts.
+    DISPLAY_ID_RE.lastIndex = 0;
+    let match: RegExpExecArray | null;
+    while ((match = DISPLAY_ID_RE.exec(valueText)) !== null) {
+      const before = match.index === 0 ? "" : valueText[match.index - 1];
+      const afterIdx = match.index + match[0].length;
+      const after = afterIdx >= valueText.length ? "" : valueText[afterIdx];
+      const boundedLeft = before === "" || !ID_CHAR_RE.test(before);
+      const boundedRight = after === "" || !ID_CHAR_RE.test(after);
+      if (!boundedLeft || !boundedRight) continue;
+      idRanges.push({
+        start: valueStart + match.index,
+        length: match[0].length,
+      });
+    }
+    out.push({
+      lineIndex: i,
+      key,
+      keyStart: indent,
+      keyLength: key.length,
+      valueStart,
+      valueLength,
+      idRanges,
+    });
+  }
+  return out;
+}

--- a/packages/markspec/lsp/entry_trailer_test.ts
+++ b/packages/markspec/lsp/entry_trailer_test.ts
@@ -1,0 +1,135 @@
+/**
+ * @module lsp/entry_trailer_test
+ *
+ * Unit tests for {@linkcode scanEntryTrailer} — walks an entry's
+ * trailer block in document text and reports per-attribute key,
+ * value, and embedded display-ID ranges.
+ */
+
+import { assertEquals } from "@std/assert";
+import type { Entry } from "../core/model/mod.ts";
+import { makeDisplayId } from "../core/model/mod.ts";
+import { scanEntryTrailer } from "./entry_trailer.ts";
+
+function makeEntry(displayId: string, line: number): Entry {
+  return {
+    displayId: makeDisplayId(displayId),
+    title: displayId,
+    body: "",
+    rawAttributes: [],
+    typedAttributes: new Map(),
+    shape: "Authored",
+    location: { file: "t.md", line, column: 1 },
+    source: "markdown",
+  };
+}
+
+Deno.test("scanEntryTrailer: identifies Id key/value ranges", () => {
+  const text = [
+    "- [REQ-001] Title",
+    "",
+    "  Body paragraph.",
+    "",
+    "      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF",
+  ].join("\n");
+  const result = scanEntryTrailer(makeEntry("REQ-001", 1), text.split("\n"), 5);
+  assertEquals(result.length, 1);
+  assertEquals(result[0].lineIndex, 4);
+  assertEquals(result[0].key, "Id");
+  assertEquals(result[0].keyStart, 6);
+  assertEquals(result[0].keyLength, 2);
+  assertEquals(result[0].valueStart, 10);
+  assertEquals(result[0].valueLength, 26);
+  // The ULID matches the display-ID token grammar shared with
+  // `hover.ts` / `rename.ts` (alphanumeric start, ID chars, ≥3).
+  assertEquals(result[0].idRanges, [{ start: 10, length: 26 }]);
+});
+
+Deno.test("scanEntryTrailer: extracts display IDs inside Satisfies value", () => {
+  const text = [
+    "- [REQ-001] Title",
+    "",
+    "      Satisfies: STK-001, STK-002",
+  ].join("\n");
+  const result = scanEntryTrailer(makeEntry("REQ-001", 1), text.split("\n"), 3);
+  assertEquals(result.length, 1);
+  assertEquals(result[0].key, "Satisfies");
+  assertEquals(result[0].idRanges.length, 2);
+  // First ID "STK-001" starts at column index 17 (6 indent + 9 key + colon + space)
+  assertEquals(result[0].idRanges[0].start, 17);
+  assertEquals(result[0].idRanges[0].length, 7);
+  assertEquals(result[0].idRanges[1].start, 26);
+  assertEquals(result[0].idRanges[1].length, 7);
+});
+
+Deno.test("scanEntryTrailer: handles multiple spaces after colon", () => {
+  const text = [
+    "- [REQ-001] Title",
+    "",
+    "      Satisfies:   STK-001",
+  ].join("\n");
+  const result = scanEntryTrailer(makeEntry("REQ-001", 1), text.split("\n"), 3);
+  assertEquals(result.length, 1);
+  assertEquals(result[0].key, "Satisfies");
+  assertEquals(result[0].idRanges.length, 1);
+  // Line: "      Satisfies:   STK-001"
+  //        0123456789012345678901234567
+  // STK-001 starts at column 19 (6 indent + 9 key + ':' + 3 spaces = 19).
+  assertEquals(result[0].idRanges[0].start, 19);
+  assertEquals(result[0].idRanges[0].length, 7);
+  assertEquals(result[0].valueStart, 19);
+});
+
+Deno.test("scanEntryTrailer: stops at next entry's title line", () => {
+  const text = [
+    "- [REQ-001] First",
+    "",
+    "      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF",
+    "",
+    "- [REQ-002] Second",
+    "",
+    "      Id: 01HGW2Q8MNP3RSTVWXYZABCDEG",
+  ].join("\n");
+  const result = scanEntryTrailer(makeEntry("REQ-001", 1), text.split("\n"), 5);
+  assertEquals(result.length, 1);
+  assertEquals(result[0].lineIndex, 2);
+});
+
+Deno.test("scanEntryTrailer: matches digit-leading and dotted display IDs", () => {
+  const text = [
+    "- [REQ-001] Title",
+    "",
+    "      Satisfies: 001.alpha, lower-case",
+  ].join("\n");
+  const result = scanEntryTrailer(makeEntry("REQ-001", 1), text.split("\n"), 3);
+  assertEquals(result.length, 1);
+  assertEquals(result[0].key, "Satisfies");
+  assertEquals(result[0].idRanges.length, 2);
+  // Line: "      Satisfies: 001.alpha, lower-case"
+  //        0123456789012345678901234567890123456789
+  // "001.alpha" starts at column 17, length 9.
+  assertEquals(result[0].idRanges[0].start, 17);
+  assertEquals(result[0].idRanges[0].length, 9);
+  // "lower-case" starts at column 28, length 10.
+  assertEquals(result[0].idRanges[1].start, 28);
+  assertEquals(result[0].idRanges[1].length, 10);
+});
+
+Deno.test("scanEntryTrailer: empty for entry with no trailer", () => {
+  const text = ["- [REQ-001] Title", "", "  Body only."].join("\n");
+  const result = scanEntryTrailer(makeEntry("REQ-001", 1), text.split("\n"), 3);
+  assertEquals(result, []);
+});
+
+Deno.test("scanEntryTrailer: trims trailing whitespace from valueLength", () => {
+  // Line ends with 3 trailing spaces.
+  const text = [
+    "- [REQ-001] Title",
+    "",
+    "      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF   ",
+  ].join("\n");
+  const result = scanEntryTrailer(makeEntry("REQ-001", 1), text.split("\n"), 3);
+  assertEquals(result.length, 1);
+  // Without the fix, valueLength would be 29 (26 ULID + 3 trailing spaces).
+  assertEquals(result[0].valueLength, 26);
+});

--- a/packages/markspec/lsp/semantic_tokens.ts
+++ b/packages/markspec/lsp/semantic_tokens.ts
@@ -1,0 +1,401 @@
+/**
+ * @module lsp/semantic_tokens
+ *
+ * Produce LSP semantic tokens for an entry's title, embedded display
+ * IDs, trailer attribute keys/values, and labels (with a validity
+ * modifier sourced from the active profile's `labels` catalog).
+ *
+ * The builder returns an intermediate `SemanticToken[]` shape that
+ * the LSP server encodes into the LSP wire format. Keeping the
+ * intermediate is what makes the builder testable without
+ * reimplementing the wire encoding in test code.
+ *
+ * An empty profile labels catalog is treated as "open set" — every
+ * label is valid. The `modification` modifier is set only when the
+ * catalog is non-empty AND the label is not in it.
+ */
+
+import type { EffectiveProfile, Entry } from "../core/model/mod.ts";
+import { scanEntryTrailer } from "./entry_trailer.ts";
+
+/** LSP semantic-token legend exported by the server's capabilities. */
+export const SEMANTIC_TOKEN_LEGEND = {
+  tokenTypes: [
+    "class",
+    "enum",
+    "enumMember",
+    "keyword",
+    "property",
+    "string",
+  ] as const,
+  tokenModifiers: ["declaration", "static", "modification"] as const,
+} as const;
+
+/** One of the token types declared in {@linkcode SEMANTIC_TOKEN_LEGEND}. */
+export type SemanticTokenType =
+  (typeof SEMANTIC_TOKEN_LEGEND.tokenTypes)[number];
+
+/** One of the token modifiers declared in {@linkcode SEMANTIC_TOKEN_LEGEND}. */
+export type SemanticTokenModifier =
+  (typeof SEMANTIC_TOKEN_LEGEND.tokenModifiers)[number];
+
+/** A single semantic token with column-based positions. */
+export interface SemanticToken {
+  /** 0-based line index in the document. */
+  readonly line: number;
+  /** 0-based column where the token starts. */
+  readonly startChar: number;
+  /** Length of the token in characters. */
+  readonly length: number;
+  /** Token type from the legend. */
+  readonly tokenType: SemanticTokenType;
+  /** Zero or more modifiers from the legend. */
+  readonly tokenModifiers: readonly SemanticTokenModifier[];
+}
+
+/**
+ * Title line pattern: `- [DISPLAY_ID] Title text`.
+ *
+ * The ID class mirrors the project's canonical display-ID grammar used
+ * by `entry_trailer.ts` (`DISPLAY_ID_RE`) and `hover.ts`
+ * (`DISPLAY_ID_TOKEN_RE`): a leading alphanumeric followed by at least
+ * two more characters from the set `[A-Za-z0-9._/-]`. The `{2,}`
+ * quantifier (not `+`) enforces the ≥3-char total length that those
+ * modules also require, so semantic-tokens highlighting covers every
+ * ID the parser, hover, rename, and references already accept (e.g.
+ * `my-entry`, `my.entry`, `ns/entry`).
+ */
+const TITLE_LINE_RE =
+  /^(\s*-\s+\[)(@?[A-Za-z0-9][A-Za-z0-9._/-]{2,})(\]\s*)(.*)$/;
+
+/**
+ * Build semantic tokens for every entry in `entries`. Tokens are
+ * returned sorted by (line, startChar) — encoding to the LSP wire
+ * format requires sorted input.
+ */
+export function buildSemanticTokens(
+  entries: readonly Entry[],
+  profile: EffectiveProfile | undefined,
+  lines: readonly string[],
+): SemanticToken[] {
+  const tokens: SemanticToken[] = [];
+  const allowedLabels = collectAllowedLabels(profile);
+
+  // Sort entries so we know each entry's end (= next entry's start).
+  const sorted = [...entries].sort(
+    (a, b) => a.location.line - b.location.line,
+  );
+
+  for (let i = 0; i < sorted.length; i++) {
+    const entry = sorted[i];
+    const endLineExclusive = i + 1 < sorted.length
+      ? sorted[i + 1].location.line - 1
+      : lines.length;
+
+    addTitleTokens(tokens, entry, lines);
+    addBodyKeywordTokens(tokens, entry, lines, endLineExclusive);
+    addTrailerTokens(tokens, entry, lines, endLineExclusive, allowedLabels);
+  }
+
+  tokens.sort((a, b) =>
+    a.line !== b.line ? a.line - b.line : a.startChar - b.startChar
+  );
+  return tokens;
+}
+
+/** Collect the active profile's allowed label names, or `undefined` when empty. */
+function collectAllowedLabels(
+  profile: EffectiveProfile | undefined,
+): Set<string> | undefined {
+  if (!profile) return undefined;
+  const names = new Set<string>();
+  for (const [name] of profile.labels) names.add(name);
+  return names.size > 0 ? names : undefined;
+}
+
+/** Emit `enum` (display ID) and `class` (title text) tokens on the entry's title line. */
+function addTitleTokens(
+  out: SemanticToken[],
+  entry: Entry,
+  lines: readonly string[],
+): void {
+  const lineIndex = entry.location.line - 1;
+  if (lineIndex < 0 || lineIndex >= lines.length) return;
+  const line = lines[lineIndex];
+  const m = TITLE_LINE_RE.exec(line);
+  if (!m) return;
+  const prefix = m[1];
+  const id = m[2];
+  const close = m[3];
+  const title = m[4];
+  const idStart = prefix.length;
+  out.push({
+    line: lineIndex,
+    startChar: idStart,
+    length: id.length,
+    tokenType: "enum",
+    tokenModifiers: ["declaration"],
+  });
+  const titleStart = prefix.length + id.length + close.length;
+  if (title.length > 0) {
+    out.push({
+      line: lineIndex,
+      startChar: titleStart,
+      length: title.length,
+      tokenType: "class",
+      tokenModifiers: ["declaration"],
+    });
+  }
+}
+
+/**
+ * RFC 2119 modal verbs (lowercase canonical form) and the five EARS
+ * pattern triggers. Matched case-insensitively as whole words inside
+ * entry body prose, then emitted as `keyword` tokens so themes paint
+ * them prominently — the same treatment language keywords get.
+ *
+ * `not` is intentionally not in the set; negation reads as part of
+ * the modal phrase (e.g., `shall not`) and highlighting only the modal
+ * verb is enough to anchor the eye.
+ */
+const BODY_KEYWORD_RE =
+  /\b(shall|should|may|must|will|when|while|if|where|then)\b/gi;
+
+/**
+ * Gherkin section keywords — section headers, not steps. Rendered as
+ * `class` semantic tokens to mirror GitHub Linguist's
+ * `entity.name.section.*` and Rouge's `Generic::Heading` scoping;
+ * themes paint these like type/heading names.
+ *
+ * Multi-word keywords (`Scenario Outline`, `Scenario Template`) are
+ * matched as single units; bare `Scenario` matches when the longer
+ * form isn't present.
+ */
+const GHERKIN_SECTION_RE =
+  /\b(Feature|Background|Rule|Scenario Outline|Scenario Template|Scenarios|Examples|Scenario)\b/g;
+
+/**
+ * Gherkin step keywords — rendered as `keyword` semantic tokens to
+ * mirror `keyword.control.cucumber` / Rouge `Keyword`. Themes paint
+ * these with a strong colour + bold, the same treatment programming-
+ * language keywords get.
+ */
+const GHERKIN_STEP_RE = /\b(Given|When|Then|And|But)\b/g;
+
+/** Detect a fenced code block opener with a `feature` or `gherkin` language tag. */
+const FEATURE_FENCE_OPEN_RE = /^\s*(```+|~~~+)\s*(feature|gherkin)\b/i;
+
+/** Detect a fenced code block closer using the same fence character set. */
+const FENCE_CLOSE_RE = /^\s*(```+|~~~+)\s*$/;
+
+/**
+ * Inline `$Identifier` entity reference (spec §2.5.2). Matched directly
+ * against body lines for highlighting; the full parser also tracks
+ * `$$…$$` math fences and `\$` escapes, but for visual rendering a
+ * straight regex is good enough and avoids relying on parser-emitted
+ * positions that are body-relative.
+ */
+const ENTITY_REF_RE = /\$[A-Za-z][A-Za-z0-9_]*/g;
+
+/**
+ * Emit `keyword` tokens for modal verbs and EARS triggers in entry
+ * body prose, and for Gherkin keywords inside fenced `feature` /
+ * `gherkin` blocks. The scan covers lines between the entry's title
+ * line and the next entry (or document end), excluding trailer lines.
+ */
+function addBodyKeywordTokens(
+  out: SemanticToken[],
+  entry: Entry,
+  lines: readonly string[],
+  endLineExclusive: number,
+): void {
+  const trailerLines = scanEntryTrailer(entry, lines, endLineExclusive);
+  // Body ends at the first trailer line. Lines AFTER the trailer block
+  // (and up to the next entry's title) are inter-entry prose, not the
+  // entry's body — they must not be tokenized as part of this entry.
+  const bodyEndExclusive = trailerLines.length > 0
+    ? trailerLines[0].lineIndex
+    : endLineExclusive;
+  // Body starts on the line after the title (1-based location.line is
+  // the title line; 0-based body starts at location.line).
+  const startIndex = entry.location.line;
+  let insideFeatureBlock = false;
+  for (let i = startIndex; i < bodyEndExclusive && i < lines.length; i++) {
+    const line = lines[i];
+
+    // Track fenced feature/gherkin blocks. The fence delimiters
+    // themselves are not tokenized; lines inside emit Gherkin section
+    // keywords (Feature/Scenario/...) as `class` and step keywords
+    // (Given/When/Then/...) as `keyword`, matching the GitHub Linguist
+    // and Rouge conventions for Cucumber.
+    if (insideFeatureBlock) {
+      if (FENCE_CLOSE_RE.test(line)) {
+        insideFeatureBlock = false;
+        continue;
+      }
+      emitTypedMatches(out, GHERKIN_SECTION_RE, line, i, "class", []);
+      emitKeywordMatches(out, GHERKIN_STEP_RE, line, i);
+      continue;
+    }
+    if (FEATURE_FENCE_OPEN_RE.test(line)) {
+      insideFeatureBlock = true;
+      continue;
+    }
+    if (line.trim() === "") continue;
+    emitKeywordMatches(out, BODY_KEYWORD_RE, line, i);
+    emitEntityRefMatches(out, line, i);
+  }
+}
+
+/** Scan a body line for `$Identifier` tokens and emit `string` tokens. */
+function emitEntityRefMatches(
+  out: SemanticToken[],
+  line: string,
+  lineIndex: number,
+): void {
+  ENTITY_REF_RE.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = ENTITY_REF_RE.exec(line)) !== null) {
+    // Skip the second half of a `$$…$$` math fence.
+    if (match.index > 0 && line[match.index - 1] === "$") continue;
+    // Skip escaped `\$`.
+    if (match.index > 0 && line[match.index - 1] === "\\") continue;
+    out.push({
+      line: lineIndex,
+      startChar: match.index,
+      length: match[0].length,
+      tokenType: "string",
+      tokenModifiers: [],
+    });
+  }
+}
+
+/** Run a `g`-flag regex across `line` and push a `keyword` token per match. */
+function emitKeywordMatches(
+  out: SemanticToken[],
+  re: RegExp,
+  line: string,
+  lineIndex: number,
+): void {
+  emitTypedMatches(out, re, line, lineIndex, "keyword", []);
+}
+
+/**
+ * Run a `g`-flag regex across `line` and push a token of the given
+ * type/modifiers per match. Shared by the modal/EARS scanner (keyword)
+ * and the Gherkin section scanner (class).
+ */
+function emitTypedMatches(
+  out: SemanticToken[],
+  re: RegExp,
+  line: string,
+  lineIndex: number,
+  tokenType: SemanticTokenType,
+  tokenModifiers: readonly SemanticTokenModifier[],
+): void {
+  re.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(line)) !== null) {
+    out.push({
+      line: lineIndex,
+      startChar: match.index,
+      length: match[0].length,
+      tokenType,
+      tokenModifiers,
+    });
+  }
+}
+
+/** Emit tokens for every trailer line in the entry. */
+function addTrailerTokens(
+  out: SemanticToken[],
+  entry: Entry,
+  lines: readonly string[],
+  endLineExclusive: number,
+  allowedLabels: Set<string> | undefined,
+): void {
+  const trailerLines = scanEntryTrailer(entry, lines, endLineExclusive);
+  for (const tl of trailerLines) {
+    // Attribute key — property + static.
+    out.push({
+      line: tl.lineIndex,
+      startChar: tl.keyStart,
+      length: tl.keyLength,
+      tokenType: "property",
+      tokenModifiers: ["static"],
+    });
+
+    if (tl.key === "Labels") {
+      // One enumMember per label, with `modification` when invalid.
+      addLabelTokens(out, tl, lines[tl.lineIndex], allowedLabels);
+    } else if (tl.idRanges.length > 0) {
+      // Trace attribute with display IDs — emit enumMember per ID, leave
+      // the rest of the value uncolored (themes paint the surrounding
+      // text via the prose color).
+      for (const r of tl.idRanges) {
+        out.push({
+          line: tl.lineIndex,
+          startChar: r.start,
+          length: r.length,
+          tokenType: "enumMember",
+          tokenModifiers: [],
+        });
+      }
+    } else {
+      // Plain value — string token covers the whole value range.
+      if (tl.valueLength > 0) {
+        out.push({
+          line: tl.lineIndex,
+          startChar: tl.valueStart,
+          length: tl.valueLength,
+          tokenType: "string",
+          tokenModifiers: [],
+        });
+      }
+    }
+  }
+}
+
+/** Emit one `enumMember` token per comma-separated label, with `modification` when invalid. */
+function addLabelTokens(
+  out: SemanticToken[],
+  tl: { lineIndex: number; valueStart: number; valueLength: number },
+  line: string,
+  allowedLabels: Set<string> | undefined,
+): void {
+  const value = line.slice(tl.valueStart, tl.valueStart + tl.valueLength);
+  for (const segment of splitWithOffsets(value)) {
+    const trimmed = segment.text.trim();
+    if (trimmed.length === 0) continue;
+    const trimmedStart = segment.text.indexOf(trimmed);
+    const start = tl.valueStart + segment.offset + trimmedStart;
+    const modifiers: SemanticTokenModifier[] =
+      allowedLabels && !allowedLabels.has(trimmed) ? ["modification"] : [];
+    out.push({
+      line: tl.lineIndex,
+      startChar: start,
+      length: trimmed.length,
+      tokenType: "enumMember",
+      tokenModifiers: modifiers,
+    });
+  }
+}
+
+/** A comma-split segment with its offset back into the source value string. */
+interface Segment {
+  text: string;
+  offset: number;
+}
+
+/** Split `value` on commas, returning each segment together with its starting offset. */
+function splitWithOffsets(value: string): Segment[] {
+  const out: Segment[] = [];
+  let start = 0;
+  for (let i = 0; i <= value.length; i++) {
+    if (i === value.length || value[i] === ",") {
+      out.push({ text: value.slice(start, i), offset: start });
+      start = i + 1;
+    }
+  }
+  return out;
+}

--- a/packages/markspec/lsp/semantic_tokens_test.ts
+++ b/packages/markspec/lsp/semantic_tokens_test.ts
@@ -1,0 +1,575 @@
+/**
+ * @module lsp/semantic_tokens_test
+ *
+ * Unit tests for {@linkcode buildSemanticTokens} — produces LSP
+ * semantic tokens for an entry's title, display IDs, attribute
+ * keys, attribute values, and labels (with validity modifier).
+ */
+
+import { assertEquals } from "@std/assert";
+import type { EffectiveProfile, Entry } from "../core/model/mod.ts";
+import { makeDisplayId } from "../core/model/mod.ts";
+import {
+  buildSemanticTokens,
+  SEMANTIC_TOKEN_LEGEND,
+} from "./semantic_tokens.ts";
+
+function makeEntry(): Entry {
+  return {
+    displayId: makeDisplayId("REQ-001"),
+    title: "Brake response time",
+    body: "",
+    rawAttributes: [
+      { key: "Id", value: "01HGW2Q8MNP3RSTVWXYZABCDEF" },
+      { key: "Satisfies", value: "STK-001" },
+      { key: "Labels", value: "ASIL-B, custom-label" },
+    ],
+    typedAttributes: new Map([
+      ["Id", ["01HGW2Q8MNP3RSTVWXYZABCDEF"]],
+      ["Satisfies", ["STK-001"]],
+      ["Labels", ["ASIL-B", "custom-label"]],
+    ]),
+    shape: "Authored",
+    location: { file: "t.md", line: 1, column: 1 },
+    source: "markdown",
+  };
+}
+
+function makeProfile(allowedLabels: string[]): EffectiveProfile {
+  // Minimal stub — only `labels` is consulted by the builder.
+  return {
+    chain: [],
+    labels: new Map(
+      allowedLabels.map((name) => [
+        name,
+        {
+          value: { name, kind: "enum" as const, values: [] },
+          origin: "test",
+        },
+      ]),
+    ),
+  } as unknown as EffectiveProfile;
+}
+
+Deno.test("buildSemanticTokens: legend lists expected types and modifiers", () => {
+  assertEquals(SEMANTIC_TOKEN_LEGEND.tokenTypes, [
+    "class",
+    "enum",
+    "enumMember",
+    "keyword",
+    "property",
+    "string",
+  ]);
+  assertEquals(SEMANTIC_TOKEN_LEGEND.tokenModifiers, [
+    "declaration",
+    "static",
+    "modification",
+  ]);
+});
+
+Deno.test("buildSemanticTokens: title line emits class + enum tokens", () => {
+  const text = ["- [REQ-001] Brake response time"].join("\n");
+  const tokens = buildSemanticTokens(
+    [makeEntry()],
+    makeProfile([]),
+    text.split("\n"),
+  );
+  // Title line carries: `[REQ-001]` (enum, declaration) and the title
+  // text (class, declaration). Both use the *.declaration token shape so
+  // themes paint them with the same colour family; the extension layers
+  // a bold decoration on top of the title range for visual weight.
+  const titleTokens = tokens.filter((t) => t.line === 0);
+  assertEquals(titleTokens.length, 2);
+  assertEquals(titleTokens[0].tokenType, "enum");
+  assertEquals(titleTokens[0].tokenModifiers, ["declaration"]);
+  assertEquals(titleTokens[0].startChar, 3); // after `- [`
+  assertEquals(titleTokens[0].length, 7); // `REQ-001`
+  assertEquals(titleTokens[1].tokenType, "class");
+  assertEquals(titleTokens[1].tokenModifiers, ["declaration"]);
+  assertEquals(titleTokens[1].startChar, 12); // after `- [REQ-001] `
+  assertEquals(titleTokens[1].length, "Brake response time".length);
+});
+
+Deno.test("buildSemanticTokens: trailer Id emits property + enumMember (uniform with trace attrs)", () => {
+  const text = [
+    "- [REQ-001] Brake response time",
+    "",
+    "      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF",
+  ].join("\n");
+  const tokens = buildSemanticTokens(
+    [makeEntry()],
+    makeProfile([]),
+    text.split("\n"),
+  );
+  const idLineTokens = tokens.filter((t) => t.line === 2);
+  assertEquals(idLineTokens.length, 2);
+  assertEquals(idLineTokens[0].tokenType, "property");
+  assertEquals(idLineTokens[0].tokenModifiers, ["static"]);
+  // ULID matches the display-ID grammar — no special case, gets the
+  // same enumMember token as cross-references in trace attributes.
+  assertEquals(idLineTokens[1].tokenType, "enumMember");
+});
+
+Deno.test("buildSemanticTokens: Satisfies value tokenizes the display ID as enumMember", () => {
+  const text = [
+    "- [REQ-001] Brake response time",
+    "",
+    "      Satisfies: STK-001",
+  ].join("\n");
+  const tokens = buildSemanticTokens(
+    [makeEntry()],
+    makeProfile([]),
+    text.split("\n"),
+  );
+  const satisfiesLine = tokens.filter((t) => t.line === 2);
+  // property (key) + enumMember (the ID — no separate string token because the value IS the ID)
+  const idToken = satisfiesLine.find((t) => t.tokenType === "enumMember");
+  assertEquals(idToken !== undefined, true);
+  assertEquals(idToken!.length, 7);
+});
+
+Deno.test("buildSemanticTokens: Labels value emits one enumMember per label", () => {
+  const text = [
+    "- [REQ-001] Brake response time",
+    "",
+    "      Labels: ASIL-B, custom-label",
+  ].join("\n");
+  const tokens = buildSemanticTokens(
+    [makeEntry()],
+    makeProfile(["ASIL-B"]),
+    text.split("\n"),
+  );
+  const labelLine = tokens.filter((t) => t.line === 2);
+  const labels = labelLine.filter((t) => t.tokenType === "enumMember");
+  assertEquals(labels.length, 2);
+  // ASIL-B is in the catalog — no modification modifier.
+  assertEquals(labels[0].tokenModifiers, []);
+  // custom-label is not in the catalog — modification modifier set.
+  assertEquals(labels[1].tokenModifiers, ["modification"]);
+});
+
+Deno.test("buildSemanticTokens: empty profile catalog leaves all labels valid", () => {
+  const text = [
+    "- [REQ-001] Brake response time",
+    "",
+    "      Labels: ASIL-B, custom-label",
+  ].join("\n");
+  const tokens = buildSemanticTokens(
+    [makeEntry()],
+    makeProfile([]),
+    text.split("\n"),
+  );
+  const labels = tokens.filter(
+    (t) => t.line === 2 && t.tokenType === "enumMember",
+  );
+  assertEquals(labels.length, 2);
+  assertEquals(labels[0].tokenModifiers, []);
+  assertEquals(labels[1].tokenModifiers, []);
+});
+
+Deno.test("buildSemanticTokens: multi-entry file scopes trailer tokens to each entry", () => {
+  // Two entries; the first's trailer must stop before the second's
+  // title line, and the second must also receive its own title tokens.
+  // Exercises the `endLineExclusive = sorted[i + 1].location.line - 1`
+  // branch in the builder.
+  const text = [
+    "- [REQ-001] First", //                line 0 (entry 1 title)
+    "  Body.", //                          line 1
+    "", //                                  line 2
+    "      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF", // line 3
+    "", //                                  line 4
+    "- [REQ-002] Second", //                line 5 (entry 2 title)
+    "  Body.", //                          line 6
+    "", //                                  line 7
+    "      Id: 01HGW2Q8MNP3RSTVWXYZABCDEG", // line 8
+  ].join("\n");
+  const entry1: Entry = {
+    displayId: makeDisplayId("REQ-001"),
+    title: "First",
+    body: "",
+    rawAttributes: [{ key: "Id", value: "01HGW2Q8MNP3RSTVWXYZABCDEF" }],
+    typedAttributes: new Map([["Id", ["01HGW2Q8MNP3RSTVWXYZABCDEF"]]]),
+    shape: "Authored",
+    location: { file: "t.md", line: 1, column: 1 },
+    source: "markdown",
+  };
+  const entry2: Entry = {
+    displayId: makeDisplayId("REQ-002"),
+    title: "Second",
+    body: "",
+    rawAttributes: [{ key: "Id", value: "01HGW2Q8MNP3RSTVWXYZABCDEG" }],
+    typedAttributes: new Map([["Id", ["01HGW2Q8MNP3RSTVWXYZABCDEG"]]]),
+    shape: "Authored",
+    location: { file: "t.md", line: 6, column: 1 },
+    source: "markdown",
+  };
+  const tokens = buildSemanticTokens(
+    [entry1, entry2],
+    makeProfile([]),
+    text.split("\n"),
+  );
+  // Exactly two `class/declaration` title tokens — one per entry.
+  const classTokens = tokens.filter(
+    (t) => t.tokenType === "class" && t.tokenModifiers.includes("declaration"),
+  );
+  assertEquals(classTokens.length, 2);
+  assertEquals(classTokens[0].line, 0);
+  assertEquals(classTokens[1].line, 5);
+  // Each title line also carries an enum/declaration token for the ID.
+  const enumDeclTokens = tokens.filter(
+    (t) => t.tokenType === "enum" && t.tokenModifiers.includes("declaration"),
+  );
+  assertEquals(enumDeclTokens.length, 2);
+  assertEquals(enumDeclTokens[0].line, 0);
+  assertEquals(enumDeclTokens[1].line, 5);
+  // Trailer tokens for entry 1 live on line 3 and entry 2 on line 8.
+  const propTokens = tokens.filter((t) => t.tokenType === "property");
+  assertEquals(propTokens.length, 2);
+  assertEquals(propTokens[0].line, 3);
+  assertEquals(propTokens[1].line, 8);
+});
+
+Deno.test("buildSemanticTokens: plain-text attribute value gets a single string token", () => {
+  // `ok` is 2 chars — fails the display-ID grammar's ≥3-char rule —
+  // so the trailer scanner returns no idRanges and the builder falls
+  // through to the plain-string branch.
+  const text = [
+    "- [REQ-001] Title",
+    "",
+    "      Note: ok",
+  ].join("\n");
+  const entry: Entry = {
+    displayId: makeDisplayId("REQ-001"),
+    title: "Title",
+    body: "",
+    rawAttributes: [{ key: "Note", value: "ok" }],
+    typedAttributes: new Map([["Note", ["ok"]]]),
+    shape: "Authored",
+    location: { file: "t.md", line: 1, column: 1 },
+    source: "markdown",
+  };
+  const tokens = buildSemanticTokens(
+    [entry],
+    makeProfile([]),
+    text.split("\n"),
+  );
+  const noteLine = tokens.filter((t) => t.line === 2);
+  // Exactly: property (Note key) + string (ok value). No enumMember.
+  assertEquals(noteLine.length, 2);
+  assertEquals(noteLine[0].tokenType, "property");
+  assertEquals(noteLine[0].tokenModifiers, ["static"]);
+  assertEquals(noteLine[1].tokenType, "string");
+  assertEquals(noteLine[1].length, 2); // "ok"
+  const enumMembers = noteLine.filter((t) => t.tokenType === "enumMember");
+  assertEquals(enumMembers.length, 0);
+});
+
+Deno.test("buildSemanticTokens: title with lowercase-hyphenated display ID still highlights", () => {
+  // Regression guard: TITLE_LINE_RE must accept the same display-ID
+  // grammar as the core parser (entry_trailer.ts, hover.ts, rename.ts).
+  const text = ["- [my-entry] A title"].join("\n");
+  const entry: Entry = {
+    displayId: makeDisplayId("my-entry"),
+    title: "A title",
+    body: "",
+    rawAttributes: [],
+    typedAttributes: new Map(),
+    shape: "Authored",
+    location: { file: "t.md", line: 1, column: 1 },
+    source: "markdown",
+  };
+  const tokens = buildSemanticTokens(
+    [entry],
+    makeProfile([]),
+    text.split("\n"),
+  );
+  const titleTokens = tokens.filter((t) => t.line === 0);
+  assertEquals(titleTokens.length, 2);
+  assertEquals(titleTokens[0].tokenType, "enum");
+  assertEquals(titleTokens[0].tokenModifiers, ["declaration"]);
+  assertEquals(titleTokens[0].startChar, 3); // after `- [`
+  assertEquals(titleTokens[0].length, "my-entry".length);
+  assertEquals(titleTokens[1].tokenType, "class");
+  assertEquals(titleTokens[1].tokenModifiers, ["declaration"]);
+  assertEquals(titleTokens[1].length, "A title".length);
+});
+
+Deno.test("buildSemanticTokens: title with dotted display ID still highlights", () => {
+  const text = ["- [my.entry] Dotted title"].join("\n");
+  const entry: Entry = {
+    displayId: makeDisplayId("my.entry"),
+    title: "Dotted title",
+    body: "",
+    rawAttributes: [],
+    typedAttributes: new Map(),
+    shape: "Authored",
+    location: { file: "t.md", line: 1, column: 1 },
+    source: "markdown",
+  };
+  const tokens = buildSemanticTokens(
+    [entry],
+    makeProfile([]),
+    text.split("\n"),
+  );
+  const titleTokens = tokens.filter((t) => t.line === 0);
+  assertEquals(titleTokens.length, 2);
+  assertEquals(titleTokens[0].tokenType, "enum");
+  assertEquals(titleTokens[0].length, "my.entry".length);
+  assertEquals(titleTokens[1].tokenType, "class");
+});
+
+Deno.test("buildSemanticTokens: title with slashed display ID still highlights", () => {
+  const text = ["- [ns/entry] Slashed title"].join("\n");
+  const entry: Entry = {
+    displayId: makeDisplayId("ns/entry"),
+    title: "Slashed title",
+    body: "",
+    rawAttributes: [],
+    typedAttributes: new Map(),
+    shape: "Authored",
+    location: { file: "t.md", line: 1, column: 1 },
+    source: "markdown",
+  };
+  const tokens = buildSemanticTokens(
+    [entry],
+    makeProfile([]),
+    text.split("\n"),
+  );
+  const titleTokens = tokens.filter((t) => t.line === 0);
+  assertEquals(titleTokens.length, 2);
+  assertEquals(titleTokens[0].tokenType, "enum");
+  assertEquals(titleTokens[0].length, "ns/entry".length);
+  assertEquals(titleTokens[1].tokenType, "class");
+});
+
+Deno.test("buildSemanticTokens: body modal verbs emit keyword tokens", () => {
+  const text = [
+    "- [REQ-001] Title",
+    "",
+    "  The system shall respond when the brake pedal must trigger.",
+  ].join("\n");
+  const tokens = buildSemanticTokens(
+    [makeEntry()],
+    makeProfile([]),
+    text.split("\n"),
+  );
+  const keywords = tokens.filter((t) => t.tokenType === "keyword");
+  // Expected: "shall", "when", "must" — three keyword matches on line 2.
+  assertEquals(keywords.length, 3);
+  assertEquals(keywords.every((t) => t.line === 2), true);
+  // First match is "shall" at the position of "shall " in the body line.
+  const line = text.split("\n")[2];
+  assertEquals(keywords[0].startChar, line.indexOf("shall"));
+  assertEquals(keywords[0].length, "shall".length);
+});
+
+Deno.test("buildSemanticTokens: EARS triggers (When/While/If/Where) emit keyword tokens", () => {
+  const text = [
+    "- [REQ-001] Title",
+    "",
+    "  When the trigger fires, while the state holds,",
+    "  if the guard passes, where the feature is on, then act.",
+  ].join("\n");
+  const tokens = buildSemanticTokens(
+    [makeEntry()],
+    makeProfile([]),
+    text.split("\n"),
+  );
+  const keywords = tokens.filter((t) => t.tokenType === "keyword");
+  // Expected matches: When, while, if, where, then — five EARS triggers
+  // spread across two body lines.
+  assertEquals(keywords.length, 5);
+  const matched = keywords.map((t) =>
+    text.split("\n")[t.line].slice(t.startChar, t.startChar + t.length)
+      .toLowerCase()
+  );
+  assertEquals(matched, ["when", "while", "if", "where", "then"]);
+});
+
+Deno.test("buildSemanticTokens: trailer-line keywords are NOT tokenized as body keywords", () => {
+  // A trailer value containing "shall" or "when" must not produce a
+  // keyword token — trailer values already get their own treatment.
+  const text = [
+    "- [REQ-001] Title",
+    "",
+    "  Body has no keywords here.",
+    "",
+    "      Note: when in doubt, shall not exit.",
+  ].join("\n");
+  const entry: Entry = {
+    displayId: makeDisplayId("REQ-001"),
+    title: "Title",
+    body: "",
+    rawAttributes: [{ key: "Note", value: "when in doubt, shall not exit." }],
+    typedAttributes: new Map(),
+    shape: "Authored",
+    location: { file: "t.md", line: 1, column: 1 },
+    source: "markdown",
+  };
+  const tokens = buildSemanticTokens(
+    [entry],
+    makeProfile([]),
+    text.split("\n"),
+  );
+  // Only the body line (line index 2) had no modal/EARS words, so
+  // zero keyword tokens.
+  const keywords = tokens.filter((t) => t.tokenType === "keyword");
+  assertEquals(keywords.length, 0);
+});
+
+Deno.test("buildSemanticTokens: $Identifier entity refs in body emit string tokens", () => {
+  const text = [
+    "- [REQ-001] Title",
+    "",
+    "  Uses $BrakeController to read $rawPressure.",
+  ].join("\n");
+  const tokens = buildSemanticTokens(
+    [makeEntry()],
+    makeProfile([]),
+    text.split("\n"),
+  );
+  const stringTokens = tokens.filter(
+    (t) => t.tokenType === "string" && t.line === 2,
+  );
+  assertEquals(stringTokens.length, 2);
+  const line = text.split("\n")[2];
+  assertEquals(stringTokens[0].startChar, line.indexOf("$BrakeController"));
+  assertEquals(stringTokens[0].length, "$BrakeController".length);
+  assertEquals(stringTokens[1].startChar, line.indexOf("$rawPressure"));
+  assertEquals(stringTokens[1].length, "$rawPressure".length);
+});
+
+Deno.test("buildSemanticTokens: $$math$$ fence interior is not tokenized as entity refs", () => {
+  const text = [
+    "- [REQ-001] Title",
+    "",
+    "  See $$a + b$$ and $foo.",
+  ].join("\n");
+  const tokens = buildSemanticTokens(
+    [makeEntry()],
+    makeProfile([]),
+    text.split("\n"),
+  );
+  // Only `$foo` should be tokenized; the `$a` and `$b` inside `$$..$$`
+  // are math, not entity refs. The trailing-`$` guard discards `$b`,
+  // but `$a` immediately after `$$` is also discarded by the same
+  // guard (the preceding char is `$`).
+  const stringTokens = tokens.filter(
+    (t) => t.tokenType === "string" && t.line === 2,
+  );
+  assertEquals(stringTokens.length, 1);
+  assertEquals(stringTokens[0].length, "$foo".length);
+});
+
+Deno.test("buildSemanticTokens: Gherkin sections emit class tokens, steps emit keyword tokens", () => {
+  const text = [
+    "- [REQ-001] Title",
+    "",
+    "  Scenario follows:",
+    "",
+    "  ```feature",
+    "  Feature: Braking",
+    "    Scenario: stops in time",
+    "      Given the speed is 60",
+    "      When the obstacle appears",
+    "      Then the system shall brake",
+    "  ```",
+    "",
+    "  After the block, shall is still highlighted.",
+  ].join("\n");
+  const tokens = buildSemanticTokens(
+    [makeEntry()],
+    makeProfile([]),
+    text.split("\n"),
+  );
+  // Sections (Feature, Scenario) → class tokens — matches GitHub
+  // Linguist / Rouge convention of section-heading scope.
+  const blockSectionTokens = tokens.filter(
+    (t) => t.tokenType === "class" && t.line >= 5 && t.line <= 9,
+  );
+  assertEquals(blockSectionTokens.length, 2);
+  // Steps (Given, When, Then) → keyword tokens.
+  const blockStepTokens = tokens.filter(
+    (t) => t.tokenType === "keyword" && t.line >= 5 && t.line <= 9,
+  );
+  assertEquals(blockStepTokens.length, 3);
+  // Body modal verb after the block: "shall" on line 12.
+  const modalTokens = tokens.filter(
+    (t) => t.tokenType === "keyword" && t.line === 12,
+  );
+  assertEquals(modalTokens.length, 1);
+});
+
+Deno.test("buildSemanticTokens: inter-entry prose after trailer is NOT scanned for keywords", () => {
+  // After an entry's trailer block, lines belong to inter-entry prose
+  // (section headers, intro text for the next section) — not to the
+  // entry's body. Keywords there must not be tokenized.
+  const text = [
+    "- [REQ-001] First entry",
+    "",
+    "  The system shall do X.",
+    "",
+    "      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF",
+    "",
+    "## Next section header",
+    "",
+    "Intro prose that mentions shall, should, when, while — these must",
+    "not be tokenized because they live between entries.",
+    "",
+    "- [REQ-002] Second entry",
+    "",
+    "  Another body that may use should.",
+    "",
+    "      Id: 01HGW2Q8MNP3RSTVWXYZABCDEG",
+  ].join("\n");
+  const entry1: Entry = {
+    displayId: makeDisplayId("REQ-001"),
+    title: "First entry",
+    body: "",
+    rawAttributes: [],
+    typedAttributes: new Map(),
+    shape: "Authored",
+    location: { file: "t.md", line: 1, column: 1 },
+    source: "markdown",
+  };
+  const entry2: Entry = {
+    ...entry1,
+    displayId: makeDisplayId("REQ-002"),
+    title: "Second entry",
+    // 1-based line 12 maps to 0-based index 11 — the "- [REQ-002] ..." line.
+    location: { file: "t.md", line: 12, column: 1 },
+  };
+  const tokens = buildSemanticTokens(
+    [entry1, entry2],
+    makeProfile([]),
+    text.split("\n"),
+  );
+  const keywords = tokens.filter((t) => t.tokenType === "keyword");
+  // Expected: "shall" on line 2 (entry 1 body) and "may"+"should" on
+  // line 13 (entry 2 body). NOT the words on line 8 (inter-entry prose).
+  const onLine2 = keywords.filter((t) => t.line === 2);
+  const onLine8 = keywords.filter((t) => t.line === 8);
+  const onLine13 = keywords.filter((t) => t.line === 13);
+  assertEquals(onLine2.length, 1);
+  assertEquals(onLine8.length, 0);
+  assertEquals(onLine13.length, 2);
+});
+
+Deno.test("buildSemanticTokens: outside feature blocks, Gherkin-only words are NOT keyworded", () => {
+  // "Given" and "And" are Gherkin step keywords but not modal/EARS.
+  // In plain body prose (no fenced feature block) they should NOT
+  // emit keyword tokens.
+  const text = [
+    "- [REQ-001] Title",
+    "",
+    "  Given the input, and the conditions, perform the action.",
+  ].join("\n");
+  const tokens = buildSemanticTokens(
+    [makeEntry()],
+    makeProfile([]),
+    text.split("\n"),
+  );
+  const keywords = tokens.filter((t) => t.tokenType === "keyword");
+  // No modal verbs / EARS triggers in this sentence — zero keywords.
+  assertEquals(keywords.length, 0);
+});

--- a/packages/markspec/lsp/server.ts
+++ b/packages/markspec/lsp/server.ts
@@ -51,6 +51,11 @@ import { findOccurrencesInFile } from "./highlights.ts";
 import { findReferencingEntries } from "./references.ts";
 import { findIdOccurrencesInFile, prepareRenameRange } from "./rename.ts";
 import {
+  buildSemanticTokens,
+  SEMANTIC_TOKEN_LEGEND,
+} from "./semantic_tokens.ts";
+import { buildEntryRanges, type EntryRangesResponse } from "./entry_ranges.ts";
+import {
   entriesToDocumentSymbols,
   entriesToWorkspaceSymbols,
 } from "./symbols.ts";
@@ -116,6 +121,10 @@ let projectRoot: string | undefined;
 let _config: ProjectConfig = DEFAULT_PROJECT_CONFIG;
 let profile: EffectiveProfile | undefined;
 const index = new WorkspaceIndex();
+// Cached cross-file validation result. Updated by publishAllDiagnostics
+// and read by request handlers (e.g. markspec/entryRanges) so they
+// don't re-run validateAll() on every keystroke.
+let lastDiagnostics: readonly CoreDiagnostic[] = [];
 
 // ---------------------------------------------------------------------------
 // File reader for core functions (uses Deno APIs — allowed in entry points)
@@ -152,6 +161,7 @@ function publishFileDiagnostics(
 /** Run cross-file validation and publish diagnostics for all files. */
 function publishAllDiagnostics(): void {
   const allDiags = index.validateAll(profile ?? null);
+  lastDiagnostics = allDiags;
   const grouped = groupDiagnosticsByFile(allDiags);
 
   // Send diagnostics for files that have issues
@@ -203,6 +213,36 @@ function getEntryTypes(): EntryTypeInfo[] {
     types.push({ name, prefix, nextNumber });
   }
   return types;
+}
+
+/**
+ * Encode the intermediate semantic-token shape to the LSP wire
+ * format — a flat number array where each token contributes 5 ints:
+ * deltaLine, deltaStart, length, tokenType, tokenModifiers (bitmask).
+ *
+ * Input tokens MUST be sorted by (line, startChar). `buildSemanticTokens`
+ * returns them sorted.
+ */
+function encodeSemanticTokens(
+  tokens: ReturnType<typeof buildSemanticTokens>,
+): number[] {
+  const data: number[] = [];
+  let prevLine = 0;
+  let prevChar = 0;
+  for (const t of tokens) {
+    const deltaLine = t.line - prevLine;
+    const deltaStart = deltaLine === 0 ? t.startChar - prevChar : t.startChar;
+    const typeIndex = SEMANTIC_TOKEN_LEGEND.tokenTypes.indexOf(t.tokenType);
+    let modMask = 0;
+    for (const m of t.tokenModifiers) {
+      const idx = SEMANTIC_TOKEN_LEGEND.tokenModifiers.indexOf(m);
+      if (idx >= 0) modMask |= 1 << idx;
+    }
+    data.push(deltaLine, deltaStart, t.length, typeIndex, modMask);
+    prevLine = t.line;
+    prevChar = t.startChar;
+  }
+  return data;
 }
 
 // ---------------------------------------------------------------------------
@@ -259,6 +299,14 @@ connection.onInitialize(
         foldingRangeProvider: true,
         documentHighlightProvider: true,
         codeActionProvider: { codeActionKinds: ["quickfix"] },
+        semanticTokensProvider: {
+          legend: {
+            tokenTypes: [...SEMANTIC_TOKEN_LEGEND.tokenTypes],
+            tokenModifiers: [...SEMANTIC_TOKEN_LEGEND.tokenModifiers],
+          },
+          range: false,
+          full: true,
+        },
       },
       serverInfo: {
         name: "markspec",
@@ -704,6 +752,43 @@ connection.onFoldingRanges((params) => {
   // deno-lint-ignore no-explicit-any
   return entriesToFoldingRanges(entries, totalLines) as any;
 });
+
+// ---------------------------------------------------------------------------
+// Semantic tokens
+// ---------------------------------------------------------------------------
+
+connection.languages.semanticTokens.on((params) => {
+  const document = documents.get(params.textDocument.uri);
+  if (!document) return { data: [] };
+  const filePath = uriToPath(params.textDocument.uri);
+  if (!isMarkspecFile(filePath)) return { data: [] };
+  const entries = index.getEntriesForFile(filePath);
+  const lines = document.getText().split("\n");
+  const tokens = buildSemanticTokens(entries, profile, lines);
+  return { data: encodeSemanticTokens(tokens) };
+});
+
+// ---------------------------------------------------------------------------
+// markspec/entryRanges — custom request driving VS Code decorations
+// ---------------------------------------------------------------------------
+
+connection.onRequest(
+  "markspec/entryRanges",
+  (params: { uri: string }): EntryRangesResponse => {
+    const document = documents.get(params.uri);
+    if (!document) return { entries: [] };
+    const filePath = uriToPath(params.uri);
+    if (!isMarkspecFile(filePath)) return { entries: [] };
+    const entries = index.getEntriesForFile(filePath);
+    // Reuse the cached cross-file validation result that
+    // publishAllDiagnostics maintains, so we don't re-run validateAll()
+    // on every keystroke (the handler is invoked per-edit by the
+    // VS Code DecorationManager).
+    const diagnostics = lastDiagnostics;
+    const lines = document.getText().split("\n");
+    return buildEntryRanges(entries, profile, diagnostics, lines);
+  },
+);
 
 // ---------------------------------------------------------------------------
 // Shutdown

--- a/scripts/check_tokens.sh
+++ b/scripts/check_tokens.sh
@@ -9,11 +9,13 @@ deno run --allow-read --allow-write scripts/gen_theme.ts > /dev/null 2>&1
 if ! git diff --quiet packages/markspec-typst/tokens.typ \
                       packages/markspec-typst/themes/light.typ \
                       packages/markspec-typst/themes/dark.typ \
-                      theme/markspec.css 2>/dev/null; then
+                      theme/markspec.css \
+                      editors/vscode/package.json 2>/dev/null; then
   echo "error: generated theme files are stale — run 'deno run --allow-read --allow-write scripts/gen_theme.ts' and stage the results"
   git diff --stat packages/markspec-typst/tokens.typ \
                   packages/markspec-typst/themes/light.typ \
                   packages/markspec-typst/themes/dark.typ \
-                  theme/markspec.css
+                  theme/markspec.css \
+                  editors/vscode/package.json
   exit 1
 fi

--- a/scripts/gen_theme.ts
+++ b/scripts/gen_theme.ts
@@ -323,3 +323,158 @@ for (const [path, content] of writes) {
   const rel = path.replace(ROOT + "/", "");
   console.log(`  wrote ${rel}`);
 }
+
+// ── Generate VS Code workbench colors ───────────────────────────────────
+
+const VSCODE_PACKAGE = join(ROOT, "editors/vscode/package.json");
+
+interface VscodeColorDef {
+  id: string;
+  description: string;
+  defaults: {
+    dark: string;
+    light: string;
+    highContrast: string;
+    highContrastLight: string;
+  };
+}
+
+function genVscodeColors(): VscodeColorDef[] {
+  const blue = tokens.diagram.blue;
+  const labelColors: VscodeColorDef[] = [
+    {
+      id: "markspec.label.background",
+      description: "Background colour for label pills in MarkSpec entries.",
+      defaults: {
+        dark: `${blue.screen}22`,
+        light: `${blue.print}1A`,
+        highContrast: `${blue.screen}33`,
+        highContrastLight: `${blue.print}1A`,
+      },
+    },
+    {
+      id: "markspec.label.foreground",
+      description: "Foreground (text) colour for label pills.",
+      defaults: {
+        dark: "editorForeground",
+        light: "editorForeground",
+        highContrast: "editorForeground",
+        highContrastLight: "editorForeground",
+      },
+    },
+    {
+      id: "markspec.label.border",
+      description: "Border colour for valid label pills.",
+      defaults: {
+        dark: blue.screen,
+        light: blue.print,
+        highContrast: blue.screen,
+        highContrastLight: blue.print,
+      },
+    },
+    {
+      id: "markspec.label.invalidBorder",
+      description:
+        "Border colour for label pills whose value is not in the active profile catalog.",
+      defaults: {
+        dark: "errorForeground",
+        light: "errorForeground",
+        highContrast: "errorForeground",
+        highContrastLight: "errorForeground",
+      },
+    },
+  ];
+
+  // Admonition colours sourced from the existing tokens.alerts palette
+  // (Paul Tol bright for light themes, vibrant for dark themes). On
+  // dark themes the alert.bg is too bright for an editor background,
+  // so we use the border hue with a low alpha tint instead.
+  const admonitionKinds = [
+    "note",
+    "tip",
+    "important",
+    "warning",
+    "caution",
+  ] as const;
+  const admonitionColors: VscodeColorDef[] = [];
+  for (const kind of admonitionKinds) {
+    const alert = tokens.alerts[kind];
+    admonitionColors.push({
+      id: `markspec.admonition.${kind}.border`,
+      description:
+        `Border colour for ${kind} admonitions (> [!${kind.toUpperCase()}]) in MarkSpec entries.`,
+      defaults: {
+        dark: alert.screen.border,
+        light: alert.print.border,
+        highContrast: alert.screen.border,
+        highContrastLight: alert.print.border,
+      },
+    });
+    admonitionColors.push({
+      id: `markspec.admonition.${kind}.background`,
+      description:
+        `Background tint for ${kind} admonitions in MarkSpec entries.`,
+      defaults: {
+        dark: `${alert.screen.border}1A`,
+        light: alert.print.bg,
+        highContrast: `${alert.screen.border}33`,
+        highContrastLight: alert.print.bg,
+      },
+    });
+  }
+  admonitionColors.push({
+    id: "markspec.admonition.plain.border",
+    description: "Border colour for plain blockquotes (no [!KIND] marker).",
+    defaults: {
+      dark: "editorLineNumber.foreground",
+      light: "editorLineNumber.foreground",
+      highContrast: "editorLineNumber.foreground",
+      highContrastLight: "editorLineNumber.foreground",
+    },
+  });
+  admonitionColors.push({
+    id: "markspec.admonition.plain.background",
+    description: "Background tint for plain blockquotes.",
+    defaults: {
+      dark: "#BBBBBB14",
+      light: "#88888814",
+      highContrast: "#BBBBBB22",
+      highContrastLight: "#88888822",
+    },
+  });
+
+  // Left-bar colour painted at column 0 of every entry line (title
+  // through last trailer line). Materialises the entry boundary
+  // without an intrusive background fill. Neutral by default; users
+  // can override per-theme via workbench.colorCustomizations.
+  const entryColors: VscodeColorDef[] = [
+    {
+      id: "markspec.entry.border",
+      description:
+        "Colour of the 3px left-bar that marks each MarkSpec entry block.",
+      defaults: {
+        dark: "editorIndentGuide.activeBackground",
+        light: "editorIndentGuide.activeBackground",
+        highContrast: "editorIndentGuide.activeBackground",
+        highContrastLight: "editorIndentGuide.activeBackground",
+      },
+    },
+  ];
+
+  return [...labelColors, ...admonitionColors, ...entryColors];
+}
+
+async function writeVscodeColors(): Promise<void> {
+  const existing = await Deno.readTextFile(VSCODE_PACKAGE);
+  const pkg = JSON.parse(existing) as {
+    contributes?: { colors?: VscodeColorDef[] };
+  };
+  if (!pkg.contributes) pkg.contributes = {};
+  pkg.contributes.colors = genVscodeColors();
+  const text = JSON.stringify(pkg, null, 2) + "\n";
+  if (text !== existing) {
+    await Deno.writeTextFile(VSCODE_PACKAGE, text);
+  }
+}
+
+await writeVscodeColors();

--- a/tests/e2e/lsp_entry_ranges_test.ts
+++ b/tests/e2e/lsp_entry_ranges_test.ts
@@ -1,0 +1,75 @@
+/**
+ * @module tests/e2e/lsp_entry_ranges_test
+ *
+ * E2E: spawn the LSP server, open a Markdown file, send the
+ * markspec/entryRanges custom request, and assert the response
+ * structure.
+ */
+
+import { assertEquals } from "@std/assert";
+import { LspTestClient } from "./lsp_helpers.ts";
+
+interface EntryRangesResponse {
+  entries: Array<{
+    titleRange: {
+      start: { line: number; character: number };
+      end: { line: number; character: number };
+    };
+    trailerDimRanges: Array<{
+      start: { line: number; character: number };
+      end: { line: number; character: number };
+    }>;
+    labelRanges: Array<{
+      range: {
+        start: { line: number; character: number };
+        end: { line: number; character: number };
+      };
+      valid: boolean;
+      diagnostic?: string;
+    }>;
+  }>;
+}
+
+Deno.test("LSP: markspec/entryRanges returns per-entry layout info", async () => {
+  const fixture = [
+    "# Doc",
+    "",
+    "- [REQ-001] Brake response time",
+    "",
+    "  Body.",
+    "",
+    "      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF",
+    "      Satisfies: STK-001",
+    "      Labels: ASIL-B",
+    "",
+  ].join("\n");
+
+  const client = await LspTestClient.create({ "doc.md": fixture });
+  try {
+    await client.initialize();
+    await client.notify("textDocument/didOpen", {
+      textDocument: {
+        uri: `file://${client.workDir}/doc.md`,
+        languageId: "markdown",
+        version: 1,
+        text: fixture,
+      },
+    });
+    await new Promise((r) => setTimeout(r, 300));
+
+    const result = await client.request("markspec/entryRanges", {
+      uri: `file://${client.workDir}/doc.md`,
+    }) as EntryRangesResponse;
+
+    assertEquals(result.entries.length, 1);
+    const e = result.entries[0];
+    assertEquals(e.titleRange.start.line, 2); // 0-based
+    // At least three dim ranges (one per trailer line, possibly more if
+    // split around the Satisfies display ID).
+    assertEquals(e.trailerDimRanges.length >= 3, true);
+    assertEquals(e.labelRanges.length, 1);
+    assertEquals(e.labelRanges[0].range.start.line, 8); // Labels line (0-based)
+  } finally {
+    await client.shutdown();
+  }
+});

--- a/tests/e2e/lsp_semantic_tokens_test.ts
+++ b/tests/e2e/lsp_semantic_tokens_test.ts
@@ -1,0 +1,66 @@
+/**
+ * @module tests/e2e/lsp_semantic_tokens_test
+ *
+ * E2E: spawn the LSP server, open a Markdown file containing an
+ * entry, request `textDocument/semanticTokens/full`, and assert the
+ * encoded response carries the expected token count.
+ *
+ * Full structural assertions live in the unit test
+ * (`packages/markspec/lsp/semantic_tokens_test.ts`); this test
+ * verifies the wire integration.
+ */
+
+import { assertEquals } from "@std/assert";
+import { LspTestClient } from "./lsp_helpers.ts";
+
+Deno.test("LSP: semanticTokens/full returns encoded tokens", async () => {
+  const fixture = [
+    "# Doc",
+    "",
+    "- [REQ-001] Brake response time",
+    "",
+    "  Body.",
+    "",
+    "      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF",
+    "      Satisfies: STK-001",
+    "      Labels: ASIL-B",
+    "",
+  ].join("\n");
+
+  const client = await LspTestClient.create({
+    "doc.md": fixture,
+  });
+
+  try {
+    const init = await client.initialize() as {
+      capabilities: { semanticTokensProvider?: unknown };
+    };
+    assertEquals(typeof init.capabilities.semanticTokensProvider, "object");
+
+    await client.notify("textDocument/didOpen", {
+      textDocument: {
+        uri: `file://${client.workDir}/doc.md`,
+        languageId: "markdown",
+        version: 1,
+        text: fixture,
+      },
+    });
+
+    // Give the server time to parse and index.
+    await new Promise((r) => setTimeout(r, 300));
+
+    const result = await client.request("textDocument/semanticTokens/full", {
+      textDocument: { uri: `file://${client.workDir}/doc.md` },
+    }) as { data: number[] };
+
+    // Each token is 5 numbers; we expect at least:
+    //   title line: enum (display ID) + class (title)            → 2
+    //   Id line: property (key) + string (value)                  → 2
+    //   Satisfies line: property (key) + enumMember (STK-001)     → 2
+    //   Labels line: property (key) + enumMember (ASIL-B)         → 2
+    // Total: 8 tokens × 5 ints = 40 entries.
+    assertEquals(result.data.length, 40);
+  } finally {
+    await client.shutdown();
+  }
+});


### PR DESCRIPTION
## Summary

Implements [the design spec](https://github.com/driftsys/markspec/blob/feat/vscode-entry-rendering/docs/superpowers/specs/2026-05-22-vscode-entry-rendering-design.md) so MarkSpec entries read as cards in the VS Code source view.

### Visual treatment

- **Entry boundary** — 3px left bar at column 0 from title through the last trailer line (workbench colour `markspec.entry.border`, defaults to the editor's active indent-guide shade)
- **Title** — bold (decoration) on top of `class.declaration` semantic-token colour
- **Bracketed display ID** in the title line — `enum.declaration` semantic token (same colour family as the title)
- **Trailer attributes** — 60% opacity, except trace-attribute display IDs which stay bright (`enumMember` tokens) so cross-refs remain discoverable
- **Labels** — bordered rounded pills via `markspec.label.background` / `.border`; red border + hover diagnostic when the label is not in the active profile catalog
- **Modal verbs and EARS triggers** in entry body (`shall`, `should`, `may`, `must`, `will`, `When`, `While`, `If`, `Where`, `Then`) — `keyword` tokens
- **Gherkin keywords** inside `` ```feature `` / `` ```gherkin `` fenced blocks — sections (`Feature`, `Scenario`, `Background`, `Rule`, `Examples`) as `class` tokens, steps (`Given`, `When`, `Then`, `And`, `But`) as `keyword` tokens, matching GitHub Linguist and Rouge Cucumber conventions
- **`$Identifier` entity references** — `string` tokens (inline-code colour family)
- **Admonitions** — `> [!NOTE]`, `> [!TIP]`, `> [!IMPORTANT]`, `> [!WARNING]`, `> [!CAUTION]` get a 3px coloured left bar per kind and the `[!KIND]` marker renders as a coloured pill; plain `> …` blockquotes get a neutral left bar

### Architecture

- **Pure builders** in `packages/markspec/lsp/` (`entry_trailer.ts`, `semantic_tokens.ts`, `entry_ranges.ts`) with colocated unit tests; no I/O, no LSP types beyond shape-compatible local interfaces
- **LSP server** advertises `textDocument/semanticTokens/full` and a custom `markspec/entryRanges` request returning per-entry title / trailer-dim / label / blockquote / entry-boundary ranges. `validateAll()` result is cached so the custom request stays cheap on every keystroke
- **VS Code extension** (`editors/vscode/src/decorations.ts`) owns decoration types for entry border, trailer dim, title bold, valid/invalid label pills, six per-kind blockquote left bars, and five admonition marker pills; refreshed on editor change and debounced doc edit
- **Workbench colours** generated by `scripts/gen_theme.ts` from `theme/tokens.yaml`: the Paul Tol alert palette feeds the admonition kinds, the editor's indent-guide tint feeds the entry border, the diagram.blue hue feeds the label pills. `scripts/check_tokens.sh` gates against drift.

### Showcase

`docs/examples/entry-rendering.md` is expanded with EARS patterns (one entry per pattern), code blocks with entity refs, Gherkin `Scenario Outline` + `Examples` tables, parameter tables with `$variables`, `$$..$$` display math, and admonition examples for every kind.

## Test plan

- [ ] `just check` passes (1664+ tests, deno lint, dprint, four-target type-check)
- [ ] `deno test --allow-read --allow-write --allow-env packages/markspec/lsp/` — 165 unit tests pass
- [ ] `deno test --allow-read --allow-write --allow-run --allow-env tests/e2e/lsp_semantic_tokens_test.ts tests/e2e/lsp_entry_ranges_test.ts` — e2e roundtrips pass
- [ ] `cd editors/vscode && npm run compile && npm run test` — extension compiles, 19 unit tests pass
- [ ] `just tokens && git diff --exit-code` — no token drift
- [ ] Manual smoke: open `docs/examples/entry-rendering.md` in the VS Code Extension Development Host with this extension; verify entry borders, dimmed trailers, label pills, modal/EARS/Gherkin keyword highlighting, entity refs, and per-kind admonition styling render as described

## Implementation plan

[docs/superpowers/plans/2026-05-22-vscode-entry-rendering.md](https://github.com/driftsys/markspec/blob/feat/vscode-entry-rendering/docs/superpowers/plans/2026-05-22-vscode-entry-rendering.md) — executed via `superpowers:subagent-driven-development`.

## Follow-up

Epic #409 — **Body-token AST** — replaces the duplicated lexers across LSP / validator / skills with a parser-emitted token stream, and unlocks source-file (Rust `///`, Kotlin KDoc, Java javadoc, C/C++) doc-comment rendering. Currently broken because regex-level prefix detection is the wrong layer; the in-PR attempt has been reverted in favour of doing it correctly at the parser layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
