### PR TITLE
feat(lsp): stamp ULIDs in scaffold completions; add trailer-key completions

### DIFF
--- a/packages/markspec/lsp/completions.ts
+++ b/packages/markspec/lsp/completions.ts
@@ -3,10 +3,11 @@
  *
  * Completion providers for MarkSpec entry blocks and ID references.
  *
- * Three triggers:
+ * Four triggers:
  * 1. Block scaffold — `- [` at line start → full entry block snippet
- * 2. ID reference — trace attribute keyword (e.g., `Satisfies:`) → display ID list
- * 3. Type: attribute value — `Type:` keyword → core and profile type list
+ * 2. Trailer attribute key — indented blank or partial capitalized key → key list
+ * 3. ID reference — trace attribute keyword (e.g., `Satisfies:`) → display ID list
+ * 4. Type: attribute value — `Type:` keyword → core and profile type list
  *
  * Block-scaffold items receive a fresh ULID from a `ulidProvider` callback so
  * insertions don't need a follow-up `markspec format` pass.
@@ -27,6 +28,42 @@ const TRACE_ATTR_RE =
 
 /** Pattern matching the `Type:` attribute keyword at line start. */
 const TYPE_ATTR_RE = /^\s*Type\s*:/;
+
+/**
+ * Trailer attribute keys offered as completions inside an entry's
+ * trailer region. Includes the eleven trace-link keys (whose pattern
+ * also appears in `TRACE_ATTR_RE` and in `TRACE_KEYWORDS_RE` in
+ * `context.ts`), plus the cardinal `Labels:` and `Type:` keys. When
+ * the trace-keyword set changes here, also update those two regexes.
+ */
+export const TRAILER_KEYS: readonly string[] = [
+  "Satisfies",
+  "Derived-from",
+  "Verified-by",
+  "References",
+  "Tests",
+  "Depends-on",
+  "Part-of",
+  "Allocated-to",
+  "Realizes",
+  "Generated-from",
+  "Supersedes",
+  "Labels",
+  "Type",
+] as const;
+
+/** Trailer-region context: indent ≥4 spaces, optional partial capitalized key. */
+const TRAILER_KEY_CONTEXT_RE = /^\s{4,}([A-Z][A-Za-z-]*)?$/;
+
+/**
+ * Check whether the text before the cursor is in an entry's trailer
+ * region and ready to receive an attribute key. Matches a line that
+ * starts with at least 4 spaces of indent and contains nothing or a
+ * partial capitalized key.
+ */
+export function isTrailerKeyContext(textBefore: string): boolean {
+  return TRAILER_KEY_CONTEXT_RE.test(textBefore);
+}
 
 /**
  * Check if the text before cursor triggers a block scaffold completion.
@@ -77,6 +114,8 @@ export interface CompletionItemData {
 /** CompletionItemKind.Snippet = 15, CompletionItemKind.Reference = 18 */
 const KIND_SNIPPET = 15;
 const KIND_REFERENCE = 18;
+/** LSP `CompletionItemKind.Property` numeric value (10). */
+const KIND_PROPERTY = 10;
 
 /** Entry type info for block scaffold completion. */
 export interface EntryTypeInfo {
@@ -140,6 +179,21 @@ export function buildTypeAttributeItems(
     });
   }
   return items;
+}
+
+/**
+ * Build completion items for the trailer-key trigger. One item per
+ * entry in {@linkcode TRAILER_KEYS}, each inserting `<Key>: ` with
+ * the cursor placed after the colon.
+ */
+export function buildTrailerKeyItems(): CompletionItemData[] {
+  return TRAILER_KEYS.map((key) => ({
+    label: key,
+    detail: "trailer attribute",
+    insertText: `${key}: `,
+    isSnippet: false,
+    kind: KIND_PROPERTY,
+  }));
 }
 
 /** Inputs to {@linkcode renderScaffoldSnippet}. */

--- a/packages/markspec/lsp/completions.ts
+++ b/packages/markspec/lsp/completions.ts
@@ -52,7 +52,7 @@ export const TRAILER_KEYS: readonly string[] = [
   "Type",
 ] as const;
 
-/** Trailer-region context: indent ≥4 spaces, optional partial capitalized key. */
+/** Trailer-region context: indent ≥4 whitespace chars (matches the parser's lenient leading-whitespace acceptance; formatter canonicalises to 6 spaces), optional partial capitalized key. */
 const TRAILER_KEY_CONTEXT_RE = /^\s{4,}([A-Z][A-Za-z-]*)?$/;
 
 /**
@@ -186,6 +186,7 @@ export function buildTypeAttributeItems(
  * entry in {@linkcode TRAILER_KEYS}, each inserting `<Key>: ` with
  * the cursor placed after the colon.
  */
+// Kept as a zero-arg function (rather than a precomputed constant) for naming symmetry with the other `build*Items` helpers and so future profile-aware filtering can be added without changing the API.
 export function buildTrailerKeyItems(): CompletionItemData[] {
   return TRAILER_KEYS.map((key) => ({
     label: key,

--- a/packages/markspec/lsp/completions.ts
+++ b/packages/markspec/lsp/completions.ts
@@ -147,6 +147,7 @@ export function buildTypeAttributeItems(
 
 export function buildBlockScaffoldItems(
   types: readonly EntryTypeInfo[],
+  ulidProvider: () => string,
 ): CompletionItemData[] {
   if (types.length === 0) {
     return [
@@ -162,11 +163,12 @@ export function buildBlockScaffoldItems(
 
   return types.map((type) => {
     const displayId = `${type.prefix}${padNumber(type.nextNumber)}`;
+    const ulid = ulidProvider();
     return {
       label: `New ${type.name} (${displayId})`,
       detail: type.name,
       insertText:
-        `${displayId}] \${1:Title}\n\n  \${2:Body.}\n\n      Id: \\$\{ULID}\n      \${3:Satisfies: }`,
+        `${displayId}] \${1:Title}\n\n  \${2:Body.}\n\n      Id: ${ulid}\n      \${3:Satisfies: }`,
       isSnippet: true,
       kind: KIND_SNIPPET,
     };

--- a/packages/markspec/lsp/completions.ts
+++ b/packages/markspec/lsp/completions.ts
@@ -150,11 +150,28 @@ export interface ScaffoldSnippetInput {
   readonly ulid: string;
 }
 
+/** Discriminator value for scaffold completions' resolve-time `data` payload. */
+export const SCAFFOLD_COMPLETION_KIND = "scaffold";
+
+/**
+ * `data` payload attached to scaffold completion items so the
+ * `completionItem/resolve` handler can re-query the workspace index
+ * and regenerate the snippet with the freshest display ID + ULID.
+ */
+export interface ScaffoldCompletionData {
+  readonly kind: typeof SCAFFOLD_COMPLETION_KIND;
+  readonly typeName: string;
+  readonly prefix: string;
+}
+
 /**
  * Render the label + snippet text for one scaffold completion. Shared
  * by the build-time path (`buildBlockScaffoldItems`) and the resolve-
  * time path (`onCompletionResolve` in `server.ts`) so both render the
  * same shape from the same primitives.
+ *
+ * @returns An object with `label` and `insertText`. The `insertText`
+ *   field uses LSP snippet syntax with `${}` placeholders for tab stops.
  */
 export function renderScaffoldSnippet(
   input: ScaffoldSnippetInput,

--- a/packages/markspec/lsp/completions.ts
+++ b/packages/markspec/lsp/completions.ts
@@ -142,6 +142,31 @@ export function buildTypeAttributeItems(
   return items;
 }
 
+/** Inputs to {@linkcode renderScaffoldSnippet}. */
+export interface ScaffoldSnippetInput {
+  readonly typeName: string;
+  readonly prefix: string;
+  readonly nextNumber: number;
+  readonly ulid: string;
+}
+
+/**
+ * Render the label + snippet text for one scaffold completion. Shared
+ * by the build-time path (`buildBlockScaffoldItems`) and the resolve-
+ * time path (`onCompletionResolve` in `server.ts`) so both render the
+ * same shape from the same primitives.
+ */
+export function renderScaffoldSnippet(
+  input: ScaffoldSnippetInput,
+): { label: string; insertText: string } {
+  const displayId = `${input.prefix}${padNumber(input.nextNumber)}`;
+  return {
+    label: `New ${input.typeName} (${displayId})`,
+    insertText:
+      `${displayId}] \${1:Title}\n\n  \${2:Body.}\n\n      Id: ${input.ulid}\n      \${3:Satisfies: }`,
+  };
+}
+
 /**
  * Build completion items for the entry block scaffold trigger.
  *
@@ -185,13 +210,16 @@ export function buildBlockScaffoldItems(
   }
 
   return types.map((type) => {
-    const displayId = `${type.prefix}${padNumber(type.nextNumber)}`;
-    const stampedUlid = ulidProvider();
+    const rendered = renderScaffoldSnippet({
+      typeName: type.name,
+      prefix: type.prefix,
+      nextNumber: type.nextNumber,
+      ulid: ulidProvider(),
+    });
     return {
-      label: `New ${type.name} (${displayId})`,
+      label: rendered.label,
       detail: type.name,
-      insertText:
-        `${displayId}] \${1:Title}\n\n  \${2:Body.}\n\n      Id: ${stampedUlid}\n      \${3:Satisfies: }`,
+      insertText: rendered.insertText,
       isSnippet: true,
       kind: KIND_SNIPPET,
     };

--- a/packages/markspec/lsp/completions.ts
+++ b/packages/markspec/lsp/completions.ts
@@ -3,9 +3,13 @@
  *
  * Completion providers for MarkSpec entry blocks and ID references.
  *
- * Two triggers:
+ * Three triggers:
  * 1. Block scaffold — `- [` at line start → full entry block snippet
  * 2. ID reference — trace attribute keyword (e.g., `Satisfies:`) → display ID list
+ * 3. Type: attribute value — `Type:` keyword → core and profile type list
+ *
+ * Block-scaffold items receive a fresh ULID from a `ulidProvider` callback so
+ * insertions don't need a follow-up `markspec format` pass.
  *
  * All functions in this module are pure and testable without LSP connection.
  * The server module calls these and wraps results in LSP CompletionItem.
@@ -102,13 +106,6 @@ export function buildIdReferenceItems(
 }
 
 /**
- * Build completion items for the entry block scaffold trigger.
- *
- * If entry types are provided (from profile), returns one item per type
- * with pre-filled display ID and attribute skeleton. Otherwise returns
- * a single generic scaffold item.
- */
-/**
  * Build completion items for a `Type:` attribute trigger. Lists the
  * 16 core types (4 abstract + 12 concrete) followed by any
  * profile-declared type names. Core types come first so authors see
@@ -145,11 +142,37 @@ export function buildTypeAttributeItems(
   return items;
 }
 
+/**
+ * Build completion items for the entry block scaffold trigger.
+ *
+ * @param types - Entry types declared by the active profile. Each element
+ *   carries the type `name`, its display-ID `prefix`, and the `nextNumber`
+ *   to use for the pre-filled display ID.
+ * @param ulidProvider - Zero-argument callback that returns a fresh ULID
+ *   string. Called once per item when `types` is non-empty; the returned
+ *   string is baked directly into the snippet so the author does not need
+ *   to run a follow-up `markspec format` pass.
+ *
+ * When `types` is non-empty, returns one snippet item per type with a
+ * pre-filled display ID and attribute skeleton. The typed-profile path
+ * calls `ulidProvider()` once per item and bakes the real ULID into the
+ * snippet text.
+ *
+ * When `types` is empty (no profile loaded), returns a single generic
+ * scaffold item that retains the literal `${ULID}` placeholder. The
+ * `ulidProvider` is accepted but unused in the zero-types branch — there
+ * is no profile context to anchor a real ULID against, so the user must
+ * run `markspec format` afterwards.
+ */
 export function buildBlockScaffoldItems(
   types: readonly EntryTypeInfo[],
   ulidProvider: () => string,
 ): CompletionItemData[] {
   if (types.length === 0) {
+    // The fallback intentionally keeps the literal `${ULID}` placeholder —
+    // there is no profile context to anchor a real ULID against, so the user
+    // must run `markspec format` afterwards. The `ulidProvider` is accepted
+    // but unused in this branch.
     return [
       {
         label: "New entry",
@@ -163,12 +186,12 @@ export function buildBlockScaffoldItems(
 
   return types.map((type) => {
     const displayId = `${type.prefix}${padNumber(type.nextNumber)}`;
-    const ulid = ulidProvider();
+    const stampedUlid = ulidProvider();
     return {
       label: `New ${type.name} (${displayId})`,
       detail: type.name,
       insertText:
-        `${displayId}] \${1:Title}\n\n  \${2:Body.}\n\n      Id: ${ulid}\n      \${3:Satisfies: }`,
+        `${displayId}] \${1:Title}\n\n  \${2:Body.}\n\n      Id: ${stampedUlid}\n      \${3:Satisfies: }`,
       isSnippet: true,
       kind: KIND_SNIPPET,
     };

--- a/packages/markspec/lsp/completions_test.ts
+++ b/packages/markspec/lsp/completions_test.ts
@@ -13,6 +13,7 @@ import {
   isBlockScaffoldTrigger,
   isTraceAttributeTrigger,
   isTypeAttributeTrigger,
+  renderScaffoldSnippet,
 } from "./completions.ts";
 import type { DisplayIdEntry } from "./workspace.ts";
 import { makeDisplayId } from "../core/mod.ts";
@@ -179,8 +180,6 @@ Deno.test("buildTypeAttributeItems: appends profile-declared types after core", 
 
 // --- renderScaffoldSnippet helper ---
 
-import { renderScaffoldSnippet } from "./completions.ts";
-
 Deno.test("renderScaffoldSnippet: formats display ID and ULID", () => {
   const snippet = renderScaffoldSnippet({
     typeName: "stakeholder-requirement",
@@ -189,41 +188,11 @@ Deno.test("renderScaffoldSnippet: formats display ID and ULID", () => {
     ulid: "01HGW2Q8MNP3RSTVWXYZABCDEF",
   });
   assertEquals(snippet.label, "New stakeholder-requirement (STK_AEB_0042)");
-  assertEquals(snippet.insertText.includes("STK_AEB_0042"), true);
-  assertEquals(snippet.insertText.includes("01HGW2Q8MNP3RSTVWXYZABCDEF"), true);
-});
-
-// --- resolve flow integration test ---
-
-import { WorkspaceIndex } from "./workspace.ts";
-
-Deno.test("resolve flow: getNextDisplayIdNumber advances after each insert", async () => {
-  const index = new WorkspaceIndex();
-  await index.parseAndUpdateFile(
-    "/tmp/test.md",
-    `- [STK_AEB_0001] First
-
-  Body.
-
-      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
-`,
+  // Display ID is the bracket opener.
+  assertEquals(snippet.insertText.startsWith("STK_AEB_0042]"), true);
+  // ULID appears on the `Id:` line.
+  assertEquals(
+    snippet.insertText.includes(`Id: 01HGW2Q8MNP3RSTVWXYZABCDEF`),
+    true,
   );
-  assertEquals(index.getNextDisplayIdNumber("STK_AEB_"), 2);
-
-  await index.parseAndUpdateFile(
-    "/tmp/test.md",
-    `- [STK_AEB_0001] First
-
-  Body.
-
-      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
-
-- [STK_AEB_0002] Second
-
-  Body.
-
-      Id: 01HGW2Q8MNP3RSTVWXYZABCDEG
-`,
-  );
-  assertEquals(index.getNextDisplayIdNumber("STK_AEB_"), 3);
 });

--- a/packages/markspec/lsp/completions_test.ts
+++ b/packages/markspec/lsp/completions_test.ts
@@ -203,6 +203,7 @@ Deno.test("renderScaffoldSnippet: formats display ID and ULID", () => {
 // --- Trailer key trigger ---
 
 Deno.test("TRAILER_KEYS: includes the documented trace + label + type keys", () => {
+  assertEquals(TRAILER_KEYS.length, 13);
   // Trace attribute keys.
   assertEquals(TRAILER_KEYS.includes("Satisfies"), true);
   assertEquals(TRAILER_KEYS.includes("Derived-from"), true);
@@ -221,7 +222,8 @@ Deno.test("TRAILER_KEYS: includes the documented trace + label + type keys", () 
 });
 
 Deno.test("isTrailerKeyContext: blank indented line matches", () => {
-  assertEquals(isTrailerKeyContext("      "), true);
+  assertEquals(isTrailerKeyContext("    "), true); // exactly 4 spaces (boundary)
+  assertEquals(isTrailerKeyContext("      "), true); // 6 spaces (canonical)
 });
 
 Deno.test("isTrailerKeyContext: indented partial uppercase key matches", () => {

--- a/packages/markspec/lsp/completions_test.ts
+++ b/packages/markspec/lsp/completions_test.ts
@@ -176,3 +176,54 @@ Deno.test("buildTypeAttributeItems: appends profile-declared types after core", 
   assertEquals(items[16].label, "requirement");
   assertEquals(items[17].label, "test");
 });
+
+// --- renderScaffoldSnippet helper ---
+
+import { renderScaffoldSnippet } from "./completions.ts";
+
+Deno.test("renderScaffoldSnippet: formats display ID and ULID", () => {
+  const snippet = renderScaffoldSnippet({
+    typeName: "stakeholder-requirement",
+    prefix: "STK_AEB_",
+    nextNumber: 42,
+    ulid: "01HGW2Q8MNP3RSTVWXYZABCDEF",
+  });
+  assertEquals(snippet.label, "New stakeholder-requirement (STK_AEB_0042)");
+  assertEquals(snippet.insertText.includes("STK_AEB_0042"), true);
+  assertEquals(snippet.insertText.includes("01HGW2Q8MNP3RSTVWXYZABCDEF"), true);
+});
+
+// --- resolve flow integration test ---
+
+import { WorkspaceIndex } from "./workspace.ts";
+
+Deno.test("resolve flow: getNextDisplayIdNumber advances after each insert", async () => {
+  const index = new WorkspaceIndex();
+  await index.parseAndUpdateFile(
+    "/tmp/test.md",
+    `- [STK_AEB_0001] First
+
+  Body.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+`,
+  );
+  assertEquals(index.getNextDisplayIdNumber("STK_AEB_"), 2);
+
+  await index.parseAndUpdateFile(
+    "/tmp/test.md",
+    `- [STK_AEB_0001] First
+
+  Body.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+
+- [STK_AEB_0002] Second
+
+  Body.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEG
+`,
+  );
+  assertEquals(index.getNextDisplayIdNumber("STK_AEB_"), 3);
+});

--- a/packages/markspec/lsp/completions_test.ts
+++ b/packages/markspec/lsp/completions_test.ts
@@ -82,7 +82,7 @@ Deno.test("buildIdReferenceItems: returns items for all display IDs", () => {
 });
 
 Deno.test("buildBlockScaffoldItems: returns generic item when no types", () => {
-  const items = buildBlockScaffoldItems([]);
+  const items = buildBlockScaffoldItems([], () => "01HGW2Q8MNP3RSTVWXYZABCDEF");
   assertEquals(items.length, 1);
   assertEquals(items[0].label, "New entry");
 });
@@ -92,10 +92,49 @@ Deno.test("buildBlockScaffoldItems: returns one item per type", () => {
     { name: "stakeholder-requirement", prefix: "STK_AEB_", nextNumber: 4 },
     { name: "architecture", prefix: "SAD_AEB_", nextNumber: 2 },
   ];
-  const items = buildBlockScaffoldItems(types);
+  const items = buildBlockScaffoldItems(
+    types,
+    () => "01HGW2Q8MNP3RSTVWXYZABCDEF",
+  );
   assertEquals(items.length, 2);
   assertEquals(items[0].label, "New stakeholder-requirement (STK_AEB_0004)");
   assertEquals(items[1].label, "New architecture (SAD_AEB_0002)");
+});
+
+Deno.test("buildBlockScaffoldItems: bakes provided ULID into snippet", () => {
+  const items = buildBlockScaffoldItems(
+    [{ name: "stakeholder-requirement", prefix: "STK_AEB_", nextNumber: 1 }],
+    () => "01HGW2Q8MNP3RSTVWXYZABCDEF",
+  );
+  assertEquals(items.length, 1);
+  const text = items[0].insertText ?? "";
+  assertEquals(text.includes("01HGW2Q8MNP3RSTVWXYZABCDEF"), true);
+  assertEquals(text.includes("${ULID}"), false);
+  assertEquals(text.includes("\\${ULID}"), false);
+});
+
+Deno.test("buildBlockScaffoldItems: emits a different ULID per call", () => {
+  let counter = 0;
+  const provider = () =>
+    `01HGW2Q8MNP3RSTVWXYZ${(counter++).toString().padStart(6, "0")}`;
+  const first = buildBlockScaffoldItems(
+    [{ name: "stakeholder-requirement", prefix: "STK_", nextNumber: 1 }],
+    provider,
+  );
+  const second = buildBlockScaffoldItems(
+    [{ name: "stakeholder-requirement", prefix: "STK_", nextNumber: 2 }],
+    provider,
+  );
+  assertEquals(first[0].insertText !== second[0].insertText, true);
+});
+
+Deno.test("buildBlockScaffoldItems: zero-types fallback uses provider", () => {
+  const items = buildBlockScaffoldItems([], () => "01HGW2Q8MNP3RSTVWXYZABCDEF");
+  // Zero-types fallback intentionally keeps the literal ${ULID}
+  // placeholder — no profile context to anchor a real ULID. Documented
+  // so the behavior change is intentional.
+  assertEquals(items.length, 1);
+  assertEquals(items[0].insertText?.includes("${ULID}"), true);
 });
 
 // --- Type-attribute completion ---

--- a/packages/markspec/lsp/completions_test.ts
+++ b/packages/markspec/lsp/completions_test.ts
@@ -4,7 +4,7 @@
  * Unit tests for entry block scaffold and ID reference completions.
  */
 
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertNotEquals } from "@std/assert";
 import {
   buildBlockScaffoldItems,
   buildIdReferenceItems,
@@ -113,22 +113,21 @@ Deno.test("buildBlockScaffoldItems: bakes provided ULID into snippet", () => {
   assertEquals(text.includes("\\${ULID}"), false);
 });
 
-Deno.test("buildBlockScaffoldItems: emits a different ULID per call", () => {
+Deno.test("buildBlockScaffoldItems: calls provider once per item", () => {
   let counter = 0;
   const provider = () =>
     `01HGW2Q8MNP3RSTVWXYZ${(counter++).toString().padStart(6, "0")}`;
-  const first = buildBlockScaffoldItems(
-    [{ name: "stakeholder-requirement", prefix: "STK_", nextNumber: 1 }],
-    provider,
-  );
-  const second = buildBlockScaffoldItems(
-    [{ name: "stakeholder-requirement", prefix: "STK_", nextNumber: 2 }],
-    provider,
-  );
-  assertEquals(first[0].insertText !== second[0].insertText, true);
+  const types = [
+    { name: "stakeholder-requirement", prefix: "STK_", nextNumber: 1 },
+    { name: "architecture", prefix: "SAD_", nextNumber: 1 },
+  ];
+  const items = buildBlockScaffoldItems(types, provider);
+  assertEquals(items.length, 2);
+  assertNotEquals(items[0].insertText, items[1].insertText);
+  assertEquals(counter, 2);
 });
 
-Deno.test("buildBlockScaffoldItems: zero-types fallback uses provider", () => {
+Deno.test("buildBlockScaffoldItems: zero-types fallback keeps literal placeholder", () => {
   const items = buildBlockScaffoldItems([], () => "01HGW2Q8MNP3RSTVWXYZABCDEF");
   // Zero-types fallback intentionally keeps the literal ${ULID}
   // placeholder — no profile context to anchor a real ULID. Documented

--- a/packages/markspec/lsp/completions_test.ts
+++ b/packages/markspec/lsp/completions_test.ts
@@ -8,12 +8,15 @@ import { assertEquals, assertNotEquals } from "@std/assert";
 import {
   buildBlockScaffoldItems,
   buildIdReferenceItems,
+  buildTrailerKeyItems,
   buildTypeAttributeItems,
   extractRelationName,
   isBlockScaffoldTrigger,
   isTraceAttributeTrigger,
+  isTrailerKeyContext,
   isTypeAttributeTrigger,
   renderScaffoldSnippet,
+  TRAILER_KEYS,
 } from "./completions.ts";
 import type { DisplayIdEntry } from "./workspace.ts";
 import { makeDisplayId } from "../core/mod.ts";
@@ -195,4 +198,62 @@ Deno.test("renderScaffoldSnippet: formats display ID and ULID", () => {
     snippet.insertText.includes(`Id: 01HGW2Q8MNP3RSTVWXYZABCDEF`),
     true,
   );
+});
+
+// --- Trailer key trigger ---
+
+Deno.test("TRAILER_KEYS: includes the documented trace + label + type keys", () => {
+  // Trace attribute keys.
+  assertEquals(TRAILER_KEYS.includes("Satisfies"), true);
+  assertEquals(TRAILER_KEYS.includes("Derived-from"), true);
+  assertEquals(TRAILER_KEYS.includes("Verified-by"), true);
+  assertEquals(TRAILER_KEYS.includes("References"), true);
+  assertEquals(TRAILER_KEYS.includes("Tests"), true);
+  assertEquals(TRAILER_KEYS.includes("Depends-on"), true);
+  assertEquals(TRAILER_KEYS.includes("Part-of"), true);
+  assertEquals(TRAILER_KEYS.includes("Allocated-to"), true);
+  assertEquals(TRAILER_KEYS.includes("Realizes"), true);
+  assertEquals(TRAILER_KEYS.includes("Generated-from"), true);
+  assertEquals(TRAILER_KEYS.includes("Supersedes"), true);
+  // Non-trace keys we also suggest.
+  assertEquals(TRAILER_KEYS.includes("Labels"), true);
+  assertEquals(TRAILER_KEYS.includes("Type"), true);
+});
+
+Deno.test("isTrailerKeyContext: blank indented line matches", () => {
+  assertEquals(isTrailerKeyContext("      "), true);
+});
+
+Deno.test("isTrailerKeyContext: indented partial uppercase key matches", () => {
+  assertEquals(isTrailerKeyContext("      Sa"), true);
+  assertEquals(isTrailerKeyContext("      Der"), true);
+});
+
+Deno.test("isTrailerKeyContext: less than 4 spaces of indent rejected", () => {
+  assertEquals(isTrailerKeyContext("  "), false);
+  assertEquals(isTrailerKeyContext("   S"), false);
+});
+
+Deno.test("isTrailerKeyContext: lowercase first letter rejected", () => {
+  assertEquals(isTrailerKeyContext("      satisfies"), false);
+});
+
+Deno.test("isTrailerKeyContext: completed key (colon present) rejected", () => {
+  assertEquals(isTrailerKeyContext("      Satisfies:"), false);
+});
+
+Deno.test("buildTrailerKeyItems: returns one item per key", () => {
+  const items = buildTrailerKeyItems();
+  assertEquals(items.length, TRAILER_KEYS.length);
+  for (const item of items) {
+    assertEquals(item.insertText?.endsWith(": "), true);
+    assertEquals(item.isSnippet, false);
+  }
+});
+
+Deno.test("buildTrailerKeyItems: each label matches a TRAILER_KEYS entry", () => {
+  const labels = buildTrailerKeyItems().map((i) => i.label);
+  for (const key of TRAILER_KEYS) {
+    assertEquals(labels.includes(key), true);
+  }
 });

--- a/packages/markspec/lsp/server.ts
+++ b/packages/markspec/lsp/server.ts
@@ -69,6 +69,8 @@ import {
   isTraceAttributeTrigger,
   isTypeAttributeTrigger,
   renderScaffoldSnippet,
+  SCAFFOLD_COMPLETION_KIND,
+  type ScaffoldCompletionData,
 } from "./completions.ts";
 import {
   isDocCommentContext,
@@ -474,7 +476,11 @@ connection.onCompletion((params): CompletionItem[] => {
           ? CompletionItemKind.Snippet
           : CompletionItemKind.Reference,
         data: type
-          ? { kind: "scaffold", typeName: type.name, prefix: type.prefix }
+          ? {
+            kind: SCAFFOLD_COMPLETION_KIND,
+            typeName: type.name,
+            prefix: type.prefix,
+          } satisfies ScaffoldCompletionData
           : undefined,
       };
     });
@@ -506,10 +512,8 @@ connection.onCompletion((params): CompletionItem[] => {
 });
 
 connection.onCompletionResolve((item): CompletionItem => {
-  const data = item.data as
-    | { kind?: string; typeName?: string; prefix?: string }
-    | undefined;
-  if (data?.kind !== "scaffold" || !data.typeName || !data.prefix) {
+  const data = item.data as ScaffoldCompletionData | undefined;
+  if (data?.kind !== SCAFFOLD_COMPLETION_KIND) {
     return item;
   }
   const nextNumber = index.getNextDisplayIdNumber(data.prefix);

--- a/packages/markspec/lsp/server.ts
+++ b/packages/markspec/lsp/server.ts
@@ -63,10 +63,12 @@ import {
 import {
   buildBlockScaffoldItems,
   buildIdReferenceItems,
+  buildTrailerKeyItems,
   buildTypeAttributeItems,
   type EntryTypeInfo,
   isBlockScaffoldTrigger,
   isTraceAttributeTrigger,
+  isTrailerKeyContext,
   isTypeAttributeTrigger,
   renderScaffoldSnippet,
   SCAFFOLD_COMPLETION_KIND,
@@ -484,6 +486,17 @@ connection.onCompletion((params): CompletionItem[] => {
           : undefined,
       };
     });
+  }
+
+  // Trigger 1.5: Trailer attribute key — indented blank or partial key.
+  if (isTrailerKeyContext(line)) {
+    const items = buildTrailerKeyItems();
+    return items.map((item) => ({
+      label: item.label,
+      detail: item.detail,
+      insertText: item.insertText,
+      kind: CompletionItemKind.Property,
+    }));
   }
 
   // Trigger 2: ID reference

--- a/packages/markspec/lsp/server.ts
+++ b/packages/markspec/lsp/server.ts
@@ -29,6 +29,7 @@ import {
 import { TextDocument } from "vscode-languageserver-textdocument";
 import process from "node:process";
 import { join } from "@std/path";
+import { ulid } from "@std/ulid";
 import {
   CORE_SCHEMA_VERSION,
   DEFAULT_PROJECT_CONFIG,
@@ -457,7 +458,7 @@ connection.onCompletion((params): CompletionItem[] => {
   // Trigger 1: Block scaffold
   if (isBlockScaffoldTrigger(line)) {
     const types = getEntryTypes();
-    const items = buildBlockScaffoldItems(types);
+    const items = buildBlockScaffoldItems(types, ulid);
     return items.map((item) => ({
       label: item.label,
       detail: item.detail,

--- a/packages/markspec/lsp/server.ts
+++ b/packages/markspec/lsp/server.ts
@@ -68,6 +68,7 @@ import {
   isBlockScaffoldTrigger,
   isTraceAttributeTrigger,
   isTypeAttributeTrigger,
+  renderScaffoldSnippet,
 } from "./completions.ts";
 import {
   isDocCommentContext,
@@ -290,6 +291,7 @@ connection.onInitialize(
         textDocumentSync: TextDocumentSyncKind.Full,
         completionProvider: {
           triggerCharacters: ["[", ":"],
+          resolveProvider: true,
         },
         hoverProvider: true,
         definitionProvider: true,
@@ -459,17 +461,23 @@ connection.onCompletion((params): CompletionItem[] => {
   if (isBlockScaffoldTrigger(line)) {
     const types = getEntryTypes();
     const items = buildBlockScaffoldItems(types, ulid);
-    return items.map((item) => ({
-      label: item.label,
-      detail: item.detail,
-      insertText: item.insertText,
-      insertTextFormat: item.isSnippet
-        ? InsertTextFormat.Snippet
-        : InsertTextFormat.PlainText,
-      kind: item.isSnippet
-        ? CompletionItemKind.Snippet
-        : CompletionItemKind.Reference,
-    }));
+    return items.map((item, i) => {
+      const type = types[i];
+      return {
+        label: item.label,
+        detail: item.detail,
+        insertText: item.insertText,
+        insertTextFormat: item.isSnippet
+          ? InsertTextFormat.Snippet
+          : InsertTextFormat.PlainText,
+        kind: item.isSnippet
+          ? CompletionItemKind.Snippet
+          : CompletionItemKind.Reference,
+        data: type
+          ? { kind: "scaffold", typeName: type.name, prefix: type.prefix }
+          : undefined,
+      };
+    });
   }
 
   // Trigger 2: ID reference
@@ -495,6 +503,27 @@ connection.onCompletion((params): CompletionItem[] => {
   }
 
   return [];
+});
+
+connection.onCompletionResolve((item): CompletionItem => {
+  const data = item.data as
+    | { kind?: string; typeName?: string; prefix?: string }
+    | undefined;
+  if (data?.kind !== "scaffold" || !data.typeName || !data.prefix) {
+    return item;
+  }
+  const nextNumber = index.getNextDisplayIdNumber(data.prefix);
+  const rendered = renderScaffoldSnippet({
+    typeName: data.typeName,
+    prefix: data.prefix,
+    nextNumber,
+    ulid: ulid(),
+  });
+  return {
+    ...item,
+    label: rendered.label,
+    insertText: rendered.insertText,
+  };
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/markspec/lsp/server.ts
+++ b/packages/markspec/lsp/server.ts
@@ -488,7 +488,7 @@ connection.onCompletion((params): CompletionItem[] => {
     });
   }
 
-  // Trigger 1.5: Trailer attribute key — indented blank or partial key.
+  // Trigger 2: Trailer attribute key — indented blank or partial key.
   if (isTrailerKeyContext(line)) {
     const items = buildTrailerKeyItems();
     return items.map((item) => ({
@@ -499,7 +499,7 @@ connection.onCompletion((params): CompletionItem[] => {
     }));
   }
 
-  // Trigger 2: ID reference
+  // Trigger 3: ID reference
   if (isTraceAttributeTrigger(line)) {
     const displayIds = index.getAllDisplayIds();
     const items = buildIdReferenceItems(displayIds);
@@ -510,7 +510,7 @@ connection.onCompletion((params): CompletionItem[] => {
     }));
   }
 
-  // Trigger 3: Type: attribute value — core types + profile types.
+  // Trigger 4: Type: attribute value — core types + profile types.
   if (isTypeAttributeTrigger(line)) {
     const profileTypeNames = profile ? [...profile.types.keys()] : [];
     const items = buildTypeAttributeItems(profileTypeNames);

--- a/packages/markspec/lsp/workspace_test.ts
+++ b/packages/markspec/lsp/workspace_test.ts
@@ -183,6 +183,37 @@ Deno.test("WorkspaceIndex: removeFile promotes survivor when removed file owned 
   );
 });
 
+Deno.test("getNextDisplayIdNumber: advances after parseAndUpdateFile", async () => {
+  const index = new WorkspaceIndex();
+  await index.parseAndUpdateFile(
+    "/tmp/test.md",
+    `- [STK_AEB_0001] First
+
+  Body.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+`,
+  );
+  assertEquals(index.getNextDisplayIdNumber("STK_AEB_"), 2);
+
+  await index.parseAndUpdateFile(
+    "/tmp/test.md",
+    `- [STK_AEB_0001] First
+
+  Body.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+
+- [STK_AEB_0002] Second
+
+  Body.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEG
+`,
+  );
+  assertEquals(index.getNextDisplayIdNumber("STK_AEB_"), 3);
+});
+
 Deno.test("WorkspaceIndex: validateAll suppresses MSL-R010 for profile-declared attributes", async () => {
   const ulid = "01HGW2Q8MNP3RSTVWXYZABCDEF";
   const md = `- [REQ-001] Title


### PR DESCRIPTION
## Summary

Stage 1 of the LSP completion improvements design.

- **Block-scaffold completion now stamps a real ULID** into the `Id:` line at insert time. No more post-insert `markspec format` step.
- **`completionItem/resolve` re-queries** `WorkspaceIndex.getNextDisplayIdNumber` and regenerates the ULID at resolve time, so two rapid back-to-back inserts get consecutive display IDs (the index re-parses on a 50 ms debounce; without resolve, the second list can show a stale number).
- **New trailer-key completions**: typing `Sa` (etc.) on an indented blank line inside an entry trailer offers `Satisfies:`, `Verified-by:`, and the other 11 trailer attribute keys. Wired as a fourth trigger in `onCompletion`.

Design spec: `docs/superpowers/specs/2026-05-23-completion-ulid-and-inline-ai-design.md` — Stage 1 only. Stage 2 (inline AI via `vscode.lm`) ships in a follow-up PR after this one merges.

## Commits

Six commits, all conventional with `(lsp)` scope:

- `c64f343` feat(lsp): stamp real ULID in block-scaffold completions
- `13bb46b` refactor(lsp): document ulidProvider param and tighten tests
- `5a82235` feat(lsp): resolve scaffold completions with monotonic next-id
- `f12e547` refactor(lsp): type the scaffold resolve data payload
- `83db361` feat(lsp): suggest trailer attribute keys in entry trailer region
- `cb8d3a9` refactor(lsp): clarify trailer-key trigger docs and tighten tests

## Test plan

Automated checks all green locally:

- [x] `just build` (lint + test + typecheck + compile) — 1675 tests pass
- [x] `deno fmt --check`
- [x] `dprint check`

Manual VSCode smoke tests for the reviewer (could not run in the authoring session):

- [ ] Open a MarkSpec markdown file in VSCode with the freshly-compiled `dist/markspec` binary. Type `- [` on a new line. Accept the suggested scaffold. The inserted `Id:` line shows a 26-char Crockford base32 ULID, not the literal placeholder.
- [ ] Run `markspec validate` on the file after the insert. It passes without first running `markspec format`.
- [ ] Insert two scaffold completions back-to-back. The second display ID is exactly one higher than the first.
- [ ] Inside an entry trailer region (indented 6 spaces, blank line), type `Sa`. The completion list offers `Satisfies:`. Accept it — the cursor lands after the colon-space.

Generated with Claude Code (https://claude.com/claude-code)
