### PR TITLE
fix(lsp): formal-review findings from #411 (resolve format, snippet escaping)

### DIFF
--- a/packages/markspec/lsp/completions.ts
+++ b/packages/markspec/lsp/completions.ts
@@ -35,6 +35,9 @@ const TYPE_ATTR_RE = /^\s*Type\s*:/;
  * also appears in `TRACE_ATTR_RE` and in `TRACE_KEYWORDS_RE` in
  * `context.ts`), plus the cardinal `Labels:` and `Type:` keys. When
  * the trace-keyword set changes here, also update those two regexes.
+ *
+ * `Id:` is intentionally excluded — the formatter stamps it
+ * automatically, and hand-written ULIDs fail validation.
  */
 export const TRAILER_KEYS: readonly string[] = [
   "Satisfies",
@@ -52,7 +55,11 @@ export const TRAILER_KEYS: readonly string[] = [
   "Type",
 ] as const;
 
-/** Trailer-region context: indent ≥4 whitespace chars (matches the parser's lenient leading-whitespace acceptance; formatter canonicalises to 6 spaces), optional partial capitalized key. */
+/**
+ * Trailer-region context: indent ≥4 whitespace chars (matches the
+ * parser's lenient leading-whitespace acceptance; the formatter
+ * canonicalises to 6 spaces), optional partial capitalized key.
+ */
 const TRAILER_KEY_CONTEXT_RE = /^\s{4,}([A-Z][A-Za-z-]*)?$/;
 
 /**
@@ -185,8 +192,11 @@ export function buildTypeAttributeItems(
  * Build completion items for the trailer-key trigger. One item per
  * entry in {@linkcode TRAILER_KEYS}, each inserting `<Key>: ` with
  * the cursor placed after the colon.
+ *
+ * Kept as a zero-arg function (rather than a precomputed constant) for
+ * naming symmetry with the other `build*Items` helpers and so future
+ * profile-aware filtering can be added without changing the API.
  */
-// Kept as a zero-arg function (rather than a precomputed constant) for naming symmetry with the other `build*Items` helpers and so future profile-aware filtering can be added without changing the API.
 export function buildTrailerKeyItems(): CompletionItemData[] {
   return TRAILER_KEYS.map((key) => ({
     label: key,
@@ -205,18 +215,37 @@ export interface ScaffoldSnippetInput {
   readonly ulid: string;
 }
 
-/** Discriminator value for scaffold completions' resolve-time `data` payload. */
+/**
+ * Discriminator value for scaffold completions' resolve-time `data` payload.
+ *
+ * @internal Exported only so `server.ts` can attach and recognise the
+ *   payload across the `onCompletion` / `onCompletionResolve` boundary.
+ */
 export const SCAFFOLD_COMPLETION_KIND = "scaffold";
 
 /**
  * `data` payload attached to scaffold completion items so the
  * `completionItem/resolve` handler can re-query the workspace index
  * and regenerate the snippet with the freshest display ID + ULID.
+ *
+ * @internal Exported only so `server.ts` can attach and recognise the
+ *   payload across the `onCompletion` / `onCompletionResolve` boundary.
  */
 export interface ScaffoldCompletionData {
   readonly kind: typeof SCAFFOLD_COMPLETION_KIND;
   readonly typeName: string;
   readonly prefix: string;
+}
+
+/**
+ * Escape user-provided text for inclusion in LSP snippet syntax. `$` and
+ * `\` are the only metacharacters in the LSP snippet grammar (§Snippet
+ * Syntax). Profile-declared prefixes / type names flow in from user-edited
+ * `project.yaml` and must not be able to inject tab stops or placeholders
+ * into the rendered snippet.
+ */
+function escapeSnippet(s: string): string {
+  return s.replace(/\\/g, "\\\\").replace(/\$/g, "\\$");
 }
 
 /**
@@ -231,9 +260,11 @@ export interface ScaffoldCompletionData {
 export function renderScaffoldSnippet(
   input: ScaffoldSnippetInput,
 ): { label: string; insertText: string } {
-  const displayId = `${input.prefix}${padNumber(input.nextNumber)}`;
+  const safePrefix = escapeSnippet(input.prefix);
+  const safeTypeName = escapeSnippet(input.typeName);
+  const displayId = `${safePrefix}${padNumber(input.nextNumber)}`;
   return {
-    label: `New ${input.typeName} (${displayId})`,
+    label: `New ${safeTypeName} (${displayId})`,
     insertText:
       `${displayId}] \${1:Title}\n\n  \${2:Body.}\n\n      Id: ${input.ulid}\n      \${3:Satisfies: }`,
   };

--- a/packages/markspec/lsp/completions_test.ts
+++ b/packages/markspec/lsp/completions_test.ts
@@ -198,6 +198,23 @@ Deno.test("renderScaffoldSnippet: formats display ID and ULID", () => {
     snippet.insertText.includes(`Id: 01HGW2Q8MNP3RSTVWXYZABCDEF`),
     true,
   );
+  // Tab-stop ordering must match the inserted-snippet contract.
+  assertEquals(snippet.insertText.includes("${1:Title}"), true);
+  assertEquals(snippet.insertText.includes("${2:Body.}"), true);
+  assertEquals(snippet.insertText.includes("${3:Satisfies: }"), true);
+});
+
+Deno.test("renderScaffoldSnippet: escapes $ in profile-provided prefix and typeName", () => {
+  const snippet = renderScaffoldSnippet({
+    typeName: "type-with-$",
+    prefix: "STK_$_",
+    nextNumber: 1,
+    ulid: "01HGW2Q8MNP3RSTVWXYZABCDEF",
+  });
+  // The $ characters must be escaped as \$ so the editor's snippet parser
+  // does not interpret them as tab stops.
+  assertEquals(snippet.insertText.includes("STK_\\$_0001"), true);
+  assertEquals(snippet.label.includes("type-with-\\$"), true);
 });
 
 // --- Trailer key trigger ---
@@ -242,6 +259,11 @@ Deno.test("isTrailerKeyContext: lowercase first letter rejected", () => {
 
 Deno.test("isTrailerKeyContext: completed key (colon present) rejected", () => {
   assertEquals(isTrailerKeyContext("      Satisfies:"), false);
+});
+
+Deno.test("isTrailerKeyContext: tab-indented line matches (≥4 whitespace chars)", () => {
+  assertEquals(isTrailerKeyContext("\t\t\t\t"), true); // 4 tabs
+  assertEquals(isTrailerKeyContext("\t   "), true); // tab + 3 spaces = 4 ws chars
 });
 
 Deno.test("buildTrailerKeyItems: returns one item per key", () => {

--- a/packages/markspec/lsp/server.ts
+++ b/packages/markspec/lsp/server.ts
@@ -529,6 +529,14 @@ connection.onCompletionResolve((item): CompletionItem => {
   if (data?.kind !== SCAFFOLD_COMPLETION_KIND) {
     return item;
   }
+  // Defend against tampered or malformed resolve payloads from a hostile or
+  // buggy LSP client. The typed cast above does not validate at runtime.
+  if (
+    typeof data.prefix !== "string" || data.prefix.length > 64 ||
+    typeof data.typeName !== "string" || data.typeName.length > 128
+  ) {
+    return item;
+  }
   const nextNumber = index.getNextDisplayIdNumber(data.prefix);
   const rendered = renderScaffoldSnippet({
     typeName: data.typeName,
@@ -540,6 +548,7 @@ connection.onCompletionResolve((item): CompletionItem => {
     ...item,
     label: rendered.label,
     insertText: rendered.insertText,
+    insertTextFormat: InsertTextFormat.Snippet,
   };
 });
 


### PR DESCRIPTION
## Summary

Follow-up to #411. Addresses the formal-review findings posted to that PR shortly before it merged — Stage 1 shipped without these fixes.

**Critical**
- **C1** `onCompletionResolve` now sets `insertTextFormat: InsertTextFormat.Snippet`. Without it, clients that strip the `CompletionItem` before sending it to resolve (per LSP §3.16.2) default to `PlainText` and the resolved item inserts `${1:Title}` literally. VSCode masks this by echoing the full item; Neovim/coc.nvim, Helix, and Zed do not.

**Important — security hardening**
- **I1** Type + length guards in `onCompletionResolve` for `data.prefix` (≤64 chars) and `data.typeName` (≤128 chars). Prevents hostile/buggy LSP clients from forcing an unbounded `String.prototype.startsWith` scan against the workspace index.
- **I2** New `escapeSnippet` helper escapes `$` and `\` in `prefix` and `typeName` before interpolating them into snippet syntax. Prevents a crafted profile `prefix` from injecting tab stops into the rendered snippet. Includes a new test that exercises the escape with `STK_$_` and `type-with-$`.

**Important — docs**
- **I3** `TRAILER_KEYS` JSDoc documents why `Id:` is excluded (formatter stamps it; hand-written ULIDs fail validation).
- **I4** Inline rationale comment on `buildTrailerKeyItems` moved into its JSDoc block.

**Minor**
- **M1** `TRAILER_KEY_CONTEXT_RE` doc comment switched to multi-line JSDoc for style consistency.
- **M2** New test: `isTrailerKeyContext` accepts tab-indented lines (documents the current `\s{4,}` behavior).
- **M3** Three tab-stop assertions added to the `renderScaffoldSnippet` test (`${1:Title}`, `${2:Body.}`, `${3:Satisfies: }`).
- **M4** `@internal` JSDoc tag added to `SCAFFOLD_COMPLETION_KIND` and `ScaffoldCompletionData` (exported only for `server.ts` to consume across the build/resolve boundary).

## Test plan

- [x] `just build` (lint + test + typecheck + compile) — 1715 tests pass
- [x] Pre-push `just check` ran clean
- [ ] Reviewer: confirm the snippet `insertText` includes `\$` escapes when a profile prefix contains `$` (the new test pins this).
- [ ] Reviewer: confirm `onCompletionResolve` still produces a Snippet-typed item by acting on a real LSP client (VSCode + one of Neovim/Helix/Zed, if available).

Cherry-picked from `feat/lsp-completion-stage-1` (PR #411) as that branch was already merged.

Generated with Claude Code (https://claude.com/claude-code)
