### PR TITLE
feat(repo): inline AI completion via vscode.lm

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -90,6 +90,18 @@
             "mcp"
           ],
           "description": "Arguments passed to the markspec binary to start the MCP server. Mirrors 'markspec.server.args' but for the MCP subcommand."
+        },
+        "markspec.inlineCompletion.enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Register the MarkSpec inline AI completion provider. When false, the provider is not registered and Copilot's default inline completion is used as-is."
+        },
+        "markspec.inlineCompletion.maxWorkspaceEntries": {
+          "type": "integer",
+          "default": 200,
+          "minimum": 0,
+          "maximum": 5000,
+          "description": "Maximum number of workspace entries (display ID + title) packed into the AI prompt context. Higher values give the model more workspace awareness but consume more tokens."
         }
       }
     },

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -284,7 +284,7 @@
     "bundle": "deno run --config ../../deno.json --allow-read --allow-write scripts/bundleBinary.ts",
     "package": "npm run bundle && vsce package",
     "lint": "eslint src",
-    "test": "tsc -p tsconfig.json && node --require ./out/test-setup.js --test out/serverOptions.test.js out/mcpDefinition.test.js"
+    "test": "tsc -p tsconfig.json && node --require ./out/test-setup.js --test out/serverOptions.test.js out/mcpDefinition.test.js out/inlineCompletions.test.js"
   },
   "dependencies": {
     "vscode-languageclient": "^9.0.1"

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -13,6 +13,9 @@ import {
   commands,
   EventEmitter,
   type ExtensionContext,
+  InlineCompletionItem,
+  LanguageModelChatMessage,
+  languages,
   lm,
   McpStdioServerDefinition,
   type OutputChannel,
@@ -26,6 +29,12 @@ import {
   LanguageClient,
   type LanguageClientOptions,
 } from "vscode-languageclient/node";
+import {
+  MarkspecInlineCompletionProvider,
+  type ModelInvoker,
+  type RawInlineCompletionItem,
+} from "./inlineCompletions";
+import type { EntryRef } from "./prompts";
 import { resolveServerOptions } from "./serverOptions";
 import { resolveMcpDefinition } from "./mcpDefinition";
 import { createStatusBar } from "./statusBar";
@@ -52,6 +61,27 @@ function debounce<T extends (...args: never[]) => void>(
     if (timer !== undefined) clearTimeout(timer);
     timer = setTimeout(() => fn(...args), delayMs);
   };
+}
+
+/**
+ * Project the result of `vscode.executeDocumentSymbolProvider` /
+ * `vscode.executeWorkspaceSymbolProvider` to the plain `EntryRef[]`
+ * shape the inline-completion provider consumes. Discards any item
+ * without a string `name`; pulls the title from `detail` (document
+ * symbol convention) or `containerName` (workspace symbol convention).
+ */
+function symbolsToEntryRefs(symbols: unknown): EntryRef[] {
+  if (!Array.isArray(symbols)) return [];
+  return symbols.flatMap((s) => {
+    const name = typeof s?.name === "string" ? s.name : undefined;
+    if (!name) return [];
+    const detail = typeof s?.detail === "string" ? s.detail : undefined;
+    const containerName = typeof s?.containerName === "string"
+      ? s.containerName
+      : undefined;
+    const title = detail ?? containerName ?? name;
+    return [{ displayId: name, title }];
+  });
 }
 
 export function activate(context: ExtensionContext): void {
@@ -136,6 +166,75 @@ export function activate(context: ExtensionContext): void {
   }
 
   registerMcpProvider(context);
+
+  // Inline AI completion provider. Gated by `markspec.inlineCompletion.enabled`.
+  if (config.get<boolean>("inlineCompletion.enabled", true)) {
+    const maxWorkspaceEntries = config.get<number>(
+      "inlineCompletion.maxWorkspaceEntries",
+      200,
+    );
+
+    const modelInvoker: ModelInvoker = async function* (messages, token) {
+      const [model] = await lm.selectChatModels({ vendor: "copilot" });
+      if (!model) return;
+      const chatMessages = messages.map((m) =>
+        LanguageModelChatMessage.User(m)
+      );
+      const response = await model.sendRequest(chatMessages, {}, token);
+      for await (const chunk of response.text) {
+        if (token.isCancellationRequested) return;
+        yield chunk;
+      }
+    };
+
+    const listDocumentSymbols = async () =>
+      symbolsToEntryRefs(
+        await commands.executeCommand(
+          "vscode.executeDocumentSymbolProvider",
+          window.activeTextEditor?.document.uri,
+        ),
+      );
+    const listWorkspaceSymbols = async (query: string) =>
+      symbolsToEntryRefs(
+        await commands.executeCommand(
+          "vscode.executeWorkspaceSymbolProvider",
+          query,
+        ),
+      );
+
+    const provider = new MarkspecInlineCompletionProvider({
+      modelInvoker,
+      listDocumentSymbols,
+      listWorkspaceSymbols,
+      maxWorkspaceEntries,
+    });
+
+    context.subscriptions.push(
+      languages.registerInlineCompletionItemProvider(
+        { language: "markdown" },
+        {
+          provideInlineCompletionItems: async (
+            document,
+            position,
+            ctx,
+            token,
+          ) => {
+            const raw = await provider.provideInlineCompletionItems(
+              document,
+              position,
+              ctx,
+              token,
+            );
+            if (!raw) return null;
+            return raw.map(
+              (r: RawInlineCompletionItem) =>
+                new InlineCompletionItem(r.insertText),
+            );
+          },
+        },
+      ),
+    );
+  }
 
   context.subscriptions.push({
     dispose: () => {

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -32,7 +32,6 @@ import {
 import {
   MarkspecInlineCompletionProvider,
   type ModelInvoker,
-  type RawInlineCompletionItem,
 } from "./inlineCompletions";
 import type { EntryRef } from "./prompts";
 import { resolveServerOptions } from "./serverOptions";
@@ -75,13 +74,27 @@ function symbolsToEntryRefs(symbols: unknown): EntryRef[] {
   return symbols.flatMap((s) => {
     const name = typeof s?.name === "string" ? s.name : undefined;
     if (!name) return [];
-    const detail = typeof s?.detail === "string" ? s.detail : undefined;
+    const rawDetail = typeof s?.detail === "string" ? s.detail : undefined;
     const containerName = typeof s?.containerName === "string"
       ? s.containerName
       : undefined;
+    // Document symbols carry the title in `detail` as either
+    // "<type> — <title>" (when a profile assigns a type) or just
+    // "<title>" (no type). Workspace symbols carry the title in
+    // `containerName`. Strip the optional type prefix from `detail`
+    // so the prompt sees only the entry title.
+    const detail = stripTypePrefix(rawDetail);
     const title = detail ?? containerName ?? name;
     return [{ displayId: name, title }];
   });
+}
+
+/** Remove a leading "<type> — " segment if present. */
+function stripTypePrefix(detail: string | undefined): string | undefined {
+  if (!detail) return undefined;
+  const idx = detail.indexOf(" — ");
+  if (idx < 0) return detail;
+  return detail.slice(idx + 3);
 }
 
 export function activate(context: ExtensionContext): void {
@@ -187,12 +200,14 @@ export function activate(context: ExtensionContext): void {
       }
     };
 
-    const listDocumentSymbols = async () =>
+    const listDocumentSymbols = async (document: TextDocument) =>
       symbolsToEntryRefs(
-        await commands.executeCommand(
-          "vscode.executeDocumentSymbolProvider",
-          window.activeTextEditor?.document.uri,
-        ),
+        await commands
+          .executeCommand(
+            "vscode.executeDocumentSymbolProvider",
+            document.uri,
+          )
+          .then((v) => v, () => undefined),
       );
     const listWorkspaceSymbols = async (query: string) =>
       symbolsToEntryRefs(
@@ -211,7 +226,7 @@ export function activate(context: ExtensionContext): void {
 
     context.subscriptions.push(
       languages.registerInlineCompletionItemProvider(
-        { language: "markdown" },
+        { scheme: "file", language: "markdown" },
         {
           provideInlineCompletionItems: async (
             document,
@@ -226,10 +241,7 @@ export function activate(context: ExtensionContext): void {
               token,
             );
             if (!raw) return null;
-            return raw.map(
-              (r: RawInlineCompletionItem) =>
-                new InlineCompletionItem(r.insertText),
-            );
+            return raw.map((r) => new InlineCompletionItem(r.insertText));
           },
         },
       ),

--- a/editors/vscode/src/inlineCompletions.test.ts
+++ b/editors/vscode/src/inlineCompletions.test.ts
@@ -1,0 +1,100 @@
+import { test } from "node:test";
+import { strict as assert } from "node:assert";
+import { classifyContext, type InlineContext } from "./inlineCompletions";
+
+interface FakePosition {
+  readonly line: number;
+  readonly character: number;
+}
+
+interface FakeDocument {
+  readonly lineCount: number;
+  lineAt(line: number): { text: string };
+  getText(range?: unknown): string;
+}
+
+function makeDoc(lines: readonly string[]): FakeDocument {
+  return {
+    lineCount: lines.length,
+    lineAt: (line: number) => ({ text: lines[line] ?? "" }),
+    getText: () => lines.join("\n"),
+  };
+}
+
+function pos(line: number, character: number): FakePosition {
+  return { line, character };
+}
+
+test("classifyContext: skip when cursor is on Id: line", () => {
+  const doc = makeDoc([
+    "- [STK_AEB_0001] Title",
+    "",
+    "  Body.",
+    "",
+    "      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF",
+  ]);
+  const ctx = classifyContext(doc as never, pos(4, 41) as never);
+  assert.equal(ctx.kind, "skip");
+});
+
+test("classifyContext: title-after-bracket when cursor just after `- [STK_..._NNNN] `", () => {
+  const doc = makeDoc([
+    "- [STK_AEB_0042] ",
+  ]);
+  const ctx = classifyContext(doc as never, pos(0, 17) as never);
+  assert.equal(ctx.kind, "title-after-bracket");
+  if (ctx.kind === "title-after-bracket") {
+    assert.equal(ctx.displayId, "STK_AEB_0042");
+  }
+});
+
+test("classifyContext: entry-body when cursor on indented blank line inside an entry's body", () => {
+  const doc = makeDoc([
+    "- [STK_AEB_0001] Title",
+    "",
+    "  ",
+  ]);
+  const ctx = classifyContext(doc as never, pos(2, 2) as never);
+  assert.equal(ctx.kind, "entry-body");
+  if (ctx.kind === "entry-body") {
+    assert.equal(ctx.entryLine, 0);
+    assert.equal(ctx.entryTitle, "Title");
+  }
+});
+
+test("classifyContext: trace-attribute after `Satisfies: `", () => {
+  const doc = makeDoc([
+    "- [STK_AEB_0001] Title",
+    "",
+    "  Body.",
+    "",
+    "      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF",
+    "      Satisfies: ",
+  ]);
+  const ctx = classifyContext(doc as never, pos(5, 17) as never);
+  assert.equal(ctx.kind, "trace-attribute");
+  if (ctx.kind === "trace-attribute") {
+    assert.equal(ctx.attribute, "Satisfies");
+    assert.equal(ctx.entryTitle, "Title");
+  }
+});
+
+test("classifyContext: doc-prose when cursor is on plain markdown outside any entry", () => {
+  const doc = makeDoc([
+    "# Some heading",
+    "",
+    "Just some paragraph text.",
+  ]);
+  const ctx = classifyContext(doc as never, pos(2, 24) as never);
+  assert.equal(ctx.kind, "doc-prose");
+});
+
+test("classifyContext: skip when cursor is at start of empty document", () => {
+  const doc = makeDoc([""]);
+  const ctx = classifyContext(doc as never, pos(0, 0) as never);
+  assert.equal(ctx.kind, "doc-prose");
+});
+
+// Suppress unused-variable warning for the type-only import.
+const _typeProbe: InlineContext = { kind: "skip" };
+void _typeProbe;

--- a/editors/vscode/src/inlineCompletions.test.ts
+++ b/editors/vscode/src/inlineCompletions.test.ts
@@ -135,3 +135,84 @@ test("classifyContext: skip when cursor is on a Type: trailer value line", () =>
 // Suppress unused-variable warning for the type-only import.
 const _typeProbe: InlineContext = { kind: "skip" };
 void _typeProbe;
+
+import { buildUserPrompt, type PromptContext, SYSTEM_PROMPT } from "./prompts";
+
+test("SYSTEM_PROMPT: mentions entry block syntax and EARS pattern", () => {
+  assert.match(SYSTEM_PROMPT, /entry block/i);
+  assert.match(SYSTEM_PROMPT, /EARS/i);
+  assert.match(SYSTEM_PROMPT, /\bId:/);
+});
+
+test("buildUserPrompt: title-after-bracket includes display ID and asks for a title", () => {
+  const ctx: PromptContext = {
+    cursorContext: {
+      kind: "title-after-bracket",
+      displayId: "STK_AEB_0042",
+    },
+    localWindow:
+      "# Emergency braking\n\nAuthor stakeholder requirements here.\n",
+    currentFileEntries: [],
+    workspaceEntries: [],
+  };
+  const prompt = buildUserPrompt(ctx);
+  assert.match(prompt, /STK_AEB_0042/);
+  assert.match(prompt, /Emergency braking/);
+  assert.match(prompt, /title/i);
+});
+
+test("buildUserPrompt: trace-attribute includes workspace entry list as candidates", () => {
+  const ctx: PromptContext = {
+    cursorContext: {
+      kind: "trace-attribute",
+      attribute: "Satisfies",
+      entryTitle: "Sensor debouncing",
+    },
+    localWindow: "      Satisfies: ",
+    currentFileEntries: [],
+    workspaceEntries: [
+      { displayId: "SYS_AEB_0010", title: "Object threat assessment" },
+      { displayId: "SYS_AEB_0011", title: "Brake actuation" },
+    ],
+  };
+  const prompt = buildUserPrompt(ctx);
+  assert.match(prompt, /Sensor debouncing/);
+  assert.match(prompt, /Satisfies/);
+  assert.match(prompt, /SYS_AEB_0010/);
+  assert.match(prompt, /SYS_AEB_0011/);
+});
+
+test("buildUserPrompt: entry-body includes the current file entries but not the workspace", () => {
+  const ctx: PromptContext = {
+    cursorContext: {
+      kind: "entry-body",
+      entryLine: 0,
+      entryTitle: "Sensor debouncing",
+    },
+    localWindow: "- [STK_AEB_0001] Sensor debouncing\n\n  |\n",
+    currentFileEntries: [
+      { displayId: "STK_AEB_0001", title: "Sensor debouncing" },
+    ],
+    workspaceEntries: [
+      { displayId: "SYS_AEB_0010", title: "Should not appear" },
+    ],
+  };
+  const prompt = buildUserPrompt(ctx);
+  assert.match(prompt, /Sensor debouncing/);
+  assert.match(prompt, /STK_AEB_0001/);
+  assert.equal(prompt.includes("SYS_AEB_0010"), false);
+});
+
+test("buildUserPrompt: doc-prose includes only the local window", () => {
+  const ctx: PromptContext = {
+    cursorContext: { kind: "doc-prose" },
+    localWindow: "Some prose around the cursor.",
+    currentFileEntries: [
+      { displayId: "STK_AEB_0001", title: "Should not appear in prose prompt" },
+    ],
+    workspaceEntries: [],
+  };
+  const prompt = buildUserPrompt(ctx);
+  assert.match(prompt, /Some prose around the cursor/);
+  assert.equal(prompt.includes("STK_AEB_0001"), false);
+});

--- a/editors/vscode/src/inlineCompletions.test.ts
+++ b/editors/vscode/src/inlineCompletions.test.ts
@@ -237,7 +237,7 @@ test("MarkspecInlineCompletionProvider: returns null for skip context", async ()
   };
   const provider = new MarkspecInlineCompletionProvider({
     modelInvoker: invoker,
-    listDocumentSymbols: async () => [],
+    listDocumentSymbols: async (_doc) => [],
     listWorkspaceSymbols: async () => [],
     maxWorkspaceEntries: 200,
   });
@@ -265,7 +265,7 @@ test("MarkspecInlineCompletionProvider: forwards model output as the completion 
   };
   const provider = new MarkspecInlineCompletionProvider({
     modelInvoker: invoker,
-    listDocumentSymbols: async () => [],
+    listDocumentSymbols: async (_doc) => [],
     listWorkspaceSymbols: async () => [],
     maxWorkspaceEntries: 200,
   });
@@ -299,7 +299,7 @@ test("MarkspecInlineCompletionProvider: caps workspace symbols at maxWorkspaceEn
   };
   const provider = new MarkspecInlineCompletionProvider({
     modelInvoker: invoker,
-    listDocumentSymbols: async () => [],
+    listDocumentSymbols: async (_doc) => [],
     listWorkspaceSymbols: async () => workspaceSymbols,
     maxWorkspaceEntries: 200,
   });
@@ -334,7 +334,7 @@ test("MarkspecInlineCompletionProvider: aborts when the cancellation token fires
   };
   const provider = new MarkspecInlineCompletionProvider({
     modelInvoker: invoker,
-    listDocumentSymbols: async () => [],
+    listDocumentSymbols: async (_doc) => [],
     listWorkspaceSymbols: async () => [],
     maxWorkspaceEntries: 200,
   });
@@ -356,7 +356,7 @@ test("MarkspecInlineCompletionProvider: entry-body context surfaces current-file
   };
   const provider = new MarkspecInlineCompletionProvider({
     modelInvoker: invoker,
-    listDocumentSymbols: async () => [
+    listDocumentSymbols: async (_doc) => [
       { displayId: "STK_AEB_0001", title: "Sensor debouncing" },
       { displayId: "STK_AEB_0002", title: "Range gating" },
     ],

--- a/editors/vscode/src/inlineCompletions.test.ts
+++ b/editors/vscode/src/inlineCompletions.test.ts
@@ -1,6 +1,12 @@
 import { test } from "node:test";
 import { strict as assert } from "node:assert";
-import { classifyContext, type InlineContext } from "./inlineCompletions";
+import {
+  classifyContext,
+  type InlineContext,
+  MarkspecInlineCompletionProvider,
+  type ModelInvoker,
+} from "./inlineCompletions";
+import { buildUserPrompt, type PromptContext, SYSTEM_PROMPT } from "./prompts";
 
 interface FakePosition {
   readonly line: number;
@@ -136,8 +142,6 @@ test("classifyContext: skip when cursor is on a Type: trailer value line", () =>
 const _typeProbe: InlineContext = { kind: "skip" };
 void _typeProbe;
 
-import { buildUserPrompt, type PromptContext, SYSTEM_PROMPT } from "./prompts";
-
 test("SYSTEM_PROMPT: mentions entry block syntax and EARS pattern", () => {
   assert.match(SYSTEM_PROMPT, /entry block/i);
   assert.match(SYSTEM_PROMPT, /EARS/i);
@@ -227,11 +231,6 @@ test("buildUserPrompt: doc-prose includes only the local window", () => {
   assert.equal(prompt.includes("STK_AEB_0001"), false);
 });
 
-import {
-  MarkspecInlineCompletionProvider,
-  type ModelInvoker,
-} from "./inlineCompletions";
-
 test("MarkspecInlineCompletionProvider: returns null for skip context", async () => {
   const invoker: ModelInvoker = async function* () {
     yield "should-not-appear";
@@ -280,14 +279,9 @@ test("MarkspecInlineCompletionProvider: forwards model output as the completion 
     {} as never,
     fakeToken,
   );
-  assert.notEqual(items, null);
-  if (items && Array.isArray(items)) {
-    assert.equal(items.length, 1);
-    assert.equal(
-      (items[0] as { insertText: string }).insertText,
-      "Sensor debouncing",
-    );
-  }
+  assert.ok(items);
+  assert.equal(items.length, 1);
+  assert.equal(items[0].insertText, "Sensor debouncing");
 });
 
 test("MarkspecInlineCompletionProvider: caps workspace symbols at maxWorkspaceEntries", async () => {
@@ -352,4 +346,36 @@ test("MarkspecInlineCompletionProvider: aborts when the cancellation token fires
     fakeToken as never,
   );
   assert.equal(items, null);
+});
+
+test("MarkspecInlineCompletionProvider: entry-body context surfaces current-file entries in the prompt", async () => {
+  let promptSeen = "";
+  const invoker: ModelInvoker = async function* (messages) {
+    promptSeen = messages.join("\n");
+    yield "ok";
+  };
+  const provider = new MarkspecInlineCompletionProvider({
+    modelInvoker: invoker,
+    listDocumentSymbols: async () => [
+      { displayId: "STK_AEB_0001", title: "Sensor debouncing" },
+      { displayId: "STK_AEB_0002", title: "Range gating" },
+    ],
+    listWorkspaceSymbols: async () => [],
+    maxWorkspaceEntries: 200,
+  });
+  const doc = makeDoc([
+    "- [STK_AEB_0001] Sensor debouncing",
+    "",
+    "  ",
+  ]);
+  const fakeToken = { isCancellationRequested: false } as never;
+  await provider.provideInlineCompletionItems(
+    doc as never,
+    pos(2, 2) as never,
+    {} as never,
+    fakeToken,
+  );
+  assert.equal(promptSeen.includes("STK_AEB_0001"), true);
+  assert.equal(promptSeen.includes("STK_AEB_0002"), true);
+  assert.equal(promptSeen.includes("Range gating"), true);
 });

--- a/editors/vscode/src/inlineCompletions.test.ts
+++ b/editors/vscode/src/inlineCompletions.test.ts
@@ -177,7 +177,7 @@ test("buildUserPrompt: trace-attribute includes workspace entry list as candidat
   };
   const prompt = buildUserPrompt(ctx);
   assert.match(prompt, /Sensor debouncing/);
-  assert.match(prompt, /Satisfies/);
+  assert.match(prompt, /`Satisfies:`/);
   assert.match(prompt, /SYS_AEB_0010/);
   assert.match(prompt, /SYS_AEB_0011/);
 });
@@ -201,6 +201,16 @@ test("buildUserPrompt: entry-body includes the current file entries but not the 
   assert.match(prompt, /Sensor debouncing/);
   assert.match(prompt, /STK_AEB_0001/);
   assert.equal(prompt.includes("SYS_AEB_0010"), false);
+});
+
+test("buildUserPrompt: throws when called with skip context", () => {
+  const ctx: PromptContext = {
+    cursorContext: { kind: "skip" },
+    localWindow: "",
+    currentFileEntries: [],
+    workspaceEntries: [],
+  };
+  assert.throws(() => buildUserPrompt(ctx), /skip/);
 });
 
 test("buildUserPrompt: doc-prose includes only the local window", () => {

--- a/editors/vscode/src/inlineCompletions.test.ts
+++ b/editors/vscode/src/inlineCompletions.test.ts
@@ -226,3 +226,130 @@ test("buildUserPrompt: doc-prose includes only the local window", () => {
   assert.match(prompt, /Some prose around the cursor/);
   assert.equal(prompt.includes("STK_AEB_0001"), false);
 });
+
+import {
+  MarkspecInlineCompletionProvider,
+  type ModelInvoker,
+} from "./inlineCompletions";
+
+test("MarkspecInlineCompletionProvider: returns null for skip context", async () => {
+  const invoker: ModelInvoker = async function* () {
+    yield "should-not-appear";
+  };
+  const provider = new MarkspecInlineCompletionProvider({
+    modelInvoker: invoker,
+    listDocumentSymbols: async () => [],
+    listWorkspaceSymbols: async () => [],
+    maxWorkspaceEntries: 200,
+  });
+  const doc = makeDoc([
+    "- [STK_AEB_0001] Title",
+    "",
+    "  Body.",
+    "",
+    "      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF",
+  ]);
+  const fakeToken = { isCancellationRequested: false } as never;
+  const items = await provider.provideInlineCompletionItems(
+    doc as never,
+    pos(4, 41) as never,
+    {} as never,
+    fakeToken,
+  );
+  assert.equal(items, null);
+});
+
+test("MarkspecInlineCompletionProvider: forwards model output as the completion item text", async () => {
+  const invoker: ModelInvoker = async function* () {
+    yield "Sensor ";
+    yield "debouncing";
+  };
+  const provider = new MarkspecInlineCompletionProvider({
+    modelInvoker: invoker,
+    listDocumentSymbols: async () => [],
+    listWorkspaceSymbols: async () => [],
+    maxWorkspaceEntries: 200,
+  });
+  const doc = makeDoc([
+    "- [STK_AEB_0042] ",
+  ]);
+  const fakeToken = { isCancellationRequested: false } as never;
+  const items = await provider.provideInlineCompletionItems(
+    doc as never,
+    pos(0, 17) as never,
+    {} as never,
+    fakeToken,
+  );
+  assert.notEqual(items, null);
+  if (items && Array.isArray(items)) {
+    assert.equal(items.length, 1);
+    assert.equal(
+      (items[0] as { insertText: string }).insertText,
+      "Sensor debouncing",
+    );
+  }
+});
+
+test("MarkspecInlineCompletionProvider: caps workspace symbols at maxWorkspaceEntries", async () => {
+  const workspaceSymbols = Array.from(
+    { length: 500 },
+    (_, i) => ({
+      displayId: `SYS_${i.toString().padStart(4, "0")}`,
+      title: `Title ${i}`,
+    }),
+  );
+  let promptSeen = "";
+  const invoker: ModelInvoker = async function* (messages) {
+    promptSeen = messages.join("\n");
+    yield "ok";
+  };
+  const provider = new MarkspecInlineCompletionProvider({
+    modelInvoker: invoker,
+    listDocumentSymbols: async () => [],
+    listWorkspaceSymbols: async () => workspaceSymbols,
+    maxWorkspaceEntries: 200,
+  });
+  const doc = makeDoc([
+    "- [STK_AEB_0001] Title",
+    "",
+    "  Body.",
+    "",
+    "      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF",
+    "      Satisfies: ",
+  ]);
+  const fakeToken = { isCancellationRequested: false } as never;
+  await provider.provideInlineCompletionItems(
+    doc as never,
+    pos(5, 17) as never,
+    {} as never,
+    fakeToken,
+  );
+  assert.equal(promptSeen.includes("SYS_0000"), true);
+  assert.equal(promptSeen.includes("SYS_0199"), true);
+  assert.equal(promptSeen.includes("SYS_0200"), false);
+});
+
+test("MarkspecInlineCompletionProvider: aborts when the cancellation token fires mid-stream", async () => {
+  const fakeToken = { isCancellationRequested: false } as {
+    isCancellationRequested: boolean;
+  };
+  const invoker: ModelInvoker = async function* () {
+    yield "first";
+    fakeToken.isCancellationRequested = true;
+    yield "should-not-appear";
+  };
+  const provider = new MarkspecInlineCompletionProvider({
+    modelInvoker: invoker,
+    listDocumentSymbols: async () => [],
+    listWorkspaceSymbols: async () => [],
+    maxWorkspaceEntries: 200,
+  });
+  const doc = makeDoc(["- [STK_AEB_0042] "]);
+  const items = await provider.provideInlineCompletionItems(
+    doc as never,
+    pos(0, 17) as never,
+    {} as never,
+    fakeToken as never,
+  );
+  assert.equal(items, null);
+});

--- a/editors/vscode/src/inlineCompletions.test.ts
+++ b/editors/vscode/src/inlineCompletions.test.ts
@@ -10,14 +10,12 @@ interface FakePosition {
 interface FakeDocument {
   readonly lineCount: number;
   lineAt(line: number): { text: string };
-  getText(range?: unknown): string;
 }
 
 function makeDoc(lines: readonly string[]): FakeDocument {
   return {
     lineCount: lines.length,
     lineAt: (line: number) => ({ text: lines[line] ?? "" }),
-    getText: () => lines.join("\n"),
   };
 }
 
@@ -89,10 +87,49 @@ test("classifyContext: doc-prose when cursor is on plain markdown outside any en
   assert.equal(ctx.kind, "doc-prose");
 });
 
-test("classifyContext: skip when cursor is at start of empty document", () => {
+test("classifyContext: doc-prose when cursor is at start of empty document", () => {
   const doc = makeDoc([""]);
   const ctx = classifyContext(doc as never, pos(0, 0) as never);
   assert.equal(ctx.kind, "doc-prose");
+});
+
+test("classifyContext: doc-prose when cursor mid-title on an existing title line", () => {
+  // Regression for the `TITLE_SLOT_RE`-against-`beforeCursor` false positive.
+  // Cursor at column 13 of `- [STK_001] Existing Title` — there is real
+  // title text after the cursor, so this is NOT a title-slot completion.
+  const doc = makeDoc([
+    "- [STK_001] Existing Title",
+  ]);
+  const ctx = classifyContext(doc as never, pos(0, 13) as never);
+  assert.notEqual(ctx.kind, "title-after-bracket");
+});
+
+test("classifyContext: skip when cursor is on a Labels: trailer value line", () => {
+  // Regression: trailer attribute keys that are not trace-link keys must
+  // skip, not fall through to doc-prose.
+  const doc = makeDoc([
+    "- [STK_AEB_0001] Title",
+    "",
+    "  Body.",
+    "",
+    "      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF",
+    "      Labels: ASIL-",
+  ]);
+  const ctx = classifyContext(doc as never, pos(5, 19) as never);
+  assert.equal(ctx.kind, "skip");
+});
+
+test("classifyContext: skip when cursor is on a Type: trailer value line", () => {
+  const doc = makeDoc([
+    "- [STK_AEB_0001] Title",
+    "",
+    "  Body.",
+    "",
+    "      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF",
+    "      Type: stakeholder-requ",
+  ]);
+  const ctx = classifyContext(doc as never, pos(5, 27) as never);
+  assert.equal(ctx.kind, "skip");
 });
 
 // Suppress unused-variable warning for the type-only import.

--- a/editors/vscode/src/inlineCompletions.ts
+++ b/editors/vscode/src/inlineCompletions.ts
@@ -163,7 +163,9 @@ export type ModelInvoker = (
 /** Constructor dependencies for {@linkcode MarkspecInlineCompletionProvider}. */
 export interface InlineProviderDeps {
   readonly modelInvoker: ModelInvoker;
-  readonly listDocumentSymbols: () => Promise<readonly EntryRef[]>;
+  readonly listDocumentSymbols: (
+    document: TextDocument,
+  ) => Promise<readonly EntryRef[]>;
   readonly listWorkspaceSymbols: (
     query: string,
   ) => Promise<readonly EntryRef[]>;
@@ -203,7 +205,7 @@ export class MarkspecInlineCompletionProvider {
 
     const localWindow = readLocalWindow(document, position);
     const [currentFileEntries, workspaceEntries] = await Promise.all([
-      this.deps.listDocumentSymbols(),
+      this.deps.listDocumentSymbols(document),
       this.deps.listWorkspaceSymbols(""),
     ]);
 

--- a/editors/vscode/src/inlineCompletions.ts
+++ b/editors/vscode/src/inlineCompletions.ts
@@ -43,7 +43,7 @@ export type InlineContext =
   | { readonly kind: "doc-prose" }
   | { readonly kind: "skip" };
 
-/** Lines scanned either side of the cursor when looking for the enclosing entry. */
+/** Lines scanned backward from the cursor when looking for the enclosing entry opener. */
 const ENTRY_SEARCH_RADIUS = 50;
 
 /** Entry-block opener: `- [DISPLAY_ID] Title` (trailing content optional). */
@@ -81,9 +81,9 @@ export function classifyContext(
     return { kind: "skip" };
   }
 
-  // Title slot: line matches `- [DISPLAY_ID] ` and cursor is at end of line.
-  const titleMatch = TITLE_SLOT_RE.exec(beforeCursor);
-  if (titleMatch && position.character === beforeCursor.length) {
+  // Title slot: full line matches `- [DISPLAY_ID] ` with nothing after.
+  const titleMatch = TITLE_SLOT_RE.exec(line);
+  if (titleMatch) {
     return { kind: "title-after-bracket", displayId: titleMatch[1] };
   }
 
@@ -98,6 +98,14 @@ export function classifyContext(
         entryTitle: enclosing.title,
       };
     }
+  }
+
+  // Trailer region (indent ≥ 4) with a non-trace attribute key: skip.
+  // The eleven trace-link keys are already handled above; this guard
+  // covers `Labels:`, `Type:`, and any unknown trailer key so we don't
+  // send the AI a prose prompt on an attribute-value line.
+  if (/^\s{4,}[A-Z][A-Za-z-]*\s*:/.test(line)) {
+    return { kind: "skip" };
   }
 
   // Entry body: scan backward for an entry opener within the search radius;

--- a/editors/vscode/src/inlineCompletions.ts
+++ b/editors/vscode/src/inlineCompletions.ts
@@ -12,17 +12,16 @@
 import type {
   CancellationToken,
   InlineCompletionContext,
-  InlineCompletionItem,
   Position,
   TextDocument,
 } from "vscode";
+import { buildUserPrompt, type EntryRef, SYSTEM_PROMPT } from "./prompts";
 
 // Re-export the vscode types so downstream files can import them from
 // this module without duplicating the dependency declaration.
 export type {
   CancellationToken,
   InlineCompletionContext,
-  InlineCompletionItem,
   Position,
   TextDocument,
 };
@@ -150,8 +149,6 @@ function findEnclosingEntry(
   return undefined;
 }
 
-import { buildUserPrompt, type EntryRef, SYSTEM_PROMPT } from "./prompts";
-
 /**
  * Lazy producer of model output. Each yielded string is a fresh chunk.
  * The provider concatenates chunks and aborts when the cancellation
@@ -166,13 +163,22 @@ export type ModelInvoker = (
 /** Constructor dependencies for {@linkcode MarkspecInlineCompletionProvider}. */
 export interface InlineProviderDeps {
   readonly modelInvoker: ModelInvoker;
-  readonly listDocumentSymbols: (
-    uri: unknown,
-  ) => Promise<readonly EntryRef[]>;
+  readonly listDocumentSymbols: () => Promise<readonly EntryRef[]>;
   readonly listWorkspaceSymbols: (
     query: string,
   ) => Promise<readonly EntryRef[]>;
   readonly maxWorkspaceEntries: number;
+}
+
+/**
+ * Raw completion item shape produced by the provider. The production
+ * registration site in `extension.ts` converts each into a real
+ * `vscode.InlineCompletionItem` before returning to VSCode. Tests
+ * assert against this plain shape, so the cast at the registration
+ * boundary is the only place the VSCode class is constructed.
+ */
+export interface RawInlineCompletionItem {
+  readonly insertText: string;
 }
 
 /**
@@ -191,13 +197,13 @@ export class MarkspecInlineCompletionProvider {
     position: Position,
     _context: InlineCompletionContext,
     token: CancellationToken,
-  ): Promise<readonly InlineCompletionItem[] | null> {
+  ): Promise<readonly RawInlineCompletionItem[] | null> {
     const cursorContext = classifyContext(document, position);
     if (cursorContext.kind === "skip") return null;
 
     const localWindow = readLocalWindow(document, position);
     const [currentFileEntries, workspaceEntries] = await Promise.all([
-      this.deps.listDocumentSymbols(undefined),
+      this.deps.listDocumentSymbols(),
       this.deps.listWorkspaceSymbols(""),
     ]);
 
@@ -225,10 +231,7 @@ export class MarkspecInlineCompletionProvider {
     if (token.isCancellationRequested) return null;
     if (text.length === 0) return null;
 
-    // Return a plain object the production registration site converts
-    // to `vscode.InlineCompletionItem`. Tests assert on the
-    // `insertText` shape directly.
-    return [{ insertText: text } as unknown as InlineCompletionItem];
+    return [{ insertText: text }];
   }
 }
 
@@ -236,11 +239,17 @@ function readLocalWindow(
   document: TextDocument,
   position: Position,
 ): string {
-  const start = Math.max(0, position.line - LOCAL_WINDOW_RADIUS);
-  const end = Math.min(
-    document.lineCount - 1,
-    position.line + LOCAL_WINDOW_RADIUS,
+  if (document.lineCount === 0) return "";
+  // Clamp the cursor line so an out-of-range position can't index past
+  // the last line. The VSCode runtime guarantees in-range positions in
+  // practice, but the function is unit-tested and may be called with
+  // arbitrary fixtures.
+  const safeLine = Math.min(
+    position.line,
+    Math.max(0, document.lineCount - 1),
   );
+  const start = Math.max(0, safeLine - LOCAL_WINDOW_RADIUS);
+  const end = Math.min(document.lineCount - 1, safeLine + LOCAL_WINDOW_RADIUS);
   const lines: string[] = [];
   for (let i = start; i <= end; i++) {
     lines.push(document.lineAt(i).text);

--- a/editors/vscode/src/inlineCompletions.ts
+++ b/editors/vscode/src/inlineCompletions.ts
@@ -149,3 +149,101 @@ function findEnclosingEntry(
   }
   return undefined;
 }
+
+import { buildUserPrompt, type EntryRef, SYSTEM_PROMPT } from "./prompts";
+
+/**
+ * Lazy producer of model output. Each yielded string is a fresh chunk.
+ * The provider concatenates chunks and aborts when the cancellation
+ * token fires. In production this wraps `vscode.lm.sendRequest(...)`;
+ * in tests it is replaced with a hand-rolled generator.
+ */
+export type ModelInvoker = (
+  messages: readonly string[],
+  token: CancellationToken,
+) => AsyncIterable<string>;
+
+/** Constructor dependencies for {@linkcode MarkspecInlineCompletionProvider}. */
+export interface InlineProviderDeps {
+  readonly modelInvoker: ModelInvoker;
+  readonly listDocumentSymbols: (
+    uri: unknown,
+  ) => Promise<readonly EntryRef[]>;
+  readonly listWorkspaceSymbols: (
+    query: string,
+  ) => Promise<readonly EntryRef[]>;
+  readonly maxWorkspaceEntries: number;
+}
+
+/**
+ * Lines of the document collected either side of the cursor and packed
+ * into the prompt's `localWindow`. Kept tight to stay under typical
+ * model context limits while preserving enough surrounding text for
+ * the model to follow voice and structure.
+ */
+const LOCAL_WINDOW_RADIUS = 30;
+
+export class MarkspecInlineCompletionProvider {
+  constructor(private readonly deps: InlineProviderDeps) {}
+
+  async provideInlineCompletionItems(
+    document: TextDocument,
+    position: Position,
+    _context: InlineCompletionContext,
+    token: CancellationToken,
+  ): Promise<readonly InlineCompletionItem[] | null> {
+    const cursorContext = classifyContext(document, position);
+    if (cursorContext.kind === "skip") return null;
+
+    const localWindow = readLocalWindow(document, position);
+    const [currentFileEntries, workspaceEntries] = await Promise.all([
+      this.deps.listDocumentSymbols(undefined),
+      this.deps.listWorkspaceSymbols(""),
+    ]);
+
+    if (token.isCancellationRequested) return null;
+
+    const cappedWorkspace = workspaceEntries.slice(
+      0,
+      this.deps.maxWorkspaceEntries,
+    );
+
+    const promptCtx = {
+      cursorContext,
+      localWindow,
+      currentFileEntries,
+      workspaceEntries: cappedWorkspace,
+    };
+    const userPrompt = buildUserPrompt(promptCtx);
+    const messages = [SYSTEM_PROMPT, userPrompt];
+
+    let text = "";
+    for await (const chunk of this.deps.modelInvoker(messages, token)) {
+      if (token.isCancellationRequested) return null;
+      text += chunk;
+    }
+    if (token.isCancellationRequested) return null;
+    if (text.length === 0) return null;
+
+    // Return a plain object the production registration site converts
+    // to `vscode.InlineCompletionItem`. Tests assert on the
+    // `insertText` shape directly.
+    return [{ insertText: text } as unknown as InlineCompletionItem];
+  }
+}
+
+function readLocalWindow(
+  document: TextDocument,
+  position: Position,
+): string {
+  const start = Math.max(0, position.line - LOCAL_WINDOW_RADIUS);
+  const end = Math.min(
+    document.lineCount - 1,
+    position.line + LOCAL_WINDOW_RADIUS,
+  );
+  const lines: string[] = [];
+  for (let i = start; i <= end; i++) {
+    lines.push(document.lineAt(i).text);
+  }
+  return lines.join("\n");
+}

--- a/editors/vscode/src/inlineCompletions.ts
+++ b/editors/vscode/src/inlineCompletions.ts
@@ -1,0 +1,143 @@
+/**
+ * MarkSpec inline AI completion provider.
+ *
+ * Provides ghost-text completions backed by `vscode.lm` (Copilot's
+ * Language Model API). The classifier in this module decides what kind
+ * of MarkSpec authoring context the cursor sits in and shapes the
+ * prompt accordingly. Workspace context is pulled via the standard
+ * VSCode symbol provider commands so we re-use the LSP's existing
+ * `workspace/symbol` and `textDocument/documentSymbol` indexing.
+ */
+
+import type {
+  CancellationToken,
+  InlineCompletionContext,
+  InlineCompletionItem,
+  Position,
+  TextDocument,
+} from "vscode";
+
+// Re-export the vscode types so downstream files can import them from
+// this module without duplicating the dependency declaration.
+export type {
+  CancellationToken,
+  InlineCompletionContext,
+  InlineCompletionItem,
+  Position,
+  TextDocument,
+};
+
+/** A specific MarkSpec authoring context derived from the cursor position. */
+export type InlineContext =
+  | { readonly kind: "title-after-bracket"; readonly displayId: string }
+  | {
+    readonly kind: "entry-body";
+    readonly entryLine: number;
+    readonly entryTitle: string;
+  }
+  | {
+    readonly kind: "trace-attribute";
+    readonly attribute: string;
+    readonly entryTitle: string;
+  }
+  | { readonly kind: "doc-prose" }
+  | { readonly kind: "skip" };
+
+/** Lines scanned either side of the cursor when looking for the enclosing entry. */
+const ENTRY_SEARCH_RADIUS = 50;
+
+/** Entry-block opener: `- [DISPLAY_ID] Title` (trailing content optional). */
+const ENTRY_OPENER_RE = /^\s*-\s+\[([A-Z][A-Z0-9_-]+)\]\s*(.*)$/;
+
+/** Title-slot trigger: cursor at end of `- [DISPLAY_ID] ` with nothing after. */
+const TITLE_SLOT_RE = /^\s*-\s+\[([A-Z][A-Z0-9_-]+)\]\s*$/;
+
+/** Trace attribute keyword followed by the colon and any leading value. */
+const TRACE_ATTR_RE =
+  /^\s{4,}(Satisfies|Derived-from|Verified-by|References|Tests|Depends-on|Part-of|Allocated-to|Realizes|Generated-from|Supersedes)\s*:\s*/;
+
+/** `Id:` trailer line — completions are suppressed here. */
+const ID_TRAILER_RE = /^\s{4,}Id\s*:/;
+
+/**
+ * Classify the cursor context for inline-completion purposes.
+ *
+ * Cheap regex-based decision over a small window around the cursor.
+ * No AST, no parser. Five outcomes: `skip` (no completion offered);
+ * `title-after-bracket` (right after `- [DISPLAY_ID] `);
+ * `entry-body` (inside an entry's body region);
+ * `trace-attribute` (right after `Satisfies:` etc.);
+ * `doc-prose` (anywhere else in a markdown file).
+ */
+export function classifyContext(
+  document: TextDocument,
+  position: Position,
+): InlineContext {
+  const line = document.lineAt(position.line).text;
+  const beforeCursor = line.slice(0, position.character);
+
+  // Hard-skip: cursor on an `Id:` trailer line.
+  if (ID_TRAILER_RE.test(line)) {
+    return { kind: "skip" };
+  }
+
+  // Title slot: line matches `- [DISPLAY_ID] ` and cursor is at end of line.
+  const titleMatch = TITLE_SLOT_RE.exec(beforeCursor);
+  if (titleMatch && position.character === beforeCursor.length) {
+    return { kind: "title-after-bracket", displayId: titleMatch[1] };
+  }
+
+  // Trace attribute: cursor after `Satisfies: ` (etc.) on an indented line.
+  const traceMatch = TRACE_ATTR_RE.exec(beforeCursor);
+  if (traceMatch) {
+    const enclosing = findEnclosingEntry(document, position.line);
+    if (enclosing) {
+      return {
+        kind: "trace-attribute",
+        attribute: traceMatch[1],
+        entryTitle: enclosing.title,
+      };
+    }
+  }
+
+  // Entry body: scan backward for an entry opener within the search radius;
+  // if found and the cursor is on an indented (≥2 spaces) line that is NOT
+  // in the trailer region (≥4 spaces) and NOT another entry opener, classify
+  // as `entry-body`.
+  const enclosing = findEnclosingEntry(document, position.line);
+  if (enclosing && enclosing.line !== position.line) {
+    const indentMatch = /^(\s*)/.exec(line);
+    const indent = indentMatch ? indentMatch[1].length : 0;
+    if (indent >= 2 && indent < 4) {
+      return {
+        kind: "entry-body",
+        entryLine: enclosing.line,
+        entryTitle: enclosing.title,
+      };
+    }
+  }
+
+  // Default: plain markdown prose.
+  return { kind: "doc-prose" };
+}
+
+interface EnclosingEntry {
+  readonly line: number;
+  readonly displayId: string;
+  readonly title: string;
+}
+
+function findEnclosingEntry(
+  document: TextDocument,
+  fromLine: number,
+): EnclosingEntry | undefined {
+  const minLine = Math.max(0, fromLine - ENTRY_SEARCH_RADIUS);
+  for (let i = fromLine; i >= minLine; i--) {
+    const text = document.lineAt(i).text;
+    const match = ENTRY_OPENER_RE.exec(text);
+    if (match) {
+      return { line: i, displayId: match[1], title: match[2].trim() };
+    }
+  }
+  return undefined;
+}

--- a/editors/vscode/src/prompts.ts
+++ b/editors/vscode/src/prompts.ts
@@ -37,13 +37,13 @@ export const SYSTEM_PROMPT =
 
 MarkSpec is a Markdown flavor for traceable requirements. A typical entry block looks like:
 
-  - [STK_AEB_0001] Sensor debouncing
+- [STK_AEB_0001] Sensor debouncing
 
-    The sensor driver shall debounce raw inputs within 20 ms.
+  The sensor driver shall debounce raw inputs within 20 ms.
 
-        Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
-        Satisfies: SYS_AEB_0001
-        Labels: ASIL-B
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      Satisfies: SYS_AEB_0001
+      Labels: ASIL-B
 
 Authoring conventions:
 - One requirement per entry block. Single responsibility. Active voice.
@@ -78,9 +78,7 @@ export function buildUserPrompt(ctx: PromptContext): string {
       sections.push(`# Surrounding markdown\n${ctx.localWindow}`);
       if (ctx.currentFileEntries.length > 0) {
         sections.push(
-          `# Other entries in this file\n${
-            formatEntryList(ctx.currentFileEntries)
-          }`,
+          `# Entries in this file\n${formatEntryList(ctx.currentFileEntries)}`,
         );
       }
       break;
@@ -105,13 +103,22 @@ export function buildUserPrompt(ctx: PromptContext): string {
       break;
     }
     case "skip":
-      sections.push(`# Task\nNo completion.`);
-      break;
+      throw new Error(
+        "buildUserPrompt: called with 'skip' context — caller must guard against this",
+      );
+    default: {
+      const _exhaustive: never = ctx.cursorContext;
+      throw new Error(
+        `buildUserPrompt: unhandled context kind: ${
+          JSON.stringify(_exhaustive)
+        }`,
+      );
+    }
   }
 
   return sections.join("\n\n");
 }
 
-function formatEntryList(entries: readonly EntryRef[]): string {
+export function formatEntryList(entries: readonly EntryRef[]): string {
   return entries.map((e) => `- ${e.displayId} — ${e.title}`).join("\n");
 }

--- a/editors/vscode/src/prompts.ts
+++ b/editors/vscode/src/prompts.ts
@@ -1,0 +1,117 @@
+/**
+ * Prompt assembly for the MarkSpec inline AI completion provider.
+ *
+ * `SYSTEM_PROMPT` is a static description of the MarkSpec entry format,
+ * the EARS / Gherkin patterns we expect in requirement bodies, and the
+ * editing conventions the completion should respect.
+ *
+ * `buildUserPrompt(ctx)` shapes the user prompt to the cursor context:
+ * what the model sees on each call depends on whether we're completing
+ * an entry title, body prose, a trace attribute value, or generic
+ * markdown prose.
+ *
+ * This module is pure — no `vscode` imports, no I/O. The seam between
+ * the provider and the language model lives here so unit tests can pin
+ * the prompt shape with snapshot-style assertions.
+ */
+
+import type { InlineContext } from "./inlineCompletions";
+
+/** A workspace entry pointer used for trace-attribute candidate lists. */
+export interface EntryRef {
+  readonly displayId: string;
+  readonly title: string;
+}
+
+/** Full prompt context — what `buildUserPrompt` consumes. */
+export interface PromptContext {
+  readonly cursorContext: InlineContext;
+  readonly localWindow: string;
+  readonly currentFileEntries: readonly EntryRef[];
+  readonly workspaceEntries: readonly EntryRef[];
+}
+
+/** Static system prompt sent on every request. */
+export const SYSTEM_PROMPT =
+  `You are an AI assistant embedded in a MarkSpec editor.
+
+MarkSpec is a Markdown flavor for traceable requirements. A typical entry block looks like:
+
+  - [STK_AEB_0001] Sensor debouncing
+
+    The sensor driver shall debounce raw inputs within 20 ms.
+
+        Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+        Satisfies: SYS_AEB_0001
+        Labels: ASIL-B
+
+Authoring conventions:
+- One requirement per entry block. Single responsibility. Active voice.
+- Bodies must be measurable: include units, thresholds, tolerances. Avoid "fast" / "reliable" / "user-friendly".
+- Use EARS patterns when possible: ubiquitous, event-driven, state-driven, optional, unwanted.
+- Use Gherkin (Given/When/Then) inside fenced \`gherkin\` blocks when scenarios are clearer than EARS.
+- Trace attributes (Satisfies, Derived-from, Verified-by, etc.) reference other entries by their display ID.
+
+Inline completion guidance:
+- When suggesting a title, produce a short noun phrase (≤8 words). No trailing period.
+- When suggesting body prose, use one sentence in active voice with a measurable predicate.
+- When suggesting a trace-attribute value, return only display IDs that appear in the supplied workspace context, never invent new ones.
+- Suggest only the text to insert. Do not echo the surrounding document.
+`;
+
+/** Build the user prompt for the current cursor context. */
+export function buildUserPrompt(ctx: PromptContext): string {
+  const sections: string[] = [];
+
+  switch (ctx.cursorContext.kind) {
+    case "title-after-bracket": {
+      sections.push(
+        `# Task\nSuggest a short title for the entry whose display ID is ${ctx.cursorContext.displayId}.`,
+      );
+      sections.push(`# Surrounding markdown\n${ctx.localWindow}`);
+      break;
+    }
+    case "entry-body": {
+      sections.push(
+        `# Task\nContinue the body of entry "${ctx.cursorContext.entryTitle}" with one measurable, active-voice sentence following an EARS pattern.`,
+      );
+      sections.push(`# Surrounding markdown\n${ctx.localWindow}`);
+      if (ctx.currentFileEntries.length > 0) {
+        sections.push(
+          `# Other entries in this file\n${
+            formatEntryList(ctx.currentFileEntries)
+          }`,
+        );
+      }
+      break;
+    }
+    case "trace-attribute": {
+      sections.push(
+        `# Task\nSuggest the display ID(s) that should appear after \`${ctx.cursorContext.attribute}:\` for the entry titled "${ctx.cursorContext.entryTitle}".`,
+      );
+      sections.push(`# Surrounding markdown\n${ctx.localWindow}`);
+      if (ctx.workspaceEntries.length > 0) {
+        sections.push(
+          `# Candidate workspace entries\n${
+            formatEntryList(ctx.workspaceEntries)
+          }`,
+        );
+      }
+      break;
+    }
+    case "doc-prose": {
+      sections.push(`# Task\nContinue the prose at the cursor.`);
+      sections.push(`# Surrounding markdown\n${ctx.localWindow}`);
+      break;
+    }
+    case "skip":
+      sections.push(`# Task\nNo completion.`);
+      break;
+  }
+
+  return sections.join("\n\n");
+}
+
+function formatEntryList(entries: readonly EntryRef[]): string {
+  return entries.map((e) => `- ${e.displayId} — ${e.title}`).join("\n");
+}


### PR DESCRIPTION
## Summary

Stage 2 of the LSP completion improvements design. Adds an AI-backed inline completion provider to the MarkSpec VSCode extension.

- **Cursor-aware completions.** A regex classifier picks one of `title-after-bracket`, `entry-body`, `trace-attribute`, `doc-prose`, or `skip`. The prompt is shaped accordingly.
- **Workspace context via existing LSP requests.** Pulls current-file entries via `vscode.executeDocumentSymbolProvider` and workspace entries via `vscode.executeWorkspaceSymbolProvider`. Workspace list capped (default 200).
- **`vscode.lm` for the model.** Uses Copilot (`selectChatModels({ vendor: "copilot" })`). First call surfaces VSCode's consent dialog automatically.
- **Cancellation honoured.** Three guard points: after the parallel symbol fetch, before each streamed chunk, and after the loop closes.
- **No live LM in CI.** The provider takes a `ModelInvoker` in its constructor; tests supply a stub generator.

Design spec: `docs/superpowers/specs/2026-05-23-completion-ulid-and-inline-ai-design.md` (§2).
Implementation plan: `docs/superpowers/plans/2026-05-23-vscode-inline-ai-completion-stage-2.md`.

## Commits

Nine commits, all `(repo)`-scoped (the VSCode-extension scope per the project's commit-msg policy):

- `b45754a` feat(repo): add inline-completion configuration entries
- `907c594` feat(repo): add inline-completion cursor context classifier
- `63320db` fix(repo): tighten inline classifier (full-line title match, trailer skip)
- `165a8a7` feat(repo): add prompt builder for inline AI completion
- `b5e12ae` refactor(repo): correct prompt indentation and tighten exhaustiveness
- `7bb705c` feat(repo): inline completion provider with model injection
- `bf90957` refactor(repo): hoist provider imports and tighten return contract
- `bff70fa` feat(repo): register MarkSpec inline AI completion provider
- `8ab87f7` fix(repo): thread document URI through inline completion provider

## Files

- `editors/vscode/src/inlineCompletions.ts` (new) — classifier + provider class + ModelInvoker DI
- `editors/vscode/src/prompts.ts` (new) — system + user prompt builders
- `editors/vscode/src/inlineCompletions.test.ts` (new) — 17 unit tests (classifier + prompts + provider with mocked invoker)
- `editors/vscode/src/extension.ts` — registers the provider on activation, wires the production ModelInvoker, converts RawInlineCompletionItem to vscode.InlineCompletionItem at the boundary
- `editors/vscode/package.json` — two new contributes.configuration.properties entries; extends npm test file list

## Test plan

Automated checks all green locally:

- [x] `just build` (lint + test + typecheck + compile)
- [x] `cd editors/vscode && npm test` — 39/39 pass
- [x] `deno fmt --check`
- [x] `dprint check`

Manual VSCode smoke tests for reviewer (could not run in the authoring session):

- [ ] Type `- [STK_AEB_0042] ` on a new line in a MarkSpec markdown file. Wait. Ghost text proposes a title; Tab accepts.
- [ ] Pause on a blank body line (indent 2) inside an entry. Ghost text proposes body prose in active voice with measurable predicate.
- [ ] Type `      Satisfies: ` inside an entry trailer. Ghost text proposes a display ID that exists in the workspace symbol list.
- [ ] Set `markspec.inlineCompletion.enabled: false` and reload. Inline AI no longer triggers; Stage 1 LSP completions still work.
- [ ] Sign out of Copilot. Triggers silently no-op (no error toast).

Generated with Claude Code (https://claude.com/claude-code)
