### PR TITLE
fix(repo): un-skip Windows tests and support cross-drive doc build

### DIFF
--- a/packages/markspec/cli/commands/doc.ts
+++ b/packages/markspec/cli/commands/doc.ts
@@ -5,7 +5,8 @@
  */
 
 import { Command } from "@cliffy/command";
-import { fromFileUrl, resolve } from "@std/path";
+import { dirname, fromFileUrl, parse, resolve } from "@std/path";
+import { copy } from "@std/fs/copy";
 import { compileProject, requireProjectConfig } from "../helpers.ts";
 
 export const docCmd = new Command()
@@ -19,28 +20,72 @@ export const docCmd = new Command()
     const { renderPdf } = await import("../../render/mod.ts");
 
     const markdown = await Deno.readTextFile(file);
-    const typstPackagePath = fromFileUrl(
+    const bundledTypstPackagePath = fromFileUrl(
       new URL("../../../markspec-typst/", import.meta.url),
     );
     const sourceFilePath = resolve(Deno.cwd(), file);
-    const result = renderPdf(markdown, {
-      compiled,
-      config,
-      typstPackagePath,
+    const { path: typstPackagePath, cleanup } = await stageTypstPackage(
+      bundledTypstPackagePath,
       sourceFilePath,
-      profile: chain?.effective,
-    });
+    );
+    try {
+      const result = renderPdf(markdown, {
+        compiled,
+        config,
+        typstPackagePath,
+        sourceFilePath,
+        profile: chain?.effective,
+      });
 
-    for (const d of result.diagnostics) {
-      console.error(`${d.severity}[${d.code}]: ${d.message}`);
+      for (const d of result.diagnostics) {
+        console.error(`${d.severity}[${d.code}]: ${d.message}`);
+      }
+
+      if (result.output.length === 0) {
+        console.error("error: PDF rendering failed");
+        Deno.exit(1);
+      }
+
+      const outPath = options.output ?? file.replace(/\.md$/, ".pdf");
+      await Deno.writeFile(outPath, result.output);
+      console.error(`wrote ${outPath}`);
+    } finally {
+      await cleanup();
     }
-
-    if (result.output.length === 0) {
-      console.error("error: PDF rendering failed");
-      Deno.exit(1);
-    }
-
-    const outPath = options.output ?? file.replace(/\.md$/, ".pdf");
-    await Deno.writeFile(outPath, result.output);
-    console.error(`wrote ${outPath}`);
   });
+
+/**
+ * Ensure the markspec-typst package is reachable from the same Typst
+ * workspace as the source document.
+ *
+ * The Typst compiler requires every input under a single workspace root.
+ * On Windows the package may live on a different drive than the source
+ * (e.g., installed CLI on `C:` rendering docs on `D:`), and cross-drive
+ * paths share no common ancestor. When that happens we copy the package
+ * (≈1 MB) to a temp dir next to the source so the workspace computation
+ * finds a real ancestor. POSIX hosts never trigger this path.
+ *
+ * The returned `cleanup` is a no-op when no copy was made.
+ */
+async function stageTypstPackage(
+  bundledPath: string,
+  sourceFilePath: string,
+): Promise<{ path: string; cleanup: () => Promise<void> }> {
+  if (Deno.build.os !== "windows") {
+    return { path: bundledPath, cleanup: () => Promise.resolve() };
+  }
+  const pkgRoot = parse(bundledPath).root.toLowerCase();
+  const srcRoot = parse(sourceFilePath).root.toLowerCase();
+  if (pkgRoot === srcRoot) {
+    return { path: bundledPath, cleanup: () => Promise.resolve() };
+  }
+  const stagingDir = await Deno.makeTempDir({
+    dir: dirname(sourceFilePath),
+    prefix: ".markspec-typst-",
+  });
+  await copy(bundledPath, stagingDir, { overwrite: true });
+  return {
+    path: stagingDir,
+    cleanup: () => Deno.remove(stagingDir, { recursive: true }).catch(() => {}),
+  };
+}

--- a/packages/markspec/core/config/markspec_test.ts
+++ b/packages/markspec/core/config/markspec_test.ts
@@ -5,6 +5,7 @@
  */
 
 import { assertEquals, assertExists, assertStringIncludes } from "@std/assert";
+import { join, resolve } from "@std/path";
 import {
   addProfileSpecifier,
   MARKSPEC_YAML_FILENAME,
@@ -25,13 +26,12 @@ Deno.test("readMarkspecYaml: returns null when file absent", async () => {
   assertEquals(result, null);
 });
 
-Deno.test("readMarkspecYaml: returns contents when file present", {
-  ignore: Deno.build.os === "windows",
-}, async () => {
+Deno.test("readMarkspecYaml: returns contents when file present", async () => {
+  const project = resolve("/project");
   const result = await readMarkspecYaml(
-    "/project",
+    project,
     mockReadFile({
-      [`/project/${MARKSPEC_YAML_FILENAME}`]: "profiles: []\n",
+      [join(project, MARKSPEC_YAML_FILENAME)]: "profiles: []\n",
     }),
   );
   assertEquals(result, "profiles: []\n");
@@ -199,9 +199,8 @@ Deno.test("parseMarkspecYaml: npm specifier missing version range errors", () =>
   assertEquals(result.diagnostics[0].code, "MARKSPEC-YAML-003");
 });
 
-Deno.test("addProfileSpecifier: creates file when absent", {
-  ignore: Deno.build.os === "windows",
-}, async () => {
+Deno.test("addProfileSpecifier: creates file when absent", async () => {
+  const project = resolve("/project");
   const writes: Record<string, string> = {};
   await addProfileSpecifier(
     "npm:@markspec/profile-default@^1.0",
@@ -210,17 +209,16 @@ Deno.test("addProfileSpecifier: creates file when absent", {
       writes[path] = content;
       return Promise.resolve();
     },
-    "/project",
+    project,
   );
-  const written = writes["/project/.markspec.yaml"];
+  const written = writes[join(project, ".markspec.yaml")];
   assertExists(written);
   assertStringIncludes(written, "profiles:");
   assertStringIncludes(written, "npm:@markspec/profile-default@^1.0");
 });
 
-Deno.test("addProfileSpecifier: appends to existing profiles list", {
-  ignore: Deno.build.os === "windows",
-}, async () => {
+Deno.test("addProfileSpecifier: appends to existing profiles list", async () => {
+  const project = resolve("/project");
   const existing = 'profiles:\n  - "./local-profile"\n';
   const writes: Record<string, string> = {};
   await addProfileSpecifier(
@@ -230,17 +228,16 @@ Deno.test("addProfileSpecifier: appends to existing profiles list", {
       writes[path] = content;
       return Promise.resolve();
     },
-    "/project",
+    project,
   );
-  const written = writes["/project/.markspec.yaml"];
+  const written = writes[join(project, ".markspec.yaml")];
   assertExists(written);
   assertStringIncludes(written, "./local-profile");
   assertStringIncludes(written, "npm:@markspec/profile-default@^1.0");
 });
 
-Deno.test("addProfileSpecifier: adds profiles key when missing", {
-  ignore: Deno.build.os === "windows",
-}, async () => {
+Deno.test("addProfileSpecifier: adds profiles key when missing", async () => {
+  const project = resolve("/project");
   const existing = "# some comment\n";
   const writes: Record<string, string> = {};
   await addProfileSpecifier(
@@ -250,9 +247,9 @@ Deno.test("addProfileSpecifier: adds profiles key when missing", {
       writes[path] = content;
       return Promise.resolve();
     },
-    "/project",
+    project,
   );
-  const written = writes["/project/.markspec.yaml"];
+  const written = writes[join(project, ".markspec.yaml")];
   assertExists(written);
   assertStringIncludes(written, "# some comment");
   assertStringIncludes(written, "profiles:");
@@ -296,11 +293,11 @@ Deno.test("parseMarkspecYaml: non-boolean default-profile emits MARKSPEC-YAML-00
   assertEquals(result.diagnostics[0].code, "MARKSPEC-YAML-003");
 });
 
-Deno.test("addProfileSpecifier: preserves an existing default-profile key", {
-  ignore: Deno.build.os === "windows",
-}, async () => {
+Deno.test("addProfileSpecifier: preserves an existing default-profile key", async () => {
+  const p = resolve("/p");
+  const yamlPath = join(p, ".markspec.yaml");
   const store: Record<string, string> = {
-    "/p/.markspec.yaml": "default-profile: false\nprofiles:\n  - ./a\n",
+    [yamlPath]: "default-profile: false\nprofiles:\n  - ./a\n",
   };
   await addProfileSpecifier(
     "./b",
@@ -309,8 +306,8 @@ Deno.test("addProfileSpecifier: preserves an existing default-profile key", {
       store[path] = content;
       return Promise.resolve();
     },
-    "/p",
+    p,
   );
-  assertStringIncludes(store["/p/.markspec.yaml"], "default-profile: false");
-  assertStringIncludes(store["/p/.markspec.yaml"], '- "./b"');
+  assertStringIncludes(store[yamlPath], "default-profile: false");
+  assertStringIncludes(store[yamlPath], '- "./b"');
 });

--- a/packages/markspec/core/config/mod_test.ts
+++ b/packages/markspec/core/config/mod_test.ts
@@ -1,4 +1,5 @@
 import { assertEquals, assertStringIncludes, assertThrows } from "@std/assert";
+import { join, resolve } from "@std/path";
 import {
   ConfigError,
   DEFAULT_PROJECT_CONFIG,
@@ -167,26 +168,27 @@ Deno.test("parseProjectConfig: numeric version emits coercion warning", () => {
 // discoverProjectRoot
 // ---------------------------------------------------------------------------
 
-Deno.test("discoverProjectRoot: finds project.yaml in current directory", {
-  ignore: Deno.build.os === "windows",
-}, async () => {
+Deno.test("discoverProjectRoot: finds project.yaml in current directory", async () => {
+  const a = resolve("/a");
+  const yamlPath = join(a, "project.yaml");
   const readFile = (path: string) =>
     Promise.resolve(
-      path.endsWith("project.yaml") && path === "/a/project.yaml"
+      path.endsWith("project.yaml") && path === yamlPath
         ? "name: test"
         : undefined,
     );
-  const root = await discoverProjectRoot("/a", readFile);
-  assertEquals(root, "/a");
+  const root = await discoverProjectRoot(a, readFile);
+  assertEquals(root, a);
 });
 
-Deno.test("discoverProjectRoot: finds project.yaml two levels up", {
-  ignore: Deno.build.os === "windows",
-}, async () => {
+Deno.test("discoverProjectRoot: finds project.yaml two levels up", async () => {
+  const a = resolve("/a");
+  const yamlPath = join(a, "project.yaml");
+  const deep = join(a, "b", "c");
   const readFile = (path: string) =>
-    Promise.resolve(path === "/a/project.yaml" ? "name: test" : undefined);
-  const root = await discoverProjectRoot("/a/b/c", readFile);
-  assertEquals(root, "/a");
+    Promise.resolve(path === yamlPath ? "name: test" : undefined);
+  const root = await discoverProjectRoot(deep, readFile);
+  assertEquals(root, a);
 });
 
 Deno.test("discoverProjectRoot: returns undefined when not found", async () => {
@@ -199,16 +201,15 @@ Deno.test("discoverProjectRoot: returns undefined when not found", async () => {
 // loadConfig
 // ---------------------------------------------------------------------------
 
-Deno.test("loadConfig: discovers and returns valid config", {
-  ignore: Deno.build.os === "windows",
-}, async () => {
+Deno.test("loadConfig: discovers and returns valid config", async () => {
+  const proj = resolve("/proj");
   const files: Record<string, string> = {
-    "/proj/project.yaml": "name: my-project\n",
+    [join(proj, "project.yaml")]: "name: my-project\n",
   };
   const readFile = (path: string) => Promise.resolve(files[path]);
-  const result = await loadConfig("/proj/src/deep", readFile);
+  const result = await loadConfig(join(proj, "src", "deep"), readFile);
   assertEquals(result?.config.name, "my-project");
-  assertEquals(result?.projectRoot, "/proj");
+  assertEquals(result?.projectRoot, proj);
 });
 
 Deno.test("loadConfig: returns undefined when no project.yaml found", async () => {
@@ -217,15 +218,14 @@ Deno.test("loadConfig: returns undefined when no project.yaml found", async () =
   assertEquals(result, undefined);
 });
 
-Deno.test("loadConfig: throws ConfigError on invalid project.yaml", {
-  ignore: Deno.build.os === "windows",
-}, async () => {
+Deno.test("loadConfig: throws ConfigError on invalid project.yaml", async () => {
+  const proj = resolve("/proj");
   const files: Record<string, string> = {
-    "/proj/project.yaml": "domain: bad\n",
+    [join(proj, "project.yaml")]: "domain: bad\n",
   };
   const readFile = (path: string) => Promise.resolve(files[path]);
   try {
-    await loadConfig("/proj", readFile);
+    await loadConfig(proj, readFile);
     throw new Error("should have thrown");
   } catch (err) {
     assertEquals(err instanceof ConfigError, true);

--- a/packages/markspec/core/profile/cache_test.ts
+++ b/packages/markspec/core/profile/cache_test.ts
@@ -1,31 +1,30 @@
 import { assertEquals } from "@std/assert";
+import { join, resolve } from "@std/path";
 import { cacheDir } from "./cache.ts";
 
-Deno.test("cacheDir: uses XDG_CACHE_HOME when set", {
-  ignore: Deno.build.os === "windows",
-}, () => {
-  const dir = cacheDir({ XDG_CACHE_HOME: "/custom/cache" });
-  assertEquals(dir, "/custom/cache/markspec");
+Deno.test("cacheDir: uses XDG_CACHE_HOME when set", () => {
+  const xdg = resolve("/custom/cache");
+  const dir = cacheDir({ XDG_CACHE_HOME: xdg });
+  assertEquals(dir, join(xdg, "markspec"));
 });
 
 Deno.test(
   "cacheDir: falls back to platform default when XDG_CACHE_HOME unset",
-  { ignore: Deno.build.os === "windows" },
   () => {
+    const home = resolve("/Users/test");
     const dir = cacheDir(
-      { XDG_CACHE_HOME: undefined, HOME: "/Users/test" },
+      { XDG_CACHE_HOME: undefined, HOME: home },
       "darwin",
     );
-    assertEquals(dir, "/Users/test/Library/Caches/markspec");
+    assertEquals(dir, join(home, "Library", "Caches", "markspec"));
   },
 );
 
-Deno.test("cacheDir: uses ~/.cache/markspec on linux without XDG", {
-  ignore: Deno.build.os === "windows",
-}, () => {
+Deno.test("cacheDir: uses ~/.cache/markspec on linux without XDG", () => {
+  const home = resolve("/home/user");
   const dir = cacheDir(
-    { XDG_CACHE_HOME: undefined, HOME: "/home/user" },
+    { XDG_CACHE_HOME: undefined, HOME: home },
     "linux",
   );
-  assertEquals(dir, "/home/user/.cache/markspec");
+  assertEquals(dir, join(home, ".cache", "markspec"));
 });

--- a/packages/markspec/core/profile/chain_test.ts
+++ b/packages/markspec/core/profile/chain_test.ts
@@ -5,6 +5,7 @@
  */
 
 import { assertEquals } from "@std/assert";
+import { join, resolve } from "@std/path";
 import { loadChain } from "./chain.ts";
 import type { RunGit } from "./git-cache.ts";
 import { computeCacheLocation } from "./git-cache.ts";
@@ -15,15 +16,16 @@ function mockReadFile(map: Record<string, string>) {
     Promise.resolve(map[path]);
 }
 
-Deno.test("loadChain: happy path returns a one-tier chain", {
-  ignore: Deno.build.os === "windows",
-}, async () => {
+Deno.test("loadChain: happy path returns a one-tier chain", async () => {
+  const project = resolve("/project");
+  const customDir = join(project, "profiles", "custom");
+  const customYaml = join(customDir, "markspec.yaml");
   const result = await loadChain(
     { kind: "local", path: "./profiles/custom" },
-    "/project",
-    "/project",
+    project,
+    project,
     mockReadFile({
-      "/project/profiles/custom/markspec.yaml":
+      [customYaml]:
         `id: "@acme/custom"\nversion: 1.0.0\nmarkspec-schema: "1"\n`,
     }),
   );
@@ -33,15 +35,16 @@ Deno.test("loadChain: happy path returns a one-tier chain", {
   assertEquals(tier?.id, "@acme/custom");
   assertEquals(tier?.version, "1.0.0");
   assertEquals(tier?.specifier, { kind: "local", path: "./profiles/custom" });
-  assertEquals(tier?.sourcePath, "/project/profiles/custom/markspec.yaml");
-  assertEquals(tier?.baseDir, "/project/profiles/custom");
+  assertEquals(tier?.sourcePath, customYaml);
+  assertEquals(tier?.baseDir, customDir);
 });
 
 Deno.test("loadChain: unresolvable specifier propagates PROFILE-LOAD-001", async () => {
+  const project = resolve("/project");
   const result = await loadChain(
     { kind: "local", path: "./profiles/missing" },
-    "/project",
-    "/project",
+    project,
+    project,
     mockReadFile({}),
   );
   assertEquals(result.chain, null);
@@ -49,15 +52,14 @@ Deno.test("loadChain: unresolvable specifier propagates PROFILE-LOAD-001", async
   assertEquals(result.diagnostics[0].code, "PROFILE-LOAD-001");
 });
 
-Deno.test("loadChain: malformed manifest propagates PROFILE-LOAD-003", {
-  ignore: Deno.build.os === "windows",
-}, async () => {
+Deno.test("loadChain: malformed manifest propagates PROFILE-LOAD-003", async () => {
+  const project = resolve("/project");
   const result = await loadChain(
     { kind: "local", path: "./profiles/broken" },
-    "/project",
-    "/project",
+    project,
+    project,
     mockReadFile({
-      "/project/profiles/broken/markspec.yaml": `no_id: true\n`,
+      [join(project, "profiles", "broken", "markspec.yaml")]: `no_id: true\n`,
     }),
   );
   assertEquals(result.chain, null);
@@ -66,17 +68,16 @@ Deno.test("loadChain: malformed manifest propagates PROFILE-LOAD-003", {
   assertEquals(codes[0], "PROFILE-LOAD-003");
 });
 
-Deno.test("loadChain: two-tier chain loads in root→leaf order", {
-  ignore: Deno.build.os === "windows",
-}, async () => {
+Deno.test("loadChain: two-tier chain loads in root→leaf order", async () => {
+  const project = resolve("/project");
   const result = await loadChain(
     { kind: "local", path: "./profiles/child" },
-    "/project",
-    "/project",
+    project,
+    project,
     mockReadFile({
-      "/project/profiles/child/markspec.yaml":
+      [join(project, "profiles", "child", "markspec.yaml")]:
         `id: "@acme/child"\nversion: 1.0.0\nmarkspec-schema: "1"\nextends: "../base"\n`,
-      "/project/profiles/base/markspec.yaml":
+      [join(project, "profiles", "base", "markspec.yaml")]:
         `id: "@acme/base"\nversion: 1.0.0\nmarkspec-schema: "1"\n`,
     }),
   );
@@ -87,19 +88,18 @@ Deno.test("loadChain: two-tier chain loads in root→leaf order", {
   assertEquals(result.chain?.tiers[1].id, "@acme/child");
 });
 
-Deno.test("loadChain: three-tier chain loads in order", {
-  ignore: Deno.build.os === "windows",
-}, async () => {
+Deno.test("loadChain: three-tier chain loads in order", async () => {
+  const project = resolve("/project");
   const result = await loadChain(
     { kind: "local", path: "./profiles/leaf" },
-    "/project",
-    "/project",
+    project,
+    project,
     mockReadFile({
-      "/project/profiles/leaf/markspec.yaml":
+      [join(project, "profiles", "leaf", "markspec.yaml")]:
         `id: "@acme/leaf"\nversion: 1.0.0\nmarkspec-schema: "1"\nextends: "../mid"\n`,
-      "/project/profiles/mid/markspec.yaml":
+      [join(project, "profiles", "mid", "markspec.yaml")]:
         `id: "@acme/mid"\nversion: 1.0.0\nmarkspec-schema: "1"\nextends: "../base"\n`,
-      "/project/profiles/base/markspec.yaml":
+      [join(project, "profiles", "base", "markspec.yaml")]:
         `id: "@acme/base"\nversion: 1.0.0\nmarkspec-schema: "1"\n`,
     }),
   );
@@ -111,17 +111,16 @@ Deno.test("loadChain: three-tier chain loads in order", {
   ]);
 });
 
-Deno.test("loadChain: direct cycle emits PROFILE-LOAD-004", {
-  ignore: Deno.build.os === "windows",
-}, async () => {
+Deno.test("loadChain: direct cycle emits PROFILE-LOAD-004", async () => {
+  const project = resolve("/project");
   const result = await loadChain(
     { kind: "local", path: "./profiles/a" },
-    "/project",
-    "/project",
+    project,
+    project,
     mockReadFile({
-      "/project/profiles/a/markspec.yaml":
+      [join(project, "profiles", "a", "markspec.yaml")]:
         `id: "@acme/a"\nversion: 1.0.0\nmarkspec-schema: "1"\nextends: "../b"\n`,
-      "/project/profiles/b/markspec.yaml":
+      [join(project, "profiles", "b", "markspec.yaml")]:
         `id: "@acme/b"\nversion: 1.0.0\nmarkspec-schema: "1"\nextends: "../a"\n`,
     }),
   );
@@ -129,15 +128,14 @@ Deno.test("loadChain: direct cycle emits PROFILE-LOAD-004", {
   assertEquals(result.diagnostics[0].code, "PROFILE-LOAD-004");
 });
 
-Deno.test("loadChain: self-cycle emits PROFILE-LOAD-004", {
-  ignore: Deno.build.os === "windows",
-}, async () => {
+Deno.test("loadChain: self-cycle emits PROFILE-LOAD-004", async () => {
+  const project = resolve("/project");
   const result = await loadChain(
     { kind: "local", path: "./profiles/me" },
-    "/project",
-    "/project",
+    project,
+    project,
     mockReadFile({
-      "/project/profiles/me/markspec.yaml":
+      [join(project, "profiles", "me", "markspec.yaml")]:
         `id: "@acme/me"\nversion: 1.0.0\nmarkspec-schema: "1"\nextends: "./"\n`,
     }),
   );
@@ -145,21 +143,20 @@ Deno.test("loadChain: self-cycle emits PROFILE-LOAD-004", {
   assertEquals(result.diagnostics[0].code, "PROFILE-LOAD-004");
 });
 
-Deno.test("loadChain: depth beyond 20 emits PROFILE-LOAD-005", {
-  ignore: Deno.build.os === "windows",
-}, async () => {
+Deno.test("loadChain: depth beyond 20 emits PROFILE-LOAD-005", async () => {
+  const project = resolve("/project");
   const files: Record<string, string> = {};
   // Build a 22-tier chain (leaf + 21 ancestors)
   for (let i = 0; i < 22; i++) {
     const id = `@acme/t${i}`;
     const extendsLine = i < 21 ? `\nextends: "../t${i + 1}"` : "";
-    files[`/project/profiles/t${i}/markspec.yaml`] =
+    files[join(project, "profiles", `t${i}`, "markspec.yaml")] =
       `id: "${id}"\nversion: 1.0.0${extendsLine}\n`;
   }
   const result = await loadChain(
     { kind: "local", path: "./profiles/t0" },
-    "/project",
-    "/project",
+    project,
+    project,
     mockReadFile(files),
   );
   assertEquals(result.chain, null);
@@ -171,14 +168,15 @@ Deno.test("loadChain: depth beyond 20 emits PROFILE-LOAD-005", {
 });
 
 Deno.test("loadChain: extends of unresolvable parent propagates PROFILE-LOAD-001", async () => {
+  const project = resolve("/project");
   const result = await loadChain(
     { kind: "local", path: "./profiles/leaf" },
-    "/project",
-    "/project",
+    project,
+    project,
     mockReadFile({
-      "/project/profiles/leaf/markspec.yaml":
+      [join(project, "profiles", "leaf", "markspec.yaml")]:
         `id: "@acme/leaf"\nversion: 1.0.0\nmarkspec-schema: "1"\nextends: "../missing"\n`,
-      // no file at /project/profiles/missing/markspec.yaml
+      // no file at <project>/profiles/missing/markspec.yaml
     }),
   );
   assertEquals(result.chain, null);
@@ -186,13 +184,14 @@ Deno.test("loadChain: extends of unresolvable parent propagates PROFILE-LOAD-001
 });
 
 Deno.test("loadChain: top-level git specifier routes through resolveGitSpecifier", async () => {
+  const project = resolve("/project");
   const spec = {
     kind: "git" as const,
     repo: "https://github.com/acme/repo.git",
     subpath: undefined,
     tag: "v1.0.0",
   };
-  const loc = await computeCacheLocation("/project", spec);
+  const loc = await computeCacheLocation(project, spec);
 
   const gitCalls: string[][] = [];
   const runGit: RunGit = (args) => {
@@ -203,8 +202,8 @@ Deno.test("loadChain: top-level git specifier routes through resolveGitSpecifier
   // Cache hit: markspec.yaml is already at the cache location.
   const result = await loadChain(
     spec,
-    "/project",
-    "/project",
+    project,
+    project,
     mockReadFile({
       [loc.manifestPath]:
         `id: "@acme/from-git"\nversion: 1.0.0\nmarkspec-schema: "1"\n`,
@@ -218,26 +217,25 @@ Deno.test("loadChain: top-level git specifier routes through resolveGitSpecifier
   assertEquals(gitCalls.length, 0); // hit — no git calls
 });
 
-Deno.test("loadChain: git specifier in extends chain is walked", {
-  ignore: Deno.build.os === "windows",
-}, async () => {
+Deno.test("loadChain: git specifier in extends chain is walked", async () => {
+  const project = resolve("/project");
   const parentSpec = {
     kind: "git" as const,
     repo: "https://github.com/acme/parent.git",
     subpath: undefined,
     tag: "v1.0.0",
   };
-  const parentLoc = await computeCacheLocation("/project", parentSpec);
+  const parentLoc = await computeCacheLocation(project, parentSpec);
 
   const runGit: RunGit = () =>
     Promise.resolve({ code: 0, stdout: "", stderr: "" });
 
   const result = await loadChain(
     { kind: "local", path: "./profiles/child" },
-    "/project",
-    "/project",
+    project,
+    project,
     mockReadFile({
-      "/project/profiles/child/markspec.yaml":
+      [join(project, "profiles", "child", "markspec.yaml")]:
         `id: "@acme/child"\nversion: 1.0.0\nmarkspec-schema: "1"\n` +
         `extends: "git+${parentSpec.repo}#${parentSpec.tag}"\n`,
       [parentLoc.manifestPath]:
@@ -254,6 +252,7 @@ Deno.test("loadChain: git specifier in extends chain is walked", {
 });
 
 Deno.test("loadChain: git clone failure propagates PROFILE-LOAD-001", async () => {
+  const project = resolve("/project");
   const failingRunGit: RunGit = (args) => {
     if (args[0] === "clone") {
       return Promise.resolve({
@@ -272,8 +271,8 @@ Deno.test("loadChain: git clone failure propagates PROFILE-LOAD-001", async () =
       subpath: undefined,
       tag: "v1.0.0",
     },
-    "/project",
-    "/project",
+    project,
+    project,
     mockReadFile({}),
     { runGit: failingRunGit },
   );
@@ -284,14 +283,14 @@ Deno.test("loadChain: git clone failure propagates PROFILE-LOAD-001", async () =
 
 Deno.test(
   "loadChain: bundledDefault splices builtin as root of an extends-less leaf",
-  { ignore: Deno.build.os === "windows" },
   async () => {
+    const project = resolve("/project");
     const result = await loadChain(
       { kind: "local", path: "./profiles/custom" },
-      "/project",
-      "/project",
+      project,
+      project,
       mockReadFile({
-        "/project/profiles/custom/markspec.yaml":
+        [join(project, "profiles", "custom", "markspec.yaml")]:
           `id: "@acme/custom"\nversion: 1.0.0\nmarkspec-schema: "1"\n`,
       }),
       { bundledDefault: true },
@@ -303,15 +302,14 @@ Deno.test(
   },
 );
 
-Deno.test("loadChain: bundledDefault disabled does not splice", {
-  ignore: Deno.build.os === "windows",
-}, async () => {
+Deno.test("loadChain: bundledDefault disabled does not splice", async () => {
+  const project = resolve("/project");
   const result = await loadChain(
     { kind: "local", path: "./profiles/custom" },
-    "/project",
-    "/project",
+    project,
+    project,
     mockReadFile({
-      "/project/profiles/custom/markspec.yaml":
+      [join(project, "profiles", "custom", "markspec.yaml")]:
         `id: "@acme/custom"\nversion: 1.0.0\nmarkspec-schema: "1"\n`,
     }),
     { bundledDefault: false },
@@ -321,10 +319,11 @@ Deno.test("loadChain: bundledDefault disabled does not splice", {
 });
 
 Deno.test("loadChain: builtin leaf with bundledDefault yields exactly one tier (no self-splice)", async () => {
+  const project = resolve("/project");
   const result = await loadChain(
     BUILTIN_DEFAULT_SPECIFIER,
-    "/project",
-    "/project",
+    project,
+    project,
     mockReadFile({}),
     { bundledDefault: true },
   );
@@ -336,17 +335,16 @@ Deno.test("loadChain: builtin leaf with bundledDefault yields exactly one tier (
   assertEquals(result.chain?.tiers[0].id, "@markspec/profile-default");
 });
 
-Deno.test("loadChain: builtin spliced below a multi-tier local chain", {
-  ignore: Deno.build.os === "windows",
-}, async () => {
+Deno.test("loadChain: builtin spliced below a multi-tier local chain", async () => {
+  const project = resolve("/project");
   const result = await loadChain(
     { kind: "local", path: "./profiles/leaf" },
-    "/project",
-    "/project",
+    project,
+    project,
     mockReadFile({
-      "/project/profiles/leaf/markspec.yaml":
+      [join(project, "profiles", "leaf", "markspec.yaml")]:
         `id: "@acme/leaf"\nversion: 1.0.0\nmarkspec-schema: "1"\nextends: "../root"\n`,
-      "/project/profiles/root/markspec.yaml":
+      [join(project, "profiles", "root", "markspec.yaml")]:
         `id: "@acme/root"\nversion: 1.0.0\nmarkspec-schema: "1"\n`,
     }),
     { bundledDefault: true },

--- a/packages/markspec/core/profile/git-cache_test.ts
+++ b/packages/markspec/core/profile/git-cache_test.ts
@@ -5,6 +5,7 @@
  */
 
 import { assertEquals } from "@std/assert";
+import { join, resolve } from "@std/path";
 import { computeCacheKey, computeCacheLocation } from "./git-cache.ts";
 import type { RunGitResult } from "./git-cache.ts";
 import { defaultRunGit } from "./git-cache.ts";
@@ -56,11 +57,10 @@ Deno.test("computeCacheKey: subpath differentiates keys", async () => {
   }
 });
 
-Deno.test("computeCacheLocation: returns absolute cache dir + manifest path", {
-  ignore: Deno.build.os === "windows",
-}, async () => {
+Deno.test("computeCacheLocation: returns absolute cache dir + manifest path", async () => {
+  const project = resolve("/project");
   const loc = await computeCacheLocation(
-    "/project",
+    project,
     {
       repo: "https://github.com/acme/repo.git",
       subpath: undefined,
@@ -68,26 +68,26 @@ Deno.test("computeCacheLocation: returns absolute cache dir + manifest path", {
     },
   );
   // cache dir: <project-root>/.markspec/cache/<key>/
-  if (!loc.dir.startsWith("/project/.markspec/cache/")) {
+  const cacheRoot = join(project, ".markspec", "cache");
+  if (!loc.dir.startsWith(cacheRoot)) {
     throw new Error(
-      `expected cache dir under /project/.markspec/cache/, got ${loc.dir}`,
+      `expected cache dir under ${cacheRoot}, got ${loc.dir}`,
     );
   }
-  assertEquals(loc.manifestPath, `${loc.dir}/markspec.yaml`);
+  assertEquals(loc.manifestPath, join(loc.dir, "markspec.yaml"));
 });
 
-Deno.test("computeCacheLocation: subpath appears in manifest path", {
-  ignore: Deno.build.os === "windows",
-}, async () => {
+Deno.test("computeCacheLocation: subpath appears in manifest path", async () => {
+  const project = resolve("/project");
   const loc = await computeCacheLocation(
-    "/project",
+    project,
     {
       repo: "https://github.com/acme/repo.git",
       subpath: "aspice",
       tag: "v1.0.0",
     },
   );
-  assertEquals(loc.manifestPath, `${loc.dir}/aspice/markspec.yaml`);
+  assertEquals(loc.manifestPath, join(loc.dir, "aspice", "markspec.yaml"));
 });
 
 Deno.test("defaultRunGit: captures stdout/stderr from a trivial git command", async () => {
@@ -134,13 +134,13 @@ function fsStub(initial: Record<string, string> = {}): FsStub {
   };
 }
 
-Deno.test("ensureCacheGitignored: appends entry when missing", {
-  ignore: Deno.build.os === "windows",
-}, async () => {
-  const fs = fsStub({ "/project/.gitignore": "node_modules/\n" });
-  await ensureCacheGitignored("/project", fs.read, fs.append);
+Deno.test("ensureCacheGitignored: appends entry when missing", async () => {
+  const project = resolve("/project");
+  const gitignore = join(project, ".gitignore");
+  const fs = fsStub({ [gitignore]: "node_modules/\n" });
+  await ensureCacheGitignored(project, fs.read, fs.append);
   assertEquals(fs.writes.length, 1);
-  assertEquals(fs.writes[0].path, "/project/.gitignore");
+  assertEquals(fs.writes[0].path, gitignore);
   if (!fs.writes[0].content.includes(".markspec/cache/")) {
     throw new Error(
       `expected .markspec/cache/ in appended content: ${fs.writes[0].content}`,
@@ -149,21 +149,26 @@ Deno.test("ensureCacheGitignored: appends entry when missing", {
 });
 
 Deno.test("ensureCacheGitignored: idempotent when entry already present", async () => {
+  const project = resolve("/project");
+  const gitignore = join(project, ".gitignore");
   const fs = fsStub({
-    "/project/.gitignore": "node_modules/\n.markspec/cache/\n",
+    [gitignore]: "node_modules/\n.markspec/cache/\n",
   });
-  await ensureCacheGitignored("/project", fs.read, fs.append);
+  await ensureCacheGitignored(project, fs.read, fs.append);
   assertEquals(fs.writes.length, 0);
 });
 
 Deno.test("ensureCacheGitignored: idempotent when broader .markspec/ is present", async () => {
-  const fs = fsStub({ "/project/.gitignore": ".markspec/\n" });
-  await ensureCacheGitignored("/project", fs.read, fs.append);
+  const project = resolve("/project");
+  const gitignore = join(project, ".gitignore");
+  const fs = fsStub({ [gitignore]: ".markspec/\n" });
+  await ensureCacheGitignored(project, fs.read, fs.append);
   assertEquals(fs.writes.length, 0);
 });
 
 Deno.test("ensureCacheGitignored: no-op when .gitignore absent", async () => {
+  const project = resolve("/project");
   const fs = fsStub({});
-  await ensureCacheGitignored("/project", fs.read, fs.append);
+  await ensureCacheGitignored(project, fs.read, fs.append);
   assertEquals(fs.writes.length, 0);
 });

--- a/packages/markspec/core/profile/load_test.ts
+++ b/packages/markspec/core/profile/load_test.ts
@@ -5,6 +5,7 @@
  */
 
 import { assertEquals } from "@std/assert";
+import { join, resolve } from "@std/path";
 import { loadProfileForCommand } from "./load.ts";
 
 function mockReadFile(map: Record<string, string>) {
@@ -13,7 +14,8 @@ function mockReadFile(map: Record<string, string>) {
 }
 
 Deno.test("loadProfileForCommand: no .markspec.yaml yields the bundled default chain", async () => {
-  const result = await loadProfileForCommand("/project", mockReadFile({}));
+  const project = resolve("/project");
+  const result = await loadProfileForCommand(project, mockReadFile({}));
   // Filter to errors: a builtin-only chain routes through mergeChain,
   // which may legitimately emit non-error (info/warning) diagnostics.
   assertEquals(
@@ -25,9 +27,10 @@ Deno.test("loadProfileForCommand: no .markspec.yaml yields the bundled default c
 });
 
 Deno.test("loadProfileForCommand: empty profiles list yields the bundled default chain", async () => {
+  const project = resolve("/project");
   const result = await loadProfileForCommand(
-    "/project",
-    mockReadFile({ "/project/.markspec.yaml": "profiles: []\n" }),
+    project,
+    mockReadFile({ [join(project, ".markspec.yaml")]: "profiles: []\n" }),
   );
   assertEquals(result.chain?.tiers.length, 1);
   assertEquals(result.chain?.tiers[0].id, "@markspec/profile-default");
@@ -35,12 +38,13 @@ Deno.test("loadProfileForCommand: empty profiles list yields the bundled default
 
 Deno.test(
   "loadProfileForCommand: default-profile false yields core-only (null chain)",
-  { ignore: Deno.build.os === "windows" },
   async () => {
+    const project = resolve("/project");
     const result = await loadProfileForCommand(
-      "/project",
+      project,
       mockReadFile({
-        "/project/.markspec.yaml": "profiles: []\ndefault-profile: false\n",
+        [join(project, ".markspec.yaml")]:
+          "profiles: []\ndefault-profile: false\n",
       }),
     );
     assertEquals(result.chain, null);
@@ -50,13 +54,13 @@ Deno.test(
 
 Deno.test(
   "loadProfileForCommand: single local profile is spliced onto the bundled default",
-  { ignore: Deno.build.os === "windows" },
   async () => {
+    const project = resolve("/project");
     const result = await loadProfileForCommand(
-      "/project",
+      project,
       mockReadFile({
-        "/project/.markspec.yaml": `profiles:\n  - ./profiles/custom\n`,
-        "/project/profiles/custom/markspec.yaml":
+        [join(project, ".markspec.yaml")]: `profiles:\n  - ./profiles/custom\n`,
+        [join(project, "profiles", "custom", "markspec.yaml")]:
           `id: "@acme/custom"\nversion: 1.0.0\nmarkspec-schema: "1"\n`,
       }),
     );
@@ -69,14 +73,14 @@ Deno.test(
 
 Deno.test(
   "loadProfileForCommand: default-profile false keeps a single-tier chain",
-  { ignore: Deno.build.os === "windows" },
   async () => {
+    const project = resolve("/project");
     const result = await loadProfileForCommand(
-      "/project",
+      project,
       mockReadFile({
-        "/project/.markspec.yaml":
+        [join(project, ".markspec.yaml")]:
           `default-profile: false\nprofiles:\n  - ./profiles/custom\n`,
-        "/project/profiles/custom/markspec.yaml":
+        [join(project, "profiles", "custom", "markspec.yaml")]:
           `id: "@acme/custom"\nversion: 1.0.0\nmarkspec-schema: "1"\n`,
       }),
     );
@@ -88,14 +92,14 @@ Deno.test(
 
 Deno.test(
   "loadProfileForCommand: explicit default-profile true still splices the bundled default",
-  { ignore: Deno.build.os === "windows" },
   async () => {
+    const project = resolve("/project");
     const result = await loadProfileForCommand(
-      "/project",
+      project,
       mockReadFile({
-        "/project/.markspec.yaml":
+        [join(project, ".markspec.yaml")]:
           `default-profile: true\nprofiles:\n  - ./profiles/custom\n`,
-        "/project/profiles/custom/markspec.yaml":
+        [join(project, "profiles", "custom", "markspec.yaml")]:
           `id: "@acme/custom"\nversion: 1.0.0\nmarkspec-schema: "1"\n`,
       }),
     );
@@ -106,13 +110,12 @@ Deno.test(
   },
 );
 
-Deno.test("loadProfileForCommand: multiple profiles emits PROFILE-LOAD-006", {
-  ignore: Deno.build.os === "windows",
-}, async () => {
+Deno.test("loadProfileForCommand: multiple profiles emits PROFILE-LOAD-006", async () => {
+  const project = resolve("/project");
   const result = await loadProfileForCommand(
-    "/project",
+    project,
     mockReadFile({
-      "/project/.markspec.yaml":
+      [join(project, ".markspec.yaml")]:
         `profiles:\n  - ./profiles/a\n  - ./profiles/b\n`,
     }),
   );
@@ -121,28 +124,26 @@ Deno.test("loadProfileForCommand: multiple profiles emits PROFILE-LOAD-006", {
   assertEquals(result.diagnostics[0].code, "PROFILE-LOAD-006");
 });
 
-Deno.test("loadProfileForCommand: .markspec.yaml YAML error surfaces", {
-  ignore: Deno.build.os === "windows",
-}, async () => {
+Deno.test("loadProfileForCommand: .markspec.yaml YAML error surfaces", async () => {
+  const project = resolve("/project");
   const result = await loadProfileForCommand(
-    "/project",
+    project,
     mockReadFile({
-      "/project/.markspec.yaml": `profiles: [\n  unclosed`,
+      [join(project, ".markspec.yaml")]: `profiles: [\n  unclosed`,
     }),
   );
   assertEquals(result.chain, null);
   assertEquals(result.diagnostics[0].code, "MARKSPEC-YAML-002");
 });
 
-Deno.test("loadProfileForCommand: unknown key warning does not block loading", {
-  ignore: Deno.build.os === "windows",
-}, async () => {
+Deno.test("loadProfileForCommand: unknown key warning does not block loading", async () => {
+  const project = resolve("/project");
   const result = await loadProfileForCommand(
-    "/project",
+    project,
     mockReadFile({
-      "/project/.markspec.yaml":
+      [join(project, ".markspec.yaml")]:
         `profiles:\n  - ./profiles/custom\nbogus: true\n`,
-      "/project/profiles/custom/markspec.yaml":
+      [join(project, "profiles", "custom", "markspec.yaml")]:
         `id: "@acme/custom"\nversion: 1.0.0\nmarkspec-schema: "1"\n`,
     }),
   );
@@ -157,13 +158,12 @@ Deno.test("loadProfileForCommand: unknown key warning does not block loading", {
   assertEquals(warnings[0].severity, "warning");
 });
 
-Deno.test("loadProfileForCommand: profile load errors propagate", {
-  ignore: Deno.build.os === "windows",
-}, async () => {
+Deno.test("loadProfileForCommand: profile load errors propagate", async () => {
+  const project = resolve("/project");
   const result = await loadProfileForCommand(
-    "/project",
+    project,
     mockReadFile({
-      "/project/.markspec.yaml": `profiles:\n  - ./profiles/missing\n`,
+      [join(project, ".markspec.yaml")]: `profiles:\n  - ./profiles/missing\n`,
     }),
   );
   assertEquals(result.chain, null);

--- a/packages/markspec/core/profile/resolver_test.ts
+++ b/packages/markspec/core/profile/resolver_test.ts
@@ -5,6 +5,7 @@
  */
 
 import { assertEquals } from "@std/assert";
+import { join, resolve } from "@std/path";
 import { resolveGitSpecifier, resolveLocalSpecifier } from "./resolver.ts";
 import { computeCacheLocation } from "./git-cache.ts";
 import type { RunGit } from "./git-cache.ts";
@@ -15,22 +16,23 @@ function mockReadFile(map: Record<string, string>) {
     Promise.resolve(map[path]);
 }
 
-Deno.test("resolveLocalSpecifier: happy path reads markspec.yaml", {
-  ignore: Deno.build.os === "windows",
-}, async () => {
+Deno.test("resolveLocalSpecifier: happy path reads markspec.yaml", async () => {
+  const project = resolve("/project");
+  const customDir = join(project, "profiles", "custom");
+  const customYaml = join(customDir, "markspec.yaml");
   const diagnostics: Diagnostic[] = [];
   const result = await resolveLocalSpecifier(
     { kind: "local", path: "./profiles/custom" },
-    "/project",
+    project,
     mockReadFile({
-      "/project/profiles/custom/markspec.yaml": "id: @acme/x\nversion: 1.0.0\n",
+      [customYaml]: "id: @acme/x\nversion: 1.0.0\n",
     }),
     diagnostics,
   );
   assertEquals(diagnostics, []);
   assertEquals(result?.rawYaml, "id: @acme/x\nversion: 1.0.0\n");
-  assertEquals(result?.sourcePath, "/project/profiles/custom/markspec.yaml");
-  assertEquals(result?.baseDir, "/project/profiles/custom");
+  assertEquals(result?.sourcePath, customYaml);
+  assertEquals(result?.baseDir, customDir);
 });
 
 Deno.test("resolveLocalSpecifier: missing markspec.yaml emits PROFILE-LOAD-001", async () => {
@@ -51,22 +53,23 @@ Deno.test("resolveLocalSpecifier: missing markspec.yaml emits PROFILE-LOAD-001",
   }
 });
 
-Deno.test("resolveLocalSpecifier: parent-relative path resolves correctly", {
-  ignore: Deno.build.os === "windows",
-}, async () => {
+Deno.test("resolveLocalSpecifier: parent-relative path resolves correctly", async () => {
+  const workspace = resolve("/workspace");
+  const project = join(workspace, "project");
+  const baseDir = join(workspace, "shared", "base");
+  const baseYaml = join(baseDir, "markspec.yaml");
   const diagnostics: Diagnostic[] = [];
   const result = await resolveLocalSpecifier(
     { kind: "local", path: "../shared/base" },
-    "/workspace/project",
+    project,
     mockReadFile({
-      "/workspace/shared/base/markspec.yaml":
-        "id: @acme/base\nversion: 1.0.0\n",
+      [baseYaml]: "id: @acme/base\nversion: 1.0.0\n",
     }),
     diagnostics,
   );
   assertEquals(diagnostics, []);
-  assertEquals(result?.sourcePath, "/workspace/shared/base/markspec.yaml");
-  assertEquals(result?.baseDir, "/workspace/shared/base");
+  assertEquals(result?.sourcePath, baseYaml);
+  assertEquals(result?.baseDir, baseDir);
 });
 
 // A RunGit that records what it would have done without touching the
@@ -157,8 +160,8 @@ function recordingRunGit(options: {
 
 Deno.test(
   "resolveGitSpecifier: cache miss clones, checks out tag, reads yaml",
-  { ignore: Deno.build.os === "windows" },
   async () => {
+    const project = resolve("/project");
     const diagnostics: Diagnostic[] = [];
     const spec = {
       kind: "git" as const,
@@ -166,21 +169,21 @@ Deno.test(
       subpath: undefined,
       tag: "v1.0.0",
     };
-    const loc = await computeCacheLocation("/project", spec);
+    const loc = await computeCacheLocation(project, spec);
 
     const files: Record<string, string> = {};
     const { runGit, calls } = recordingRunGit({
       files,
       onClone: (cloneDir) => {
         // Simulate the clone writing the manifest into the cache dir.
-        files[`${cloneDir}/markspec.yaml`] =
+        files[join(cloneDir, "markspec.yaml")] =
           "id: @acme/cloned\nversion: 1.0.0\n";
       },
     });
 
     const result = await resolveGitSpecifier(
       spec,
-      "/project",
+      project,
       (path) => Promise.resolve(files[path]),
       diagnostics,
       { runGit },
@@ -211,9 +214,8 @@ Deno.test(
   },
 );
 
-Deno.test("resolveGitSpecifier: subpath triggers sparse-checkout call", {
-  ignore: Deno.build.os === "windows",
-}, async () => {
+Deno.test("resolveGitSpecifier: subpath triggers sparse-checkout call", async () => {
+  const project = resolve("/project");
   const diagnostics: Diagnostic[] = [];
   const spec = {
     kind: "git" as const,
@@ -221,20 +223,20 @@ Deno.test("resolveGitSpecifier: subpath triggers sparse-checkout call", {
     subpath: "aspice",
     tag: "v1.0.0",
   };
-  const loc = await computeCacheLocation("/project", spec);
+  const loc = await computeCacheLocation(project, spec);
 
   const files: Record<string, string> = {};
   const { runGit, calls } = recordingRunGit({
     files,
     onClone: (cloneDir) => {
-      files[`${cloneDir}/aspice/markspec.yaml`] =
+      files[join(cloneDir, "aspice", "markspec.yaml")] =
         "id: @acme/sub\nversion: 1.0.0\n";
     },
   });
 
   const result = await resolveGitSpecifier(
     spec,
-    "/project",
+    project,
     (path) => Promise.resolve(files[path]),
     diagnostics,
     { runGit },

--- a/packages/markspec/mcp/path_test.ts
+++ b/packages/markspec/mcp/path_test.ts
@@ -5,23 +5,22 @@
  */
 
 import { assertEquals } from "@std/assert";
+import { join, resolve, SEPARATOR } from "@std/path";
 import { relativeToRoot } from "./path.ts";
 
-Deno.test("relativeToRoot: strips projectRoot prefix", {
-  ignore: Deno.build.os === "windows",
-}, () => {
+Deno.test("relativeToRoot: strips projectRoot prefix", () => {
+  const proj = resolve("/proj");
   assertEquals(
-    relativeToRoot("/proj/docs/req.md", "/proj"),
-    "docs/req.md",
+    relativeToRoot(join(proj, "docs", "req.md"), proj),
+    join("docs", "req.md"),
   );
 });
 
-Deno.test("relativeToRoot: tolerates trailing slash on projectRoot", {
-  ignore: Deno.build.os === "windows",
-}, () => {
+Deno.test("relativeToRoot: tolerates trailing slash on projectRoot", () => {
+  const proj = resolve("/proj");
   assertEquals(
-    relativeToRoot("/proj/docs/req.md", "/proj/"),
-    "docs/req.md",
+    relativeToRoot(join(proj, "docs", "req.md"), proj + SEPARATOR),
+    join("docs", "req.md"),
   );
 });
 

--- a/packages/markspec/mcp/project_test.ts
+++ b/packages/markspec/mcp/project_test.ts
@@ -7,11 +7,18 @@
  */
 
 import { assertEquals, assertExists, assertRejects } from "@std/assert";
+import { join, resolve } from "@std/path";
 import {
   checkFileStaleness,
   createProject,
   type ProjectEnv,
 } from "./project.ts";
+
+/** Platform-native project root used by `makeEnv`'s cwd. */
+const PROJ = resolve("/proj");
+const PROJECT_YAML_PATH = join(PROJ, "project.yaml");
+const REQ_MD_PATH = join(PROJ, "req.md");
+const EXTRA_MD_PATH = join(PROJ, "extra.md");
 
 /** Build a ProjectEnv that serves a fixed file map. */
 function makeEnv(files: Record<string, { content: string; mtime: number }>): {
@@ -22,7 +29,7 @@ function makeEnv(files: Record<string, { content: string; mtime: number }>): {
   const store = new Map(Object.entries(files));
   return {
     env: {
-      cwd: () => "/proj",
+      cwd: () => PROJ,
       readFile: (path) => {
         const f = store.get(path);
         return Promise.resolve(f?.content);
@@ -54,31 +61,27 @@ const REQ_DOC = `- [STK_TEST_0001] Test entry
   Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
 `;
 
-Deno.test("createProject: discovers root from project.yaml", {
-  ignore: Deno.build.os === "windows",
-}, async () => {
+Deno.test("createProject: discovers root from project.yaml", async () => {
   const { env } = makeEnv({
-    "/proj/project.yaml": { content: PROJECT_YAML, mtime: 1 },
-    "/proj/req.md": { content: REQ_DOC, mtime: 1 },
+    [PROJECT_YAML_PATH]: { content: PROJECT_YAML, mtime: 1 },
+    [REQ_MD_PATH]: { content: REQ_DOC, mtime: 1 },
   });
   const proj = await createProject(env);
-  assertEquals(proj.projectRoot, "/proj");
+  assertEquals(proj.projectRoot, PROJ);
 });
 
 Deno.test("createProject: returns null when no project.yaml", async () => {
   const { env } = makeEnv({
-    "/proj/req.md": { content: REQ_DOC, mtime: 1 },
+    [REQ_MD_PATH]: { content: REQ_DOC, mtime: 1 },
   });
   const proj = await createProject(env);
   assertEquals(proj.projectRoot, undefined);
 });
 
-Deno.test("getCompiled: compiles and caches result", {
-  ignore: Deno.build.os === "windows",
-}, async () => {
+Deno.test("getCompiled: compiles and caches result", async () => {
   const { env } = makeEnv({
-    "/proj/project.yaml": { content: PROJECT_YAML, mtime: 1 },
-    "/proj/req.md": { content: REQ_DOC, mtime: 1 },
+    [PROJECT_YAML_PATH]: { content: PROJECT_YAML, mtime: 1 },
+    [REQ_MD_PATH]: { content: REQ_DOC, mtime: 1 },
   });
   const proj = await createProject(env);
   const r1 = await proj.getCompiled();
@@ -90,12 +93,10 @@ Deno.test("getCompiled: compiles and caches result", {
   assertEquals(r1, r2);
 });
 
-Deno.test("getCompiled: recompiles when file mtime changes", {
-  ignore: Deno.build.os === "windows",
-}, async () => {
+Deno.test("getCompiled: recompiles when file mtime changes", async () => {
   const { env, bumpMtime } = makeEnv({
-    "/proj/project.yaml": { content: PROJECT_YAML, mtime: 1 },
-    "/proj/req.md": { content: REQ_DOC, mtime: 1 },
+    [PROJECT_YAML_PATH]: { content: PROJECT_YAML, mtime: 1 },
+    [REQ_MD_PATH]: { content: REQ_DOC, mtime: 1 },
   });
   const proj = await createProject(env);
   const r1 = await proj.getCompiled();
@@ -108,24 +109,22 @@ Deno.test("getCompiled: recompiles when file mtime changes", {
 
   Id: 01HGW2Q8MNP3RSTVWXYZABCDEG
 `;
-  bumpMtime("/proj/req.md", updatedDoc, Date.now() + 1000);
+  bumpMtime(REQ_MD_PATH, updatedDoc, Date.now() + 1000);
 
   const r2 = await proj.getCompiled();
   assertEquals(r2.entries.size, 2);
 });
 
-Deno.test("getCompiled: recompiles when a new file appears", {
-  ignore: Deno.build.os === "windows",
-}, async () => {
+Deno.test("getCompiled: recompiles when a new file appears", async () => {
   const { env, bumpMtime } = makeEnv({
-    "/proj/project.yaml": { content: PROJECT_YAML, mtime: 1 },
-    "/proj/req.md": { content: REQ_DOC, mtime: 1 },
+    [PROJECT_YAML_PATH]: { content: PROJECT_YAML, mtime: 1 },
+    [REQ_MD_PATH]: { content: REQ_DOC, mtime: 1 },
   });
   const proj = await createProject(env);
   await proj.getCompiled();
 
   bumpMtime(
-    "/proj/extra.md",
+    EXTRA_MD_PATH,
     `- [STK_TEST_0002] Another
 
   Body.
@@ -139,12 +138,10 @@ Deno.test("getCompiled: recompiles when a new file appears", {
   assertEquals(r2.entries.size, 2);
 });
 
-Deno.test("forceRefresh: recompiles even with no changes", {
-  ignore: Deno.build.os === "windows",
-}, async () => {
+Deno.test("forceRefresh: recompiles even with no changes", async () => {
   const { env } = makeEnv({
-    "/proj/project.yaml": { content: PROJECT_YAML, mtime: 1 },
-    "/proj/req.md": { content: REQ_DOC, mtime: 1 },
+    [PROJECT_YAML_PATH]: { content: PROJECT_YAML, mtime: 1 },
+    [REQ_MD_PATH]: { content: REQ_DOC, mtime: 1 },
   });
   const proj = await createProject(env);
   const r1 = await proj.getCompiled();
@@ -153,16 +150,14 @@ Deno.test("forceRefresh: recompiles even with no changes", {
   assertEquals(r1 !== r2, true);
 });
 
-Deno.test("getCompiled: recovers from a transient compile error", {
-  ignore: Deno.build.os === "windows",
-}, async () => {
+Deno.test("getCompiled: recovers from a transient compile error", async () => {
   // Build an env where the first compile fails (walk throws), then the
   // underlying problem clears and a subsequent getCompiled() succeeds.
   // This verifies that runCompile()'s finally resets `inFlight`, so the
   // cache doesn't get jammed into a permanent error state.
   const { env } = makeEnv({
-    "/proj/project.yaml": { content: PROJECT_YAML, mtime: 1 },
-    "/proj/req.md": { content: REQ_DOC, mtime: 1 },
+    [PROJECT_YAML_PATH]: { content: PROJECT_YAML, mtime: 1 },
+    [REQ_MD_PATH]: { content: REQ_DOC, mtime: 1 },
   });
   let failNextWalk = true;
   const wrappedEnv: ProjectEnv = {
@@ -197,12 +192,10 @@ Deno.test("getCompiled: recovers from a transient compile error", {
   assertEquals(result.entries.size, 1);
 });
 
-Deno.test("subscribeInvalidation: fires handlers after recompile", {
-  ignore: Deno.build.os === "windows",
-}, async () => {
+Deno.test("subscribeInvalidation: fires handlers after recompile", async () => {
   const { env, bumpMtime } = makeEnv({
-    "/proj/project.yaml": { content: PROJECT_YAML, mtime: 1 },
-    "/proj/req.md": { content: REQ_DOC, mtime: 1 },
+    [PROJECT_YAML_PATH]: { content: PROJECT_YAML, mtime: 1 },
+    [REQ_MD_PATH]: { content: REQ_DOC, mtime: 1 },
   });
   const proj = await createProject(env);
   await proj.getCompiled();
@@ -213,7 +206,7 @@ Deno.test("subscribeInvalidation: fires handlers after recompile", {
   });
 
   await proj.forceRefresh();
-  bumpMtime("/proj/req.md", REQ_DOC + "\n", Date.now() + 2000);
+  bumpMtime(REQ_MD_PATH, REQ_DOC + "\n", Date.now() + 2000);
   await proj.getCompiled();
 
   assertEquals(fired, 2);
@@ -284,19 +277,17 @@ Deno.test("checkFileStaleness: no stored hash → stale", async () => {
   assertEquals(result, true);
 });
 
-Deno.test("getCompiled: same content, mtime bumped → NOT stale (SHA256 gate)", {
-  ignore: Deno.build.os === "windows",
-}, async () => {
+Deno.test("getCompiled: same content, mtime bumped → NOT stale (SHA256 gate)", async () => {
   const { env, bumpMtime } = makeEnv({
-    "/proj/project.yaml": { content: PROJECT_YAML, mtime: 1 },
-    "/proj/req.md": { content: REQ_DOC, mtime: 1 },
+    [PROJECT_YAML_PATH]: { content: PROJECT_YAML, mtime: 1 },
+    [REQ_MD_PATH]: { content: REQ_DOC, mtime: 1 },
   });
   const proj = await createProject(env);
   const r1 = await proj.getCompiled();
   assertEquals(r1.entries.size, 1);
 
   // Bump mtime but keep same content (simulates `git checkout` touching mtime).
-  bumpMtime("/proj/req.md", REQ_DOC, Date.now() + 1000);
+  bumpMtime(REQ_MD_PATH, REQ_DOC, Date.now() + 1000);
 
   const r2 = await proj.getCompiled();
   assertEquals(r2.entries.size, 1);

--- a/packages/markspec/mcp/resources/entry_test.ts
+++ b/packages/markspec/mcp/resources/entry_test.ts
@@ -5,9 +5,14 @@
  */
 
 import { assertEquals, assertStringIncludes } from "@std/assert";
+import { join, resolve } from "@std/path";
 import type { Entry, Link } from "../../core/mod.ts";
 import { makeDisplayId } from "../../core/mod.ts";
 import { renderEntry } from "./entry.ts";
+
+const PROJ = resolve("/proj");
+const STK_FILE = join(PROJ, "docs", "product", "stakeholder-requirements.md");
+const VAL_FILE = join(PROJ, "tests", "val_aeb.rs");
 
 const ENTRY: Entry = {
   displayId: makeDisplayId("STK_AEB_0001"),
@@ -23,7 +28,7 @@ const ENTRY: Entry = {
   type: "stakeholder-requirement",
   shape: "Authored",
   location: {
-    file: "/proj/docs/product/stakeholder-requirements.md",
+    file: STK_FILE,
     line: 42,
     column: 1,
   },
@@ -36,7 +41,7 @@ const FORWARD: Link[] = [
     to: makeDisplayId("SYS_AEB_0012"),
     kind: "satisfies",
     location: {
-      file: "/proj/docs/product/stakeholder-requirements.md",
+      file: STK_FILE,
       line: 47,
       column: 1,
     },
@@ -48,7 +53,7 @@ const REVERSE: Link[] = [
     from: makeDisplayId("VAL_AEB_0001"),
     to: makeDisplayId("STK_AEB_0001"),
     kind: "verifies",
-    location: { file: "/proj/tests/val_aeb.rs", line: 12, column: 1 },
+    location: { file: VAL_FILE, line: 12, column: 1 },
   },
 ];
 
@@ -70,16 +75,16 @@ Deno.test("renderEntry: includes ULID and location", () => {
   assertStringIncludes(md, "stakeholder-requirements.md:42");
 });
 
-Deno.test("renderEntry: renders location relative to projectRoot", {
-  ignore: Deno.build.os === "windows",
-}, () => {
-  const md = renderEntry(ENTRY, [], [], TITLES, "/proj");
+Deno.test("renderEntry: renders location relative to projectRoot", () => {
+  const md = renderEntry(ENTRY, [], [], TITLES, PROJ);
   assertStringIncludes(
     md,
-    "**Location**: docs/product/stakeholder-requirements.md:42",
+    `**Location**: ${
+      join("docs", "product", "stakeholder-requirements.md")
+    }:42`,
   );
   assertEquals(
-    md.includes("/proj/docs/product/stakeholder-requirements.md"),
+    md.includes(STK_FILE),
     false,
   );
 });

--- a/packages/markspec/mcp/tools/validate_test.ts
+++ b/packages/markspec/mcp/tools/validate_test.ts
@@ -5,6 +5,7 @@
  */
 
 import { assertEquals, assertStringIncludes } from "@std/assert";
+import { join, resolve } from "@std/path";
 import { CallToolRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import type { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { mergeChain, parseManifest } from "../../core/mod.ts";
@@ -54,11 +55,20 @@ Deno.test("renderDiagnosticsReport: errors and warnings sections", () => {
 
 Deno.test(
   "renderDiagnosticsReport: renders locations relative to projectRoot",
-  { ignore: Deno.build.os === "windows" },
   () => {
-    const md = renderDiagnosticsReport([ERR, WARN], null, 1, "/proj");
-    assertStringIncludes(md, "docs/req.md:128:3");
-    assertStringIncludes(md.split("\n").join(" "), " docs/req.md:128:3");
+    const proj = resolve("/proj");
+    const err: Diagnostic = {
+      ...ERR,
+      location: { ...ERR.location!, file: join(proj, "docs", "req.md") },
+    };
+    const warn: Diagnostic = {
+      ...WARN,
+      location: { ...WARN.location!, file: join(proj, "docs", "req.md") },
+    };
+    const md = renderDiagnosticsReport([err, warn], null, 1, proj);
+    const expected = `${join("docs", "req.md")}:128:3`;
+    assertStringIncludes(md, expected);
+    assertStringIncludes(md.split("\n").join(" "), ` ${expected}`);
   },
 );
 
@@ -83,10 +93,17 @@ Deno.test("filterDiagnostics: passes all when files undefined", () => {
   assertStringIncludes(out.length.toString(), "2");
 });
 
-Deno.test("filterDiagnostics: keeps matching relative path", {
-  ignore: Deno.build.os === "windows",
-}, () => {
-  const out = filterDiagnostics([ERR, WARN], ["docs/req.md"], "/proj");
+Deno.test("filterDiagnostics: keeps matching relative path", () => {
+  const proj = resolve("/proj");
+  const err: Diagnostic = {
+    ...ERR,
+    location: { ...ERR.location!, file: join(proj, "docs", "req.md") },
+  };
+  const warn: Diagnostic = {
+    ...WARN,
+    location: { ...WARN.location!, file: join(proj, "docs", "req.md") },
+  };
+  const out = filterDiagnostics([err, warn], [join("docs", "req.md")], proj);
   assertStringIncludes(out.length.toString(), "2");
 });
 

--- a/packages/markspec/render/includes/mod_test.ts
+++ b/packages/markspec/render/includes/mod_test.ts
@@ -1,4 +1,5 @@
 import { assertEquals } from "@std/assert";
+import { join, resolve } from "@std/path";
 import { processIncludes } from "./mod.ts";
 import type { IncludeOptions } from "./mod.ts";
 import type { CompileResult, Entry } from "../../core/mod.ts";
@@ -45,6 +46,9 @@ function compiled(...entries: Entry[]): CompileResult {
   };
 }
 
+/** Platform-native base path for include resolution. */
+const BASE_PATH = resolve("/project");
+
 /** Build IncludeOptions with an in-memory file system. */
 function options(
   entries: Entry[] = [],
@@ -55,7 +59,7 @@ function options(
       if (path in files) return Promise.resolve(files[path]);
       return Promise.reject(new Error(`file not found: ${path}`));
     },
-    basePath: "/project",
+    basePath: BASE_PATH,
     compiled: compiled(...entries),
   };
 }
@@ -199,9 +203,7 @@ Deno.test("processIncludes: directives inside code blocks are not processed", as
 // File path with anchor
 // ---------------------------------------------------------------------------
 
-Deno.test("processIncludes: file path with anchor resolves section", {
-  ignore: Deno.build.os === "windows",
-}, async () => {
+Deno.test("processIncludes: file path with anchor resolves section", async () => {
   const fileContent = [
     "# Introduction",
     "",
@@ -220,7 +222,7 @@ Deno.test("processIncludes: file path with anchor resolves section", {
 
   const result = await processIncludes(
     input,
-    options([], { "/project/docs/spec.md": fileContent }),
+    options([], { [join(BASE_PATH, "docs", "spec.md")]: fileContent }),
   );
 
   assertEquals(result.diagnostics.length, 0);
@@ -238,16 +240,14 @@ Deno.test("processIncludes: file path with anchor resolves section", {
 // File path without anchor
 // ---------------------------------------------------------------------------
 
-Deno.test("processIncludes: file path without anchor includes full content", {
-  ignore: Deno.build.os === "windows",
-}, async () => {
+Deno.test("processIncludes: file path without anchor includes full content", async () => {
   const fileContent = "# Full Document\n\nAll content here.";
 
   const input = "<!-- include: docs/readme.md -->";
 
   const result = await processIncludes(
     input,
-    options([], { "/project/docs/readme.md": fileContent }),
+    options([], { [join(BASE_PATH, "docs", "readme.md")]: fileContent }),
   );
 
   assertEquals(result.diagnostics.length, 0);
@@ -272,15 +272,13 @@ Deno.test("processIncludes: missing file produces diagnostic", async () => {
 // Missing anchor in file
 // ---------------------------------------------------------------------------
 
-Deno.test("processIncludes: missing anchor produces diagnostic", {
-  ignore: Deno.build.os === "windows",
-}, async () => {
+Deno.test("processIncludes: missing anchor produces diagnostic", async () => {
   const fileContent = "# Introduction\n\nSome text.";
   const input = "<!-- include: docs/spec.md#nonexistent -->";
 
   const result = await processIncludes(
     input,
-    options([], { "/project/docs/spec.md": fileContent }),
+    options([], { [join(BASE_PATH, "docs", "spec.md")]: fileContent }),
   );
 
   assertEquals(result.diagnostics.length, 1);

--- a/tests/e2e/doc_build_test.ts
+++ b/tests/e2e/doc_build_test.ts
@@ -22,14 +22,11 @@ A second section with a list:
 - Item three
 `;
 
-// `markspec doc build` on Windows requires the Typst workspace to
-// contain both the markspec-typst package and the source document.
-// On cross-drive setups (typical: repo on D:, temp dir on C:) there
-// is no common ancestor and the Typst loader cannot resolve `lib.typ`.
-// Tracked in #406; tests skipped on Windows until that lands.
-Deno.test("doc build: produces PDF from Markdown", {
-  ignore: Deno.build.os === "windows",
-}, async () => {
+// `markspec doc build` works on Windows even when the source document
+// lives on a different drive than the bundled markspec-typst package
+// (e.g., installed CLI on C:, docs on D:) — see `stageTypstPackage` in
+// cli/commands/doc.ts for the cross-drive staging behaviour.
+Deno.test("doc build: produces PDF from Markdown", async () => {
   const { code, stderr } = await markspec(["doc", "build", "doc.md"], {
     files: {
       "project.yaml": PROJECT_YAML,
@@ -42,9 +39,7 @@ Deno.test("doc build: produces PDF from Markdown", {
   assertStringIncludes(stderr, "wrote");
 });
 
-Deno.test("doc build: output file has PDF magic bytes", {
-  ignore: Deno.build.os === "windows",
-}, async () => {
+Deno.test("doc build: output file has PDF magic bytes", async () => {
   // Create a temp dir manually to inspect the output file
   const dir = await Deno.makeTempDir();
   try {
@@ -90,9 +85,7 @@ Deno.test("doc build: output file has PDF magic bytes", {
   }
 });
 
-Deno.test("doc build: --output flag writes to custom path", {
-  ignore: Deno.build.os === "windows",
-}, async () => {
+Deno.test("doc build: --output flag writes to custom path", async () => {
   const dir = await Deno.makeTempDir();
   try {
     await Deno.writeTextFile(`${dir}/project.yaml`, PROJECT_YAML);


### PR DESCRIPTION
## Summary

- Replaces synthetic POSIX path fixtures in 54 unit tests with platform-native paths (`@std/path` `resolve()`+`join()`), removing the corresponding `{ ignore: Deno.build.os === "windows" }` skips introduced by PR #405.
- Adds `stageTypstPackage` in `cli/commands/doc.ts` to copy the ~1 MB markspec-typst package to a temp dir next to the source when `markspec doc build` runs on Windows with the source and bundled package on different drives — fixes the cross-drive workspace failure tracked in #406.
- Un-skips the three `tests/e2e/doc_build_test.ts` Windows tests; they exercise the cross-drive case on the GHA runner.

Two `mcp/path_test.ts` tests retain their `(POSIX)` / `(Windows)` skips by design — those encode case-sensitivity contracts that cannot hold on the opposite platform.

Closes #406.

## Test plan

- [x] `just build` green on macOS (1716 passed / 0 failed / 2 ignored)
- [x] `deno fmt --check` and `dprint check` pass
- [ ] CI Windows job passes the un-skipped unit tests
- [ ] CI Windows job passes the three un-skipped `doc_build_test.ts` tests (the cross-drive proof)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
