### PR TITLE
chore(release): trim VSIX payload and bump deprecated download-artifact

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -95,7 +95,7 @@ jobs:
           node-version: lts/*
 
       - name: Download binary artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: markspec-${{ matrix.target }}
           path: artifacts

--- a/editors/vscode/.vscodeignore
+++ b/editors/vscode/.vscodeignore
@@ -1,0 +1,28 @@
+.vscode/**
+.vscode-test/**
+
+# TypeScript sources — compiled output ships from out/.
+src/**
+**/*.ts
+!out/**/*.d.ts
+**/*.map
+tsconfig.json
+
+# Build-time scripts (only run during VSIX packaging, never at runtime).
+scripts/**
+
+# Dev dependencies that never need to ship to users.
+node_modules/typescript/**
+node_modules/@types/**
+node_modules/@vscode/**
+node_modules/**/*.md
+node_modules/**/*.ts
+node_modules/**/*.map
+node_modules/**/test/**
+node_modules/**/tests/**
+node_modules/**/.bin/**
+
+# Package metadata that VS Code does not consume.
+.gitignore
+.vscodeignore
+package-lock.json


### PR DESCRIPTION
## Summary

- Bumps `actions/download-artifact` from `@v4` to `@v8` in the `package-vsix` job (matches the version dependabot already set on the `release` job) — heads off the GHA Node-20 deprecation cutoff (2026-06-02).
- Adds `editors/vscode/.vscodeignore` to keep the VSIX lean. Excludes TypeScript sources, source maps, dev-only `@types`/`typescript`/`@vscode` packages, test fixtures, and lockfiles, while preserving the `vscode-languageclient` runtime dependency and the README needed for the marketplace listing.
- Locally `npx vsce ls` drops from 341 to 193 files.

The third item in #256 — verifying the `windows-2025` → `windows-2025-vs2026` redirect — is already covered: PR #414's `Test (windows-latest)` job ran cleanly on the post-redirect image, so no workflow change is needed.

Closes #256.

## Test plan

- [x] `deno fmt --check` and `dprint check` pass
- [x] `npx vsce ls` no longer lists `node_modules/typescript`, `@types/*`, source maps, or TypeScript sources
- [ ] Release workflow on next tag pushes a smaller VSIX without warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
