### PR TITLE
fix(release): exclude compiled tests from VSIX and document bin/ omission

### DIFF
--- a/editors/vscode/.vscodeignore
+++ b/editors/vscode/.vscodeignore
@@ -1,14 +1,23 @@
 .vscode/**
 .vscode-test/**
 
-# TypeScript sources — compiled output ships from out/.
+# TypeScript sources and type definitions — VS Code only needs the
+# compiled .js from out/ at runtime.
 src/**
 **/*.ts
-!out/**/*.d.ts
 **/*.map
 tsconfig.json
 
-# Build-time scripts (only run during VSIX packaging, never at runtime).
+# Compiled test artifacts — tsc emits these into out/ alongside the
+# runtime modules; they are inert at runtime and just bloat the VSIX.
+out/**/*.test.js
+out/test-setup.js
+
+# Build-time scripts. release.yaml invokes scripts/bundleBinary.ts via
+# `deno run` to drop the per-platform binary into bin/ before `vsce
+# package`; nothing in scripts/ is needed at extension runtime.
+# (Note: bin/ is intentionally NOT ignored — bundleBinary.ts populates
+# it at package time and the binary must ship in the VSIX.)
 scripts/**
 
 # Dev dependencies that never need to ship to users.


### PR DESCRIPTION
## Summary

Follow-up to PR #415 — the original PR was merged before this fix landed (race between the merge and my push of the review-feedback commit).

Addresses the two issues called out in the [/review comment on #415](https://github.com/driftsys/markspec/pull/415#issuecomment-4525847374):

- Drops the `!out/**/*.d.ts` negation that re-included compiled test type defs (`out/serverOptions.test.d.ts` etc.). VS Code never needs `.d.ts` files at runtime, so the negation was purely an oversight from a copy-paste of the standard template.
- Adds `out/**/*.test.js` + `out/test-setup.js` so the compiled test artifacts (`out/serverOptions.test.js`, `out/mcpDefinition.test.js`, `out/inlineCompletions.test.js`, `out/test-setup.js`) stay out of the VSIX.
- Adds a comment under `scripts/**` documenting why `bin/` is deliberately NOT in `.vscodeignore` — `scripts/bundleBinary.ts` populates it at package time and the binary must ship in the VSIX.

## Test plan

- [x] `deno fmt --check` and `dprint check` pass
- [x] After `npm run compile`, `npx vsce ls` no longer lists `out/*.test.*` or `out/test-setup.*`
- [x] After `npm run compile`, `npx vsce ls` still lists `out/extension.js` and the other runtime modules

Relates to #256.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
