### PR TITLE
docs(docs): reference Entry.bodyTokens in EARS/Gherkin/prose-review skills

### DIFF
--- a/skills/markspec-ears/SKILL.md
+++ b/skills/markspec-ears/SKILL.md
@@ -196,3 +196,16 @@ shall reduce hydraulic pressure by 30 % within 20 ms."_
 
 Do not combine more than two patterns in one sentence. If a third condition is
 needed, split into two entries.
+
+## Toolchain support
+
+The parser emits one `ears-trigger` token for each `When` / `While` / `If` /
+`Where` keyword that opens a clause in entry body prose. Tokens are sorted by
+source position and exposed on `Entry.bodyTokens` (ADR-016); the LSP highlights
+them as keywords, and profile or project rules can scan them without re-parsing.
+
+Scanning is suppressed inside fenced code blocks (`` ``` `` / `~~~`), inside
+display- and inline-math (`$$`), inside inline `` `code` `` spans, and inside
+`` ```gherkin `` / `` ```feature `` fences — there, `When` is recognised as a
+Gherkin step instead. Plain prose outside any fence is the canonical place to
+write EARS sentences.

--- a/skills/markspec-gherkin/SKILL.md
+++ b/skills/markspec-gherkin/SKILL.md
@@ -14,16 +14,16 @@ the scenario.
 
 ## Basic structure
 
-An entry with Gherkin scenarios looks like this (outer block shows the full
-MarkSpec entry; the inner `gherkin` block holds the scenarios):
+An entry with Gherkin scenarios looks like this (outer fence shows the full
+MarkSpec entry; the inner `gherkin` fence holds the scenarios):
 
-```text
+````text
 - [SWE_0060] Speed display rounds to nearest integer
 
   The instrument cluster shall display vehicle speed rounded to the nearest
   integer value in the configured unit.
 
-  ` ` `gherkin
+  ```gherkin
   Scenario: Round half-up
     Given vehicle speed is 42.5 km/h
     When the cluster updates the display
@@ -33,16 +33,16 @@ MarkSpec entry; the inner `gherkin` block holds the scenarios):
     Given vehicle speed is 100.0 km/h
     When the cluster updates the display
     Then the displayed value is 100 km/h
-  ` ` `
+  ```
 
       Id:
       Type: requirement
       Satisfies: STK_0002
       Verified-by: SWT_0060
-```
+````
 
-_(Remove the spaces in `` ` above — they are present only to prevent nesting
-issues in documentation.)_
+The fence language must be `gherkin` or `feature` — see _Toolchain support_
+below.
 
 ### Rules
 
@@ -165,3 +165,24 @@ The `Tests:` attribute on the test entry is the reverse link;
 | Implementation detail in `Given`        | Describe observable state, not code internals           |
 | Missing `Verified-by:` on requirement   | Add the link so the traceability report shows coverage  |
 | Duplicate scenario name within an entry | Names must be unique — the validator flags duplicates   |
+| Steps written in unfenced prose         | Wrap them in a `gherkin` or `feature` fence (see below) |
+
+---
+
+## Toolchain support
+
+Gherkin steps must live inside a `` ```gherkin `` or `` ```feature `` fenced
+code block to be recognised by the toolchain. The parser emits one
+`gherkin-section` token per `Feature` / `Background` / `Rule` / `Scenario` /
+`Examples` keyword and one `gherkin-step` token per `Given` / `When` / `Then` /
+`And` / `But` keyword on `Entry.bodyTokens` (ADR-016). The LSP paints sections
+as `class` and steps as `keyword`; profile and project rules can scan the same
+stream.
+
+Inside a `gherkin` / `feature` fence, modal (`shall`, `should`, …) and
+EARS-trigger scans are suppressed. That is what makes `When` a Gherkin step here
+even though the same word in plain body prose is an EARS trigger.
+
+Steps written in unfenced prose are ignored: they will not appear on
+`Entry.bodyTokens`, will not be highlighted, and will not be checked by
+profile-driven rules. Always fence your scenarios.

--- a/skills/markspec-prose-review/SKILL.md
+++ b/skills/markspec-prose-review/SKILL.md
@@ -54,6 +54,10 @@ safety module shall monitor the brake pressure."
 - [ ] No vague quantifiers: "several", "a number of", "some", "many".
 - [ ] Modal keywords are lowercase RFC 2119: `shall` (mandatory), `should`
       (recommended), `may` (optional). No bare "will" or "must".
+- [ ] No emphasis around modal verbs (`_shall_`, `**must**`). MSL-M060 scans the
+      parser's body-token stream and does not see modals wrapped in `_…_` or
+      `**…**`; plain `shall` / `must` is the only form that gets both the
+      warning and the `format` lowercase normalisation.
 
 **Flag:** "It shall process them within the defined timeout." → name the subject
 and define both referents explicitly.


### PR DESCRIPTION
## Summary

Story 7 of #409 (body-token AST epic). Author-facing skill docs updated to reflect the new `Entry.bodyTokens` model that landed in story 2 (PR #421).

- **markspec-ears** — adds a Toolchain-support section listing the `ears-trigger` token's recognised keywords (When / While / If / Where) and the scopes where scanning is suppressed (fenced code, math, inline code, `gherkin`/`feature` fences).
- **markspec-gherkin** — adds a Toolchain-support section explaining that scenarios must live inside a `` ```gherkin `` or `` ```feature `` fence to be tokenised (`gherkin-section` + `gherkin-step`), and that modal/EARS scans are suppressed inside the fence. Also fixes the canonical example to use a 4-backtick outer fence around a 3-backtick inner gherkin fence — replacing the prior workaround that hid the real syntax behind a "remove the spaces" footnote.
- **markspec-prose-review** — adds a checklist item for the bodyTokens-based MSL-M060 limitation: emphasis-wrapped modals (`_shall_`, `**must**`) are not detected, per the CHANGELOG Known-limitations note.

No code changes; no API surface touched. Refs ADR-016.

## Test plan

- [x] `dprint check` clean
- [x] `just check` (lint + test + type-check) clean via pre-push hook
- [x] Skill descriptions still <500 chars and trigger correctly
