### PR TITLE
refactor(lsp): consume Entry.bodyTokens for body keywords (ADR-016 Dec 8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@
 
 - **core:** MSL-M060 validator reads `Entry.bodyTokens` directly; the previous
   bodyAst-marker walk is removed. (#409)
+- **lsp:** semantic-tokens body-keyword path now consumes `Entry.bodyTokens`
+  via a thin `BodyTokenKind` to `SemanticTokenType` switch. The duplicated
+  per-line regex scanner (`BODY_KEYWORD_RE`, `GHERKIN_SECTION_RE`,
+  `GHERKIN_STEP_RE`, `ENTITY_REF_RE`, `FEATURE_FENCE_OPEN_RE`,
+  `FENCE_CLOSE_RE`) and the `insideFeatureBlock` state machine are deleted.
+  Source-file rendering becomes correct as a side effect once story 3 of
+  #409 lands. (#409)
 
 ### Removed
 

--- a/packages/markspec/lsp/semantic_tokens.ts
+++ b/packages/markspec/lsp/semantic_tokens.ts
@@ -2,8 +2,15 @@
  * @module lsp/semantic_tokens
  *
  * Produce LSP semantic tokens for an entry's title, embedded display
- * IDs, trailer attribute keys/values, and labels (with a validity
- * modifier sourced from the active profile's `labels` catalog).
+ * IDs, trailer attribute keys/values, labels (with a validity modifier
+ * sourced from the active profile's `labels` catalog), and body
+ * inline constructs (modal verbs, EARS triggers, Gherkin keywords,
+ * `$Identifier` entity refs).
+ *
+ * Per ADR-016 Decision 8, body inline constructs are not rediscovered
+ * here. The parser emits them on each `Entry.bodyTokens` with
+ * file-relative {@linkcode SourceLocation}; this builder is a thin
+ * switch from {@linkcode BodyTokenKind} to {@linkcode SemanticTokenType}.
  *
  * The builder returns an intermediate `SemanticToken[]` shape that
  * the LSP server encodes into the LSP wire format. Keeping the
@@ -15,7 +22,11 @@
  * catalog is non-empty AND the label is not in it.
  */
 
-import type { EffectiveProfile, Entry } from "../core/model/mod.ts";
+import type {
+  BodyTokenKind,
+  EffectiveProfile,
+  Entry,
+} from "../core/model/mod.ts";
 import { scanEntryTrailer } from "./entry_trailer.ts";
 
 /** LSP semantic-token legend exported by the server's capabilities. */
@@ -69,6 +80,22 @@ const TITLE_LINE_RE =
   /^(\s*-\s+\[)(@?[A-Za-z0-9][A-Za-z0-9._/-]{2,})(\]\s*)(.*)$/;
 
 /**
+ * Map each {@linkcode BodyTokenKind} to its LSP semantic-token type.
+ * `inline-code` is intentionally absent — the TextMate grammar already
+ * paints backtick spans, per ADR-016 Decision 8.
+ */
+const BODY_TOKEN_TYPE: Readonly<
+  Partial<Record<BodyTokenKind, SemanticTokenType>>
+> = {
+  "modal": "keyword",
+  "ears-trigger": "keyword",
+  "gherkin-section": "class",
+  "gherkin-step": "keyword",
+  "entity-ref": "string",
+  // "inline-code": no emission
+};
+
+/**
  * Build semantic tokens for every entry in `entries`. Tokens are
  * returned sorted by (line, startChar) — encoding to the LSP wire
  * format requires sorted input.
@@ -93,7 +120,7 @@ export function buildSemanticTokens(
       : lines.length;
 
     addTitleTokens(tokens, entry, lines);
-    addBodyKeywordTokens(tokens, entry, lines, endLineExclusive);
+    addBodyTokens(tokens, entry);
     addTrailerTokens(tokens, entry, lines, endLineExclusive, allowedLabels);
   }
 
@@ -149,159 +176,21 @@ function addTitleTokens(
 }
 
 /**
- * RFC 2119 modal verbs (lowercase canonical form) and the five EARS
- * pattern triggers. Matched case-insensitively as whole words inside
- * entry body prose, then emitted as `keyword` tokens so themes paint
- * them prominently — the same treatment language keywords get.
- *
- * `not` is intentionally not in the set; negation reads as part of
- * the modal phrase (e.g., `shall not`) and highlighting only the modal
- * verb is enough to anchor the eye.
+ * Emit semantic tokens for the entry's body inline constructs by mapping
+ * each {@linkcode BodyToken} to its LSP token type per ADR-016 Decision 8.
+ * Token locations are file-relative 1-based; converted here to LSP's
+ * 0-based line/character.
  */
-const BODY_KEYWORD_RE =
-  /\b(shall|should|may|must|will|when|while|if|where|then)\b/gi;
-
-/**
- * Gherkin section keywords — section headers, not steps. Rendered as
- * `class` semantic tokens to mirror GitHub Linguist's
- * `entity.name.section.*` and Rouge's `Generic::Heading` scoping;
- * themes paint these like type/heading names.
- *
- * Multi-word keywords (`Scenario Outline`, `Scenario Template`) are
- * matched as single units; bare `Scenario` matches when the longer
- * form isn't present.
- */
-const GHERKIN_SECTION_RE =
-  /\b(Feature|Background|Rule|Scenario Outline|Scenario Template|Scenarios|Examples|Scenario)\b/g;
-
-/**
- * Gherkin step keywords — rendered as `keyword` semantic tokens to
- * mirror `keyword.control.cucumber` / Rouge `Keyword`. Themes paint
- * these with a strong colour + bold, the same treatment programming-
- * language keywords get.
- */
-const GHERKIN_STEP_RE = /\b(Given|When|Then|And|But)\b/g;
-
-/** Detect a fenced code block opener with a `feature` or `gherkin` language tag. */
-const FEATURE_FENCE_OPEN_RE = /^\s*(```+|~~~+)\s*(feature|gherkin)\b/i;
-
-/** Detect a fenced code block closer using the same fence character set. */
-const FENCE_CLOSE_RE = /^\s*(```+|~~~+)\s*$/;
-
-/**
- * Inline `$Identifier` entity reference (spec §2.5.2). Matched directly
- * against body lines for highlighting; the full parser also tracks
- * `$$…$$` math fences and `\$` escapes, but for visual rendering a
- * straight regex is good enough and avoids relying on parser-emitted
- * positions that are body-relative.
- */
-const ENTITY_REF_RE = /\$[A-Za-z][A-Za-z0-9_]*/g;
-
-/**
- * Emit `keyword` tokens for modal verbs and EARS triggers in entry
- * body prose, and for Gherkin keywords inside fenced `feature` /
- * `gherkin` blocks. The scan covers lines between the entry's title
- * line and the next entry (or document end), excluding trailer lines.
- */
-function addBodyKeywordTokens(
-  out: SemanticToken[],
-  entry: Entry,
-  lines: readonly string[],
-  endLineExclusive: number,
-): void {
-  const trailerLines = scanEntryTrailer(entry, lines, endLineExclusive);
-  // Body ends at the first trailer line. Lines AFTER the trailer block
-  // (and up to the next entry's title) are inter-entry prose, not the
-  // entry's body — they must not be tokenized as part of this entry.
-  const bodyEndExclusive = trailerLines.length > 0
-    ? trailerLines[0].lineIndex
-    : endLineExclusive;
-  // Body starts on the line after the title (1-based location.line is
-  // the title line; 0-based body starts at location.line).
-  const startIndex = entry.location.line;
-  let insideFeatureBlock = false;
-  for (let i = startIndex; i < bodyEndExclusive && i < lines.length; i++) {
-    const line = lines[i];
-
-    // Track fenced feature/gherkin blocks. The fence delimiters
-    // themselves are not tokenized; lines inside emit Gherkin section
-    // keywords (Feature/Scenario/...) as `class` and step keywords
-    // (Given/When/Then/...) as `keyword`, matching the GitHub Linguist
-    // and Rouge conventions for Cucumber.
-    if (insideFeatureBlock) {
-      if (FENCE_CLOSE_RE.test(line)) {
-        insideFeatureBlock = false;
-        continue;
-      }
-      emitTypedMatches(out, GHERKIN_SECTION_RE, line, i, "class", []);
-      emitKeywordMatches(out, GHERKIN_STEP_RE, line, i);
-      continue;
-    }
-    if (FEATURE_FENCE_OPEN_RE.test(line)) {
-      insideFeatureBlock = true;
-      continue;
-    }
-    if (line.trim() === "") continue;
-    emitKeywordMatches(out, BODY_KEYWORD_RE, line, i);
-    emitEntityRefMatches(out, line, i);
-  }
-}
-
-/** Scan a body line for `$Identifier` tokens and emit `string` tokens. */
-function emitEntityRefMatches(
-  out: SemanticToken[],
-  line: string,
-  lineIndex: number,
-): void {
-  ENTITY_REF_RE.lastIndex = 0;
-  let match: RegExpExecArray | null;
-  while ((match = ENTITY_REF_RE.exec(line)) !== null) {
-    // Skip the second half of a `$$…$$` math fence.
-    if (match.index > 0 && line[match.index - 1] === "$") continue;
-    // Skip escaped `\$`.
-    if (match.index > 0 && line[match.index - 1] === "\\") continue;
+function addBodyTokens(out: SemanticToken[], entry: Entry): void {
+  for (const token of entry.bodyTokens) {
+    const tokenType = BODY_TOKEN_TYPE[token.kind];
+    if (!tokenType) continue;
     out.push({
-      line: lineIndex,
-      startChar: match.index,
-      length: match[0].length,
-      tokenType: "string",
-      tokenModifiers: [],
-    });
-  }
-}
-
-/** Run a `g`-flag regex across `line` and push a `keyword` token per match. */
-function emitKeywordMatches(
-  out: SemanticToken[],
-  re: RegExp,
-  line: string,
-  lineIndex: number,
-): void {
-  emitTypedMatches(out, re, line, lineIndex, "keyword", []);
-}
-
-/**
- * Run a `g`-flag regex across `line` and push a token of the given
- * type/modifiers per match. Shared by the modal/EARS scanner (keyword)
- * and the Gherkin section scanner (class).
- */
-function emitTypedMatches(
-  out: SemanticToken[],
-  re: RegExp,
-  line: string,
-  lineIndex: number,
-  tokenType: SemanticTokenType,
-  tokenModifiers: readonly SemanticTokenModifier[],
-): void {
-  re.lastIndex = 0;
-  let match: RegExpExecArray | null;
-  while ((match = re.exec(line)) !== null) {
-    out.push({
-      line: lineIndex,
-      startChar: match.index,
-      length: match[0].length,
+      line: token.location.line - 1,
+      startChar: token.location.column - 1,
+      length: token.text.length,
       tokenType,
-      tokenModifiers,
+      tokenModifiers: [],
     });
   }
 }

--- a/packages/markspec/lsp/semantic_tokens_test.ts
+++ b/packages/markspec/lsp/semantic_tokens_test.ts
@@ -350,52 +350,71 @@ Deno.test("buildSemanticTokens: title with slashed display ID still highlights",
 });
 
 Deno.test("buildSemanticTokens: body modal verbs emit keyword tokens", () => {
+  // bodyTokens are populated by the parser (body_tokens.ts). The LSP
+  // builder consumes them and maps `modal` -> `keyword`.
   const text = [
     "- [REQ-001] Title",
     "",
-    "  The system shall respond when the brake pedal must trigger.",
+    "  The system shall respond and must trigger.",
   ].join("\n");
+  const entry = entryWithBodyTokens([
+    {
+      kind: "modal",
+      text: "shall",
+      case: "lower",
+      location: { file: "t.md", line: 3, column: 14 },
+    },
+    {
+      kind: "modal",
+      text: "must",
+      case: "lower",
+      location: { file: "t.md", line: 3, column: 32 },
+    },
+  ]);
   const tokens = buildSemanticTokens(
-    [makeEntry()],
+    [entry],
     makeProfile([]),
     text.split("\n"),
   );
   const keywords = tokens.filter((t) => t.tokenType === "keyword");
-  // Expected: "shall", "when", "must" — three keyword matches on line 2.
-  assertEquals(keywords.length, 3);
+  assertEquals(keywords.length, 2);
   assertEquals(keywords.every((t) => t.line === 2), true);
-  // First match is "shall" at the position of "shall " in the body line.
   const line = text.split("\n")[2];
   assertEquals(keywords[0].startChar, line.indexOf("shall"));
   assertEquals(keywords[0].length, "shall".length);
+  assertEquals(keywords[1].startChar, line.indexOf("must"));
 });
 
-Deno.test("buildSemanticTokens: EARS triggers (When/While/If/Where) emit keyword tokens", () => {
+Deno.test("buildSemanticTokens: EARS triggers emit keyword tokens", () => {
+  // bodyTokens populated by the parser; LSP maps `ears-trigger` -> `keyword`.
   const text = [
     "- [REQ-001] Title",
     "",
-    "  When the trigger fires, while the state holds,",
-    "  if the guard passes, where the feature is on, then act.",
+    "  When the trigger fires, the system acts.",
   ].join("\n");
+  const entry = entryWithBodyTokens([
+    {
+      kind: "ears-trigger",
+      text: "When",
+      trigger: "When",
+      location: { file: "t.md", line: 3, column: 3 },
+    },
+  ]);
   const tokens = buildSemanticTokens(
-    [makeEntry()],
+    [entry],
     makeProfile([]),
     text.split("\n"),
   );
   const keywords = tokens.filter((t) => t.tokenType === "keyword");
-  // Expected matches: When, while, if, where, then — five EARS triggers
-  // spread across two body lines.
-  assertEquals(keywords.length, 5);
-  const matched = keywords.map((t) =>
-    text.split("\n")[t.line].slice(t.startChar, t.startChar + t.length)
-      .toLowerCase()
-  );
-  assertEquals(matched, ["when", "while", "if", "where", "then"]);
+  assertEquals(keywords.length, 1);
+  assertEquals(keywords[0].line, 2);
+  assertEquals(keywords[0].startChar, 2);
+  assertEquals(keywords[0].length, "When".length);
 });
 
 Deno.test("buildSemanticTokens: trailer-line keywords are NOT tokenized as body keywords", () => {
-  // A trailer value containing "shall" or "when" must not produce a
-  // keyword token — trailer values already get their own treatment.
+  // bodyTokens contain only body tokens — the parser does not emit
+  // bodyTokens for words appearing inside trailer attribute values.
   const text = [
     "- [REQ-001] Title",
     "",
@@ -419,20 +438,42 @@ Deno.test("buildSemanticTokens: trailer-line keywords are NOT tokenized as body 
     makeProfile([]),
     text.split("\n"),
   );
-  // Only the body line (line index 2) had no modal/EARS words, so
-  // zero keyword tokens.
   const keywords = tokens.filter((t) => t.tokenType === "keyword");
   assertEquals(keywords.length, 0);
 });
 
 Deno.test("buildSemanticTokens: $Identifier entity refs in body emit string tokens", () => {
+  // bodyTokens populated by the parser; LSP maps `entity-ref` -> `string`.
   const text = [
     "- [REQ-001] Title",
     "",
     "  Uses $BrakeController to read $rawPressure.",
   ].join("\n");
+  const line = text.split("\n")[2];
+  const entry = entryWithBodyTokens([
+    {
+      kind: "entity-ref",
+      text: "$BrakeController",
+      convention: "type",
+      location: {
+        file: "t.md",
+        line: 3,
+        column: line.indexOf("$BrakeController") + 1,
+      },
+    },
+    {
+      kind: "entity-ref",
+      text: "$rawPressure",
+      convention: "instance",
+      location: {
+        file: "t.md",
+        line: 3,
+        column: line.indexOf("$rawPressure") + 1,
+      },
+    },
+  ]);
   const tokens = buildSemanticTokens(
-    [makeEntry()],
+    [entry],
     makeProfile([]),
     text.split("\n"),
   );
@@ -440,7 +481,6 @@ Deno.test("buildSemanticTokens: $Identifier entity refs in body emit string toke
     (t) => t.tokenType === "string" && t.line === 2,
   );
   assertEquals(stringTokens.length, 2);
-  const line = text.split("\n")[2];
   assertEquals(stringTokens[0].startChar, line.indexOf("$BrakeController"));
   assertEquals(stringTokens[0].length, "$BrakeController".length);
   assertEquals(stringTokens[1].startChar, line.indexOf("$rawPressure"));
@@ -448,20 +488,27 @@ Deno.test("buildSemanticTokens: $Identifier entity refs in body emit string toke
 });
 
 Deno.test("buildSemanticTokens: $$math$$ fence interior is not tokenized as entity refs", () => {
+  // The parser excludes `$$..$$` math interior from entity-ref tokens;
+  // only `$foo` outside math is emitted. The LSP just consumes the result.
   const text = [
     "- [REQ-001] Title",
     "",
     "  See $$a + b$$ and $foo.",
   ].join("\n");
+  const line = text.split("\n")[2];
+  const entry = entryWithBodyTokens([
+    {
+      kind: "entity-ref",
+      text: "$foo",
+      convention: "instance",
+      location: { file: "t.md", line: 3, column: line.indexOf("$foo") + 1 },
+    },
+  ]);
   const tokens = buildSemanticTokens(
-    [makeEntry()],
+    [entry],
     makeProfile([]),
     text.split("\n"),
   );
-  // Only `$foo` should be tokenized; the `$a` and `$b` inside `$$..$$`
-  // are math, not entity refs. The trailing-`$` guard discards `$b`,
-  // but `$a` immediately after `$$` is also discarded by the same
-  // guard (the preceding char is `$`).
   const stringTokens = tokens.filter(
     (t) => t.tokenType === "string" && t.line === 2,
   );
@@ -470,6 +517,8 @@ Deno.test("buildSemanticTokens: $$math$$ fence interior is not tokenized as enti
 });
 
 Deno.test("buildSemanticTokens: Gherkin sections emit class tokens, steps emit keyword tokens", () => {
+  // The parser emits gherkin-section/gherkin-step inside ```feature
+  // fences and `modal` outside; LSP maps these per ADR-016 Decision 8.
   const text = [
     "- [REQ-001] Title",
     "",
@@ -485,23 +534,52 @@ Deno.test("buildSemanticTokens: Gherkin sections emit class tokens, steps emit k
     "",
     "  After the block, shall is still highlighted.",
   ].join("\n");
+  const entry = entryWithBodyTokens([
+    {
+      kind: "gherkin-section",
+      text: "Feature",
+      location: { file: "t.md", line: 6, column: 3 },
+    },
+    {
+      kind: "gherkin-section",
+      text: "Scenario",
+      location: { file: "t.md", line: 7, column: 5 },
+    },
+    {
+      kind: "gherkin-step",
+      text: "Given",
+      location: { file: "t.md", line: 8, column: 7 },
+    },
+    {
+      kind: "gherkin-step",
+      text: "When",
+      location: { file: "t.md", line: 9, column: 7 },
+    },
+    {
+      kind: "gherkin-step",
+      text: "Then",
+      location: { file: "t.md", line: 10, column: 7 },
+    },
+    {
+      kind: "modal",
+      text: "shall",
+      case: "lower",
+      location: { file: "t.md", line: 13, column: 21 },
+    },
+  ]);
   const tokens = buildSemanticTokens(
-    [makeEntry()],
+    [entry],
     makeProfile([]),
     text.split("\n"),
   );
-  // Sections (Feature, Scenario) → class tokens — matches GitHub
-  // Linguist / Rouge convention of section-heading scope.
   const blockSectionTokens = tokens.filter(
     (t) => t.tokenType === "class" && t.line >= 5 && t.line <= 9,
   );
   assertEquals(blockSectionTokens.length, 2);
-  // Steps (Given, When, Then) → keyword tokens.
   const blockStepTokens = tokens.filter(
     (t) => t.tokenType === "keyword" && t.line >= 5 && t.line <= 9,
   );
   assertEquals(blockStepTokens.length, 3);
-  // Body modal verb after the block: "shall" on line 12.
   const modalTokens = tokens.filter(
     (t) => t.tokenType === "keyword" && t.line === 12,
   );
@@ -509,9 +587,9 @@ Deno.test("buildSemanticTokens: Gherkin sections emit class tokens, steps emit k
 });
 
 Deno.test("buildSemanticTokens: inter-entry prose after trailer is NOT scanned for keywords", () => {
-  // After an entry's trailer block, lines belong to inter-entry prose
-  // (section headers, intro text for the next section) — not to the
-  // entry's body. Keywords there must not be tokenized.
+  // Inter-entry prose lives between entries — the parser never emits
+  // bodyTokens for it because it does not belong to any entry's body.
+  // Each entry only carries bodyTokens for its own body content.
   const text = [
     "- [REQ-001] First entry",
     "",
@@ -539,14 +617,34 @@ Deno.test("buildSemanticTokens: inter-entry prose after trailer is NOT scanned f
     shape: "Authored",
     location: { file: "t.md", line: 1, column: 1 },
     source: "markdown",
-    bodyTokens: [],
+    bodyTokens: [
+      {
+        kind: "modal",
+        text: "shall",
+        case: "lower",
+        location: { file: "t.md", line: 3, column: 14 },
+      },
+    ],
   };
   const entry2: Entry = {
     ...entry1,
     displayId: makeDisplayId("REQ-002"),
     title: "Second entry",
-    // 1-based line 12 maps to 0-based index 11 — the "- [REQ-002] ..." line.
     location: { file: "t.md", line: 12, column: 1 },
+    bodyTokens: [
+      {
+        kind: "modal",
+        text: "may",
+        case: "lower",
+        location: { file: "t.md", line: 14, column: 22 },
+      },
+      {
+        kind: "modal",
+        text: "should",
+        case: "lower",
+        location: { file: "t.md", line: 14, column: 30 },
+      },
+    ],
   };
   const tokens = buildSemanticTokens(
     [entry1, entry2],
@@ -554,8 +652,6 @@ Deno.test("buildSemanticTokens: inter-entry prose after trailer is NOT scanned f
     text.split("\n"),
   );
   const keywords = tokens.filter((t) => t.tokenType === "keyword");
-  // Expected: "shall" on line 2 (entry 1 body) and "may"+"should" on
-  // line 13 (entry 2 body). NOT the words on line 8 (inter-entry prose).
   const onLine2 = keywords.filter((t) => t.line === 2);
   const onLine8 = keywords.filter((t) => t.line === 8);
   const onLine13 = keywords.filter((t) => t.line === 13);
@@ -581,4 +677,243 @@ Deno.test("buildSemanticTokens: outside feature blocks, Gherkin-only words are N
   const keywords = tokens.filter((t) => t.tokenType === "keyword");
   // No modal verbs / EARS triggers in this sentence — zero keywords.
   assertEquals(keywords.length, 0);
+});
+
+// ---------------------------------------------------------------------------
+// ADR-016 Decision 8 — body tokens come from entry.bodyTokens, not from
+// regex-scanning line text. The builder is a thin switch on BodyTokenKind.
+// ---------------------------------------------------------------------------
+
+function entryWithBodyTokens(
+  bodyTokens: Entry["bodyTokens"],
+): Entry {
+  return {
+    displayId: makeDisplayId("REQ-001"),
+    title: "Title",
+    body: "",
+    rawAttributes: [],
+    typedAttributes: new Map(),
+    shape: "Authored",
+    location: { file: "t.md", line: 1, column: 1 },
+    source: "markdown",
+    bodyTokens,
+  };
+}
+
+Deno.test("buildSemanticTokens: body keywords come from entry.bodyTokens, not regex scan", () => {
+  // Body text has no modal/EARS words — a regex scanner would emit
+  // nothing. The new implementation reads bodyTokens directly, so a
+  // token placed by the parser still shows up.
+  const text = [
+    "- [REQ-001] Title",
+    "",
+    "  Plain prose without any keywords.",
+  ].join("\n");
+  const entry = entryWithBodyTokens([
+    {
+      kind: "modal",
+      text: "shall",
+      case: "lower",
+      location: { file: "t.md", line: 3, column: 5 },
+    },
+  ]);
+  const tokens = buildSemanticTokens(
+    [entry],
+    makeProfile([]),
+    text.split("\n"),
+  );
+  const keywords = tokens.filter((t) => t.tokenType === "keyword");
+  assertEquals(keywords.length, 1);
+  assertEquals(keywords[0].line, 2);
+  assertEquals(keywords[0].startChar, 4);
+  assertEquals(keywords[0].length, "shall".length);
+});
+
+Deno.test("buildSemanticTokens: BodyTokenKind 'modal' maps to 'keyword'", () => {
+  const entry = entryWithBodyTokens([
+    {
+      kind: "modal",
+      text: "shall",
+      case: "lower",
+      location: { file: "t.md", line: 3, column: 3 },
+    },
+  ]);
+  const tokens = buildSemanticTokens([entry], makeProfile([]), [
+    "- [REQ-001] Title",
+    "",
+    "  shall be x.",
+  ]);
+  const body = tokens.filter((t) => t.line === 2);
+  assertEquals(body.length, 1);
+  assertEquals(body[0].tokenType, "keyword");
+});
+
+Deno.test("buildSemanticTokens: BodyTokenKind 'ears-trigger' maps to 'keyword'", () => {
+  const entry = entryWithBodyTokens([
+    {
+      kind: "ears-trigger",
+      text: "When",
+      trigger: "When",
+      location: { file: "t.md", line: 3, column: 3 },
+    },
+  ]);
+  const tokens = buildSemanticTokens([entry], makeProfile([]), [
+    "- [REQ-001] Title",
+    "",
+    "  When the trigger fires.",
+  ]);
+  const body = tokens.filter((t) => t.line === 2);
+  assertEquals(body.length, 1);
+  assertEquals(body[0].tokenType, "keyword");
+});
+
+Deno.test("buildSemanticTokens: BodyTokenKind 'gherkin-section' maps to 'class'", () => {
+  // Wrap the Gherkin line in a feature fence so the trailer scanner
+  // (which would otherwise treat "    Scenario: stops" as a trailer
+  // attribute) skips it; the body token still emits a class token.
+  const entry = entryWithBodyTokens([
+    {
+      kind: "gherkin-section",
+      text: "Scenario",
+      location: { file: "t.md", line: 4, column: 5 },
+    },
+  ]);
+  const tokens = buildSemanticTokens([entry], makeProfile([]), [
+    "- [REQ-001] Title",
+    "",
+    "  ```feature",
+    "    Scenario: stops",
+    "  ```",
+  ]);
+  const body = tokens.filter((t) => t.line === 3);
+  assertEquals(body.length, 1);
+  assertEquals(body[0].tokenType, "class");
+  assertEquals(body[0].length, "Scenario".length);
+});
+
+Deno.test("buildSemanticTokens: BodyTokenKind 'gherkin-step' maps to 'keyword'", () => {
+  const entry = entryWithBodyTokens([
+    {
+      kind: "gherkin-step",
+      text: "Given",
+      location: { file: "t.md", line: 3, column: 7 },
+    },
+  ]);
+  const tokens = buildSemanticTokens([entry], makeProfile([]), [
+    "- [REQ-001] Title",
+    "",
+    "      Given the speed is 60",
+  ]);
+  const body = tokens.filter((t) => t.line === 2);
+  assertEquals(body.length, 1);
+  assertEquals(body[0].tokenType, "keyword");
+  assertEquals(body[0].length, "Given".length);
+});
+
+Deno.test("buildSemanticTokens: BodyTokenKind 'entity-ref' maps to 'string'", () => {
+  const entry = entryWithBodyTokens([
+    {
+      kind: "entity-ref",
+      text: "$BrakeController",
+      convention: "type",
+      location: { file: "t.md", line: 3, column: 8 },
+    },
+  ]);
+  const tokens = buildSemanticTokens([entry], makeProfile([]), [
+    "- [REQ-001] Title",
+    "",
+    "  Uses $BrakeController.",
+  ]);
+  const body = tokens.filter((t) => t.line === 2);
+  assertEquals(body.length, 1);
+  assertEquals(body[0].tokenType, "string");
+  assertEquals(body[0].length, "$BrakeController".length);
+});
+
+Deno.test("buildSemanticTokens: BodyTokenKind 'inline-code' emits NO token (TextMate paints it)", () => {
+  const entry = entryWithBodyTokens([
+    {
+      kind: "inline-code",
+      text: "`x`",
+      location: { file: "t.md", line: 3, column: 3 },
+    },
+  ]);
+  const tokens = buildSemanticTokens([entry], makeProfile([]), [
+    "- [REQ-001] Title",
+    "",
+    "  `x` is a thing.",
+  ]);
+  const body = tokens.filter((t) => t.line === 2);
+  assertEquals(body.length, 0);
+});
+
+Deno.test("buildSemanticTokens: multiple bodyTokens on one line preserve relative positions", () => {
+  const entry = entryWithBodyTokens([
+    {
+      kind: "modal",
+      text: "shall",
+      case: "lower",
+      location: { file: "t.md", line: 3, column: 5 },
+    },
+    {
+      kind: "entity-ref",
+      text: "$obj",
+      convention: "instance",
+      location: { file: "t.md", line: 3, column: 18 },
+    },
+    {
+      kind: "modal",
+      text: "must",
+      case: "lower",
+      location: { file: "t.md", line: 3, column: 27 },
+    },
+  ]);
+  const tokens = buildSemanticTokens([entry], makeProfile([]), [
+    "- [REQ-001] Title",
+    "",
+    "    shall read $obj and must.",
+  ]);
+  const body = tokens.filter((t) => t.line === 2);
+  assertEquals(body.length, 3);
+  assertEquals(body[0].startChar, 4);
+  assertEquals(body[0].tokenType, "keyword");
+  assertEquals(body[1].startChar, 17);
+  assertEquals(body[1].tokenType, "string");
+  assertEquals(body[2].startChar, 26);
+  assertEquals(body[2].tokenType, "keyword");
+});
+
+// ---------------------------------------------------------------------------
+// Integration — parser → bodyTokens → LSP. Catches drift between the
+// parser's emitted token shape and the LSP's consumer mapping.
+// ---------------------------------------------------------------------------
+
+import { parseFile } from "../core/mod.ts";
+
+Deno.test("integration: parser bodyTokens drive LSP body keyword tokens (Markdown)", async () => {
+  // End-to-end: parser emits bodyTokens; buildSemanticTokens consumes
+  // them and emits LSP tokens of matching type. Positions are whatever
+  // the parser computes; we assert the kind→type mapping holds across
+  // the whole pipeline.
+  const md = [
+    "- [REQ-001] Brake response",
+    "",
+    "  The system shall debounce $Sensor inputs and must report.",
+    "",
+    "      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF",
+  ].join("\n");
+  const result = await parseFile(md, { file: "t.md" });
+  assertEquals(result.entries.length, 1);
+  const entry = result.entries[0];
+  const kinds = entry.bodyTokens.map((t) => t.kind).sort();
+  assertEquals(kinds, ["entity-ref", "modal", "modal"]);
+
+  const tokens = buildSemanticTokens([entry], makeProfile([]), md.split("\n"));
+  const bodyTokenLine = entry.bodyTokens[0].location.line - 1;
+  const onBody = tokens.filter((t) => t.line === bodyTokenLine);
+  const keywords = onBody.filter((t) => t.tokenType === "keyword");
+  const strings = onBody.filter((t) => t.tokenType === "string");
+  assertEquals(keywords.length, 2);
+  assertEquals(strings.length, 1);
+  assertEquals(strings[0].length, "$Sensor".length);
 });


### PR DESCRIPTION
## Summary

- Story 5 of #409. Rewrites `packages/markspec/lsp/semantic_tokens.ts` body-keyword path as a thin `BodyTokenKind`→`SemanticTokenType` switch over `Entry.bodyTokens`, per ADR-016 Decision 8.
- Deletes the duplicated per-line regex scanner (`BODY_KEYWORD_RE`, `GHERKIN_SECTION_RE`, `GHERKIN_STEP_RE`, `ENTITY_REF_RE`, `FEATURE_FENCE_OPEN_RE`, `FENCE_CLOSE_RE`) and the `insideFeatureBlock` state machine. Closes ADR-016 acceptance criterion #3.
- Independent of story 3 (LineMap). The LSP migration ships now; source-file rendering becomes correct as a side effect once story 3 lands `bodyTokens` for `.rs`/`.kt`/`.java`/`.c`/`.cpp` doc comments — at that point the PR #408 regression closes without further LSP changes.

## Mapping table (ADR-016 Decision 8)

| BodyTokenKind     | Semantic-token type            |
| ----------------- | ------------------------------ |
| `modal`           | `keyword`                      |
| `ears-trigger`    | `keyword`                      |
| `gherkin-section` | `class`                        |
| `gherkin-step`    | `keyword`                      |
| `entity-ref`      | `string`                       |
| `inline-code`     | _no emission_ (TextMate paints) |

## Test plan

- [x] `deno test packages/markspec/lsp/semantic_tokens_test.ts` — 28/28 pass (19 baseline + 9 new: kind→type mapping per variant, file-relative position conversion, multi-token ordering, integration parser→bodyTokens→LSP)
- [x] `deno test` (full suite) — 1726 pass / 0 failed / 2 ignored
- [x] `just build` — `deno check` + lint + format + tests + compile, exit 0
- [x] `deno fmt --check` — clean
- [x] `dprint check` — clean

## Notes

- Pre-existing legacy regex-driven tests were updated to populate `bodyTokens` fixtures directly, since the LSP no longer scans body text. Behavior verification is preserved; only the fixture mechanism changed.
- `_SHALL_` (emphasis-wrapped modal) detection remains the documented limitation introduced in story 2 — unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
