### PR TITLE
docs: remove aspice-slice placeholder from examples guide

### DIFF
--- a/docs/guide/examples.md
+++ b/docs/guide/examples.md
@@ -1,25 +1,28 @@
 # Examples gallery
 
-> **Coming soon.**
->
-> This chapter will tour the in-repo example project — a thin slice of an
-> automotive emergency-braking system — so you can clone it and modify it on day
-> one.
+MarkSpec does not yet ship the larger in-repo `aspice-slice` corpus that older
+planning notes referenced, so this chapter focuses on the examples you can use
+right now.
 
-The gallery will be grounded in the end-to-end test corpus at
-`tests/fixtures/corpora/aspice-slice/`, which does not yet exist in the
-repository. Once the corpus ships, this chapter will cover:
+## Available examples today
+
+- **[Quickstart](quickstart.md)** — build a small self-contained project from
+  scratch and validate it locally.
+- **[`docs/examples/entry-rendering.md`](../examples/entry-rendering.md)** — see
+  every entry block rendered with the current typography and pill treatments.
+
+## What to expect from a future corpus example
+
+When a larger end-to-end corpus lands, this chapter can expand to cover:
 
 - **Project tour** — directory layout, `project.yaml`, `.markspec.yaml`, and the
-  activated ASPICE slice profile.
-- **Stakeholder requirements** — `STK` entries in Markdown, their display IDs,
-  and how they form the root of the traceability graph.
-- **Software requirements and tests** — `SRS` entries in Markdown, `SWT` entries
-  colocated in Rust doc comments, and the `Satisfies:` links that connect them.
-- **Listing documents** — the generated `glossary.md`, `components.md`, and
-  `references.md`.
-- **Cloning the example** — how to copy the corpus out of the repository and use
-  it as the starting point for a new project.
+  activated profile chain.
+- **Cross-file traceability** — Markdown requirements, source-comment entries,
+  and the links that connect them.
+- **Generated listings** — derived documents such as glossaries, component
+  indexes, and reference views.
+- **Cloning flow** — how to copy the example into a fresh repository and adapt
+  it for a new project.
 
-In the meantime, the [Quickstart](quickstart.md) walks a smaller self-contained
-example from scratch.
+Until then, use the Quickstart for onboarding and `entry-rendering.md` as the
+canonical reference example.


### PR DESCRIPTION
## Summary
- replace the placeholder examples page with links to examples that exist today
- remove the promise that `tests/fixtures/corpora/aspice-slice/` already exists
- keep a short outline for what a future end-to-end corpus chapter could cover

## Validation
- git diff --check

Closes #419