### PR TITLE
feat(core): LineMap for source-file doc-comment entries (#409)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@
   constructs (modal verbs, EARS triggers, Gherkin section/step keywords,
   `$Identifier` entity refs, inline code). Always present, sorted by source
   position. See ADR-016. (#409)
+- **core:** Source-file (`.rs`/`.kt`/`.java`/`.cpp`) doc-comment entries now
+  emit file-relative `Entry.bodyTokens`. LSP semantic-token rendering on doc
+  comments now reflects the same modal / EARS / Gherkin / entity-ref /
+  inline-code highlighting that Markdown entries get — closing the PR #408
+  source-file rendering regression. Closes ADR-016 acceptance criterion #6
+  and the last open story of epic #409. (#409)
+- **core:** `LineMap` interface + `buildBlockLineMap` factory in
+  `core/parser/line_map.ts` for buffer→file coordinate translation; reusable
+  for future source-format expansion (Python docstrings, AsciiDoc).
+  `ParseMarkdownOptions` gains `lineMap?: LineMap`. (#409)
+- **core:** Per-grammar doc-comment dispatch table
+  (`core/parser/language_spec.ts`) driving the tree-sitter walker. (#409)
 
 ### Changed
 
@@ -17,9 +29,16 @@
   via a thin `BodyTokenKind` to `SemanticTokenType` switch. The duplicated
   per-line regex scanner (`BODY_KEYWORD_RE`, `GHERKIN_SECTION_RE`,
   `GHERKIN_STEP_RE`, `ENTITY_REF_RE`, `FEATURE_FENCE_OPEN_RE`,
-  `FENCE_CLOSE_RE`) and the `insideFeatureBlock` state machine are deleted.
-  Source-file rendering becomes correct as a side effect once story 3 of
-  #409 lands. (#409)
+  `FENCE_CLOSE_RE`) and the `insideFeatureBlock` state machine are
+  deleted. (#409)
+
+### Fixed
+
+- **core:** Kotlin (`multiline_comment`) and C++ (`comment`) doc comments
+  are now recognised by the tree-sitter walker — they previously produced
+  zero entries due to grammar-specific node-type names being missed. (#409)
+- **core:** Rust `//!` inner doc comments now parse alongside `///` outer
+  doc comments. Both can carry MarkSpec entry blocks. (#409)
 
 ### Removed
 
@@ -34,14 +53,15 @@
 
 ### Known limitations
 
-- **core:** Source-file (`.rs`, `.kt`, `.java`, `.c`, `.cpp`) doc-comment entries
-  have `bodyTokens: []` until story 3 of #409 lands (`LineMap` for
-  file-relative position translation).
 - **core:** Inline-emphasis-wrapped modals (e.g. `_SHALL_`) are no longer
   detected by MSL-M060. Pre-ADR-016 marker extraction ran on a flattened-text
   projection that stripped emphasis; the new scanner runs on the raw body.
   Authors using emphasis around modal verbs will not get the lint warning.
   Plain `SHALL` and `MUST NOT` are detected correctly.
+- **grammars:** The bundled `grammars/tree-sitter-c.wasm` is compiled against
+  tree-sitter ABI v15 while the installed `web-tree-sitter` accepts v13–v14.
+  C source files therefore fail to load grammars at runtime — independent
+  of #409 and tracked separately.
 
 ## [0.5.3] (2026-05-23)
 

--- a/packages/markspec/core/mod.ts
+++ b/packages/markspec/core/mod.ts
@@ -163,10 +163,14 @@ export type {
   DetectCaptionsOptions,
   DetectDirectivesOptions,
   DetectInlineRefsOptions,
+  DocCommentBlockMeta,
+  LanguageDocCommentSpec,
+  LineMap,
   ParseFileResult,
   ParseOptions,
   ParseSourceOptions,
   ParseSourceResult,
+  SupportedLanguage,
 } from "./parser/mod.ts";
 
 // Formatter

--- a/packages/markspec/core/parser/body_tokens.ts
+++ b/packages/markspec/core/parser/body_tokens.ts
@@ -99,6 +99,7 @@ function emitGherkin(
   blocks: readonly BodyBlock[],
   out: BodyToken[],
   baseLocation: SourceLocation,
+  columnOffset: number,
 ): void {
   for (const block of blocks) {
     if (block.kind === "feature") {
@@ -118,7 +119,7 @@ function emitGherkin(
             location: {
               file: baseLocation.file,
               line: lineNo,
-              column: m.index + 1,
+              column: m.index + 1 + columnOffset,
             },
           });
         }
@@ -130,14 +131,14 @@ function emitGherkin(
             location: {
               file: baseLocation.file,
               line: lineNo,
-              column: m.index + 1,
+              column: m.index + 1 + columnOffset,
             },
           });
         }
       }
     } else if (block.kind === "list") {
       for (const item of block.items) {
-        emitGherkin(item.blocks, out, baseLocation);
+        emitGherkin(item.blocks, out, baseLocation, columnOffset);
       }
     }
   }
@@ -152,6 +153,7 @@ function emitInlineCode(
   body: string,
   out: BodyToken[],
   baseLocation: SourceLocation,
+  columnOffset: number,
 ): void {
   const tree = processor.parse(body) as Root;
   const visit = (node: RootContent | Root): void => {
@@ -165,7 +167,7 @@ function emitInlineCode(
         location: {
           file: baseLocation.file,
           line: baseLocation.line + node.position.start.line - 1,
-          column: node.position.start.column,
+          column: node.position.start.column + columnOffset,
         },
       });
       return;
@@ -185,6 +187,12 @@ function emitInlineCode(
  *   code/math/feature fence detection)
  * @param baseLocation - `SourceLocation` of the body's first line; the
  *   `file` field is propagated to every emitted token
+ * @param columnOffset - Number of source characters stripped from the
+ *   start of each body line before the body string was built. Added to
+ *   every emitted column value so columns are relative to the containing
+ *   buffer line, not the stripped body text. Defaults to 0. Source-file
+ *   callers (via parseMarkdown's lineMap path) supply the list-item
+ *   indent width so the LineMap receives buffer-relative columns.
  * @returns tokens sorted by `(line, column)`. Empty when no constructs
  *   are recognised.
  */
@@ -192,6 +200,7 @@ export function extractBodyTokens(
   body: string,
   bodyAst: readonly BodyBlock[],
   baseLocation: SourceLocation,
+  columnOffset = 0,
 ): readonly BodyToken[] {
   const tokens: BodyToken[] = [];
   const verbatimLines = collectVerbatimLines(bodyAst);
@@ -211,7 +220,7 @@ export function extractBodyTokens(
         location: {
           file: baseLocation.file,
           line: lineNo,
-          column: m.index + 1,
+          column: m.index + 1 + columnOffset,
         },
       });
     }
@@ -226,7 +235,7 @@ export function extractBodyTokens(
         location: {
           file: baseLocation.file,
           line: lineNo,
-          column: m.index + 1,
+          column: m.index + 1 + columnOffset,
         },
       });
     }
@@ -246,14 +255,14 @@ export function extractBodyTokens(
         location: {
           file: baseLocation.file,
           line: lineNo,
-          column: m.index + 1,
+          column: m.index + 1 + columnOffset,
         },
       });
     }
   }
 
-  emitGherkin(bodyAst, tokens, baseLocation);
-  emitInlineCode(body, tokens, baseLocation);
+  emitGherkin(bodyAst, tokens, baseLocation, columnOffset);
+  emitInlineCode(body, tokens, baseLocation, columnOffset);
 
   tokens.sort((a, b) =>
     a.location.line !== b.location.line

--- a/packages/markspec/core/parser/grammars.ts
+++ b/packages/markspec/core/parser/grammars.ts
@@ -82,3 +82,6 @@ async function doLoad(grammarName: string): Promise<Parser.Language> {
     return Parser.Language.load(join(GRAMMARS_DIR, `${grammarName}.wasm`));
   }
 }
+
+export { languageIdForExtension } from "./language_spec.ts";
+export type { SupportedLanguage } from "./language_spec.ts";

--- a/packages/markspec/core/parser/language_spec.ts
+++ b/packages/markspec/core/parser/language_spec.ts
@@ -1,0 +1,98 @@
+/**
+ * @module parser/language_spec
+ *
+ * Per-grammar doc-comment dispatch table. Each tree-sitter grammar names
+ * its comment nodes differently (Rust splits `line_comment`/`block_comment`;
+ * Kotlin uses `multiline_comment` for block; C/C++ collapses all comments
+ * to a single `comment` node), so the walker reads node-type names plus
+ * text predicates from this table rather than hard-coding them.
+ *
+ * Adding a new language is a single row here plus an extension entry in
+ * {@linkcode languageIdForExtension}.
+ */
+
+export type SupportedLanguage = "rust" | "kotlin" | "java" | "c" | "cpp";
+
+export interface LanguageDocCommentSpec {
+  /** Tree-sitter node type(s) for block (multi-line) comments. */
+  readonly blockCommentTypes: readonly string[];
+  /** Tree-sitter node type(s) for line (single-line) comments. */
+  readonly lineCommentTypes: readonly string[];
+  /** Predicate: this block-comment node text starts a doc block. */
+  isDocBlock(text: string): boolean;
+  /** Predicate: this line-comment node text is a doc-line comment. */
+  isDocLine(text: string): boolean;
+}
+
+const isJavadocBlock = (t: string): boolean =>
+  t.startsWith("/**") && !t.startsWith("/***");
+
+const isRustDocLine = (t: string): boolean =>
+  t.startsWith("///") || t.startsWith("//!");
+
+const noDocLine = (): boolean => false;
+
+/**
+ * Closed-form table indexed by {@linkcode SupportedLanguage}. The walker in
+ * `parser/source.ts` consults this map to know which AST node types to
+ * inspect and how to discriminate doc comments from regular ones.
+ */
+export const LANGUAGE_SPECS: Record<SupportedLanguage, LanguageDocCommentSpec> =
+  {
+    rust: {
+      blockCommentTypes: ["block_comment"],
+      lineCommentTypes: ["line_comment"],
+      isDocBlock: isJavadocBlock,
+      isDocLine: isRustDocLine,
+    },
+    java: {
+      blockCommentTypes: ["block_comment"],
+      lineCommentTypes: ["line_comment"],
+      isDocBlock: isJavadocBlock,
+      isDocLine: noDocLine,
+    },
+    kotlin: {
+      blockCommentTypes: ["multiline_comment"],
+      lineCommentTypes: ["line_comment"],
+      isDocBlock: isJavadocBlock,
+      isDocLine: noDocLine,
+    },
+    cpp: {
+      blockCommentTypes: ["comment"],
+      lineCommentTypes: ["comment"],
+      isDocBlock: isJavadocBlock,
+      isDocLine: isRustDocLine,
+    },
+    c: {
+      blockCommentTypes: ["comment"],
+      lineCommentTypes: ["comment"],
+      isDocBlock: isJavadocBlock,
+      isDocLine: isRustDocLine,
+    },
+  };
+
+/** Map a file extension (including the dot) to its language id. */
+export function languageIdForExtension(
+  ext: string,
+): SupportedLanguage | undefined {
+  switch (ext) {
+    case ".rs":
+      return "rust";
+    case ".kt":
+    case ".kts":
+      return "kotlin";
+    case ".java":
+      return "java";
+    case ".c":
+    case ".h":
+      return "c";
+    case ".cpp":
+    case ".cc":
+    case ".cxx":
+    case ".hpp":
+    case ".hxx":
+      return "cpp";
+    default:
+      return undefined;
+  }
+}

--- a/packages/markspec/core/parser/language_spec_test.ts
+++ b/packages/markspec/core/parser/language_spec_test.ts
@@ -1,0 +1,88 @@
+/**
+ * @module parser/language_spec_test
+ *
+ * Unit tests for the per-grammar doc-comment dispatch table.
+ */
+
+import { assert, assertEquals } from "@std/assert";
+import {
+  LANGUAGE_SPECS,
+  languageIdForExtension,
+  type SupportedLanguage,
+} from "./language_spec.ts";
+
+Deno.test("languageIdForExtension: maps every supported extension", () => {
+  assertEquals(languageIdForExtension(".rs"), "rust");
+  assertEquals(languageIdForExtension(".kt"), "kotlin");
+  assertEquals(languageIdForExtension(".kts"), "kotlin");
+  assertEquals(languageIdForExtension(".java"), "java");
+  assertEquals(languageIdForExtension(".c"), "c");
+  assertEquals(languageIdForExtension(".h"), "c");
+  assertEquals(languageIdForExtension(".cpp"), "cpp");
+  assertEquals(languageIdForExtension(".cc"), "cpp");
+  assertEquals(languageIdForExtension(".cxx"), "cpp");
+  assertEquals(languageIdForExtension(".hpp"), "cpp");
+  assertEquals(languageIdForExtension(".hxx"), "cpp");
+});
+
+Deno.test("languageIdForExtension: returns undefined for unknown extension", () => {
+  assertEquals(languageIdForExtension(".py"), undefined);
+  assertEquals(languageIdForExtension(""), undefined);
+});
+
+Deno.test("LANGUAGE_SPECS: every SupportedLanguage has a row", () => {
+  const ids: SupportedLanguage[] = ["rust", "kotlin", "java", "c", "cpp"];
+  for (const id of ids) {
+    assert(LANGUAGE_SPECS[id], `missing spec row for ${id}`);
+  }
+});
+
+Deno.test("LANGUAGE_SPECS.rust: block/line type names and predicates", () => {
+  const spec = LANGUAGE_SPECS.rust;
+  assertEquals(spec.blockCommentTypes, ["block_comment"]);
+  assertEquals(spec.lineCommentTypes, ["line_comment"]);
+  assertEquals(spec.isDocBlock("/** doc */"), true);
+  assertEquals(spec.isDocBlock("/* not doc */"), false);
+  assertEquals(spec.isDocBlock("/*** divider */"), false);
+  assertEquals(spec.isDocLine("/// doc"), true);
+  assertEquals(spec.isDocLine("//! inner doc"), true);
+  assertEquals(spec.isDocLine("// regular"), false);
+});
+
+Deno.test("LANGUAGE_SPECS.java: block type only, no doc-line", () => {
+  const spec = LANGUAGE_SPECS.java;
+  assertEquals(spec.blockCommentTypes, ["block_comment"]);
+  assertEquals(spec.lineCommentTypes, ["line_comment"]);
+  assertEquals(spec.isDocBlock("/** javadoc */"), true);
+  assertEquals(spec.isDocBlock("/* not */"), false);
+  assertEquals(spec.isDocLine("/// not a java thing"), false);
+});
+
+Deno.test("LANGUAGE_SPECS.kotlin: multiline_comment for block", () => {
+  const spec = LANGUAGE_SPECS.kotlin;
+  assertEquals(spec.blockCommentTypes, ["multiline_comment"]);
+  assertEquals(spec.lineCommentTypes, ["line_comment"]);
+  assertEquals(spec.isDocBlock("/** kdoc */"), true);
+  assertEquals(spec.isDocLine("/// not kotlin"), false);
+});
+
+Deno.test("LANGUAGE_SPECS.cpp: shared 'comment' node type with text predicates", () => {
+  const spec = LANGUAGE_SPECS.cpp;
+  assertEquals(spec.blockCommentTypes, ["comment"]);
+  assertEquals(spec.lineCommentTypes, ["comment"]);
+  assertEquals(spec.isDocBlock("/** doxygen */"), true);
+  assertEquals(spec.isDocBlock("// not block"), false);
+  assertEquals(spec.isDocLine("/// doc"), true);
+  assertEquals(spec.isDocLine("/* block */"), false);
+});
+
+Deno.test("LANGUAGE_SPECS.c: same shape as cpp", () => {
+  const spec = LANGUAGE_SPECS.c;
+  assertEquals(spec.blockCommentTypes, ["comment"]);
+  assertEquals(spec.lineCommentTypes, ["comment"]);
+  assertEquals(spec.isDocBlock("/** doxygen */"), true);
+  assertEquals(spec.isDocBlock("// not block"), false);
+  assertEquals(spec.isDocLine("/// doc"), true);
+  assertEquals(spec.isDocLine("//! inner"), true);
+  assertEquals(spec.isDocLine("/* block */"), false);
+});

--- a/packages/markspec/core/parser/line_map.ts
+++ b/packages/markspec/core/parser/line_map.ts
@@ -1,0 +1,76 @@
+/**
+ * @module parser/line_map
+ *
+ * Coordinate translation from a `wrapAsListItem`-wrapped buffer back to
+ * the source file the buffer was extracted from. The {@linkcode LineMap}
+ * interface is the abstract surface; {@linkcode buildBlockLineMap} is the
+ * concrete factory used by {@linkcode parser/source} for tree-sitter
+ * doc-comment blocks.
+ *
+ * The interface is deliberately small so future source formats (Python
+ * docstrings, AsciiDoc) can produce their own LineMaps without touching
+ * the consumers.
+ *
+ * Coordinate math reference: spec at
+ * `docs/superpowers/specs/2026-05-24-body-tokens-parser-source-409-design.md`.
+ */
+
+/** Translates wrapped-buffer (line, column) to source-file (line, column). */
+export interface LineMap {
+  /**
+   * Translate a 1-based `(bufferLine, bufferColumn)` to its source file
+   * coordinates. Returns `undefined` when the buffer position is outside
+   * any known cleaned line (over-run past the block's last line, or
+   * `bufferLine === 0`).
+   *
+   * For columns inside the synthetic `- ` / `  ` prepended by
+   * `wrapAsListItem` (cols 1–2 on every line), the translation falls
+   * back to the block's `startColumn` (line 1) or column 1 (line ≥ 2) —
+   * a safe under-painting rather than `undefined`, because real entity
+   * references never live in that prefix region but a defensive caller
+   * might still translate column 1 on a blank line.
+   */
+  translate(
+    bufferLine: number,
+    bufferColumn: number,
+  ): { line: number; column: number } | undefined;
+}
+
+/** Per-line metadata captured during doc-comment prefix stripping. */
+export interface DocCommentBlockMeta {
+  /** 1-based file line of the first *cleaned* line in source. */
+  readonly startLine: number;
+  /** 1-based file column of the first prefix marker. */
+  readonly startColumn: number;
+  /**
+   * One entry per cleaned line. Each value is the number of source
+   * characters stripped to produce that cleaned line — comment marker
+   * (`///`, `* `, `/**`) plus any leading space. Length must equal the
+   * cleaned-line count.
+   */
+  readonly prefixWidths: readonly number[];
+}
+
+/**
+ * Build a `LineMap` for a doc-comment block wrapped via `wrapAsListItem`.
+ *
+ * The math is documented in the spec; in short: buffer column `c >= 3`
+ * maps to source column `(c - 2) + prefixWidths[bufferLine - 1]`; columns
+ * 1–2 (the synthetic `- ` or `  ` continuation marker) safe-fall to the
+ * block's `startColumn` on line 1 and column 1 on subsequent lines.
+ */
+export function buildBlockLineMap(meta: DocCommentBlockMeta): LineMap {
+  return {
+    translate(bufferLine, bufferColumn) {
+      if (bufferLine < 1) return undefined;
+      const idx = bufferLine - 1;
+      if (idx >= meta.prefixWidths.length) return undefined;
+      const line = meta.startLine + idx;
+      if (bufferColumn < 3) {
+        return { line, column: idx === 0 ? meta.startColumn : 1 };
+      }
+      const column = (bufferColumn - 2) + meta.prefixWidths[idx];
+      return { line, column };
+    },
+  };
+}

--- a/packages/markspec/core/parser/line_map_test.ts
+++ b/packages/markspec/core/parser/line_map_test.ts
@@ -1,0 +1,115 @@
+/**
+ * @module parser/line_map_test
+ *
+ * Unit tests for the LineMap interface + buildBlockLineMap factory.
+ *
+ * Tests use only synthetic DocCommentBlockMeta inputs — no tree-sitter,
+ * no real comment strippers — to isolate the column-math.
+ */
+
+import { assertEquals } from "@std/assert";
+import { buildBlockLineMap, type DocCommentBlockMeta } from "./line_map.ts";
+
+Deno.test("buildBlockLineMap: line 1 with c >= 3 uses prefixWidths[0]", () => {
+  // Source line at file row 10, col 5: "/// foo"
+  // Cleaned line[0] = "foo", prefixWidths[0] = 4 (strips "/// ")
+  // Wrapped buffer line 1 = "- foo" (cols 1-2 are "- ", col 3 = 'f')
+  const meta: DocCommentBlockMeta = {
+    startLine: 10,
+    startColumn: 5,
+    prefixWidths: [4],
+  };
+  const lm = buildBlockLineMap(meta);
+  // buffer (1, 3) ('f' in "- foo") → source col 5 ('f' in "/// foo" at col 5)
+  assertEquals(lm.translate(1, 3), { line: 10, column: 5 });
+  // buffer (1, 5) ('o' last char in "- foo") → source col 7
+  assertEquals(lm.translate(1, 5), { line: 10, column: 7 });
+});
+
+Deno.test("buildBlockLineMap: line 1 with c < 3 falls back to startColumn", () => {
+  const meta: DocCommentBlockMeta = {
+    startLine: 10,
+    startColumn: 5,
+    prefixWidths: [4],
+  };
+  const lm = buildBlockLineMap(meta);
+  // buffer col 1 or 2 is the '- ' marker — safe fallback to startColumn
+  assertEquals(lm.translate(1, 1), { line: 10, column: 5 });
+  assertEquals(lm.translate(1, 2), { line: 10, column: 5 });
+});
+
+Deno.test("buildBlockLineMap: line N>=2 uses prefixWidths[N-1] with c>=3 offset", () => {
+  // 3-line block at file row 20: each line "/// foo" (prefix 4 chars each)
+  const meta: DocCommentBlockMeta = {
+    startLine: 20,
+    startColumn: 1,
+    prefixWidths: [4, 4, 4],
+  };
+  const lm = buildBlockLineMap(meta);
+  // buffer (2, 3) ('f' in "  foo" continuation) → source row 21 col 5
+  assertEquals(lm.translate(2, 3), { line: 21, column: 5 });
+  // buffer (3, 3) → row 22 col 5
+  assertEquals(lm.translate(3, 3), { line: 22, column: 5 });
+  // buffer (3, 5) → row 22 col 7
+  assertEquals(lm.translate(3, 5), { line: 22, column: 7 });
+});
+
+Deno.test("buildBlockLineMap: line N>=2 with c<3 falls back to col 1", () => {
+  const meta: DocCommentBlockMeta = {
+    startLine: 20,
+    startColumn: 1,
+    prefixWidths: [4, 4, 4],
+  };
+  const lm = buildBlockLineMap(meta);
+  assertEquals(lm.translate(2, 1), { line: 21, column: 1 });
+  assertEquals(lm.translate(2, 2), { line: 21, column: 1 });
+});
+
+Deno.test("buildBlockLineMap: bufferLine > prefixWidths.length returns undefined", () => {
+  const meta: DocCommentBlockMeta = {
+    startLine: 10,
+    startColumn: 1,
+    prefixWidths: [4, 4],
+  };
+  const lm = buildBlockLineMap(meta);
+  // 2 cleaned lines → buffer lines 1 and 2 valid; 3+ over-runs
+  assertEquals(lm.translate(3, 3), undefined);
+  assertEquals(lm.translate(100, 1), undefined);
+});
+
+Deno.test("buildBlockLineMap: bufferLine 0 returns undefined", () => {
+  const meta: DocCommentBlockMeta = {
+    startLine: 10,
+    startColumn: 1,
+    prefixWidths: [4],
+  };
+  const lm = buildBlockLineMap(meta);
+  assertEquals(lm.translate(0, 3), undefined);
+});
+
+Deno.test("buildBlockLineMap: variable prefix widths (block continuation)", () => {
+  // Simulates a /** Title\n * foo\n */ block:
+  //   line 0 source: "/** Title"     prefixWidth 4
+  //   line 1 source: " * foo"        prefixWidth 3
+  const meta: DocCommentBlockMeta = {
+    startLine: 5,
+    startColumn: 1,
+    prefixWidths: [4, 3],
+  };
+  const lm = buildBlockLineMap(meta);
+  // buffer (1, 3) 'T' in "- Title" → source row 5 col 5
+  assertEquals(lm.translate(1, 3), { line: 5, column: 5 });
+  // buffer (2, 3) 'f' in "  foo" → source row 6 col 4
+  assertEquals(lm.translate(2, 3), { line: 6, column: 4 });
+});
+
+Deno.test("buildBlockLineMap: empty prefixWidths returns undefined for everything", () => {
+  const meta: DocCommentBlockMeta = {
+    startLine: 1,
+    startColumn: 1,
+    prefixWidths: [],
+  };
+  const lm = buildBlockLineMap(meta);
+  assertEquals(lm.translate(1, 1), undefined);
+  assertEquals(lm.translate(1, 3), undefined);
+});

--- a/packages/markspec/core/parser/markdown.ts
+++ b/packages/markspec/core/parser/markdown.ts
@@ -17,6 +17,8 @@ import {
 import { extractBodyTokens } from "./body_tokens.ts";
 import { processor } from "./remark.ts";
 import { buildBodyAst } from "../ast/build.ts";
+import type { LineMap } from "./line_map.ts";
+import { translateEntryLocations } from "./translate.ts";
 
 /** Options for {@linkcode parseMarkdown}. */
 export interface ParseMarkdownOptions {
@@ -28,6 +30,14 @@ export interface ParseMarkdownOptions {
    * as referenced-entry candidates (the validator flags the missing `Id:`).
    */
   readonly isReferencesDoc?: boolean;
+  /**
+   * When supplied, every `SourceLocation` emitted by this parse — on
+   * entries, on `bodyAst` ranges, on `bodyTokens` — is translated through
+   * this map before being returned. Used by `parseSource` to convert
+   * doc-comment-buffer coordinates to file coordinates. See ADR-016
+   * Decision 6.
+   */
+  readonly lineMap?: LineMap;
 }
 
 /**
@@ -121,12 +131,16 @@ export function parseMarkdown(
         definitions,
         isReferencesDoc,
         diagnostics,
+        !!options?.lineMap,
       );
       if (entry) entries.push(entry);
     }
   }
 
-  return { entries, diagnostics };
+  const finalEntries = options?.lineMap
+    ? translateEntryLocations(entries, options.lineMap)
+    : entries;
+  return { entries: finalEntries, diagnostics };
 }
 
 /**
@@ -155,6 +169,7 @@ function extractEntry(
   definitions: Set<string>,
   isReferencesDoc: boolean,
   diagnostics: Diagnostic[],
+  hasLineMap = false,
 ): Entry | undefined {
   // Task list items (remark-gfm sets checked to true/false) are not entries.
   if (item.checked != null) return undefined;
@@ -486,13 +501,34 @@ function extractEntry(
   const entryLocation = { file, line, column };
 
   // Inline-construct tokens (ADR-016). Reuses the already-built bodyAst to
-  // avoid a redundant mdast parse. Tokens are file-relative: body starts
-  // on the line after the title (+1 keeps line numbers 1-based).
+  // avoid a redundant mdast parse.
+  //
+  // bodyStartLine: when a lineMap is present (source-file path), use the
+  // mdast position of the second child (the body paragraph) — the actual
+  // buffer line where the body starts. CommonMark loose lists have a blank
+  // line between title and body, so the body is at (entry_line + 2), not
+  // (entry_line + 1). Without a lineMap we keep the legacy (entry_line + 1)
+  // behaviour to avoid shifting existing markdown-file token locations.
+  //
+  // columnOffset: when a lineMap is present, body text has been stripped of
+  // the list-item indent (e.g., "  " for column-1 items), so each token
+  // column must be bumped by that indent width for the LineMap to translate
+  // to the correct source column. Without a lineMap, no offset is applied
+  // (legacy behaviour unchanged).
+  const bodyIndent = hasLineMap
+    // + 2 = the "  " continuation indent prepended by wrapAsListItem to
+    // every non-title line. Mirrors the indent computation in
+    // extractBodyContent below.
+    ? (item.position?.start.column ?? 1) - 1 + 2
+    : 0;
+  const bodyStartLine = hasLineMap
+    ? (item.children[1]?.position?.start.line ?? (line + 1))
+    : line + 1;
   const bodyTokens = extractBodyTokens(body, bodyAst, {
     file,
-    line: line + 1,
+    line: bodyStartLine,
     column: 1,
-  });
+  }, bodyIndent);
 
   return {
     displayId: makeDisplayId(displayId),

--- a/packages/markspec/core/parser/markdown_test.ts
+++ b/packages/markspec/core/parser/markdown_test.ts
@@ -8,6 +8,7 @@
 
 import { assertEquals, assertExists } from "@std/assert";
 import { parseMarkdown } from "./markdown.ts";
+import type { LineMap } from "./line_map.ts";
 
 const ULID = "01HGW2Q8MNP3RSTVWXYZABCDEF";
 
@@ -351,4 +352,41 @@ Deno.test("parseMarkdown: populates Entry.bodyTokens", () => {
   // Body contains: shall (modal), $Sensor (entity-ref)
   assertEquals(kinds.includes("modal"), true);
   assertEquals(kinds.includes("entity-ref"), true);
+});
+
+// ---------------------------------------------------------------------------
+// LineMap option (ADR-016 Decision 6)
+// ---------------------------------------------------------------------------
+
+Deno.test("parseMarkdown: applies lineMap to entry.location and bodyTokens", () => {
+  const md = `- [STK_0001] Title
+
+  The system shall do something.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+`;
+  // Identity LineMap shifted by (+10, +0)
+  const lineMap: LineMap = {
+    translate: (l, c) => ({ line: l + 10, column: c }),
+  };
+  const { entries } = parseMarkdown(md, { file: "t.md", lineMap });
+  assertEquals(entries.length, 1);
+  // Entry was on buffer line 1 → file line 11
+  assertEquals(entries[0].location.line, 11);
+  // Body paragraph is at buffer line 3 (blank line separates title and body
+  // in a CommonMark loose list) → file line 13.
+  const modals = entries[0].bodyTokens.filter((t) => t.kind === "modal");
+  assertEquals(modals.length, 1);
+  assertEquals(modals[0].location.line, 13);
+});
+
+Deno.test("parseMarkdown: without lineMap, locations stay buffer-relative", () => {
+  const md = `- [STK_0001] Title
+
+  The system shall do something.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+`;
+  const { entries } = parseMarkdown(md, { file: "t.md" });
+  assertEquals(entries[0].location.line, 1);
 });

--- a/packages/markspec/core/parser/mod.ts
+++ b/packages/markspec/core/parser/mod.ts
@@ -14,7 +14,11 @@ import { basename as pathBasename, extname } from "@std/path";
 import type { Caption, Diagnostic, Document, Entry } from "../model/mod.ts";
 import { normalizeLineEndings } from "../util/line_endings.ts";
 import { parseMarkdown } from "./markdown.ts";
-import { isSupportedExtension, loadGrammar } from "./grammars.ts";
+import {
+  isSupportedExtension,
+  languageIdForExtension,
+  loadGrammar,
+} from "./grammars.ts";
 import { parseSource } from "./source.ts";
 import { extractFrontMatter } from "./frontmatter.ts";
 import {
@@ -45,6 +49,14 @@ export {
 } from "./source.ts";
 
 export { isSupportedExtension, loadGrammar } from "./grammars.ts";
+
+export type { DocCommentBlockMeta, LineMap } from "./line_map.ts";
+export { buildBlockLineMap } from "./line_map.ts";
+export type {
+  LanguageDocCommentSpec,
+  SupportedLanguage,
+} from "./language_spec.ts";
+export { LANGUAGE_SPECS, languageIdForExtension } from "./language_spec.ts";
 
 /** Options for {@linkcode parse}. */
 export interface ParseOptions {
@@ -119,9 +131,20 @@ export async function parseFile(
 
   if (isSupportedExtension(ext)) {
     const language = await loadGrammar(ext);
+    const languageId = languageIdForExtension(ext);
+    if (!languageId) {
+      // Defensive — isSupportedExtension and languageIdForExtension are kept
+      // in sync via their shared extension lists, so this branch should be
+      // unreachable. Throwing surfaces the drift immediately rather than
+      // silently falling through to wrong grammar dispatch.
+      throw new Error(
+        `internal: no languageId for supported extension '${ext}'`,
+      );
+    }
     const result = parseSource(normalised, {
       file: options.file,
       language,
+      languageId,
     });
     return { entries: result.entries, diagnostics: [] };
   }

--- a/packages/markspec/core/parser/source.ts
+++ b/packages/markspec/core/parser/source.ts
@@ -10,6 +10,12 @@ import type { SyntaxNode } from "web-tree-sitter";
 import Parser from "web-tree-sitter";
 import type { Entry } from "../model/mod.ts";
 import { parseMarkdown } from "./markdown.ts";
+import { buildBlockLineMap } from "./line_map.ts";
+import type {
+  LanguageDocCommentSpec,
+  SupportedLanguage,
+} from "./language_spec.ts";
+import { LANGUAGE_SPECS } from "./language_spec.ts";
 
 /** Options for {@linkcode parseSource}. */
 export interface ParseSourceOptions {
@@ -17,6 +23,13 @@ export interface ParseSourceOptions {
   readonly file?: string;
   /** Pre-loaded tree-sitter language grammar. */
   readonly language: Parser.Language;
+  /**
+   * Language id for the active grammar — used by the walker to look up
+   * the doc-comment dispatch row in `LANGUAGE_SPECS`. The caller maps
+   * file extension → languageId via `languageIdForExtension` before
+   * calling `parseSource`.
+   */
+  readonly languageId: SupportedLanguage;
 }
 
 /** Result of parsing a source file. */
@@ -33,6 +46,9 @@ interface DocCommentBlock {
   readonly startLine: number;
   /** 1-based column of the first comment line. */
   readonly startColumn: number;
+  /** One value per cleaned line — bytes stripped from source to produce
+   * the line. Length equals `lines.length`. */
+  readonly prefixWidths: readonly number[];
 }
 
 /**
@@ -50,38 +66,37 @@ export function parseSource(
   options: ParseSourceOptions,
 ): ParseSourceResult {
   const file = options.file ?? "<unknown>";
+  const spec = LANGUAGE_SPECS[options.languageId];
   const parser = new Parser();
   parser.setLanguage(options.language);
   const tree = parser.parse(content);
 
   const blocks: DocCommentBlock[] = [];
-  walkForDocComments(tree.rootNode, blocks);
+  walkForDocComments(tree.rootNode, blocks, spec);
   const entries: Entry[] = [];
 
   for (const block of blocks) {
     const markdown = wrapAsListItem(block.lines);
-    const { entries: parsed } = parseMarkdown(markdown, { file });
+    const lineMap = buildBlockLineMap({
+      startLine: block.startLine,
+      startColumn: block.startColumn,
+      prefixWidths: block.prefixWidths,
+    });
+    const { entries: parsed } = parseMarkdown(markdown, { file, lineMap });
 
     for (const entry of parsed) {
-      const location = {
-        file,
-        line: block.startLine,
-        column: block.startColumn,
-      };
+      // entry.location, bodyAst ranges, and bodyTokens are already
+      // file-relative thanks to the lineMap post-pass inside parseMarkdown.
+      // Source files have no front matter; properties.file is derived from
+      // the translated entry.location.
       entries.push({
         ...entry,
         source: "doc-comment",
-        location,
-        // Story 3 (LineMap, ADR-016 Decision 6) will replace this with
-        // the file-relative token stream. For now, source-file entries
-        // get an empty array so the Entry schema is satisfied without
-        // emitting wrong-coordinate tokens.
-        bodyTokens: [],
         properties: {
           file: {
             path: file,
-            line: block.startLine,
-            column: block.startColumn,
+            line: entry.location.line,
+            column: entry.location.column,
           },
         },
       });
@@ -93,20 +108,13 @@ export function parseSource(
   return { entries };
 }
 
-/**
- * Recursively walk the tree-sitter AST and collect doc comment blocks.
- *
- * At each level, consecutive `line_comment` nodes with
- * `outer_doc_comment_marker` are grouped into a single block.
- * `block_comment` nodes starting with `/**` become individual blocks.
- * Non-comment children are recursed into so that doc comments inside
- * `mod`, `impl`, and other nested scopes are discovered.
- */
 function walkForDocComments(
   node: SyntaxNode,
   blocks: DocCommentBlock[],
+  spec: LanguageDocCommentSpec,
 ): void {
   let currentLines: string[] = [];
+  let currentPrefixWidths: number[] = [];
   let currentStartLine = 0;
   let currentStartColumn = 0;
   let lastRow = -2;
@@ -117,8 +125,10 @@ function walkForDocComments(
         lines: currentLines,
         startLine: currentStartLine,
         startColumn: currentStartColumn,
+        prefixWidths: currentPrefixWidths,
       });
       currentLines = [];
+      currentPrefixWidths = [];
       lastRow = -2;
     }
   }
@@ -126,30 +136,38 @@ function walkForDocComments(
   for (let i = 0; i < node.childCount; i++) {
     const child = node.child(i)!;
 
-    if (child.type === "line_comment" && isOuterDocComment(child)) {
+    const isLineComment = spec.lineCommentTypes.includes(child.type) &&
+      spec.isDocLine(child.text);
+    if (isLineComment) {
       const row = child.startPosition.row;
-
-      // Not consecutive — flush previous block
       if (currentLines.length > 0 && row !== lastRow + 1) {
         flushLineBlock();
       }
-
       if (currentLines.length === 0) {
-        currentStartLine = row + 1; // 1-based
-        currentStartColumn = child.startPosition.column + 1; // 1-based
+        currentStartLine = row + 1;
+        currentStartColumn = child.startPosition.column + 1;
       }
-
-      currentLines.push(stripLineCommentPrefix(child));
+      const { text, prefixWidth } = stripLineCommentPrefix(child);
+      currentLines.push(text);
+      currentPrefixWidths.push(prefixWidth);
       lastRow = row;
       continue;
     }
 
-    if (child.type === "block_comment" && child.text.startsWith("/**")) {
+    const isBlockComment = spec.blockCommentTypes.includes(child.type) &&
+      spec.isDocBlock(child.text);
+    if (isBlockComment) {
       flushLineBlock();
+      const { lines, prefixWidths, openerSkipped } = stripBlockCommentPrefix(
+        child.text,
+      );
+      if (lines.length === 0) continue;
+      const startRow = child.startPosition.row + (openerSkipped ? 1 : 0);
       blocks.push({
-        lines: stripBlockCommentPrefix(child.text),
-        startLine: child.startPosition.row + 1,
+        lines,
+        startLine: startRow + 1,
         startColumn: child.startPosition.column + 1,
+        prefixWidths,
       });
       continue;
     }
@@ -157,78 +175,123 @@ function walkForDocComments(
     // Non-comment node — flush pending line comments, then recurse.
     flushLineBlock();
     if (child.childCount > 0) {
-      walkForDocComments(child, blocks);
+      walkForDocComments(child, blocks, spec);
     }
   }
 
   flushLineBlock();
 }
 
-/** Check if a line_comment node is a `///` outer doc comment. */
-function isOuterDocComment(node: SyntaxNode): boolean {
-  for (let i = 0; i < node.childCount; i++) {
-    if (node.child(i)!.type === "outer_doc_comment_marker") return true;
-  }
-  return false;
+/** Result of stripping a prefix from one source line. */
+interface PrefixStripResult {
+  readonly text: string;
+  /** Number of source characters stripped to produce `text`. */
+  readonly prefixWidth: number;
 }
 
 /**
- * Strip the `///` prefix from a line comment node.
+ * Strip the `///` or `//!` prefix from a line comment node.
  * Uses the `doc_comment` child if available, otherwise strips manually.
  */
-export function stripLineCommentPrefix(node: SyntaxNode): string {
+export function stripLineCommentPrefix(node: SyntaxNode): PrefixStripResult {
   for (let i = 0; i < node.childCount; i++) {
     const child = node.child(i)!;
     if (child.type === "doc_comment") {
       let text = child.text.replace(/\n$/, "");
-      // Strip one leading space (convention: `/// text`)
-      if (text.startsWith(" ")) text = text.slice(1);
-      return text;
+      // The line_comment node's text starts with `///` (or `//!`); the
+      // doc_comment child is the substring after the marker. Compute
+      // prefixWidth as (line_comment_text_length - doc_comment_text_length)
+      // before stripping the conventional leading space.
+      const rawDoc = child.text.replace(/\n$/, "");
+      let prefixWidth = node.text.replace(/\n$/, "").length - rawDoc.length;
+      if (text.startsWith(" ")) {
+        text = text.slice(1);
+        prefixWidth += 1;
+      }
+      return { text, prefixWidth };
     }
   }
   // Fallback: manual prefix stripping
-  const text = node.text.replace(/\n$/, "");
-  if (text.startsWith("/// ")) return text.slice(4);
-  if (text.startsWith("///")) return text.slice(3);
-  return text;
+  const raw = node.text.replace(/\n$/, "");
+  if (raw.startsWith("/// ")) return { text: raw.slice(4), prefixWidth: 4 };
+  if (raw.startsWith("///")) return { text: raw.slice(3), prefixWidth: 3 };
+  if (raw.startsWith("//! ")) return { text: raw.slice(4), prefixWidth: 4 };
+  if (raw.startsWith("//!")) return { text: raw.slice(3), prefixWidth: 3 };
+  return { text: raw, prefixWidth: 0 };
+}
+
+/** Result of stripping a block comment. */
+interface BlockStripResult {
+  readonly lines: string[];
+  /** One value per element of `lines` — chars stripped per emitted line. */
+  readonly prefixWidths: number[];
+  /**
+   * True when the block's opener line (`/**`) had no content after the
+   * marker and was therefore not emitted into `lines`. Used by the walker
+   * to advance `startLine` by 1.
+   */
+  readonly openerSkipped: boolean;
 }
 
 /**
- * Strip block comment delimiters and leading ` * ` prefixes.
- * Returns cleaned lines.
+ * Strip block-comment delimiters and leading ` * ` prefixes.
+ * Returns cleaned lines, per-line prefix widths, and a flag indicating
+ * whether the opener was skipped (bare `/**\n`).
  */
-export function stripBlockCommentPrefix(text: string): string[] {
+export function stripBlockCommentPrefix(text: string): BlockStripResult {
   const rawLines = text.split("\n");
-  const result: string[] = [];
+  const lines: string[] = [];
+  const prefixWidths: number[] = [];
+  let openerSkipped = false;
 
   for (let i = 0; i < rawLines.length; i++) {
-    const trimmed = rawLines[i].trim();
+    const raw = rawLines[i];
+    const trimmed = raw.trim();
 
-    // Skip opening `/**` line (may have content after it)
+    // Opening `/**` line. May have content after it.
     if (i === 0) {
-      const afterOpening = trimmed.slice(3).trim();
-      if (afterOpening && afterOpening !== "/") {
-        result.push(afterOpening);
+      // Locate the `/**` marker; for canonical javadoc it's at the line
+      // start, but be defensive.
+      const markerIdx = raw.indexOf("/**");
+      const afterMarker = markerIdx >= 0
+        ? raw.slice(markerIdx + 3).replace(/^\s+/, "")
+        : "";
+      if (afterMarker && afterMarker !== "/") {
+        // Compute prefixWidth so that for "/** Title", afterMarker="Title"
+        // and prefixWidth = (raw.length - afterMarker.length) = 4 if
+        // raw="/** Title", which matches the spec table.
+        const prefixWidth = raw.length - afterMarker.length;
+        lines.push(afterMarker);
+        prefixWidths.push(prefixWidth);
+      } else {
+        openerSkipped = true;
       }
       continue;
     }
 
-    // Skip closing `*/`
-    if (i === rawLines.length - 1 && trimmed === "*/") {
-      continue;
-    }
+    // Closing `*/` line — skip.
+    if (i === rawLines.length - 1 && trimmed === "*/") continue;
 
-    // Strip leading ` * ` or ` *`
+    // Strip leading ` * ` or ` *` or bare prose.
     if (trimmed.startsWith("* ")) {
-      result.push(trimmed.slice(2));
+      // Strip up through "* " — find leading-whitespace + "* "
+      const starIdx = raw.indexOf("* ");
+      const stripped = raw.slice(starIdx + 2);
+      lines.push(stripped);
+      prefixWidths.push(starIdx + 2);
     } else if (trimmed === "*") {
-      result.push("");
+      lines.push("");
+      prefixWidths.push(raw.indexOf("*") + 1);
+    } else if (trimmed === "") {
+      lines.push("");
+      prefixWidths.push(0);
     } else {
-      result.push(trimmed);
+      lines.push(trimmed);
+      prefixWidths.push(raw.length - trimmed.length);
     }
   }
 
-  return result;
+  return { lines, prefixWidths, openerSkipped };
 }
 
 /**

--- a/packages/markspec/core/parser/source_test.ts
+++ b/packages/markspec/core/parser/source_test.ts
@@ -10,7 +10,7 @@ import { join } from "@std/path";
 import { parseSource } from "./source.ts";
 
 // ---------------------------------------------------------------------------
-// Setup: load Rust grammar once for all tests
+// Setup: load grammars once per language for all tests
 // ---------------------------------------------------------------------------
 
 const grammarsDir = join(
@@ -32,6 +32,39 @@ async function getRustLanguage(): Promise<Parser.Language> {
   return rustLanguage;
 }
 
+let javaLanguage: Parser.Language;
+
+async function getJavaLanguage(): Promise<Parser.Language> {
+  if (javaLanguage) return javaLanguage;
+  await Parser.init();
+  javaLanguage = await Parser.Language.load(
+    join(grammarsDir, "tree-sitter-java.wasm"),
+  );
+  return javaLanguage;
+}
+
+let kotlinLanguage: Parser.Language;
+
+async function getKotlinLanguage(): Promise<Parser.Language> {
+  if (kotlinLanguage) return kotlinLanguage;
+  await Parser.init();
+  kotlinLanguage = await Parser.Language.load(
+    join(grammarsDir, "tree-sitter-kotlin.wasm"),
+  );
+  return kotlinLanguage;
+}
+
+let cppLanguage: Parser.Language;
+
+async function getCppLanguage(): Promise<Parser.Language> {
+  if (cppLanguage) return cppLanguage;
+  await Parser.init();
+  cppLanguage = await Parser.Language.load(
+    join(grammarsDir, "tree-sitter-cpp.wasm"),
+  );
+  return cppLanguage;
+}
+
 // ---------------------------------------------------------------------------
 // Rust: basic entry extraction
 // ---------------------------------------------------------------------------
@@ -49,7 +82,11 @@ Deno.test("parseSource: extracts Rust doc comment entry", async () => {
 fn swt_brk_0001() {}
 `;
 
-  const result = parseSource(source, { file: "src/braking.rs", language });
+  const result = parseSource(source, {
+    file: "src/braking.rs",
+    language,
+    languageId: "rust",
+  });
   assertEquals(result.entries.length, 1);
   assertEquals(result.entries[0].displayId, "SRS_BRK_0001");
   assertEquals(result.entries[0].title, "Sensor input debouncing");
@@ -59,6 +96,20 @@ fn swt_brk_0001() {}
   assertEquals(result.entries[0].location.file, "src/braking.rs");
   assertEquals(result.entries[0].location.line, 1);
   assertEquals(result.entries[0].location.column, 1);
+
+  // NEW: bodyTokens is non-empty and file-relative.
+  const modals = result.entries[0].bodyTokens.filter(
+    (t) => t.kind === "modal",
+  );
+  assertEquals(modals.length, 1);
+  assertEquals(modals[0].text, "shall");
+  // "shall" appears on source line 3 ("/// The sensor driver shall reject…").
+  assertEquals(modals[0].location.line, 3);
+  // "shall" starts at source column 23.
+  // (/// = 3 chars, space = 1, "The sensor driver " = 18 chars, then 's')
+  // → 3 + 1 + 18 + 1 = 23.
+  assertEquals(modals[0].location.column, 23);
+  assertEquals(modals[0].location.file, "src/braking.rs");
 });
 
 Deno.test("parseSource: extracts body from Rust doc comment", async () => {
@@ -71,7 +122,11 @@ Deno.test("parseSource: extracts body from Rust doc comment", async () => {
 fn foo() {}
 `;
 
-  const { entries } = parseSource(source, { file: "test.rs", language });
+  const { entries } = parseSource(source, {
+    file: "test.rs",
+    language,
+    languageId: "rust",
+  });
   assertEquals(entries.length, 1);
   assertStringIncludes(entries[0].body, "reject transient noise");
 });
@@ -88,7 +143,11 @@ Deno.test("parseSource: extracts attributes from Rust doc comment", async () => 
 fn foo() {}
 `;
 
-  const { entries } = parseSource(source, { file: "test.rs", language });
+  const { entries } = parseSource(source, {
+    file: "test.rs",
+    language,
+    languageId: "rust",
+  });
   assertEquals(entries[0].rawAttributes.length, 3);
   assertEquals(entries[0].rawAttributes[0].key, "Id");
   assertEquals(entries[0].rawAttributes[0].value, "SRS_01HGW2Q8MNP3");
@@ -119,7 +178,11 @@ fn first() {}
 fn second() {}
 `;
 
-  const { entries } = parseSource(source, { file: "test.rs", language });
+  const { entries } = parseSource(source, {
+    file: "test.rs",
+    language,
+    languageId: "rust",
+  });
   assertEquals(entries.length, 2);
   assertEquals(entries[0].displayId, "SRS_BRK_0001");
   assertEquals(entries[1].displayId, "SRS_BRK_0002");
@@ -141,7 +204,11 @@ Deno.test("parseSource: preserves source location for offset entries", async () 
 fn foo() {}
 `;
 
-  const { entries } = parseSource(source, { file: "test.rs", language });
+  const { entries } = parseSource(source, {
+    file: "test.rs",
+    language,
+    languageId: "rust",
+  });
   assertEquals(entries.length, 1);
   assertEquals(entries[0].location.line, 3);
   assertEquals(entries[0].location.column, 1);
@@ -165,7 +232,11 @@ fn documented() {}
 fn entry() {}
 `;
 
-  const { entries } = parseSource(source, { file: "test.rs", language });
+  const { entries } = parseSource(source, {
+    file: "test.rs",
+    language,
+    languageId: "rust",
+  });
   assertEquals(entries.length, 1);
   assertEquals(entries[0].displayId, "SRS_BRK_0001");
 });
@@ -184,7 +255,11 @@ fn foo() {}
 fn bar() {}
 `;
 
-  const { entries } = parseSource(source, { file: "test.rs", language });
+  const { entries } = parseSource(source, {
+    file: "test.rs",
+    language,
+    languageId: "rust",
+  });
   assertEquals(entries.length, 1);
   assertEquals(entries[0].displayId, "SRS_BRK_0001");
 });
@@ -209,7 +284,11 @@ Deno.test("parseSource: handles doc comment with code block", async () => {
 fn foo() {}
 `;
 
-  const { entries } = parseSource(source, { file: "test.rs", language });
+  const { entries } = parseSource(source, {
+    file: "test.rs",
+    language,
+    languageId: "rust",
+  });
   assertEquals(entries.length, 1);
   assertEquals(entries[0].displayId, "SRS_BRK_0001");
   assertStringIncludes(entries[0].body, "gherkin");
@@ -221,13 +300,21 @@ Deno.test("parseSource: returns empty for file with no doc comments", async () =
 fn bar() {}
 `;
 
-  const { entries } = parseSource(source, { file: "test.rs", language });
+  const { entries } = parseSource(source, {
+    file: "test.rs",
+    language,
+    languageId: "rust",
+  });
   assertEquals(entries.length, 0);
 });
 
 Deno.test("parseSource: returns empty for empty source", async () => {
   const language = await getRustLanguage();
-  const { entries } = parseSource("", { file: "test.rs", language });
+  const { entries } = parseSource("", {
+    file: "test.rs",
+    language,
+    languageId: "rust",
+  });
   assertEquals(entries.length, 0);
 });
 
@@ -251,15 +338,18 @@ Deno.test("parseSource: fixture — in-code-rust.rs", async () => {
   const { entries } = parseSource(content, {
     file: "in-code-rust.rs",
     language,
+    languageId: "rust",
   });
 
-  assertEquals(entries.length, 1);
-  assertEquals(entries[0].displayId, "SRS_BRK_0001");
-  assertEquals(entries[0].title, "Sensor input debouncing");
-  assertEquals(entries[0].id, "SRS_01HGW2Q8MNP3");
-  assertEquals(entries[0].source, "doc-comment");
-  assertStringIncludes(entries[0].body, "debounce window");
-  assertEquals(entries[0].rawAttributes.length, 3);
+  // Two entries: the /// block (SRS_BRK_0001) and the //! block (SRS_BRK_0002).
+  assertEquals(entries.length, 2);
+  const first = entries.find((e) => e.displayId === "SRS_BRK_0001")!;
+  assertEquals(first.displayId, "SRS_BRK_0001");
+  assertEquals(first.title, "Sensor input debouncing");
+  assertEquals(first.id, "SRS_01HGW2Q8MNP3");
+  assertEquals(first.source, "doc-comment");
+  assertStringIncludes(first.body, "debounce window");
+  assertEquals(first.rawAttributes.length, 3);
 });
 
 // ---------------------------------------------------------------------------
@@ -279,7 +369,11 @@ Deno.test("parseSource: extracts entries inside mod blocks", async () => {
 }
 `;
 
-  const { entries } = parseSource(source, { file: "test.rs", language });
+  const { entries } = parseSource(source, {
+    file: "test.rs",
+    language,
+    languageId: "rust",
+  });
   assertEquals(entries.length, 1);
   assertEquals(entries[0].displayId, "SRS_BRK_0001");
   assertStringIncludes(entries[0].body, "inside mod");
@@ -309,7 +403,11 @@ mod tests {
 }
 `;
 
-    const { entries } = parseSource(source, { file: "test.rs", language });
+    const { entries } = parseSource(source, {
+      file: "test.rs",
+      language,
+      languageId: "rust",
+    });
     assertEquals(entries.length, 2);
     assertEquals(entries[0].displayId, "SRS_BRK_0001");
     assertEquals(entries[1].displayId, "SRS_BRK_0002");
@@ -330,7 +428,7 @@ Deno.test("parseSource: uses '<unknown>' when no file specified", async () => {
 fn foo() {}
 `;
 
-  const { entries } = parseSource(source, { language });
+  const { entries } = parseSource(source, { language, languageId: "rust" });
   assertEquals(entries[0].location.file, "<unknown>");
 });
 
@@ -349,11 +447,53 @@ Deno.test("parseSource: links is always empty under the four-family model", asyn
 fn foo() {}
 `;
 
-  const { entries } = parseSource(source, { file: "test.rs", language });
+  const { entries } = parseSource(source, {
+    file: "test.rs",
+    language,
+    languageId: "rust",
+  });
   assertEquals(entries.length, 1);
   // Verifies inside the entry block becomes an attribute.
   const verifies = entries[0].rawAttributes.find((a) => a.key === "Verifies");
   assertEquals(verifies?.value, "STK_BRK_0001");
+});
+
+Deno.test("parseSource: Gherkin tokens in Rust fixture are file-relative", async () => {
+  const language = await getRustLanguage();
+  const fixturePath = join(
+    import.meta.dirname!,
+    "..",
+    "..",
+    "..",
+    "..",
+    "tests",
+    "fixtures",
+    "in-code-rust.rs",
+  );
+  const content = await Deno.readTextFile(fixturePath);
+  const { entries } = parseSource(content, {
+    file: "in-code-rust.rs",
+    language,
+    languageId: "rust",
+  });
+  // Two entries: the /// block (SRS_BRK_0001) and the //! block (SRS_BRK_0002).
+  assertEquals(entries.length, 2);
+  // The fixture's Gherkin block is in the first entry (SRS_BRK_0001).
+  const first = entries.find((e) => e.displayId === "SRS_BRK_0001")!;
+  // The fixture's Gherkin block starts with "Scenario: Noise spike..."
+  // on source line 7 (after the title, blank, body, blank, ```gherkin).
+  // Verify the "Scenario" gherkin-section token is at the expected
+  // file-relative position.
+  const sections = first.bodyTokens.filter(
+    (t) => t.kind === "gherkin-section",
+  );
+  // The fixture contains "Scenario:" twice — both should be present.
+  assertEquals(sections.length, 2);
+  // First "Scenario" is on source line 7, after "/// " (4 chars), so col 5.
+  assertEquals(sections[0].text, "Scenario");
+  assertEquals(sections[0].location.line, 7);
+  assertEquals(sections[0].location.column, 5);
+  assertEquals(sections[0].location.file, "in-code-rust.rs");
 });
 
 Deno.test("parseSource: doc comments without entry blocks produce no entries", async () => {
@@ -363,6 +503,157 @@ Deno.test("parseSource: doc comments without entry blocks produce no entries", a
 fn val_aeb_0001_vehicle_stops() {}
 `;
 
-  const { entries } = parseSource(source, { file: "test.rs", language });
+  const { entries } = parseSource(source, {
+    file: "test.rs",
+    language,
+    languageId: "rust",
+  });
   assertEquals(entries.length, 0);
+});
+
+// ---------------------------------------------------------------------------
+// Rust: //! inner doc comment
+// ---------------------------------------------------------------------------
+
+Deno.test("parseSource: extracts Rust //! inner doc comment entry", async () => {
+  const language = await getRustLanguage();
+  const fixturePath = join(
+    import.meta.dirname!,
+    "..",
+    "..",
+    "..",
+    "..",
+    "tests",
+    "fixtures",
+    "in-code-rust.rs",
+  );
+  const content = await Deno.readTextFile(fixturePath);
+  const { entries } = parseSource(content, {
+    file: "in-code-rust.rs",
+    language,
+    languageId: "rust",
+  });
+  // Two entries: the original /// block and the new //! block.
+  assertEquals(entries.length, 2);
+  const inner = entries.find((e) => e.displayId === "SRS_BRK_0002");
+  assertEquals(inner?.title, "Module-level sensor debouncing policy");
+  // bodyTokens for the //! entry's "must" modal.
+  // Source line 30: "//! All sensor drivers in this module must apply..."
+  // prefixWidth = 4 ("//! "), buffer col of "must":
+  //   "  All sensor drivers in this module " = 2 + 34 = 36 chars, so col 37.
+  // File column = (37 - 2) + 4 = 39.
+  const modals = inner!.bodyTokens.filter((t) => t.kind === "modal");
+  assertEquals(modals.length, 1);
+  assertEquals(modals[0].text, "must");
+  assertEquals(modals[0].location.line, 30);
+  assertEquals(modals[0].location.column, 39);
+});
+
+// ---------------------------------------------------------------------------
+// Java: /** */ doc comment
+// ---------------------------------------------------------------------------
+
+Deno.test("parseSource: extracts Java /** */ doc comment entry", async () => {
+  const language = await getJavaLanguage();
+  const fixturePath = join(
+    import.meta.dirname!,
+    "..",
+    "..",
+    "..",
+    "..",
+    "tests",
+    "fixtures",
+    "in-code-java.java",
+  );
+  const content = await Deno.readTextFile(fixturePath);
+  const { entries } = parseSource(content, {
+    file: "in-code-java.java",
+    language,
+    languageId: "java",
+  });
+  assertEquals(entries.length, 1);
+  assertEquals(entries[0].displayId, "SRS_BRK_0001");
+  assertEquals(entries[0].title, "Sensor input debouncing");
+
+  // bodyTokens file-relative check: "shall" appears on source line 4
+  // (" * The sensor driver shall reject..."). Prefix " * " stripped (3 chars).
+  // Buffer line 3: "  The sensor driver shall..." — "shall" at buffer col 21.
+  // File column = (21 - 2) + 3 = 22.
+  const modals = entries[0].bodyTokens.filter((t) => t.kind === "modal");
+  assertEquals(modals.length, 1);
+  assertEquals(modals[0].text, "shall");
+  assertEquals(modals[0].location.line, 4);
+  assertEquals(modals[0].location.column, 22);
+});
+
+// ---------------------------------------------------------------------------
+// Kotlin: /** */ doc comment
+// ---------------------------------------------------------------------------
+
+Deno.test("parseSource: extracts Kotlin /** */ doc comment entry", async () => {
+  const language = await getKotlinLanguage();
+  const fixturePath = join(
+    import.meta.dirname!,
+    "..",
+    "..",
+    "..",
+    "..",
+    "tests",
+    "fixtures",
+    "in-code-kotlin.kt",
+  );
+  const content = await Deno.readTextFile(fixturePath);
+  const { entries } = parseSource(content, {
+    file: "in-code-kotlin.kt",
+    language,
+    languageId: "kotlin",
+  });
+  assertEquals(entries.length, 1);
+  assertEquals(entries[0].displayId, "SRS_BRK_0001");
+
+  // The Kotlin fixture has the same /** */ shape as the Java fixture.
+  // Source line 4: " * The sensor driver shall reject..."
+  // Prefix " * " stripped (3 chars). Buffer line 3: "  The sensor driver shall..."
+  // "shall" at buffer col 21. File column = (21 - 2) + 3 = 22.
+  const modals = entries[0].bodyTokens.filter((t) => t.kind === "modal");
+  assertEquals(modals.length, 1);
+  assertEquals(modals[0].text, "shall");
+  assertEquals(modals[0].location.line, 4);
+  assertEquals(modals[0].location.column, 22);
+});
+
+// ---------------------------------------------------------------------------
+// C++: /** */ doc comment
+// ---------------------------------------------------------------------------
+
+Deno.test("parseSource: extracts C++ /** */ doc comment entry", async () => {
+  const language = await getCppLanguage();
+  const fixturePath = join(
+    import.meta.dirname!,
+    "..",
+    "..",
+    "..",
+    "..",
+    "tests",
+    "fixtures",
+    "in-code-cpp.cpp",
+  );
+  const content = await Deno.readTextFile(fixturePath);
+  const { entries } = parseSource(content, {
+    file: "in-code-cpp.cpp",
+    language,
+    languageId: "cpp",
+  });
+  assertEquals(entries.length, 1);
+  assertEquals(entries[0].displayId, "SRS_BRK_0001");
+
+  // Same fixture shape as Java → same expected position.
+  // Source line 4: " * The sensor driver shall reject..."
+  // Prefix " * " stripped (3 chars). Buffer line 3: "  The sensor driver shall..."
+  // "shall" at buffer col 21. File column = (21 - 2) + 3 = 22.
+  const modals = entries[0].bodyTokens.filter((t) => t.kind === "modal");
+  assertEquals(modals.length, 1);
+  assertEquals(modals[0].text, "shall");
+  assertEquals(modals[0].location.line, 4);
+  assertEquals(modals[0].location.column, 22);
 });

--- a/packages/markspec/core/parser/translate.ts
+++ b/packages/markspec/core/parser/translate.ts
@@ -1,0 +1,143 @@
+/**
+ * @module parser/translate
+ *
+ * Post-pass that walks parsed `Entry[]` and applies a `LineMap` to every
+ * coordinate field — entry locations, body-AST node ranges (which carry
+ * `{line, column}` points without `file`), body tokens. Returns a fresh
+ * entries array; originals are not mutated.
+ *
+ * This is the **one translation point** required by ADR-016 §6. The
+ * upstream parser produces buffer-relative locations; this pass converts
+ * them to file-relative coordinates. When `LineMap.translate` returns
+ * `undefined` (over-run past the block's last line), the affected
+ * location safe-falls to the entry's own translated `location` with
+ * column reset to 1, and a single `console.warn` per entries-batch
+ * flags the drift.
+ */
+
+import type { Entry, SourceLocation } from "../model/mod.ts";
+import type { BodyBlock, ListNode, SourceRange } from "../ast/nodes.ts";
+import type { LineMap } from "./line_map.ts";
+
+type Point = SourceRange["start"]; // { line: number; column: number }
+
+/**
+ * Translate every coordinate inside `entries` through `lineMap`.
+ * Returns a new array of new entries; input is not mutated.
+ */
+export function translateEntryLocations(
+  entries: readonly Entry[],
+  lineMap: LineMap,
+): Entry[] {
+  let warned = false;
+  const warn = (): void => {
+    if (warned) return;
+    warned = true;
+    console.warn(
+      "translateEntryLocations: LineMap.translate returned undefined " +
+        "for at least one location; falling back to entry start. " +
+        "This indicates a coordinate-translation drift.",
+    );
+  };
+
+  return entries.map((entry) => {
+    const translatedEntryLoc = translateLocation(
+      entry.location,
+      lineMap,
+      entry.location,
+      warn,
+    );
+    const fallbackPoint: Point = {
+      line: translatedEntryLoc.line,
+      column: 1,
+    };
+    return {
+      ...entry,
+      location: translatedEntryLoc,
+      bodyAst: entry.bodyAst
+        ? entry.bodyAst.map((block) =>
+          translateBlock(block, lineMap, fallbackPoint, warn)
+        )
+        : entry.bodyAst,
+      bodyTokens: entry.bodyTokens.map((token) => ({
+        ...token,
+        location: translateLocation(
+          token.location,
+          lineMap,
+          translatedEntryLoc,
+          warn,
+        ),
+      })) as Entry["bodyTokens"],
+      properties: entry.properties?.file
+        ? {
+          ...entry.properties,
+          file: {
+            ...entry.properties.file,
+            line: translatedEntryLoc.line,
+            column: translatedEntryLoc.column,
+          },
+        }
+        : entry.properties,
+    };
+  });
+}
+
+/** Translate a SourceLocation (preserves `file` field). */
+function translateLocation(
+  loc: SourceLocation,
+  lineMap: LineMap,
+  fallback: SourceLocation,
+  warn: () => void,
+): SourceLocation {
+  const t = lineMap.translate(loc.line, loc.column);
+  if (!t) {
+    warn();
+    return { file: loc.file, line: fallback.line, column: 1 };
+  }
+  return { file: loc.file, line: t.line, column: t.column };
+}
+
+/** Translate a SourceRange point (no `file` field). */
+function translatePoint(
+  pt: Point,
+  lineMap: LineMap,
+  fallback: Point,
+  warn: () => void,
+): Point {
+  const t = lineMap.translate(pt.line, pt.column);
+  if (!t) {
+    warn();
+    return { line: fallback.line, column: fallback.column };
+  }
+  return { line: t.line, column: t.column };
+}
+
+function translateBlock(
+  block: BodyBlock,
+  lineMap: LineMap,
+  fallbackPoint: Point,
+  warn: () => void,
+): BodyBlock {
+  const range: SourceRange = {
+    start: translatePoint(block.range.start, lineMap, fallbackPoint, warn),
+    end: translatePoint(block.range.end, lineMap, fallbackPoint, warn),
+  };
+  if (block.kind === "list") {
+    const list = block as ListNode;
+    return {
+      ...list,
+      range,
+      items: list.items.map((item) => ({
+        ...item,
+        range: {
+          start: translatePoint(item.range.start, lineMap, fallbackPoint, warn),
+          end: translatePoint(item.range.end, lineMap, fallbackPoint, warn),
+        },
+        blocks: item.blocks.map((b) =>
+          translateBlock(b, lineMap, fallbackPoint, warn)
+        ),
+      })),
+    } satisfies ListNode;
+  }
+  return { ...block, range } as BodyBlock;
+}

--- a/packages/markspec/core/parser/translate_test.ts
+++ b/packages/markspec/core/parser/translate_test.ts
@@ -1,0 +1,154 @@
+/**
+ * @module parser/translate_test
+ *
+ * Unit tests for translateEntryLocations.
+ *
+ * Uses a fake LineMap that adds a fixed offset (dLine, dCol) so
+ * round-trips are mechanically verifiable. No real parsing involved.
+ */
+
+import { assertEquals, assertNotStrictEquals } from "@std/assert";
+import type { Entry, SourceLocation } from "../model/mod.ts";
+import type { LineMap } from "./line_map.ts";
+import { translateEntryLocations } from "./translate.ts";
+
+function fakeLineMap(dLine: number, dCol: number): LineMap {
+  return {
+    translate(line, column) {
+      return { line: line + dLine, column: column + dCol };
+    },
+  };
+}
+
+function loc(line: number, column: number, file = "t.md"): SourceLocation {
+  return { file, line, column };
+}
+
+function minimalEntry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    displayId: "STK_0001" as Entry["displayId"],
+    title: "Title",
+    body: "Body",
+    bodyAst: [],
+    rawAttributes: [],
+    typedAttributes: new Map(),
+    id: undefined,
+    type: undefined,
+    shape: "Authored",
+    location: loc(5, 1),
+    source: "markdown",
+    properties: { file: { path: "t.md", line: 5, column: 1 } },
+    bodyTokens: [],
+    ...overrides,
+  };
+}
+
+Deno.test("translateEntryLocations: translates entry.location", () => {
+  const entries = [minimalEntry({ location: loc(5, 1) })];
+  const out = translateEntryLocations(entries, fakeLineMap(10, 0));
+  assertEquals(out[0].location.line, 15);
+  assertEquals(out[0].location.column, 1);
+  assertEquals(out[0].location.file, "t.md");
+});
+
+Deno.test("translateEntryLocations: translates bodyTokens locations", () => {
+  const entries = [minimalEntry({
+    bodyTokens: [
+      {
+        kind: "modal",
+        text: "shall",
+        case: "lower",
+        location: loc(7, 3),
+      },
+    ],
+  })];
+  const out = translateEntryLocations(entries, fakeLineMap(10, 5));
+  assertEquals(out[0].bodyTokens.length, 1);
+  assertEquals(out[0].bodyTokens[0].location.line, 17);
+  assertEquals(out[0].bodyTokens[0].location.column, 8);
+});
+
+Deno.test("translateEntryLocations: translates bodyAst paragraph range", () => {
+  // SourceRange.start / .end are { line, column } — no `file` field.
+  const entries = [minimalEntry({
+    bodyAst: [
+      {
+        kind: "paragraph",
+        content: { text: "Body" },
+        range: { start: { line: 6, column: 1 }, end: { line: 6, column: 5 } },
+      },
+    ] as Entry["bodyAst"],
+  })];
+  const out = translateEntryLocations(entries, fakeLineMap(10, 0));
+  const block = out[0].bodyAst![0];
+  assertEquals(block.range.start.line, 16);
+  assertEquals(block.range.end.line, 16);
+});
+
+Deno.test("translateEntryLocations: list-block items recurse", () => {
+  const entries = [minimalEntry({
+    bodyAst: [
+      {
+        kind: "list",
+        ordered: false,
+        spread: false,
+        items: [
+          {
+            range: {
+              start: { line: 6, column: 1 },
+              end: { line: 6, column: 9 },
+            },
+            blocks: [
+              {
+                kind: "paragraph",
+                content: { text: "nested" },
+                range: {
+                  start: { line: 6, column: 3 },
+                  end: { line: 6, column: 9 },
+                },
+              },
+            ],
+          },
+        ],
+        range: { start: { line: 6, column: 1 }, end: { line: 6, column: 9 } },
+      },
+    ] as Entry["bodyAst"],
+  })];
+  const out = translateEntryLocations(entries, fakeLineMap(10, 0));
+  const listBlock = out[0].bodyAst![0];
+  assertEquals(listBlock.range.start.line, 16);
+  // Narrow the union before reaching into items.
+  if (listBlock.kind !== "list") throw new Error("expected list");
+  const nested = listBlock.items[0].blocks[0];
+  assertEquals(nested.range.start.line, 16);
+});
+
+Deno.test("translateEntryLocations: undefined translate falls back to entry.location", () => {
+  const sometimesUndefined: LineMap = {
+    translate(line, column) {
+      if (line === 99) return undefined;
+      return { line: line + 1, column };
+    },
+  };
+  const entries = [minimalEntry({
+    location: loc(5, 1),
+    bodyTokens: [
+      { kind: "modal", text: "x", case: "lower", location: loc(99, 7) },
+    ],
+  })];
+  const out = translateEntryLocations(entries, sometimesUndefined);
+  // entry.location was 5 → translates to 6 (offset +1)
+  assertEquals(out[0].location.line, 6);
+  // token was at 99 → translate returned undefined → falls back to translated
+  // entry.location.line with column reset to 1.
+  assertEquals(out[0].bodyTokens[0].location.line, 6);
+  assertEquals(out[0].bodyTokens[0].location.column, 1);
+});
+
+Deno.test("translateEntryLocations: returns a fresh array — originals not mutated", () => {
+  const original = minimalEntry({ location: loc(5, 1) });
+  const out = translateEntryLocations([original], fakeLineMap(10, 0));
+  assertEquals(original.location.line, 5); // unchanged
+  assertEquals(out[0].location.line, 15); // translated
+  assertNotStrictEquals(out[0], original);
+});

--- a/tests/e2e/source_body_tokens_test.ts
+++ b/tests/e2e/source_body_tokens_test.ts
@@ -1,0 +1,80 @@
+/**
+ * @module tests/e2e/source_body_tokens_test
+ *
+ * E2E test: `markspec compile --format json` over source-file doc-comment
+ * entries produces non-empty `bodyTokens` with file-relative coordinates
+ * pointing into the source file.
+ */
+
+import { assert, assertEquals } from "@std/assert";
+import { markspec } from "./helpers.ts";
+
+const PROJECT_YAML = `name: source-bodytokens-e2e\nversion: 0.1.0\n`;
+
+const RUST_SRC = `/// [SRS_BRK_0001] Sensor debouncing
+///
+/// The sensor driver shall reject transient noise.
+///
+///     Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+fn dummy() {}
+`;
+
+const JAVA_SRC = `/**
+ * [SRS_BRK_0002] Java entry
+ *
+ * The system shall do something.
+ *
+ *     Id: 01HGW2R9QLP4ABCDEFGHJKMNPQ
+ */
+class Dummy {}
+`;
+
+Deno.test(
+  "compile: Rust source-file entry has file-relative bodyTokens",
+  async () => {
+    const { code, stdout, stderr } = await markspec(
+      ["compile", "--format", "json", "lib.rs"],
+      {
+        files: { "project.yaml": PROJECT_YAML, "lib.rs": RUST_SRC },
+        permissions: ["--allow-env", "--allow-ffi"],
+      },
+    );
+    assertEquals(code, 0, `stderr: ${stderr}`);
+    const compiled = JSON.parse(stdout);
+    const entry = compiled.entries["SRS_BRK_0001"];
+    assert(entry, "SRS_BRK_0001 missing from compile output");
+    // bodyTokens is non-empty and includes a modal token.
+    const modals = (entry.bodyTokens as Array<
+      { kind: string; text: string; location: { file: string; line: number } }
+    >)
+      .filter((t) => t.kind === "modal");
+    assertEquals(modals.length, 1);
+    assertEquals(modals[0].text, "shall");
+    assertEquals(modals[0].location.line, 3);
+    assertEquals(modals[0].location.file, "lib.rs");
+  },
+);
+
+Deno.test(
+  "compile: Java source-file entry has file-relative bodyTokens",
+  async () => {
+    const { code, stdout, stderr } = await markspec(
+      ["compile", "--format", "json", "Foo.java"],
+      {
+        files: { "project.yaml": PROJECT_YAML, "Foo.java": JAVA_SRC },
+        permissions: ["--allow-env", "--allow-ffi"],
+      },
+    );
+    assertEquals(code, 0, `stderr: ${stderr}`);
+    const compiled = JSON.parse(stdout);
+    const entry = compiled.entries["SRS_BRK_0002"];
+    assert(entry, "SRS_BRK_0002 missing from compile output");
+    const modals = (entry.bodyTokens as Array<
+      { kind: string; text: string; location: { file: string; line: number } }
+    >)
+      .filter((t) => t.kind === "modal");
+    assertEquals(modals.length, 1);
+    assertEquals(modals[0].location.line, 4);
+    assertEquals(modals[0].location.file, "Foo.java");
+  },
+);

--- a/tests/fixtures/in-code-cpp.cpp
+++ b/tests/fixtures/in-code-cpp.cpp
@@ -1,0 +1,12 @@
+/**
+ * [SRS_BRK_0001] Sensor input debouncing
+ *
+ * The sensor driver shall reject transient noise shorter than
+ * the configured debounce window.
+ *
+ *     Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+ *     Satisfies: SYS_BRK_0042
+ *     Labels: ASIL-B
+ */
+void debounce_sensor(void) {
+}

--- a/tests/fixtures/in-code-java.java
+++ b/tests/fixtures/in-code-java.java
@@ -1,0 +1,12 @@
+/**
+ * [SRS_BRK_0001] Sensor input debouncing
+ *
+ * The sensor driver shall reject transient noise shorter than
+ * the configured debounce window.
+ *
+ *     Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+ *     Satisfies: SYS_BRK_0042
+ *     Labels: ASIL-B
+ */
+public class BrakingSensor {
+}

--- a/tests/fixtures/in-code-rust.rs
+++ b/tests/fixtures/in-code-rust.rs
@@ -24,3 +24,12 @@
 fn swt_brk_0001_debounce_filters_noise() {
     // test implementation
 }
+
+//! [SRS_BRK_0002] Module-level sensor debouncing policy
+//!
+//! All sensor drivers in this module must apply at least a 5 ms
+//! debounce window.
+//!
+//!     Id: 01HGW2R9QLP4ABCDEFGHJKMNPQ
+//!     Satisfies: SYS_BRK_0042
+//!     Labels: ASIL-B


### PR DESCRIPTION
## Summary

- Wires a `LineMap` translation layer through `parser/source.ts → parseMarkdown` so source-file (`.rs`/`.kt`/`.java`/`.cpp`) doc-comment entries finally emit **file-relative** `Entry.bodyTokens`. Closes ADR-016 acceptance criterion #6 and the last open story of epic #409.
- Fixes the pre-existing Kotlin (`multiline_comment`) and C++ (`comment`) tree-sitter walker dispatch (previously produced 0 entries silently) and adds Rust `//!` inner doc comment support alongside `///`.
- Adds per-language fixtures (`in-code-java.java`, `in-code-cpp.cpp`; extends `in-code-rust.rs`) with literal file-relative column assertions, plus a CLI roundtrip e2e test.

## Architecture

Three new modules:
- `core/parser/line_map.ts` — `LineMap` interface + `buildBlockLineMap` factory (buffer→file coordinate translation, reusable for future source formats).
- `core/parser/translate.ts` — `translateEntryLocations` post-pass; **one translation point** per ADR-016 §6 (walks `entry.location`, `bodyAst` ranges, `bodyTokens`).
- `core/parser/language_spec.ts` — closed-form per-grammar dispatch table; the tree-sitter walker reads node-type names + predicates from it instead of hard-coding Rust assumptions.

`ParseMarkdownOptions` gains optional `lineMap?: LineMap`. When supplied, the post-pass translates buffer-relative coords to file-relative coords once before returning. `parseSource` builds a per-doc-comment-block LineMap and threads it through. The `bodyTokens: []` stub and the post-hoc `entry.location` overwrite are removed.

## What's verified

- **1757 tests pass / 0 failed** (32 new tests over baseline). New unit tests for `LineMap`, `translate`, `language_spec`; per-language source tests (Rust `///`, `//!`, Java `/**`, Kotlin `/**`, C++ `/**`) with literal file-relative column assertions; e2e CLI roundtrip for source-file `bodyTokens`.
- `just build` green; `deno fmt --check` + `dprint check` clean.

## What's deferred

- **C grammar version mismatch** — `grammars/tree-sitter-c.wasm` is ABI v15 while `web-tree-sitter` accepts v13–v14. Pre-existing, independent of #409. Filed as a separate issue.

## Test plan

- [ ] CI green
- [ ] Manual smoke: in a `.rs` file with `///` doc comment containing `shall`, LSP semantic-tokens render correctly (closes PR #408's source-file rendering regression as a side effect)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
