### PR TITLE
docs(spec): resolve 11 v1.0 blocker open questions across 3 specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,39 @@
 
 ## [Unreleased]
 
+### Specs (decisions)
+
+- **toolchain-distribution:** §8 D1 (binary self-path), D2 (backup retention),
+  and D3 (VS Code verify-only-vs-offer-to-fix) resolved. Adapter list narrowed
+  to two LSP (`vscode`, `neovim`) + two MCP (`claude-desktop`, `vscode`); Zed
+  and Cursor remain `--print`-only. New `--binary-path=<path>` flag on
+  `markspec lsp install` and `markspec mcp install` for explicit binary-path
+  pinning (default writes the invoked name, surviving package-manager
+  upgrades).
+- **prose-analysis:** §8 OQ4 (xref dependency gating), OQ5 (flagship default
+  severity + allowlist ownership), and OQ6 (score roll-up + trend policy)
+  resolved. Flagship rule `xref-glossary-undefined` ships with a glossary-only
+  subset resolver in Stage-2 (`$Identifier`/RIDL rules degrade-to-silent until
+  ADR-016 marker pass lands); defaults to `warning` severity; core ships an
+  English-baseline allowlist (calendar / geography / languages) at
+  `packages/markspec/core/lexicons/capitalized-allow.txt`. Project roll-up is
+  band-counts + mean. **No trend artifact (PR comments, deltas, dashboards)
+  ships in core — this is a deliberate non-feature**, motivated by the §3.3
+  Goodhart's-law constraint that "the score is a smoke detector, not a KPI".
+  Teams that want trend output build it on top of `markspec lint --format
+  json` themselves.
+- **prose-analysis:** PA-2 sentence segmenter pick recorded — rule-based, with
+  a `prose.lexicons.sentence-abbrev` lexicon (list-additive across tiers) for
+  the abbreviation exceptions. Chosen over `Intl.Segmenter` and external NLP
+  libs for snapshot-test determinism across V8 versions.
+- **background-indexing:** all five §9 open questions resolved — verify-then-
+  use with `mtime + size` (content-hash via `--verify=content`); on-demand
+  canonical, no FS watcher; lockfile-pinned federated cache; one `index.db`
+  per worktree; surgical invalidation capped at ≈ 200 affected entries with
+  full-pass fallback above the cap. SQLite engineering eval (10–15 d) is
+  scoped as the first phase of the implementation epic rather than a
+  pre-design gate.
+
 ### Breaking (wire format)
 
 - **core:** `Entry.source` in compile-output JSON changes from a string
@@ -14,6 +47,12 @@
 
 ### Added
 
+- **core:** Core capitalized-allow lexicon at
+  `packages/markspec/core/lexicons/capitalized-allow.txt` — universally-true
+  English baseline (days, months, countries, languages) consumed by the
+  Stage-2 `xref-glossary-undefined` rule. Versioned, capped, explicitly
+  excludes domain vocabulary and standards-body acronyms (per prose-analysis
+  §2.8 / §8 OQ5 resolution).
 - **core:** `Entry.bodyTokens` — flat parser-emitted token stream for inline
   constructs (modal verbs, EARS triggers, Gherkin section/step keywords,
   `$Identifier` entity refs, inline code). Always present, sorted by source

--- a/docs/spec/internal/markspec-background-indexing.md
+++ b/docs/spec/internal/markspec-background-indexing.md
@@ -191,25 +191,82 @@ read caches an upstream's _public_ `/api/` data only.
 
 ## 9. Open questions
 
-Capped at five.
+Capped at five. All five were resolved on 2026-05-25; the original questions are
+preserved so the rationale stays in the spec.
 
 1. **Stale-index trust for `validate`/`compile`.** §4 says correctness commands
    don't trust a stale index. Do they (a) always full-parse (simple, slower CI),
    (b) trust the index iff a fast whole-project hash matches, or (c)
    verify-then-use? The CI-time cost of (a) at 100k entries may be unacceptable.
+
+   **Resolved (2026-05-25): (c) verify-then-use, with `mtime + size` as the
+   default per-file verification and a `--verify=content` flag selecting full
+   content-hash verification.** Per-file granularity localises the trust
+   decision — unchanged files are trusted from the index (one `stat` syscall
+   each), changed files are re-parsed from disk, and cross-file validation runs
+   on the merged set. This is faster than (a) at scale and safer than (b)
+   because a single corrupted entry can't shadow the whole project. Content-hash
+   fallback covers environments where `mtime` is unreliable (some sync tools
+   touch every file's `mtime` on pull) — invoked explicitly via the flag so the
+   default stays cheap.
+
 2. **Watch vs on-demand incremental.** §3.2 warm mode — file-watcher (instant,
    OS-specific, flaky on network FS) vs lazy on-query staleness check (portable,
    a small first-query latency). Which is canonical, which optional?
+
+   **Resolved (2026-05-25): on-demand canonical; no filesystem watcher in v1.**
+   CLI commands (`validate`, `compile`, `show`, `report`, …) are one-shot —
+   on-demand `mtime` check is the natural fit and a watcher would be wasted
+   overhead. The LSP already receives change notifications from the editor (LSP
+   `didChange` / `didSave`) — the editor _is_ the watcher, so a separate FS
+   watcher would be redundant. A standalone watcher only matters for a
+   hypothetical `markspec serve` / `markspec watch` mode that doesn't exist
+   today. Avoiding FS watchers as the canonical mechanism dodges the well-known
+   fragility on network filesystems, container bind-mounts, and
+   save-via-temp-rename editor patterns.
+
 3. **Federated-read cache lifetime.** §3.2 read-through cache of an upstream
    `/api/` — TTL like the sync cache (sync spec §5), or pinned strictly by the
    lockfile hash (lockfile spec §3) and only refreshed on `lock --update`?
+
+   **Resolved (2026-05-25): lockfile-pinned; refreshed only on
+   `lock --update`.** Same reasoning that gave us lockfiles in the first place:
+   a TTL on federated entries means "your CI passes today, fails next Tuesday
+   because upstream silently changed" — the exact failure mode lockfiles were
+   invented to prevent (cargo, npm, pnpm, bundler all converged here). Builds
+   must be reproducible from `(source-tree +
+   lockfile)`; a wall-clock-driven
+   cache breaks that.
+
 4. **Index sharing across worktrees.** A repo with multiple git worktrees (this
    project uses them — `.worktrees/`) — one `index.db` per worktree (isolation,
    N rebuilds) or a shared keyed store (one build, harder invalidation §5)?
+
+   **Resolved (2026-05-25): one `index.db` per worktree.** Worktrees in
+   MarkSpec's typical workflow are short-lived feature branches, so the sharing
+   benefit is small (each worktree's index is mostly the same as `main`'s, but
+   the diverged subset is exactly what needs re-indexing anyway). The sharing
+   _cost_ is large: a shared store needs content-addressed
+   `(file_path, content_hash) → entries` rather than the simpler
+   `file_path → entries`, and invalidation has to defend against "two worktrees
+   touched the same path with different content". SQLite is small at our entry
+   counts; the duplication overhead is real but manageable. Per-worktree
+   isolation also avoids cross-worktree leakage of sandbox-overlay state (an
+   existing hazard with agent-driven sessions in `.claude/worktrees/`). Revisit
+   if rebuild times become a complaint.
+
 5. **Cross-file invalidation cost ceiling.** §5.2's reverse-edge closure is
    bounded but a hub entry (compile-output §2 worst case) has a huge reverse
    set; a rename there is O(huge). Cap the closure and fall back to cold above a
    threshold, or always pay it?
+
+   **Resolved (2026-05-25): cap at a configurable threshold (default ≈ 200
+   affected entries); fall back to a full single-pass re-validate when the cap
+   is exceeded.** Below the cap, the surgical reverse-edge walk wins. Above the
+   cap, a single full pass is more cache-friendly than walking a huge dependency
+   graph, and the constant-factor difference dominates. Threshold tunable via
+   `index.invalidation-cap` (numeric; default 200) — empirical value, expected
+   to change once we have project-scale measurements from the SQLite eval epic.
 
 ## Annex — Cross-reference summary
 

--- a/docs/spec/internal/markspec-prose-analysis.md
+++ b/docs/spec/internal/markspec-prose-analysis.md
@@ -328,13 +328,21 @@ for requirement quality than half the GtWR catalog"), maps to **GtWR v4 R4
   `Definition` slugs (listing-directives §4.2 R4-c slug derivation) →
   `$Identifier` registry → profile-declared `Aliases` (listing-directives §4.3
   R4-g). First hit wins; no hit → diagnostic.
-- It defaults to `warning`, not `error`, and ships with a non-empty allowlist
-  (common English capitalized words, project nouns) so the false-positive rate
-  is bounded. The precision/recall trade and the default-severity question are
-  §8 open question 5.
-- It depends on glossary/`$Identifier` resolution, which is
-  deferred-by-dependency on `main` (§2.2 dependency note). The Stage-2 subset
-  (glossary-only resolver, no code-symbol/RIDL) is §8 open question 4.
+- It defaults to `warning`, not `error`. Core ships an **English-baseline
+  allowlist** at `packages/markspec/core/lexicons/capitalized-allow.txt`
+  (calendar terms, country and language names, common English proper nouns — no
+  domain terms). Profiles extend via `prose.lexicons.capitalized-allow` (§4.1)
+  for domain vocabulary (ASIL, ECU, CAN, …). The baseline file is versioned,
+  capped, and published as a separate auditable artifact so users can see
+  exactly what core treats as universally-defined (§8 OQ5 resolved).
+- It depends on glossary/`$Identifier` resolution. Core ships the **subset
+  resolver** for glossary `Definition` slugs (listing-directives §4.2 R4-c) +
+  in-entry `DefinitionList` terms in Stage-2; `$Identifier` code-symbol and RIDL
+  resolution stay deferred-by-dependency on the ADR-016 marker pass and the
+  rules that consume them degrade-to-silent (§5.4) until that resolver lands.
+  The rule's behaviour across the resolver-completion boundary is **additive
+  enrichment, never new false positives** — more tokens resolve as the resolver
+  grows, so the rule can only fire less, never more (§8 OQ4 resolved).
 
 ### 2.9 Suppression hygiene (`disable-*`)
 
@@ -422,7 +430,8 @@ prose:
   lexicons: # list-additive across tiers (§5.1)
     vague-terms: [snappy, blazing-fast] # extends the canonical R7 list
     escape-clauses: [best-effort] # extends the canonical R8 list
-    capitalized-allow: [ASIL, ECU, CAN]
+    capitalized-allow: [ASIL, ECU, CAN] # extends core English-baseline (§2.8)
+    sentence-abbrev: [Bzgl., Sog.] # extends core abbreviation list (§5.2)
   weights:
     xref-glossary-undefined: 5
   score:
@@ -524,9 +533,18 @@ This section constrains the Stage-2 build prompt; it is **not** implementation.
   resolution (§1.3.1), over in-scope entries (§1.1). It is **off the `fmt` path
   entirely** (AGENTS.md formatters/linters split; core-data-model §3).
 - Inputs are the **existing AST**: `ModalMarker`, `EntityRef` (core-data-model
-  §2.5), body-block types (§2.4), resolved `Type:`. Sentence segmentation uses
-  the tree-sitter Markdown grammar already in the stack (00-context-overview
-  "tree-sitter for local fact extraction"). No new parser.
+  §2.5), body-block types (§2.4), resolved `Type:`. Paragraph-level segmentation
+  reuses the tree-sitter Markdown grammar already in the stack
+  (00-context-overview "tree-sitter for local fact extraction"); no new parser.
+  **Sub-paragraph sentence segmentation is rule-based** — splits on `.`/`?`/`!`
+  followed by whitespace + an uppercase character, with an abbreviation list
+  (`Mr.`, `Dr.`, `e.g.`, `i.e.`, `etc.`, `vs.`, `No.`, `Fig.`, …) maintained as
+  the **`prose.lexicons.sentence-abbrev`** lexicon (extended list-additive by
+  profiles per §5.1). Rule-based segmentation matches §5.1's "deterministic,
+  citable, fast, offline" stance: requirement prose is short and structured, so
+  a hand-rolled tokenizer beats `Intl.Segmenter` (cross-V8-version drift would
+  silently break snapshot tests) and external NLP libs (new dependency, variable
+  determinism).
 - `$Identifier` / glossary resolution is **consumed, not re-implemented**
   (§2.2): it reuses the marker pass's resolver (`MSL-M050/M051`, core-data-model
   §2.5.2). Where that resolver is deferred-by-dependency on `main` (ADR-012 §6),
@@ -694,14 +712,53 @@ Capped at seven (cross-cutting constraint).
    these ship gated behind that resolver, or with a **glossary-only subset
    resolver** (no code-symbol/RIDL) as a Stage-2 partial?
 
+   **Resolved (2026-05-25): glossary-only subset resolver ships now;
+   `$Identifier` / RIDL rules degrade-to-silent until ADR-016's marker pass
+   lands.** The flagship rule (§2.8) is the value proposition of this stage;
+   gating the whole xref group on the deferred marker pass would defer all
+   user-visible payoff. The subset resolver handles glossary `Definition` slugs
+   and in-entry `DefinitionList` terms — both already-parsed structures on
+   `main` after listing-directives shipped in v0.5.0. The transition across the
+   resolver-completion boundary is **additive enrichment, never new false
+   positives** (§2.8): more tokens resolve as the resolver grows, so the rule
+   only fires _less_ over time, never more — the §5.4 "degrade-to-silent, never
+   false-positive" invariant is preserved.
+
 5. **Flagship precision / default severity.** Is `xref-glossary-undefined`
    `warning` or `info` by core default, and does core ship a curated
    capitalized-word allowlist lexicon, or is the allowlist profile-only (risking
    a high false-positive rate for profile-less projects)?
 
+   **Resolved (2026-05-25): default severity is `warning`; core ships an
+   English-baseline allowlist at
+   `packages/markspec/core/lexicons/capitalized-allow.txt`.** Warning is
+   consistent with the existing §2.8 posture and the §3.2 weight table (which
+   already buckets the rule at weight 3 = warn). Severity is decoupled from exit
+   code (§3.4) — warning is a triage signal, not a CI gate. The baseline
+   allowlist scope is **universally-true English only** (calendar terms, country
+   and language names, common English proper nouns — Monday, December, France,
+   NATO, …), explicitly _not_ domain vocabulary; ASIL/ECU/CAN-style additions
+   belong in a profile or `.markspec/lint.yaml` via
+   `prose.lexicons.capitalized-allow` (§4.1). The file is versioned and capped
+   so the implicit-policy footprint of the baseline stays bounded.
+
 6. **Score roll-up semantics.** Is the project roll-up a mean, a count-by-band,
    or both — and is any non-gating _trend_ (e.g. a CI PR comment) surfaced at
    all, given that even a visible trend can become a de-facto target (§3.3)?
+
+   **Resolved (2026-05-25): both (count-by-band as primary, mean as quick-look
+   secondary); core ships no trend artifact.** The dual roll-up matches the
+   existing §3.1 commitment ("count of entries by score band plus the mean —
+   never a single project number"); band counts are the honest signal (improving
+   one band can worsen another, so the histogram resists gaming) and the mean is
+   for at-a-glance. Trend artifacts (PR comments, dashboards, score-delta
+   integrations) are **explicitly out of scope for core** — they're the most
+   aggressive way to turn the score into a Goodhart target (§3.3 anti-pattern is
+   normative: "the score is a smoke detector, not a KPI"). The CLI/JSON output
+   emits the score so teams can compute trends in their own CI if they want;
+   core stays out of the trend-output business by design, not by omission. This
+   is a deliberate non-feature and is called out in CHANGELOG so it doesn't
+   accrete as "missing functionality" pressure later.
 
 7. **Vale merge boundary.** Is merging Vale diagnostics into the MarkSpec
    reporter under `--include-vale` (companion guide §8) in scope for the Stage-2

--- a/docs/spec/internal/markspec-toolchain-distribution.md
+++ b/docs/spec/internal/markspec-toolchain-distribution.md
@@ -168,28 +168,29 @@ signing are Stage-2 concerns.
 
 ```text
 markspec lsp install --editor=<id> [--scope=user|workspace]
+                      [--binary-path=<path>]
                       [--print] [--force] [--no-color]
 ```
 
-| Flag            | Meaning                                                                                                                                                                        |
-| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `--editor=<id>` | Required. One of the first-class adapter ids (§4.2). An unknown id errors with the list of known ids + a typo suggestion (clig.dev "suggest corrections").                     |
-| `--scope`       | `workspace` (default when a `markspec.yaml`/`.markspec.yaml` is found by walking up, §4.4) or `user`. Explicit flag overrides detection.                                       |
-| `--print`       | Write nothing; print the exact config block to **stdout** and the target path to **stderr** (clig.dev stream split). The universal fallback for any editor without an adapter. |
-| `--force`       | Apply the change without the interactive confirm (and the only way to write in a non-TTY context — §6.4).                                                                      |
-| `--no-color`    | Standard clig.dev color control; `NO_COLOR` env honored identically.                                                                                                           |
+| Flag                   | Meaning                                                                                                                                                                                                                                                                                                                                 |
+| ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--editor=<id>`        | Required. One of the first-class adapter ids (§4.2). An unknown id errors with the list of known ids + a typo suggestion (clig.dev "suggest corrections").                                                                                                                                                                              |
+| `--scope`              | `workspace` (default when a `markspec.yaml`/`.markspec.yaml` is found by walking up, §4.4) or `user`. Explicit flag overrides detection.                                                                                                                                                                                                |
+| `--binary-path=<path>` | Override the binary path written into the adapter's managed block. Default is the invoked name `markspec` (relying on `PATH`), which survives package-manager upgrades — see §8 Q3 resolution. Use the flag for isolated builds (e.g. `./dist/markspec`) or Nix-store / asdf-shim layouts where pinning a resolved path is intentional. |
+| `--print`              | Write nothing; print the exact config block to **stdout** and the target path to **stderr** (clig.dev stream split). The universal fallback for any editor without an adapter.                                                                                                                                                          |
+| `--force`              | Apply the change without the interactive confirm (and the only way to write in a non-TTY context — §6.4).                                                                                                                                                                                                                               |
+| `--no-color`           | Standard clig.dev color control; `NO_COLOR` env honored identically.                                                                                                                                                                                                                                                                    |
 
 ### 4.2 First-class editor adapters (v1)
 
-| `--editor` id | Target                                  | Config artifact                                                   |
-| ------------- | --------------------------------------- | ----------------------------------------------------------------- |
-| `vscode`      | VS Code / VS Codium                     | Verifies the MarkSpec extension is the LSP host; see §4.3.        |
-| `neovim`      | Neovim (`nvim-lspconfig` or native LSP) | A Lua managed block in the user's MarkSpec LSP config fragment.   |
-| `zed`         | Zed                                     | A JSON managed region in `settings.json` `lsp` / language server. |
+| `--editor` id | Target                                  | Config artifact                                                 |
+| ------------- | --------------------------------------- | --------------------------------------------------------------- |
+| `vscode`      | VS Code / VS Codium                     | Verifies the MarkSpec extension is the LSP host; see §4.3.      |
+| `neovim`      | Neovim (`nvim-lspconfig` or native LSP) | A Lua managed block in the user's MarkSpec LSP config fragment. |
 
-Any other editor: `--print` only (a documented, copyable snippet). Adding an
-adapter later is additive and does not change the command surface (Open Question
-1).
+Any other editor — including Zed — uses `--print` only (a documented, copyable
+snippet). Two LSP adapters ship in v1; adding more later is additive and does
+not change the command surface (Open Question 1).
 
 ### 4.3 VS Code is extension-hosted
 
@@ -226,19 +227,25 @@ Symmetrical with §4:
 
 ```text
 markspec mcp install --client=<id> [--scope=user|workspace]
+                      [--binary-path=<path>]
                       [--print] [--force] [--no-color]
 ```
+
+`--binary-path` has identical semantics to the LSP install variant (§4.1 table):
+default is the invoked name `markspec`; pass an explicit path for isolated
+builds or path-pinning layouts.
 
 ### 5.2 First-class client adapters (v1)
 
 | `--client` id    | Target                | Config artifact                                                                       |
 | ---------------- | --------------------- | ------------------------------------------------------------------------------------- |
 | `claude-desktop` | Claude Desktop        | A JSON managed region under `mcpServers` in the Claude Desktop config file.           |
-| `cursor`         | Cursor                | A JSON managed region in the Cursor MCP config.                                       |
 | `vscode`         | VS Code (Copilot/MCP) | Verifies the shipped extension's MCP provider; see §5.3. No `.vscode/mcp.json` write. |
 
-Any other client: `--print` the stdio server definition (`command: markspec`,
-`args: ["mcp"]`) for manual paste.
+Any other client — including Cursor — uses `--print` to emit the stdio server
+definition (`command: markspec`, `args: ["mcp"]`) for manual paste. Two MCP
+adapters ship in v1; promotion to a first-class adapter is the topic of Open
+Question 1.
 
 ### 5.3 VS Code MCP is provider-hosted
 
@@ -351,12 +358,14 @@ clig.dev"; <https://clig.dev/>):
 
 ## 8. Open questions
 
-Capped at five (Prompt-3 constraint).
+Capped at five (Prompt-3 constraint). Three were resolved on 2026-05-25; their
+decisions are recorded inline so the rationale stays with the question.
 
-1. **Adapter growth policy.** v1 ships three LSP + three MCP adapters
-   (§4.2/§5.2). Who owns the criteria for promoting an editor from `--print` to
-   a first-class adapter, and is the adapter set versioned with the binary or
-   independently extensible (a hooks-style contribution, cf. ADR-008 §10)?
+1. **Adapter growth policy.** v1 ships two LSP + two MCP adapters (§4.2/§5.2 —
+   narrowed from the original three-per-surface scope on 2026-05-19). Who owns
+   the criteria for promoting an editor from `--print` to a first-class adapter,
+   and is the adapter set versioned with the binary or independently extensible
+   (a hooks-style contribution, cf. ADR-008 §10)?
 2. **`markspec.yaml` vs `.markspec.yaml` as the workspace marker.** §4.4 treats
    either as the project root signal, matching the profile loader. If a repo has
    `project.yaml` but no `.markspec.yaml`, is that still a workspace for
@@ -367,13 +376,43 @@ Capped at five (Prompt-3 constraint).
    PATH-shimmed install may resolve to the shim. Should the installer write the
    resolved real path, the invoked name (`markspec`, relying on PATH), or make
    it a flag?
+
+   **Resolved (2026-05-25): the invoked name (`markspec`) is the default; an
+   explicit `--binary-path=<path>` flag is the override.** Writing a resolved
+   real path by default silently pins the editor to a specific binary version —
+   a real failure mode under version managers (asdf, mise, brew-cellar,
+   Nix-store) where `brew upgrade markspec` would leave the editor launching the
+   stale cellar path. The invoked name survives upgrades cleanly; §3.3's runtime
+   skew detection is the safety net when multiple `markspec` binaries end up on
+   `PATH`. The flag covers the genuine pinning cases (Nix-store,
+   `./dist/markspec` development builds, multi-version installs) without making
+   the default clever.
+
 4. **Backup retention.** §6.3 writes a timestamped backup on every apply.
    Unbounded backups accumulate. Is pruning (keep last N) in scope for the
    installer, or left to the user / OS?
+
+   **Resolved (2026-05-25): no pruning in v1; backup retention is the user's /
+   OS's responsibility.** Backups land only on _actual_ apply (idempotence §6.2
+   skips no-op re-runs), so accumulation is slow. Silent deletion of user files
+   contradicts §6.3's "preview every change" ethos. If real complaints arrive,
+   an opt-in `--keep-backups=N` flag can be added in a follow-up — YAGNI until
+   then.
+
 5. **VS Code verify-only vs offer-to-fix.** §4.3/§5.3 make VS Code verify-only.
    When the extension is absent entirely, should `install` attempt
    `code --install-extension`, or strictly stay out of the editor's extension
    manager and only print instructions?
+
+   **Resolved (2026-05-25): print instructions only; never invoke
+   `code --install-extension`.** Stays consistent with §4.3's already-committed
+   "verifies and reports, does not mutate config" posture for VS Code.
+   Auto-invoking `code --install-extension` invites a long tail of edge cases —
+   VS Codium and Cursor share the `code` binary but route to different
+   marketplaces; proxy/firewall blocks; publisher-id mismatches — and the
+   extension install bypasses the diff/preview/backup contract that §6.3 makes
+   load-bearing. The user cost of running one extra command is trivial; the
+   support tail of doing it ourselves is not.
 
 ---
 

--- a/packages/markspec/core/lexicons/capitalized-allow.txt
+++ b/packages/markspec/core/lexicons/capitalized-allow.txt
@@ -1,0 +1,138 @@
+# MarkSpec core capitalized-allow lexicon
+#
+# Words on this list are not flagged by MSL-Q500
+# (xref-glossary-undefined) even when no glossary entry defines them.
+# See `docs/spec/internal/markspec-prose-analysis.md` §2.8 for the
+# flagship-rule resolution policy.
+#
+# Scope policy (intentionally narrow):
+#
+#   - Calendar terms (days, months) — universally English, never
+#     domain-specific.
+#   - Geographic proper nouns (countries, major regions, languages) —
+#     universally referenced in compliance prose without definition.
+#
+# Out of scope:
+#
+#   - Standards-body acronyms (ISO, IEEE, RFC, NATO, …). GtWR v4 R37
+#     requires every acronym to be expanded on first use; the lint
+#     should fire on these in a compliance project, and profiles can
+#     opt them out via `prose.lexicons.capitalized-allow` if they
+#     don't.
+#   - Domain terminology (ASIL, ECU, CAN, HMI, …). These belong in a
+#     profile manifest (`prose.lexicons.capitalized-allow`) or a
+#     project `.markspec/lint.yaml` — never in core.
+#   - Vendor / product names. Same reasoning — profile-level concern.
+#
+# Format: one token per line. Blank lines and lines starting with `#`
+# are ignored. Lookup is case-sensitive (matches the parser's
+# Capitalization detection).
+#
+# Versioning: this file is part of MarkSpec's release surface. Edits
+# require a CHANGELOG entry and review.
+
+# --- Days of the week --------------------------------------------------------
+Monday
+Tuesday
+Wednesday
+Thursday
+Friday
+Saturday
+Sunday
+
+# --- Months of the year ------------------------------------------------------
+January
+February
+March
+April
+May
+June
+July
+August
+September
+October
+November
+December
+
+# --- Continents and major regions --------------------------------------------
+Africa
+Antarctica
+Asia
+Europe
+Oceania
+America
+
+# --- Countries (commonly referenced in compliance docs) ----------------------
+Argentina
+Australia
+Austria
+Belgium
+Brazil
+Canada
+Chile
+China
+Colombia
+Czechia
+Denmark
+Egypt
+Finland
+France
+Germany
+Greece
+Hungary
+India
+Indonesia
+Ireland
+Israel
+Italy
+Japan
+Korea
+Mexico
+Netherlands
+Norway
+Pakistan
+Peru
+Philippines
+Poland
+Portugal
+Romania
+Russia
+Singapore
+Slovakia
+Slovenia
+Spain
+Sweden
+Switzerland
+Taiwan
+Thailand
+Turkey
+Ukraine
+Vietnam
+
+# --- Composite / commonly abbreviated political entities ---------------------
+England
+Scotland
+Wales
+
+# --- Languages (commonly referenced in i18n / locale prose) ------------------
+Arabic
+Chinese
+Dutch
+English
+Finnish
+French
+German
+Greek
+Hebrew
+Hindi
+Hungarian
+Italian
+Japanese
+Korean
+Polish
+Portuguese
+Russian
+Spanish
+Swedish
+Turkish
+Ukrainian


### PR DESCRIPTION
## Summary

Ratifies the open-question resolutions for the three v1.0 blockers tracked
in project memory — toolchain Tier 3, prose-analysis Stage-2 PA-3, and
background indexing — and adds the core capitalized-allow lexicon those
resolutions reference. 11 decisions across 3 specs; preserves the original
questions inline with appended **Resolved (2026-05-25)** blocks so the
rationale stays in the spec.

### Toolchain — `markspec-toolchain-distribution.md` §8 D1/D2/D3 resolved
- **D1 binary self-path:** new `--binary-path=<path>` flag on `lsp install`
  and `mcp install`; default writes the invoked name (`markspec`) so
  editors track package-manager upgrades instead of pinning a resolved
  cellar path.
- **D2 backup retention:** no pruning in v1; user/OS responsibility.
- **D3 VS Code absent extension:** print instructions only; never invoke
  `code --install-extension` (publisher-id mismatch, VS-Codium/Cursor
  marketplace divergence, bypasses the diff/preview/backup contract).
- **Adapter scope narrowed:** vscode + neovim (LSP), claude-desktop +
  vscode (MCP). Zed and Cursor → `--print` only. Reflects the 2026-05-19
  Tier-3 narrowing.

### Prose PA-3 — `markspec-prose-analysis.md` §8 OQ4/OQ5/OQ6 resolved
- **OQ4 dependency gating:** flagship `xref-glossary-undefined` ships
  with a glossary-only subset resolver in Stage-2; \`\$Identifier\` / RIDL
  rules degrade-to-silent until ADR-016's marker pass lands. The
  resolver-completion boundary is **additive enrichment, never new
  false positives**.
- **OQ5 default severity + allowlist:** default = `warning`; core ships
  an English-baseline lexicon at
  `packages/markspec/core/lexicons/capitalized-allow.txt` (calendar,
  geography, languages only — no domain vocab, no standards-body
  acronyms).
- **OQ6 score roll-up:** band-counts + mean. **No trend artifact in
  core** — deliberate non-feature per §3.3 Goodhart's-law constraint.

Also records the **PA-2 sentence-segmenter pick** (rule-based, with a
`prose.lexicons.sentence-abbrev` lexicon — chosen over `Intl.Segmenter`
and external NLP libs for snapshot-test determinism).

### Background indexing — `markspec-background-indexing.md` §9 all five resolved
- Verify-then-use with `mtime + size` (`--verify=content` fallback).
- On-demand canonical; no FS watcher in v1.
- Federated-read cache lockfile-pinned, refreshed only on `lock --update`.
- One `index.db` per worktree.
- Surgical invalidation capped at ≈ 200 affected entries
  (`index.invalidation-cap`); above-cap rename falls back to a single
  full re-validate pass.
- SQLite eval (10–15 d) scoped as the first phase of the implementation
  epic rather than a pre-design gate.

### Adds
- `packages/markspec/core/lexicons/capitalized-allow.txt` — the
  versioned, capped English-baseline allowlist the §8 OQ5 resolution
  references. Not yet wired into the binary; implementation lands with
  the Stage-2 PA-3 build.

## Test plan

This is a spec-resolution + new-artifact PR; no code execution paths
change. Pre-commit hook ran the full check pipeline:

- [x] \`deno fmt --check\` — clean
- [x] \`dprint check\` — clean
- [x] \`deno lint\` — clean
- [x] \`deno check packages/markspec/{main,core/mod,lsp/server,mcp/server}.ts\` — clean
- [x] \`git std lint\` — clean
- [x] \`git status\` verified clean inside the worktree (no sandbox-overlay
      divergence — main worktree untouched)

Follow-ups for the implementation epics (out of scope for this PR):

- Wire \`core/lexicons/capitalized-allow.txt\` into the binary at compile
  time (consumed by Stage-2 PA-3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)