### PR TITLE
feat(core): typl parser foundation (PR 1 of 8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,12 @@
   Stage-2 `xref-glossary-undefined` rule. Versioned, capped, explicitly
   excludes domain vocabulary and standards-body acronyms (per prose-analysis
   §2.8 / §8 OQ5 resolution).
+- **typl parser foundation (PR 1)**: new `core/typl/` module exposes
+  `parseTyplBlock` producing a `Shape` discriminated-union AST covering
+  10 variants (primitive, range, length, pattern, array, enum, record,
+  literal, ref, optional). 9-kind vocabulary (`value` default + 8
+  explicit). 8 diagnostic codes (TYPL-001..008). No Markdown integration
+  yet — surfaces ship in PRs 2–5. See ADR-019.
 - **core:** `Entry.bodyTokens` — flat parser-emitted token stream for inline
   constructs (modal verbs, EARS triggers, Gherkin section/step keywords,
   `$Identifier` entity refs, inline code). Always present, sorted by source

--- a/docs/architecture/adr-019-typl-type-dsl.md
+++ b/docs/architecture/adr-019-typl-type-dsl.md
@@ -1,0 +1,49 @@
+# ADR-019 — typl: Type Specification DSL
+
+**Status:** Accepted **Date:** 2026-05-25 **Supersedes:** — **Related:** ADR-016
+(body-token AST)
+
+## Context
+
+MarkSpec entries reference `$Name` identifiers via ADR-016's body-token
+extractor, but the language has no way to declare their kind or shape. This
+blocks LSP affordances, cross-entry collision detection, and downstream codegen
+(the planned RIDL bridge).
+
+## Decision
+
+Introduce **typl**, a small Markdown-embedded DSL with two statement forms:
+
+- `$X : [kind] shape` — binding (kind defaults to `value`)
+- `type X = shape` — typedef
+
+Closed kind vocabulary (9): `value`, `event`, `signal`, `command`, `state`,
+`const`, `config`, `document`, `stream`.
+
+Three Markdown surfaces (fence, bullet glossary, inline backtick) all parse to
+the same Schema AST. Entry-local scope for v1; profile / file scope deferred to
+v2.
+
+## Consequences
+
+- New module `packages/markspec/core/typl/` with self-contained parser and AST.
+- `Entry` model gains `types?: { bindings, typedefs }` field (added in PR 3).
+- Compile output gains per-entry `types` + corpus-level `typeRegistry` (PRs 3
+  and 6).
+- 8 new diagnostic codes `TYPL-001..008`.
+- LSP layers hover / completion / diagnostics over the registry (PR 7).
+- Downstream RIDL emitters consume the corpus registry.
+
+## Alternatives considered
+
+- Inline-only declaration at first mention — rejected for prose readability
+  hazard.
+- GFM bindings table as a primary surface — rejected because literal `|` in
+  unions breaks tables and dprint cannot preserve def-list line structure.
+- Required named types (RIDL-style) — deferred to a strict-mode profile setting
+  in v2.
+
+## See also
+
+- Design history: brainstorming output (not in repo — local design folder).
+- Plan: PR series of 8 incremental slices; PR 1 (this) ships the pure parser.

--- a/packages/markspec/core/mod.ts
+++ b/packages/markspec/core/mod.ts
@@ -246,3 +246,5 @@ export type {
 // Lint (prose-analysis)
 export { isProseScope, runLint } from "./lint/mod.ts";
 export type { LintDiagnostic, LintOptions, LintResult } from "./lint/mod.ts";
+
+export * as typl from "./typl/mod.ts";

--- a/packages/markspec/core/typl/ast.ts
+++ b/packages/markspec/core/typl/ast.ts
@@ -47,8 +47,8 @@ export type Shape =
     max?: number;
     exact?: number;
   }
-  | { kind: "enum"; values: (string | number | boolean)[] }
-  | { kind: "record"; fields: Record<string, Shape> }
+  | { kind: "enum"; values: readonly (string | number | boolean)[] }
+  | { kind: "record"; fields: Readonly<Record<string, Shape>> }
   | { kind: "literal"; value: string | number | boolean }
   | { kind: "ref"; name: string }
   | { kind: "optional"; inner: Shape };
@@ -66,6 +66,10 @@ export interface Binding {
   readonly statementKind: "binding";
   readonly name: string; // includes leading "$"
   readonly kind: Kind;
+  /**
+   * Optional. Absent when the binding declares only a role with no payload
+   * (e.g. `$Idle : state`, or `$Click : event` with no carried data).
+   */
   readonly shape?: Shape;
   readonly position: Position;
 }

--- a/packages/markspec/core/typl/ast.ts
+++ b/packages/markspec/core/typl/ast.ts
@@ -1,0 +1,87 @@
+/**
+ * @module typl/ast
+ *
+ * AST node types for the typl DSL. These types form the foundation
+ * for the lexer, parser, validator, and evaluator.
+ */
+
+/**
+ * Closed kind vocabulary. `value` is the default kind when an author omits
+ * it from a binding.
+ */
+export const KINDS = [
+  "value",
+  "event",
+  "signal",
+  "command",
+  "state",
+  "const",
+  "config",
+  "document",
+  "stream",
+] as const;
+export type Kind = typeof KINDS[number];
+
+/** Schema AST — one discriminated union covering all shape variants. */
+export type Shape =
+  | { kind: "primitive"; type: "int" | "float" | "bool" | "string" | "bytes" }
+  | {
+    kind: "range";
+    type: "int" | "float";
+    min?: number;
+    max?: number;
+    exact?: number;
+  }
+  | {
+    kind: "length";
+    type: "string" | "bytes";
+    min?: number;
+    max?: number;
+    exact?: number;
+  }
+  | { kind: "pattern"; regex: string; flags?: string }
+  | {
+    kind: "array";
+    element: Shape;
+    min?: number;
+    max?: number;
+    exact?: number;
+  }
+  | { kind: "enum"; values: (string | number | boolean)[] }
+  | { kind: "record"; fields: Record<string, Shape> }
+  | { kind: "literal"; value: string | number | boolean }
+  | { kind: "ref"; name: string }
+  | { kind: "optional"; inner: Shape };
+
+/** Source position carried through every statement for diagnostics. */
+export interface Position {
+  /** 1-based line within the typl source. */
+  readonly line: number;
+  /** 1-based column. */
+  readonly column: number;
+}
+
+/** A `$X : [kind] shape` declaration. */
+export interface Binding {
+  readonly statementKind: "binding";
+  readonly name: string; // includes leading "$"
+  readonly kind: Kind;
+  readonly shape?: Shape;
+  readonly position: Position;
+}
+
+/** A `type X = shape` declaration. */
+export interface Typedef {
+  readonly statementKind: "typedef";
+  readonly name: string; // no leading "$"
+  readonly shape: Shape;
+  readonly position: Position;
+}
+
+export type Statement = Binding | Typedef;
+
+/** A parsed typl source unit. */
+export interface TyplBlock {
+  readonly bindings: readonly Binding[];
+  readonly typedefs: readonly Typedef[];
+}

--- a/packages/markspec/core/typl/ast_test.ts
+++ b/packages/markspec/core/typl/ast_test.ts
@@ -1,0 +1,31 @@
+import { assertEquals } from "@std/assert";
+import type { Shape } from "./ast.ts";
+
+Deno.test("Shape: exhaustive discriminated-union switch", () => {
+  function describe(s: Shape): string {
+    switch (s.kind) {
+      case "primitive":
+        return s.type;
+      case "range":
+        return `${s.type} range`;
+      case "length":
+        return `${s.type} length`;
+      case "pattern":
+        return `pattern /${s.regex}/${s.flags ?? ""}`;
+      case "array":
+        return "array";
+      case "enum":
+        return `enum(${s.values.length})`;
+      case "record":
+        return `record(${Object.keys(s.fields).length})`;
+      case "literal":
+        return `literal ${String(s.value)}`;
+      case "ref":
+        return `ref ${s.name}`;
+      case "optional":
+        return "optional";
+    }
+  }
+  const sample: Shape = { kind: "primitive", type: "int" };
+  assertEquals(describe(sample), "int");
+});

--- a/packages/markspec/core/typl/diagnostics.ts
+++ b/packages/markspec/core/typl/diagnostics.ts
@@ -18,6 +18,17 @@ const EXPLICIT_KIND_LIST: string = KINDS.filter((k) => k !== "value").join(
   ", ",
 );
 
+/** Union of all valid TYPL diagnostic codes. */
+export type TyplCode =
+  | "TYPL-001"
+  | "TYPL-002"
+  | "TYPL-003"
+  | "TYPL-004"
+  | "TYPL-005"
+  | "TYPL-006"
+  | "TYPL-007"
+  | "TYPL-008";
+
 /** Shape of each entry in {@linkcode TYPL_CODES}. */
 export interface TyplCodeEntry {
   readonly severity: Severity;
@@ -34,13 +45,13 @@ export interface TyplCodeEntry {
  * containing file path; see PR 6 in the implementation plan.
  */
 export interface TyplDiagnostic {
-  readonly code: string;
+  readonly code: TyplCode;
   readonly severity: Severity;
   readonly message: string;
   readonly position: Position;
 }
 
-export const TYPL_CODES: Record<string, TyplCodeEntry> = {
+export const TYPL_CODES: Record<TyplCode, TyplCodeEntry> = {
   "TYPL-001": {
     severity: "error",
     template:
@@ -89,7 +100,7 @@ export const TYPL_CODES: Record<string, TyplCodeEntry> = {
  * for now, callers should test message-formatting for each code.
  */
 export function typlDiagnostic(
-  code: string,
+  code: TyplCode,
   params: Record<string, string | number>,
   position: Position,
 ): TyplDiagnostic {

--- a/packages/markspec/core/typl/diagnostics.ts
+++ b/packages/markspec/core/typl/diagnostics.ts
@@ -1,0 +1,61 @@
+// packages/markspec/core/typl/diagnostics.ts
+import type { Position } from "./ast.ts";
+
+export interface TyplDiagnostic {
+  readonly code: keyof typeof TYPL_CODES;
+  readonly severity: "error" | "warning" | "info";
+  readonly message: string;
+  readonly position: Position;
+}
+
+export const TYPL_CODES = {
+  "TYPL-001": {
+    severity: "error" as const,
+    template:
+      "Duplicate binding for ${name} in the same entry (first wins, this is a duplicate).",
+  },
+  "TYPL-002": {
+    severity: "error" as const,
+    template:
+      "${name} is declared as kind ${kindA} here and ${kindB} in ${otherFile}:${otherLine}.",
+  },
+  "TYPL-003": {
+    severity: "error" as const,
+    template:
+      "${name} is declared with a different shape than in ${otherFile}:${otherLine}.",
+  },
+  "TYPL-004": {
+    severity: "error" as const,
+    template: "Typedef ${name} is redefined within the same entry.",
+  },
+  "TYPL-005": {
+    severity: "error" as const,
+    template: "Reference to undefined typedef ${name}.",
+  },
+  "TYPL-006": {
+    severity: "error" as const,
+    template: "Malformed schema: ${detail}.",
+  },
+  "TYPL-007": {
+    severity: "error" as const,
+    template:
+      "Unknown kind keyword ${keyword}. Expected one of: event, signal, command, state, const, config, document, stream.",
+  },
+  "TYPL-008": {
+    severity: "error" as const,
+    template: "Literal ${value} violates declared ${constraint} (${detail}).",
+  },
+} as const;
+
+export function typlDiagnostic<C extends keyof typeof TYPL_CODES>(
+  code: C,
+  params: Record<string, string | number>,
+  position: Position,
+): TyplDiagnostic {
+  const entry = TYPL_CODES[code];
+  let message: string = entry.template;
+  for (const [k, v] of Object.entries(params)) {
+    message = message.replaceAll(`\${${k}}`, String(v));
+  }
+  return { code, severity: entry.severity, message, position };
+}

--- a/packages/markspec/core/typl/diagnostics.ts
+++ b/packages/markspec/core/typl/diagnostics.ts
@@ -14,7 +14,15 @@ import type { Severity } from "../model/mod.ts";
  * `KINDS` (excluding the implicit default "value") so the message stays
  * in sync with the authoritative vocabulary automatically.
  */
-const EXPLICIT_KIND_LIST = KINDS.filter((k) => k !== "value").join(", ");
+const EXPLICIT_KIND_LIST: string = KINDS.filter((k) => k !== "value").join(
+  ", ",
+);
+
+/** Shape of each entry in {@linkcode TYPL_CODES}. */
+export interface TyplCodeEntry {
+  readonly severity: Severity;
+  readonly template: string;
+}
 
 /**
  * A diagnostic emitted by the typl parser.
@@ -26,50 +34,50 @@ const EXPLICIT_KIND_LIST = KINDS.filter((k) => k !== "value").join(", ");
  * containing file path; see PR 6 in the implementation plan.
  */
 export interface TyplDiagnostic {
-  readonly code: keyof typeof TYPL_CODES;
+  readonly code: string;
   readonly severity: Severity;
   readonly message: string;
   readonly position: Position;
 }
 
-export const TYPL_CODES = {
+export const TYPL_CODES: Record<string, TyplCodeEntry> = {
   "TYPL-001": {
-    severity: "error" as const,
+    severity: "error",
     template:
       "Duplicate binding for ${name} in the same entry (first wins, this is a duplicate).",
   },
   "TYPL-002": {
-    severity: "error" as const,
+    severity: "error",
     template:
       "${name} is declared as kind ${kindA} here and ${kindB} in ${otherFile}:${otherLine}.",
   },
   "TYPL-003": {
-    severity: "error" as const,
+    severity: "error",
     template:
       "${name} is declared with a different shape than in ${otherFile}:${otherLine}.",
   },
   "TYPL-004": {
-    severity: "error" as const,
+    severity: "error",
     template: "Typedef ${name} is redefined within the same entry.",
   },
   "TYPL-005": {
-    severity: "error" as const,
+    severity: "error",
     template: "Reference to undefined typedef ${name}.",
   },
   "TYPL-006": {
-    severity: "error" as const,
+    severity: "error",
     template: "Malformed schema: ${detail}.",
   },
   "TYPL-007": {
-    severity: "error" as const,
+    severity: "error",
     template:
       `Unknown kind keyword \${keyword}. Expected one of: ${EXPLICIT_KIND_LIST}.`,
   },
   "TYPL-008": {
-    severity: "error" as const,
+    severity: "error",
     template: "Literal ${value} violates declared ${constraint} (${detail}).",
   },
-} as const;
+};
 
 /**
  * Construct a typl diagnostic by substituting `${var}` placeholders in the
@@ -80,12 +88,15 @@ export const TYPL_CODES = {
  * mapping per code is possible with conditional types but is deferred;
  * for now, callers should test message-formatting for each code.
  */
-export function typlDiagnostic<C extends keyof typeof TYPL_CODES>(
-  code: C,
+export function typlDiagnostic(
+  code: string,
   params: Record<string, string | number>,
   position: Position,
 ): TyplDiagnostic {
   const entry = TYPL_CODES[code];
+  if (!entry) {
+    throw new Error(`Unknown TYPL code: ${code}`);
+  }
   let message: string = entry.template;
   for (const [k, v] of Object.entries(params)) {
     message = message.replaceAll(`\${${k}}`, String(v));

--- a/packages/markspec/core/typl/diagnostics.ts
+++ b/packages/markspec/core/typl/diagnostics.ts
@@ -1,9 +1,33 @@
-// packages/markspec/core/typl/diagnostics.ts
+/**
+ * @module typl/diagnostics
+ *
+ * Diagnostic codes emitted by the typl parser and validator (TYPL-001
+ * through TYPL-008). Each code carries a severity and a template; the
+ * `typlDiagnostic` helper performs `${var}` substitution.
+ */
 import type { Position } from "./ast.ts";
+import { KINDS } from "./ast.ts";
+import type { Severity } from "../model/mod.ts";
 
+/**
+ * The explicit-kind list used in TYPL-007 error messages. Derived from
+ * `KINDS` (excluding the implicit default "value") so the message stays
+ * in sync with the authoritative vocabulary automatically.
+ */
+const EXPLICIT_KIND_LIST = KINDS.filter((k) => k !== "value").join(", ");
+
+/**
+ * A diagnostic emitted by the typl parser.
+ *
+ * Carries only line/column position because the parser operates on raw
+ * typl source strings (extracted from fences, bullets, or inline code
+ * spans) without knowing the host file. Surface adapters bridge
+ * TyplDiagnostic to the core `Diagnostic` type by attaching the
+ * containing file path; see PR 6 in the implementation plan.
+ */
 export interface TyplDiagnostic {
   readonly code: keyof typeof TYPL_CODES;
-  readonly severity: "error" | "warning" | "info";
+  readonly severity: Severity;
   readonly message: string;
   readonly position: Position;
 }
@@ -39,7 +63,7 @@ export const TYPL_CODES = {
   "TYPL-007": {
     severity: "error" as const,
     template:
-      "Unknown kind keyword ${keyword}. Expected one of: event, signal, command, state, const, config, document, stream.",
+      `Unknown kind keyword \${keyword}. Expected one of: ${EXPLICIT_KIND_LIST}.`,
   },
   "TYPL-008": {
     severity: "error" as const,
@@ -47,6 +71,15 @@ export const TYPL_CODES = {
   },
 } as const;
 
+/**
+ * Construct a typl diagnostic by substituting `${var}` placeholders in the
+ * code's template with the supplied params.
+ *
+ * Note: param keys are not type-checked against the template — a missing
+ * key leaves a raw `${key}` placeholder in the message. Compile-time
+ * mapping per code is possible with conditional types but is deferred;
+ * for now, callers should test message-formatting for each code.
+ */
 export function typlDiagnostic<C extends keyof typeof TYPL_CODES>(
   code: C,
   params: Record<string, string | number>,

--- a/packages/markspec/core/typl/diagnostics_test.ts
+++ b/packages/markspec/core/typl/diagnostics_test.ts
@@ -23,5 +23,8 @@ Deno.test("typlDiagnostic: formats template substitutions", () => {
   });
   assertEquals(d.code, "TYPL-007");
   assertEquals(d.severity, "error");
-  assertEquals(d.message.includes("stream"), true);
+  assertEquals(
+    d.message,
+    "Unknown kind keyword stream. Expected one of: event, signal, command, state, const, config, document, stream.",
+  );
 });

--- a/packages/markspec/core/typl/diagnostics_test.ts
+++ b/packages/markspec/core/typl/diagnostics_test.ts
@@ -1,0 +1,27 @@
+// packages/markspec/core/typl/diagnostics_test.ts
+import { assertEquals } from "@std/assert";
+import { TYPL_CODES, typlDiagnostic } from "./diagnostics.ts";
+
+Deno.test("TYPL codes: 001..008 present with severity + template", () => {
+  const expected = [
+    "TYPL-001",
+    "TYPL-002",
+    "TYPL-003",
+    "TYPL-004",
+    "TYPL-005",
+    "TYPL-006",
+    "TYPL-007",
+    "TYPL-008",
+  ];
+  assertEquals(Object.keys(TYPL_CODES).sort(), expected);
+});
+
+Deno.test("typlDiagnostic: formats template substitutions", () => {
+  const d = typlDiagnostic("TYPL-007", { keyword: "stream" }, {
+    line: 1,
+    column: 12,
+  });
+  assertEquals(d.code, "TYPL-007");
+  assertEquals(d.severity, "error");
+  assertEquals(d.message.includes("stream"), true);
+});

--- a/packages/markspec/core/typl/grammar.ts
+++ b/packages/markspec/core/typl/grammar.ts
@@ -4,9 +4,6 @@
  * Statement-level parser for the typl DSL. Converts a flat `Token[]`
  * stream (from the lexer) into a `TyplBlock` AST containing `Binding[]`
  * and `Typedef[]` statements.
- *
- * Shape parsing (`parseShape` / `parseShapeOptional`) is stubbed in this
- * task and filled in by Task 6.
  */
 
 import {
@@ -36,13 +33,7 @@ const PRIMITIVE_NAMES = new Set<string>([
   "bytes",
 ]);
 
-/**
- * Recursive-descent parser for a typl source block.
- *
- * The `protected parseShape*` methods are stubs intentionally left for
- * Task 6 to fill in. Subclasses (or an override in Task 6) will provide
- * the real implementation.
- */
+/** Recursive-descent parser for a typl source block. */
 class Parser {
   private i = 0;
   private diagnostics: TyplDiagnostic[] = [];
@@ -153,20 +144,282 @@ class Parser {
   }
 
   // -----------------------------------------------------------------------
-  // Shape parsing — stubbed. Task 6 fills these in.
+  // Shape parsing
   // -----------------------------------------------------------------------
-
-  /** Parse a mandatory shape expression. Returns `undefined` when absent. */
-  private parseShape(): Shape | undefined {
-    return undefined;
-  }
 
   /**
    * Parse an optional shape expression. Returns `undefined` when no shape
    * token follows (e.g. `$Idle : state` with no payload).
    */
   private parseShapeOptional(): Shape | undefined {
+    if (this.peek().kind === "EOF" || this.peek().kind === "COMMENT") {
+      return undefined;
+    }
+    return this.parseShape();
+  }
+
+  /** Parse a mandatory shape expression. Returns `undefined` when absent. */
+  private parseShape(): Shape | undefined {
+    const base = this.parsePrimary();
+    if (!base) return undefined;
+    return this.wrapArrayOrOptional(base);
+  }
+
+  private parsePrimary(): Shape | undefined {
+    const t = this.peek();
+
+    // Pattern
+    if (t.kind === "REGEX") {
+      this.advance();
+      const flagsTok = this.peek().kind === "REGEX_FLAGS"
+        ? this.advance()
+        : undefined;
+      return flagsTok
+        ? { kind: "pattern", regex: t.value, flags: flagsTok.value }
+        : { kind: "pattern", regex: t.value };
+    }
+
+    // Record
+    if (t.kind === "LBRACE") return this.parseRecord();
+
+    // Enum (literal followed by PIPE) — also handles a single literal
+    if (t.kind === "STRING" || t.kind === "NUMBER" || t.kind === "BOOL") {
+      return this.parseEnumOrLiteral();
+    }
+
+    // Primitive | typedef ref
+    if (t.kind === "IDENT") {
+      const name = t.value;
+      if (["int", "float"].includes(name)) {
+        this.advance();
+        if (this.peek().kind === "LBRACKET") {
+          // `[]` empty brackets → array (never a range). Leave for wrapArrayOrOptional.
+          // For float, `[N]` (no DOTDOT) is also an array-exact. Leave for wrapper.
+          // For int, `[N]` (no DOTDOT) is a range-exact → enter parseRangeBody.
+          const isEmpty = this.tokens[this.i + 1]?.kind === "RBRACKET";
+          const hasDotDot = this.bracketHasDotDot();
+          if (!isEmpty && (name === "int" || hasDotDot)) {
+            return this.parseRangeBody(name as "int" | "float");
+          }
+          // Otherwise leave `[…]` for wrapArrayOrOptional.
+        }
+        return { kind: "primitive", type: name as "int" | "float" };
+      }
+      if (["string", "bytes"].includes(name)) {
+        this.advance();
+        if (this.peek().kind === "LBRACKET") {
+          return this.parseLengthBody(name as "string" | "bytes");
+        }
+        return { kind: "primitive", type: name as "string" | "bytes" };
+      }
+      if (name === "bool") {
+        this.advance();
+        return { kind: "primitive", type: "bool" };
+      }
+      this.advance();
+      return { kind: "ref", name };
+    }
+
     return undefined;
+  }
+
+  private parseRangeBody(type: "int" | "float"): Shape | undefined {
+    if (!this.expect("LBRACKET")) return undefined;
+    const first = this.peek();
+    if (
+      first.kind === "NUMBER" && this.tokens[this.i + 1].kind === "RBRACKET"
+    ) {
+      const n = Number(this.advance().value);
+      this.expect("RBRACKET");
+      return { kind: "range", type, exact: n };
+    }
+    let min: number | undefined;
+    let max: number | undefined;
+    if (this.peek().kind === "NUMBER") min = Number(this.advance().value);
+    if (this.peek().kind !== "DOTDOT") {
+      this.diagnostics.push(
+        typlDiagnostic(
+          "TYPL-006",
+          { detail: "expected '..'" },
+          this.peek().position,
+        ),
+      );
+      return undefined;
+    }
+    this.advance();
+    if (this.peek().kind === "NUMBER") max = Number(this.advance().value);
+    if (!this.expect("RBRACKET")) return undefined;
+    if (type === "int") {
+      if (min !== undefined && !Number.isInteger(min)) {
+        this.diagnostics.push(
+          typlDiagnostic(
+            "TYPL-008",
+            {
+              value: min,
+              constraint: "int range",
+              detail: "non-integer literal",
+            },
+            first.position,
+          ),
+        );
+      }
+      if (max !== undefined && !Number.isInteger(max)) {
+        this.diagnostics.push(
+          typlDiagnostic(
+            "TYPL-008",
+            {
+              value: max,
+              constraint: "int range",
+              detail: "non-integer literal",
+            },
+            first.position,
+          ),
+        );
+      }
+    }
+    const out: Shape = { kind: "range", type };
+    if (min !== undefined) (out as Record<string, unknown>).min = min;
+    if (max !== undefined) (out as Record<string, unknown>).max = max;
+    return out;
+  }
+
+  private parseLengthBody(type: "string" | "bytes"): Shape | undefined {
+    if (!this.expect("LBRACKET")) return undefined;
+    if (
+      this.peek().kind === "NUMBER" &&
+      this.tokens[this.i + 1].kind === "RBRACKET"
+    ) {
+      const exact = Number(this.advance().value);
+      this.expect("RBRACKET");
+      return { kind: "length", type, exact };
+    }
+    let min: number | undefined;
+    let max: number | undefined;
+    if (this.peek().kind === "NUMBER") min = Number(this.advance().value);
+    if (this.peek().kind !== "DOTDOT") return undefined;
+    this.advance();
+    if (this.peek().kind === "NUMBER") max = Number(this.advance().value);
+    if (!this.expect("RBRACKET")) return undefined;
+    const out: Shape = { kind: "length", type };
+    if (min !== undefined) (out as Record<string, unknown>).min = min;
+    if (max !== undefined) (out as Record<string, unknown>).max = max;
+    return out;
+  }
+
+  private parseRecord(): Shape | undefined {
+    if (!this.expect("LBRACE")) return undefined;
+    const fields: Record<string, Shape> = {};
+    while (this.peek().kind !== "RBRACE" && this.peek().kind !== "EOF") {
+      const nameTok = this.expect("IDENT");
+      if (!nameTok) break;
+      // shorthand `{ a, b }` => fields with ref to typedef of same name
+      if (this.peek().kind === "COMMA" || this.peek().kind === "RBRACE") {
+        fields[nameTok.value] = { kind: "ref", name: nameTok.value };
+      } else {
+        if (!this.expect("COLON")) break;
+        const fieldShape = this.parseShape();
+        if (!fieldShape) break;
+        fields[nameTok.value] = fieldShape;
+      }
+      if (this.peek().kind === "COMMA") this.advance();
+    }
+    this.expect("RBRACE");
+    return { kind: "record", fields };
+  }
+
+  private parseEnumOrLiteral(): Shape | undefined {
+    const values: (string | number | boolean)[] = [];
+    const t = this.advance();
+    values.push(this.literalValue(t));
+    while (this.peek().kind === "PIPE") {
+      this.advance();
+      const next = this.peek();
+      if (
+        next.kind !== "STRING" && next.kind !== "NUMBER" &&
+        next.kind !== "BOOL"
+      ) {
+        this.diagnostics.push(
+          typlDiagnostic(
+            "TYPL-006",
+            { detail: "expected literal after '|'" },
+            next.position,
+          ),
+        );
+        break;
+      }
+      values.push(this.literalValue(this.advance()));
+    }
+    if (values.length === 1) return { kind: "literal", value: values[0] };
+    return { kind: "enum", values };
+  }
+
+  private literalValue(t: Token): string | number | boolean {
+    if (t.kind === "STRING") return t.value;
+    if (t.kind === "BOOL") return t.value === "true";
+    return Number(t.value);
+  }
+
+  /**
+   * Lookahead: does the upcoming `[…]` bracket contain a DOTDOT token?
+   * Used to disambiguate `float[4]` (array-exact) from `float[0..300]` (range).
+   * Scans forward from `i+1` (the token after LBRACKET) without consuming.
+   */
+  private bracketHasDotDot(): boolean {
+    let j = this.i + 1; // skip over the LBRACKET itself (not yet consumed here)
+    while (j < this.tokens.length) {
+      const k = this.tokens[j].kind;
+      if (k === "RBRACKET" || k === "EOF") return false;
+      if (k === "DOTDOT") return true;
+      j++;
+    }
+    return false;
+  }
+
+  private wrapArrayOrOptional(base: Shape): Shape {
+    let s = base;
+    while (true) {
+      if (this.peek().kind === "LBRACKET") {
+        this.advance();
+        if (this.peek().kind === "RBRACKET") {
+          this.advance();
+          s = { kind: "array", element: s };
+          if (this.peek().kind === "LPAREN") {
+            this.advance();
+            let min: number | undefined;
+            let max: number | undefined;
+            if (this.peek().kind === "NUMBER") {
+              min = Number(this.advance().value);
+            }
+            if (this.peek().kind === "DOTDOT") {
+              this.advance();
+              if (this.peek().kind === "NUMBER") {
+                max = Number(this.advance().value);
+              }
+            }
+            this.expect("RPAREN");
+            const arr = s as {
+              kind: "array";
+              element: Shape;
+              min?: number;
+              max?: number;
+            };
+            if (min !== undefined) arr.min = min;
+            if (max !== undefined) arr.max = max;
+            s = arr;
+          }
+        } else if (this.peek().kind === "NUMBER") {
+          const exact = Number(this.advance().value);
+          this.expect("RBRACKET");
+          s = { kind: "array", element: s, exact };
+        }
+      } else if (this.peek().kind === "QUESTION") {
+        this.advance();
+        s = { kind: "optional", inner: s };
+      } else {
+        break;
+      }
+    }
+    return s;
   }
 
   // -----------------------------------------------------------------------

--- a/packages/markspec/core/typl/grammar.ts
+++ b/packages/markspec/core/typl/grammar.ts
@@ -208,7 +208,18 @@ class Parser {
       if (["string", "bytes"].includes(name)) {
         this.advance();
         if (this.peek().kind === "LBRACKET") {
-          return this.parseLengthBody(name as "string" | "bytes");
+          // `[]` empty brackets → array (never a length). Leave for wrapArrayOrOptional.
+          // `[N]` single number → length exact → enter parseLengthBody.
+          // `[N..M]` range form → length range → enter parseLengthBody.
+          const isEmpty = this.tokens[this.i + 1]?.kind === "RBRACKET";
+          const hasDotDot = this.bracketHasDotDot();
+          if (
+            !isEmpty &&
+            (hasDotDot || this.tokens[this.i + 1]?.kind === "NUMBER")
+          ) {
+            return this.parseLengthBody(name as "string" | "bytes");
+          }
+          // Otherwise (empty `[]`) leave for wrapArrayOrOptional.
         }
         return { kind: "primitive", type: name as "string" | "bytes" };
       }

--- a/packages/markspec/core/typl/grammar.ts
+++ b/packages/markspec/core/typl/grammar.ts
@@ -1,0 +1,215 @@
+/**
+ * @module typl/grammar
+ *
+ * Statement-level parser for the typl DSL. Converts a flat `Token[]`
+ * stream (from the lexer) into a `TyplBlock` AST containing `Binding[]`
+ * and `Typedef[]` statements.
+ *
+ * Shape parsing (`parseShape` / `parseShapeOptional`) is stubbed in this
+ * task and filled in by Task 6.
+ */
+
+import {
+  type Binding,
+  type Kind,
+  KINDS,
+  type Shape,
+  type Statement,
+  type Typedef,
+  type TyplBlock,
+} from "./ast.ts";
+import { type TyplDiagnostic, typlDiagnostic } from "./diagnostics.ts";
+import { type Token, tokenize } from "./lexer.ts";
+
+/** Fast set of valid kind keywords (excluding "value" which is the implicit default). */
+const KIND_NAMES = new Set<string>(KINDS);
+
+/**
+ * Lowercase primitive type names. Used in the kind-detection heuristic to
+ * distinguish a primitive type token from an unknown kind keyword.
+ */
+const PRIMITIVE_NAMES = new Set<string>([
+  "int",
+  "float",
+  "bool",
+  "string",
+  "bytes",
+]);
+
+/**
+ * Recursive-descent parser for a typl source block.
+ *
+ * The `protected parseShape*` methods are stubs intentionally left for
+ * Task 6 to fill in. Subclasses (or an override in Task 6) will provide
+ * the real implementation.
+ */
+class Parser {
+  private i = 0;
+  private diagnostics: TyplDiagnostic[] = [];
+
+  constructor(private tokens: Token[]) {}
+
+  parseBlock(): { ast: TyplBlock; diagnostics: TyplDiagnostic[] } {
+    const bindings: Binding[] = [];
+    const typedefs: Typedef[] = [];
+    while (this.peek().kind !== "EOF") {
+      const stmt = this.parseStatement();
+      if (stmt) {
+        if (stmt.statementKind === "binding") bindings.push(stmt);
+        else typedefs.push(stmt);
+      }
+      this.skipToNextLine();
+    }
+    return { ast: { bindings, typedefs }, diagnostics: this.diagnostics };
+  }
+
+  private parseStatement(): Statement | undefined {
+    const t = this.peek();
+    if (t.kind === "COMMENT") {
+      this.advance();
+      return undefined;
+    }
+    if (t.kind === "DOLLAR_IDENT") return this.parseBinding();
+    if (t.kind === "TYPE") return this.parseTypedef();
+    this.diagnostics.push(
+      typlDiagnostic(
+        "TYPL-006",
+        { detail: `unexpected token ${t.kind}` },
+        t.position,
+      ),
+    );
+    return undefined;
+  }
+
+  private parseBinding(): Binding | undefined {
+    const nameTok = this.expect("DOLLAR_IDENT");
+    if (!nameTok) return undefined;
+    if (!this.expect("COLON")) return undefined;
+
+    const next = this.peek();
+    let kind: Kind = "value";
+
+    if (next.kind === "IDENT") {
+      if (KIND_NAMES.has(next.value)) {
+        // Known kind keyword — consume and record.
+        kind = next.value as Kind;
+        this.advance();
+      } else if (!PRIMITIVE_NAMES.has(next.value)) {
+        // Not a primitive. Apply the heuristic: lowercase-starting tokens
+        // that are not known primitives are likely mistyped kind keywords.
+        // PascalCase tokens are typedef references and are left for the
+        // shape parser.
+        if (next.value[0] && next.value[0] === next.value[0].toLowerCase()) {
+          this.diagnostics.push(
+            typlDiagnostic(
+              "TYPL-007",
+              { keyword: next.value },
+              next.position,
+            ),
+          );
+          // Consume the bad keyword so the shape parser does not trip on it.
+          this.advance();
+        }
+        // PascalCase identifier: typedef ref — leave for parseShapeOptional.
+      }
+    }
+
+    const shape = this.parseShapeOptional();
+    return {
+      statementKind: "binding",
+      name: nameTok.value,
+      kind,
+      shape,
+      position: nameTok.position,
+    };
+  }
+
+  private parseTypedef(): Typedef | undefined {
+    const typeTok = this.expect("TYPE");
+    if (!typeTok) return undefined;
+    const nameTok = this.expect("IDENT");
+    if (!nameTok) return undefined;
+    if (!this.expect("EQUALS")) return undefined;
+    const shape = this.parseShape();
+    if (!shape) return undefined;
+    return {
+      statementKind: "typedef",
+      name: nameTok.value,
+      shape,
+      position: typeTok.position,
+    };
+  }
+
+  // -----------------------------------------------------------------------
+  // Shape parsing — stubbed. Task 6 fills these in.
+  // -----------------------------------------------------------------------
+
+  /** Parse a mandatory shape expression. Returns `undefined` when absent. */
+  protected parseShape(): Shape | undefined {
+    return undefined;
+  }
+
+  /**
+   * Parse an optional shape expression. Returns `undefined` when no shape
+   * token follows (e.g. `$Idle : state` with no payload).
+   */
+  protected parseShapeOptional(): Shape | undefined {
+    return undefined;
+  }
+
+  // -----------------------------------------------------------------------
+  // Low-level helpers
+  // -----------------------------------------------------------------------
+
+  private peek(): Token {
+    return this.tokens[this.i];
+  }
+
+  private advance(): Token {
+    return this.tokens[this.i++];
+  }
+
+  private expect(kind: Token["kind"]): Token | undefined {
+    const t = this.peek();
+    if (t.kind !== kind) {
+      this.diagnostics.push(
+        typlDiagnostic(
+          "TYPL-006",
+          { detail: `expected ${kind} but got ${t.kind}` },
+          t.position,
+        ),
+      );
+      return undefined;
+    }
+    return this.advance();
+  }
+
+  /**
+   * Advance past all remaining tokens on the current line so that a parse
+   * error on one statement does not cascade into the next. Stops at the
+   * first token whose line number is greater than the current peek's line,
+   * or at EOF.
+   */
+  private skipToNextLine(): void {
+    const startLine = this.peek().position.line;
+    while (
+      this.peek().kind !== "EOF" &&
+      this.peek().position.line === startLine
+    ) {
+      this.advance();
+    }
+  }
+}
+
+/**
+ * Parse a typl source block into a `TyplBlock` AST.
+ *
+ * @param source - Raw typl text (may be multi-line).
+ * @returns Parsed AST and any diagnostics emitted during parsing.
+ */
+export function parseTyplBlock(
+  source: string,
+): { ast: TyplBlock; diagnostics: readonly TyplDiagnostic[] } {
+  const tokens = tokenize(source);
+  return new Parser(tokens).parseBlock();
+}

--- a/packages/markspec/core/typl/grammar.ts
+++ b/packages/markspec/core/typl/grammar.ts
@@ -307,7 +307,16 @@ class Parser {
     let min: number | undefined;
     let max: number | undefined;
     if (this.peek().kind === "NUMBER") min = Number(this.advance().value);
-    if (this.peek().kind !== "DOTDOT") return undefined;
+    if (this.peek().kind !== "DOTDOT") {
+      this.diagnostics.push(
+        typlDiagnostic(
+          "TYPL-006",
+          { detail: "expected '..'" },
+          this.peek().position,
+        ),
+      );
+      return undefined;
+    }
     this.advance();
     if (this.peek().kind === "NUMBER") max = Number(this.advance().value);
     if (!this.expect("RBRACKET")) return undefined;
@@ -422,6 +431,15 @@ class Parser {
           const exact = Number(this.advance().value);
           this.expect("RBRACKET");
           s = { kind: "array", element: s, exact };
+        } else {
+          this.diagnostics.push(
+            typlDiagnostic(
+              "TYPL-006",
+              { detail: `unexpected token ${this.peek().kind} inside '['` },
+              this.peek().position,
+            ),
+          );
+          break;
         }
       } else if (this.peek().kind === "QUESTION") {
         this.advance();

--- a/packages/markspec/core/typl/grammar.ts
+++ b/packages/markspec/core/typl/grammar.ts
@@ -53,12 +53,21 @@ class Parser {
     const bindings: Binding[] = [];
     const typedefs: Typedef[] = [];
     while (this.peek().kind !== "EOF") {
+      const lineBefore = this.peek().position.line;
       const stmt = this.parseStatement();
       if (stmt) {
         if (stmt.statementKind === "binding") bindings.push(stmt);
         else typedefs.push(stmt);
       }
-      this.skipToNextLine();
+      // Only skip remaining tokens on the same line. If the cursor has
+      // already advanced past lineBefore (parseStatement consumed the whole
+      // line), we're already at the next statement — don't eat into it.
+      if (
+        this.peek().kind !== "EOF" &&
+        this.peek().position.line === lineBefore
+      ) {
+        this.skipToNextLine();
+      }
     }
     return { ast: { bindings, typedefs }, diagnostics: this.diagnostics };
   }
@@ -99,7 +108,10 @@ class Parser {
         // that are not known primitives are likely mistyped kind keywords.
         // PascalCase tokens are typedef references and are left for the
         // shape parser.
-        if (next.value[0] && next.value[0] === next.value[0].toLowerCase()) {
+        const firstChar = next.value[0];
+        if (firstChar >= "a" && firstChar <= "z") {
+          // Lowercase non-primitive non-kind → likely a typo on a kind keyword.
+          // _-prefixed identifiers are typedef references, not kind keywords.
           this.diagnostics.push(
             typlDiagnostic(
               "TYPL-007",
@@ -110,7 +122,7 @@ class Parser {
           // Consume the bad keyword so the shape parser does not trip on it.
           this.advance();
         }
-        // PascalCase identifier: typedef ref — leave for parseShapeOptional.
+        // PascalCase or _-prefixed identifier: typedef ref — leave for parseShapeOptional.
       }
     }
 
@@ -145,7 +157,7 @@ class Parser {
   // -----------------------------------------------------------------------
 
   /** Parse a mandatory shape expression. Returns `undefined` when absent. */
-  protected parseShape(): Shape | undefined {
+  private parseShape(): Shape | undefined {
     return undefined;
   }
 
@@ -153,7 +165,7 @@ class Parser {
    * Parse an optional shape expression. Returns `undefined` when no shape
    * token follows (e.g. `$Idle : state` with no payload).
    */
-  protected parseShapeOptional(): Shape | undefined {
+  private parseShapeOptional(): Shape | undefined {
     return undefined;
   }
 

--- a/packages/markspec/core/typl/grammar.ts
+++ b/packages/markspec/core/typl/grammar.ts
@@ -43,12 +43,31 @@ class Parser {
   parseBlock(): { ast: TyplBlock; diagnostics: TyplDiagnostic[] } {
     const bindings: Binding[] = [];
     const typedefs: Typedef[] = [];
+    const seenBindingNames = new Set<string>();
+    const seenTypedefNames = new Set<string>();
     while (this.peek().kind !== "EOF") {
       const lineBefore = this.peek().position.line;
       const stmt = this.parseStatement();
       if (stmt) {
-        if (stmt.statementKind === "binding") bindings.push(stmt);
-        else typedefs.push(stmt);
+        if (stmt.statementKind === "binding") {
+          if (seenBindingNames.has(stmt.name)) {
+            this.diagnostics.push(
+              typlDiagnostic("TYPL-001", { name: stmt.name }, stmt.position),
+            );
+          } else {
+            seenBindingNames.add(stmt.name);
+            bindings.push(stmt);
+          }
+        } else {
+          if (seenTypedefNames.has(stmt.name)) {
+            this.diagnostics.push(
+              typlDiagnostic("TYPL-004", { name: stmt.name }, stmt.position),
+            );
+          } else {
+            seenTypedefNames.add(stmt.name);
+            typedefs.push(stmt);
+          }
+        }
       }
       // Only skip remaining tokens on the same line. If the cursor has
       // already advanced past lineBefore (parseStatement consumed the whole

--- a/packages/markspec/core/typl/grammar_test.ts
+++ b/packages/markspec/core/typl/grammar_test.ts
@@ -1,0 +1,59 @@
+// packages/markspec/core/typl/grammar_test.ts
+import { assertEquals } from "@std/assert";
+import { parseTyplBlock } from "./grammar.ts";
+
+Deno.test("parseTyplBlock: explicit kind + range", () => {
+  const { ast, diagnostics } = parseTyplBlock(
+    "$Speed : signal float[0..300]",
+  );
+  assertEquals(diagnostics, []);
+  assertEquals(ast.bindings.length, 1);
+  const b = ast.bindings[0];
+  assertEquals(b.name, "$Speed");
+  assertEquals(b.kind, "signal");
+  assertEquals(b.shape, {
+    kind: "range",
+    type: "float",
+    min: 0,
+    max: 300,
+  });
+});
+
+Deno.test("parseTyplBlock: omitted kind defaults to value", () => {
+  const { ast, diagnostics } = parseTyplBlock("$count : int[0..]");
+  assertEquals(diagnostics, []);
+  assertEquals(ast.bindings[0].kind, "value");
+  assertEquals(ast.bindings[0].shape, {
+    kind: "range",
+    type: "int",
+    min: 0,
+  });
+});
+
+Deno.test("parseTyplBlock: typedef with record", () => {
+  const { ast, diagnostics } = parseTyplBlock(
+    "type BrakeReq = { force_N: float[0..12000] }",
+  );
+  assertEquals(diagnostics, []);
+  assertEquals(ast.typedefs.length, 1);
+  const t = ast.typedefs[0];
+  assertEquals(t.name, "BrakeReq");
+  assertEquals(t.shape, {
+    kind: "record",
+    fields: {
+      force_N: { kind: "range", type: "float", min: 0, max: 12000 },
+    },
+  });
+});
+
+Deno.test("parseTyplBlock: comment line yields no statement", () => {
+  const { ast, diagnostics } = parseTyplBlock("# just a note");
+  assertEquals(diagnostics, []);
+  assertEquals(ast.bindings.length + ast.typedefs.length, 0);
+});
+
+Deno.test("parseTyplBlock: unknown kind emits TYPL-007", () => {
+  const { diagnostics } = parseTyplBlock("$X : blah int[0..]");
+  assertEquals(diagnostics.length, 1);
+  assertEquals(diagnostics[0].code, "TYPL-007");
+});

--- a/packages/markspec/core/typl/grammar_test.ts
+++ b/packages/markspec/core/typl/grammar_test.ts
@@ -57,3 +57,13 @@ Deno.test("parseTyplBlock: unknown kind emits TYPL-007", () => {
   assertEquals(diagnostics.length, 1);
   assertEquals(diagnostics[0].code, "TYPL-007");
 });
+
+Deno.test("parseTyplBlock: multi-line block — every statement parsed", () => {
+  const { ast, diagnostics } = parseTyplBlock(
+    "$A : signal\n$B : event\n$C : state",
+  );
+  assertEquals(diagnostics, []);
+  assertEquals(ast.bindings.length, 3);
+  assertEquals(ast.bindings.map((b) => b.name), ["$A", "$B", "$C"]);
+  assertEquals(ast.bindings.map((b) => b.kind), ["signal", "event", "state"]);
+});

--- a/packages/markspec/core/typl/grammar_test.ts
+++ b/packages/markspec/core/typl/grammar_test.ts
@@ -67,3 +67,31 @@ Deno.test("parseTyplBlock: multi-line block — every statement parsed", () => {
   assertEquals(ast.bindings.map((b) => b.name), ["$A", "$B", "$C"]);
   assertEquals(ast.bindings.map((b) => b.kind), ["signal", "event", "state"]);
 });
+
+Deno.test("parseTyplBlock: TYPL-001 on duplicate $Name in same block", () => {
+  const { ast, diagnostics } = parseTyplBlock(
+    "$Speed : signal float[0..300]\n$Speed : event",
+  );
+  assertEquals(ast.bindings.length, 1);
+  assertEquals(ast.bindings[0].kind, "signal"); // first wins
+  assertEquals(diagnostics.length, 1);
+  assertEquals(diagnostics[0].code, "TYPL-001");
+});
+
+Deno.test("parseTyplBlock: TYPL-004 on duplicate typedef in same block", () => {
+  const { ast, diagnostics } = parseTyplBlock(
+    "type Frame = int[0..255]\ntype Frame = float[0.0..1.0]",
+  );
+  assertEquals(ast.typedefs.length, 1);
+  assertEquals(diagnostics.length, 1);
+  assertEquals(diagnostics[0].code, "TYPL-004");
+});
+
+Deno.test("parseTyplBlock: binding without shape (e.g. $Idle : state)", () => {
+  const { ast, diagnostics } = parseTyplBlock("$Idle : state");
+  assertEquals(diagnostics, []);
+  assertEquals(ast.bindings.length, 1);
+  assertEquals(ast.bindings[0].name, "$Idle");
+  assertEquals(ast.bindings[0].kind, "state");
+  assertEquals(ast.bindings[0].shape, undefined);
+});

--- a/packages/markspec/core/typl/lexer.ts
+++ b/packages/markspec/core/typl/lexer.ts
@@ -113,7 +113,7 @@ export function tokenize(source: string): Token[] {
     if (ch === "#") {
       const startCol = column;
       let value = "";
-      while (i < source.length && source[i] !== "\n") {
+      while (i < source.length && source[i] !== "\n" && source[i] !== "\r") {
         value += source[i];
         i++;
         column++;
@@ -123,6 +123,8 @@ export function tokenize(source: string): Token[] {
     }
 
     // ── Dollar-prefixed identifier — `$Speed` ────────────────────────
+    // $ identifier — body uses IDENT_BODY_RE (allows digits) intentionally;
+    // names like $1st are lexically valid and rejected by the parser
     if (ch === "$") {
       const startCol = column;
       let value = "$";
@@ -162,13 +164,14 @@ export function tokenize(source: string): Token[] {
       }
       push("REGEX", regex, startCol);
       // Optional flags after the closing `/`.
+      const flagsStartCol = column;
       let flags = "";
       while (i < source.length && /[a-z]/.test(source[i])) {
         flags += source[i];
         i++;
         column++;
       }
-      if (flags) push("REGEX_FLAGS", flags, startCol);
+      if (flags) push("REGEX_FLAGS", flags, flagsStartCol);
       continue;
     }
 

--- a/packages/markspec/core/typl/lexer.ts
+++ b/packages/markspec/core/typl/lexer.ts
@@ -1,0 +1,279 @@
+/**
+ * @module typl/lexer
+ *
+ * Tokenizer for the typl DSL. Converts a source string into a flat
+ * `Token[]` stream. Whitespace (except newlines) is silently skipped;
+ * newlines advance the line counter for position tracking. Comments
+ * (`#` to end-of-line) are emitted as `COMMENT` tokens so the parser
+ * can skip whole lines cleanly.
+ *
+ * The lexer is intentionally lenient — unrecognised characters are
+ * skipped. The parser surfaces TYPL-006 when grammar expectations are
+ * not met, keeping diagnostic responsibility clearly separated.
+ */
+
+import type { Position } from "./ast.ts";
+
+/** All token kinds produced by the typl tokenizer. */
+export type TokenKind =
+  | "DOLLAR_IDENT"
+  | "IDENT"
+  | "NUMBER"
+  | "STRING"
+  | "BOOL"
+  | "REGEX"
+  | "REGEX_FLAGS"
+  | "COLON"
+  | "EQUALS"
+  | "TYPE"
+  | "DOTDOT"
+  | "DOT"
+  | "COMMA"
+  | "PIPE"
+  | "QUESTION"
+  | "LBRACE"
+  | "RBRACE"
+  | "LBRACKET"
+  | "RBRACKET"
+  | "LPAREN"
+  | "RPAREN"
+  | "COMMENT"
+  | "EOF";
+
+/** A single token emitted by {@linkcode tokenize}. */
+export interface Token {
+  readonly kind: TokenKind;
+  /** Raw text of the token (empty string for EOF). */
+  readonly value: string;
+  /** 1-based source position of the token's first character. */
+  readonly position: Position;
+}
+
+/** Single-character token map (punctuation). */
+const SINGLE_CHAR_MAP: Readonly<Record<string, TokenKind>> = {
+  ":": "COLON",
+  "=": "EQUALS",
+  ",": "COMMA",
+  "|": "PIPE",
+  "?": "QUESTION",
+  "{": "LBRACE",
+  "}": "RBRACE",
+  "[": "LBRACKET",
+  "]": "RBRACKET",
+  "(": "LPAREN",
+  ")": "RPAREN",
+};
+
+/** Pattern for identifier-body characters (after the first character). */
+const IDENT_BODY_RE = /[A-Za-z0-9_]/;
+
+/** Pattern for the first character of an identifier (excluding `$`). */
+const IDENT_START_RE = /[A-Za-z_]/;
+
+/** Pattern for digit characters (used in numeric tokens). */
+const DIGIT_RE = /[0-9]/;
+
+/**
+ * Tokenize a typl source string.
+ *
+ * Returns a `Token[]` terminated by an `EOF` token. Position values are
+ * 1-based (line 1, column 1 is the first character of the source). The
+ * stream always ends with exactly one `EOF` token.
+ */
+export function tokenize(source: string): Token[] {
+  const tokens: Token[] = [];
+  let line = 1;
+  let column = 1;
+  let i = 0;
+
+  /** Append a token using the current position tracking. */
+  const push = (kind: TokenKind, value: string, startCol: number): void => {
+    tokens.push({ kind, value, position: { line, column: startCol } });
+  };
+
+  while (i < source.length) {
+    const ch = source[i];
+
+    // ── Newline — advance line counter ───────────────────────────────
+    if (ch === "\n") {
+      line++;
+      column = 1;
+      i++;
+      continue;
+    }
+
+    // ── Other whitespace — skip silently ─────────────────────────────
+    if (/\s/.test(ch)) {
+      i++;
+      column++;
+      continue;
+    }
+
+    // ── Comment — `#` to end-of-line ─────────────────────────────────
+    if (ch === "#") {
+      const startCol = column;
+      let value = "";
+      while (i < source.length && source[i] !== "\n") {
+        value += source[i];
+        i++;
+        column++;
+      }
+      push("COMMENT", value, startCol);
+      continue;
+    }
+
+    // ── Dollar-prefixed identifier — `$Speed` ────────────────────────
+    if (ch === "$") {
+      const startCol = column;
+      let value = "$";
+      i++;
+      column++;
+      while (i < source.length && IDENT_BODY_RE.test(source[i])) {
+        value += source[i];
+        i++;
+        column++;
+      }
+      push("DOLLAR_IDENT", value, startCol);
+      continue;
+    }
+
+    // ── Regex literal — `/pattern/flags` ─────────────────────────────
+    if (ch === "/") {
+      const startCol = column;
+      i++;
+      column++;
+      let regex = "";
+      while (i < source.length && source[i] !== "/") {
+        if (source[i] === "\\" && i + 1 < source.length) {
+          // Preserve escape sequences verbatim inside the regex body.
+          regex += source[i] + source[i + 1];
+          i += 2;
+          column += 2;
+        } else {
+          regex += source[i];
+          i++;
+          column++;
+        }
+      }
+      // Consume the closing `/`.
+      if (i < source.length && source[i] === "/") {
+        i++;
+        column++;
+      }
+      push("REGEX", regex, startCol);
+      // Optional flags after the closing `/`.
+      let flags = "";
+      while (i < source.length && /[a-z]/.test(source[i])) {
+        flags += source[i];
+        i++;
+        column++;
+      }
+      if (flags) push("REGEX_FLAGS", flags, startCol);
+      continue;
+    }
+
+    // ── String literal — `'…'` or `"…"` ─────────────────────────────
+    if (ch === "'" || ch === '"') {
+      const startCol = column;
+      const quote = ch;
+      let value = "";
+      i++;
+      column++;
+      while (i < source.length && source[i] !== quote) {
+        if (source[i] === "\\" && i + 1 < source.length) {
+          value += source[i + 1];
+          i += 2;
+          column += 2;
+        } else {
+          value += source[i];
+          i++;
+          column++;
+        }
+      }
+      // Consume closing quote.
+      if (i < source.length && source[i] === quote) {
+        i++;
+        column++;
+      }
+      push("STRING", value, startCol);
+      continue;
+    }
+
+    // ── Numeric literal (and negative numbers starting with `-`) ─────
+    // Negative: `-` followed immediately by a digit.
+    // Must stop at `..` (DOTDOT) to correctly lex `int[0..300]`.
+    if (
+      DIGIT_RE.test(ch) ||
+      (ch === "-" && i + 1 < source.length && DIGIT_RE.test(source[i + 1]))
+    ) {
+      const startCol = column;
+      let value = "";
+      if (ch === "-") {
+        value = "-";
+        i++;
+        column++;
+      }
+      while (i < source.length) {
+        // Stop at `..` so `0..300` produces NUMBER(0) DOTDOT NUMBER(300).
+        if (
+          source[i] === "." && i + 1 < source.length && source[i + 1] === "."
+        ) break;
+        if (!DIGIT_RE.test(source[i]) && source[i] !== ".") break;
+        value += source[i];
+        i++;
+        column++;
+      }
+      push("NUMBER", value, startCol);
+      continue;
+    }
+
+    // ── Identifier or keyword ─────────────────────────────────────────
+    if (IDENT_START_RE.test(ch)) {
+      const startCol = column;
+      let value = "";
+      while (i < source.length && IDENT_BODY_RE.test(source[i])) {
+        value += source[i];
+        i++;
+        column++;
+      }
+      if (value === "type") push("TYPE", value, startCol);
+      else if (value === "true" || value === "false") {
+        push("BOOL", value, startCol);
+      } else push("IDENT", value, startCol);
+      continue;
+    }
+
+    // ── DOTDOT — must be checked before DOT ──────────────────────────
+    if (ch === "." && i + 1 < source.length && source[i + 1] === ".") {
+      push("DOTDOT", "..", column);
+      i += 2;
+      column += 2;
+      continue;
+    }
+
+    // ── Single-character DOT ──────────────────────────────────────────
+    if (ch === ".") {
+      push("DOT", ".", column);
+      i++;
+      column++;
+      continue;
+    }
+
+    // ── Single-character punctuation ──────────────────────────────────
+    const singleKind = SINGLE_CHAR_MAP[ch];
+    if (singleKind !== undefined) {
+      push(singleKind, ch, column);
+      i++;
+      column++;
+      continue;
+    }
+
+    // ── Unrecognised character — skip silently ────────────────────────
+    // The parser will surface TYPL-006 when grammar expectations are unmet.
+    i++;
+    column++;
+  }
+
+  tokens.push({ kind: "EOF", value: "", position: { line, column } });
+  return tokens;
+}

--- a/packages/markspec/core/typl/lexer_test.ts
+++ b/packages/markspec/core/typl/lexer_test.ts
@@ -1,0 +1,52 @@
+// packages/markspec/core/typl/lexer_test.ts
+import { assertEquals } from "@std/assert";
+import { tokenize } from "./lexer.ts";
+
+Deno.test("tokenize: binding with explicit kind + range", () => {
+  const tokens = tokenize("$Speed : signal float[0..300]");
+  assertEquals(tokens.map((t) => t.kind), [
+    "DOLLAR_IDENT", // $Speed
+    "COLON", // :
+    "IDENT", // signal
+    "IDENT", // float
+    "LBRACKET", // [
+    "NUMBER", // 0
+    "DOTDOT", // ..
+    "NUMBER", // 300
+    "RBRACKET", // ]
+    "EOF",
+  ]);
+});
+
+Deno.test("tokenize: typedef line", () => {
+  const tokens = tokenize("type BrakeReq = { force_N: float[0..12000] }");
+  assertEquals(tokens.map((t) => t.kind), [
+    "TYPE",
+    "IDENT",
+    "EQUALS",
+    "LBRACE",
+    "IDENT",
+    "COLON",
+    "IDENT",
+    "LBRACKET",
+    "NUMBER",
+    "DOTDOT",
+    "NUMBER",
+    "RBRACKET",
+    "RBRACE",
+    "EOF",
+  ]);
+});
+
+Deno.test("tokenize: regex pattern keeps body intact", () => {
+  const tokens = tokenize("$VIN : /^[A-Z]{17}$/i");
+  const regex = tokens.find((t) => t.kind === "REGEX");
+  assertEquals(regex?.value, "^[A-Z]{17}$");
+  const flags = tokens.find((t) => t.kind === "REGEX_FLAGS");
+  assertEquals(flags?.value, "i");
+});
+
+Deno.test("tokenize: comment line", () => {
+  const tokens = tokenize("# this is ignored");
+  assertEquals(tokens.map((t) => t.kind), ["COMMENT", "EOF"]);
+});

--- a/packages/markspec/core/typl/lexer_test.ts
+++ b/packages/markspec/core/typl/lexer_test.ts
@@ -50,3 +50,31 @@ Deno.test("tokenize: comment line", () => {
   const tokens = tokenize("# this is ignored");
   assertEquals(tokens.map((t) => t.kind), ["COMMENT", "EOF"]);
 });
+
+Deno.test("tokenize: positions are 1-based; line increments on \\n", () => {
+  const tokens = tokenize("$X\n$Y");
+  // $X on line 1 col 1, $Y on line 2 col 1
+  assertEquals(tokens[0].position, { line: 1, column: 1 });
+  assertEquals(tokens[1].position, { line: 2, column: 1 });
+});
+
+Deno.test("tokenize: empty source emits only EOF at line 1 col 1", () => {
+  const tokens = tokenize("");
+  assertEquals(tokens.length, 1);
+  assertEquals(tokens[0].kind, "EOF");
+  assertEquals(tokens[0].position, { line: 1, column: 1 });
+});
+
+Deno.test("tokenize: REGEX_FLAGS position points at the flags, not the opening /", () => {
+  const tokens = tokenize("/abc/i");
+  const flags = tokens.find((t) => t.kind === "REGEX_FLAGS");
+  // Opening / is at col 1; pattern abc is cols 2-4; closing / at col 5; flag i at col 6
+  assertEquals(flags?.position, { line: 1, column: 6 });
+});
+
+Deno.test("tokenize: string with escape preserves the escaped char (backslash stripped)", () => {
+  const tokens = tokenize("'\\n'");
+  const str = tokens.find((t) => t.kind === "STRING");
+  // Documents the design: backslash is consumed, next char taken verbatim
+  assertEquals(str?.value, "n");
+});

--- a/packages/markspec/core/typl/mod.ts
+++ b/packages/markspec/core/typl/mod.ts
@@ -1,0 +1,9 @@
+/**
+ * @module typl
+ *
+ * Type Specification DSL — declarations of $Name identifiers and named
+ * shapes, embedded in MarkSpec entry bodies. See
+ * docs/superpowers/specs/2026-05-24-typl-design.md.
+ */
+
+export const VERSION = "0.1.0";

--- a/packages/markspec/core/typl/mod.ts
+++ b/packages/markspec/core/typl/mod.ts
@@ -2,8 +2,8 @@
  * @module typl
  *
  * Type Specification DSL — declarations of $Name identifiers and named
- * shapes, embedded in MarkSpec entry bodies. See
- * docs/superpowers/specs/2026-05-24-typl-design.md.
+ * shapes, embedded in MarkSpec entry bodies. See ADR-017
+ * (docs/architecture/adr-017-typl-type-dsl.md) for the language spec.
  */
 
 export const VERSION = "0.1.0";

--- a/packages/markspec/core/typl/mod.ts
+++ b/packages/markspec/core/typl/mod.ts
@@ -2,8 +2,8 @@
  * @module typl
  *
  * Type Specification DSL — declarations of $Name identifiers and named
- * shapes, embedded in MarkSpec entry bodies. See ADR-017
- * (docs/architecture/adr-017-typl-type-dsl.md) for the language spec.
+ * shapes, embedded in MarkSpec entry bodies. See ADR-019
+ * (docs/architecture/adr-019-typl-type-dsl.md) for the language spec.
  */
 
 export type {

--- a/packages/markspec/core/typl/mod.ts
+++ b/packages/markspec/core/typl/mod.ts
@@ -6,8 +6,6 @@
  * (docs/architecture/adr-017-typl-type-dsl.md) for the language spec.
  */
 
-export const VERSION = "0.1.0";
-
 export type {
   Binding,
   Kind,

--- a/packages/markspec/core/typl/mod.ts
+++ b/packages/markspec/core/typl/mod.ts
@@ -19,7 +19,7 @@ export type {
 } from "./ast.ts";
 export { KINDS } from "./ast.ts";
 
-export type { TyplCodeEntry, TyplDiagnostic } from "./diagnostics.ts";
+export type { TyplCode, TyplCodeEntry, TyplDiagnostic } from "./diagnostics.ts";
 export { TYPL_CODES, typlDiagnostic } from "./diagnostics.ts";
 
 export { parseTyplBlock } from "./grammar.ts";

--- a/packages/markspec/core/typl/mod.ts
+++ b/packages/markspec/core/typl/mod.ts
@@ -7,3 +7,19 @@
  */
 
 export const VERSION = "0.1.0";
+
+export type {
+  Binding,
+  Kind,
+  Position,
+  Shape,
+  Statement,
+  Typedef,
+  TyplBlock,
+} from "./ast.ts";
+export { KINDS } from "./ast.ts";
+
+export type { TyplCodeEntry, TyplDiagnostic } from "./diagnostics.ts";
+export { TYPL_CODES, typlDiagnostic } from "./diagnostics.ts";
+
+export { parseTyplBlock } from "./grammar.ts";

--- a/packages/markspec/core/typl/mod_test.ts
+++ b/packages/markspec/core/typl/mod_test.ts
@@ -1,0 +1,6 @@
+import { assertEquals } from "@std/assert";
+import { VERSION } from "./mod.ts";
+
+Deno.test("typl module exports VERSION", () => {
+  assertEquals(typeof VERSION, "string");
+});

--- a/packages/markspec/core/typl/mod_test.ts
+++ b/packages/markspec/core/typl/mod_test.ts
@@ -1,9 +1,5 @@
 import { assertEquals } from "@std/assert";
-import { KINDS, parseTyplBlock, TYPL_CODES, VERSION } from "./mod.ts";
-
-Deno.test("typl module exports VERSION", () => {
-  assertEquals(typeof VERSION, "string");
-});
+import { KINDS, parseTyplBlock, TYPL_CODES } from "./mod.ts";
 
 Deno.test("typl module exposes parseTyplBlock", () => {
   const { ast, diagnostics } = parseTyplBlock("$Speed : signal float[0..300]");

--- a/packages/markspec/core/typl/mod_test.ts
+++ b/packages/markspec/core/typl/mod_test.ts
@@ -1,6 +1,17 @@
 import { assertEquals } from "@std/assert";
-import { VERSION } from "./mod.ts";
+import { KINDS, parseTyplBlock, TYPL_CODES, VERSION } from "./mod.ts";
 
 Deno.test("typl module exports VERSION", () => {
   assertEquals(typeof VERSION, "string");
+});
+
+Deno.test("typl module exposes parseTyplBlock", () => {
+  const { ast, diagnostics } = parseTyplBlock("$Speed : signal float[0..300]");
+  assertEquals(diagnostics, []);
+  assertEquals(ast.bindings[0].kind, "signal");
+});
+
+Deno.test("typl module exposes KINDS and TYPL_CODES", () => {
+  assertEquals(KINDS.includes("signal"), true);
+  assertEquals("TYPL-007" in TYPL_CODES, true);
 });

--- a/packages/markspec/core/typl/shape_test.ts
+++ b/packages/markspec/core/typl/shape_test.ts
@@ -169,6 +169,12 @@ Deno.test("shape: string and bytes lengths still work", () => {
   });
 });
 
+Deno.test("shape: single literal (single value, no pipe)", () => {
+  assertEquals(shapeOf("'fixed'"), { kind: "literal", value: "fixed" });
+  assertEquals(shapeOf("42"), { kind: "literal", value: 42 });
+  assertEquals(shapeOf("true"), { kind: "literal", value: true });
+});
+
 Deno.test("shape: malformed shapes emit TYPL-006 (not silent undefined)", () => {
   // Helper that returns both shape and diagnostics
   const result1 = parseTyplBlock("$X : string[3 4]");

--- a/packages/markspec/core/typl/shape_test.ts
+++ b/packages/markspec/core/typl/shape_test.ts
@@ -168,3 +168,30 @@ Deno.test("shape: string and bytes lengths still work", () => {
     max: 4096,
   });
 });
+
+Deno.test("shape: malformed shapes emit TYPL-006 (not silent undefined)", () => {
+  // Helper that returns both shape and diagnostics
+  const result1 = parseTyplBlock("$X : string[3 4]");
+  // Missing DOTDOT after first number in length body
+  assertEquals(
+    result1.diagnostics.some((d) => d.code === "TYPL-006"),
+    true,
+    "string[3 4] should emit TYPL-006",
+  );
+
+  const result2 = parseTyplBlock("$X : float[bad]");
+  // Non-number content inside array length brackets
+  assertEquals(
+    result2.diagnostics.some((d) => d.code === "TYPL-006"),
+    true,
+    "float[bad] should emit TYPL-006",
+  );
+
+  const result3 = parseTyplBlock("$X : int[0..");
+  // Unclosed bracket
+  assertEquals(
+    result3.diagnostics.length > 0,
+    true,
+    "int[0.. should emit some diagnostic",
+  );
+});

--- a/packages/markspec/core/typl/shape_test.ts
+++ b/packages/markspec/core/typl/shape_test.ts
@@ -132,3 +132,39 @@ Deno.test("shape: optional", () => {
     inner: { kind: "primitive", type: "string" },
   });
 });
+
+Deno.test("shape: string and bytes arrays", () => {
+  assertEquals(shapeOf("string[]"), {
+    kind: "array",
+    element: { kind: "primitive", type: "string" },
+  });
+  assertEquals(shapeOf("bytes[]"), {
+    kind: "array",
+    element: { kind: "primitive", type: "bytes" },
+  });
+  assertEquals(shapeOf("string[](..4)"), {
+    kind: "array",
+    element: { kind: "primitive", type: "string" },
+    max: 4,
+  });
+});
+
+Deno.test("shape: string and bytes lengths still work", () => {
+  assertEquals(shapeOf("string[3..6]"), {
+    kind: "length",
+    type: "string",
+    min: 3,
+    max: 6,
+  });
+  assertEquals(shapeOf("string[17]"), {
+    kind: "length",
+    type: "string",
+    exact: 17,
+  });
+  assertEquals(shapeOf("bytes[0..4096]"), {
+    kind: "length",
+    type: "bytes",
+    min: 0,
+    max: 4096,
+  });
+});

--- a/packages/markspec/core/typl/shape_test.ts
+++ b/packages/markspec/core/typl/shape_test.ts
@@ -1,0 +1,134 @@
+// packages/markspec/core/typl/shape_test.ts
+import { assertEquals } from "@std/assert";
+import { parseTyplBlock } from "./grammar.ts";
+
+function shapeOf(source: string) {
+  const { ast, diagnostics } = parseTyplBlock(`$X : ${source}`);
+  if (diagnostics.length) throw new Error(JSON.stringify(diagnostics));
+  return ast.bindings[0].shape;
+}
+
+Deno.test("shape: primitives", () => {
+  assertEquals(shapeOf("int"), { kind: "primitive", type: "int" });
+  assertEquals(shapeOf("float"), { kind: "primitive", type: "float" });
+  assertEquals(shapeOf("bool"), { kind: "primitive", type: "bool" });
+  assertEquals(shapeOf("string"), { kind: "primitive", type: "string" });
+  assertEquals(shapeOf("bytes"), { kind: "primitive", type: "bytes" });
+});
+
+Deno.test("shape: int range", () => {
+  assertEquals(shapeOf("int[0..255]"), {
+    kind: "range",
+    type: "int",
+    min: 0,
+    max: 255,
+  });
+  assertEquals(shapeOf("int[0..]"), {
+    kind: "range",
+    type: "int",
+    min: 0,
+  });
+  assertEquals(shapeOf("int[..255]"), {
+    kind: "range",
+    type: "int",
+    max: 255,
+  });
+  assertEquals(shapeOf("int[5]"), {
+    kind: "range",
+    type: "int",
+    exact: 5,
+  });
+});
+
+Deno.test("shape: float range with int literals coerces", () => {
+  assertEquals(shapeOf("float[0..300]"), {
+    kind: "range",
+    type: "float",
+    min: 0,
+    max: 300,
+  });
+});
+
+Deno.test("shape: string length", () => {
+  assertEquals(shapeOf("string[3..6]"), {
+    kind: "length",
+    type: "string",
+    min: 3,
+    max: 6,
+  });
+  assertEquals(shapeOf("string[17]"), {
+    kind: "length",
+    type: "string",
+    exact: 17,
+  });
+});
+
+Deno.test("shape: pattern", () => {
+  assertEquals(shapeOf("/^[A-Z]{3}$/"), {
+    kind: "pattern",
+    regex: "^[A-Z]{3}$",
+  });
+  assertEquals(shapeOf("/^x/i"), {
+    kind: "pattern",
+    regex: "^x",
+    flags: "i",
+  });
+});
+
+Deno.test("shape: array variants", () => {
+  assertEquals(shapeOf("int[]"), {
+    kind: "array",
+    element: { kind: "primitive", type: "int" },
+  });
+  assertEquals(shapeOf("int[](..8)"), {
+    kind: "array",
+    element: { kind: "primitive", type: "int" },
+    max: 8,
+  });
+  assertEquals(shapeOf("int[](1..8)"), {
+    kind: "array",
+    element: { kind: "primitive", type: "int" },
+    min: 1,
+    max: 8,
+  });
+  assertEquals(shapeOf("float[4]"), {
+    kind: "array",
+    element: { kind: "primitive", type: "float" },
+    exact: 4,
+  });
+});
+
+Deno.test("shape: enum", () => {
+  assertEquals(shapeOf("'low' | 'mid' | 'high'"), {
+    kind: "enum",
+    values: ["low", "mid", "high"],
+  });
+  assertEquals(shapeOf("1 | 2 | 3"), {
+    kind: "enum",
+    values: [1, 2, 3],
+  });
+});
+
+Deno.test("shape: record", () => {
+  assertEquals(
+    shapeOf("{ id: int[0..15], payload: int[0..255] }"),
+    {
+      kind: "record",
+      fields: {
+        id: { kind: "range", type: "int", min: 0, max: 15 },
+        payload: { kind: "range", type: "int", min: 0, max: 255 },
+      },
+    },
+  );
+});
+
+Deno.test("shape: ref (bare PascalCase identifier)", () => {
+  assertEquals(shapeOf("Frame"), { kind: "ref", name: "Frame" });
+});
+
+Deno.test("shape: optional", () => {
+  assertEquals(shapeOf("string?"), {
+    kind: "optional",
+    inner: { kind: "primitive", type: "string" },
+  });
+});


### PR DESCRIPTION
## Summary

Introduces `packages/markspec/core/typl/` — a self-contained recursive-descent parser for the **typl** Type Specification DSL (**ADR-019**, renumbered from 017 after rebase — slots 017/018 are now `discipline-classification` and `core-discipline-ssot`). This is PR 1 of an 8-PR series; subsequent PRs add Markdown surfaces, entry-model integration, validator wiring, LSP support, and documentation closeout.

Modules shipped:

- `ast.ts` — 10-variant `Shape` discriminated union; `Binding`, `Typedef`, `TyplBlock` interfaces; 9-item `Kind` vocabulary (`value` default + `event | signal | command | state | const | config | document | stream`)
- `diagnostics.ts` — 8 diagnostic codes (TYPL-001..008) with `TyplCode` string-literal union for compile-time call-site safety; template interpolation
- `lexer.ts` — position-tracking tokenizer (23 token kinds, CRLF-safe)
- `grammar.ts` — recursive-descent parser exposing `parseTyplBlock(source) → { ast, diagnostics }`. Implements per-block duplicate detection (TYPL-001/004); shape parser covers all 10 variants
- `mod.ts` — public API barrel
- `core/mod.ts` — `export * as typl from "./typl/mod.ts"` namespace re-export (avoids `VERSION` collision)
- `docs/architecture/adr-019-typl-type-dsl.md` — accepted ADR
- `CHANGELOG.md` — entry under `[Unreleased] → Added`

No Markdown integration in this PR — surfaces (fence, bullet glossary, inline backtick) ship in PRs 2–5. Validator wiring (cross-entry collision) ships in PR 6.

## Test plan

- [x] `just check` — 1812 tests pass, 0 failed, 2 ignored
- [x] `deno fmt --check` — 336 files clean
- [x] `dprint check` — clean
- [x] `just compile` — binary builds
- [x] Rebased on latest main, conflicts resolved (ADR renumbered, CHANGELOG merged)
- [ ] Reviewer: spot-check `parseTyplBlock` against ADR-019 examples
- [ ] Reviewer: confirm `core.typl.*` namespace is the intended public surface

## Spec / plan

- Spec: brainstorming output (local design history — not in repo)
- Plan: 8-PR series, PR 1 fully detailed at execution start

🤖 Generated with [Claude Code](https://claude.com/claude-code)