### PR TITLE
feat(core): typl fence surface adapter (PR 2 of 8)

### DIFF
--- a/packages/markspec/core/typl/fence.ts
+++ b/packages/markspec/core/typl/fence.ts
@@ -1,0 +1,46 @@
+/**
+ * @module typl/fence
+ *
+ * Fence surface adapter — extracts typl source from fenced code blocks
+ * whose info-string is "typl". Operates on the canonical body AST
+ * (BodyBlock[]) produced by core/ast/build.ts.
+ *
+ * This module is parser-side only — it returns the raw typl source and
+ * its source range. PR 3 will wire the extracted source through
+ * parseTyplBlock and attach results to Entry.types.
+ */
+import type { BodyBlock, SourceRange } from "../ast/nodes.ts";
+
+/** A single typl fence found inside a body. */
+export interface TyplFenceExtraction {
+  /** The verbatim typl source from inside the fence (CodeNode.text). */
+  readonly source: string;
+  /** Source range of the whole fence (opening ``` through closing ```). */
+  readonly range: SourceRange;
+}
+
+/**
+ * Walk a body AST and return every typl fence found. Recurses into
+ * container nodes (ListNode via ListItemNode.blocks) so typl fences
+ * nested inside list items are discovered.
+ *
+ * BlockquoteNode and NoteNode carry only InlineContent (not nested
+ * BodyBlock[]), so they are not recursed into.
+ *
+ * Returns fences in source order (depth-first traversal).
+ */
+export function extractTyplFences(
+  blocks: readonly BodyBlock[],
+): readonly TyplFenceExtraction[] {
+  const results: TyplFenceExtraction[] = [];
+  for (const block of blocks) {
+    if (block.kind === "code" && block.lang === "typl") {
+      results.push({ source: block.text, range: block.range });
+    } else if (block.kind === "list") {
+      for (const item of block.items) {
+        results.push(...extractTyplFences(item.blocks));
+      }
+    }
+  }
+  return results;
+}

--- a/packages/markspec/core/typl/fence_test.ts
+++ b/packages/markspec/core/typl/fence_test.ts
@@ -1,5 +1,10 @@
 import { assertEquals } from "@std/assert";
-import type { BodyBlock, CodeNode, ListItemNode, ListNode } from "../ast/nodes.ts";
+import type {
+  BodyBlock,
+  CodeNode,
+  ListItemNode,
+  ListNode,
+} from "../ast/nodes.ts";
 import { extractTyplFences } from "./fence.ts";
 
 function code(lang: string | undefined, text: string, line = 1): CodeNode {

--- a/packages/markspec/core/typl/fence_test.ts
+++ b/packages/markspec/core/typl/fence_test.ts
@@ -1,0 +1,81 @@
+import { assertEquals } from "@std/assert";
+import type { BodyBlock, CodeNode, ListItemNode, ListNode } from "../ast/nodes.ts";
+import { extractTyplFences } from "./fence.ts";
+
+function code(lang: string | undefined, text: string, line = 1): CodeNode {
+  return {
+    kind: "code",
+    lang,
+    text,
+    range: {
+      start: { line, column: 1 },
+      end: { line: line + text.split("\n").length + 1, column: 4 },
+    },
+  };
+}
+
+Deno.test("extractTyplFences: empty input → empty result", () => {
+  assertEquals(extractTyplFences([]), []);
+});
+
+Deno.test("extractTyplFences: ignores non-typl fences", () => {
+  const blocks: BodyBlock[] = [
+    code("ts", "const x = 1;"),
+    code("json", "{}"),
+    code(undefined, "bare fence"),
+  ];
+  assertEquals(extractTyplFences(blocks), []);
+});
+
+Deno.test("extractTyplFences: finds single typl fence at top level", () => {
+  const fence = code("typl", "$Speed : signal float[0..300]", 5);
+  const result = extractTyplFences([fence]);
+  assertEquals(result.length, 1);
+  assertEquals(result[0].source, "$Speed : signal float[0..300]");
+  assertEquals(result[0].range, fence.range);
+});
+
+Deno.test("extractTyplFences: multiple fences returned in source order", () => {
+  const f1 = code("typl", "$A : signal", 3);
+  const f2 = code("ts", "ignored", 5);
+  const f3 = code("typl", "$B : event", 7);
+  const result = extractTyplFences([f1, f2, f3]);
+  assertEquals(result.length, 2);
+  assertEquals(result[0].source, "$A : signal");
+  assertEquals(result[1].source, "$B : event");
+});
+
+Deno.test("extractTyplFences: recurses into list-item children", () => {
+  // ListNode.items is readonly ListItemNode[]; each ListItemNode.blocks
+  // carries nested BodyBlock[]. Build a list with two items, one of which
+  // contains a typl fence.
+  const nestedFence = code("typl", "$Pressure : signal float[0..10]", 12);
+  const otherCode = code("ts", "// ignored", 10);
+
+  const item1: ListItemNode = {
+    blocks: [otherCode],
+    range: { start: { line: 10, column: 1 }, end: { line: 11, column: 4 } },
+  };
+  const item2: ListItemNode = {
+    blocks: [nestedFence],
+    range: { start: { line: 12, column: 1 }, end: { line: 15, column: 4 } },
+  };
+  const list: ListNode = {
+    kind: "list",
+    ordered: false,
+    spread: false,
+    items: [item1, item2],
+    range: { start: { line: 10, column: 1 }, end: { line: 15, column: 4 } },
+  };
+
+  const blocks: BodyBlock[] = [list];
+  const result = extractTyplFences(blocks);
+  assertEquals(result.length, 1);
+  assertEquals(result[0].source, "$Pressure : signal float[0..10]");
+  assertEquals(result[0].range, nestedFence.range);
+});
+
+Deno.test("extractTyplFences: case-sensitive — 'TYPL' is NOT recognised", () => {
+  const blocks: BodyBlock[] = [code("TYPL", "$X : signal")];
+  assertEquals(extractTyplFences(blocks), []);
+});

--- a/packages/markspec/core/typl/mod.ts
+++ b/packages/markspec/core/typl/mod.ts
@@ -21,3 +21,6 @@ export type { TyplCode, TyplCodeEntry, TyplDiagnostic } from "./diagnostics.ts";
 export { TYPL_CODES, typlDiagnostic } from "./diagnostics.ts";
 
 export { parseTyplBlock } from "./grammar.ts";
+
+export type { TyplFenceExtraction } from "./fence.ts";
+export { extractTyplFences } from "./fence.ts";

--- a/packages/markspec/core/typl/mod_test.ts
+++ b/packages/markspec/core/typl/mod_test.ts
@@ -1,5 +1,5 @@
 import { assertEquals } from "@std/assert";
-import { KINDS, parseTyplBlock, TYPL_CODES } from "./mod.ts";
+import { extractTyplFences, KINDS, parseTyplBlock, TYPL_CODES } from "./mod.ts";
 
 Deno.test("typl module exposes parseTyplBlock", () => {
   const { ast, diagnostics } = parseTyplBlock("$Speed : signal float[0..300]");
@@ -10,4 +10,10 @@ Deno.test("typl module exposes parseTyplBlock", () => {
 Deno.test("typl module exposes KINDS and TYPL_CODES", () => {
   assertEquals(KINDS.includes("signal"), true);
   assertEquals("TYPL-007" in TYPL_CODES, true);
+});
+
+Deno.test("typl module exposes extractTyplFences", () => {
+  // Use it on an empty input — just confirm import resolves
+  const result = extractTyplFences([]);
+  assertEquals(result, []);
 });


### PR DESCRIPTION
## Summary

PR 2 of 8 in the typl DSL series. Adds the **fence surface adapter** — detection of ` ```typl ` fenced code blocks in entry bodies. Operates on the canonical body AST (BodyBlock[]), not raw mdast.

New file `packages/markspec/core/typl/fence.ts` exposing:

- `TyplFenceExtraction` interface — `{ source: string; range: SourceRange }`
- `extractTyplFences(blocks): readonly TyplFenceExtraction[]` — depth-first walker recursing through ListNode → ListItemNode.blocks so fences nested in list items are discovered

Both re-exported from `core/typl/mod.ts` (and reachable via `core.typl.*`).

This PR is parser-side only — `Entry` mutation and compile-output wiring lands in PR 3.

Builds on:
- PR 1 (parser foundation, ADR-019) — merged via #431

## Test plan

- [x] 7 new typl tests (6 fence + 1 barrel) — all passing
- [x] Full `just check` — 1835 tests pass, 0 failed
- [x] `deno fmt --check`, `dprint check` — clean
- [x] `just compile` — binary builds
- [ ] Reviewer: confirm BlockquoteNode / NoteNode correctly NOT recursed (they carry InlineContent only, not BodyBlock[])
- [ ] Reviewer: confirm `lang === "typl"` exact-match is the right granularity (not prefix, not case-insensitive)

## What's NOT in this PR

- Markdown integration — Entry.types population (PR 3)
- Bullet glossary surface (PR 4)
- Inline backtick surface (PR 5)
- Validation + corpus registry (PR 6)
- LSP integration (PR 7)
- Docs closeout (PR 8)
- CHANGELOG entry — per project rule, CHANGELOG updates batched at release time only

🤖 Generated with [Claude Code](https://claude.com/claude-code)
