### PR TITLE
feat(core): typl entry-model integration + compile output (PR 3 of 8)

### DIFF
--- a/packages/markspec/core/model/mod.ts
+++ b/packages/markspec/core/model/mod.ts
@@ -9,6 +9,7 @@
 // cleanly because both directions are `import type`.
 import type { BodyBlock } from "../ast/nodes.ts";
 import type { Discipline } from "./discipline.ts";
+import type { TyplBlock } from "../typl/mod.ts";
 
 export {
   ATTRIBUTE_CATALOG,
@@ -449,6 +450,18 @@ export interface Entry {
    * Always present — empty array when no constructs are recognised.
    */
   readonly bodyTokens: readonly BodyToken[];
+  /**
+   * typl declarations extracted from typl-info-string fences in the
+   * entry body, if any. Absent when the entry contains no typl fences.
+   *
+   * Populated by the parser via {@linkcode extractTyplFences} +
+   * {@linkcode parseTyplBlock} aggregated across all fences in the
+   * entry. Per-fence diagnostics are bridged to file-relative core
+   * diagnostics and surface in the parser's diagnostic stream.
+   *
+   * See ADR-019.
+   */
+  readonly types?: TyplBlock;
   /**
    * Discipline kind resolved by the classifier per ADR-017 Invariant 1
    * (channels 1–4 with default `system`).

--- a/packages/markspec/core/parser/markdown.ts
+++ b/packages/markspec/core/parser/markdown.ts
@@ -19,6 +19,12 @@ import { processor } from "./remark.ts";
 import { buildBodyAst } from "../ast/build.ts";
 import type { LineMap } from "./line_map.ts";
 import { translateEntryLocations } from "./translate.ts";
+import {
+  bridgeTyplDiagnostic,
+  extractTyplFences,
+  parseTyplBlock,
+  type TyplBlock,
+} from "../typl/mod.ts";
 
 /** Options for {@linkcode parseMarkdown}. */
 export interface ParseMarkdownOptions {
@@ -530,6 +536,30 @@ function extractEntry(
     column: 1,
   }, bodyIndent);
 
+  // Extract typl declarations from any ```typl fences in the body.
+  // Per-fence diagnostics are bridged to file-relative positions and
+  // pushed into the parser's diagnostic stream. Cross-entry collision
+  // detection lands in a later PR; this PR just aggregates intra-entry
+  // bindings + typedefs.
+  let types: TyplBlock | undefined;
+  const typlFences = extractTyplFences(bodyAst);
+  if (typlFences.length > 0) {
+    const allBindings: TyplBlock["bindings"][number][] = [];
+    const allTypedefs: TyplBlock["typedefs"][number][] = [];
+    for (const fence of typlFences) {
+      const result = parseTyplBlock(fence.source);
+      allBindings.push(...result.ast.bindings);
+      allTypedefs.push(...result.ast.typedefs);
+      const fenceFileStartLine = bodyStartLine + fence.range.start.line - 1;
+      for (const td of result.diagnostics) {
+        diagnostics.push(bridgeTyplDiagnostic(td, file, fenceFileStartLine));
+      }
+    }
+    if (allBindings.length > 0 || allTypedefs.length > 0) {
+      types = { bindings: allBindings, typedefs: allTypedefs };
+    }
+  }
+
   return {
     displayId: makeDisplayId(displayId),
     title: title ?? "",
@@ -544,6 +574,7 @@ function extractEntry(
     source: { kind: "markdown" },
     properties: { file: { path: file, line, column } },
     bodyTokens,
+    ...(types ? { types } : {}),
   };
 }
 

--- a/packages/markspec/core/parser/markdown_test.ts
+++ b/packages/markspec/core/parser/markdown_test.ts
@@ -390,3 +390,97 @@ Deno.test("parseMarkdown: without lineMap, locations stay buffer-relative", () =
   const { entries } = parseMarkdown(md, { file: "t.md" });
   assertEquals(entries[0].location.line, 1);
 });
+
+// ---------------------------------------------------------------------------
+// typl fence extraction (ADR-019)
+// ---------------------------------------------------------------------------
+
+Deno.test("parseMarkdown: entry with typl fence populates entry.types", () => {
+  const md = [
+    "- [REQ_0001] Brake on close approach",
+    "",
+    "  When TTC drops below threshold the system shall brake.",
+    "",
+    "  ```typl",
+    "  $Speed : signal float[0..300]",
+    "  $Brake : command BrakeReq",
+    "  type BrakeReq = { force_N: float[0..12000] }",
+    "  ```",
+    "",
+    "      Id: 01HZZZ0000000000000000000A",
+  ].join("\n");
+
+  const { entries } = parseMarkdown(md, { file: "test.md" });
+  assertEquals(entries.length, 1);
+  const entry = entries[0];
+
+  assertExists(entry.types);
+  assertEquals(entry.types?.bindings.length, 2);
+  assertEquals(entry.types?.bindings[0].name, "$Speed");
+  assertEquals(entry.types?.bindings[0].kind, "signal");
+  assertEquals(entry.types?.bindings[1].name, "$Brake");
+  assertEquals(entry.types?.bindings[1].kind, "command");
+  assertEquals(entry.types?.typedefs.length, 1);
+  assertEquals(entry.types?.typedefs[0].name, "BrakeReq");
+});
+
+Deno.test("parseMarkdown: entry without typl fence leaves entry.types undefined", () => {
+  const md = [
+    "- [REQ_0002] Simple requirement",
+    "",
+    "  Body text here.",
+    "",
+    "      Id: 01HZZZ0000000000000000000B",
+  ].join("\n");
+  const { entries } = parseMarkdown(md, { file: "test.md" });
+  assertEquals(entries[0].types, undefined);
+});
+
+Deno.test("parseMarkdown: typl parse error is bridged to file-relative diagnostic", () => {
+  const md = [
+    "- [REQ_0003] Bad typl",
+    "",
+    "  Body.",
+    "",
+    "  ```typl",
+    "  $X : blah int[0..]",
+    "  ```",
+    "",
+    "      Id: 01HZZZ0000000000000000000C",
+  ].join("\n");
+  const { diagnostics } = parseMarkdown(md, { file: "test.md" });
+  const typlDiag = diagnostics.find((d) => d.code === "TYPL-007");
+  assertExists(typlDiag);
+  assertEquals(typlDiag.location?.file, "test.md");
+  // Don't assert the exact line — the test would couple to indentation
+  // details. The bridge correctness is unit-tested in bridge_test.ts; here
+  // we just assert that a file is attached and the line is >= 1.
+  assertEquals((typlDiag.location?.line ?? 0) >= 1, true);
+});
+
+Deno.test("parseMarkdown: multiple typl fences in one entry aggregate", () => {
+  const md = [
+    "- [REQ_0004] Two fences",
+    "",
+    "  Some prose.",
+    "",
+    "  ```typl",
+    "  $A : signal",
+    "  ```",
+    "",
+    "  More prose.",
+    "",
+    "  ```typl",
+    "  $B : event",
+    "  type T = int",
+    "  ```",
+    "",
+    "      Id: 01HZZZ0000000000000000000D",
+  ].join("\n");
+  const { entries } = parseMarkdown(md, { file: "test.md" });
+  const entry = entries[0];
+  assertExists(entry.types);
+  assertEquals(entry.types?.bindings.map((b) => b.name), ["$A", "$B"]);
+  assertEquals(entry.types?.typedefs.length, 1);
+  assertEquals(entry.types?.typedefs[0].name, "T");
+});

--- a/packages/markspec/core/typl/bridge.ts
+++ b/packages/markspec/core/typl/bridge.ts
@@ -1,0 +1,47 @@
+/**
+ * @module typl/bridge
+ *
+ * Bridges between fence-relative {@linkcode TyplDiagnostic}s emitted by
+ * the typl parser and file-relative core {@linkcode Diagnostic}s
+ * consumed by the validator and CLI.
+ *
+ * The typl parser operates on raw typl source strings without knowing
+ * the host file. Surface adapters (fence, bullet, inline) attach the
+ * file path and a position offset when bridging.
+ *
+ * See ADR-019.
+ */
+import type { Diagnostic } from "../model/mod.ts";
+import type { TyplDiagnostic } from "./diagnostics.ts";
+
+/**
+ * Convert a fence-relative typl diagnostic into a file-relative core
+ * diagnostic.
+ *
+ * The fence's opening ` ``` ` line is at `fenceStartLine` (1-based).
+ * The typl content begins on the line _after_ the opening fence, so a
+ * typl diagnostic at line N corresponds to file line `fenceStartLine + N`.
+ * Column is passed through unchanged (the spec acknowledges a minor
+ * indent-translation wart for fences inside indented list items —
+ * tracked separately, not in scope here).
+ *
+ * @param diag        the fence-relative diagnostic emitted by parseTyplBlock
+ * @param file        the host file path
+ * @param fenceStartLine 1-based line of the opening ``` in the host file
+ */
+export function bridgeTyplDiagnostic(
+  diag: TyplDiagnostic,
+  file: string,
+  fenceStartLine: number,
+): Diagnostic {
+  return {
+    code: diag.code,
+    severity: diag.severity,
+    message: diag.message,
+    location: {
+      file,
+      line: fenceStartLine + diag.position.line,
+      column: diag.position.column,
+    },
+  };
+}

--- a/packages/markspec/core/typl/bridge_test.ts
+++ b/packages/markspec/core/typl/bridge_test.ts
@@ -1,0 +1,43 @@
+import { assertEquals } from "@std/assert";
+import { bridgeTyplDiagnostic } from "./bridge.ts";
+import { typlDiagnostic } from "./diagnostics.ts";
+
+Deno.test("bridgeTyplDiagnostic: line is fence-start + typl-position; column passes through", () => {
+  // Fence opens at file line 10. A typl diagnostic at typl-position
+  // line 2 col 5 should map to file line 12 col 5.
+  const td = typlDiagnostic(
+    "TYPL-007",
+    { keyword: "blah" },
+    { line: 2, column: 5 },
+  );
+  const d = bridgeTyplDiagnostic(td, "docs/example.md", 10);
+  assertEquals(d.code, "TYPL-007");
+  assertEquals(d.severity, "error");
+  assertEquals(d.location, {
+    file: "docs/example.md",
+    line: 12, // 10 + 2
+    column: 5,
+  });
+});
+
+Deno.test("bridgeTyplDiagnostic: message is passed through verbatim", () => {
+  const td = typlDiagnostic(
+    "TYPL-005",
+    { name: "Frame" },
+    { line: 1, column: 1 },
+  );
+  const d = bridgeTyplDiagnostic(td, "x.md", 0);
+  assertEquals(d.message, td.message);
+});
+
+Deno.test("bridgeTyplDiagnostic: works at fence-start line 0 (degenerate)", () => {
+  // Edge case: caller passes 0 for fenceStartLine.
+  // Result line should equal the typl diagnostic's line.
+  const td = typlDiagnostic(
+    "TYPL-006",
+    { detail: "bad" },
+    { line: 3, column: 1 },
+  );
+  const d = bridgeTyplDiagnostic(td, "x.md", 0);
+  assertEquals(d.location?.line, 3);
+});

--- a/packages/markspec/core/typl/mod.ts
+++ b/packages/markspec/core/typl/mod.ts
@@ -24,3 +24,5 @@ export { parseTyplBlock } from "./grammar.ts";
 
 export type { TyplFenceExtraction } from "./fence.ts";
 export { extractTyplFences } from "./fence.ts";
+
+export { bridgeTyplDiagnostic } from "./bridge.ts";

--- a/packages/markspec/core/typl/mod_test.ts
+++ b/packages/markspec/core/typl/mod_test.ts
@@ -4,8 +4,8 @@ import {
   extractTyplFences,
   KINDS,
   parseTyplBlock,
-  type TyplDiagnostic,
   TYPL_CODES,
+  type TyplDiagnostic,
 } from "./mod.ts";
 
 Deno.test("typl module exposes parseTyplBlock", () => {

--- a/packages/markspec/core/typl/mod_test.ts
+++ b/packages/markspec/core/typl/mod_test.ts
@@ -1,5 +1,12 @@
 import { assertEquals } from "@std/assert";
-import { extractTyplFences, KINDS, parseTyplBlock, TYPL_CODES } from "./mod.ts";
+import {
+  bridgeTyplDiagnostic,
+  extractTyplFences,
+  KINDS,
+  parseTyplBlock,
+  type TyplDiagnostic,
+  TYPL_CODES,
+} from "./mod.ts";
 
 Deno.test("typl module exposes parseTyplBlock", () => {
   const { ast, diagnostics } = parseTyplBlock("$Speed : signal float[0..300]");
@@ -16,4 +23,15 @@ Deno.test("typl module exposes extractTyplFences", () => {
   // Use it on an empty input — just confirm import resolves
   const result = extractTyplFences([]);
   assertEquals(result, []);
+});
+
+Deno.test("typl module exposes bridgeTyplDiagnostic", () => {
+  // Type check via call signature; we don't need to assert behaviour here
+  // — that's covered by bridge_test.ts.
+  const fn: (
+    diag: TyplDiagnostic,
+    file: string,
+    fenceStartLine: number,
+  ) => unknown = bridgeTyplDiagnostic;
+  assertEquals(typeof fn, "function");
 });

--- a/tests/e2e/typl_fence_test.ts
+++ b/tests/e2e/typl_fence_test.ts
@@ -1,0 +1,145 @@
+/**
+ * @module tests/e2e/typl_fence_test
+ *
+ * E2E tests confirming that `entry.types` (parsed typl declarations) flows
+ * through the `markspec compile --format json` output when an entry body
+ * contains a typl-info-string fence.
+ */
+
+import { assertEquals } from "@std/assert";
+import { markspec } from "./helpers.ts";
+
+const PROJECT_YAML = "name: test-project\nversion: 0.1.0\n";
+
+// ---------------------------------------------------------------------------
+// Positive case — entry with a typl fence
+// ---------------------------------------------------------------------------
+
+const WITH_TYPL_MD = `- [STK_BRK_0001] Brake when target stops
+
+  When the lead vehicle stops the system shall apply braking.
+
+  \`\`\`typl
+  $Speed     : signal float[0..300]
+  $Brake     : command BrakeReq
+  $Threshold : const 1.4
+
+  type BrakeReq = { force_N: float[0..12000] }
+  \`\`\`
+
+      Id: 01HZZZ0000000000000000000A
+`;
+
+// ---------------------------------------------------------------------------
+// Negative case — entry without a typl fence
+// ---------------------------------------------------------------------------
+
+const WITHOUT_TYPL_MD = `- [STK_BRK_0002] Driver override
+
+  The driver shall be able to override the braking system.
+
+      Id: 01HZZZ0000000000000000000B
+`;
+
+Deno.test(
+  "compile: entry.types populated for entry with typl fence",
+  async () => {
+    const { code, stdout } = await markspec(
+      ["compile", "--format", "json", "req.md"],
+      {
+        files: { "project.yaml": PROJECT_YAML, "req.md": WITH_TYPL_MD },
+      },
+    );
+    assertEquals(code, 0);
+
+    let parsed: ReturnType<typeof JSON.parse>;
+    try {
+      parsed = JSON.parse(stdout);
+    } catch (err) {
+      throw new Error(
+        `Failed to parse compile JSON output: ${err}\nstdout: ${stdout}`,
+      );
+    }
+
+    const entry = parsed.entries["STK_BRK_0001"];
+    if (!entry) throw new Error("STK_BRK_0001 not found in compile output");
+
+    // entry.types must be present
+    if (!entry.types) {
+      throw new Error(
+        `entry.types is absent for an entry with a typl fence; full entry: ${
+          JSON.stringify(entry, null, 2)
+        }`,
+      );
+    }
+
+    // --- bindings ---
+    const { bindings, typedefs } = entry.types;
+    assertEquals(bindings.length, 3, "expected 3 bindings");
+
+    // $Speed : signal float[0..300]
+    const speedBinding = bindings.find((b: { name: string }) =>
+      b.name === "$Speed"
+    );
+    if (!speedBinding) throw new Error("$Speed binding not found");
+    assertEquals(speedBinding.kind, "signal");
+    assertEquals(speedBinding.shape.kind, "range");
+    assertEquals(speedBinding.shape.type, "float");
+    assertEquals(speedBinding.shape.min, 0);
+    assertEquals(speedBinding.shape.max, 300);
+
+    // $Brake : command BrakeReq
+    const brakeBinding = bindings.find((b: { name: string }) =>
+      b.name === "$Brake"
+    );
+    if (!brakeBinding) throw new Error("$Brake binding not found");
+    assertEquals(brakeBinding.kind, "command");
+    assertEquals(brakeBinding.shape.kind, "ref");
+    assertEquals(brakeBinding.shape.name, "BrakeReq");
+
+    // $Threshold : const 1.4
+    const thresholdBinding = bindings.find((b: { name: string }) =>
+      b.name === "$Threshold"
+    );
+    if (!thresholdBinding) throw new Error("$Threshold binding not found");
+    assertEquals(thresholdBinding.kind, "const");
+
+    // --- typedefs ---
+    assertEquals(typedefs.length, 1, "expected 1 typedef");
+    const brakeReqTypedef = typedefs[0];
+    assertEquals(brakeReqTypedef.name, "BrakeReq");
+    assertEquals(brakeReqTypedef.shape.kind, "record");
+  },
+);
+
+Deno.test(
+  "compile: entry.types absent for entry without typl fence",
+  async () => {
+    const { code, stdout } = await markspec(
+      ["compile", "--format", "json", "req.md"],
+      {
+        files: { "project.yaml": PROJECT_YAML, "req.md": WITHOUT_TYPL_MD },
+      },
+    );
+    assertEquals(code, 0);
+
+    let parsed: ReturnType<typeof JSON.parse>;
+    try {
+      parsed = JSON.parse(stdout);
+    } catch (err) {
+      throw new Error(
+        `Failed to parse compile JSON output: ${err}\nstdout: ${stdout}`,
+      );
+    }
+
+    const entry = parsed.entries["STK_BRK_0002"];
+    if (!entry) throw new Error("STK_BRK_0002 not found in compile output");
+
+    // entry.types must be absent when no typl fence is present
+    assertEquals(
+      entry.types,
+      undefined,
+      "entry.types should be absent for an entry without a typl fence",
+    );
+  },
+);


### PR DESCRIPTION
## Summary

PR 3 of 8 in the typl DSL series. First PR with **observable end-user behaviour**: `markspec compile` JSON output now includes per-entry typl declarations.

### What is new

- `Entry.types?: TyplBlock` field on the core model — populated by the parser when an entry body contains ` ```typl ` fences; absent otherwise
- `core/typl/bridge.ts` — `bridgeTyplDiagnostic(diag, file, fenceStartLine)` translates fence-relative typl diagnostics into file-relative core diagnostics
- `parser/markdown.ts` hook — walks body AST for typl fences, parses each via `parseTyplBlock`, aggregates `{ bindings, typedefs }` into `Entry.types`, bridges per-fence parse diagnostics (TYPL-006/007/008/etc.) into the file diagnostic stream
- E2E test `tests/e2e/typl_fence_test.ts` — confirms the data flows through `markspec compile --format json`

### How it composes

Each entry typl content goes through:

```
body Markdown
  -> buildBodyAst (existing)
  -> extractTyplFences (PR 2)
  -> parseTyplBlock per fence (PR 1)
  -> aggregate bindings + typedefs
  -> Entry.types
  -> compile output JSON (via existing entry spread in compiler/mod.ts)
```

Per-fence diagnostics use this offset formula: `fileLine = bodyStartLine + fence.range.start.line - 1 + typlDiag.position.line`. Column is passed through unchanged (minor indent-translation wart for fences inside indented list items is acknowledged in the bridge JSDoc).

### What is NOT in this PR

- Bullet glossary surface (PR 4)
- Inline backtick surface (PR 5)
- Cross-entry collision detection + corpus `typeRegistry` (PR 6) — duplicate `$Name` across entries is currently silent; per-block dupes (TYPL-001/004) already fire from PR 1
- LSP integration (PR 7)
- Docs closeout (PR 8)
- CHANGELOG entry — per project rule, batched at release time

## Test plan

- [x] Unit: 3 new bridge tests, 4 new parser tests, 1 barrel smoke test
- [x] E2E: 2 new tests (positive + negative) — full CLI invocation via `markspec` helper
- [x] Full `just check` — 1845 tests pass, 0 failed
- [x] `deno fmt --check`, `dprint check` — clean
- [x] `just compile` — binary builds
- [ ] Reviewer: confirm the `bodyStartLine + range.start.line - 1` offset formula matches the canonical body-AST line semantics
- [ ] Reviewer: confirm conditional spread `...(types ? { types } : {})` does not break any downstream entry consumer

Builds on:
- PR 1 (parser foundation, ADR-019) — merged via #431
- PR 2 (fence adapter, `extractTyplFences`) — merged via #433

🤖 Generated with [Claude Code](https://claude.com/claude-code)
