### PR TITLE
feat(core): typl bullet-glossary surface (PR 4 of 8)

### DIFF
--- a/packages/markspec/core/parser/markdown.ts
+++ b/packages/markspec/core/parser/markdown.ts
@@ -21,6 +21,7 @@ import type { LineMap } from "./line_map.ts";
 import { translateEntryLocations } from "./translate.ts";
 import {
   bridgeTyplDiagnostic,
+  extractTyplBullets,
   extractTyplFences,
   parseTyplBlock,
   type TyplBlock,
@@ -536,28 +537,43 @@ function extractEntry(
     column: 1,
   }, bodyIndent);
 
-  // Extract typl declarations from any ```typl fences in the body.
-  // Per-fence diagnostics are bridged to file-relative positions and
-  // pushed into the parser's diagnostic stream. Cross-entry collision
-  // detection lands in a later PR; this PR just aggregates intra-entry
-  // bindings + typedefs.
+  // Extract typl declarations from any ```typl fences AND bullet-glossary
+  // items in the body. Per-fence and per-item diagnostics are bridged to
+  // file-relative positions and pushed into the parser's diagnostic stream.
+  // Cross-entry collision detection lands in PR 6; this PR aggregates all
+  // intra-entry bindings + typedefs from both surfaces.
   let types: TyplBlock | undefined;
-  const typlFences = extractTyplFences(bodyAst);
-  if (typlFences.length > 0) {
-    const allBindings: TyplBlock["bindings"][number][] = [];
-    const allTypedefs: TyplBlock["typedefs"][number][] = [];
-    for (const fence of typlFences) {
-      const result = parseTyplBlock(fence.source);
-      allBindings.push(...result.ast.bindings);
-      allTypedefs.push(...result.ast.typedefs);
-      const fenceFileStartLine = bodyStartLine + fence.range.start.line - 1;
-      for (const td of result.diagnostics) {
-        diagnostics.push(bridgeTyplDiagnostic(td, file, fenceFileStartLine));
-      }
+  const allBindings: TyplBlock["bindings"][number][] = [];
+  const allTypedefs: TyplBlock["typedefs"][number][] = [];
+
+  for (const fence of extractTyplFences(bodyAst)) {
+    const result = parseTyplBlock(fence.source);
+    allBindings.push(...result.ast.bindings);
+    allTypedefs.push(...result.ast.typedefs);
+    // Fence content starts on the line AFTER the opening ```, so the
+    // bridge offset is the file line of the opening fence.
+    const fenceFileStartLine = bodyStartLine + fence.range.start.line - 1;
+    for (const td of result.diagnostics) {
+      diagnostics.push(bridgeTyplDiagnostic(td, file, fenceFileStartLine));
     }
-    if (allBindings.length > 0 || allTypedefs.length > 0) {
-      types = { bindings: allBindings, typedefs: allTypedefs };
+  }
+
+  for (const bullet of extractTyplBullets(bodyAst)) {
+    const result = parseTyplBlock(bullet.source);
+    allBindings.push(...result.ast.bindings);
+    allTypedefs.push(...result.ast.typedefs);
+    // A bullet item IS the typl content (single line). The bridge
+    // computes line as `offset + diag.position.line`; we want diag
+    // position.line 1 to map to the item's file line, so offset is
+    // `itemFileLine - 1` = `bodyStartLine + bullet.range.start.line - 2`.
+    const bulletFileOffset = bodyStartLine + bullet.range.start.line - 2;
+    for (const td of result.diagnostics) {
+      diagnostics.push(bridgeTyplDiagnostic(td, file, bulletFileOffset));
     }
+  }
+
+  if (allBindings.length > 0 || allTypedefs.length > 0) {
+    types = { bindings: allBindings, typedefs: allTypedefs };
   }
 
   return {

--- a/packages/markspec/core/parser/markdown_test.ts
+++ b/packages/markspec/core/parser/markdown_test.ts
@@ -8,6 +8,7 @@
 
 import { assertEquals, assertExists } from "@std/assert";
 import { parseMarkdown } from "./markdown.ts";
+import { parseFile } from "./mod.ts";
 import type { LineMap } from "./line_map.ts";
 
 const ULID = "01HGW2Q8MNP3RSTVWXYZABCDEF";
@@ -483,4 +484,97 @@ Deno.test("parseMarkdown: multiple typl fences in one entry aggregate", () => {
   assertEquals(entry.types?.bindings.map((b) => b.name), ["$A", "$B"]);
   assertEquals(entry.types?.typedefs.length, 1);
   assertEquals(entry.types?.typedefs[0].name, "T");
+});
+
+// ---------------------------------------------------------------------------
+// typl bullet-glossary extraction (ADR-019, PR 4)
+// ---------------------------------------------------------------------------
+
+Deno.test("parseMarkdown: entry with bullet-glossary typl populates entry.types", async () => {
+  const source = [
+    "- [REQ_0010] Bullet glossary entry",
+    "",
+    "  Prose describing the requirement.",
+    "",
+    "  - $Speed     : signal float[0..300]",
+    "  - $Brake     : command BrakeReq",
+    "  - $Threshold : const 1.4",
+    "  - type BrakeReq = { force_N: float[0..12000] }",
+    "",
+    "      Id: 01HZZZ0000000000000000000E",
+  ].join("\n");
+
+  const result = await parseFile(source, { file: "test.md" });
+  assertEquals(result.entries.length, 1);
+  const entry = result.entries[0];
+
+  assertExists(entry.types);
+  assertEquals(entry.types?.bindings.length, 3);
+  assertEquals(entry.types?.bindings.map((b) => b.name), [
+    "$Speed",
+    "$Brake",
+    "$Threshold",
+  ]);
+  assertEquals(entry.types?.typedefs.length, 1);
+  assertEquals(entry.types?.typedefs[0].name, "BrakeReq");
+});
+
+Deno.test("parseMarkdown: bullet list with mixed typl and prose only extracts typl items", async () => {
+  const source = [
+    "- [REQ_0011] Mixed list entry",
+    "",
+    "  The system has these signals:",
+    "",
+    "  - This is a regular bullet describing context.",
+    "  - $Vehicle  : signal",
+    "  - Another regular bullet.",
+    "  - $Driver   : signal",
+    "",
+    "      Id: 01HZZZ0000000000000000000F",
+  ].join("\n");
+
+  const result = await parseFile(source, { file: "test.md" });
+  const entry = result.entries[0];
+
+  assertExists(entry.types);
+  assertEquals(entry.types?.bindings.length, 2);
+  assertEquals(entry.types?.bindings.map((b) => b.name), ["$Vehicle", "$Driver"]);
+});
+
+Deno.test("parseMarkdown: entry combining fence AND bullet typl aggregates both", async () => {
+  const source = [
+    "- [REQ_0012] Combined surfaces",
+    "",
+    "  ```typl",
+    "  $InFence : signal",
+    "  ```",
+    "",
+    "  Some prose.",
+    "",
+    "  - $InBullet : event",
+    "",
+    "      Id: 01HZZZ0000000000000000000G",
+  ].join("\n");
+
+  const result = await parseFile(source, { file: "test.md" });
+  const entry = result.entries[0];
+
+  assertExists(entry.types);
+  assertEquals(entry.types?.bindings.length, 2);
+  assertEquals(entry.types?.bindings.map((b) => b.name), ["$InFence", "$InBullet"]);
+});
+
+Deno.test("parseMarkdown: bullet typl parse error is bridged to file-relative diagnostic", async () => {
+  const source = [
+    "- [REQ_0013] Bad bullet typl",
+    "",
+    "  - $X : blah int[0..]",
+    "",
+    "      Id: 01HZZZ0000000000000000000H",
+  ].join("\n");
+  const result = await parseFile(source, { file: "test.md" });
+  const typlDiag = result.diagnostics.find((d) => d.code === "TYPL-007");
+  assertExists(typlDiag);
+  assertEquals(typlDiag.location?.file, "test.md");
+  assertEquals((typlDiag.location?.line ?? 0) >= 1, true);
 });

--- a/packages/markspec/core/parser/markdown_test.ts
+++ b/packages/markspec/core/parser/markdown_test.ts
@@ -538,7 +538,10 @@ Deno.test("parseMarkdown: bullet list with mixed typl and prose only extracts ty
 
   assertExists(entry.types);
   assertEquals(entry.types?.bindings.length, 2);
-  assertEquals(entry.types?.bindings.map((b) => b.name), ["$Vehicle", "$Driver"]);
+  assertEquals(entry.types?.bindings.map((b) => b.name), [
+    "$Vehicle",
+    "$Driver",
+  ]);
 });
 
 Deno.test("parseMarkdown: entry combining fence AND bullet typl aggregates both", async () => {
@@ -561,7 +564,10 @@ Deno.test("parseMarkdown: entry combining fence AND bullet typl aggregates both"
 
   assertExists(entry.types);
   assertEquals(entry.types?.bindings.length, 2);
-  assertEquals(entry.types?.bindings.map((b) => b.name), ["$InFence", "$InBullet"]);
+  assertEquals(entry.types?.bindings.map((b) => b.name), [
+    "$InFence",
+    "$InBullet",
+  ]);
 });
 
 Deno.test("parseMarkdown: bullet typl parse error is bridged to file-relative diagnostic", async () => {

--- a/packages/markspec/core/typl/bullet.ts
+++ b/packages/markspec/core/typl/bullet.ts
@@ -1,0 +1,73 @@
+/**
+ * @module typl/bullet
+ *
+ * Bullet-glossary surface adapter — recognises CommonMark bullet list
+ * items whose first paragraph matches typl syntax (`$X : ...` binding
+ * or `type X = ...` typedef). Mixed lists are supported: items that
+ * match are treated as typl declarations; non-matching bullets are
+ * left alone.
+ *
+ * Each matching item produces one TyplBulletExtraction; the parser
+ * integration calls parseTyplBlock on each `source` independently.
+ * Per-item position-bridging uses the item's range and formula
+ * documented in bridgeTyplDiagnostic.
+ *
+ * See ADR-019.
+ */
+import type { BodyBlock, ParagraphNode, SourceRange } from "../ast/nodes.ts";
+
+/** A single typl bullet item found inside a body. */
+export interface TyplBulletExtraction {
+  /** The typl source from one matching bullet item (paragraph text). */
+  readonly source: string;
+  /** Source range of the bullet's first paragraph. */
+  readonly range: SourceRange;
+}
+
+/** Matches a typl binding bullet (paragraph text). */
+const BULLET_BINDING_RE = /^\$[A-Za-z_][A-Za-z0-9_]*\s*:/;
+
+/** Matches a typl typedef bullet (paragraph text). */
+const BULLET_TYPEDEF_RE = /^type\s+[A-Za-z_][A-Za-z0-9_]*\s*=/;
+
+function isTyplBulletText(text: string): boolean {
+  return BULLET_BINDING_RE.test(text) || BULLET_TYPEDEF_RE.test(text);
+}
+
+/**
+ * Walk a body AST and return every bullet-list item whose first
+ * paragraph matches typl syntax. Recurses through ListNode →
+ * ListItemNode.blocks for nested lists (typl bullets inside a nested
+ * list are picked up).
+ *
+ * Returns matches in source order (depth-first).
+ */
+export function extractTyplBullets(
+  blocks: readonly BodyBlock[],
+): readonly TyplBulletExtraction[] {
+  const results: TyplBulletExtraction[] = [];
+  for (const block of blocks) {
+    if (block.kind === "list") {
+      for (const item of block.items) {
+        if (item.blocks.length === 0) continue;
+        const first = item.blocks[0];
+        if (first.kind === "paragraph") {
+          const para = first as ParagraphNode;
+          if (isTyplBulletText(para.content.text)) {
+            results.push({
+              source: para.content.text,
+              range: para.range,
+            });
+          }
+        }
+        // Recurse into nested blocks (the item may itself contain a list)
+        if (item.blocks.length > 1) {
+          results.push(...extractTyplBullets(item.blocks.slice(1)));
+        } else if (first.kind === "list") {
+          results.push(...extractTyplBullets([first]));
+        }
+      }
+    }
+  }
+  return results;
+}

--- a/packages/markspec/core/typl/bullet_test.ts
+++ b/packages/markspec/core/typl/bullet_test.ts
@@ -1,0 +1,132 @@
+import { assertEquals } from "@std/assert";
+import type {
+  BodyBlock,
+  ListItemNode,
+  ListNode,
+  ParagraphNode,
+} from "../ast/nodes.ts";
+import { extractTyplBullets } from "./bullet.ts";
+
+function para(text: string, line = 1): ParagraphNode {
+  return {
+    kind: "paragraph",
+    content: { text },
+    range: {
+      start: { line, column: 1 },
+      end: { line, column: text.length + 1 },
+    },
+  };
+}
+
+function item(blocks: BodyBlock[], line = 1): ListItemNode {
+  return {
+    blocks,
+    range: {
+      start: { line, column: 1 },
+      end: { line, column: 1 },
+    },
+  };
+}
+
+function list(items: ListItemNode[], ordered = false): ListNode {
+  return {
+    kind: "list",
+    ordered,
+    spread: false,
+    items,
+    range: {
+      start: { line: 1, column: 1 },
+      end: { line: items.length, column: 1 },
+    },
+  };
+}
+
+Deno.test("extractTyplBullets: empty input → empty result", () => {
+  assertEquals(extractTyplBullets([]), []);
+});
+
+Deno.test("extractTyplBullets: ignores non-list blocks", () => {
+  const blocks: BodyBlock[] = [
+    para("This is a paragraph, not a list", 1),
+  ];
+  assertEquals(extractTyplBullets(blocks), []);
+});
+
+Deno.test("extractTyplBullets: ignores list with no typl-shaped items", () => {
+  const blocks: BodyBlock[] = [
+    list([
+      item([para("regular bullet 1")]),
+      item([para("regular bullet 2")]),
+    ]),
+  ];
+  assertEquals(extractTyplBullets(blocks), []);
+});
+
+Deno.test("extractTyplBullets: finds typl binding bullet", () => {
+  const p = para("$Speed : signal float[0..300]", 5);
+  const blocks: BodyBlock[] = [list([item([p])])];
+  const result = extractTyplBullets(blocks);
+  assertEquals(result.length, 1);
+  assertEquals(result[0].source, "$Speed : signal float[0..300]");
+  assertEquals(result[0].range, p.range);
+});
+
+Deno.test("extractTyplBullets: finds typl typedef bullet", () => {
+  const p = para("type Frame = { id: int[0..255] }", 5);
+  const blocks: BodyBlock[] = [list([item([p])])];
+  const result = extractTyplBullets(blocks);
+  assertEquals(result.length, 1);
+  assertEquals(result[0].source, "type Frame = { id: int[0..255] }");
+});
+
+Deno.test("extractTyplBullets: mixed list — only typl items extracted", () => {
+  const p1 = para("regular intro bullet", 3);
+  const p2 = para("$A : signal", 4);
+  const p3 = para("another regular bullet", 5);
+  const p4 = para("$B : event", 6);
+  const p5 = para("type T = int", 7);
+  const blocks: BodyBlock[] = [
+    list([
+      item([p1]),
+      item([p2]),
+      item([p3]),
+      item([p4]),
+      item([p5]),
+    ]),
+  ];
+  const result = extractTyplBullets(blocks);
+  assertEquals(result.length, 3);
+  assertEquals(result.map((r) => r.source), [
+    "$A : signal",
+    "$B : event",
+    "type T = int",
+  ]);
+});
+
+Deno.test("extractTyplBullets: recurses into nested list-in-item", () => {
+  // An item whose first block is a paragraph AND second block is a nested
+  // list containing typl bullets — both the outer paragraph (if it matches)
+  // and the nested matching items should be returned.
+  const outer = para("$Outer : signal", 3);
+  const inner = para("$Inner : event", 5);
+  const blocks: BodyBlock[] = [
+    list([
+      item([outer, list([item([inner])])]),
+    ]),
+  ];
+  const result = extractTyplBullets(blocks);
+  assertEquals(result.length, 2);
+  assertEquals(result.map((r) => r.source), ["$Outer : signal", "$Inner : event"]);
+});
+
+Deno.test("extractTyplBullets: ignores `$` not followed by colon (not a binding)", () => {
+  const p = para("$Foo is a great name", 3);
+  const blocks: BodyBlock[] = [list([item([p])])];
+  assertEquals(extractTyplBullets(blocks), []);
+});
+
+Deno.test("extractTyplBullets: ignores `type` not followed by `=` (not a typedef)", () => {
+  const p = para("type of error", 3);
+  const blocks: BodyBlock[] = [list([item([p])])];
+  assertEquals(extractTyplBullets(blocks), []);
+});

--- a/packages/markspec/core/typl/bullet_test.ts
+++ b/packages/markspec/core/typl/bullet_test.ts
@@ -116,7 +116,10 @@ Deno.test("extractTyplBullets: recurses into nested list-in-item", () => {
   ];
   const result = extractTyplBullets(blocks);
   assertEquals(result.length, 2);
-  assertEquals(result.map((r) => r.source), ["$Outer : signal", "$Inner : event"]);
+  assertEquals(result.map((r) => r.source), [
+    "$Outer : signal",
+    "$Inner : event",
+  ]);
 });
 
 Deno.test("extractTyplBullets: ignores `$` not followed by colon (not a binding)", () => {

--- a/packages/markspec/core/typl/mod.ts
+++ b/packages/markspec/core/typl/mod.ts
@@ -26,3 +26,6 @@ export type { TyplFenceExtraction } from "./fence.ts";
 export { extractTyplFences } from "./fence.ts";
 
 export { bridgeTyplDiagnostic } from "./bridge.ts";
+
+export type { TyplBulletExtraction } from "./bullet.ts";
+export { extractTyplBullets } from "./bullet.ts";

--- a/tests/e2e/typl_bullet_test.ts
+++ b/tests/e2e/typl_bullet_test.ts
@@ -15,7 +15,8 @@ const PROJECT_YAML = "name: test-project\nversion: 0.1.0\n";
 // Fixture: two entries in one file — fence vs bullet surface, same payload
 // ---------------------------------------------------------------------------
 
-const FENCE_AND_BULLET_MD = `- [STK_FENCE_0001] Brake when target stops (fence form)
+const FENCE_AND_BULLET_MD =
+  `- [STK_FENCE_0001] Brake when target stops (fence form)
 
   When the lead vehicle stops the system shall apply braking.
 
@@ -105,23 +106,31 @@ Deno.test(
 
     if (!fenceEntry.types) {
       throw new Error(
-        `fenceEntry.types is absent; full entry: ${JSON.stringify(fenceEntry, null, 2)}`,
+        `fenceEntry.types is absent; full entry: ${
+          JSON.stringify(fenceEntry, null, 2)
+        }`,
       );
     }
     if (!bulletEntry.types) {
       throw new Error(
-        `bulletEntry.types is absent; full entry: ${JSON.stringify(bulletEntry, null, 2)}`,
+        `bulletEntry.types is absent; full entry: ${
+          JSON.stringify(bulletEntry, null, 2)
+        }`,
       );
     }
 
-    const fenceBindings: Array<{ name: string; kind: string; shape?: unknown; position: unknown }> =
-      fenceEntry.types.bindings;
-    const bulletBindings: Array<{ name: string; kind: string; shape?: unknown; position: unknown }> =
-      bulletEntry.types.bindings;
-    const fenceTypedefs: Array<{ name: string; shape: unknown; position: unknown }> =
-      fenceEntry.types.typedefs;
-    const bulletTypedefs: Array<{ name: string; shape: unknown; position: unknown }> =
-      bulletEntry.types.typedefs;
+    const fenceBindings: Array<
+      { name: string; kind: string; shape?: unknown; position: unknown }
+    > = fenceEntry.types.bindings;
+    const bulletBindings: Array<
+      { name: string; kind: string; shape?: unknown; position: unknown }
+    > = bulletEntry.types.bindings;
+    const fenceTypedefs: Array<
+      { name: string; shape: unknown; position: unknown }
+    > = fenceEntry.types.typedefs;
+    const bulletTypedefs: Array<
+      { name: string; shape: unknown; position: unknown }
+    > = bulletEntry.types.typedefs;
 
     // Both surfaces must yield the same number of bindings and typedefs.
     assertEquals(
@@ -208,21 +217,29 @@ Deno.test(
     assertEquals(
       bindings.length,
       2,
-      `expected 2 typl bindings but got ${bindings.length}: ${JSON.stringify(bindings.map((b: { name: string }) => b.name))}`,
+      `expected 2 typl bindings but got ${bindings.length}: ${
+        JSON.stringify(bindings.map((b: { name: string }) => b.name))
+      }`,
     );
 
     const names: string[] = bindings.map((b: { name: string }) => b.name);
     if (!names.includes("$Vehicle")) {
-      throw new Error(`$Vehicle binding missing; got: ${JSON.stringify(names)}`);
+      throw new Error(
+        `$Vehicle binding missing; got: ${JSON.stringify(names)}`,
+      );
     }
     if (!names.includes("$Driver")) {
       throw new Error(`$Driver binding missing; got: ${JSON.stringify(names)}`);
     }
 
     // Verify kinds
-    const vehicleB = bindings.find((b: { name: string }) => b.name === "$Vehicle");
+    const vehicleB = bindings.find((b: { name: string }) =>
+      b.name === "$Vehicle"
+    );
     assertEquals(vehicleB.kind, "signal");
-    const driverB = bindings.find((b: { name: string }) => b.name === "$Driver");
+    const driverB = bindings.find((b: { name: string }) =>
+      b.name === "$Driver"
+    );
     assertEquals(driverB.kind, "signal");
   },
 );

--- a/tests/e2e/typl_bullet_test.ts
+++ b/tests/e2e/typl_bullet_test.ts
@@ -1,0 +1,228 @@
+/**
+ * @module tests/e2e/typl_bullet_test
+ *
+ * E2E tests confirming that a bullet-glossary typl surface produces the same
+ * `entry.types` JSON shape as the equivalent typl-fence surface through the
+ * `markspec compile --format json` pipeline.
+ */
+
+import { assertEquals } from "@std/assert";
+import { markspec } from "./helpers.ts";
+
+const PROJECT_YAML = "name: test-project\nversion: 0.1.0\n";
+
+// ---------------------------------------------------------------------------
+// Fixture: two entries in one file — fence vs bullet surface, same payload
+// ---------------------------------------------------------------------------
+
+const FENCE_AND_BULLET_MD = `- [STK_FENCE_0001] Brake when target stops (fence form)
+
+  When the lead vehicle stops the system shall apply braking.
+
+  \`\`\`typl
+  $Speed     : signal float[0..300]
+  $Brake     : command BrakeReq
+  $Threshold : const 1.4
+
+  type BrakeReq = { force_N: float[0..12000] }
+  \`\`\`
+
+      Id: 01HZZZ0000000000000000000A
+
+- [STK_BULLET_0001] Brake when target stops (bullet form)
+
+  When the lead vehicle stops the system shall apply braking.
+
+  - $Speed     : signal float[0..300]
+  - $Brake     : command BrakeReq
+  - $Threshold : const 1.4
+  - type BrakeReq = { force_N: float[0..12000] }
+
+      Id: 01HZZZ0000000000000000000B
+`;
+
+// ---------------------------------------------------------------------------
+// Fixture: entry with a mixed bullet list (typl + prose items)
+// ---------------------------------------------------------------------------
+
+const MIXED_BULLET_MD = `- [STK_MIXED_0001] Entry with mixed bullet list
+
+  The system has the following interface signals:
+
+  - This bullet describes context only.
+  - $Vehicle  : signal float[0..200]
+  - Another prose bullet — not a typl item.
+  - $Driver   : signal bool
+
+      Id: 01HZZZ0000000000000000000C
+`;
+
+// ---------------------------------------------------------------------------
+// Helper: strip `position` from a binding or typedef before comparing
+// ---------------------------------------------------------------------------
+
+type PositionStripped<T> = Omit<T, "position">;
+
+function stripPosition<T extends { position: unknown }>(
+  item: T,
+): PositionStripped<T> {
+  const { position: _pos, ...rest } = item;
+  return rest as PositionStripped<T>;
+}
+
+// ---------------------------------------------------------------------------
+// Test 1: bullet glossary produces same entry.types as fence equivalent
+// ---------------------------------------------------------------------------
+
+Deno.test(
+  "compile: bullet glossary produces same entry.types as fence equivalent",
+  async () => {
+    const { code, stdout } = await markspec(
+      ["compile", "--format", "json", "req.md"],
+      {
+        files: { "project.yaml": PROJECT_YAML, "req.md": FENCE_AND_BULLET_MD },
+      },
+    );
+    assertEquals(code, 0);
+
+    let parsed: ReturnType<typeof JSON.parse>;
+    try {
+      parsed = JSON.parse(stdout);
+    } catch (err) {
+      throw new Error(
+        `Failed to parse compile JSON output: ${err}\nstdout: ${stdout}`,
+      );
+    }
+
+    const fenceEntry = parsed.entries["STK_FENCE_0001"];
+    if (!fenceEntry) {
+      throw new Error("STK_FENCE_0001 not found in compile output");
+    }
+    const bulletEntry = parsed.entries["STK_BULLET_0001"];
+    if (!bulletEntry) {
+      throw new Error("STK_BULLET_0001 not found in compile output");
+    }
+
+    if (!fenceEntry.types) {
+      throw new Error(
+        `fenceEntry.types is absent; full entry: ${JSON.stringify(fenceEntry, null, 2)}`,
+      );
+    }
+    if (!bulletEntry.types) {
+      throw new Error(
+        `bulletEntry.types is absent; full entry: ${JSON.stringify(bulletEntry, null, 2)}`,
+      );
+    }
+
+    const fenceBindings: Array<{ name: string; kind: string; shape?: unknown; position: unknown }> =
+      fenceEntry.types.bindings;
+    const bulletBindings: Array<{ name: string; kind: string; shape?: unknown; position: unknown }> =
+      bulletEntry.types.bindings;
+    const fenceTypedefs: Array<{ name: string; shape: unknown; position: unknown }> =
+      fenceEntry.types.typedefs;
+    const bulletTypedefs: Array<{ name: string; shape: unknown; position: unknown }> =
+      bulletEntry.types.typedefs;
+
+    // Both surfaces must yield the same number of bindings and typedefs.
+    assertEquals(
+      bulletBindings.length,
+      fenceBindings.length,
+      "binding count mismatch between bullet and fence surfaces",
+    );
+    assertEquals(
+      bulletTypedefs.length,
+      fenceTypedefs.length,
+      "typedef count mismatch between bullet and fence surfaces",
+    );
+
+    // Compare each binding by name, kind, and shape — ignoring position.
+    for (const fenceB of fenceBindings) {
+      const bulletB = bulletBindings.find((b) => b.name === fenceB.name);
+      if (!bulletB) {
+        throw new Error(
+          `binding '${fenceB.name}' present in fence entry but missing from bullet entry`,
+        );
+      }
+      assertEquals(
+        stripPosition(bulletB),
+        stripPosition(fenceB),
+        `binding '${fenceB.name}' shape/kind mismatch between surfaces`,
+      );
+    }
+
+    // Compare each typedef by name and shape — ignoring position.
+    for (const fenceT of fenceTypedefs) {
+      const bulletT = bulletTypedefs.find((t) => t.name === fenceT.name);
+      if (!bulletT) {
+        throw new Error(
+          `typedef '${fenceT.name}' present in fence entry but missing from bullet entry`,
+        );
+      }
+      assertEquals(
+        stripPosition(bulletT),
+        stripPosition(fenceT),
+        `typedef '${fenceT.name}' shape mismatch between surfaces`,
+      );
+    }
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Test 2: mixed bullet list only extracts typl items into entry.types
+// ---------------------------------------------------------------------------
+
+Deno.test(
+  "compile: mixed bullet list (typl + prose) only extracts typl items",
+  async () => {
+    const { code, stdout } = await markspec(
+      ["compile", "--format", "json", "req.md"],
+      {
+        files: { "project.yaml": PROJECT_YAML, "req.md": MIXED_BULLET_MD },
+      },
+    );
+    assertEquals(code, 0);
+
+    let parsed: ReturnType<typeof JSON.parse>;
+    try {
+      parsed = JSON.parse(stdout);
+    } catch (err) {
+      throw new Error(
+        `Failed to parse compile JSON output: ${err}\nstdout: ${stdout}`,
+      );
+    }
+
+    const entry = parsed.entries["STK_MIXED_0001"];
+    if (!entry) throw new Error("STK_MIXED_0001 not found in compile output");
+
+    if (!entry.types) {
+      throw new Error(
+        `entry.types is absent; full entry: ${JSON.stringify(entry, null, 2)}`,
+      );
+    }
+
+    const { bindings } = entry.types;
+
+    // Only the two $-prefixed bullets should appear — the two prose bullets
+    // ("This bullet describes context only." and "Another prose bullet — not a
+    // typl item.") must NOT surface in entry.types.bindings.
+    assertEquals(
+      bindings.length,
+      2,
+      `expected 2 typl bindings but got ${bindings.length}: ${JSON.stringify(bindings.map((b: { name: string }) => b.name))}`,
+    );
+
+    const names: string[] = bindings.map((b: { name: string }) => b.name);
+    if (!names.includes("$Vehicle")) {
+      throw new Error(`$Vehicle binding missing; got: ${JSON.stringify(names)}`);
+    }
+    if (!names.includes("$Driver")) {
+      throw new Error(`$Driver binding missing; got: ${JSON.stringify(names)}`);
+    }
+
+    // Verify kinds
+    const vehicleB = bindings.find((b: { name: string }) => b.name === "$Vehicle");
+    assertEquals(vehicleB.kind, "signal");
+    const driverB = bindings.find((b: { name: string }) => b.name === "$Driver");
+    assertEquals(driverB.kind, "signal");
+  },
+);


### PR DESCRIPTION
## Summary

PR 4 of 8 in the typl DSL series. Adds the **bullet-glossary surface** — recognises CommonMark bullet list items whose first paragraph matches typl syntax (`$X : ...` binding or `type X = ...` typedef).

### What is new

- `core/typl/bullet.ts` — `extractTyplBullets(blocks)` walks the body AST for `ListNode → ListItemNode → ParagraphNode` patterns and tests each item's text against typl regexes:
  - `/^\$[A-Za-z_][A-Za-z0-9_]*\s*:/` — binding
  - `/^type\s+[A-Za-z_][A-Za-z0-9_]*\s*=/` — typedef
- Mixed lists are supported: matching items become typl declarations, non-matching bullets are left alone.
- Recurses through nested lists.
- Wired into `parser/markdown.ts` alongside the existing fence handling — both surfaces aggregate into the same `Entry.types.bindings[]` / `typedefs[]`.
- Diagnostic bridging uses offset `bodyStartLine + bullet.range.start.line - 2` (because a bullet IS the typl content, so diag.position.line 1 must map to the item's file line).

### Example

```markdown
- [REQ_0010] Brake on close approach

  The system shall brake when threshold exceeded.

  - $Speed     : signal float[0..300]
  - $Brake     : command BrakeReq
  - $Threshold : const 1.4
  - type BrakeReq = { force_N: float[0..12000] }

      Id: 01HZZZ0000000000000000000A
```

Compiles to the same `entry.types` JSON as the fence-equivalent entry — the e2e test exercises this equivalence directly.

### What is NOT in this PR

- Inline backtick surface (PR 5)
- Cross-entry collision detection + corpus `typeRegistry` (PR 6) — duplicate `$Name` across entries and across surfaces in the same entry are currently silent; per-block dupes (TYPL-001/004) already fire from PR 1
- LSP integration (PR 7)
- Docs closeout (PR 8)
- CHANGELOG entry — per project rule, batched at release time

## Test plan

- [x] Unit: 9 new bullet adapter tests + 4 new parser integration tests
- [x] E2E: 2 new tests — bullet/fence equivalence + mixed-list extraction
- [x] Full `just check` — 1860 tests pass, 0 failed
- [x] `deno fmt --check`, `dprint check` — clean
- [x] `just compile` — binary builds
- [ ] Reviewer: confirm the `-2` offset formula for bullets matches what you would derive from a bullet at body line N
- [ ] Reviewer: confirm mixed-list behaviour (non-matching bullets ignored) matches the spec intent

Builds on:
- PR 1 (parser foundation) — #431
- PR 2 (fence adapter) — #433
- PR 3 (entry-model integration) — #437

🤖 Generated with [Claude Code](https://claude.com/claude-code)
