### PR TITLE
feat(core): slice 2 — rule-based sentence segmenter for prose lint

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -24,7 +24,8 @@
     "@std/fs": "jsr:@std/fs@^1",
     "@std/ulid": "jsr:@std/ulid@^1",
     "@std/yaml": "jsr:@std/yaml@^1",
-    "@std/path": "jsr:@std/path@^1"
+    "@std/path": "jsr:@std/path@^1",
+    "@std/testing": "jsr:@std/testing@^1"
   },
   "workspace": [
     "./packages/markspec"

--- a/deno.lock
+++ b/deno.lock
@@ -6,21 +6,22 @@
     "jsr:@cliffy/internal@1.0.0": "1.0.0",
     "jsr:@cliffy/table@1.0.0": "1.0.0",
     "jsr:@david/code-block-writer@^13.0.3": "13.0.3",
-    "jsr:@db/sqlite@0.13": "0.13.0",
     "jsr:@deno/dnt@~0.42.3": "0.42.3",
-    "jsr:@denosaurs/plug@1": "1.1.0",
     "jsr:@std/assert@1": "1.0.13",
+    "jsr:@std/assert@^1.0.19": "1.0.19",
     "jsr:@std/cli@1": "1.0.28",
-    "jsr:@std/encoding@1": "1.0.10",
     "jsr:@std/fmt@1": "1.0.9",
     "jsr:@std/fmt@^1.0.9": "1.0.9",
     "jsr:@std/fs@1": "1.0.18",
-    "jsr:@std/internal@^1.0.12": "1.0.12",
+    "jsr:@std/fs@^1.0.23": "1.0.23",
+    "jsr:@std/internal@^1.0.12": "1.0.13",
+    "jsr:@std/internal@^1.0.13": "1.0.13",
     "jsr:@std/internal@^1.0.6": "1.0.12",
     "jsr:@std/path@1": "1.1.0",
-    "jsr:@std/path@1.0": "1.0.9",
     "jsr:@std/path@^1.1.0": "1.1.0",
+    "jsr:@std/path@^1.1.4": "1.1.4",
     "jsr:@std/semver@^1.0.8": "1.0.8",
+    "jsr:@std/testing@1": "1.0.18",
     "jsr:@std/text@^1.0.17": "1.0.17",
     "jsr:@std/ulid@1": "1.0.0",
     "jsr:@std/yaml@1": "1.0.12",
@@ -74,30 +75,14 @@
     "@david/code-block-writer@13.0.3": {
       "integrity": "f98c77d320f5957899a61bfb7a9bead7c6d83ad1515daee92dbacc861e13bb7f"
     },
-    "@db/sqlite@0.13.0": {
-      "integrity": "4545c635e0b3d4ddfdc0f2240f932f24b8ad0178e9c2e3a0f9403e7b18ae2fb5",
-      "dependencies": [
-        "jsr:@denosaurs/plug",
-        "jsr:@std/path@1.0"
-      ]
-    },
     "@deno/dnt@0.42.3": {
       "integrity": "62a917a0492f3c8af002dce90605bb0d41f7d29debc06aca40dba72ab65d8ae3",
       "dependencies": [
         "jsr:@david/code-block-writer",
         "jsr:@std/fmt@1",
-        "jsr:@std/fs",
+        "jsr:@std/fs@1",
         "jsr:@std/path@1",
         "jsr:@ts-morph/bootstrap"
-      ]
-    },
-    "@denosaurs/plug@1.1.0": {
-      "integrity": "eb2f0b7546c7bca2000d8b0282c54d50d91cf6d75cb26a80df25a6de8c4bc044",
-      "dependencies": [
-        "jsr:@std/encoding",
-        "jsr:@std/fmt@1",
-        "jsr:@std/fs",
-        "jsr:@std/path@1"
       ]
     },
     "@std/assert@1.0.13": {
@@ -106,15 +91,18 @@
         "jsr:@std/internal@^1.0.6"
       ]
     },
+    "@std/assert@1.0.19": {
+      "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
+      "dependencies": [
+        "jsr:@std/internal@^1.0.12"
+      ]
+    },
     "@std/cli@1.0.28": {
       "integrity": "74ef9b976db59ca6b23a5283469c9072be6276853807a83ec6c7ce412135c70a",
       "dependencies": [
         "jsr:@std/fmt@^1.0.9",
         "jsr:@std/internal@^1.0.12"
       ]
-    },
-    "@std/encoding@1.0.10": {
-      "integrity": "8783c6384a2d13abd5e9e87a7ae0520a30e9f56aeeaa3bdf910a3eaaf5c811a1"
     },
     "@std/fmt@1.0.8": {
       "integrity": "71e1fc498787e4434d213647a6e43e794af4fd393ef8f52062246e06f7e372b7"
@@ -128,20 +116,42 @@
         "jsr:@std/path@^1.1.0"
       ]
     },
+    "@std/fs@1.0.23": {
+      "integrity": "3ecbae4ce4fee03b180fa710caff36bb5adb66631c46a6460aaad49515565a37",
+      "dependencies": [
+        "jsr:@std/internal@^1.0.12",
+        "jsr:@std/path@^1.1.4"
+      ]
+    },
     "@std/internal@1.0.7": {
       "integrity": "39eeb5265190a7bc5d5591c9ff019490bd1f2c3907c044a11b0d545796158a0f"
     },
     "@std/internal@1.0.12": {
       "integrity": "972a634fd5bc34b242024402972cd5143eac68d8dffaca5eaa4dba30ce17b027"
     },
-    "@std/path@1.0.9": {
-      "integrity": "260a49f11edd3db93dd38350bf9cd1b4d1366afa98e81b86167b4e3dd750129e"
+    "@std/internal@1.0.13": {
+      "integrity": "2f9546691d4ac2d32859c82dff284aaeac980ddeca38430d07941e7e288725c0"
     },
     "@std/path@1.1.0": {
       "integrity": "ddc94f8e3c275627281cbc23341df6b8bcc874d70374f75fec2533521e3d6886"
     },
+    "@std/path@1.1.4": {
+      "integrity": "1d2d43f39efb1b42f0b1882a25486647cb851481862dc7313390b2bb044314b5",
+      "dependencies": [
+        "jsr:@std/internal@^1.0.12"
+      ]
+    },
     "@std/semver@1.0.8": {
       "integrity": "dc830e8b8b6a380c895d53fbfd1258dc253704ca57bbe1629ac65fd7830179b7"
+    },
+    "@std/testing@1.0.18": {
+      "integrity": "d3152f57b11666bf6358d0e127c7e3488e91178b0c2d8fbf0793e1c53cd13cb1",
+      "dependencies": [
+        "jsr:@std/assert@^1.0.19",
+        "jsr:@std/fs@^1.0.23",
+        "jsr:@std/internal@^1.0.13",
+        "jsr:@std/path@^1.1.4"
+      ]
     },
     "@std/text@1.0.17": {
       "integrity": "4b2c4ef67ae5b6c1dfd447c81c83a43718f52e3c7e748d8b33f694aba9895f95"
@@ -161,7 +171,7 @@
     "@ts-morph/common@0.27.0": {
       "integrity": "c7b73592d78ce8479b356fd4f3d6ec3c460d77753a8680ff196effea7a939052",
       "dependencies": [
-        "jsr:@std/fs",
+        "jsr:@std/fs@1",
         "jsr:@std/path@1"
       ]
     }
@@ -1377,6 +1387,7 @@
       "jsr:@std/cli@1",
       "jsr:@std/fs@1",
       "jsr:@std/path@1",
+      "jsr:@std/testing@1",
       "jsr:@std/ulid@1",
       "jsr:@std/yaml@1"
     ],

--- a/packages/markspec/core/lint/__snapshots__/segmenter_test.ts.snap
+++ b/packages/markspec/core/lint/__snapshots__/segmenter_test.ts.snap
@@ -1,0 +1,34 @@
+export const snapshot = {};
+
+snapshot[`segmenter: corpus snapshot 1`] = `
+[
+  {
+    offset: 0,
+    text: "The brake controller shall debounce sensor inputs.",
+  },
+  {
+    offset: 51,
+    text: "When the pedal is
+pressed, the system shall apply pressure within 200 ms.",
+  },
+  {
+    offset: 125,
+    text: "The pressure
+shall be released, e.g. when the parking brake is engaged, by the
+release subsystem.",
+  },
+  {
+    offset: 223,
+    text: "Fig. 3 shows the data flow.",
+  },
+  {
+    offset: 251,
+    text: "See vol. II for details.",
+  },
+  {
+    offset: 276,
+    text: "If a sensor reading is invalid, then the brake controller shall ignore
+it.",
+  },
+]
+`;

--- a/packages/markspec/core/lint/mod.ts
+++ b/packages/markspec/core/lint/mod.ts
@@ -8,3 +8,5 @@
 export type { LintDiagnostic } from "./types.ts";
 export { isProseScope, runLint } from "./runner.ts";
 export type { LintOptions, LintResult } from "./runner.ts";
+export { segmentSentences } from "./segmenter.ts";
+export type { Sentence } from "./segmenter.ts";

--- a/packages/markspec/core/lint/segmenter.ts
+++ b/packages/markspec/core/lint/segmenter.ts
@@ -1,0 +1,95 @@
+/**
+ * @module core/lint/segmenter
+ *
+ * Rule-based sentence segmenter for prose-analysis rules
+ * (markspec-prose-analysis §5.2). Splits on `.`/`?`/`!` followed by
+ * whitespace + an uppercase character, honoring an abbreviation
+ * lexicon. Deterministic; no I/O.
+ *
+ * ADR-020 Decision 3 pins the rule-based approach: Intl.Segmenter
+ * drift across V8 versions silently breaks snapshot tests, and
+ * external NLP libraries add non-deterministic dependencies. Reach
+ * for the prose.lexicons.sentence-abbrev lexicon to extend coverage,
+ * not for a smarter algorithm.
+ */
+
+export interface Sentence {
+  /** Sentence text including terminal punctuation. */
+  readonly text: string;
+  /** Byte offset of the sentence's first character in the source text. */
+  readonly offset: number;
+}
+
+/**
+ * Walk `text` once, accumulating characters into the current sentence
+ * until a terminator (`.`/`?`/`!`) followed by whitespace + uppercase
+ * is observed. The terminator is included in the sentence; the
+ * whitespace begins the next sentence's leading skip.
+ *
+ * Abbreviation guard: when the terminator is `.` and the token that
+ * just ended (including the `.`) is a member of `abbrevs`, the
+ * terminator is treated as an in-word period and does not split.
+ */
+export function segmentSentences(
+  text: string,
+  abbrevs: ReadonlySet<string>,
+): Sentence[] {
+  if (text.length === 0) return [];
+  const out: Sentence[] = [];
+  let start = 0;
+  let i = 0;
+  const n = text.length;
+
+  while (i < n) {
+    const ch = text[i];
+    const isTerminator = ch === "." || ch === "?" || ch === "!";
+    if (!isTerminator) {
+      i++;
+      continue;
+    }
+
+    // Look ahead for whitespace + uppercase.
+    let j = i + 1;
+    while (j < n && /\s/.test(text[j])) j++;
+    const next = j < n ? text[j] : "";
+    const isUpperNext = next >= "A" && next <= "Z";
+
+    if (!isUpperNext) {
+      i++;
+      continue;
+    }
+
+    // Abbreviation guard — only `.` can be in an abbreviation token.
+    if (ch === ".") {
+      const tokStart = findTokenStart(text, i);
+      const tok = text.slice(tokStart, i + 1);
+      if (abbrevs.has(tok)) {
+        i++;
+        continue;
+      }
+    }
+
+    // Split here. Sentence is [start, i+1).
+    out.push({
+      text: text.slice(start, i + 1),
+      offset: start,
+    });
+    start = j;
+    i = j;
+  }
+
+  // Tail
+  if (start < n) {
+    out.push({ text: text.slice(start, n), offset: start });
+  }
+
+  return out;
+}
+
+/** Walk back from `idx` until whitespace or string start; return the
+ * index of the first character of that token. */
+function findTokenStart(text: string, idx: number): number {
+  let k = idx;
+  while (k > 0 && !/\s/.test(text[k - 1])) k--;
+  return k;
+}

--- a/packages/markspec/core/lint/segmenter_test.ts
+++ b/packages/markspec/core/lint/segmenter_test.ts
@@ -34,13 +34,21 @@ Deno.test("segmenter: two sentences split on period + space + uppercase", () => 
   assertEquals(s[1].offset, 23);
 });
 
-Deno.test("segmenter: does not split on abbreviation 'e.g.'", () => {
+Deno.test("segmenter: abbreviation guard suppresses split before uppercase", () => {
+  // 'e.g.' is followed by space + uppercase 'A'. Without the abbrev guard,
+  // the .?!+whitespace+uppercase rule would split before 'Active'.
+  // The lexicon entry for 'e.g.' suppresses the split. This is the
+  // dedicated unit test for the guard logic; remove the guard and this
+  // test fails while the corpus snapshot also fails on 'vol. II'.
   const s = segmentSentences(
-    "Sensors e.g. radar shall debounce. The system shall log.",
+    "Use sensors e.g. Active radar shall debounce inputs.",
     ABBREVS,
   );
-  assertEquals(s.length, 2);
-  assertEquals(s[0].text, "Sensors e.g. radar shall debounce.");
+  assertEquals(s.length, 1);
+  assertEquals(
+    s[0].text,
+    "Use sensors e.g. Active radar shall debounce inputs.",
+  );
 });
 
 Deno.test("segmenter: ? and ! terminate sentences", () => {

--- a/packages/markspec/core/lint/segmenter_test.ts
+++ b/packages/markspec/core/lint/segmenter_test.ts
@@ -1,0 +1,76 @@
+/**
+ * @module core/lint/segmenter_test
+ *
+ * Unit tests for the rule-based sentence segmenter.
+ */
+
+import { assertEquals } from "@std/assert";
+import { assertSnapshot } from "@std/testing/snapshot";
+import { segmentSentences } from "./segmenter.ts";
+import { loadLexicon } from "../lexicons/mod.ts";
+
+const ABBREVS = loadLexicon("sentence-abbrev");
+
+Deno.test("segmenter: empty input", () => {
+  assertEquals(segmentSentences("", ABBREVS), []);
+});
+
+Deno.test("segmenter: single sentence no terminal punctuation", () => {
+  const s = segmentSentences("The system shall apply pressure", ABBREVS);
+  assertEquals(s.length, 1);
+  assertEquals(s[0].text, "The system shall apply pressure");
+  assertEquals(s[0].offset, 0);
+});
+
+Deno.test("segmenter: two sentences split on period + space + uppercase", () => {
+  const s = segmentSentences(
+    "The brake shall apply. The pedal shall release.",
+    ABBREVS,
+  );
+  assertEquals(s.length, 2);
+  assertEquals(s[0].text, "The brake shall apply.");
+  assertEquals(s[0].offset, 0);
+  assertEquals(s[1].text, "The pedal shall release.");
+  assertEquals(s[1].offset, 23);
+});
+
+Deno.test("segmenter: does not split on abbreviation 'e.g.'", () => {
+  const s = segmentSentences(
+    "Sensors e.g. radar shall debounce. The system shall log.",
+    ABBREVS,
+  );
+  assertEquals(s.length, 2);
+  assertEquals(s[0].text, "Sensors e.g. radar shall debounce.");
+});
+
+Deno.test("segmenter: ? and ! terminate sentences", () => {
+  const s = segmentSentences("Is it raining? The system shall halt!", ABBREVS);
+  assertEquals(s.length, 2);
+});
+
+Deno.test("segmenter: lowercase after period is not a split", () => {
+  const s = segmentSentences("v1.0 is current.", ABBREVS);
+  assertEquals(s.length, 1);
+});
+
+Deno.test("segmenter: deterministic on repeated calls", () => {
+  const text = "First. Second. Third.";
+  const a = segmentSentences(text, ABBREVS);
+  const b = segmentSentences(text, ABBREVS);
+  assertEquals(a, b);
+});
+
+// Snapshot test for corpus stability.
+const CORPUS = `
+The brake controller shall debounce sensor inputs. When the pedal is
+pressed, the system shall apply pressure within 200 ms. The pressure
+shall be released, e.g. when the parking brake is engaged, by the
+release subsystem. Fig. 3 shows the data flow. See vol. II for details.
+If a sensor reading is invalid, then the brake controller shall ignore
+it.
+`.trim();
+
+Deno.test("segmenter: corpus snapshot", async (t) => {
+  const sentences = segmentSentences(CORPUS, ABBREVS);
+  await assertSnapshot(t, sentences);
+});


### PR DESCRIPTION
## Summary

- Adds the pure `segmentSentences(text, abbrevs)` function — splits on `.`/`?`/`!` followed by whitespace + uppercase, with an abbreviation-lexicon guard.
- Deterministic, O(n) single pass; no I/O, no input mutation.
- Honors `sentence-abbrev` lexicon from slice 1 so `e.g.` / `i.e.` / `Fig.` / `vol.` / `Mr.` etc. don't split when followed by an uppercase letter.
- Foundation for slices 5-8 (Q500 flagship, EARS, modal-sentence, INCOSE sentence-level rules).

This is **slice 2 of 10** for the Stage-2 PA-3 prose-analysis build. ADR-020 Decision 3 pins the rule-based approach (no `Intl.Segmenter`, no NLP libs) — module doc comment cites it.

## Scope

In:
- `segmentSentences()` + `Sentence` type.
- `sentence-abbrev` lexicon already shipped in slice 1; consumed here.
- 8 unit tests + 1 corpus snapshot.

Out (out of scope for this slice):
- Wiring into rules (slices 5-8).
- Sentence-range data on LintDiagnostic (slice 3).
- Any change to `runLint` or PA-1.

## Behaviour pinned by tests

| Case                                                         | Behaviour                |
|--------------------------------------------------------------|--------------------------|
| Empty input                                                  | `[]`                     |
| Single sentence, no terminator                               | one Sentence, offset 0   |
| `.` + whitespace + uppercase                                 | split                    |
| `.` + whitespace + lowercase                                 | no split                 |
| `.` + whitespace + digit                                     | no split                 |
| Abbreviation `e.g. Active` (uppercase after, in lexicon)     | **no split** (guard wins)|
| `?` and `!` followed by whitespace + uppercase               | split                    |
| Repeated calls with same input                               | identical output         |

## Test plan

- [x] 7 unit tests + 1 corpus snapshot (8 total in `core/lint/segmenter_test.ts`).
- [x] Corpus snapshot pinned with 6 sentences covering `e.g. when` (lowercase next), `Fig. 3` (digit next), and the critical `vol. II` case (uppercase next + abbreviation guard fires).
- [x] `just check` clean; `deno fmt --check` + `dprint check` clean.
- [x] 1862 tests passing, 0 failing.

## Reviews completed

- **Spec compliance + code quality** (single sonnet pass, since slice is small): spec compliant; code-quality flagged that the original `e.g.` unit test passed for the wrong reason (lowercase suffix meant the uppercase-lookahead rule already suppressed the split, not the abbreviation guard). Fixed in the follow-up commit on this branch: new input uses `e.g. Active` so the guard is the sole suppression reason; removing the guard from the segmenter now fails this test (alongside the corpus snapshot's `vol. II` case).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
