### PR TITLE
feat(core): typl inline backtick surface (PR 5 of 8)

### DIFF
--- a/packages/markspec/core/parser/markdown.ts
+++ b/packages/markspec/core/parser/markdown.ts
@@ -23,6 +23,7 @@ import {
   bridgeTyplDiagnostic,
   extractTyplBullets,
   extractTyplFences,
+  extractTyplInlines,
   parseTyplBlock,
   type TyplBlock,
 } from "../typl/mod.ts";
@@ -537,11 +538,12 @@ function extractEntry(
     column: 1,
   }, bodyIndent);
 
-  // Extract typl declarations from any ```typl fences AND bullet-glossary
-  // items in the body. Per-fence and per-item diagnostics are bridged to
-  // file-relative positions and pushed into the parser's diagnostic stream.
-  // Cross-entry collision detection lands in PR 6; this PR aggregates all
-  // intra-entry bindings + typedefs from both surfaces.
+  // Extract typl declarations from all three surfaces in the body:
+  // (1) ```typl fences, (2) bullet-glossary items, (3) inline code spans.
+  // Per-surface diagnostics are bridged to file-relative positions and
+  // pushed into the parser's diagnostic stream. Cross-entry collision
+  // detection lands in a later PR; this PR aggregates all intra-entry
+  // bindings + typedefs from every surface.
   let types: TyplBlock | undefined;
   const allBindings: TyplBlock["bindings"][number][] = [];
   const allTypedefs: TyplBlock["typedefs"][number][] = [];
@@ -569,6 +571,23 @@ function extractEntry(
     const bulletFileOffset = bodyStartLine + bullet.range.start.line - 2;
     for (const td of result.diagnostics) {
       diagnostics.push(bridgeTyplDiagnostic(td, file, bulletFileOffset));
+    }
+  }
+
+  for (const inline of extractTyplInlines(bodyTokens)) {
+    const result = parseTyplBlock(inline.source);
+    allBindings.push(...result.ast.bindings);
+    allTypedefs.push(...result.ast.typedefs);
+    // inline.location is already file-relative (translated by the
+    // bodyTokens extractor). The bridge computes file line as
+    // `offset + diag.position.line`; for inline content where
+    // diag.position.line is 1 (single-line span), offset is
+    // `inline.location.line - 1`.
+    const inlineFileOffset = inline.location.line - 1;
+    for (const td of result.diagnostics) {
+      diagnostics.push(
+        bridgeTyplDiagnostic(td, inline.location.file, inlineFileOffset),
+      );
     }
   }
 

--- a/packages/markspec/core/parser/markdown_test.ts
+++ b/packages/markspec/core/parser/markdown_test.ts
@@ -8,7 +8,6 @@
 
 import { assertEquals, assertExists } from "@std/assert";
 import { parseMarkdown } from "./markdown.ts";
-import { parseFile } from "./mod.ts";
 import type { LineMap } from "./line_map.ts";
 
 const ULID = "01HGW2Q8MNP3RSTVWXYZABCDEF";

--- a/packages/markspec/core/parser/markdown_test.ts
+++ b/packages/markspec/core/parser/markdown_test.ts
@@ -490,8 +490,8 @@ Deno.test("parseMarkdown: multiple typl fences in one entry aggregate", () => {
 // typl bullet-glossary extraction (ADR-019, PR 4)
 // ---------------------------------------------------------------------------
 
-Deno.test("parseMarkdown: entry with bullet-glossary typl populates entry.types", async () => {
-  const source = [
+Deno.test("parseMarkdown: entry with bullet-glossary typl populates entry.types", () => {
+  const md = [
     "- [REQ_0010] Bullet glossary entry",
     "",
     "  Prose describing the requirement.",
@@ -504,9 +504,9 @@ Deno.test("parseMarkdown: entry with bullet-glossary typl populates entry.types"
     "      Id: 01HZZZ0000000000000000000E",
   ].join("\n");
 
-  const result = await parseFile(source, { file: "test.md" });
-  assertEquals(result.entries.length, 1);
-  const entry = result.entries[0];
+  const { entries } = parseMarkdown(md, { file: "test.md" });
+  assertEquals(entries.length, 1);
+  const entry = entries[0];
 
   assertExists(entry.types);
   assertEquals(entry.types?.bindings.length, 3);
@@ -519,8 +519,8 @@ Deno.test("parseMarkdown: entry with bullet-glossary typl populates entry.types"
   assertEquals(entry.types?.typedefs[0].name, "BrakeReq");
 });
 
-Deno.test("parseMarkdown: bullet list with mixed typl and prose only extracts typl items", async () => {
-  const source = [
+Deno.test("parseMarkdown: bullet list with mixed typl and prose only extracts typl items", () => {
+  const md = [
     "- [REQ_0011] Mixed list entry",
     "",
     "  The system has these signals:",
@@ -533,8 +533,8 @@ Deno.test("parseMarkdown: bullet list with mixed typl and prose only extracts ty
     "      Id: 01HZZZ0000000000000000000F",
   ].join("\n");
 
-  const result = await parseFile(source, { file: "test.md" });
-  const entry = result.entries[0];
+  const { entries } = parseMarkdown(md, { file: "test.md" });
+  const entry = entries[0];
 
   assertExists(entry.types);
   assertEquals(entry.types?.bindings.length, 2);
@@ -544,8 +544,8 @@ Deno.test("parseMarkdown: bullet list with mixed typl and prose only extracts ty
   ]);
 });
 
-Deno.test("parseMarkdown: entry combining fence AND bullet typl aggregates both", async () => {
-  const source = [
+Deno.test("parseMarkdown: entry combining fence AND bullet typl aggregates both", () => {
+  const md = [
     "- [REQ_0012] Combined surfaces",
     "",
     "  ```typl",
@@ -559,8 +559,8 @@ Deno.test("parseMarkdown: entry combining fence AND bullet typl aggregates both"
     "      Id: 01HZZZ0000000000000000000G",
   ].join("\n");
 
-  const result = await parseFile(source, { file: "test.md" });
-  const entry = result.entries[0];
+  const { entries } = parseMarkdown(md, { file: "test.md" });
+  const entry = entries[0];
 
   assertExists(entry.types);
   assertEquals(entry.types?.bindings.length, 2);
@@ -570,16 +570,101 @@ Deno.test("parseMarkdown: entry combining fence AND bullet typl aggregates both"
   ]);
 });
 
-Deno.test("parseMarkdown: bullet typl parse error is bridged to file-relative diagnostic", async () => {
-  const source = [
+Deno.test("parseMarkdown: bullet typl parse error is bridged to file-relative diagnostic", () => {
+  const md = [
     "- [REQ_0013] Bad bullet typl",
     "",
     "  - $X : blah int[0..]",
     "",
     "      Id: 01HZZZ0000000000000000000H",
   ].join("\n");
-  const result = await parseFile(source, { file: "test.md" });
-  const typlDiag = result.diagnostics.find((d) => d.code === "TYPL-007");
+  const { diagnostics } = parseMarkdown(md, { file: "test.md" });
+  const typlDiag = diagnostics.find((d) => d.code === "TYPL-007");
+  assertExists(typlDiag);
+  assertEquals(typlDiag.location?.file, "test.md");
+  assertEquals((typlDiag.location?.line ?? 0) >= 1, true);
+});
+
+// ---------------------------------------------------------------------------
+// typl inline backtick extraction (ADR-019, PR 5)
+// ---------------------------------------------------------------------------
+
+Deno.test("parseMarkdown: entry with inline typl spans populates entry.types", () => {
+  const md = [
+    "- [REQ_0020] Inline typl entry",
+    "",
+    "  The `$Speed : signal float[0..300]` shall update at 50 Hz, and",
+    "  the controller publishes `$Brake : command BrakeReq` on overrun.",
+    "",
+    "  Type definition: `type BrakeReq = { force_N: float[0..12000] }`.",
+    "",
+    "      Id: 01HZZZ0000000000000000000I",
+  ].join("\n");
+
+  const { entries } = parseMarkdown(md, { file: "test.md" });
+  assertEquals(entries.length, 1);
+  const entry = entries[0];
+
+  assertExists(entry.types);
+  assertEquals(entry.types?.bindings.length, 2);
+  assertEquals(entry.types?.bindings.map((b) => b.name).sort(), [
+    "$Brake",
+    "$Speed",
+  ]);
+  assertEquals(entry.types?.typedefs.length, 1);
+  assertEquals(entry.types?.typedefs[0].name, "BrakeReq");
+});
+
+Deno.test("parseMarkdown: code-span that is NOT typl syntax is ignored", () => {
+  const md = [
+    "- [REQ_0021] Mixed prose",
+    "",
+    "  The function `compute(x, y)` returns a value, and the constant",
+    "  `MAX_SPEED` is defined elsewhere. No typl bindings here.",
+    "",
+    "      Id: 01HZZZ0000000000000000000J",
+  ].join("\n");
+  const { entries } = parseMarkdown(md, { file: "test.md" });
+  assertEquals(entries[0].types, undefined);
+});
+
+Deno.test("parseMarkdown: entry combining fence, bullet AND inline typl aggregates all", () => {
+  const md = [
+    "- [REQ_0022] All three surfaces",
+    "",
+    "  ```typl",
+    "  $InFence : signal",
+    "  ```",
+    "",
+    "  - $InBullet : event",
+    "",
+    "  And the inline form: `$InInline : command`.",
+    "",
+    "      Id: 01HZZZ0000000000000000000K",
+  ].join("\n");
+
+  const { entries } = parseMarkdown(md, { file: "test.md" });
+  const entry = entries[0];
+
+  assertExists(entry.types);
+  assertEquals(entry.types?.bindings.length, 3);
+  assertEquals(entry.types?.bindings.map((b) => b.name).sort(), [
+    "$InBullet",
+    "$InFence",
+    "$InInline",
+  ]);
+});
+
+Deno.test("parseMarkdown: inline typl parse error is bridged to file-relative diagnostic", () => {
+  const md = [
+    "- [REQ_0023] Bad inline typl",
+    "",
+    "  The `$X : blah int[0..]` is not a valid typl declaration.",
+    "",
+    "      Id: 01HZZZ0000000000000000000L",
+  ].join("\n");
+  const { diagnostics } = parseMarkdown(md, { file: "test.md" });
+  const typlDiag = diagnostics.find((d) => d.code === "TYPL-007");
   assertExists(typlDiag);
   assertEquals(typlDiag.location?.file, "test.md");
   assertEquals((typlDiag.location?.line ?? 0) >= 1, true);

--- a/packages/markspec/core/typl/inline.ts
+++ b/packages/markspec/core/typl/inline.ts
@@ -33,9 +33,34 @@ function isTyplInlineText(text: string): boolean {
 }
 
 /**
+ * Strip the surrounding backtick delimiter(s) from an inline-code token's
+ * `text` field. `body_tokens.ts` stores inline-code text as `` `value` ``
+ * (with backtick delimiters). The typl patterns and `parseTyplBlock` need
+ * the inner value only.
+ *
+ * Handles both single-backtick (`` `…` ``) and double-backtick (` ``…`` `)
+ * delimiters. Returns the original string unchanged when it does not start
+ * and end with a matching backtick fence.
+ */
+function stripBackticks(text: string): string {
+  if (text.startsWith("``") && text.endsWith("``") && text.length > 4) {
+    return text.slice(2, -2);
+  }
+  if (text.startsWith("`") && text.endsWith("`") && text.length > 2) {
+    return text.slice(1, -1);
+  }
+  return text;
+}
+
+/**
  * Filter bodyTokens to inline-code spans whose contents match typl
  * syntax. Returns extractions in source order (the bodyTokens contract
  * guarantees source order).
+ *
+ * `inline-code` tokens in `bodyTokens` store their `text` field with
+ * surrounding backtick delimiters (e.g., `` `$X : signal` ``). This
+ * function strips those delimiters before pattern-matching and before
+ * setting `source`, so `parseTyplBlock` receives the raw typl source.
  */
 export function extractTyplInlines(
   bodyTokens: readonly BodyToken[],
@@ -43,8 +68,9 @@ export function extractTyplInlines(
   const results: TyplInlineExtraction[] = [];
   for (const token of bodyTokens) {
     if (token.kind !== "inline-code") continue;
-    if (!isTyplInlineText(token.text)) continue;
-    results.push({ source: token.text, location: token.location });
+    const inner = stripBackticks(token.text);
+    if (!isTyplInlineText(inner)) continue;
+    results.push({ source: inner, location: token.location });
   }
   return results;
 }

--- a/packages/markspec/core/typl/inline.ts
+++ b/packages/markspec/core/typl/inline.ts
@@ -1,0 +1,50 @@
+/**
+ * @module typl/inline
+ *
+ * Inline backtick surface adapter — recognises typl declarations
+ * wrapped in CommonMark code spans, e.g. `` `$X : signal float[0..300]` ``
+ * scattered through entry prose.
+ *
+ * Filters Entry.bodyTokens (ADR-016) for `inline-code` tokens whose text
+ * matches typl syntax. Each matching span produces one
+ * TyplInlineExtraction; the parser integration calls parseTyplBlock on
+ * each `source` independently.
+ *
+ * See ADR-019.
+ */
+import type { BodyToken, SourceLocation } from "../model/mod.ts";
+
+/** A single typl inline-code declaration found in an entry body. */
+export interface TyplInlineExtraction {
+  /** The typl source from one matching code span (text between backticks). */
+  readonly source: string;
+  /** File-relative location of the code span. */
+  readonly location: SourceLocation;
+}
+
+/** Matches a typl binding span (code-span text). */
+const INLINE_BINDING_RE = /^\$[A-Za-z_][A-Za-z0-9_]*\s*:/;
+
+/** Matches a typl typedef span (code-span text). */
+const INLINE_TYPEDEF_RE = /^type\s+[A-Za-z_][A-Za-z0-9_]*\s*=/;
+
+function isTyplInlineText(text: string): boolean {
+  return INLINE_BINDING_RE.test(text) || INLINE_TYPEDEF_RE.test(text);
+}
+
+/**
+ * Filter bodyTokens to inline-code spans whose contents match typl
+ * syntax. Returns extractions in source order (the bodyTokens contract
+ * guarantees source order).
+ */
+export function extractTyplInlines(
+  bodyTokens: readonly BodyToken[],
+): readonly TyplInlineExtraction[] {
+  const results: TyplInlineExtraction[] = [];
+  for (const token of bodyTokens) {
+    if (token.kind !== "inline-code") continue;
+    if (!isTyplInlineText(token.text)) continue;
+    results.push({ source: token.text, location: token.location });
+  }
+  return results;
+}

--- a/packages/markspec/core/typl/inline_test.ts
+++ b/packages/markspec/core/typl/inline_test.ts
@@ -1,0 +1,88 @@
+import { assertEquals } from "@std/assert";
+import type { BodyToken } from "../model/mod.ts";
+import { extractTyplInlines } from "./inline.ts";
+
+function inlineCode(text: string, line = 1, column = 1): BodyToken {
+  return {
+    kind: "inline-code",
+    text,
+    location: { file: "x.md", line, column },
+  };
+}
+
+function modal(text: string, line = 1): BodyToken {
+  return {
+    kind: "modal",
+    text,
+    case: "lower",
+    location: { file: "x.md", line, column: 1 },
+  };
+}
+
+Deno.test("extractTyplInlines: empty input → empty result", () => {
+  assertEquals(extractTyplInlines([]), []);
+});
+
+Deno.test("extractTyplInlines: ignores non-inline-code tokens", () => {
+  const tokens: BodyToken[] = [
+    modal("shall", 1),
+    {
+      kind: "entity-ref",
+      text: "$Foo",
+      convention: "type",
+      location: { file: "x.md", line: 2, column: 5 },
+    },
+  ];
+  assertEquals(extractTyplInlines(tokens), []);
+});
+
+Deno.test("extractTyplInlines: ignores inline-code that is not typl syntax", () => {
+  const tokens: BodyToken[] = [
+    inlineCode("foo.bar()", 1, 5),
+    inlineCode("just a code reference", 2, 1),
+    inlineCode("const x = 5", 3, 1),
+  ];
+  assertEquals(extractTyplInlines(tokens), []);
+});
+
+Deno.test("extractTyplInlines: finds typl binding span", () => {
+  const span = inlineCode("$Speed : signal float[0..300]", 5, 3);
+  const result = extractTyplInlines([span]);
+  assertEquals(result.length, 1);
+  assertEquals(result[0].source, "$Speed : signal float[0..300]");
+  assertEquals(result[0].location, span.location);
+});
+
+Deno.test("extractTyplInlines: finds typl typedef span", () => {
+  const span = inlineCode("type BrakeReq = { force: int[0..255] }", 7, 1);
+  const result = extractTyplInlines([span]);
+  assertEquals(result.length, 1);
+  assertEquals(result[0].source, "type BrakeReq = { force: int[0..255] }");
+});
+
+Deno.test("extractTyplInlines: returns multiple spans in source order", () => {
+  const tokens: BodyToken[] = [
+    inlineCode("$A : signal", 1, 5),
+    inlineCode("ignored ref", 1, 30),
+    inlineCode("$B : event", 2, 1),
+    modal("shall", 3),
+    inlineCode("type T = int", 4, 10),
+  ];
+  const result = extractTyplInlines(tokens);
+  assertEquals(result.length, 3);
+  assertEquals(result.map((r) => r.source), [
+    "$A : signal",
+    "$B : event",
+    "type T = int",
+  ]);
+});
+
+Deno.test("extractTyplInlines: ignores `$` not followed by colon", () => {
+  const tokens: BodyToken[] = [inlineCode("$Foo bar", 1, 1)];
+  assertEquals(extractTyplInlines(tokens), []);
+});
+
+Deno.test("extractTyplInlines: ignores `type` not followed by `=`", () => {
+  const tokens: BodyToken[] = [inlineCode("type of error", 1, 1)];
+  assertEquals(extractTyplInlines(tokens), []);
+});

--- a/packages/markspec/core/typl/mod.ts
+++ b/packages/markspec/core/typl/mod.ts
@@ -29,3 +29,6 @@ export { bridgeTyplDiagnostic } from "./bridge.ts";
 
 export type { TyplBulletExtraction } from "./bullet.ts";
 export { extractTyplBullets } from "./bullet.ts";
+
+export type { TyplInlineExtraction } from "./inline.ts";
+export { extractTyplInlines } from "./inline.ts";

--- a/tests/e2e/typl_inline_test.ts
+++ b/tests/e2e/typl_inline_test.ts
@@ -25,7 +25,8 @@ const PROJECT_YAML = "name: test-project\nversion: 0.1.0\n";
 // each expressing the same bindings + typedef.
 // ---------------------------------------------------------------------------
 
-const FENCE_AND_INLINE_MD = `- [STK_FENCE_0001] Brake when target stops (fence form)
+const FENCE_AND_INLINE_MD =
+  `- [STK_FENCE_0001] Brake when target stops (fence form)
 
   When the lead vehicle stops the system shall apply braking.
 
@@ -54,7 +55,8 @@ const FENCE_AND_INLINE_MD = `- [STK_FENCE_0001] Brake when target stops (fence f
 // a sibling entry whose code spans carry non-typl content.
 // ---------------------------------------------------------------------------
 
-const PURE_INLINE_MD = `- [STK_INLINE_0002] Speed limit enforcement (pure inline)
+const PURE_INLINE_MD =
+  `- [STK_INLINE_0002] Speed limit enforcement (pure inline)
 
   The system shall enforce the speed limit by reading \`$Speed : signal float[0..300]\`
   and comparing it against \`$Limit : const 130.0\` at each evaluation cycle.
@@ -117,12 +119,16 @@ Deno.test(
 
     if (!fenceEntry.types) {
       throw new Error(
-        `fenceEntry.types is absent; full entry: ${JSON.stringify(fenceEntry, null, 2)}`,
+        `fenceEntry.types is absent; full entry: ${
+          JSON.stringify(fenceEntry, null, 2)
+        }`,
       );
     }
     if (!inlineEntry.types) {
       throw new Error(
-        `inlineEntry.types is absent; full entry: ${JSON.stringify(inlineEntry, null, 2)}`,
+        `inlineEntry.types is absent; full entry: ${
+          JSON.stringify(inlineEntry, null, 2)
+        }`,
       );
     }
 
@@ -243,7 +249,9 @@ Deno.test(
     );
     if (!speedBinding) {
       throw new Error(
-        `$Speed binding not found; got: ${JSON.stringify(bindings.map((b: { name: string }) => b.name))}`,
+        `$Speed binding not found; got: ${
+          JSON.stringify(bindings.map((b: { name: string }) => b.name))
+        }`,
       );
     }
     assertEquals(speedBinding.kind, "signal");
@@ -258,7 +266,9 @@ Deno.test(
     );
     if (!limitBinding) {
       throw new Error(
-        `$Limit binding not found; got: ${JSON.stringify(bindings.map((b: { name: string }) => b.name))}`,
+        `$Limit binding not found; got: ${
+          JSON.stringify(bindings.map((b: { name: string }) => b.name))
+        }`,
       );
     }
     assertEquals(limitBinding.kind, "const");

--- a/tests/e2e/typl_inline_test.ts
+++ b/tests/e2e/typl_inline_test.ts
@@ -1,0 +1,279 @@
+/**
+ * @module tests/e2e/typl_inline_test
+ *
+ * E2E tests confirming that a typl inline-backtick surface produces the same
+ * `entry.types` JSON shape as the equivalent typl-fence surface through the
+ * `markspec compile --format json` pipeline.
+ *
+ * Two tests:
+ *  1. Equivalence: one file contains a fence entry and an inline entry with
+ *     identical bindings + typedef. Both must produce equivalent `entry.types`
+ *     after stripping `position` (which differs between surfaces).
+ *  2. Pure-inline: inline backtick declarations scattered through prose are
+ *     extracted into `entry.types.bindings`. A sibling entry whose code spans
+ *     are not typl syntax (`foo()`, `MAX_SPEED`) must leave `entry.types`
+ *     absent.
+ */
+
+import { assertEquals } from "@std/assert";
+import { markspec } from "./helpers.ts";
+
+const PROJECT_YAML = "name: test-project\nversion: 0.1.0\n";
+
+// ---------------------------------------------------------------------------
+// Fixture 1: two entries in one file — fence and inline surface,
+// each expressing the same bindings + typedef.
+// ---------------------------------------------------------------------------
+
+const FENCE_AND_INLINE_MD = `- [STK_FENCE_0001] Brake when target stops (fence form)
+
+  When the lead vehicle stops the system shall apply braking.
+
+  \`\`\`typl
+  $Speed     : signal float[0..300]
+  $Brake     : command BrakeReq
+  $Threshold : const 1.4
+
+  type BrakeReq = { force_N: float[0..12000] }
+  \`\`\`
+
+      Id: 01HZZZ0000000000000000000A
+
+- [STK_INLINE_0001] Brake when target stops (inline form)
+
+  When the lead vehicle stops the system shall apply braking such that
+  \`$Speed : signal float[0..300]\` drops below \`$Threshold : const 1.4\`
+  before \`$Brake : command BrakeReq\` is issued. The payload shape is
+  \`type BrakeReq = { force_N: float[0..12000] }\` defined above.
+
+      Id: 01HZZZ0000000000000000000B
+`;
+
+// ---------------------------------------------------------------------------
+// Fixture 2: pure-inline entry (all declarations in prose code spans) plus
+// a sibling entry whose code spans carry non-typl content.
+// ---------------------------------------------------------------------------
+
+const PURE_INLINE_MD = `- [STK_INLINE_0002] Speed limit enforcement (pure inline)
+
+  The system shall enforce the speed limit by reading \`$Speed : signal float[0..300]\`
+  and comparing it against \`$Limit : const 130.0\` at each evaluation cycle.
+
+      Id: 01HZZZ0000000000000000000C
+
+- [STK_NOTYPL_0001] Driver override (no typl code spans)
+
+  The driver shall be able to override the system using \`foo()\` or the
+  \`MAX_SPEED\` constant defined in the firmware header.
+
+      Id: 01HZZZ0000000000000000000D
+`;
+
+// ---------------------------------------------------------------------------
+// Helper: strip `position` from a binding or typedef before comparing
+// ---------------------------------------------------------------------------
+
+type PositionStripped<T> = Omit<T, "position">;
+
+function stripPosition<T extends { position: unknown }>(
+  item: T,
+): PositionStripped<T> {
+  const { position: _pos, ...rest } = item;
+  return rest as PositionStripped<T>;
+}
+
+// ---------------------------------------------------------------------------
+// Test 1: inline surface produces same entry.types as fence equivalent
+// ---------------------------------------------------------------------------
+
+Deno.test(
+  "compile: inline backtick surface produces same entry.types as fence surface",
+  async () => {
+    const { code, stdout } = await markspec(
+      ["compile", "--format", "json", "req.md"],
+      {
+        files: { "project.yaml": PROJECT_YAML, "req.md": FENCE_AND_INLINE_MD },
+      },
+    );
+    assertEquals(code, 0);
+
+    let parsed: ReturnType<typeof JSON.parse>;
+    try {
+      parsed = JSON.parse(stdout);
+    } catch (err) {
+      throw new Error(
+        `Failed to parse compile JSON output: ${err}\nstdout: ${stdout}`,
+      );
+    }
+
+    const fenceEntry = parsed.entries["STK_FENCE_0001"];
+    if (!fenceEntry) {
+      throw new Error("STK_FENCE_0001 not found in compile output");
+    }
+    const inlineEntry = parsed.entries["STK_INLINE_0001"];
+    if (!inlineEntry) {
+      throw new Error("STK_INLINE_0001 not found in compile output");
+    }
+
+    if (!fenceEntry.types) {
+      throw new Error(
+        `fenceEntry.types is absent; full entry: ${JSON.stringify(fenceEntry, null, 2)}`,
+      );
+    }
+    if (!inlineEntry.types) {
+      throw new Error(
+        `inlineEntry.types is absent; full entry: ${JSON.stringify(inlineEntry, null, 2)}`,
+      );
+    }
+
+    const fenceBindings: Array<{
+      name: string;
+      kind: string;
+      shape?: unknown;
+      position: unknown;
+    }> = fenceEntry.types.bindings;
+    const inlineBindings: Array<{
+      name: string;
+      kind: string;
+      shape?: unknown;
+      position: unknown;
+    }> = inlineEntry.types.bindings;
+
+    const fenceTypedefs: Array<{
+      name: string;
+      shape: unknown;
+      position: unknown;
+    }> = fenceEntry.types.typedefs;
+    const inlineTypedefs: Array<{
+      name: string;
+      shape: unknown;
+      position: unknown;
+    }> = inlineEntry.types.typedefs;
+
+    // Both surfaces must yield the same number of bindings and typedefs.
+    assertEquals(
+      inlineBindings.length,
+      fenceBindings.length,
+      "binding count mismatch between inline and fence surfaces",
+    );
+    assertEquals(
+      inlineTypedefs.length,
+      fenceTypedefs.length,
+      "typedef count mismatch between inline and fence surfaces",
+    );
+
+    // Compare each binding by name, kind, and shape — ignoring position.
+    // Use fence as the reference surface; look up by name so order differences
+    // between surfaces do not cause false failures.
+    for (const fenceB of fenceBindings) {
+      const inlineB = inlineBindings.find((b) => b.name === fenceB.name);
+      if (!inlineB) {
+        throw new Error(
+          `binding '${fenceB.name}' present in fence entry but missing from inline entry`,
+        );
+      }
+      assertEquals(
+        stripPosition(inlineB),
+        stripPosition(fenceB),
+        `binding '${fenceB.name}' shape/kind mismatch between inline and fence surfaces`,
+      );
+    }
+
+    // Compare each typedef by name and shape — ignoring position.
+    for (const fenceT of fenceTypedefs) {
+      const inlineT = inlineTypedefs.find((t) => t.name === fenceT.name);
+      if (!inlineT) {
+        throw new Error(
+          `typedef '${fenceT.name}' present in fence entry but missing from inline entry`,
+        );
+      }
+      assertEquals(
+        stripPosition(inlineT),
+        stripPosition(fenceT),
+        `typedef '${fenceT.name}' shape mismatch between inline and fence surfaces`,
+      );
+    }
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Test 2: pure-inline entry populates entry.types; non-typl sibling does not
+// ---------------------------------------------------------------------------
+
+Deno.test(
+  "compile: pure-inline typl declarations populate entry.types; non-typl code spans leave entry.types absent",
+  async () => {
+    const { code, stdout } = await markspec(
+      ["compile", "--format", "json", "req.md"],
+      {
+        files: { "project.yaml": PROJECT_YAML, "req.md": PURE_INLINE_MD },
+      },
+    );
+    assertEquals(code, 0);
+
+    let parsed: ReturnType<typeof JSON.parse>;
+    try {
+      parsed = JSON.parse(stdout);
+    } catch (err) {
+      throw new Error(
+        `Failed to parse compile JSON output: ${err}\nstdout: ${stdout}`,
+      );
+    }
+
+    // --- positive case: entry with inline typl declarations ---
+    const inlineEntry = parsed.entries["STK_INLINE_0002"];
+    if (!inlineEntry) {
+      throw new Error("STK_INLINE_0002 not found in compile output");
+    }
+
+    if (!inlineEntry.types) {
+      throw new Error(
+        `inlineEntry.types is absent for an entry with inline typl code spans; full entry: ${
+          JSON.stringify(inlineEntry, null, 2)
+        }`,
+      );
+    }
+
+    const { bindings } = inlineEntry.types;
+    assertEquals(bindings.length, 2, "expected 2 bindings from inline spans");
+
+    // $Speed : signal float[0..300]
+    const speedBinding = bindings.find((b: { name: string }) =>
+      b.name === "$Speed"
+    );
+    if (!speedBinding) {
+      throw new Error(
+        `$Speed binding not found; got: ${JSON.stringify(bindings.map((b: { name: string }) => b.name))}`,
+      );
+    }
+    assertEquals(speedBinding.kind, "signal");
+    assertEquals(speedBinding.shape.kind, "range");
+    assertEquals(speedBinding.shape.type, "float");
+    assertEquals(speedBinding.shape.min, 0);
+    assertEquals(speedBinding.shape.max, 300);
+
+    // $Limit : const 130.0
+    const limitBinding = bindings.find((b: { name: string }) =>
+      b.name === "$Limit"
+    );
+    if (!limitBinding) {
+      throw new Error(
+        `$Limit binding not found; got: ${JSON.stringify(bindings.map((b: { name: string }) => b.name))}`,
+      );
+    }
+    assertEquals(limitBinding.kind, "const");
+
+    // --- negative case: entry with non-typl code spans has no entry.types ---
+    const noTyplEntry = parsed.entries["STK_NOTYPL_0001"];
+    if (!noTyplEntry) {
+      throw new Error("STK_NOTYPL_0001 not found in compile output");
+    }
+
+    // `foo()` and `MAX_SPEED` must NOT be parsed as typl declarations.
+    assertEquals(
+      noTyplEntry.types,
+      undefined,
+      "entry.types should be absent for an entry whose code spans are not typl syntax",
+    );
+  },
+);


### PR DESCRIPTION
## Summary

PR 5 of 8 in the typl DSL series. Adds the **inline backtick surface** — recognises typl declarations wrapped in CommonMark code spans inside prose, e.g. `` `$Speed : signal float[0..300]` `` scattered through requirement text. This is the third and final surface adapter.

### What is new

- `core/typl/inline.ts` — `extractTyplInlines(bodyTokens)` filters `Entry.bodyTokens` for `inline-code` tokens whose text matches typl syntax (same binding/typedef regexes as the bullet adapter).
- Backtick stripping — `inline-code` BodyTokens store `text` with delimiters; `stripBackticks()` handles single and double backtick fences before pattern matching.
- Wired into `parser/markdown.ts` as the third surface — fences, bullets, and inlines all aggregate into the same `Entry.types.bindings[]` / `typedefs[]`.
- Diagnostic bridging uses offset `inline.location.line - 1` (since `inline.location` is already file-relative, translated by the bodyTokens extractor).

### Example

```markdown
- [REQ_0020] Brake on close approach

  The system shall enforce limits — `$Speed : signal float[0..300]`
  is sampled at 50 Hz, and `$Brake : command BrakeReq` issues when
  threshold exceeded. The payload shape: `type BrakeReq = { force_N: float[0..12000] }`.

      Id: 01HZZZ0000000000000000000I
```

Compiles to equivalent `entry.types` as the fence and bullet forms.

### Closes the three-surface set

With PR 5 merged, all three Markdown surfaces from the design are operational:

1. ` ```typl ` fences (PR 2 + PR 3)
2. `- $X : ...` bullet glossary (PR 4)
3. `` `$X : ...` `` inline backtick spans (this PR)

Any combination in a single entry aggregates into one `Entry.types`.

### What is NOT in this PR

- Cross-entry collision detection + corpus `typeRegistry` (PR 6) — duplicate `$Name` across entries (or across surfaces in the same entry) is currently silent; per-block dupes (TYPL-001/004) already fire from PR 1
- LSP integration (PR 7)
- Docs closeout (PR 8)
- CHANGELOG entry — per project rule, batched at release time

## Test plan

- [x] Unit: 8 new inline adapter tests + 4 new parser integration tests
- [x] E2E: 2 new tests — inline/fence equivalence + non-typl-spans negative case
- [x] Full `just check` — 1890 tests pass, 0 failed
- [x] `deno fmt --check`, `dprint check` — clean
- [x] `just compile` — binary builds
- [x] Rebased on latest main (which includes PR 4); conflicts resolved in `core/typl/mod.ts`, `parser/markdown.ts`, `parser/markdown_test.ts`
- [ ] Reviewer: confirm `stripBackticks` handles both single and double backtick spans correctly
- [ ] Reviewer: confirm the three-loop typl extraction order (fence → bullet → inline) is acceptable for aggregation

Builds on:
- PR 1 (parser foundation) — #431
- PR 2 (fence adapter) — #433
- PR 3 (entry-model integration) — #437
- PR 4 (bullet glossary) — #441

🤖 Generated with [Claude Code](https://claude.com/claude-code)
