### PR TITLE
feat(lsp): slice 3 — sentence-range field on LintDiagnostic

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -6,18 +6,22 @@
     "jsr:@cliffy/internal@1.0.0": "1.0.0",
     "jsr:@cliffy/table@1.0.0": "1.0.0",
     "jsr:@david/code-block-writer@^13.0.3": "13.0.3",
+    "jsr:@db/sqlite@0.13": "0.13.0",
     "jsr:@deno/dnt@~0.42.3": "0.42.3",
+    "jsr:@denosaurs/plug@1": "1.1.0",
     "jsr:@std/assert@1": "1.0.13",
     "jsr:@std/assert@^1.0.19": "1.0.19",
     "jsr:@std/cli@1": "1.0.28",
+    "jsr:@std/encoding@1": "1.0.10",
     "jsr:@std/fmt@1": "1.0.9",
     "jsr:@std/fmt@^1.0.9": "1.0.9",
-    "jsr:@std/fs@1": "1.0.18",
+    "jsr:@std/fs@1": "1.0.23",
     "jsr:@std/fs@^1.0.23": "1.0.23",
     "jsr:@std/internal@^1.0.12": "1.0.13",
     "jsr:@std/internal@^1.0.13": "1.0.13",
     "jsr:@std/internal@^1.0.6": "1.0.12",
-    "jsr:@std/path@1": "1.1.0",
+    "jsr:@std/path@1": "1.1.4",
+    "jsr:@std/path@1.0": "1.0.9",
     "jsr:@std/path@^1.1.0": "1.1.0",
     "jsr:@std/path@^1.1.4": "1.1.4",
     "jsr:@std/semver@^1.0.8": "1.0.8",
@@ -75,6 +79,13 @@
     "@david/code-block-writer@13.0.3": {
       "integrity": "f98c77d320f5957899a61bfb7a9bead7c6d83ad1515daee92dbacc861e13bb7f"
     },
+    "@db/sqlite@0.13.0": {
+      "integrity": "4545c635e0b3d4ddfdc0f2240f932f24b8ad0178e9c2e3a0f9403e7b18ae2fb5",
+      "dependencies": [
+        "jsr:@denosaurs/plug",
+        "jsr:@std/path@1.0"
+      ]
+    },
     "@deno/dnt@0.42.3": {
       "integrity": "62a917a0492f3c8af002dce90605bb0d41f7d29debc06aca40dba72ab65d8ae3",
       "dependencies": [
@@ -83,6 +94,15 @@
         "jsr:@std/fs@1",
         "jsr:@std/path@1",
         "jsr:@ts-morph/bootstrap"
+      ]
+    },
+    "@denosaurs/plug@1.1.0": {
+      "integrity": "eb2f0b7546c7bca2000d8b0282c54d50d91cf6d75cb26a80df25a6de8c4bc044",
+      "dependencies": [
+        "jsr:@std/encoding",
+        "jsr:@std/fmt@1",
+        "jsr:@std/fs@1",
+        "jsr:@std/path@1"
       ]
     },
     "@std/assert@1.0.13": {
@@ -103,6 +123,9 @@
         "jsr:@std/fmt@^1.0.9",
         "jsr:@std/internal@^1.0.12"
       ]
+    },
+    "@std/encoding@1.0.10": {
+      "integrity": "8783c6384a2d13abd5e9e87a7ae0520a30e9f56aeeaa3bdf910a3eaaf5c811a1"
     },
     "@std/fmt@1.0.8": {
       "integrity": "71e1fc498787e4434d213647a6e43e794af4fd393ef8f52062246e06f7e372b7"
@@ -131,6 +154,9 @@
     },
     "@std/internal@1.0.13": {
       "integrity": "2f9546691d4ac2d32859c82dff284aaeac980ddeca38430d07941e7e288725c0"
+    },
+    "@std/path@1.0.9": {
+      "integrity": "260a49f11edd3db93dd38350bf9cd1b4d1366afa98e81b86167b4e3dd750129e"
     },
     "@std/path@1.1.0": {
       "integrity": "ddc94f8e3c275627281cbc23341df6b8bcc874d70374f75fec2533521e3d6886"

--- a/packages/markspec/core/lint/types.ts
+++ b/packages/markspec/core/lint/types.ts
@@ -8,6 +8,7 @@
  */
 
 import type { Diagnostic } from "../model/mod.ts";
+import type { SourceRange } from "../ast/nodes.ts";
 
 /** A prose-quality diagnostic with slug and group metadata. */
 export interface LintDiagnostic extends Diagnostic {
@@ -17,4 +18,9 @@ export interface LintDiagnostic extends Diagnostic {
   readonly group: "ears" | "modal" | "incose" | "struct" | "xref" | "disable";
   /** Entry-level score contribution for this firing. */
   readonly scoreContribution: number;
+  /** Sentence- or token-span range within the source file. When present,
+   * the LSP bridge uses this for precise highlighting; when absent, the
+   * entry-level `location` is used as a degenerate EOL-clamped range.
+   * Positions are 1-based (matching {@linkcode SourceRange} convention). */
+  readonly range?: SourceRange;
 }

--- a/packages/markspec/core/lint/types.ts
+++ b/packages/markspec/core/lint/types.ts
@@ -18,9 +18,15 @@ export interface LintDiagnostic extends Diagnostic {
   readonly group: "ears" | "modal" | "incose" | "struct" | "xref" | "disable";
   /** Entry-level score contribution for this firing. */
   readonly scoreContribution: number;
-  /** Sentence- or token-span range within the source file. When present,
-   * the LSP bridge uses this for precise highlighting; when absent, the
-   * entry-level `location` is used as a degenerate EOL-clamped range.
-   * Positions are 1-based (matching {@linkcode SourceRange} convention). */
+  /** Sentence- or token-span range. When present, the LSP bridge uses
+   * this for precise highlighting; when absent, the entry-level
+   * `location` is used as a degenerate EOL-clamped range.
+   *
+   * Positions are **1-based and file-absolute** — i.e. the same
+   * convention as {@linkcode Diagnostic.location}, NOT the body-relative
+   * convention {@linkcode SourceRange} carries when used on body-AST
+   * nodes. The structural shape is re-used; the semantics differ. Rules
+   * populating this field must convert body-relative offsets to
+   * file-absolute line/column before emitting. */
   readonly range?: SourceRange;
 }

--- a/packages/markspec/lsp/diagnostics.ts
+++ b/packages/markspec/lsp/diagnostics.ts
@@ -6,7 +6,11 @@
  * diagnostics by file for per-document publishing.
  */
 
-import type { Diagnostic as CoreDiagnostic, Severity } from "../core/mod.ts";
+import type {
+  Diagnostic as CoreDiagnostic,
+  Severity,
+  SourceRange,
+} from "../core/mod.ts";
 
 /**
  * LSP Diagnostic — a subset of the full LSP type.
@@ -55,12 +59,7 @@ export function toLspDiagnostic(diagnostic: CoreDiagnostic): LspDiagnostic {
   // Prefer range when the diagnostic carries one (LintDiagnostic from
   // prose analysis); else fall back to a 1-line range starting at
   // location and ending at EOL (existing behaviour).
-  const ext = diagnostic as CoreDiagnostic & {
-    range?: {
-      start: { line: number; column: number };
-      end: { line: number; column: number };
-    };
-  };
+  const ext = diagnostic as CoreDiagnostic & { range?: SourceRange };
   let lspRange: LspDiagnostic["range"];
   if (ext.range) {
     lspRange = {

--- a/packages/markspec/lsp/diagnostics.ts
+++ b/packages/markspec/lsp/diagnostics.ts
@@ -52,13 +52,37 @@ function buildRuleDocUrl(code: string): string {
 }
 
 export function toLspDiagnostic(diagnostic: CoreDiagnostic): LspDiagnostic {
-  const line = diagnostic.location ? diagnostic.location.line - 1 : 0;
-  const character = diagnostic.location ? diagnostic.location.column - 1 : 0;
-  const base: LspDiagnostic = {
-    range: {
+  // Prefer range when the diagnostic carries one (LintDiagnostic from
+  // prose analysis); else fall back to a 1-line range starting at
+  // location and ending at EOL (existing behaviour).
+  const ext = diagnostic as CoreDiagnostic & {
+    range?: {
+      start: { line: number; column: number };
+      end: { line: number; column: number };
+    };
+  };
+  let lspRange: LspDiagnostic["range"];
+  if (ext.range) {
+    lspRange = {
+      start: {
+        line: ext.range.start.line - 1,
+        character: ext.range.start.column - 1,
+      },
+      end: {
+        line: ext.range.end.line - 1,
+        character: ext.range.end.column - 1,
+      },
+    };
+  } else {
+    const line = diagnostic.location ? diagnostic.location.line - 1 : 0;
+    const character = diagnostic.location ? diagnostic.location.column - 1 : 0;
+    lspRange = {
       start: { line, character },
       end: { line, character: Number.MAX_SAFE_INTEGER },
-    },
+    };
+  }
+  const base: LspDiagnostic = {
+    range: lspRange,
     severity: toLspSeverity(diagnostic.severity),
     source: "markspec",
     code: diagnostic.code,

--- a/packages/markspec/lsp/diagnostics_test.ts
+++ b/packages/markspec/lsp/diagnostics_test.ts
@@ -69,6 +69,11 @@ Deno.test("toLspDiagnostic: prefers range when present", () => {
   assertEquals(lsp.range.start.character, 9);
   assertEquals(lsp.range.end.line, 4);
   assertEquals(lsp.range.end.character, 24);
+  // codeDescription must still be populated for MSL-Q* on the range path.
+  assertEquals(
+    lsp.codeDescription?.href,
+    "https://markspec.dev/lint/rules/msl-q302",
+  );
 });
 
 Deno.test("toLspDiagnostic: falls back to location when range absent", () => {

--- a/packages/markspec/lsp/diagnostics_test.ts
+++ b/packages/markspec/lsp/diagnostics_test.ts
@@ -53,6 +53,50 @@ Deno.test("toLspDiagnostic: handles undefined location", () => {
   assertEquals(lsp.range.start.character, 0);
 });
 
+Deno.test("toLspDiagnostic: prefers range when present", () => {
+  const d = {
+    code: "MSL-Q302",
+    severity: "warning" as const,
+    message: "vague",
+    location: { file: "x.md", line: 5, column: 1 },
+    range: {
+      start: { line: 5, column: 10 },
+      end: { line: 5, column: 25 },
+    },
+  };
+  const lsp = toLspDiagnostic(d);
+  assertEquals(lsp.range.start.line, 4); // 1-based → 0-based
+  assertEquals(lsp.range.start.character, 9);
+  assertEquals(lsp.range.end.line, 4);
+  assertEquals(lsp.range.end.character, 24);
+});
+
+Deno.test("toLspDiagnostic: falls back to location when range absent", () => {
+  const d = {
+    code: "MSL-Q302",
+    severity: "warning" as const,
+    message: "vague",
+    location: { file: "x.md", line: 5, column: 1 },
+  };
+  const lsp = toLspDiagnostic(d);
+  assertEquals(lsp.range.start.line, 4);
+  assertEquals(lsp.range.start.character, 0);
+  // Existing behaviour: end is MAX_SAFE_INTEGER (clamped to EOL).
+  assertEquals(lsp.range.end.character, Number.MAX_SAFE_INTEGER);
+});
+
+Deno.test("toLspDiagnostic: PA-1 diagnostic without range still works", () => {
+  const d = {
+    code: "MSL-Q302",
+    severity: "warning" as const,
+    message: "found 'some' in entry body",
+    location: { file: "x.md", line: 10, column: 1 },
+  };
+  const lsp = toLspDiagnostic(d);
+  assertEquals(lsp.range.start.line, 9);
+  assertEquals(lsp.range.end.character, Number.MAX_SAFE_INTEGER);
+});
+
 Deno.test("groupDiagnosticsByFile: groups diagnostics by file path", () => {
   const diagnostics: CoreDiagnostic[] = [
     {


### PR DESCRIPTION
## Summary

- Extends `LintDiagnostic` with optional `readonly range?: SourceRange` for sentence- and token-span highlighting.
- LSP bridge (`toLspDiagnostic`) prefers `range` when present; falls back to the existing entry-level + EOL-clamp behaviour when absent.
- No rule behaviour changes — this is mechanical infrastructure for slices 5-10 (Q500 flagship and the sentence-level rules) to populate.

This is **slice 3 of 10** for the Stage-2 PA-3 prose-analysis build. ADR-021 Decision 1 + 2 will be the consumers (Q500's token-span ranges).

## Semantic note

`SourceRange` carries body-relative semantics when used on body-AST nodes (see `core/ast/nodes.ts`), but `LintDiagnostic.range` is **file-absolute** — same convention as `Diagnostic.location`. The structural shape is re-used; the semantics differ. The doc-comment on the field calls this out so future rule implementers don't emit body-relative positions and silently produce wrong LSP highlights.

## Scope

In:
- Optional `range` field on `LintDiagnostic`.
- Bridge update: prefer range, fall back to location.
- 3 new bridge tests covering both paths + PA-1 regression check.

Out:
- Any PA-1 rule update (they don't emit `range`; they remain on EOL-clamp).
- Any new rule logic (slices 5-10).
- Profile config.

## Test plan

- [x] 9 bridge tests pass (6 pre-existing + 3 new).
- [x] Full suite: 1880 tests passing, 0 failing.
- [x] `just check` clean; `deno fmt --check` + `dprint check` clean.
- [x] Existing PA-1 diagnostics still produce EOL-clamped ranges (verified by the no-range regression test).

## Reviews completed

- **Spec compliance + code quality** (single sonnet pass, slice is small): spec compliant; code-quality flagged three Important items (now addressed in the follow-up commit on this branch):
  1. The doc-comment on `LintDiagnostic.range` now explicitly says file-absolute, not the body-relative semantics `SourceRange` carries on AST nodes.
  2. The structural cast in `diagnostics.ts` now imports `SourceRange` instead of inlining the shape.
  3. The range-present test now asserts `codeDescription.href` so requirement 6 is nailed down on the new path.

## Note on deno.lock

`deno.lock` picks up `@db/sqlite` / `@denosaurs/plug` transitive entries from the `eval/sqlite-indexing/` bench scripts. No production impact; the eval tree is not part of the binary build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
