### PR TITLE
chore(repo): size bench + ADR-020 §Results header pass

### DIFF
--- a/docs/architecture/adr-020-sqlite-indexing-eval.md
+++ b/docs/architecture/adr-020-sqlite-indexing-eval.md
@@ -74,11 +74,12 @@ alternative — that's an early Phase 1 sub-decision.
 
 ## Results
 
-> **Cold scan + warm incremental + lookups complete; size / concurrency
-> pending.** All numbers below are from the bench scripts under
-> [`eval/sqlite-indexing/bench/`](../../eval/sqlite-indexing/bench/) on a single
-> dev machine (Apple Silicon aarch64-darwin, APFS, local disk). Iteration /
-> warmup counts and target selection are per-bench (see each section).
+> **All Phase 1 benches complete.** Numbers below are from the bench scripts
+> under [`eval/sqlite-indexing/bench/`](../../eval/sqlite-indexing/bench/) and
+> [`eval/sqlite-indexing/concurrency/`](../../eval/sqlite-indexing/concurrency/)
+> on a single dev machine (Apple Silicon aarch64-darwin, APFS, local disk).
+> Iteration / warmup counts and target selection are per-bench (see each
+> section).
 
 ### Cold scan (§6 budget: 10k < 5 s)
 
@@ -194,11 +195,33 @@ scales, hundreds of times under §6's 5 ms budget.)
 
 ### Index file size
 
-| Scale | db (MB) | wal (MB) | post-checkpoint (MB) | post-vacuum (MB) |
-| ----- | ------- | -------- | -------------------- | ---------------- |
-| 1k    | _TBD_   | _TBD_    | _TBD_                | _TBD_            |
-| 10k   | _TBD_   | _TBD_    | _TBD_                | _TBD_            |
-| 100k  | _TBD_   | _TBD_    | _TBD_                | _TBD_            |
+Cold-scanned, then `PRAGMA wal_checkpoint(TRUNCATE)`, then `VACUUM`, stat'ing
+after each step. Steady-state size is the `post-checkpoint db` column (`VACUUM`
+itself writes to the WAL, so the post-vacuum total re-grows the WAL — only the
+main `.db` file reflects compacted state).
+
+| Scale | raw db (MB) | raw WAL (MB) | post-checkpoint db (MB) | post-vacuum db (MB) | bytes/entry |
+| ----- | ----------- | ------------ | ----------------------- | ------------------- | ----------- |
+| 1k    | 0.004       | 0.87         | 0.80                    | 0.80                | 815         |
+| 10k   | 7.94        | 8.05         | 7.95                    | 7.57                | 757         |
+| 100k  | 79.56       | 46.53        | 79.63                   | 76.00               | 760         |
+
+**Size observations:**
+
+- **~750–815 bytes per entry** post-vacuum, consistent across scales. Includes
+  the entry row, its share of edges (~3 per entry at the generator's
+  `edgeDensity`), and the relevant indices.
+- **At 100k entries the on-disk index is ~76 MB** — modest, comfortably fits on
+  any modern dev machine. The §8 privacy paragraph can commit to "expect ~80 MB
+  at 100k entries" as a defensible upper bound.
+- **Raw size at 1k is dominated by the WAL** (~870 KB WAL vs 4 KB main file)
+  because SQLite's default WAL auto-checkpoint threshold is 1000 pages — at 1k
+  entries the cold scan hasn't crossed that yet. At larger scales the
+  auto-checkpoint fires during the scan and the WAL stays bounded.
+- **Production-relevant takeaway:** the indexer should run an explicit
+  `wal_checkpoint(TRUNCATE)` after cold-scan completes so the WAL doesn't sit at
+  the cold-scan size between editor restarts. A periodic checkpoint on idle is
+  the standard pattern.
 
 ### Concurrency survival
 

--- a/eval/sqlite-indexing/bench/size.ts
+++ b/eval/sqlite-indexing/bench/size.ts
@@ -1,36 +1,154 @@
 /**
  * @module bench/size
  *
- * Index file-size benchmark. After cold-scan completes, measure:
- *   - size of `.db` file
- *   - size of `.db-wal` file (if WAL active and not yet checkpointed)
- *   - size of `.db-shm` file
- *   - size after `PRAGMA wal_checkpoint(TRUNCATE)`
- *   - size after `VACUUM`
+ * Index file-size benchmark. Cold-scans the corpus, stats the on-disk
+ * files, then runs `PRAGMA wal_checkpoint(TRUNCATE)` + `VACUUM` and
+ * re-stats. Reports raw / post-checkpoint / post-vacuum sizes at each
+ * scale.
  *
- * Reported per scale. Lets the ADR commit to a defensible disk-budget number
- * for §8 (privacy) — the user needs to know roughly how big this cache will
- * grow on their machine.
+ * Informational — no §6 budget — but lets the §8 privacy paragraph
+ * commit to a defensible disk-budget number ("expect ~X MB at 100k
+ * entries on this machine").
  */
 
-export interface SizeResult {
-  readonly scale: "1k" | "10k" | "100k";
-  readonly dbBytes: number;
-  readonly walBytes: number;
-  readonly shmBytes: number;
-  readonly postCheckpointBytes: number;
-  readonly postVacuumBytes: number;
-  readonly timestamp: string;
+import {
+  generateProject,
+  type GenOptions,
+  SCALE_100K,
+  SCALE_10K,
+  SCALE_1K,
+} from "../corpus/generator.ts";
+import { createAdapter, type PragmaSet } from "./adapter.ts";
+import { SqliteAdapter } from "./sqlite_adapter.ts";
+import { record } from "./harness.ts";
+
+const TUNED: PragmaSet = {
+  journalMode: "wal",
+  synchronous: "normal",
+  cacheSizeKb: 64_000,
+  mmapSizeMb: 0,
+  tempStore: "memory",
+};
+
+async function statBytes(path: string): Promise<number> {
+  try {
+    const s = await Deno.stat(path);
+    return s.size;
+  } catch {
+    return 0;
+  }
+}
+
+async function totalBytes(dbPath: string): Promise<{
+  db: number;
+  wal: number;
+  shm: number;
+  total: number;
+}> {
+  const db = await statBytes(dbPath);
+  const wal = await statBytes(`${dbPath}-wal`);
+  const shm = await statBytes(`${dbPath}-shm`);
+  return { db, wal, shm, total: db + wal + shm };
 }
 
 export async function runSizeMeasurement(
-  _scale: "1k" | "10k" | "100k",
+  scale: "1k" | "10k" | "100k",
+  resultsDir: string,
 ): Promise<void> {
-  // TODO(phase-1): cold-scan the corpus, stat the resulting files, then
-  // checkpoint + vacuum and re-stat. Record as a SizeResult.
-  throw new Error("runSizeMeasurement: not yet implemented");
+  const baseOpts = scale === "100k"
+    ? SCALE_100K
+    : scale === "10k"
+    ? SCALE_10K
+    : SCALE_1K;
+  const opts: GenOptions = baseOpts;
+  console.error(`size: scale=${scale} entries=${opts.entryCount}`);
+
+  const project = generateProject(opts);
+  const tmpDir = await Deno.makeTempDir({ prefix: "markspec-eval-size-" });
+  const dbPath = `${tmpDir}/index.db`;
+
+  try {
+    const adapter = await createAdapter("sqlite3");
+    await adapter.open(dbPath, TUNED);
+    await adapter.bulkInsertEntries(project.entries);
+    await adapter.bulkInsertEdges(project.edges);
+    await adapter.bulkInsertGlossary(project.glossary);
+
+    const raw = (adapter as SqliteAdapter).raw();
+
+    const sizesRaw = await totalBytes(dbPath);
+    console.error(
+      `  raw:             db=${sizesRaw.db} wal=${sizesRaw.wal} ` +
+        `shm=${sizesRaw.shm} total=${sizesRaw.total}`,
+    );
+
+    // Checkpoint truncates the WAL so its contents are folded into the
+    // main db file. The .db file grows, the .db-wal file shrinks to 0.
+    raw.exec("PRAGMA wal_checkpoint(TRUNCATE)");
+    const sizesPostCheckpoint = await totalBytes(dbPath);
+    console.error(
+      `  post-checkpoint: db=${sizesPostCheckpoint.db} ` +
+        `wal=${sizesPostCheckpoint.wal} shm=${sizesPostCheckpoint.shm} ` +
+        `total=${sizesPostCheckpoint.total}`,
+    );
+
+    // VACUUM rebuilds the main db file densely-packed, reclaiming any
+    // free pages. The size reported here is the steady-state size for
+    // a freshly-built index.
+    raw.exec("VACUUM");
+    const sizesPostVacuum = await totalBytes(dbPath);
+    console.error(
+      `  post-vacuum:     db=${sizesPostVacuum.db} ` +
+        `wal=${sizesPostVacuum.wal} shm=${sizesPostVacuum.shm} ` +
+        `total=${sizesPostVacuum.total}`,
+    );
+
+    await adapter.close();
+
+    const bytesPerEntry = Math.round(sizesPostVacuum.db / opts.entryCount);
+
+    await record({
+      bench: "size",
+      scale,
+      driver: "sqlite3",
+      pragmas: {
+        journalMode: TUNED.journalMode,
+        synchronous: TUNED.synchronous,
+      },
+      iterations: 1,
+      warmup: 0,
+      samplesMs: [],
+      p50Ms: 0,
+      p95Ms: 0,
+      p99Ms: 0,
+      meanMs: 0,
+      maxMs: 0,
+      totalMs: 0,
+      notes: {
+        entries: project.entries.length,
+        edges: project.edges.length,
+        glossary: project.glossary.length,
+        rawDbBytes: sizesRaw.db,
+        rawWalBytes: sizesRaw.wal,
+        rawShmBytes: sizesRaw.shm,
+        rawTotalBytes: sizesRaw.total,
+        postCheckpointDbBytes: sizesPostCheckpoint.db,
+        postCheckpointWalBytes: sizesPostCheckpoint.wal,
+        postCheckpointTotalBytes: sizesPostCheckpoint.total,
+        postVacuumDbBytes: sizesPostVacuum.db,
+        postVacuumTotalBytes: sizesPostVacuum.total,
+        bytesPerEntryVacuumed: bytesPerEntry,
+      },
+      timestamp: new Date().toISOString(),
+    }, resultsDir);
+    console.error(`  ~${bytesPerEntry} bytes per entry (post-vacuum db only)`);
+  } finally {
+    await Deno.remove(tmpDir, { recursive: true });
+  }
 }
 
 if (import.meta.main) {
-  await runSizeMeasurement("1k");
+  const resultsDir = new URL("../results", import.meta.url).pathname;
+  const scale = (Deno.args[0] ?? "1k") as "1k" | "10k" | "100k";
+  await runSizeMeasurement(scale, resultsDir);
 }


### PR DESCRIPTION
## Summary

- Phase 1's final bench: implements `size.ts` (raw / post-checkpoint /
  post-vacuum on-disk sizes) at 1k / 10k / 100k. Informational — no §6
  budget — but lets §8 privacy commit to a disk-budget number.
- ADR-020 §Results header note flipped to "All Phase 1 benches
  complete."

## Results (Apple Silicon aarch64-darwin, APFS, local disk)

| Scale | raw db (MB) | raw WAL (MB) | post-checkpoint db (MB) | post-vacuum db (MB) | bytes/entry |
| ----- | ----------- | ------------ | ----------------------- | ------------------- | ----------- |
| 1k    | 0.004       | 0.87         | 0.80                    | 0.80                | 815         |
| 10k   | 7.94        | 8.05         | 7.95                    | 7.57                | 757         |
| 100k  | 79.56       | 46.53        | 79.63                   | 76.00               | 760         |

## Headlines

1. **~750–815 bytes per entry post-vacuum**, consistent across scales.
   Includes the entry row, its share of edges (~3 per entry), and
   indices.
2. **100k index is ~76 MB on disk** — modest, fits any modern dev
   machine. §8 privacy can commit to "expect ~80 MB at 100k entries."
3. **Raw size at 1k is WAL-dominated** (~870 KB WAL vs 4 KB main file)
   because SQLite's default WAL auto-checkpoint threshold (1000 pages)
   isn't crossed during a 1k cold scan. At larger scales the
   auto-checkpoint fires during the scan.
4. **Production guidance:** the indexer should run an explicit
   `wal_checkpoint(TRUNCATE)` after cold-scan completes so the WAL
   doesn't sit at the cold-scan size between editor restarts.

## Phase 1 status after this lands

All 7 benches done. ADR-020 §Results section fully populated.
Remaining work: a final §Decisions / §Recommendations pass to mark
the design confirmed, change Status from Draft → Accepted, and
unblock Phase 2 (production indexer).

## Test plan

- [x] `deno check` passes
- [x] `deno fmt --check` clean
- [x] `dprint check` clean
- [x] Bench runs end-to-end at 1k / 10k / 100k

🤖 Generated with [Claude Code](https://claude.com/claude-code)
