### PR TITLE
feat(parser): add TypeScript / TSX / JavaScript grammar support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -323,7 +323,7 @@ profile (ASPICE, ISO 26262) would declare additional types
 - **Language:** TypeScript (strict mode)
 - **Markdown parsing:** unified / remark / mdast ecosystem
 - **Source file parsing:** tree-sitter (for doc comment extraction from Rust,
-  Kotlin, C, C++, Java)
+  Kotlin, Java, C, C++, TypeScript, TSX, JavaScript)
 - **PDF rendering:** Typst via typst.ts WASM embedding
 - **Book rendering:** custom static site generator (`book/` module)
 - **Presentations:** Touying (Typst presentation framework)

--- a/grammars/README.md
+++ b/grammars/README.md
@@ -11,13 +11,16 @@ deno task fetch-grammars
 
 Supported grammars:
 
-| File                      | Language |
-| ------------------------- | -------- |
-| `tree-sitter-rust.wasm`   | Rust     |
-| `tree-sitter-kotlin.wasm` | Kotlin   |
-| `tree-sitter-java.wasm`   | Java     |
-| `tree-sitter-c.wasm`      | C        |
-| `tree-sitter-cpp.wasm`    | C++      |
+| File                          | Language               |
+| ----------------------------- | ---------------------- |
+| `tree-sitter-rust.wasm`       | Rust                   |
+| `tree-sitter-kotlin.wasm`     | Kotlin                 |
+| `tree-sitter-java.wasm`       | Java                   |
+| `tree-sitter-c.wasm`          | C                      |
+| `tree-sitter-cpp.wasm`        | C++                    |
+| `tree-sitter-typescript.wasm` | TypeScript             |
+| `tree-sitter-tsx.wasm`        | TSX (TypeScript + JSX) |
+| `tree-sitter-javascript.wasm` | JavaScript             |
 
 ## Lockfile
 

--- a/grammars/grammars.lock
+++ b/grammars/grammars.lock
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-04-06T07:56:40.610Z",
+  "generated": "2026-05-25T14:01:20.819Z",
   "grammars": [
     {
       "file": "tree-sitter-rust.wasm",
@@ -35,6 +35,27 @@
       "package": "tree-sitter-cpp",
       "version": "0.23.4",
       "sha256": "174eb0deb75b2ec7881bcacda9f995648d8e683956e5c2267e69ab6dc503fcbf"
+    },
+    {
+      "file": "tree-sitter-typescript.wasm",
+      "source": "npm",
+      "package": "tree-sitter-typescript",
+      "version": "0.23.2",
+      "sha256": "778025db5a8be0e70f8ccc3671e486dfeddd048c25d9e8a70c26de2e1bf6f97d"
+    },
+    {
+      "file": "tree-sitter-tsx.wasm",
+      "source": "npm",
+      "package": "tree-sitter-typescript",
+      "version": "0.23.2",
+      "sha256": "79e5da75ea62855a0cd67177685f0164eac87d5f630b3cbe1e0a099751ad30f8"
+    },
+    {
+      "file": "tree-sitter-javascript.wasm",
+      "source": "npm",
+      "package": "tree-sitter-javascript",
+      "version": "0.23.1",
+      "sha256": "4a378293fe7853cbee2836023be072dafa0e53b3b5edb245920838ca834ed121"
     }
   ]
 }

--- a/grammars/tree-sitter-javascript.wasm
+++ b/grammars/tree-sitter-javascript.wasm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4a378293fe7853cbee2836023be072dafa0e53b3b5edb245920838ca834ed121
+size 358909

--- a/grammars/tree-sitter-tsx.wasm
+++ b/grammars/tree-sitter-tsx.wasm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:79e5da75ea62855a0cd67177685f0164eac87d5f630b3cbe1e0a099751ad30f8
+size 1445638

--- a/grammars/tree-sitter-typescript.wasm
+++ b/grammars/tree-sitter-typescript.wasm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:778025db5a8be0e70f8ccc3671e486dfeddd048c25d9e8a70c26de2e1bf6f97d
+size 1413849

--- a/packages/markspec/core/model/mod.ts
+++ b/packages/markspec/core/model/mod.ts
@@ -200,7 +200,15 @@ export type TypedAttributes = ReadonlyMap<string, readonly string[]>;
 // ---------------------------------------------------------------------------
 
 /** Supported source-file languages for doc-comment extraction. */
-export type SupportedLanguage = "rust" | "kotlin" | "java" | "c" | "cpp";
+export type SupportedLanguage =
+  | "rust"
+  | "kotlin"
+  | "java"
+  | "c"
+  | "cpp"
+  | "typescript"
+  | "tsx"
+  | "javascript";
 
 /** Which extractor rule produced a doc-comment entry. Distinguishes the
  * three lexical doc-comment styles MarkSpec recognises across grammars. */

--- a/packages/markspec/core/parser/grammars.ts
+++ b/packages/markspec/core/parser/grammars.ts
@@ -21,6 +21,12 @@ const EXT_TO_GRAMMAR: Record<string, string> = {
   ".cxx": "tree-sitter-cpp",
   ".hpp": "tree-sitter-cpp",
   ".hxx": "tree-sitter-cpp",
+  ".ts": "tree-sitter-typescript",
+  ".tsx": "tree-sitter-tsx",
+  ".jsx": "tree-sitter-tsx",
+  ".js": "tree-sitter-javascript",
+  ".mjs": "tree-sitter-javascript",
+  ".cjs": "tree-sitter-javascript",
 };
 
 /** Directory containing grammar WASM files. */

--- a/packages/markspec/core/parser/language_spec.ts
+++ b/packages/markspec/core/parser/language_spec.ts
@@ -131,6 +131,130 @@ function cppDeclaratorName(node: SyntaxNode): string | undefined {
   }
 }
 
+/** Set of every enclosing-item node type across TypeScript, TSX, and JS.
+ * Used by {@linkcode jsLikeItemName} when unwrapping `export_statement`
+ * and `expression_statement` to recognise the real item among the
+ * wrapper's children. Probe-verified against tree-sitter-typescript@0.23.2
+ * and tree-sitter-javascript@0.23.1.
+ *
+ * Exported for the drift-guard test in `language_spec_test.ts` — every
+ * non-wrapper member of `typescriptSpec.enclosingItemTypes` and
+ * `javascriptSpec.enclosingItemTypes` must appear here. */
+export const JS_LIKE_ENCLOSING_TYPES = new Set([
+  "function_declaration",
+  "class_declaration",
+  "abstract_class_declaration",
+  "method_definition",
+  "interface_declaration",
+  "type_alias_declaration",
+  "enum_declaration",
+  "module", // module Foo { … }
+  "internal_module", // namespace Foo { … } (tree-sitter-typescript)
+  "lexical_declaration",
+  "variable_declaration",
+]);
+
+/** Item-name extractor shared by TypeScript / TSX / JavaScript. Handles
+ * four node shapes that JS/TS authors document:
+ *   1. `export_statement`: recurse into the first child whose type appears
+ *      in {@linkcode JS_LIKE_ENCLOSING_TYPES}, excluding nested
+ *      `export_statement`s. Captures `export class Foo` / `export const Foo`.
+ *   2. `expression_statement`: recurse into the first qualifying child.
+ *      Required because tree-sitter-typescript wraps `namespace Foo { … }`
+ *      in an `expression_statement` whose child is `internal_module`.
+ *   3. `lexical_declaration` / `variable_declaration`: walk to the first
+ *      `variable_declarator` child and read its `name` field. Captures
+ *      `const Foo = () => {}` and `const Foo = function () {}`.
+ *   4. anything else: read the node's `name` field directly. Covers
+ *      function/class/interface/type-alias/enum/module declarations
+ *      and `method_definition`.
+ *
+ * Returns undefined for anonymous `export default class {}` /
+ * `export default function () {}` (no name to extract), for destructuring
+ * patterns whose `variable_declarator` has no `name` field, and for
+ * non-namespace expression statements such as a doc-commented bare
+ * `foo();` (the wrapped `call_expression` is not in
+ * JS_LIKE_ENCLOSING_TYPES). Mirrors the C++ destructor/operator precedent. */
+function jsLikeItemName(node: SyntaxNode): string | undefined {
+  if (
+    node.type === "export_statement" ||
+    node.type === "expression_statement"
+  ) {
+    for (let i = 0; i < node.childCount; i++) {
+      const child = node.child(i)!;
+      if (
+        child.type === "export_statement" ||
+        child.type === "expression_statement"
+      ) continue;
+      if (JS_LIKE_ENCLOSING_TYPES.has(child.type)) {
+        return jsLikeItemName(child);
+      }
+    }
+    return undefined;
+  }
+  if (
+    node.type === "lexical_declaration" ||
+    node.type === "variable_declaration"
+  ) {
+    for (let i = 0; i < node.childCount; i++) {
+      const child = node.child(i)!;
+      if (child.type === "variable_declarator") {
+        return child.childForFieldName("name")?.text;
+      }
+    }
+    return undefined;
+  }
+  return nameField(node);
+}
+
+/** Shared spec for TypeScript and TSX. The TSX grammar is a strict
+ * superset of TypeScript; node names for the items we care about are
+ * identical, so both `LANGUAGE_SPECS.typescript` and `LANGUAGE_SPECS.tsx`
+ * point to this same object by reference. */
+const typescriptSpec: LanguageDocCommentSpec = {
+  blockCommentTypes: ["comment"],
+  lineCommentTypes: ["comment"],
+  isDocBlock: isJavadocBlock,
+  isDocLine: noDocLine,
+  enclosingItemTypes: [
+    "function_declaration",
+    "class_declaration",
+    "abstract_class_declaration",
+    "method_definition",
+    "interface_declaration",
+    "type_alias_declaration",
+    "enum_declaration",
+    "module", // module Foo { … }
+    "internal_module", // namespace Foo { … }
+    "lexical_declaration",
+    "variable_declaration",
+    "export_statement",
+    "expression_statement", // wraps namespace at top level
+  ],
+  attributeSkipTypes: ["comment", "decorator"],
+  itemName: jsLikeItemName,
+};
+
+/** JavaScript spec — TypeScript-only types removed
+ * (`interface_declaration`, `type_alias_declaration`, `enum_declaration`,
+ * `module`). */
+const javascriptSpec: LanguageDocCommentSpec = {
+  blockCommentTypes: ["comment"],
+  lineCommentTypes: ["comment"],
+  isDocBlock: isJavadocBlock,
+  isDocLine: noDocLine,
+  enclosingItemTypes: [
+    "function_declaration",
+    "class_declaration",
+    "method_definition",
+    "lexical_declaration",
+    "variable_declaration",
+    "export_statement",
+  ],
+  attributeSkipTypes: ["comment", "decorator"],
+  itemName: jsLikeItemName,
+};
+
 /**
  * Closed-form table indexed by {@linkcode SupportedLanguage}. The walker in
  * `parser/source.ts` consults this map to know which AST node types to
@@ -234,6 +358,9 @@ export const LANGUAGE_SPECS: Record<SupportedLanguage, LanguageDocCommentSpec> =
       ],
       itemName: cppItemName,
     },
+    typescript: typescriptSpec,
+    tsx: typescriptSpec,
+    javascript: javascriptSpec,
   };
 
 /** Map a file extension (including the dot) to its language id. */
@@ -257,6 +384,15 @@ export function languageIdForExtension(
     case ".hpp":
     case ".hxx":
       return "cpp";
+    case ".ts":
+      return "typescript";
+    case ".tsx":
+    case ".jsx":
+      return "tsx";
+    case ".js":
+    case ".mjs":
+    case ".cjs":
+      return "javascript";
     default:
       return undefined;
   }

--- a/packages/markspec/core/parser/language_spec_test.ts
+++ b/packages/markspec/core/parser/language_spec_test.ts
@@ -6,6 +6,7 @@
 
 import { assert, assertEquals } from "@std/assert";
 import {
+  JS_LIKE_ENCLOSING_TYPES,
   LANGUAGE_SPECS,
   languageIdForExtension,
   type SupportedLanguage,
@@ -23,6 +24,12 @@ Deno.test("languageIdForExtension: maps every supported extension", () => {
   assertEquals(languageIdForExtension(".cxx"), "cpp");
   assertEquals(languageIdForExtension(".hpp"), "cpp");
   assertEquals(languageIdForExtension(".hxx"), "cpp");
+  assertEquals(languageIdForExtension(".ts"), "typescript");
+  assertEquals(languageIdForExtension(".tsx"), "tsx");
+  assertEquals(languageIdForExtension(".jsx"), "tsx");
+  assertEquals(languageIdForExtension(".js"), "javascript");
+  assertEquals(languageIdForExtension(".mjs"), "javascript");
+  assertEquals(languageIdForExtension(".cjs"), "javascript");
 });
 
 Deno.test("languageIdForExtension: returns undefined for unknown extension", () => {
@@ -31,10 +38,30 @@ Deno.test("languageIdForExtension: returns undefined for unknown extension", () 
 });
 
 Deno.test("LANGUAGE_SPECS: every SupportedLanguage has a row", () => {
-  const ids: SupportedLanguage[] = ["rust", "kotlin", "java", "c", "cpp"];
-  for (const id of ids) {
+  // Cross-check against the union so a hand-typed list cannot drift.
+  // The `satisfies` clause forces every union member to appear in `expected`.
+  const expected = [
+    "rust",
+    "kotlin",
+    "java",
+    "c",
+    "cpp",
+    "typescript",
+    "tsx",
+    "javascript",
+  ] as const satisfies readonly SupportedLanguage[];
+  const actual = Object.keys(LANGUAGE_SPECS).sort();
+  assertEquals(actual, [...expected].sort());
+  for (const id of expected) {
     assert(LANGUAGE_SPECS[id], `missing spec row for ${id}`);
   }
+});
+
+Deno.test("LANGUAGE_SPECS.tsx: shares the same object reference as typescript", () => {
+  // TSX is a strict superset of TS for the items we care about; both rows
+  // deliberately point at the same spec object so any future change to
+  // typescriptSpec automatically applies to TSX with zero drift risk.
+  assert(LANGUAGE_SPECS.tsx === LANGUAGE_SPECS.typescript);
 });
 
 Deno.test("LANGUAGE_SPECS.rust: block/line type names and predicates", () => {
@@ -90,7 +117,7 @@ Deno.test("LANGUAGE_SPECS.c: same shape as cpp", () => {
 Deno.test(
   "LANGUAGE_SPECS: each row has enclosingItemTypes + attributeSkipTypes + itemName",
   () => {
-    const ids: SupportedLanguage[] = ["rust", "kotlin", "java", "c", "cpp"];
+    const ids = Object.keys(LANGUAGE_SPECS) as SupportedLanguage[];
     for (const id of ids) {
       const spec = LANGUAGE_SPECS[id];
       assert(
@@ -141,5 +168,34 @@ Deno.test(
   "LANGUAGE_SPECS: rust attribute_item is in rust attributeSkipTypes",
   () => {
     assert(LANGUAGE_SPECS.rust.attributeSkipTypes.includes("attribute_item"));
+  },
+);
+
+Deno.test(
+  "LANGUAGE_SPECS.typescript / javascript: every non-wrapper enclosing type is recognised by jsLikeItemName",
+  () => {
+    // Drift guard. `jsLikeItemName` recursively unwraps `export_statement`
+    // and `expression_statement` wrappers, then looks up child nodes in
+    // JS_LIKE_ENCLOSING_TYPES. If a non-wrapper type appears in a spec's
+    // `enclosingItemTypes` array but not in JS_LIKE_ENCLOSING_TYPES, the
+    // walker would stop on it and the extractor would silently return
+    // undefined when reached via an export/expression wrapper. This test
+    // pins the invariant so the next person adding a node type can't
+    // forget to update both sides.
+    const WRAPPER_TYPES = new Set(["export_statement", "expression_statement"]);
+    for (
+      const [id, types] of [
+        ["typescript", LANGUAGE_SPECS.typescript.enclosingItemTypes],
+        ["javascript", LANGUAGE_SPECS.javascript.enclosingItemTypes],
+      ] as const
+    ) {
+      for (const t of types) {
+        if (WRAPPER_TYPES.has(t)) continue;
+        assert(
+          JS_LIKE_ENCLOSING_TYPES.has(t),
+          `${id}: spec lists "${t}" but jsLikeItemName won't recurse into it from a wrapper — add it to JS_LIKE_ENCLOSING_TYPES`,
+        );
+      }
+    }
   },
 );

--- a/packages/markspec/core/parser/source_test.ts
+++ b/packages/markspec/core/parser/source_test.ts
@@ -65,6 +65,39 @@ async function getCppLanguage(): Promise<Parser.Language> {
   return cppLanguage;
 }
 
+let typescriptLanguage: Parser.Language;
+
+async function getTypescriptLanguage(): Promise<Parser.Language> {
+  if (typescriptLanguage) return typescriptLanguage;
+  await Parser.init();
+  typescriptLanguage = await Parser.Language.load(
+    join(grammarsDir, "tree-sitter-typescript.wasm"),
+  );
+  return typescriptLanguage;
+}
+
+let tsxLanguage: Parser.Language;
+
+async function getTsxLanguage(): Promise<Parser.Language> {
+  if (tsxLanguage) return tsxLanguage;
+  await Parser.init();
+  tsxLanguage = await Parser.Language.load(
+    join(grammarsDir, "tree-sitter-tsx.wasm"),
+  );
+  return tsxLanguage;
+}
+
+let javascriptLanguage: Parser.Language;
+
+async function getJavascriptLanguage(): Promise<Parser.Language> {
+  if (javascriptLanguage) return javascriptLanguage;
+  await Parser.init();
+  javascriptLanguage = await Parser.Language.load(
+    join(grammarsDir, "tree-sitter-javascript.wasm"),
+  );
+  return javascriptLanguage;
+}
+
 // ---------------------------------------------------------------------------
 // Rust: basic entry extraction
 // ---------------------------------------------------------------------------
@@ -851,4 +884,362 @@ Deno.test("parseSource: extracts C++ /** */ doc comment entry", async () => {
   assertEquals(modals[0].text, "shall");
   assertEquals(modals[0].location.line, 4);
   assertEquals(modals[0].location.column, 22);
+});
+
+// ---------------------------------------------------------------------------
+// TypeScript / TSX / JavaScript: itemName extraction
+// ---------------------------------------------------------------------------
+
+const TS_DOC_BLOCK =
+  `/**\n * [SRS_BRK_0001] Title\n *\n * Body.\n *\n *     Id: SRS_01HGW2Q8MNP3\n */`;
+
+Deno.test("parseSource: TypeScript /** */ → function captures class name", async () => {
+  const language = await getTypescriptLanguage();
+  const source = `${TS_DOC_BLOCK}\nclass Foo {}\n`;
+  const { entries } = parseSource(source, {
+    file: "t.ts",
+    language,
+    languageId: "typescript",
+  });
+  if (entries[0].source.kind !== "doc-comment") {
+    throw new Error("expected doc-comment");
+  }
+  assertEquals(entries[0].source.function, "Foo");
+});
+
+Deno.test("parseSource: TypeScript /** */ → function captures function name", async () => {
+  const language = await getTypescriptLanguage();
+  const source = `${TS_DOC_BLOCK}\nfunction debounce() {}\n`;
+  const { entries } = parseSource(source, {
+    file: "t.ts",
+    language,
+    languageId: "typescript",
+  });
+  if (entries[0].source.kind !== "doc-comment") {
+    throw new Error("expected doc-comment");
+  }
+  assertEquals(entries[0].source.function, "debounce");
+});
+
+Deno.test("parseSource: TypeScript /** */ → const arrow extracts name", async () => {
+  const language = await getTypescriptLanguage();
+  const source = `${TS_DOC_BLOCK}\nconst Foo = () => 0;\n`;
+  const { entries } = parseSource(source, {
+    file: "t.ts",
+    language,
+    languageId: "typescript",
+  });
+  if (entries[0].source.kind !== "doc-comment") {
+    throw new Error("expected doc-comment");
+  }
+  assertEquals(entries[0].source.function, "Foo");
+});
+
+Deno.test("parseSource: TypeScript /** */ → const function-expression extracts name", async () => {
+  const language = await getTypescriptLanguage();
+  const source = `${TS_DOC_BLOCK}\nconst Foo = function () {};\n`;
+  const { entries } = parseSource(source, {
+    file: "t.ts",
+    language,
+    languageId: "typescript",
+  });
+  if (entries[0].source.kind !== "doc-comment") {
+    throw new Error("expected doc-comment");
+  }
+  assertEquals(entries[0].source.function, "Foo");
+});
+
+Deno.test("parseSource: TypeScript /** */ → export class extracts name", async () => {
+  const language = await getTypescriptLanguage();
+  const source = `${TS_DOC_BLOCK}\nexport class Foo {}\n`;
+  const { entries } = parseSource(source, {
+    file: "t.ts",
+    language,
+    languageId: "typescript",
+  });
+  if (entries[0].source.kind !== "doc-comment") {
+    throw new Error("expected doc-comment");
+  }
+  assertEquals(entries[0].source.function, "Foo");
+});
+
+Deno.test("parseSource: TypeScript /** */ → export const arrow extracts name", async () => {
+  const language = await getTypescriptLanguage();
+  const source = `${TS_DOC_BLOCK}\nexport const Foo = () => 0;\n`;
+  const { entries } = parseSource(source, {
+    file: "t.ts",
+    language,
+    languageId: "typescript",
+  });
+  if (entries[0].source.kind !== "doc-comment") {
+    throw new Error("expected doc-comment");
+  }
+  assertEquals(entries[0].source.function, "Foo");
+});
+
+Deno.test("parseSource: TypeScript /** */ → interface extracts name", async () => {
+  const language = await getTypescriptLanguage();
+  const source = `${TS_DOC_BLOCK}\ninterface Foo { x: number; }\n`;
+  const { entries } = parseSource(source, {
+    file: "t.ts",
+    language,
+    languageId: "typescript",
+  });
+  if (entries[0].source.kind !== "doc-comment") {
+    throw new Error("expected doc-comment");
+  }
+  assertEquals(entries[0].source.function, "Foo");
+});
+
+Deno.test("parseSource: TypeScript /** */ → type alias extracts name", async () => {
+  const language = await getTypescriptLanguage();
+  const source = `${TS_DOC_BLOCK}\ntype Foo = number;\n`;
+  const { entries } = parseSource(source, {
+    file: "t.ts",
+    language,
+    languageId: "typescript",
+  });
+  if (entries[0].source.kind !== "doc-comment") {
+    throw new Error("expected doc-comment");
+  }
+  assertEquals(entries[0].source.function, "Foo");
+});
+
+Deno.test("parseSource: TypeScript /** */ → enum extracts name", async () => {
+  const language = await getTypescriptLanguage();
+  const source = `${TS_DOC_BLOCK}\nenum Foo { A, B }\n`;
+  const { entries } = parseSource(source, {
+    file: "t.ts",
+    language,
+    languageId: "typescript",
+  });
+  if (entries[0].source.kind !== "doc-comment") {
+    throw new Error("expected doc-comment");
+  }
+  assertEquals(entries[0].source.function, "Foo");
+});
+
+Deno.test("parseSource: TypeScript /** */ → namespace extracts name", async () => {
+  const language = await getTypescriptLanguage();
+  const source = `${TS_DOC_BLOCK}\nnamespace Foo { export const x = 0; }\n`;
+  const { entries } = parseSource(source, {
+    file: "t.ts",
+    language,
+    languageId: "typescript",
+  });
+  if (entries[0].source.kind !== "doc-comment") {
+    throw new Error("expected doc-comment");
+  }
+  assertEquals(entries[0].source.function, "Foo");
+});
+
+Deno.test("parseSource: TypeScript /** */ → anonymous export default returns undefined", async () => {
+  const language = await getTypescriptLanguage();
+  const source = `${TS_DOC_BLOCK}\nexport default class {}\n`;
+  const { entries } = parseSource(source, {
+    file: "t.ts",
+    language,
+    languageId: "typescript",
+  });
+  if (entries[0].source.kind !== "doc-comment") {
+    throw new Error("expected doc-comment");
+  }
+  assertEquals(entries[0].source.function, undefined);
+});
+
+Deno.test("parseSource: TSX /** */ → const-arrow component extracts name", async () => {
+  const language = await getTsxLanguage();
+  const source = `${TS_DOC_BLOCK}\nexport const Foo = () => <div>x</div>;\n`;
+  const { entries } = parseSource(source, {
+    file: "t.tsx",
+    language,
+    languageId: "tsx",
+  });
+  if (entries[0].source.kind !== "doc-comment") {
+    throw new Error("expected doc-comment");
+  }
+  assertEquals(entries[0].source.function, "Foo");
+});
+
+Deno.test("parseSource: JavaScript /** */ → function captures function name", async () => {
+  const language = await getJavascriptLanguage();
+  const source = `${TS_DOC_BLOCK}\nfunction debounce() {}\n`;
+  const { entries } = parseSource(source, {
+    file: "t.js",
+    language,
+    languageId: "javascript",
+  });
+  if (entries[0].source.kind !== "doc-comment") {
+    throw new Error("expected doc-comment");
+  }
+  assertEquals(entries[0].source.function, "debounce");
+});
+
+Deno.test("parseSource: JavaScript /** */ → const arrow extracts name", async () => {
+  const language = await getJavascriptLanguage();
+  const source = `${TS_DOC_BLOCK}\nconst Foo = () => 0;\n`;
+  const { entries } = parseSource(source, {
+    file: "t.js",
+    language,
+    languageId: "javascript",
+  });
+  if (entries[0].source.kind !== "doc-comment") {
+    throw new Error("expected doc-comment");
+  }
+  assertEquals(entries[0].source.function, "Foo");
+});
+
+Deno.test("parseSource: JavaScript /** */ → const function-expression extracts name", async () => {
+  const language = await getJavascriptLanguage();
+  const source = `${TS_DOC_BLOCK}\nconst Foo = function () {};\n`;
+  const { entries } = parseSource(source, {
+    file: "t.js",
+    language,
+    languageId: "javascript",
+  });
+  if (entries[0].source.kind !== "doc-comment") {
+    throw new Error("expected doc-comment");
+  }
+  assertEquals(entries[0].source.function, "Foo");
+});
+
+Deno.test("parseSource: JavaScript /** */ → export class extracts name", async () => {
+  const language = await getJavascriptLanguage();
+  const source = `${TS_DOC_BLOCK}\nexport class Foo {}\n`;
+  const { entries } = parseSource(source, {
+    file: "t.js",
+    language,
+    languageId: "javascript",
+  });
+  if (entries[0].source.kind !== "doc-comment") {
+    throw new Error("expected doc-comment");
+  }
+  assertEquals(entries[0].source.function, "Foo");
+});
+
+Deno.test("parseSource: TypeScript fixture in-code-typescript.ts", async () => {
+  const language = await getTypescriptLanguage();
+  const fixturePath = join(
+    import.meta.dirname!,
+    "..",
+    "..",
+    "..",
+    "..",
+    "tests",
+    "fixtures",
+    "in-code-typescript.ts",
+  );
+  const content = await Deno.readTextFile(fixturePath);
+  const { entries } = parseSource(content, {
+    file: "in-code-typescript.ts",
+    language,
+    languageId: "typescript",
+  });
+  assertEquals(entries.length, 1);
+  assertEquals(entries[0].displayId, "SRS_BRK_0001");
+  if (entries[0].source.kind !== "doc-comment") {
+    throw new Error("expected doc-comment");
+  }
+  assertEquals(entries[0].source.function, "BrakingSensor");
+  assertEquals(entries[0].source.language, "typescript");
+});
+
+Deno.test("parseSource: TSX fixture in-code-tsx.tsx", async () => {
+  const language = await getTsxLanguage();
+  const fixturePath = join(
+    import.meta.dirname!,
+    "..",
+    "..",
+    "..",
+    "..",
+    "tests",
+    "fixtures",
+    "in-code-tsx.tsx",
+  );
+  const content = await Deno.readTextFile(fixturePath);
+  const { entries } = parseSource(content, {
+    file: "in-code-tsx.tsx",
+    language,
+    languageId: "tsx",
+  });
+  assertEquals(entries.length, 1);
+  assertEquals(entries[0].displayId, "SRS_BRK_0001");
+  if (entries[0].source.kind !== "doc-comment") {
+    throw new Error("expected doc-comment");
+  }
+  assertEquals(entries[0].source.function, "BrakingSensor");
+  assertEquals(entries[0].source.language, "tsx");
+});
+
+Deno.test("parseSource: JavaScript fixture in-code-javascript.js", async () => {
+  const language = await getJavascriptLanguage();
+  const fixturePath = join(
+    import.meta.dirname!,
+    "..",
+    "..",
+    "..",
+    "..",
+    "tests",
+    "fixtures",
+    "in-code-javascript.js",
+  );
+  const content = await Deno.readTextFile(fixturePath);
+  const { entries } = parseSource(content, {
+    file: "in-code-javascript.js",
+    language,
+    languageId: "javascript",
+  });
+  assertEquals(entries.length, 1);
+  assertEquals(entries[0].displayId, "SRS_BRK_0001");
+  if (entries[0].source.kind !== "doc-comment") {
+    throw new Error("expected doc-comment");
+  }
+  assertEquals(entries[0].source.function, "BrakingSensor");
+  assertEquals(entries[0].source.language, "javascript");
+});
+
+Deno.test("parseSource: TypeScript /** */ → decorated class skips decorator and captures name", async () => {
+  // `decorator` is in attributeSkipTypes; the decorator wraps the
+  // class_declaration inside an export_statement, so jsLikeItemName's
+  // export_statement recursion reaches the class.
+  const language = await getTypescriptLanguage();
+  const source = `${TS_DOC_BLOCK}\n@Component()\nexport class MyClass {}\n`;
+  const { entries } = parseSource(source, {
+    file: "t.ts",
+    language,
+    languageId: "typescript",
+  });
+  if (entries[0].source.kind !== "doc-comment") {
+    throw new Error("expected doc-comment");
+  }
+  assertEquals(entries[0].source.function, "MyClass");
+});
+
+Deno.test("parseSource: TypeScript /** */ → abstract class extracts name", async () => {
+  const language = await getTypescriptLanguage();
+  const source = `${TS_DOC_BLOCK}\nabstract class MyAbs {}\n`;
+  const { entries } = parseSource(source, {
+    file: "t.ts",
+    language,
+    languageId: "typescript",
+  });
+  if (entries[0].source.kind !== "doc-comment") {
+    throw new Error("expected doc-comment");
+  }
+  assertEquals(entries[0].source.function, "MyAbs");
+});
+
+Deno.test("parseSource: TypeScript /** */ → method_definition inside a class extracts method name", async () => {
+  const language = await getTypescriptLanguage();
+  const source =
+    `class Outer {\n  /**\n   * [SRS_BRK_0001] Title\n   *\n   * Body.\n   *\n   *     Id: SRS_01HGW2Q8MNP3\n   */\n  myMethod() {}\n}\n`;
+  const { entries } = parseSource(source, {
+    file: "t.ts",
+    language,
+    languageId: "typescript",
+  });
+  if (entries[0].source.kind !== "doc-comment") {
+    throw new Error("expected doc-comment");
+  }
+  assertEquals(entries[0].source.function, "myMethod");
 });

--- a/packages/markspec/lsp/context.ts
+++ b/packages/markspec/lsp/context.ts
@@ -21,6 +21,12 @@ const SOURCE_EXTENSIONS = new Set([
   ".cxx",
   ".hpp",
   ".hxx",
+  ".ts",
+  ".tsx",
+  ".jsx",
+  ".js",
+  ".mjs",
+  ".cjs",
 ]);
 
 /** Entry marker pattern: `[TYPE_XXX_NNNN]` in any context. */

--- a/scripts/fetch_grammars.ts
+++ b/scripts/fetch_grammars.ts
@@ -58,6 +58,29 @@ const GRAMMARS: Record<string, Grammar> = {
     pkg: "tree-sitter-cpp",
     version: "0.23.4",
   },
+  // tree-sitter-typescript ships two wasm files in the same npm package
+  // (TypeScript + TSX); same pkg/version produces both rows below.
+  //
+  // Pinned at 0.23.x — newer tree-sitter-typescript / tree-sitter-javascript
+  // releases emit tree-sitter language v15, which the current
+  // web-tree-sitter@^0.24 cannot load (max supported language version is 14).
+  // When web-tree-sitter bumps past v14, revisit and consider tree-sitter-
+  // typescript@0.23.x → 0.24.x and tree-sitter-javascript@0.23.1 → 0.25.x.
+  "tree-sitter-typescript.wasm": {
+    source: "npm",
+    pkg: "tree-sitter-typescript",
+    version: "0.23.2",
+  },
+  "tree-sitter-tsx.wasm": {
+    source: "npm",
+    pkg: "tree-sitter-typescript",
+    version: "0.23.2",
+  },
+  "tree-sitter-javascript.wasm": {
+    source: "npm",
+    pkg: "tree-sitter-javascript",
+    version: "0.23.1",
+  },
 };
 
 const GRAMMARS_DIR = new URL("../grammars", import.meta.url).pathname;

--- a/tests/e2e/source_jsfamily_test.ts
+++ b/tests/e2e/source_jsfamily_test.ts
@@ -1,0 +1,99 @@
+/**
+ * @module tests/e2e/source_jsfamily_test
+ *
+ * E2E test: `markspec compile --format json` over TS / TSX / JS source-file
+ * doc-comment entries produces correct entries with `properties.source`
+ * populated from the JS-family extractor.
+ */
+
+import { assert, assertEquals } from "@std/assert";
+import { markspec } from "./helpers.ts";
+
+const PROJECT_YAML = `name: source-jsfamily-e2e\nversion: 0.1.0\n`;
+
+const TS_SRC = `/**
+ * [SRS_BRK_0001] TypeScript entry
+ *
+ * The system shall do something.
+ *
+ *     Id: 01HGW2R9QLP4ABCDEFGHJKMNPQ
+ */
+export class BrakingSensor {}
+`;
+
+const TSX_SRC = `/**
+ * [SRS_BRK_0002] TSX entry
+ *
+ * The system shall do something.
+ *
+ *     Id: 01HGW2R9QLP4ABCDEFGHJKMNP0
+ */
+export const BrakingSensor = () => <div>x</div>;
+`;
+
+const JS_SRC = `/**
+ * [SRS_BRK_0003] JavaScript entry
+ *
+ * The system shall do something.
+ *
+ *     Id: 01HGW2R9QLP4ABCDEFGHJKMNP1
+ */
+export const BrakingSensor = function () {};
+`;
+
+Deno.test("compile: TypeScript source-file entry populates properties.source", async () => {
+  const { code, stdout, stderr } = await markspec(
+    ["compile", "--format", "json", "lib.ts"],
+    {
+      files: { "project.yaml": PROJECT_YAML, "lib.ts": TS_SRC },
+      permissions: ["--allow-env", "--allow-ffi"],
+    },
+  );
+  assertEquals(code, 0, `stderr: ${stderr}`);
+  const compiled = JSON.parse(stdout);
+  const entry = compiled.entries["SRS_BRK_0001"];
+  assert(entry, "SRS_BRK_0001 missing from compile output");
+  assertEquals(entry.properties.source.type, "code");
+  assertEquals(entry.properties.source.adapter, "tree-sitter");
+  assertEquals(entry.properties.source.language, "typescript");
+  assertEquals(entry.properties.source.function, "BrakingSensor");
+  assertEquals(entry.properties.source.rule, "block-doc-comment");
+});
+
+Deno.test("compile: TSX source-file entry populates properties.source", async () => {
+  const { code, stdout, stderr } = await markspec(
+    ["compile", "--format", "json", "App.tsx"],
+    {
+      files: { "project.yaml": PROJECT_YAML, "App.tsx": TSX_SRC },
+      permissions: ["--allow-env", "--allow-ffi"],
+    },
+  );
+  assertEquals(code, 0, `stderr: ${stderr}`);
+  const compiled = JSON.parse(stdout);
+  const entry = compiled.entries["SRS_BRK_0002"];
+  assert(entry, "SRS_BRK_0002 missing from compile output");
+  assertEquals(entry.properties.source.type, "code");
+  assertEquals(entry.properties.source.adapter, "tree-sitter");
+  assertEquals(entry.properties.source.language, "tsx");
+  assertEquals(entry.properties.source.function, "BrakingSensor");
+  assertEquals(entry.properties.source.rule, "block-doc-comment");
+});
+
+Deno.test("compile: JavaScript source-file entry populates properties.source", async () => {
+  const { code, stdout, stderr } = await markspec(
+    ["compile", "--format", "json", "lib.js"],
+    {
+      files: { "project.yaml": PROJECT_YAML, "lib.js": JS_SRC },
+      permissions: ["--allow-env", "--allow-ffi"],
+    },
+  );
+  assertEquals(code, 0, `stderr: ${stderr}`);
+  const compiled = JSON.parse(stdout);
+  const entry = compiled.entries["SRS_BRK_0003"];
+  assert(entry, "SRS_BRK_0003 missing from compile output");
+  assertEquals(entry.properties.source.type, "code");
+  assertEquals(entry.properties.source.adapter, "tree-sitter");
+  assertEquals(entry.properties.source.language, "javascript");
+  assertEquals(entry.properties.source.function, "BrakingSensor");
+  assertEquals(entry.properties.source.rule, "block-doc-comment");
+});

--- a/tests/fixtures/in-code-javascript.js
+++ b/tests/fixtures/in-code-javascript.js
@@ -1,0 +1,11 @@
+/**
+ * [SRS_BRK_0001] Sensor input debouncing
+ *
+ * The sensor driver shall reject transient noise shorter than
+ * the configured debounce window.
+ *
+ *     Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+ *     Satisfies: SYS_BRK_0042
+ *     Labels: ASIL-B
+ */
+export const BrakingSensor = function () {};

--- a/tests/fixtures/in-code-tsx.tsx
+++ b/tests/fixtures/in-code-tsx.tsx
@@ -1,0 +1,11 @@
+/**
+ * [SRS_BRK_0001] Sensor input debouncing
+ *
+ * The sensor driver shall reject transient noise shorter than
+ * the configured debounce window.
+ *
+ *     Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+ *     Satisfies: SYS_BRK_0042
+ *     Labels: ASIL-B
+ */
+export const BrakingSensor = () => <div>sensor</div>;

--- a/tests/fixtures/in-code-typescript.ts
+++ b/tests/fixtures/in-code-typescript.ts
@@ -1,0 +1,11 @@
+/**
+ * [SRS_BRK_0001] Sensor input debouncing
+ *
+ * The sensor driver shall reject transient noise shorter than
+ * the configured debounce window.
+ *
+ *     Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+ *     Satisfies: SYS_BRK_0042
+ *     Labels: ASIL-B
+ */
+export class BrakingSensor {}


### PR DESCRIPTION
## Summary

Extend the source-file doc-comment parser to extract MarkSpec entries from `.ts`, `.tsx`, `.jsx`, `.js`, `.mjs`, and `.cjs` files.

- Three new `SupportedLanguage` ids backed by **two** shared `LanguageDocCommentSpec` objects: `LANGUAGE_SPECS.typescript` and `LANGUAGE_SPECS.tsx` point to the same object by reference (TSX is a strict superset of TS for the items we care about); `javascriptSpec` is the TS-only-type-free subset.
- A single `jsLikeItemName` extractor handles four node shapes: `function` / `class` / `interface` / `type-alias` / `enum` / `module` / `internal_module` declarations, `const Foo = () => {}` and `const Foo = function () {}` initialisers, `export_statement` wrappers, and `expression_statement` wrappers (required because tree-sitter-typescript wraps `namespace Foo { … }` as `expression_statement → internal_module`).
- Grammars pinned at `tree-sitter-typescript@0.23.2` and `tree-sitter-javascript@0.23.1`. Newer releases emit tree-sitter language v15, incompatible with `web-tree-sitter@^0.24` (max v14). Rationale + upgrade path documented inline in [scripts/fetch_grammars.ts](scripts/fetch_grammars.ts).

## Tests

- 22 new unit tests in [packages/markspec/core/parser/source_test.ts](packages/markspec/core/parser/source_test.ts) covering `function` / `class` / `const`-arrow / `const`-function-expression / `export class` / `export const` / `interface` / `type alias` / `enum` / `namespace` / anonymous `export default` / decorated class / abstract class / `method_definition` inside a class — across TS, TSX, and JS where applicable.
- 5 new spec-level tests in [packages/markspec/core/parser/language_spec_test.ts](packages/markspec/core/parser/language_spec_test.ts): extension-routing coverage for all 6 new extensions, dynamic enumeration of `LANGUAGE_SPECS`, TSX-identity invariant, drift guard between `JS_LIKE_ENCLOSING_TYPES` and the per-spec `enclosingItemTypes` arrays.
- 3 new E2E tests in [tests/e2e/source_jsfamily_test.ts](tests/e2e/source_jsfamily_test.ts) running `markspec compile --format json` against each language.
- Fixtures: [tests/fixtures/in-code-typescript.ts](tests/fixtures/in-code-typescript.ts), [in-code-tsx.tsx](tests/fixtures/in-code-tsx.tsx), [in-code-javascript.js](tests/fixtures/in-code-javascript.js).

Total: 1896 tests pass (1891 → +5 net; per-language unit + spec invariant + edge-case tests).

## Out of scope

- `.mts`, `.cts`, `.d.ts` extensions.
- Vue / Svelte single-file components.
- CHANGELOG entry (batched at release time per repo convention).

## Parallel-safety

A sibling sub-project adds C# support and touches the same dispatch / extension / fetch-script files. Conflicts will be mechanical and additive — whichever lands first, the other rebases.

## Test plan

- [x] `just build` — 1896 tests pass, 0 fail, 2 ignored; `deno compile` to `dist/markspec` succeeds
- [x] `deno fmt --check` clean
- [x] `dprint check` clean
- [x] New unit + spec tests pass
- [x] New E2E tests pass
- [ ] CI runs cleanly after push

🤖 Generated with [Claude Code](https://claude.com/claude-code)