### PR TITLE
feat(cli): markspec lsp install --editor=neovim (Toolchain Tier 3 Slice A)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -22,10 +22,10 @@
     "@std/assert": "jsr:@std/assert@^1",
     "@std/cli": "jsr:@std/cli@^1",
     "@std/fs": "jsr:@std/fs@^1",
+    "@std/testing": "jsr:@std/testing@^1",
     "@std/ulid": "jsr:@std/ulid@^1",
     "@std/yaml": "jsr:@std/yaml@^1",
-    "@std/path": "jsr:@std/path@^1",
-    "@std/testing": "jsr:@std/testing@^1"
+    "@std/path": "jsr:@std/path@^1"
   },
   "workspace": [
     "./packages/markspec"

--- a/packages/markspec/cli/commands/lsp_cmd.ts
+++ b/packages/markspec/cli/commands/lsp_cmd.ts
@@ -2,6 +2,12 @@
  * @module cli/commands/lsp_cmd
  *
  * `markspec lsp` — start the LSP server or install its configuration.
+ *
+ * Slice A (this iteration): Neovim install runs through the full
+ * `runLspInstall` orchestrator — workspace marker detection, managed
+ * Lua block, timestamped sidecar backup, diff preview, atomic write.
+ * VS Code and Zed adapters remain print-only inside the orchestrator
+ * until Slice B/C migrate them.
  */
 
 import { Command } from "@cliffy/command";
@@ -20,40 +26,56 @@ export const lspCmd = new Command()
     await import("../../lsp/server.ts");
   })
   .command("install")
-  .description("Print LSP server configuration for an editor")
+  .description("Install or print LSP server configuration for an editor")
   .option("--editor <editor:string>", "Editor ID (vscode|neovim|zed)", {
     required: true,
   })
+  .option("--scope <scope:string>", "Config scope: user|workspace")
   .option(
-    "--scope <scope:string>",
-    "Config scope: user|workspace (reserved for Tier 3)",
+    "--binary-path <path:string>",
+    "Path or invoked name written into config",
+    {
+      default: "markspec",
+    },
   )
+  .option(
+    "--print",
+    "Write the new file contents to stdout; do not write to disk",
+  )
+  .option("--force", "Apply without TTY confirmation; required in non-TTY")
+  // Cliffy converts `--no-color` into the `color: boolean` option, default
+  // true; we invert it back into `noColor` for the orchestrator. The flag
+  // is reserved for future colorized diff output — no color is emitted yet.
+  .option("--no-color", "Disable color output")
+  .option("--remove", "Remove the managed block from the config file")
   .action(
-    async (options: { editor: string; scope?: string }) => {
-      const { LSP_EDITOR_IDS, suggestId } = await import(
-        "../install/adapters.ts"
-      );
-      const editorId = options.editor;
-      if (!LSP_EDITOR_IDS.includes(editorId as "vscode" | "neovim" | "zed")) {
-        const suggestion = suggestId(editorId, LSP_EDITOR_IDS);
-        const hint = suggestion ? `\n  did you mean: ${suggestion}` : "";
-        console.error(
-          `error: unknown editor '${editorId}' (known: ${
-            LSP_EDITOR_IDS.join(", ")
-          })${hint}`,
-        );
-        Deno.exit(1);
+    async (
+      options: {
+        editor: string;
+        scope?: string;
+        binaryPath: string;
+        print?: boolean;
+        force?: boolean;
+        color?: boolean;
+        remove?: boolean;
+      },
+    ) => {
+      const { runLspInstall } = await import("../install/orchestrator.ts");
+      const result = await runLspInstall({
+        editor: options.editor,
+        scope: options.scope,
+        binaryPath: options.binaryPath,
+        print: options.print,
+        force: options.force,
+        noColor: options.color === false,
+        remove: options.remove,
+      });
+      if (result.stdout) {
+        await Deno.stdout.write(new TextEncoder().encode(result.stdout));
       }
-      const { neovimAdapter, vscodeAdapter, zedAdapter } = await import(
-        "../install/lsp_adapters.ts"
-      );
-      const result = editorId === "neovim"
-        ? neovimAdapter()
-        : editorId === "zed"
-        ? zedAdapter()
-        : await vscodeAdapter();
-      if (result.stdout) console.log(result.stdout);
-      if (result.stderr) console.error(result.stderr);
+      if (result.stderr) {
+        await Deno.stderr.write(new TextEncoder().encode(result.stderr));
+      }
       Deno.exit(result.exitCode);
     },
   );

--- a/packages/markspec/cli/install/adapters.ts
+++ b/packages/markspec/cli/install/adapters.ts
@@ -50,6 +50,35 @@ export function suggestId(
   return bestDist <= MAX_SUGGESTION_DISTANCE ? best : undefined;
 }
 
+/** Input passed to an adapter's `renderBlock` function. */
+export interface RenderBlockInput {
+  /** Binary path to embed in the block — invoked name or absolute path. */
+  readonly binaryPath: string;
+}
+
+/**
+ * Adapter descriptor consumed by the install orchestrator. Each adapter
+ * exposes pure functions (no I/O) for path resolution and block rendering;
+ * the orchestrator handles file reads, diff/preview, backup, and writes.
+ */
+export interface LspAdapter {
+  readonly id: LspEditorId;
+  /**
+   * Resolve the config file path for the given scope.
+   * - `home` is `Deno.env.get("HOME")` (POSIX) or the Windows equivalent.
+   * - `workspaceRoot` is the directory containing the workspace marker;
+   *   required when `scope === "workspace"`, ignored otherwise.
+   */
+  resolveConfigPath(
+    scope: "user" | "workspace",
+    cwd: string,
+    home: string,
+    workspaceRoot?: string,
+  ): string;
+  /** Render the managed-block content (lines between the fence sentinels). */
+  renderBlock(input: RenderBlockInput): string;
+}
+
 /** Iterative O(n·m) Levenshtein distance with a single row buffer. */
 function levenshtein(a: string, b: string): number {
   if (a === b) return 0;

--- a/packages/markspec/cli/install/backup.ts
+++ b/packages/markspec/cli/install/backup.ts
@@ -1,0 +1,35 @@
+/**
+ * @module cli/install/backup
+ *
+ * Timestamped sidecar backup. Per toolchain-distribution.md §6.3, every
+ * apply (not no-op re-runs) writes a `<path>.markspec-bak-<ISO8601>`
+ * file alongside the original before mutating. ISO 8601 with `:`
+ * replaced by `-` so the filename is portable across all platforms.
+ *
+ * Pruning is the user's / OS's responsibility (§8 D2 — "no pruning in v1").
+ */
+
+/**
+ * Compute the sidecar backup path for an original file.
+ *
+ * @param originalPath - The original file path.
+ * @param now - The timestamp to use for the backup suffix.
+ * @returns The path of the timestamped backup file.
+ */
+export function backupPath(originalPath: string, now: Date): string {
+  const iso = now.toISOString().replace(/\.\d+Z$/, "Z").replaceAll(":", "-");
+  return `${originalPath}.markspec-bak-${iso}`;
+}
+
+/**
+ * Copy the original file to a timestamped sidecar backup.
+ *
+ * @param originalPath - The original file path. Caller must verify it exists.
+ * @returns The path to the created backup file.
+ * @throws If the source file does not exist or cannot be read.
+ */
+export async function writeBackup(originalPath: string): Promise<string> {
+  const target = backupPath(originalPath, new Date());
+  await Deno.copyFile(originalPath, target);
+  return target;
+}

--- a/packages/markspec/cli/install/backup_test.ts
+++ b/packages/markspec/cli/install/backup_test.ts
@@ -1,0 +1,58 @@
+import { assert, assertEquals, assertMatch } from "@std/assert";
+import { backupPath, writeBackup } from "./backup.ts";
+
+Deno.test("backupPath: appends .markspec-bak-<ISO8601>", () => {
+  const p = backupPath("/tmp/foo.lua", new Date("2026-05-25T15:30:45.000Z"));
+  assertEquals(p, "/tmp/foo.lua.markspec-bak-2026-05-25T15-30-45Z");
+});
+
+Deno.test("backupPath: dot-files get the suffix appended (not prepended)", () => {
+  const p = backupPath("/tmp/.config", new Date("2026-05-25T15:30:45.000Z"));
+  assertEquals(p, "/tmp/.config.markspec-bak-2026-05-25T15-30-45Z");
+});
+
+Deno.test("backupPath: zero-padded date parts", () => {
+  const p = backupPath(
+    "/home/user/file.txt",
+    new Date("2026-01-05T09:05:03.789Z"),
+  );
+  assertEquals(p, "/home/user/file.txt.markspec-bak-2026-01-05T09-05-03Z");
+});
+
+Deno.test("writeBackup: copies the original file byte-identically", async () => {
+  const tmp = await Deno.makeTempDir();
+  const orig = `${tmp}/source.lua`;
+  await Deno.writeTextFile(orig, "original content\n");
+  try {
+    const backup = await writeBackup(orig);
+    const restored = await Deno.readTextFile(backup);
+    assertEquals(restored, "original content\n");
+    assertMatch(backup, /\.markspec-bak-\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}Z$/);
+  } finally {
+    await Deno.remove(tmp, { recursive: true });
+  }
+});
+
+Deno.test("writeBackup: preserves binary content exactly", async () => {
+  const tmp = await Deno.makeTempDir();
+  const orig = `${tmp}/binary.bin`;
+  const binaryContent = new Uint8Array([0, 1, 127, 128, 255]);
+  await Deno.writeFile(orig, binaryContent);
+  try {
+    const backup = await writeBackup(orig);
+    const restored = await Deno.readFile(backup);
+    assertEquals(restored, binaryContent);
+  } finally {
+    await Deno.remove(tmp, { recursive: true });
+  }
+});
+
+Deno.test("writeBackup: missing source file → throws", async () => {
+  let threw = false;
+  try {
+    await writeBackup("/nonexistent/path.lua");
+  } catch {
+    threw = true;
+  }
+  assert(threw);
+});

--- a/packages/markspec/cli/install/lsp_adapters.ts
+++ b/packages/markspec/cli/install/lsp_adapters.ts
@@ -11,7 +11,12 @@
  * stderr carries status messages, file paths, and instructions.
  */
 
-import type { AdapterResult } from "./adapters.ts";
+import { join } from "@std/path";
+import type {
+  AdapterResult,
+  LspAdapter,
+  RenderBlockInput,
+} from "./adapters.ts";
 
 /**
  * Return the canonical Lua snippet for nvim-lspconfig.
@@ -49,6 +54,38 @@ export function zedAdapter(): AdapterResult {
     "Merge the JSON block above into your Zed settings.json (~/.config/zed/settings.json).";
   return { stdout, stderr, exitCode: 0 };
 }
+
+// ---------------------------------------------------------------------------
+// neovimDescriptor — new descriptor shape (consumed by orchestrator, Task 6)
+// ---------------------------------------------------------------------------
+
+/**
+ * Descriptor for the Neovim editor adapter. Pure functions — no I/O.
+ * The install orchestrator (Task 6) handles file reads, diff/preview,
+ * backup, and writes using this descriptor.
+ */
+export const neovimDescriptor: LspAdapter = {
+  id: "neovim",
+  resolveConfigPath(scope, _cwd, home, workspaceRoot) {
+    if (scope === "user") {
+      return join(home, ".config", "nvim", "lsp", "markspec.lua");
+    }
+    if (!workspaceRoot) {
+      throw new Error("workspace scope requires a workspaceRoot");
+    }
+    return join(workspaceRoot, ".nvim", "markspec.lua");
+  },
+  renderBlock(input: RenderBlockInput): string {
+    return [
+      `-- markspec LSP (managed by markspec lsp install — do not edit)`,
+      `require('lspconfig').markspec.setup({`,
+      `  cmd = { '${input.binaryPath}', 'lsp', '--stdio' },`,
+      `  filetypes = { 'markdown' },`,
+      `  root_dir = require('lspconfig.util').root_pattern('markspec.yaml', '.markspec.yaml', 'project.yaml'),`,
+      `})`,
+    ].join("\n");
+  },
+};
 
 /**
  * VS Code adapter — verify-only.

--- a/packages/markspec/cli/install/lsp_adapters_test.ts
+++ b/packages/markspec/cli/install/lsp_adapters_test.ts
@@ -1,5 +1,5 @@
-import { assertStringIncludes } from "@std/assert";
-import { neovimAdapter, zedAdapter } from "./lsp_adapters.ts";
+import { assert, assertEquals, assertStringIncludes } from "@std/assert";
+import { neovimAdapter, neovimDescriptor, zedAdapter } from "./lsp_adapters.ts";
 
 Deno.test("neovim adapter: output contains lsp and --stdio args", () => {
   const { stdout } = neovimAdapter();
@@ -41,3 +41,102 @@ Deno.test("zed adapter: stdout contains BINARY_PATH placeholder", () => {
   const { stdout } = zedAdapter();
   assertStringIncludes(stdout, "<BINARY_PATH>");
 });
+
+// ---------------------------------------------------------------------------
+// neovimDescriptor (new descriptor shape — Task 5)
+// ---------------------------------------------------------------------------
+
+Deno.test("neovimDescriptor: id matches editor id", () => {
+  assertEquals(neovimDescriptor.id, "neovim");
+});
+
+// Normalize backslash → forward-slash so path assertions are portable
+// across POSIX and Windows runners. @std/path's `join()` produces native
+// separators (backslash on Windows); the implementation must walk through
+// `join()` for cross-platform path correctness, so the test verifies
+// behavior after normalization.
+function normalizePath(p: string): string {
+  return p.replaceAll("\\", "/");
+}
+
+Deno.test(
+  "neovimDescriptor: user-scope config path is <home>/.config/nvim/lsp/markspec.lua",
+  () => {
+    const path = neovimDescriptor.resolveConfigPath(
+      "user",
+      "/cwd",
+      "/home/test",
+    );
+    assertEquals(
+      normalizePath(path),
+      "/home/test/.config/nvim/lsp/markspec.lua",
+    );
+  },
+);
+
+Deno.test(
+  "neovimDescriptor: workspace-scope path is <root>/.nvim/markspec.lua",
+  () => {
+    const path = neovimDescriptor.resolveConfigPath(
+      "workspace",
+      "/cwd",
+      "/home/test",
+      "/repo",
+    );
+    assertEquals(normalizePath(path), "/repo/.nvim/markspec.lua");
+  },
+);
+
+Deno.test(
+  "neovimDescriptor: workspace scope without workspaceRoot → throws",
+  () => {
+    let threw = false;
+    try {
+      neovimDescriptor.resolveConfigPath("workspace", "/cwd", "/home/test");
+    } catch {
+      threw = true;
+    }
+    assert(threw);
+  },
+);
+
+Deno.test(
+  "neovimDescriptor: renderBlock embeds the binary path verbatim",
+  () => {
+    const block = neovimDescriptor.renderBlock({ binaryPath: "markspec" });
+    assertStringIncludes(block, "cmd = { 'markspec', 'lsp', '--stdio' }");
+    assertStringIncludes(block, "filetypes = { 'markdown' }");
+  },
+);
+
+Deno.test(
+  "neovimDescriptor: renderBlock with absolute binary path uses it",
+  () => {
+    const block = neovimDescriptor.renderBlock({
+      binaryPath: "/Users/x/.local/bin/markspec",
+    });
+    assertStringIncludes(block, "cmd = { '/Users/x/.local/bin/markspec'");
+  },
+);
+
+Deno.test(
+  "neovimDescriptor: renderBlock includes all three workspace markers in root_pattern",
+  () => {
+    const block = neovimDescriptor.renderBlock({ binaryPath: "markspec" });
+    assertStringIncludes(block, "'markspec.yaml'");
+    assertStringIncludes(block, "'.markspec.yaml'");
+    assertStringIncludes(block, "'project.yaml'");
+  },
+);
+
+Deno.test(
+  "neovimAdapter (legacy print-only) still returns AdapterResult",
+  () => {
+    // Do not remove the existing API in Slice A — Slice B/C migrate the
+    // print-only path. Confirms the legacy shape survives this refactor.
+    const r = neovimAdapter();
+    assert(typeof r.stdout === "string");
+    assert(typeof r.stderr === "string");
+    assert(typeof r.exitCode === "number");
+  },
+);

--- a/packages/markspec/cli/install/managed_block.ts
+++ b/packages/markspec/cli/install/managed_block.ts
@@ -1,0 +1,101 @@
+/**
+ * @module cli/install/managed_block
+ *
+ * Managed-block writer for `markspec lsp install` / `mcp install`.
+ *
+ * The installer never owns the user's config file — it owns a single
+ * delimited, idempotent region inside it (toolchain-distribution.md §6.1).
+ *
+ * For block-style targets (Neovim Lua), the region is fenced by sentinel
+ * comments. Content between the fences is owned by the installer; every-
+ * thing else is the user's.
+ *
+ * Idempotence: re-applying the same content yields a byte-identical file.
+ * Removal: stripping the region cleans both fences and the trailing
+ * newline that was solely the separator.
+ */
+
+export const LUA_FENCE_OPEN = "-- >>> markspec (managed) >>>";
+export const LUA_FENCE_CLOSE = "-- <<< markspec (managed) <<<";
+
+/**
+ * Insert or replace the managed region in `currentContent`.
+ *
+ * - If no managed block exists, appends the fenced block at the end,
+ *   separated by a blank line when the file already has content.
+ * - If a managed block exists, replaces only the region between the
+ *   fences (inclusive). Everything outside the fences is untouched.
+ *
+ * The resulting string always ends with a newline after the close fence.
+ *
+ * Pure: no I/O.
+ */
+export function applyLuaBlock(
+  currentContent: string,
+  newBlockContent: string,
+): string {
+  const openIdx = currentContent.indexOf(LUA_FENCE_OPEN);
+  const closeIdx = currentContent.indexOf(LUA_FENCE_CLOSE);
+
+  const managedRegion =
+    `${LUA_FENCE_OPEN}\n${newBlockContent}\n${LUA_FENCE_CLOSE}\n`;
+
+  if (openIdx !== -1 && closeIdx !== -1 && closeIdx > openIdx) {
+    // Replace the existing managed region. The region spans from the
+    // opening fence to (and including) the newline after the closing fence.
+    const closeFenceEnd = closeIdx + LUA_FENCE_CLOSE.length;
+    // Consume the newline that follows the close fence, if present.
+    const afterClose = closeFenceEnd < currentContent.length &&
+        currentContent[closeFenceEnd] === "\n"
+      ? closeFenceEnd + 1
+      : closeFenceEnd;
+
+    const before = currentContent.slice(0, openIdx);
+    const after = currentContent.slice(afterClose);
+    return `${before}${managedRegion}${after}`;
+  }
+
+  // No existing block — append at the end.
+  if (currentContent.length === 0) {
+    return managedRegion;
+  }
+
+  // Ensure there is exactly one blank line between the user's content
+  // and the managed block. If the file ends with \n, add one more \n
+  // (blank line); if it doesn't end with \n, add \n\n (newline + blank line).
+  const separator = currentContent.endsWith("\n") ? "\n" : "\n\n";
+  return `${currentContent}${separator}${managedRegion}`;
+}
+
+/**
+ * Remove the managed region from `currentContent`.
+ *
+ * - Deletes both fences and the content between them (inclusive of the
+ *   trailing newline after the close fence).
+ * - If the character immediately before the opening fence is a blank line
+ *   (i.e., `\n\n`), removes that extra blank line so the surrounding text
+ *   stays tidy.
+ * - Returns the input unchanged when no managed block is present.
+ *
+ * Pure: no I/O.
+ */
+export function removeLuaBlock(currentContent: string): string {
+  const openIdx = currentContent.indexOf(LUA_FENCE_OPEN);
+  const closeIdx = currentContent.indexOf(LUA_FENCE_CLOSE);
+
+  if (openIdx === -1 || closeIdx === -1 || closeIdx <= openIdx) {
+    return currentContent;
+  }
+
+  const closeFenceEnd = closeIdx + LUA_FENCE_CLOSE.length;
+  // Consume the newline that follows the close fence, if present.
+  const afterClose = closeFenceEnd < currentContent.length &&
+      currentContent[closeFenceEnd] === "\n"
+    ? closeFenceEnd + 1
+    : closeFenceEnd;
+
+  const before = currentContent.slice(0, openIdx);
+  const after = currentContent.slice(afterClose);
+
+  return `${before}${after}`;
+}

--- a/packages/markspec/cli/install/managed_block_test.ts
+++ b/packages/markspec/cli/install/managed_block_test.ts
@@ -1,0 +1,143 @@
+import { assertEquals } from "@std/assert";
+import {
+  applyLuaBlock,
+  LUA_FENCE_CLOSE,
+  LUA_FENCE_OPEN,
+  removeLuaBlock,
+} from "./managed_block.ts";
+
+const FENCE_OPEN = "-- >>> markspec (managed) >>>";
+const FENCE_CLOSE = "-- <<< markspec (managed) <<<";
+
+Deno.test("LUA_FENCE constants match spec §6.1", () => {
+  assertEquals(LUA_FENCE_OPEN, FENCE_OPEN);
+  assertEquals(LUA_FENCE_CLOSE, FENCE_CLOSE);
+});
+
+Deno.test("applyLuaBlock: empty file → adds block at end", () => {
+  const result = applyLuaBlock("", "require('lspconfig').markspec.setup({})");
+  assertEquals(
+    result,
+    `${FENCE_OPEN}\nrequire('lspconfig').markspec.setup({})\n${FENCE_CLOSE}\n`,
+  );
+});
+
+Deno.test("applyLuaBlock: existing content, no block → appends block", () => {
+  const input = "-- user's own config\nrequire('plugin').setup()\n";
+  const result = applyLuaBlock(
+    input,
+    "require('lspconfig').markspec.setup({})",
+  );
+  assertEquals(
+    result,
+    `${input}\n${FENCE_OPEN}\nrequire('lspconfig').markspec.setup({})\n${FENCE_CLOSE}\n`,
+  );
+});
+
+Deno.test(
+  "applyLuaBlock: existing block with same content → idempotent (byte-identical)",
+  () => {
+    const block =
+      `${FENCE_OPEN}\nrequire('lspconfig').markspec.setup({})\n${FENCE_CLOSE}\n`;
+    const input = `-- prelude\n\n${block}-- epilogue\n`;
+    const result = applyLuaBlock(
+      input,
+      "require('lspconfig').markspec.setup({})",
+    );
+    assertEquals(result, input);
+  },
+);
+
+Deno.test(
+  "applyLuaBlock: existing block with different content → replaces region only",
+  () => {
+    const oldBlock =
+      `${FENCE_OPEN}\nrequire('lspconfig').markspec.setup({ old = true })\n${FENCE_CLOSE}\n`;
+    const input = `-- prelude\n\n${oldBlock}-- epilogue\n`;
+    const result = applyLuaBlock(
+      input,
+      "require('lspconfig').markspec.setup({})",
+    );
+    const expected =
+      `-- prelude\n\n${FENCE_OPEN}\nrequire('lspconfig').markspec.setup({})\n${FENCE_CLOSE}\n-- epilogue\n`;
+    assertEquals(result, expected);
+  },
+);
+
+Deno.test("applyLuaBlock: handles multi-line content correctly", () => {
+  const content =
+    `require('lspconfig').markspec.setup({\n  cmd = { 'markspec', 'lsp' },\n})`;
+  const result = applyLuaBlock("", content);
+  assertEquals(result, `${FENCE_OPEN}\n${content}\n${FENCE_CLOSE}\n`);
+});
+
+Deno.test("removeLuaBlock: removes the fenced region cleanly", () => {
+  const block = `${FENCE_OPEN}\nfoo\n${FENCE_CLOSE}\n`;
+  const input = `-- prelude\n\n${block}-- epilogue\n`;
+  const result = removeLuaBlock(input);
+  assertEquals(result, "-- prelude\n\n-- epilogue\n");
+});
+
+Deno.test("removeLuaBlock: no block present → input unchanged", () => {
+  const input = "-- just user content\n";
+  assertEquals(removeLuaBlock(input), input);
+});
+
+Deno.test("removeLuaBlock: removes trailing newline that was the separator", () => {
+  const block = `${FENCE_OPEN}\nfoo\n${FENCE_CLOSE}\n`;
+  const input = `prelude\n${block}`;
+  const result = removeLuaBlock(input);
+  assertEquals(result, "prelude\n");
+});
+
+// --- Extra edge cases ---
+
+Deno.test("removeLuaBlock: block at end of file with no epilogue", () => {
+  const block = `${FENCE_OPEN}\nfoo\n${FENCE_CLOSE}\n`;
+  const input = `-- prelude\n\n${block}`;
+  const result = removeLuaBlock(input);
+  assertEquals(result, "-- prelude\n\n");
+});
+
+Deno.test("removeLuaBlock: block is entire file content", () => {
+  const block = `${FENCE_OPEN}\nfoo\n${FENCE_CLOSE}\n`;
+  const result = removeLuaBlock(block);
+  assertEquals(result, "");
+});
+
+Deno.test("applyLuaBlock: block at end of file (no epilogue) → idempotent", () => {
+  const block =
+    `${FENCE_OPEN}\nrequire('lspconfig').markspec.setup({})\n${FENCE_CLOSE}\n`;
+  const input = `-- prelude\n\n${block}`;
+  const result = applyLuaBlock(
+    input,
+    "require('lspconfig').markspec.setup({})",
+  );
+  assertEquals(result, input);
+});
+
+Deno.test(
+  "applyLuaBlock: existing content without trailing newline → appends block after newline",
+  () => {
+    // File content that does not end with \n — e.g., freshly created without trailing newline
+    const input = "-- user config";
+    const result = applyLuaBlock(
+      input,
+      "require('lspconfig').markspec.setup({})",
+    );
+    assertEquals(
+      result,
+      `-- user config\n\n${FENCE_OPEN}\nrequire('lspconfig').markspec.setup({})\n${FENCE_CLOSE}\n`,
+    );
+  },
+);
+
+Deno.test("applyLuaBlock: empty string content inside block is valid", () => {
+  // Edge: installing an empty managed block (e.g., placeholder)
+  const result = applyLuaBlock("", "");
+  assertEquals(result, `${FENCE_OPEN}\n\n${FENCE_CLOSE}\n`);
+});
+
+Deno.test("removeLuaBlock: empty file → empty file", () => {
+  assertEquals(removeLuaBlock(""), "");
+});

--- a/packages/markspec/cli/install/orchestrator.ts
+++ b/packages/markspec/cli/install/orchestrator.ts
@@ -1,0 +1,285 @@
+/**
+ * @module cli/install/orchestrator
+ *
+ * `markspec lsp install` orchestrator — wires Tasks 1-5 (workspace
+ * discovery, managed-block writer, backup, preview, adapter descriptors)
+ * into the full user-facing flow described in
+ * `docs/spec/internal/markspec-toolchain-distribution.md` §4, §6, §7.
+ *
+ * Boundary contract (kept pure for testability): `runLspInstall(options)`
+ * returns an `OrchestratorResult`. No `process.exit`, no global state.
+ * The CLI action wrapper in `lsp_cmd.ts` writes stdout/stderr and exits
+ * with the returned `exitCode`.
+ *
+ * Slice A scope:
+ *   - Full Neovim flow (workspace marker, managed-block, backup, diff,
+ *     non-TTY safety, --print, --force, --remove).
+ *   - VS Code / Zed remain print-only (legacy adapter wrappers); Slice B/C
+ *     migrate them onto this same orchestrator.
+ *
+ * The TTY confirmation path is intentionally simplified for Slice A:
+ * `--force` is the only way to apply. TTY-but-no-`--force` prints the
+ * diff and aborts with a remediation hint; live interactive `confirm()`
+ * integration is deferred.
+ */
+
+import { dirname } from "@std/path";
+import { LSP_EDITOR_IDS, type LspEditorId, suggestId } from "./adapters.ts";
+import { neovimDescriptor, vscodeAdapter, zedAdapter } from "./lsp_adapters.ts";
+import { findWorkspaceRoot, NO_WORKSPACE_MARKER_STDERR } from "./workspace.ts";
+import { applyLuaBlock, removeLuaBlock } from "./managed_block.ts";
+import { writeBackup } from "./backup.ts";
+import { renderDiff } from "./preview.ts";
+
+/** Options accepted by {@linkcode runLspInstall}. */
+export interface LspInstallOptions {
+  readonly editor: string;
+  readonly scope?: string;
+  readonly binaryPath: string;
+  readonly print?: boolean;
+  readonly force?: boolean;
+  /** Reserved; no color output is emitted yet. */
+  readonly noColor?: boolean;
+  readonly remove?: boolean;
+  /**
+   * Test-only seam: lets unit tests inject a known cwd, HOME, and TTY
+   * verdict without touching the host environment. Production callers
+   * (the CLI action) omit this — the orchestrator falls back to Deno.cwd(),
+   * Deno.env.get("HOME"), and Deno.stdin.isTerminal().
+   */
+  readonly env?: {
+    readonly cwd?: string;
+    readonly home?: string;
+    readonly isTty?: boolean;
+  };
+}
+
+/** Result shape returned by the orchestrator. */
+export interface OrchestratorResult {
+  readonly stdout: string;
+  readonly stderr: string;
+  readonly exitCode: number;
+}
+
+/**
+ * Run `markspec lsp install` with the supplied options. Pure boundary:
+ * returns the stdout/stderr/exitCode triple the CLI action will surface.
+ * Performs file I/O internally — that's a CLI internal, not a library
+ * concern.
+ */
+export async function runLspInstall(
+  options: LspInstallOptions,
+): Promise<OrchestratorResult> {
+  // 1. Validate --editor.
+  if (!LSP_EDITOR_IDS.includes(options.editor as LspEditorId)) {
+    const suggestion = suggestId(options.editor, LSP_EDITOR_IDS);
+    const hint = suggestion ? `\n  did you mean: ${suggestion}` : "";
+    return {
+      stdout: "",
+      stderr: `error: unknown editor '${options.editor}' (known: ${
+        LSP_EDITOR_IDS.join(", ")
+      })${hint}\n`,
+      exitCode: 1,
+    };
+  }
+  const editorId = options.editor as LspEditorId;
+
+  // 2. Legacy print-only fallback for vscode/zed (Slice B/C migrates them).
+  if (editorId === "vscode") {
+    const r = await vscodeAdapter();
+    return {
+      stdout: r.stdout ? `${r.stdout}\n` : "",
+      stderr: r.stderr ? `${r.stderr}\n` : "",
+      exitCode: r.exitCode,
+    };
+  }
+  if (editorId === "zed") {
+    const r = zedAdapter();
+    return {
+      stdout: r.stdout ? `${r.stdout}\n` : "",
+      stderr: r.stderr ? `${r.stderr}\n` : "",
+      exitCode: r.exitCode,
+    };
+  }
+
+  // 3. Neovim full path.
+  const cwd = options.env?.cwd ?? Deno.cwd();
+  // HOME is read lazily so workspace-scope invocations don't require
+  // `--allow-env` (resolveConfigPath only consults `home` for user scope).
+  const readHome = (): string => {
+    if (options.env?.home !== undefined) return options.env.home;
+    try {
+      return Deno.env.get("HOME") ?? "";
+    } catch {
+      return "";
+    }
+  };
+  const isTty = options.env?.isTty ?? Deno.stdin.isTerminal();
+
+  // Resolve scope per §4.4: explicit user → user, explicit workspace → walk
+  // up + fallback to user with a preamble warning, auto-detect when no flag.
+  let stderrPreamble = "";
+  let resolvedScope: "user" | "workspace";
+  let workspaceRoot: string | undefined;
+
+  if (options.scope === "user") {
+    resolvedScope = "user";
+  } else if (options.scope === "workspace") {
+    workspaceRoot = await findWorkspaceRoot(cwd);
+    if (workspaceRoot) {
+      resolvedScope = "workspace";
+    } else {
+      stderrPreamble += `${NO_WORKSPACE_MARKER_STDERR}\n`;
+      resolvedScope = "user";
+    }
+  } else if (options.scope === undefined) {
+    workspaceRoot = await findWorkspaceRoot(cwd);
+    resolvedScope = workspaceRoot ? "workspace" : "user";
+  } else {
+    return {
+      stdout: "",
+      stderr:
+        `error: unknown scope '${options.scope}' (known: user, workspace)\n`,
+      exitCode: 1,
+    };
+  }
+
+  const configPath = neovimDescriptor.resolveConfigPath(
+    resolvedScope,
+    cwd,
+    resolvedScope === "user" ? readHome() : "",
+    workspaceRoot,
+  );
+
+  // 4. Read current file content. Missing file → empty string.
+  let current = "";
+  let fileExists = true;
+  try {
+    current = await Deno.readTextFile(configPath);
+  } catch (err) {
+    if (err instanceof Deno.errors.NotFound) {
+      current = "";
+      fileExists = false;
+    } else {
+      return {
+        stdout: "",
+        stderr: `${stderrPreamble}error: cannot read ${configPath}: ${
+          (err as Error).message
+        }\n`,
+        exitCode: 1,
+      };
+    }
+  }
+
+  // 5. Compute next content. Block rendering is only needed for the
+  // apply path — the remove path has no use for blockContent.
+  const next = options.remove ? removeLuaBlock(current) : applyLuaBlock(
+    current,
+    neovimDescriptor.renderBlock({
+      binaryPath: options.binaryPath,
+    }),
+  );
+
+  // 6. Idempotence check.
+  if (next === current) {
+    const msg = options.remove
+      ? `markspec lsp install: already removed (no managed block at ${configPath})\n`
+      : `markspec lsp install: already up to date (${configPath})\n`;
+    return {
+      stdout: "",
+      stderr: `${stderrPreamble}${msg}`,
+      exitCode: 0,
+    };
+  }
+
+  // 7. --print path: emit `next` to stdout, "would write" hint to stderr.
+  if (options.print) {
+    return {
+      stdout: next,
+      stderr: `${stderrPreamble}would write to ${configPath}\n`,
+      exitCode: 0,
+    };
+  }
+
+  // 8. TTY / non-TTY handling.
+  if (!options.force) {
+    const diff = renderDiff(current, next, configPath);
+    if (!isTty) {
+      return {
+        stdout: "",
+        stderr: `${stderrPreamble}${diff}` +
+          `error: non-interactive context (stdin is not a TTY); pass --force to apply or --print to skip writing\n`,
+        exitCode: 1,
+      };
+    }
+    // Slice A: TTY-but-no-`--force` aborts with a remediation hint.
+    // Live `confirm()` integration is deferred to a follow-up.
+    return {
+      stdout: "",
+      stderr: `${stderrPreamble}${diff}` +
+        `aborted: re-run with --force to apply\n`,
+      exitCode: 0,
+    };
+  }
+
+  // 9. Write path. Backup is taken whenever the original file existed —
+  // even an empty placeholder file is intentional user content (§6.3).
+  let backupNote = "";
+  if (fileExists) {
+    try {
+      const backupAt = await writeBackup(configPath);
+      backupNote = `backup: ${backupAt}\n`;
+    } catch (err) {
+      return {
+        stdout: "",
+        stderr: `${stderrPreamble}error: backup failed for ${configPath}: ${
+          (err as Error).message
+        }\n`,
+        exitCode: 1,
+      };
+    }
+  }
+
+  // Ensure parent directory exists (e.g. .nvim/ or ~/.config/nvim/lsp/).
+  try {
+    await Deno.mkdir(dirname(configPath), { recursive: true });
+  } catch (err) {
+    if (!(err instanceof Deno.errors.AlreadyExists)) {
+      return {
+        stdout: "",
+        stderr:
+          `${stderrPreamble}${backupNote}error: cannot create parent directory for ${configPath}: ${
+            (err as Error).message
+          }\n`,
+        exitCode: 1,
+      };
+    }
+  }
+
+  // Atomic write: stage to `<path>.tmp`, then rename. Prevents partial
+  // files on crash mid-write.
+  const tmpPath = `${configPath}.tmp`;
+  try {
+    await Deno.writeTextFile(tmpPath, next);
+    await Deno.rename(tmpPath, configPath);
+  } catch (err) {
+    // Best-effort cleanup of the staged tmp file.
+    try {
+      await Deno.remove(tmpPath);
+    } catch { /* ignore */ }
+    return {
+      stdout: "",
+      stderr:
+        `${stderrPreamble}${backupNote}error: write failed for ${configPath}: ${
+          (err as Error).message
+        }\n`,
+      exitCode: 1,
+    };
+  }
+
+  return {
+    stdout: "",
+    stderr: `${stderrPreamble}${backupNote}wrote ${configPath}\n`,
+    exitCode: 0,
+  };
+}

--- a/packages/markspec/cli/install/preview.ts
+++ b/packages/markspec/cli/install/preview.ts
@@ -1,0 +1,99 @@
+/**
+ * @module cli/install/preview
+ *
+ * Preview and confirm helpers for `markspec lsp install` / `mcp install`.
+ * Per toolchain-distribution.md §6.3:
+ * - Print the diff of (current file) vs (new file) to stderr.
+ * - Prompt for confirmation on TTY.
+ * - Reject in non-TTY without --force (§6.4 / clig.dev).
+ *
+ * The diff is a minimal line-based unified diff — managed blocks are
+ * small, no need for an external diff library or context lines.
+ */
+
+/** Stdin abstraction — lets tests inject answers without a real TTY. */
+export interface LineReader {
+  /** Read one line; return null on EOF. */
+  readLine(): Promise<string | null>;
+}
+
+/**
+ * Render a minimal unified-style diff between `current` and `next`.
+ *
+ * Header lines:
+ *   `--- <path>`
+ *   `+++ <path> (new)`
+ *
+ * Body: for each index in `0..max(oldLines, newLines)`:
+ *   - If lines are identical: emit nothing (no context lines).
+ *   - Otherwise: emit `-<oldLine>` if defined, then `+<newLine>` if defined.
+ *
+ * Inputs are split on `\n`; a trailing empty segment (file ends with `\n`)
+ * is dropped before the comparison walk.
+ */
+export function renderDiff(
+  current: string,
+  next: string,
+  path: string,
+): string {
+  const splitLines = (s: string): string[] => {
+    const parts = s.split("\n");
+    // Drop trailing empty segment produced by a final newline.
+    if (parts.length > 0 && parts[parts.length - 1] === "") {
+      parts.pop();
+    }
+    return parts;
+  };
+
+  const oldLines = splitLines(current);
+  const newLines = splitLines(next);
+
+  const outputLines: string[] = [];
+  outputLines.push(`--- ${path}`);
+  outputLines.push(`+++ ${path} (new)`);
+
+  const len = Math.max(oldLines.length, newLines.length);
+  for (let i = 0; i < len; i++) {
+    const oldLine = oldLines[i];
+    const newLine = newLines[i];
+    if (oldLine === newLine) {
+      // Identical — omit (no context lines).
+      continue;
+    }
+    if (oldLine !== undefined) {
+      outputLines.push(`-${oldLine}`);
+    }
+    if (newLine !== undefined) {
+      outputLines.push(`+${newLine}`);
+    }
+  }
+
+  return outputLines.join("\n") + "\n";
+}
+
+/**
+ * Prompt the user for confirmation on a TTY.
+ *
+ * When `isNonTty` is true, throws immediately — non-interactive contexts
+ * must use `--force` or `--print` instead of interactive confirmation
+ * (clig.dev / toolchain-distribution.md §6.4).
+ *
+ * Otherwise, writes `<prompt> [y/N] ` to stderr and reads one line via
+ * `stdin`. Returns `true` for `"y"` or `"yes"` (case-insensitive),
+ * `false` for any other input including a blank line.
+ */
+export async function confirm(
+  prompt: string,
+  stdin: LineReader,
+  isNonTty: boolean,
+): Promise<boolean> {
+  if (isNonTty) {
+    throw new Error(
+      "non-interactive context (stdin is not a TTY); pass --force to apply or --print to skip writing",
+    );
+  }
+  await Deno.stderr.write(new TextEncoder().encode(`${prompt} [y/N] `));
+  const line = (await stdin.readLine()) ?? "";
+  const answer = line.trim().toLowerCase();
+  return answer === "y" || answer === "yes";
+}

--- a/packages/markspec/cli/install/preview_test.ts
+++ b/packages/markspec/cli/install/preview_test.ts
@@ -1,0 +1,66 @@
+/**
+ * @module cli/install/preview_test
+ *
+ * Unit tests for the preview module (diff render + TTY confirm).
+ */
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { confirm, renderDiff } from "./preview.ts";
+
+Deno.test("renderDiff: empty current vs new content — emits + lines for added", () => {
+  const d = renderDiff("", "alpha\nbeta\n", "/tmp/x.lua");
+  assertStringIncludes(d, "--- /tmp/x.lua");
+  assertStringIncludes(d, "+++ /tmp/x.lua (new)");
+  assertStringIncludes(d, "+alpha");
+  assertStringIncludes(d, "+beta");
+});
+
+Deno.test("renderDiff: same content → empty diff body", () => {
+  const d = renderDiff("alpha\n", "alpha\n", "/tmp/x.lua");
+  // Header still present, no - or + lines.
+  assertStringIncludes(d, "--- /tmp/x.lua");
+  assertEquals(d.includes("+alpha"), false);
+  assertEquals(d.includes("-alpha"), false);
+});
+
+Deno.test("renderDiff: line replacement shows both - and +", () => {
+  const d = renderDiff("alpha\n", "beta\n", "/tmp/x.lua");
+  assertStringIncludes(d, "-alpha");
+  assertStringIncludes(d, "+beta");
+});
+
+Deno.test("confirm: yes/y/Y returns true", async () => {
+  assertEquals(await confirm("Apply?", makeStdinStub("y\n"), false), true);
+  assertEquals(await confirm("Apply?", makeStdinStub("Y\n"), false), true);
+  assertEquals(await confirm("Apply?", makeStdinStub("yes\n"), false), true);
+});
+
+Deno.test("confirm: no/n/empty returns false", async () => {
+  assertEquals(await confirm("Apply?", makeStdinStub("n\n"), false), false);
+  assertEquals(await confirm("Apply?", makeStdinStub("\n"), false), false);
+  assertEquals(await confirm("Apply?", makeStdinStub("no\n"), false), false);
+});
+
+Deno.test("confirm: non-TTY → throws containing 'non-interactive'", async () => {
+  let threw = false;
+  let msg = "";
+  try {
+    await confirm("Apply?", makeStdinStub("y\n"), true);
+  } catch (err) {
+    threw = true;
+    msg = (err as Error).message;
+  }
+  assertEquals(threw, true);
+  assertStringIncludes(msg, "non-interactive");
+});
+
+function makeStdinStub(answer: string): { readLine(): Promise<string | null> } {
+  let consumed = false;
+  return {
+    readLine: () => {
+      if (consumed) return Promise.resolve(null);
+      consumed = true;
+      return Promise.resolve(answer.replace(/\n$/, ""));
+    },
+  };
+}

--- a/packages/markspec/cli/install/workspace.ts
+++ b/packages/markspec/cli/install/workspace.ts
@@ -1,0 +1,48 @@
+/**
+ * @module cli/install/workspace
+ *
+ * Workspace marker discovery for `markspec lsp install` / `mcp install`.
+ * Walks up from a starting directory looking for any of three accepted
+ * markers per toolchain-distribution.md §4.4: markspec.yaml,
+ * .markspec.yaml, project.yaml.
+ */
+
+import { dirname, join } from "@std/path";
+
+/** Workspace markers in priority order — §4.4 / §8 Q2 resolution. */
+export const WORKSPACE_MARKERS: readonly string[] = [
+  "markspec.yaml",
+  ".markspec.yaml",
+  "project.yaml",
+] as const;
+
+/**
+ * Walk up from `startDir` looking for any workspace marker. Returns the
+ * directory containing the first found marker, or `undefined` when the
+ * walk reaches the filesystem root without finding any.
+ */
+export async function findWorkspaceRoot(
+  startDir: string,
+): Promise<string | undefined> {
+  let dir = startDir;
+  // Guard against empty startDir to avoid checking markers in current working dir.
+  if (dir === "") return undefined;
+  while (true) {
+    for (const marker of WORKSPACE_MARKERS) {
+      try {
+        const stat = await Deno.stat(join(dir, marker));
+        if (stat.isFile) return dir;
+      } catch {
+        // Any Deno.stat failure (not found, permission denied, etc.) is
+        // treated as "marker not present" — install falls back to user scope.
+      }
+    }
+    const parent = dirname(dir);
+    if (parent === dir) return undefined; // reached root
+    dir = parent;
+  }
+}
+
+/** Exact stderr line emitted when no marker found and --scope was workspace. */
+export const NO_WORKSPACE_MARKER_STDERR =
+  "markspec lsp install: no workspace marker found, using --scope=user";

--- a/packages/markspec/cli/install/workspace_test.ts
+++ b/packages/markspec/cli/install/workspace_test.ts
@@ -1,0 +1,70 @@
+import { assertEquals } from "@std/assert";
+import { findWorkspaceRoot } from "./workspace.ts";
+
+Deno.test("findWorkspaceRoot: empty startDir terminates with undefined", async () => {
+  const result = await findWorkspaceRoot("");
+  // Empty startDir leads to dirname("") === "." → dirname(".") === "." → returns undefined.
+  // Using assertEquals catches the test in a timeout if it actually loops.
+  assertEquals(result, undefined);
+});
+
+Deno.test("findWorkspaceRoot: finds markspec.yaml", async () => {
+  const tmp = await Deno.makeTempDir();
+  await Deno.writeTextFile(`${tmp}/markspec.yaml`, "");
+  try {
+    assertEquals(await findWorkspaceRoot(tmp), tmp);
+  } finally {
+    await Deno.remove(tmp, { recursive: true });
+  }
+});
+
+Deno.test("findWorkspaceRoot: finds .markspec.yaml", async () => {
+  const tmp = await Deno.makeTempDir();
+  await Deno.writeTextFile(`${tmp}/.markspec.yaml`, "");
+  try {
+    assertEquals(await findWorkspaceRoot(tmp), tmp);
+  } finally {
+    await Deno.remove(tmp, { recursive: true });
+  }
+});
+
+Deno.test("findWorkspaceRoot: finds project.yaml", async () => {
+  const tmp = await Deno.makeTempDir();
+  await Deno.writeTextFile(`${tmp}/project.yaml`, "");
+  try {
+    assertEquals(await findWorkspaceRoot(tmp), tmp);
+  } finally {
+    await Deno.remove(tmp, { recursive: true });
+  }
+});
+
+Deno.test("findWorkspaceRoot: walks up to parent", async () => {
+  const tmp = await Deno.makeTempDir();
+  await Deno.mkdir(`${tmp}/sub/deeper`, { recursive: true });
+  await Deno.writeTextFile(`${tmp}/project.yaml`, "");
+  try {
+    assertEquals(await findWorkspaceRoot(`${tmp}/sub/deeper`), tmp);
+  } finally {
+    await Deno.remove(tmp, { recursive: true });
+  }
+});
+
+Deno.test("findWorkspaceRoot: returns undefined when none found", async () => {
+  const tmp = await Deno.makeTempDir();
+  try {
+    assertEquals(await findWorkspaceRoot(tmp), undefined);
+  } finally {
+    await Deno.remove(tmp, { recursive: true });
+  }
+});
+
+Deno.test("findWorkspaceRoot: both markers in same dir — finds the dir", async () => {
+  const tmp = await Deno.makeTempDir();
+  await Deno.writeTextFile(`${tmp}/markspec.yaml`, "");
+  await Deno.writeTextFile(`${tmp}/project.yaml`, "");
+  try {
+    assertEquals(await findWorkspaceRoot(tmp), tmp);
+  } finally {
+    await Deno.remove(tmp, { recursive: true });
+  }
+});

--- a/tests/e2e/__snapshots__/lsp_install_test.ts.snap
+++ b/tests/e2e/__snapshots__/lsp_install_test.ts.snap
@@ -1,0 +1,3 @@
+export const snapshot = {};
+
+snapshot[`lsp install neovim: workspace requested but no marker → fallback (snapshot stderr) 1`] = `"markspec lsp install: no workspace marker found, using --scope=user"`;

--- a/tests/e2e/install_test.ts
+++ b/tests/e2e/install_test.ts
@@ -3,11 +3,13 @@ import { fromFileUrl } from "@std/path";
 import { markspec } from "./helpers.ts";
 
 Deno.test(
-  "lsp install --editor=neovim: exits 0, stdout contains lspconfig",
+  "lsp install --editor=neovim --print: exits 0, stdout contains lspconfig",
   async () => {
+    // The bare `--editor=neovim` invocation now flows through the
+    // orchestrator (Slice A) — passing --print keeps it side-effect-free.
     const { code, stdout } = await markspec(
-      ["lsp", "install", "--editor=neovim"],
-      { permissions: ["--allow-run"] },
+      ["lsp", "install", "--editor=neovim", "--print", "--scope=user"],
+      { permissions: ["--allow-run", "--allow-env"] },
     );
     assertEquals(code, 0);
     assertStringIncludes(stdout, "lspconfig");

--- a/tests/e2e/lsp_install_test.ts
+++ b/tests/e2e/lsp_install_test.ts
@@ -1,0 +1,175 @@
+/**
+ * @module tests/e2e/lsp_install_test
+ *
+ * End-to-end tests for `markspec lsp install --editor=neovim`. Exercises
+ * the orchestrator wiring Tasks 1-5 — workspace marker discovery,
+ * managed Lua block, timestamped sidecar backup, diff preview, atomic
+ * write, --print, --remove, idempotence, and non-TTY safety.
+ *
+ * The `markspec()` helper spawns the CLI as a subprocess with piped
+ * stdin, so `Deno.stdin.isTerminal()` returns false inside the test —
+ * which is exactly what we want to exercise the non-TTY branch.
+ */
+
+import {
+  assert,
+  assertEquals,
+  assertNotEquals,
+  assertStringIncludes,
+} from "@std/assert";
+import { assertSnapshot } from "@std/testing/snapshot";
+import { markspec } from "./helpers.ts";
+
+Deno.test(
+  "lsp install neovim: workspace + --force writes block to workspace path",
+  async () => {
+    const { code, stdout, stderr } = await markspec(
+      [
+        "lsp",
+        "install",
+        "--editor=neovim",
+        "--scope=workspace",
+        "--binary-path=/usr/local/bin/markspec",
+        "--force",
+      ],
+      {
+        files: { "markspec.yaml": "" },
+        permissions: ["--allow-env"],
+      },
+    );
+    assertEquals(code, 0);
+    assertEquals(stdout, "");
+    assertStringIncludes(stderr, "wrote ");
+    // Normalize path separators so the assertion is portable across
+    // POSIX and Windows runners (CI runs on both).
+    assertStringIncludes(stderr.replaceAll("\\", "/"), ".nvim/markspec.lua");
+    // Backup is NOT written when the original file didn't exist.
+    assert(!stderr.includes("backup:"));
+  },
+);
+
+Deno.test(
+  "lsp install neovim: --print emits file content to stdout, would-write to stderr",
+  async () => {
+    const { code, stdout, stderr } = await markspec(
+      [
+        "lsp",
+        "install",
+        "--editor=neovim",
+        "--scope=user",
+        "--print",
+        "--binary-path=markspec",
+      ],
+      { permissions: ["--allow-env"] },
+    );
+    assertEquals(code, 0);
+    assertStringIncludes(stdout, "-- >>> markspec (managed) >>>");
+    assertStringIncludes(stdout, "cmd = { 'markspec', 'lsp', '--stdio' }");
+    assertStringIncludes(stderr, "would write to ");
+  },
+);
+
+Deno.test(
+  "lsp install neovim: workspace requested but no marker → fallback (snapshot stderr)",
+  async (t) => {
+    const { code, stderr } = await markspec(
+      [
+        "lsp",
+        "install",
+        "--editor=neovim",
+        "--scope=workspace",
+        "--print",
+      ],
+      { permissions: ["--allow-env"] },
+    );
+    assertEquals(code, 0);
+    // Snapshot only the workspace-fallback preamble line — the
+    // "would write to <user-config>" line varies by host HOME.
+    const preamble = stderr.split("\n")[0];
+    assertNotEquals(preamble, "");
+    await assertSnapshot(t, preamble);
+  },
+);
+
+Deno.test(
+  "lsp install: unknown editor suggests correction",
+  async () => {
+    const { code, stderr } = await markspec(
+      ["lsp", "install", "--editor=neoviim", "--print"],
+      { permissions: ["--allow-env"] },
+    );
+    assertEquals(code, 1);
+    assertStringIncludes(stderr, "unknown editor 'neoviim'");
+    assertStringIncludes(stderr, "did you mean: neovim");
+  },
+);
+
+Deno.test(
+  "lsp install neovim: non-TTY without --force → exit 1 with remediation",
+  async () => {
+    const { code, stderr } = await markspec(
+      ["lsp", "install", "--editor=neovim", "--scope=workspace"],
+      {
+        files: { "markspec.yaml": "" },
+        permissions: ["--allow-env"],
+      },
+    );
+    assertEquals(code, 1);
+    assertStringIncludes(stderr, "non-interactive");
+    assertStringIncludes(stderr, "--force");
+    // Verify diff and remediation message are separated by exactly one newline
+    // (renderDiff returns content with a trailing \n; there must be no blank
+    // line between the diff and the error message).
+    assert(!stderr.includes("\n\nerror: non-interactive"));
+    assertStringIncludes(stderr, "\nerror: non-interactive");
+  },
+);
+
+Deno.test(
+  "lsp install neovim: existing empty config file → backup is still created",
+  async () => {
+    // Pre-populate .nvim/markspec.lua as an empty file. Per §6.3, the
+    // orchestrator must back up any extant file, even an empty placeholder.
+    const { code, stderr } = await markspec(
+      [
+        "lsp",
+        "install",
+        "--editor=neovim",
+        "--scope=workspace",
+        "--binary-path=markspec",
+        "--force",
+      ],
+      {
+        files: {
+          "markspec.yaml": "",
+          ".nvim/markspec.lua": "",
+        },
+        permissions: ["--allow-env"],
+      },
+    );
+    assertEquals(code, 0);
+    assertStringIncludes(stderr, "backup:");
+  },
+);
+
+Deno.test(
+  "lsp install neovim: --remove with no existing block → exit 0 already-removed",
+  async () => {
+    const { code, stderr } = await markspec(
+      [
+        "lsp",
+        "install",
+        "--editor=neovim",
+        "--scope=workspace",
+        "--remove",
+        "--force",
+      ],
+      {
+        files: { "markspec.yaml": "" },
+        permissions: ["--allow-env"],
+      },
+    );
+    assertEquals(code, 0);
+    assertStringIncludes(stderr, "already removed");
+  },
+);


### PR DESCRIPTION
## Summary

Toolchain Tier 3 Slice A — upgrades `markspec lsp install --editor=neovim` from a print-only stub to a fully spec-compliant install command per [`markspec-toolchain-distribution.md`](docs/spec/internal/markspec-toolchain-distribution.md) §4 + §6.

- New `cli/install/managed_block.ts` — Lua fenced managed-block writer (open: `-- >>> markspec (managed) >>>`, close: `-- <<< markspec (managed) <<<`). Idempotent: re-applying the same content yields a byte-identical file.
- New `cli/install/backup.ts` — timestamped sidecar (`<path>.markspec-bak-<ISO8601>`). Writes on every apply against an extant file (per §6.3).
- New `cli/install/preview.ts` — minimal line-based diff render + TTY confirm helper (`LineReader` interface for testability).
- New `cli/install/workspace.ts` — workspace marker discovery for `markspec.yaml`, `.markspec.yaml`, `project.yaml` (per §4.4 / §8 Q2, ratified in #443).
- New `cli/install/orchestrator.ts` — pulls it all together; pure `runLspInstall(options) → OrchestratorResult`. Optional `env` seam for `cwd` / `home` / `isTty` injection.
- `cli/install/lsp_adapters.ts` — added `neovimDescriptor` (the `LspAdapter` shape) alongside the legacy `neovimAdapter` function. Existing `vscode` and `zed` paths preserved; Slice B/C will migrate them (and fix the §8 Q5 violation in `vscodeAdapter`).
- `cli/commands/lsp_cmd.ts` — full flag set: `--scope`, `--binary-path`, `--print`, `--force`, `--no-color`, `--remove`.

## Out of scope (deferred)

- Slice B — vscode adapter rework + §8 Q5 fix (remove `code --install-extension` suggestion).
- Slice C — `markspec mcp install` + claude-desktop adapter + JSON managed-block.
- Slice D — MCP-side `markspec/version` notification parity.
- Live TTY confirm (Cliffy `ttyConfirm`) — Slice A treats no-`--force` as decline with `aborted: re-run with --force to apply`. The non-TTY-error path (the load-bearing one for CI) is fully wired.

## Test plan

- [x] Unit tests for managed-block (15), backup (6), preview (6), workspace (7), neovim descriptor (8). All colocated as `<module>_test.ts`.
- [x] E2E tests covering: happy-path write, `--print` round-trip, unknown editor + typo suggestion, non-TTY without `--force` (exit 1), workspace-fallback (snapshot), `--remove` on no-block file (already-removed), existing-empty-file backup creation.
- [x] `just build` clean (1918 passed / 0 failed / 2 ignored).
- [x] `deno fmt --check` + `dprint check` clean.
- [ ] Manual smoke test: `markspec lsp install --editor=neovim --scope=workspace --print` against a real workspace.

## Notes

- The orchestrator uses an optional `env` injection seam (`options.env`) so unit tests can inject `cwd`, `home`, and `isTty` without environment mutation. Documented as test-only in the orchestrator's module docstring.
- Atomic write via tmp + rename. Backup written only when a prior file existed (any non-empty path); idempotent re-runs do not write a backup.
- Snapshot test pins the exact workspace-fallback stderr line so automation can rely on it: `markspec lsp install: no workspace marker found, using --scope=user`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
