### PR TITLE
feat(core): typl validation + corpus typeRegistry (PR 6 of 8)

### DIFF
--- a/packages/markspec/core/compiler/manifest_test.ts
+++ b/packages/markspec/core/compiler/manifest_test.ts
@@ -58,6 +58,7 @@ function makeResult(
     reverse,
     documents: new Map(),
     diagnostics: [],
+    typeRegistry: { bindings: new Map(), typedefs: new Map() },
   };
 }
 

--- a/packages/markspec/core/compiler/mod.ts
+++ b/packages/markspec/core/compiler/mod.ts
@@ -22,6 +22,7 @@ import {
   suppressDeclaredAttrR010,
   validate,
 } from "../validator/mod.ts";
+import { type TypeRegistry, validateTypl } from "../typl/mod.ts";
 import { CORE_DISCIPLINE_REGISTRY } from "../model/mod.ts";
 import { ATTR_TO_LINK_KIND } from "./constants.ts";
 import { classifyDiscipline } from "./discipline_classifier.ts";
@@ -149,6 +150,11 @@ export interface CompileResult {
   readonly documents: ReadonlyMap<string, Document>;
   /** Diagnostics from parsing and validation. */
   readonly diagnostics: readonly Diagnostic[];
+  /**
+   * Corpus-wide index of typl bindings and typedefs across all entries.
+   * See ADR-019. Built by validateTypl during compile.
+   */
+  readonly typeRegistry: TypeRegistry;
 }
 
 /**
@@ -342,13 +348,20 @@ export async function compile(
   const forward = buildAdjacency(links, (l) => l.from);
   const reverse = buildAdjacency(links, (l) => l.to);
 
+  // Build the corpus typl registry. validateTypl is also called inside
+  // validate() (via validationDiagnostics) for the cross-entry TYPL
+  // diagnostics. Here we call it again only to capture the registry — the
+  // diagnostics are already included in validationDiagnostics, so we discard
+  // them to avoid duplicates in the output.
+  const { registry: typeRegistry } = validateTypl([...entries.values()]);
+
   const diagnostics = [
     ...parseDiagnostics,
     ...validationDiagnostics,
     ...linkTargetDiags,
   ];
 
-  return { entries, links, forward, reverse, documents, diagnostics };
+  return { entries, links, forward, reverse, documents, diagnostics, typeRegistry };
 }
 
 /** Extract traceability links from entry attributes. */
@@ -429,7 +442,11 @@ function buildAdjacency(
 
 // Re-export serialization helper.
 export { serializeCompileResult } from "./schema.ts";
-export type { SerializedCompileResult, SerializedEntry } from "./schema.ts";
+export type {
+  SerializedCompileResult,
+  SerializedEntry,
+  SerializedTypeRegistry,
+} from "./schema.ts";
 
 // Re-export inverse generation.
 export { generateInverses } from "./inverses.ts";

--- a/packages/markspec/core/compiler/mod.ts
+++ b/packages/markspec/core/compiler/mod.ts
@@ -361,7 +361,15 @@ export async function compile(
     ...linkTargetDiags,
   ];
 
-  return { entries, links, forward, reverse, documents, diagnostics, typeRegistry };
+  return {
+    entries,
+    links,
+    forward,
+    reverse,
+    documents,
+    diagnostics,
+    typeRegistry,
+  };
 }
 
 /** Extract traceability links from entry attributes. */

--- a/packages/markspec/core/compiler/mod_test.ts
+++ b/packages/markspec/core/compiler/mod_test.ts
@@ -610,3 +610,46 @@ Deno.test(
     );
   },
 );
+
+// ---------------------------------------------------------------------------
+// typeRegistry
+// ---------------------------------------------------------------------------
+
+Deno.test("compile: typeRegistry is present and empty for entries without typl", async () => {
+  const files = {
+    "req.md": `- [REQ-001] Title
+
+  Body.
+
+      Id: ${ULID_A}
+`,
+  };
+  const result = await compile(["req.md"], { readFile: reader(files) });
+  // Registry must be present (no undefined)
+  assertEquals(typeof result.typeRegistry, "object");
+  assertEquals(result.typeRegistry.bindings instanceof Map, true);
+  assertEquals(result.typeRegistry.typedefs instanceof Map, true);
+  assertEquals(result.typeRegistry.bindings.size, 0);
+  assertEquals(result.typeRegistry.typedefs.size, 0);
+});
+
+Deno.test("compile: typeRegistry collects $Name bindings from typl fences", async () => {
+  const files = {
+    "req.md": `- [REQ-001] Speed signal
+
+  Body.
+
+  \`\`\`typl
+  $Speed : signal float[0..300]
+  \`\`\`
+
+      Id: ${ULID_A}
+`,
+  };
+  const result = await compile(["req.md"], { readFile: reader(files) });
+  assertEquals(result.typeRegistry.bindings.size, 1);
+  const speedDecls = result.typeRegistry.bindings.get("$Speed");
+  assertEquals(Array.isArray(speedDecls), true);
+  assertEquals(speedDecls?.length, 1);
+  assertEquals(speedDecls?.[0].binding.kind, "signal");
+});

--- a/packages/markspec/core/compiler/schema.ts
+++ b/packages/markspec/core/compiler/schema.ts
@@ -8,6 +8,7 @@
 
 import type { CompileResult } from "./mod.ts";
 import type { Diagnostic, Entry, Link } from "../model/mod.ts";
+import type { RegistryBinding, RegistryTypedef } from "../typl/mod.ts";
 
 /**
  * JSON-serializable form of {@linkcode Entry}.
@@ -19,6 +20,19 @@ import type { Diagnostic, Entry, Link } from "../model/mod.ts";
 export type SerializedEntry = Omit<Entry, "typedAttributes"> & {
   readonly typedAttributes?: Record<string, readonly string[]>;
 };
+
+/**
+ * Serialized form of the {@linkcode TypeRegistry}.
+ *
+ * `ReadonlyMap` fields are converted to plain objects so the result is
+ * JSON-serializable.
+ */
+export interface SerializedTypeRegistry {
+  /** Keyed by $Name (including leading `$`). */
+  readonly bindings: Record<string, readonly RegistryBinding[]>;
+  /** Keyed by typedef name (no `$`). */
+  readonly typedefs: Record<string, readonly RegistryTypedef[]>;
+}
 
 /**
  * Serialized form of {@linkcode CompileResult}.
@@ -37,6 +51,8 @@ export interface SerializedCompileResult {
   readonly reverse: Record<string, readonly Link[]>;
   /** Diagnostics from parsing and validation. */
   readonly diagnostics: readonly Diagnostic[];
+  /** Corpus-wide typl type registry. */
+  readonly typeRegistry: SerializedTypeRegistry;
 }
 
 /**
@@ -61,6 +77,21 @@ export function serializeCompileResult(
     forward: Object.fromEntries(result.forward),
     reverse: Object.fromEntries(result.reverse),
     diagnostics: result.diagnostics,
+    typeRegistry: serializeTypeRegistry(result.typeRegistry),
+  };
+}
+
+/**
+ * Convert the {@linkcode TypeRegistry} Maps to plain objects for
+ * JSON serialization. `ReadonlyMap` serializes as `{}` in `JSON.stringify`,
+ * so explicit conversion is required.
+ */
+function serializeTypeRegistry(
+  registry: CompileResult["typeRegistry"],
+): SerializedTypeRegistry {
+  return {
+    bindings: Object.fromEntries(registry.bindings),
+    typedefs: Object.fromEntries(registry.typedefs),
   };
 }
 

--- a/packages/markspec/core/compiler/schema_test.ts
+++ b/packages/markspec/core/compiler/schema_test.ts
@@ -262,7 +262,10 @@ Deno.test("serializeCompileResult: typeRegistry Maps are converted to plain obje
   const json = JSON.stringify(serialized);
   const parsed = JSON.parse(json);
   assertEquals(Array.isArray(parsed.typeRegistry.bindings["$Speed"]), true);
-  assertEquals(parsed.typeRegistry.bindings["$Speed"][0].binding.kind, "signal");
+  assertEquals(
+    parsed.typeRegistry.bindings["$Speed"][0].binding.kind,
+    "signal",
+  );
   assertEquals(typeof parsed.typeRegistry.typedefs, "object");
 });
 

--- a/packages/markspec/core/compiler/schema_test.ts
+++ b/packages/markspec/core/compiler/schema_test.ts
@@ -5,6 +5,13 @@ import type { SerializedEntry } from "./schema.ts";
 import type { CompileResult } from "./mod.ts";
 import type { DisplayId, Entry, Link } from "../model/mod.ts";
 import { makeDisplayId } from "../model/mod.ts";
+import type { TypeRegistry } from "../typl/mod.ts";
+
+/** An empty TypeRegistry for use in test fixtures. */
+const EMPTY_REGISTRY: TypeRegistry = {
+  bindings: new Map(),
+  typedefs: new Map(),
+};
 
 /** Build a minimal Entry for testing. */
 function makeEntry(displayId: string): Entry {
@@ -50,6 +57,7 @@ Deno.test("serializeCompileResult: converts Maps to plain objects", () => {
     reverse,
     documents: new Map(),
     diagnostics: [],
+    typeRegistry: EMPTY_REGISTRY,
   };
 
   const serialized = serializeCompileResult(result);
@@ -78,6 +86,7 @@ Deno.test("serializeCompileResult: entries keyed by displayId", () => {
     reverse: new Map(),
     documents: new Map(),
     diagnostics: [],
+    typeRegistry: EMPTY_REGISTRY,
   };
 
   const serialized = serializeCompileResult(result);
@@ -106,6 +115,7 @@ Deno.test("serializeCompileResult: links preserved as-is", () => {
     reverse: new Map(),
     documents: new Map(),
     diagnostics: [],
+    typeRegistry: EMPTY_REGISTRY,
   };
 
   const serialized = serializeCompileResult(result);
@@ -136,6 +146,7 @@ Deno.test("serializeCompileResult: round-trip via JSON.parse", () => {
         location: undefined,
       },
     ],
+    typeRegistry: EMPTY_REGISTRY,
   };
 
   const serialized = serializeCompileResult(result);
@@ -179,6 +190,7 @@ Deno.test("serializeCompileResult: strips sync.* from entry properties", () => {
     reverse: new Map(),
     documents: new Map(),
     diagnostics: [],
+    typeRegistry: EMPTY_REGISTRY,
   };
 
   const serialized = serializeCompileResult(result);
@@ -204,12 +216,54 @@ Deno.test("serializeCompileResult: drops properties entirely when sync is the on
     reverse: new Map(),
     documents: new Map(),
     diagnostics: [],
+    typeRegistry: EMPTY_REGISTRY,
   };
 
   const serialized = serializeCompileResult(result);
   const serializedEntry: SerializedEntry = serialized.entries["STK_0002"];
 
   assertEquals(serializedEntry.properties, undefined);
+});
+
+Deno.test("serializeCompileResult: typeRegistry Maps are converted to plain objects", () => {
+  const result: CompileResult = {
+    entries: new Map(),
+    links: [],
+    forward: new Map(),
+    reverse: new Map(),
+    documents: new Map(),
+    diagnostics: [],
+    typeRegistry: {
+      bindings: new Map([
+        ["$Speed", [{
+          entryDisplayId: "REQ-001",
+          entryFile: "req.md",
+          binding: {
+            statementKind: "binding",
+            name: "$Speed",
+            kind: "signal",
+            shape: undefined,
+            position: { line: 1, column: 1 },
+          },
+        }]],
+      ]),
+      typedefs: new Map(),
+    },
+  };
+
+  const serialized = serializeCompileResult(result);
+
+  // typeRegistry must be a plain object (not a Map)
+  assertEquals(serialized.typeRegistry instanceof Map, false);
+  assertEquals(typeof serialized.typeRegistry.bindings, "object");
+  assertEquals(serialized.typeRegistry.bindings instanceof Map, false);
+
+  // Content must round-trip via JSON
+  const json = JSON.stringify(serialized);
+  const parsed = JSON.parse(json);
+  assertEquals(Array.isArray(parsed.typeRegistry.bindings["$Speed"]), true);
+  assertEquals(parsed.typeRegistry.bindings["$Speed"][0].binding.kind, "signal");
+  assertEquals(typeof parsed.typeRegistry.typedefs, "object");
 });
 
 Deno.test("serializeCompileResult propagates derivedDiscipline to JSON entries", async () => {

--- a/packages/markspec/core/mod.ts
+++ b/packages/markspec/core/mod.ts
@@ -223,6 +223,7 @@ export type {
   GenerateInversesResult,
   SerializedCompileResult,
   SerializedEntry,
+  SerializedTypeRegistry,
 } from "./compiler/mod.ts";
 export { buildManifest } from "./compiler/manifest.ts";
 export type {

--- a/packages/markspec/core/mod_test.ts
+++ b/packages/markspec/core/mod_test.ts
@@ -176,6 +176,7 @@ Deno.test("report produces traceability output", () => {
     reverse: new Map(),
     documents: new Map(),
     diagnostics: [],
+    typeRegistry: { bindings: new Map(), typedefs: new Map() },
   };
   const opts: ReportOptions = { kind: "traceability", format: "md" };
   const output = report(emptyResult, opts);

--- a/packages/markspec/core/reporter/mod_test.ts
+++ b/packages/markspec/core/reporter/mod_test.ts
@@ -77,6 +77,7 @@ function makeResult(
     reverse,
     documents: new Map(),
     diagnostics: [],
+    typeRegistry: { bindings: new Map(), typedefs: new Map() },
   };
 }
 

--- a/packages/markspec/core/typl/mod.ts
+++ b/packages/markspec/core/typl/mod.ts
@@ -33,7 +33,11 @@ export { extractTyplBullets } from "./bullet.ts";
 export type { TyplInlineExtraction } from "./inline.ts";
 export { extractTyplInlines } from "./inline.ts";
 
-export type { RegistryBinding, RegistryTypedef, TypeRegistry } from "./registry.ts";
+export type {
+  RegistryBinding,
+  RegistryTypedef,
+  TypeRegistry,
+} from "./registry.ts";
 export { buildTypeRegistry } from "./registry.ts";
 
 export { validateTypl } from "./validator.ts";

--- a/packages/markspec/core/typl/mod.ts
+++ b/packages/markspec/core/typl/mod.ts
@@ -32,3 +32,8 @@ export { extractTyplBullets } from "./bullet.ts";
 
 export type { TyplInlineExtraction } from "./inline.ts";
 export { extractTyplInlines } from "./inline.ts";
+
+export type { RegistryBinding, RegistryTypedef, TypeRegistry } from "./registry.ts";
+export { buildTypeRegistry } from "./registry.ts";
+
+export { validateTypl } from "./validator.ts";

--- a/packages/markspec/core/typl/registry.ts
+++ b/packages/markspec/core/typl/registry.ts
@@ -1,0 +1,68 @@
+/**
+ * @module typl/registry
+ *
+ * Corpus-level index of every $Name binding and named typedef across all
+ * entries. Built by buildTypeRegistry; consumed by validateTypl (cross-
+ * entry collision detection) and future downstream emitters (RIDL bridge,
+ * LSP go-to-definition).
+ *
+ * See ADR-019.
+ */
+import type { Entry } from "../model/mod.ts";
+import type { Binding, Typedef } from "./ast.ts";
+
+/** One binding declaration record, with backref to its host entry. */
+export interface RegistryBinding {
+  readonly entryDisplayId: string;
+  readonly entryFile: string;
+  readonly binding: Binding;
+}
+
+/** One typedef declaration record, with backref to its host entry. */
+export interface RegistryTypedef {
+  readonly entryDisplayId: string;
+  readonly entryFile: string;
+  readonly typedef: Typedef;
+}
+
+/**
+ * Corpus-wide index. Each $Name (and each typedef name) maps to ALL
+ * declarations found — collisions are NOT collapsed; the validator
+ * surfaces them via TYPL-002/003.
+ */
+export interface TypeRegistry {
+  /** Keyed by $Name (including leading `$`). */
+  readonly bindings: ReadonlyMap<string, readonly RegistryBinding[]>;
+  /** Keyed by typedef name (no `$`). */
+  readonly typedefs: ReadonlyMap<string, readonly RegistryTypedef[]>;
+}
+
+/**
+ * Build the corpus type registry from the entries. Entries without
+ * `entry.types` are ignored. Source order is preserved within each name's
+ * list (first declaration first).
+ */
+export function buildTypeRegistry(
+  entries: readonly Entry[],
+): TypeRegistry {
+  const bindings = new Map<string, RegistryBinding[]>();
+  const typedefs = new Map<string, RegistryTypedef[]>();
+
+  for (const entry of entries) {
+    if (!entry.types) continue;
+    const entryFile = entry.location.file;
+    const entryDisplayId = entry.displayId;
+    for (const binding of entry.types.bindings) {
+      const list = bindings.get(binding.name) ?? [];
+      list.push({ entryDisplayId, entryFile, binding });
+      bindings.set(binding.name, list);
+    }
+    for (const typedef of entry.types.typedefs) {
+      const list = typedefs.get(typedef.name) ?? [];
+      list.push({ entryDisplayId, entryFile, typedef });
+      typedefs.set(typedef.name, list);
+    }
+  }
+
+  return { bindings, typedefs };
+}

--- a/packages/markspec/core/typl/registry_test.ts
+++ b/packages/markspec/core/typl/registry_test.ts
@@ -1,0 +1,100 @@
+import { assertEquals } from "@std/assert";
+import type { Entry } from "../model/mod.ts";
+import { buildTypeRegistry } from "./registry.ts";
+
+function entry(
+  displayId: string,
+  file: string,
+  types?: Entry["types"],
+): Entry {
+  return {
+    displayId: displayId as Entry["displayId"],
+    title: "t",
+    body: "",
+    rawAttributes: [],
+    typedAttributes: new Map(),
+    id: "01HZZZ0000000000000000000A",
+    type: undefined,
+    shape: "Authored",
+    location: { file, line: 1, column: 1 },
+    source: { kind: "markdown" },
+    properties: { file: { path: file, line: 1, column: 1 } },
+    bodyTokens: [],
+    types,
+  };
+}
+
+Deno.test("buildTypeRegistry: empty input → empty registry", () => {
+  const r = buildTypeRegistry([]);
+  assertEquals(r.bindings.size, 0);
+  assertEquals(r.typedefs.size, 0);
+});
+
+Deno.test("buildTypeRegistry: ignores entries without types field", () => {
+  const r = buildTypeRegistry([entry("REQ_0001", "a.md")]);
+  assertEquals(r.bindings.size, 0);
+});
+
+Deno.test("buildTypeRegistry: collects bindings from one entry", () => {
+  const e = entry("REQ_0001", "a.md", {
+    bindings: [
+      {
+        statementKind: "binding",
+        name: "$Speed",
+        kind: "signal",
+        shape: { kind: "primitive", type: "int" },
+        position: { line: 5, column: 1 },
+      },
+    ],
+    typedefs: [],
+  });
+  const r = buildTypeRegistry([e]);
+  assertEquals(r.bindings.size, 1);
+  assertEquals(r.bindings.get("$Speed")?.length, 1);
+  assertEquals(r.bindings.get("$Speed")?.[0].entryDisplayId, "REQ_0001");
+});
+
+Deno.test("buildTypeRegistry: collects multiple declarations of same name across entries", () => {
+  const a = entry("REQ_A", "a.md", {
+    bindings: [
+      {
+        statementKind: "binding",
+        name: "$Speed",
+        kind: "signal",
+        position: { line: 3, column: 1 },
+      },
+    ],
+    typedefs: [],
+  });
+  const b = entry("REQ_B", "b.md", {
+    bindings: [
+      {
+        statementKind: "binding",
+        name: "$Speed",
+        kind: "signal",
+        position: { line: 7, column: 1 },
+      },
+    ],
+    typedefs: [],
+  });
+  const r = buildTypeRegistry([a, b]);
+  assertEquals(r.bindings.get("$Speed")?.length, 2);
+  assertEquals(r.bindings.get("$Speed")?.[0].entryFile, "a.md");
+  assertEquals(r.bindings.get("$Speed")?.[1].entryFile, "b.md");
+});
+
+Deno.test("buildTypeRegistry: collects typedefs from entries", () => {
+  const e = entry("REQ_0001", "a.md", {
+    bindings: [],
+    typedefs: [
+      {
+        statementKind: "typedef",
+        name: "Frame",
+        shape: { kind: "primitive", type: "int" },
+        position: { line: 10, column: 1 },
+      },
+    ],
+  });
+  const r = buildTypeRegistry([e]);
+  assertEquals(r.typedefs.get("Frame")?.length, 1);
+});

--- a/packages/markspec/core/typl/validator.ts
+++ b/packages/markspec/core/typl/validator.ts
@@ -1,0 +1,154 @@
+/**
+ * @module typl/validator
+ *
+ * Cross-entry collision detection (TYPL-002 kind mismatch, TYPL-003
+ * shape mismatch) and intra-entry undefined-typedef-reference checks
+ * (TYPL-005).
+ *
+ * Per the v1 entry-local scope rule, typedef references are resolved
+ * within the binding's own entry — references to typedefs declared in
+ * other entries are TYPL-005 errors.
+ *
+ * See ADR-019.
+ */
+import type { Diagnostic, Entry } from "../model/mod.ts";
+import type { Binding, Shape } from "./ast.ts";
+import { typlDiagnostic } from "./diagnostics.ts";
+import { buildTypeRegistry, type TypeRegistry } from "./registry.ts";
+
+/**
+ * Validate the typl declarations across all entries.
+ *
+ * Returns the built corpus registry plus any diagnostics. The registry
+ * is returned even when diagnostics are present so callers (compiler,
+ * LSP) can use it for navigation and emission.
+ */
+export function validateTypl(
+  entries: readonly Entry[],
+): { registry: TypeRegistry; diagnostics: readonly Diagnostic[] } {
+  const registry = buildTypeRegistry(entries);
+  const diagnostics: Diagnostic[] = [];
+
+  // Cross-entry $Name collisions (TYPL-002 + TYPL-003)
+  for (const [name, decls] of registry.bindings) {
+    if (decls.length < 2) continue;
+    const first = decls[0];
+    for (let i = 1; i < decls.length; i++) {
+      const dup = decls[i];
+      if (dup.binding.kind !== first.binding.kind) {
+        const td = typlDiagnostic(
+          "TYPL-002",
+          {
+            name,
+            kindA: dup.binding.kind,
+            kindB: first.binding.kind,
+            otherFile: first.entryFile,
+            otherLine: first.binding.position.line,
+          },
+          dup.binding.position,
+        );
+        diagnostics.push({
+          code: td.code,
+          severity: td.severity,
+          message: td.message,
+          location: { file: dup.entryFile, line: 1, column: 1 },
+        });
+      } else if (!shapesEqual(dup.binding.shape, first.binding.shape)) {
+        const td = typlDiagnostic(
+          "TYPL-003",
+          {
+            name,
+            otherFile: first.entryFile,
+            otherLine: first.binding.position.line,
+          },
+          dup.binding.position,
+        );
+        diagnostics.push({
+          code: td.code,
+          severity: td.severity,
+          message: td.message,
+          location: { file: dup.entryFile, line: 1, column: 1 },
+        });
+      }
+    }
+  }
+
+  // Intra-entry undefined typedef ref (TYPL-005)
+  for (const entry of entries) {
+    if (!entry.types) continue;
+    const localTypedefs = new Set(entry.types.typedefs.map((t) => t.name));
+    for (const binding of entry.types.bindings) {
+      if (binding.shape) {
+        collectRefDiagnostics(
+          binding.shape,
+          localTypedefs,
+          entry,
+          binding.position.line,
+          diagnostics,
+        );
+      }
+    }
+    for (const typedef of entry.types.typedefs) {
+      collectRefDiagnostics(
+        typedef.shape,
+        localTypedefs,
+        entry,
+        typedef.position.line,
+        diagnostics,
+      );
+    }
+  }
+
+  return { registry, diagnostics };
+}
+
+function collectRefDiagnostics(
+  shape: Shape,
+  localTypedefs: ReadonlySet<string>,
+  entry: Entry,
+  line: number,
+  out: Diagnostic[],
+): void {
+  switch (shape.kind) {
+    case "ref":
+      if (!localTypedefs.has(shape.name)) {
+        const td = typlDiagnostic(
+          "TYPL-005",
+          { name: shape.name },
+          { line: 1, column: 1 },
+        );
+        out.push({
+          code: td.code,
+          severity: td.severity,
+          message: td.message,
+          location: { file: entry.location.file, line, column: 1 },
+        });
+      }
+      break;
+    case "array":
+      collectRefDiagnostics(shape.element, localTypedefs, entry, line, out);
+      break;
+    case "optional":
+      collectRefDiagnostics(shape.inner, localTypedefs, entry, line, out);
+      break;
+    case "record":
+      for (const fieldShape of Object.values(shape.fields)) {
+        collectRefDiagnostics(fieldShape, localTypedefs, entry, line, out);
+      }
+      break;
+    // All other variants (primitive, range, length, pattern, enum, literal)
+    // are leaves with no nested shape — nothing to recurse into.
+  }
+}
+
+function shapesEqual(
+  a: Shape | undefined,
+  b: Shape | undefined,
+): boolean {
+  if (a === b) return true;
+  if (!a || !b) return false;
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+// Re-export Binding for consumers that import from this module.
+export type { Binding };

--- a/packages/markspec/core/typl/validator.ts
+++ b/packages/markspec/core/typl/validator.ts
@@ -136,8 +136,8 @@ function collectRefDiagnostics(
         collectRefDiagnostics(fieldShape, localTypedefs, entry, line, out);
       }
       break;
-    // All other variants (primitive, range, length, pattern, enum, literal)
-    // are leaves with no nested shape — nothing to recurse into.
+      // All other variants (primitive, range, length, pattern, enum, literal)
+      // are leaves with no nested shape — nothing to recurse into.
   }
 }
 

--- a/packages/markspec/core/typl/validator_test.ts
+++ b/packages/markspec/core/typl/validator_test.ts
@@ -1,0 +1,176 @@
+import { assertEquals } from "@std/assert";
+import type { Entry } from "../model/mod.ts";
+import { validateTypl } from "./validator.ts";
+
+function entry(
+  displayId: string,
+  file: string,
+  types?: Entry["types"],
+): Entry {
+  return {
+    displayId: displayId as Entry["displayId"],
+    title: "t",
+    body: "",
+    rawAttributes: [],
+    typedAttributes: new Map(),
+    id: "01HZZZ0000000000000000000A",
+    type: undefined,
+    shape: "Authored",
+    location: { file, line: 1, column: 1 },
+    source: { kind: "markdown" },
+    properties: { file: { path: file, line: 1, column: 1 } },
+    bodyTokens: [],
+    types,
+  };
+}
+
+Deno.test("validateTypl: empty input → no diagnostics", () => {
+  const { diagnostics } = validateTypl([]);
+  assertEquals(diagnostics.length, 0);
+});
+
+Deno.test("validateTypl: same $Name same kind+shape across entries → no diagnostic", () => {
+  const binding = {
+    statementKind: "binding" as const,
+    name: "$Speed",
+    kind: "signal" as const,
+    shape: { kind: "primitive" as const, type: "int" as const },
+    position: { line: 1, column: 1 },
+  };
+  const a = entry("REQ_A", "a.md", { bindings: [binding], typedefs: [] });
+  const b = entry("REQ_B", "b.md", { bindings: [binding], typedefs: [] });
+  const { diagnostics } = validateTypl([a, b]);
+  assertEquals(diagnostics.length, 0);
+});
+
+Deno.test("validateTypl: TYPL-002 on different kind", () => {
+  const a = entry("REQ_A", "a.md", {
+    bindings: [{
+      statementKind: "binding",
+      name: "$Speed",
+      kind: "signal",
+      position: { line: 1, column: 1 },
+    }],
+    typedefs: [],
+  });
+  const b = entry("REQ_B", "b.md", {
+    bindings: [{
+      statementKind: "binding",
+      name: "$Speed",
+      kind: "event",
+      position: { line: 1, column: 1 },
+    }],
+    typedefs: [],
+  });
+  const { diagnostics } = validateTypl([a, b]);
+  assertEquals(diagnostics.length, 1);
+  assertEquals(diagnostics[0].code, "TYPL-002");
+});
+
+Deno.test("validateTypl: TYPL-003 on different shape (same kind)", () => {
+  const a = entry("REQ_A", "a.md", {
+    bindings: [{
+      statementKind: "binding",
+      name: "$Speed",
+      kind: "signal",
+      shape: { kind: "primitive", type: "int" },
+      position: { line: 1, column: 1 },
+    }],
+    typedefs: [],
+  });
+  const b = entry("REQ_B", "b.md", {
+    bindings: [{
+      statementKind: "binding",
+      name: "$Speed",
+      kind: "signal",
+      shape: { kind: "primitive", type: "float" },
+      position: { line: 1, column: 1 },
+    }],
+    typedefs: [],
+  });
+  const { diagnostics } = validateTypl([a, b]);
+  assertEquals(diagnostics.length, 1);
+  assertEquals(diagnostics[0].code, "TYPL-003");
+});
+
+Deno.test("validateTypl: TYPL-005 on undefined typedef ref in binding", () => {
+  const e = entry("REQ_A", "a.md", {
+    bindings: [{
+      statementKind: "binding",
+      name: "$Brake",
+      kind: "command",
+      shape: { kind: "ref", name: "MissingType" },
+      position: { line: 5, column: 1 },
+    }],
+    typedefs: [],
+  });
+  const { diagnostics } = validateTypl([e]);
+  assertEquals(diagnostics.length, 1);
+  assertEquals(diagnostics[0].code, "TYPL-005");
+});
+
+Deno.test("validateTypl: ref resolves to typedef in same entry → no diagnostic", () => {
+  const e = entry("REQ_A", "a.md", {
+    bindings: [{
+      statementKind: "binding",
+      name: "$Brake",
+      kind: "command",
+      shape: { kind: "ref", name: "BrakeReq" },
+      position: { line: 5, column: 1 },
+    }],
+    typedefs: [{
+      statementKind: "typedef",
+      name: "BrakeReq",
+      shape: { kind: "primitive", type: "int" },
+      position: { line: 7, column: 1 },
+    }],
+  });
+  const { diagnostics } = validateTypl([e]);
+  assertEquals(diagnostics.length, 0);
+});
+
+Deno.test("validateTypl: cross-entry typedef ref does NOT resolve (entry-local scope)", () => {
+  const a = entry("REQ_A", "a.md", {
+    bindings: [],
+    typedefs: [{
+      statementKind: "typedef",
+      name: "BrakeReq",
+      shape: { kind: "primitive", type: "int" },
+      position: { line: 1, column: 1 },
+    }],
+  });
+  const b = entry("REQ_B", "b.md", {
+    bindings: [{
+      statementKind: "binding",
+      name: "$Brake",
+      kind: "command",
+      shape: { kind: "ref", name: "BrakeReq" }, // references typedef from entry A
+      position: { line: 5, column: 1 },
+    }],
+    typedefs: [],
+  });
+  const { diagnostics } = validateTypl([a, b]);
+  // Entry B's ref to BrakeReq is undefined within entry B's local scope.
+  // v1 scope is entry-local; cross-entry typedef sharing is v2.
+  assertEquals(diagnostics.some((d) => d.code === "TYPL-005"), true);
+});
+
+Deno.test("validateTypl: ref inside record field is checked", () => {
+  const e = entry("REQ_A", "a.md", {
+    bindings: [{
+      statementKind: "binding",
+      name: "$Combo",
+      kind: "command",
+      shape: {
+        kind: "record",
+        fields: {
+          part: { kind: "ref", name: "MissingPart" },
+        },
+      },
+      position: { line: 5, column: 1 },
+    }],
+    typedefs: [],
+  });
+  const { diagnostics } = validateTypl([e]);
+  assertEquals(diagnostics.some((d) => d.code === "TYPL-005"), true);
+});

--- a/packages/markspec/core/validator/mod.ts
+++ b/packages/markspec/core/validator/mod.ts
@@ -24,6 +24,7 @@ import {
   URI_SCHEME_RE,
 } from "../model/mod.ts";
 import { HTTP_URL_RE } from "./value_types.ts";
+import { validateTypl } from "../typl/mod.ts";
 
 /** Universal attribute keys the core recognizes. */
 const UNIVERSAL_KEYS = new Set(UNIVERSAL_ATTRIBUTE_KEYS);
@@ -68,6 +69,12 @@ export function validate(entries: readonly Entry[]): ValidateResult {
 
   checkStructural(entries, diagnostics);
   checkReferences(entries, diagnostics);
+
+  // Typl cross-entry collisions (TYPL-002/003) and undefined-typedef-refs
+  // (TYPL-005). Per-block diagnostics (TYPL-001/004/006/007/008) already
+  // fired during parse via the bridge.
+  const typlResult = validateTypl(entries);
+  diagnostics.push(...typlResult.diagnostics);
 
   const valid = !diagnostics.some((d) => d.severity === "error");
   return { diagnostics, valid };

--- a/packages/markspec/core/validator/mod_test.ts
+++ b/packages/markspec/core/validator/mod_test.ts
@@ -10,6 +10,7 @@ import { assertEquals } from "@std/assert";
 import type { Entry } from "../model/mod.ts";
 import { makeDisplayId } from "../model/mod.ts";
 import { validate } from "./mod.ts";
+import type { TyplBlock } from "../typl/mod.ts";
 
 function entry(
   partial: Partial<Omit<Entry, "displayId">> & { displayId: string },
@@ -26,6 +27,7 @@ function entry(
     source: partial.source ?? { kind: "markdown" },
     typedAttributes: partial.typedAttributes ?? new Map(),
     bodyTokens: partial.bodyTokens ?? [],
+    types: partial.types,
   };
 }
 
@@ -337,4 +339,66 @@ Deno.test("validate: complete valid set → no error diagnostics", () => {
     result.diagnostics.filter((d) => d.severity === "error"),
     [],
   );
+});
+
+// ---------------------------------------------------------------------------
+// Typl cross-entry collision detection (TYPL-002/TYPL-003)
+// ---------------------------------------------------------------------------
+
+/** Build a minimal TyplBlock with a single binding for testing. */
+function typlBlock(
+  name: string,
+  kind: TyplBlock["bindings"][0]["kind"],
+): TyplBlock {
+  return {
+    bindings: [{
+      statementKind: "binding",
+      name,
+      kind,
+      shape: undefined,
+      position: { line: 1, column: 1 },
+    }],
+    typedefs: [],
+  };
+}
+
+Deno.test("validate: same $Name + same kind across entries → no TYPL-002", () => {
+  const entryA = entry({
+    displayId: "REQ-001",
+    rawAttributes: [{ key: "Id", value: ULID_A }],
+    id: ULID_A,
+    location: { file: "a.md", line: 1, column: 1 },
+    types: typlBlock("$Speed", "signal"),
+  });
+  const entryB = entry({
+    displayId: "REQ-002",
+    rawAttributes: [{ key: "Id", value: ULID_B }],
+    id: ULID_B,
+    location: { file: "b.md", line: 1, column: 1 },
+    types: typlBlock("$Speed", "signal"),
+  });
+  const result = validate([entryA, entryB]);
+  const typl002 = result.diagnostics.filter((d) => d.code === "TYPL-002");
+  assertEquals(typl002, []);
+});
+
+Deno.test("validate: $Name with different kinds across entries → TYPL-002", () => {
+  const entryA = entry({
+    displayId: "REQ-001",
+    rawAttributes: [{ key: "Id", value: ULID_A }],
+    id: ULID_A,
+    location: { file: "a.md", line: 1, column: 1 },
+    types: typlBlock("$Speed", "signal"),
+  });
+  const entryB = entry({
+    displayId: "REQ-002",
+    rawAttributes: [{ key: "Id", value: ULID_B }],
+    id: ULID_B,
+    location: { file: "b.md", line: 1, column: 1 },
+    types: typlBlock("$Speed", "event"),
+  });
+  const result = validate([entryA, entryB]);
+  const typl002 = result.diagnostics.filter((d) => d.code === "TYPL-002");
+  assertEquals(typl002.length, 1);
+  assertEquals(result.valid, false);
 });

--- a/packages/markspec/mcp/resources/mod_test.ts
+++ b/packages/markspec/mcp/resources/mod_test.ts
@@ -28,6 +28,7 @@ function mkProject(entries: Entry[]): Project {
     reverse: new Map(),
     documents: new Map(),
     diagnostics: [],
+    typeRegistry: { bindings: new Map(), typedefs: new Map() },
   };
   const chain: ProfileChain | null = null;
   return {

--- a/packages/markspec/mcp/tools/context_test.ts
+++ b/packages/markspec/mcp/tools/context_test.ts
@@ -51,6 +51,7 @@ function buildResult(
     reverse: new Map(),
     documents: new Map(),
     diagnostics: [],
+    typeRegistry: { bindings: new Map(), typedefs: new Map() },
   };
 }
 

--- a/packages/markspec/mcp/tools/validate_test.ts
+++ b/packages/markspec/mcp/tools/validate_test.ts
@@ -176,6 +176,7 @@ function emptyCompileResult(): CompileResult {
     reverse: new Map(),
     documents: new Map(),
     diagnostics: [],
+    typeRegistry: { bindings: new Map(), typedefs: new Map() },
   };
 }
 

--- a/packages/markspec/render/includes/mod_test.ts
+++ b/packages/markspec/render/includes/mod_test.ts
@@ -44,6 +44,7 @@ function compiled(...entries: Entry[]): CompileResult {
     reverse: new Map(),
     documents: new Map(),
     diagnostics: [],
+    typeRegistry: { bindings: new Map(), typedefs: new Map() },
   };
 }
 

--- a/packages/markspec/render/mod_test.ts
+++ b/packages/markspec/render/mod_test.ts
@@ -11,6 +11,7 @@ function emptyCompileResult(): CompileResult {
     reverse: new Map(),
     documents: new Map(),
     diagnostics: [],
+    typeRegistry: { bindings: new Map(), typedefs: new Map() },
   };
 }
 

--- a/packages/markspec/render/mustache/mod_test.ts
+++ b/packages/markspec/render/mustache/mod_test.ts
@@ -56,6 +56,7 @@ function makeCompiled(entries: Entry[]): CompileResult {
     reverse: new Map(),
     documents: new Map(),
     diagnostics: [],
+    typeRegistry: { bindings: new Map(), typedefs: new Map() },
   };
 }
 

--- a/packages/markspec/render/styles/mod_test.ts
+++ b/packages/markspec/render/styles/mod_test.ts
@@ -48,6 +48,7 @@ function buildCompiled(
     reverse: new Map(),
     documents: new Map(),
     diagnostics: [],
+    typeRegistry: { bindings: new Map(), typedefs: new Map() },
   };
 }
 

--- a/tests/e2e/typl_validation_test.ts
+++ b/tests/e2e/typl_validation_test.ts
@@ -1,0 +1,366 @@
+/**
+ * @module tests/e2e/typl_validation_test
+ *
+ * Blackbox E2E tests confirming that `markspec validate` emits TYPL-002,
+ * TYPL-003, and TYPL-005 diagnostics for cross-entry and intra-entry typl
+ * violations, and that `markspec compile --format json` outputs a populated
+ * `typeRegistry` field.
+ *
+ * Six scenarios:
+ *  1. Cross-entry TYPL-002 — same $Name, different kind
+ *  2. Cross-entry TYPL-003 — same $Name, same kind, different shape
+ *  3. Intra-entry TYPL-005 — binding references an undefined typedef
+ *  4. TYPL-005 fires when typedef is defined in a sibling entry (entry-local scope)
+ *  5. typeRegistry appears in compile JSON with populated bindings/typedefs
+ *  6. Identical $Name declarations across entries do NOT trigger TYPL-002/003
+ */
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { markspec } from "./helpers.ts";
+
+const PROJECT_YAML = "name: test-project\nversion: 0.1.0\n";
+
+// ---------------------------------------------------------------------------
+// Test 1: Cross-entry TYPL-002 — same $Speed name, different kinds
+// ---------------------------------------------------------------------------
+
+const DIFF_KIND_MD = `- [STK_TYPL_0001] Speed signal from radar
+
+  The radar sensor shall emit vehicle speed.
+
+  \`\`\`typl
+  $Speed : signal float[0..300]
+  \`\`\`
+
+      Id: 01HZZZ0000000000000000001A
+
+- [STK_TYPL_0002] Speed event from CAN bus
+
+  The CAN bus shall publish a speed event.
+
+  \`\`\`typl
+  $Speed : event float[0..300]
+  \`\`\`
+
+      Id: 01HZZZ0000000000000000001B
+`;
+
+Deno.test(
+  "validate: cross-entry kind mismatch emits TYPL-002",
+  async () => {
+    const { code, stderr } = await markspec(
+      ["validate", "req.md"],
+      {
+        files: { "project.yaml": PROJECT_YAML, "req.md": DIFF_KIND_MD },
+      },
+    );
+    if (code === 0) {
+      throw new Error(
+        `Expected non-zero exit code for TYPL-002 violation; stderr: ${stderr}`,
+      );
+    }
+    assertStringIncludes(stderr, "TYPL-002", "TYPL-002 code must appear in stderr");
+    assertStringIncludes(stderr, "$Speed", "$Speed name must appear in the diagnostic");
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Test 2: Cross-entry TYPL-003 — same $Speed name + kind, different shape
+// ---------------------------------------------------------------------------
+
+const DIFF_SHAPE_MD = `- [STK_TYPL_0003] Speed signal first entry
+
+  The first entry declares $Speed with range [0..300].
+
+  \`\`\`typl
+  $Speed : signal float[0..300]
+  \`\`\`
+
+      Id: 01HZZZ0000000000000000002A
+
+- [STK_TYPL_0004] Speed signal second entry
+
+  The second entry declares $Speed with a wider range [0..500].
+
+  \`\`\`typl
+  $Speed : signal float[0..500]
+  \`\`\`
+
+      Id: 01HZZZ0000000000000000002B
+`;
+
+Deno.test(
+  "validate: cross-entry shape mismatch emits TYPL-003",
+  async () => {
+    const { code, stderr } = await markspec(
+      ["validate", "req.md"],
+      {
+        files: { "project.yaml": PROJECT_YAML, "req.md": DIFF_SHAPE_MD },
+      },
+    );
+    if (code === 0) {
+      throw new Error(
+        `Expected non-zero exit code for TYPL-003 violation; stderr: ${stderr}`,
+      );
+    }
+    assertStringIncludes(stderr, "TYPL-003", "TYPL-003 code must appear in stderr");
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Test 3: Intra-entry TYPL-005 — binding references an undefined typedef
+// ---------------------------------------------------------------------------
+
+const UNDEF_REF_MD = `- [STK_TYPL_0005] Brake command with undefined type
+
+  The system shall issue a brake command of the payload type.
+
+  \`\`\`typl
+  $Brake : command BrakePayload
+  \`\`\`
+
+      Id: 01HZZZ0000000000000000003A
+`;
+
+Deno.test(
+  "validate: binding referencing an undefined typedef emits TYPL-005",
+  async () => {
+    const { code, stderr } = await markspec(
+      ["validate", "req.md"],
+      {
+        files: { "project.yaml": PROJECT_YAML, "req.md": UNDEF_REF_MD },
+      },
+    );
+    if (code === 0) {
+      throw new Error(
+        `Expected non-zero exit code for TYPL-005 violation; stderr: ${stderr}`,
+      );
+    }
+    assertStringIncludes(stderr, "TYPL-005", "TYPL-005 code must appear in stderr");
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Test 4: TYPL-005 fires when typedef is local only to a sibling entry
+//
+// Entry A defines `type Frame = { id: int[0..255] }`. Entry B references
+// `Frame` from a binding with no local typedef — v1 scope is entry-local,
+// so this is a TYPL-005 error.
+// ---------------------------------------------------------------------------
+
+const CROSS_ENTRY_TYPEDEF_MD = `- [STK_TYPL_0006] Frame type definition
+
+  Entry A defines the Frame typedef locally.
+
+  \`\`\`typl
+  type Frame = { id: int[0..255] }
+  \`\`\`
+
+      Id: 01HZZZ0000000000000000004A
+
+- [STK_TYPL_0007] Frame command without local typedef
+
+  Entry B references Frame in a binding but has no local typedef.
+
+  \`\`\`typl
+  $Msg : command Frame
+  \`\`\`
+
+      Id: 01HZZZ0000000000000000004B
+`;
+
+Deno.test(
+  "validate: typedef defined in sibling entry is invisible — TYPL-005 fires",
+  async () => {
+    const { code, stderr } = await markspec(
+      ["validate", "req.md"],
+      {
+        files: { "project.yaml": PROJECT_YAML, "req.md": CROSS_ENTRY_TYPEDEF_MD },
+      },
+    );
+    if (code === 0) {
+      throw new Error(
+        `Expected non-zero exit code (typedef from sibling entry must not satisfy TYPL-005); stderr: ${stderr}`,
+      );
+    }
+    assertStringIncludes(
+      stderr,
+      "TYPL-005",
+      "TYPL-005 must fire when typedef is declared in a sibling entry only",
+    );
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Test 5: typeRegistry appears in compile JSON with populated bindings/typedefs
+// ---------------------------------------------------------------------------
+
+const TWO_ENTRY_TYPL_MD = `- [STK_TYPL_0008] Throttle signal declaration
+
+  The throttle actuator shall accept a throttle signal.
+
+  \`\`\`typl
+  $Throttle : signal float[0..100]
+  type ThrottleCmd = { pct: float[0..100] }
+  \`\`\`
+
+      Id: 01HZZZ0000000000000000005A
+
+- [STK_TYPL_0009] Brake signal declaration
+
+  The brake actuator shall accept a brake signal.
+
+  \`\`\`typl
+  $Brake : signal float[0..12000]
+  type BrakeCmd = { force_N: float[0..12000] }
+  \`\`\`
+
+      Id: 01HZZZ0000000000000000005B
+`;
+
+Deno.test(
+  "compile: typeRegistry field is present and populated",
+  async () => {
+    const { code, stdout } = await markspec(
+      ["compile", "--format", "json", "req.md"],
+      {
+        files: { "project.yaml": PROJECT_YAML, "req.md": TWO_ENTRY_TYPL_MD },
+      },
+    );
+    assertEquals(code, 0);
+
+    let parsed: ReturnType<typeof JSON.parse>;
+    try {
+      parsed = JSON.parse(stdout);
+    } catch (err) {
+      throw new Error(
+        `Failed to parse compile JSON output: ${err}\nstdout: ${stdout}`,
+      );
+    }
+
+    // typeRegistry must be present as an object (not undefined or null)
+    if (!parsed.typeRegistry || typeof parsed.typeRegistry !== "object") {
+      throw new Error(
+        `typeRegistry field absent or not an object; full output: ${
+          JSON.stringify(parsed, null, 2)
+        }`,
+      );
+    }
+
+    // bindings must be an object keyed by $Name
+    const { bindings, typedefs } = parsed.typeRegistry;
+    if (!bindings || typeof bindings !== "object") {
+      throw new Error(
+        `typeRegistry.bindings absent or not an object; typeRegistry: ${
+          JSON.stringify(parsed.typeRegistry, null, 2)
+        }`,
+      );
+    }
+    if (!typedefs || typeof typedefs !== "object") {
+      throw new Error(
+        `typeRegistry.typedefs absent or not an object; typeRegistry: ${
+          JSON.stringify(parsed.typeRegistry, null, 2)
+        }`,
+      );
+    }
+
+    // $Throttle and $Brake must be present in bindings
+    if (!bindings["$Throttle"]) {
+      throw new Error(
+        `$Throttle missing from typeRegistry.bindings; keys: ${
+          JSON.stringify(Object.keys(bindings))
+        }`,
+      );
+    }
+    if (!bindings["$Brake"]) {
+      throw new Error(
+        `$Brake missing from typeRegistry.bindings; keys: ${
+          JSON.stringify(Object.keys(bindings))
+        }`,
+      );
+    }
+
+    // Each value must be an array of declaration records
+    const throttleDecls = bindings["$Throttle"];
+    if (!Array.isArray(throttleDecls) || throttleDecls.length === 0) {
+      throw new Error(
+        `typeRegistry.bindings["$Throttle"] must be a non-empty array; got: ${
+          JSON.stringify(throttleDecls)
+        }`,
+      );
+    }
+
+    // ThrottleCmd and BrakeCmd must be present in typedefs
+    if (!typedefs["ThrottleCmd"]) {
+      throw new Error(
+        `ThrottleCmd missing from typeRegistry.typedefs; keys: ${
+          JSON.stringify(Object.keys(typedefs))
+        }`,
+      );
+    }
+    if (!typedefs["BrakeCmd"]) {
+      throw new Error(
+        `BrakeCmd missing from typeRegistry.typedefs; keys: ${
+          JSON.stringify(Object.keys(typedefs))
+        }`,
+      );
+    }
+
+    // Typedef values must be arrays too
+    const throttleCmdDecls = typedefs["ThrottleCmd"];
+    if (!Array.isArray(throttleCmdDecls) || throttleCmdDecls.length === 0) {
+      throw new Error(
+        `typeRegistry.typedefs["ThrottleCmd"] must be a non-empty array; got: ${
+          JSON.stringify(throttleCmdDecls)
+        }`,
+      );
+    }
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Test 6: Identical $Name + kind + shape across entries → no TYPL-002/003
+// ---------------------------------------------------------------------------
+
+const SAME_DECL_MD = `- [STK_TYPL_0010] Speed signal primary declaration
+
+  The primary requirement declares $Speed as a signal.
+
+  \`\`\`typl
+  $Speed : signal float[0..300]
+  \`\`\`
+
+      Id: 01HZZZ0000000000000000006A
+
+- [STK_TYPL_0011] Speed signal redundant declaration
+
+  The secondary requirement repeats $Speed identically.
+
+  \`\`\`typl
+  $Speed : signal float[0..300]
+  \`\`\`
+
+      Id: 01HZZZ0000000000000000006B
+`;
+
+Deno.test(
+  "validate: identical cross-entry declarations do not trigger TYPL-002/003",
+  async () => {
+    const { code, stderr } = await markspec(
+      ["validate", "req.md"],
+      {
+        files: { "project.yaml": PROJECT_YAML, "req.md": SAME_DECL_MD },
+      },
+    );
+    assertEquals(
+      code,
+      0,
+      `Expected exit code 0 for identical declarations but got ${code}; stderr: ${stderr}`,
+    );
+    if (stderr.includes("TYPL-002") || stderr.includes("TYPL-003")) {
+      throw new Error(
+        `TYPL-002/003 must not fire for identical declarations; stderr: ${stderr}`,
+      );
+    }
+  },
+);

--- a/tests/e2e/typl_validation_test.ts
+++ b/tests/e2e/typl_validation_test.ts
@@ -59,8 +59,16 @@ Deno.test(
         `Expected non-zero exit code for TYPL-002 violation; stderr: ${stderr}`,
       );
     }
-    assertStringIncludes(stderr, "TYPL-002", "TYPL-002 code must appear in stderr");
-    assertStringIncludes(stderr, "$Speed", "$Speed name must appear in the diagnostic");
+    assertStringIncludes(
+      stderr,
+      "TYPL-002",
+      "TYPL-002 code must appear in stderr",
+    );
+    assertStringIncludes(
+      stderr,
+      "$Speed",
+      "$Speed name must appear in the diagnostic",
+    );
   },
 );
 
@@ -103,7 +111,11 @@ Deno.test(
         `Expected non-zero exit code for TYPL-003 violation; stderr: ${stderr}`,
       );
     }
-    assertStringIncludes(stderr, "TYPL-003", "TYPL-003 code must appear in stderr");
+    assertStringIncludes(
+      stderr,
+      "TYPL-003",
+      "TYPL-003 code must appear in stderr",
+    );
   },
 );
 
@@ -136,7 +148,11 @@ Deno.test(
         `Expected non-zero exit code for TYPL-005 violation; stderr: ${stderr}`,
       );
     }
-    assertStringIncludes(stderr, "TYPL-005", "TYPL-005 code must appear in stderr");
+    assertStringIncludes(
+      stderr,
+      "TYPL-005",
+      "TYPL-005 code must appear in stderr",
+    );
   },
 );
 
@@ -175,7 +191,10 @@ Deno.test(
     const { code, stderr } = await markspec(
       ["validate", "req.md"],
       {
-        files: { "project.yaml": PROJECT_YAML, "req.md": CROSS_ENTRY_TYPEDEF_MD },
+        files: {
+          "project.yaml": PROJECT_YAML,
+          "req.md": CROSS_ENTRY_TYPEDEF_MD,
+        },
       },
     );
     if (code === 0) {


### PR DESCRIPTION
## Summary

PR 6 of 8 in the typl DSL series. Adds **cross-entry validation** (TYPL-002/003) + **intra-entry undefined-typedef-ref detection** (TYPL-005) + **corpus typeRegistry** in compile output.

### What is new

- `core/typl/registry.ts` — `buildTypeRegistry(entries): TypeRegistry` collects every `$Name` binding and named typedef across the whole entry corpus, keyed by name. Multiple declarations of the same name are collected (not collapsed) so the validator can surface collisions.
- `core/typl/validator.ts` — `validateTypl(entries): { registry, diagnostics }`:
  - **TYPL-002**: same `$Name` declared with different `kind` in two entries (e.g. signal vs event)
  - **TYPL-003**: same `$Name` with the same kind but different shape
  - **TYPL-005**: a binding's shape references a typedef name that is NOT defined in the SAME entry (v1 scope is entry-local; cross-entry typedef sharing is v2 catalog work)
  - Recursively walks `record.fields`, `array.element`, `optional.inner` shapes to catch nested refs
- `core/validator/mod.ts` — `validate()` now includes typl diagnostics in its diagnostic stream
- `core/compiler/mod.ts` — `CompileResult` gains `typeRegistry: TypeRegistry`; `compile()` calls `validateTypl` once and returns the registry
- `core/compiler/schema.ts` — `serializeTypeRegistry()` converts the two `ReadonlyMap` fields into plain objects for JSON output (without this, `JSON.stringify` silently produces `{}` for Maps)

### What is NOT in this PR

- LSP integration (PR 7) — hover, completion, diagnostics surfaced in the editor
- Docs closeout (PR 8) — language spec chapter, guide, examples
- Cross-entry typedef sharing (deferred to v2 profile catalog)
- CHANGELOG entry — per project rule, batched at release time

### Example diagnostics

```text
docs/req.md:1:1  TYPL-002  $Speed is declared as kind event here and signal in docs/other.md:3.
docs/req.md:5:1  TYPL-005  Reference to undefined typedef BrakeReq.
```

### typeRegistry JSON shape

```json
{
  "typeRegistry": {
    "bindings": {
      "$Speed": [
        { "entryDisplayId": "REQ_A", "entryFile": "docs/req.md", "binding": { ... } },
        { "entryDisplayId": "REQ_B", "entryFile": "docs/other.md", "binding": { ... } }
      ]
    },
    "typedefs": {
      "BrakeReq": [
        { "entryDisplayId": "REQ_A", "entryFile": "docs/req.md", "typedef": { ... } }
      ]
    }
  }
}
```

## Test plan

- [x] Unit: 5 registry + 8 validator + 4 wiring + 1 round-trip = 18 new unit tests
- [x] E2E: 6 new `tests/e2e/typl_validation_test.ts` tests covering all six scenarios
- [x] Full `just check` — 1914 tests pass, 0 failed
- [x] `deno fmt --check`, `dprint check` — clean
- [x] `just compile` — binary builds
- [x] 10 pre-existing test fixtures updated to satisfy the new mandatory `typeRegistry` field on `CompileResult`
- [ ] Reviewer: confirm the cross-entry diagnostic location strategy (points at the dup's entry file with line 1, column 1) is acceptable for v1 — could be refined with real positions in a follow-up
- [ ] Reviewer: confirm the entry-local typedef-scope rule matches v1 spec intent (cross-entry typedef refs fire TYPL-005)

Builds on:
- PR 1 (parser foundation) — #431
- PR 2 (fence adapter) — #433
- PR 3 (entry-model integration) — #437
- PR 4 (bullet glossary) — #441
- PR 5 (inline backtick) — #451

🤖 Generated with [Claude Code](https://claude.com/claude-code)
