### PR TITLE
feat(core): slice 4 — glossary-only subset resolver

### DIFF
--- a/packages/markspec/core/lint/glossary.ts
+++ b/packages/markspec/core/lint/glossary.ts
@@ -21,7 +21,7 @@
  */
 
 import type { Entry } from "../model/mod.ts";
-import { deriveTermSlug } from "../parser/glossary.ts";
+import { deriveTermSlug, extractHeadingText } from "../parser/glossary.ts";
 import { processor } from "../parser/remark.ts";
 import type { Heading, Root } from "mdast";
 
@@ -67,8 +67,9 @@ export async function buildGlossaryIndex(
   }
 
   // (2) Glossary file H3 terms + R4-g aliases.
-  for (const path of glossaryFilePaths) {
-    const file = await readFile(path);
+  // Read all files in parallel — order doesn't matter for the index.
+  const files = await Promise.all(glossaryFilePaths.map((p) => readFile(p)));
+  for (const file of files) {
     if (!file) continue;
     const tree = processor.parse(file.content) as Root;
     for (const node of tree.children) {
@@ -97,19 +98,4 @@ export async function buildGlossaryIndex(
     has: (slug: string) => slugs.has(slug),
     size: () => slugs.size,
   };
-}
-
-/** Extract plain text from a heading node by concatenating Text and
- * InlineCode child values. Mirrors the same helper in parser/glossary.ts
- * but kept local so this module has no dependency on that module's
- * non-exported internals. */
-function extractHeadingText(node: Heading): string {
-  let text = "";
-  for (const child of node.children) {
-    if (child.type === "text") text += (child as { value: string }).value;
-    else if (child.type === "inlineCode") {
-      text += (child as { value: string }).value;
-    }
-  }
-  return text;
 }

--- a/packages/markspec/core/lint/glossary.ts
+++ b/packages/markspec/core/lint/glossary.ts
@@ -1,0 +1,115 @@
+/**
+ * @module core/lint/glossary
+ *
+ * Glossary-only subset resolver for the flagship MSL-Q500 rule
+ * (markspec-prose-analysis §2.8, §8 OQ4 resolved). Indexes:
+ *
+ *   1. In-entry DefinitionList terms (Term: definition pairs in any
+ *      in-scope entry's bodyAst).
+ *   2. H3 terms in glossary files (R4-c slug derivation via
+ *      `deriveTermSlug` from core/parser/glossary.ts) plus
+ *      parenthetical acronym aliases (R4-g).
+ *
+ * Built once per runLint invocation. The $Identifier registry leg
+ * (resolver step 3 in §2.8) and profile Aliases (step 4) are NOT
+ * indexed here — they remain deferred-by-dependency on the ADR-016
+ * marker pass and rule promotion respectively. Q500 receives a no-op
+ * hook for the $Identifier leg.
+ *
+ * See also: ADR-021 Decision 1 (the deferred-resolver posture and
+ * the additive-enrichment invariant).
+ */
+
+import type { Entry } from "../model/mod.ts";
+import { deriveTermSlug } from "../parser/glossary.ts";
+import { processor } from "../parser/remark.ts";
+import type { Heading, Root } from "mdast";
+
+/** Whether a slug is present in the glossary subset. */
+export interface GlossaryIndex {
+  has(slug: string): boolean;
+  /** For diagnostics & debugging only. */
+  size(): number;
+}
+
+/** Read a glossary file's content. Returns undefined if missing. */
+export type FileReader = (
+  path: string,
+) => Promise<{ content: string; file: string } | undefined>;
+
+/**
+ * Build the glossary index from in-entry DefinitionList nodes and
+ * (optionally) a list of known glossary file paths.
+ *
+ * @param entries - All entries in scope (their `bodyAst` is walked for
+ *   DefinitionList nodes).
+ * @param readFile - Async file reader; returns undefined for missing files.
+ * @param glossaryFilePaths - Paths of `markspec:glossary` files to index.
+ *   Defaults to an empty array — callers (slice 5 / runLint) supply this.
+ */
+export async function buildGlossaryIndex(
+  entries: readonly Entry[],
+  readFile: FileReader,
+  glossaryFilePaths: readonly string[] = [],
+): Promise<GlossaryIndex> {
+  const slugs = new Set<string>();
+
+  // (1) In-entry DefinitionList terms.
+  for (const entry of entries) {
+    const blocks = entry.bodyAst ?? [];
+    for (const block of blocks) {
+      if (block.kind !== "definition-list") continue;
+      for (const pair of block.items) {
+        const slug = deriveTermSlug(pair.term.text);
+        if (slug.length > 0) slugs.add(slug);
+      }
+    }
+  }
+
+  // (2) Glossary file H3 terms + R4-g aliases.
+  for (const path of glossaryFilePaths) {
+    const file = await readFile(path);
+    if (!file) continue;
+    const tree = processor.parse(file.content) as Root;
+    for (const node of tree.children) {
+      if (node.type !== "heading") continue;
+      const h = node as unknown as Heading;
+      if (h.depth !== 3) continue;
+      const text = extractHeadingText(h);
+      // R4-g: extract parenthetical acronym alias before slugifying the
+      // primary term, so the primary slug is derived from the non-parenthetical
+      // portion only (e.g. "Automotive Safety Integrity Level (ASIL)" →
+      // primary "automotive-safety-integrity-level" + alias "asil").
+      const aliasMatch = text.match(/\(([^)]+)\)/);
+      const textForPrimary = aliasMatch
+        ? text.slice(0, aliasMatch.index).trimEnd()
+        : text;
+      const primary = deriveTermSlug(textForPrimary);
+      if (primary.length > 0) slugs.add(primary);
+      if (aliasMatch) {
+        const aliasSlug = deriveTermSlug(aliasMatch[1]);
+        if (aliasSlug.length > 0) slugs.add(aliasSlug);
+      }
+    }
+  }
+
+  return {
+    has: (slug: string) => slugs.has(slug),
+    size: () => slugs.size,
+  };
+}
+
+/** Extract plain text from a heading node by concatenating Text and
+ * InlineCode child values. Mirrors the same helper in parser/glossary.ts
+ * but kept local so this module has no dependency on that module's
+ * non-exported internals. */
+function extractHeadingText(node: Heading): string {
+  let text = "";
+  for (const child of node.children) {
+    if (child.type === "text") text += (child as { value: string }).value;
+    else if (child.type === "inlineCode") {
+      text += (child as { value: string }).value;
+    }
+  }
+  return text;
+}

--- a/packages/markspec/core/lint/glossary_test.ts
+++ b/packages/markspec/core/lint/glossary_test.ts
@@ -1,0 +1,76 @@
+/**
+ * @module core/lint/glossary_test
+ *
+ * Tests for the glossary-only subset resolver (Slice 4).
+ */
+
+import { assertEquals } from "@std/assert";
+import { buildGlossaryIndex } from "./glossary.ts";
+import { parseFile } from "../parser/mod.ts";
+
+Deno.test("glossary index: indexes in-entry DefinitionList terms", async () => {
+  const md = `
+- [STK_0001] Test entry
+
+  Body paragraph.
+
+  Foo
+  : the foo concept
+
+  Bar Baz
+  : another concept
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+`;
+  const { entries } = await parseFile(md, { file: "/x.md" });
+  const idx = await buildGlossaryIndex(
+    entries,
+    () => Promise.resolve(undefined),
+  );
+  assertEquals(idx.has("foo"), true);
+  assertEquals(idx.has("bar-baz"), true);
+  assertEquals(idx.has("nope"), false);
+});
+
+Deno.test("glossary index: indexes glossary file H3 terms + aliases", async () => {
+  const entries: never[] = [];
+  const glossaryMd = `<!-- markspec:glossary -->
+# Glossary
+
+## A
+
+### Automotive Safety Integrity Level (ASIL)
+
+Body.
+
+### Active Distance Sensor
+
+Body.
+`;
+  const idx = await buildGlossaryIndex(entries, (path) => {
+    if (path === "/glossary.md") {
+      return Promise.resolve({ content: glossaryMd, file: "/glossary.md" });
+    }
+    return Promise.resolve(undefined);
+  }, ["/glossary.md"]);
+  assertEquals(idx.has("automotive-safety-integrity-level"), true);
+  assertEquals(idx.has("asil"), true); // R4-g alias
+  assertEquals(idx.has("active-distance-sensor"), true);
+});
+
+Deno.test("glossary index: empty inputs → empty index", async () => {
+  const idx = await buildGlossaryIndex([], () => Promise.resolve(undefined));
+  assertEquals(idx.has("anything"), false);
+  assertEquals(idx.size(), 0);
+});
+
+Deno.test("glossary index: missing glossary file is silent (returns undefined reader)", async () => {
+  // Reader returns undefined for paths that don't exist. The index
+  // should not throw — missing files just contribute nothing.
+  const idx = await buildGlossaryIndex(
+    [],
+    () => Promise.resolve(undefined),
+    ["/missing.md"],
+  );
+  assertEquals(idx.size(), 0);
+});

--- a/packages/markspec/core/parser/glossary.ts
+++ b/packages/markspec/core/parser/glossary.ts
@@ -40,9 +40,11 @@ export function deriveTermSlug(text: string): string {
 
 /**
  * Extract the plain-text content from a heading node by walking its
- * inline children and concatenating Text node values.
+ * inline children and concatenating `text` and `inlineCode` node values.
+ * Exported so the lint pipeline (`core/lint/glossary.ts`) can reuse the
+ * same convention without duplicating the walk.
  */
-function headingText(node: Heading): string {
+export function extractHeadingText(node: Heading): string {
   let text = "";
   for (const child of node.children) {
     if (child.type === "text") {
@@ -92,7 +94,7 @@ export function validateGlossaryStructure(
       const h = node as unknown as Heading;
       nodes.push({
         depth: h.depth,
-        text: headingText(h),
+        text: extractHeadingText(h),
         line: h.position?.start.line ?? 1,
         column: h.position?.start.column ?? 1,
       });
@@ -166,7 +168,7 @@ export function validateGlossaryStructure(
       events.push({
         kind: "heading",
         depth: h.depth,
-        text: headingText(h),
+        text: extractHeadingText(h),
         line: h.position?.start.line ?? 1,
         col: h.position?.start.column ?? 1,
       });


### PR DESCRIPTION
## Summary

- Adds `buildGlossaryIndex(entries, readFile, glossaryFilePaths?)` — an async, built-once-per-`runLint` index over in-entry `DefinitionList` terms + glossary file H3 terms + R4-g parenthetical aliases.
- `GlossaryIndex.has(slug)` is the only consumer surface; `size()` for debug.
- Foundation for the flagship MSL-Q500 rule (slice 5). The `$Identifier` registry leg of the §2.8 resolver order is deliberately NOT indexed — that stays deferred-by-dependency on ADR-016's marker pass per [ADR-021 Decision 1](docs/architecture/adr-021-prose-analysis-flagship-build.md).

This is **slice 4 of 10** for the Stage-2 PA-3 prose-analysis build.

## R4-g handling

`### Automotive Safety Integrity Level (ASIL)` produces two slugs:
- primary: `automotive-safety-integrity-level` (heading text with the parenthetical stripped, then slugified)
- alias: `asil` (the parenthetical content slugified separately)

This required a small deviation from the plan's reference snippet — passing the raw heading text through `deriveTermSlug` would have produced `automotive-safety-integrity-level-asil` (parens dropped but `ASIL` joined as another segment). The implementation strips the parenthetical first.

## Scope

In:
- New `core/lint/glossary.ts` (+ tests).
- Export the existing private `headingText` helper from `core/parser/glossary.ts` as `extractHeadingText` so the lint resolver reuses it (eliminates a duplication hazard the reviewer flagged).
- Parallel file reads via `Promise.all`.

Out:
- Wiring into `runLint` (slice 5).
- Q500 rule itself (slice 5).
- `$Identifier` resolution and profile Aliases.

## Test plan

- [x] 4 new glossary tests pass.
- [x] All 172 parser tests still pass after the `headingText` → `extractHeadingText` rename.
- [x] Full suite: 1898 passing, 0 failing.
- [x] `just check` clean; `deno fmt --check` + `dprint check` clean.

## Reviews completed

- **Spec compliance + code quality** (single sonnet pass): spec compliant; code quality flagged two Important items (now addressed in the follow-up commit on this branch):
  1. The local `extractHeadingText` helper duplicated a private function in `parser/glossary.ts`. Fixed by exporting it from `parser/glossary.ts` and importing here.
  2. Sequential `await readFile(path)` in a loop is now `Promise.all(paths.map(readFile))`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
