### PR TITLE
feat(parser): add C# grammar support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -323,7 +323,7 @@ profile (ASPICE, ISO 26262) would declare additional types
 - **Language:** TypeScript (strict mode)
 - **Markdown parsing:** unified / remark / mdast ecosystem
 - **Source file parsing:** tree-sitter (for doc comment extraction from Rust,
-  Kotlin, Java, C, C++, TypeScript, TSX, JavaScript)
+  Kotlin, Java, C, C++, TypeScript, TSX, JavaScript, C#)
 - **PDF rendering:** Typst via typst.ts WASM embedding
 - **Book rendering:** custom static site generator (`book/` module)
 - **Presentations:** Touying (Typst presentation framework)

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -660,8 +660,8 @@ defined in your profile.
 in the project.
 
 **Source file context guard** — in source files (Rust, Kotlin, Java, C, C++,
-TypeScript, TSX, JavaScript), completions only activate near entry markers or
-trace keywords. The server won't interfere with your language's native LSP
+TypeScript, TSX, JavaScript, C#), completions only activate near entry markers
+or trace keywords. The server won't interfere with your language's native LSP
 (rust-analyzer, kotlin-lsp, etc.).
 
 ### VS Code

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -127,6 +127,7 @@ export function activate(context: ExtensionContext): void {
       { scheme: "file", language: "typescriptreact" },
       { scheme: "file", language: "javascript" },
       { scheme: "file", language: "javascriptreact" },
+      { scheme: "file", language: "csharp" },
     ],
     synchronize: {
       fileEvents: workspace.createFileSystemWatcher("**/*.md"),

--- a/grammars/README.md
+++ b/grammars/README.md
@@ -21,6 +21,7 @@ Supported grammars:
 | `tree-sitter-typescript.wasm` | TypeScript             |
 | `tree-sitter-tsx.wasm`        | TSX (TypeScript + JSX) |
 | `tree-sitter-javascript.wasm` | JavaScript             |
+| `tree-sitter-c-sharp.wasm`    | C#                     |
 
 ## Lockfile
 

--- a/grammars/grammars.lock
+++ b/grammars/grammars.lock
@@ -56,6 +56,13 @@
       "package": "tree-sitter-javascript",
       "version": "0.23.1",
       "sha256": "4a378293fe7853cbee2836023be072dafa0e53b3b5edb245920838ca834ed121"
+    },
+    {
+      "file": "tree-sitter-c-sharp.wasm",
+      "source": "npm",
+      "package": "tree-sitter-c-sharp",
+      "version": "0.23.1",
+      "sha256": "d7fe0bf8e8b8d26b2b253f375e3c43386b332d23f7b7b3e15d49fff180fe46e3"
     }
   ]
 }

--- a/grammars/tree-sitter-c-sharp.wasm
+++ b/grammars/tree-sitter-c-sharp.wasm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d7fe0bf8e8b8d26b2b253f375e3c43386b332d23f7b7b3e15d49fff180fe46e3
+size 5926763

--- a/packages/markspec/core/model/mod.ts
+++ b/packages/markspec/core/model/mod.ts
@@ -208,7 +208,8 @@ export type SupportedLanguage =
   | "cpp"
   | "typescript"
   | "tsx"
-  | "javascript";
+  | "javascript"
+  | "csharp";
 
 /** Which extractor rule produced a doc-comment entry. Distinguishes the
  * three lexical doc-comment styles MarkSpec recognises across grammars. */

--- a/packages/markspec/core/parser/grammars.ts
+++ b/packages/markspec/core/parser/grammars.ts
@@ -27,6 +27,7 @@ const EXT_TO_GRAMMAR: Record<string, string> = {
   ".js": "tree-sitter-javascript",
   ".mjs": "tree-sitter-javascript",
   ".cjs": "tree-sitter-javascript",
+  ".cs": "tree-sitter-c-sharp",
 };
 
 /** Directory containing grammar WASM files. */

--- a/packages/markspec/core/parser/language_spec.ts
+++ b/packages/markspec/core/parser/language_spec.ts
@@ -295,7 +295,6 @@ function csharpItemName(node: SyntaxNode): string | undefined {
   }
 }
 
-
 /**
  * Closed-form table indexed by {@linkcode SupportedLanguage}. The walker in
  * `parser/source.ts` consults this map to know which AST node types to

--- a/packages/markspec/core/parser/language_spec.ts
+++ b/packages/markspec/core/parser/language_spec.ts
@@ -43,6 +43,11 @@ const isJavadocBlock = (t: string): boolean =>
 const isRustDocLine = (t: string): boolean =>
   t.startsWith("///") || t.startsWith("//!");
 
+/** C# uses `///` for XML doc comments. Unlike Rust, there is no
+ * inner-doc form (`//!`), so this predicate is intentionally
+ * narrower than `isRustDocLine`. */
+const isCsharpXmlDocLine = (t: string): boolean => t.startsWith("///");
+
 const noDocLine = (): boolean => false;
 
 /** Read a node's `name` field as text, or undefined if absent. */
@@ -255,6 +260,42 @@ const javascriptSpec: LanguageDocCommentSpec = {
   itemName: jsLikeItemName,
 };
 
+/** C#: most declarations use the `name` field. Three exceptions
+ * deviate from the simple path:
+ *   - field_declaration / event_field_declaration nest the name inside
+ *     `variable_declaration → first variable_declarator → name` field.
+ *     Multi-name decls (`int a, b, c;`) return the first name.
+ *   - operator_declaration / indexer_declaration have no plain
+ *     identifier (return undefined).
+ * Note destructor_declaration is NOT special-cased here: the C#
+ * grammar exposes the class identifier as the destructor's name
+ * field (so `~Outer()` yields "Outer"). This differs from cppItemName
+ * because the grammars are shaped differently. Probe-verified at
+ * grammar v0.23.1. */
+function csharpItemName(node: SyntaxNode): string | undefined {
+  switch (node.type) {
+    case "operator_declaration":
+    case "indexer_declaration":
+      return undefined;
+    case "field_declaration":
+    case "event_field_declaration": {
+      for (let i = 0; i < node.childCount; i++) {
+        const child = node.child(i);
+        if (child?.type !== "variable_declaration") continue;
+        for (let j = 0; j < child.childCount; j++) {
+          const grand = child.child(j);
+          if (grand?.type !== "variable_declarator") continue;
+          return grand.childForFieldName("name")?.text;
+        }
+      }
+      return undefined;
+    }
+    default:
+      return nameField(node);
+  }
+}
+
+
 /**
  * Closed-form table indexed by {@linkcode SupportedLanguage}. The walker in
  * `parser/source.ts` consults this map to know which AST node types to
@@ -361,6 +402,33 @@ export const LANGUAGE_SPECS: Record<SupportedLanguage, LanguageDocCommentSpec> =
     typescript: typescriptSpec,
     tsx: typescriptSpec,
     javascript: javascriptSpec,
+    csharp: {
+      blockCommentTypes: ["comment"],
+      lineCommentTypes: ["comment"],
+      isDocBlock: isJavadocBlock,
+      isDocLine: isCsharpXmlDocLine,
+      enclosingItemTypes: [
+        "class_declaration",
+        "struct_declaration",
+        "interface_declaration",
+        "record_declaration", // covers `record X` AND `record struct X`
+        "enum_declaration",
+        "method_declaration",
+        "constructor_declaration",
+        "destructor_declaration",
+        "property_declaration",
+        "field_declaration",
+        "event_field_declaration",
+        "delegate_declaration",
+        "operator_declaration",
+        "indexer_declaration",
+        "local_function_statement",
+        "namespace_declaration",
+        "file_scoped_namespace_declaration",
+      ],
+      attributeSkipTypes: ["comment", "attribute_list", "modifier"],
+      itemName: csharpItemName,
+    },
   };
 
 /** Map a file extension (including the dot) to its language id. */
@@ -393,6 +461,8 @@ export function languageIdForExtension(
     case ".mjs":
     case ".cjs":
       return "javascript";
+    case ".cs":
+      return "csharp";
     default:
       return undefined;
   }

--- a/packages/markspec/core/parser/language_spec_test.ts
+++ b/packages/markspec/core/parser/language_spec_test.ts
@@ -30,6 +30,7 @@ Deno.test("languageIdForExtension: maps every supported extension", () => {
   assertEquals(languageIdForExtension(".js"), "javascript");
   assertEquals(languageIdForExtension(".mjs"), "javascript");
   assertEquals(languageIdForExtension(".cjs"), "javascript");
+  assertEquals(languageIdForExtension(".cs"), "csharp");
 });
 
 Deno.test("languageIdForExtension: returns undefined for unknown extension", () => {
@@ -49,6 +50,7 @@ Deno.test("LANGUAGE_SPECS: every SupportedLanguage has a row", () => {
     "typescript",
     "tsx",
     "javascript",
+    "csharp",
   ] as const satisfies readonly SupportedLanguage[];
   const actual = Object.keys(LANGUAGE_SPECS).sort();
   assertEquals(actual, [...expected].sort());
@@ -114,6 +116,18 @@ Deno.test("LANGUAGE_SPECS.c: same shape as cpp", () => {
   assertEquals(spec.isDocLine("/* block */"), false);
 });
 
+Deno.test("LANGUAGE_SPECS.csharp: shared 'comment' node type with XML doc-line", () => {
+  const spec = LANGUAGE_SPECS.csharp;
+  assertEquals(spec.blockCommentTypes, ["comment"]);
+  assertEquals(spec.lineCommentTypes, ["comment"]);
+  assertEquals(spec.isDocBlock("/** javadoc-ish */"), true);
+  assertEquals(spec.isDocBlock("// not block"), false);
+  assertEquals(spec.isDocLine("/// xml doc"), true);
+  // C# has no //! inner-doc form (Rust-only).
+  assertEquals(spec.isDocLine("//! inner"), false);
+  assertEquals(spec.isDocLine("/* block */"), false);
+});
+
 Deno.test(
   "LANGUAGE_SPECS: each row has enclosingItemTypes + attributeSkipTypes + itemName",
   () => {
@@ -161,6 +175,20 @@ Deno.test(
     assert(spec.enclosingItemTypes.includes("function_definition"));
     assert(spec.enclosingItemTypes.includes("class_specifier"));
     assert(spec.enclosingItemTypes.includes("struct_specifier"));
+  },
+);
+
+Deno.test(
+  "LANGUAGE_SPECS.csharp: enclosingItemTypes covers class/struct/interface/record/method",
+  () => {
+    const t = LANGUAGE_SPECS.csharp.enclosingItemTypes;
+    assert(t.includes("class_declaration"));
+    assert(t.includes("struct_declaration"));
+    assert(t.includes("interface_declaration"));
+    assert(t.includes("record_declaration"));
+    assert(t.includes("method_declaration"));
+    assert(t.includes("namespace_declaration"));
+    assert(t.includes("file_scoped_namespace_declaration"));
   },
 );
 

--- a/packages/markspec/core/parser/source_test.ts
+++ b/packages/markspec/core/parser/source_test.ts
@@ -1574,3 +1574,39 @@ public class JavadocStyle {}
     assertEquals(entries[0].source.function, "JavadocStyle");
   }
 });
+
+// ---------------------------------------------------------------------------
+// C#: fixture file
+// ---------------------------------------------------------------------------
+
+Deno.test("parseSource: fixture — in-code-csharp.cs", async () => {
+  const language = await getCsharpLanguage();
+  const fixturePath = join(
+    import.meta.dirname!,
+    "..",
+    "..",
+    "..",
+    "..",
+    "tests",
+    "fixtures",
+    "in-code-csharp.cs",
+  );
+  const content = await Deno.readTextFile(fixturePath);
+  const { entries } = parseSource(content, {
+    file: "in-code-csharp.cs",
+    language,
+    languageId: "csharp",
+  });
+  assertEquals(entries.length, 1);
+  const entry = entries[0];
+  assertEquals(entry.displayId, "SRS_BRK_0001");
+  assertEquals(entry.title, "Sensor input debouncing");
+  assertEquals(entry.id, "01HGW2Q8MNP3RSTVWXYZABCDEF");
+  assertEquals(entry.source.kind, "doc-comment");
+  assertStringIncludes(entry.body, "debounce window");
+  assertEquals(entry.rawAttributes.length, 3);
+  if (entry.source.kind === "doc-comment") {
+    assertEquals(entry.source.language, "csharp");
+    assertEquals(entry.source.function, "BrakingSensor");
+  }
+});

--- a/packages/markspec/core/parser/source_test.ts
+++ b/packages/markspec/core/parser/source_test.ts
@@ -98,6 +98,17 @@ async function getJavascriptLanguage(): Promise<Parser.Language> {
   return javascriptLanguage;
 }
 
+let csharpLanguage: Parser.Language;
+
+async function getCsharpLanguage(): Promise<Parser.Language> {
+  if (csharpLanguage) return csharpLanguage;
+  await Parser.init();
+  csharpLanguage = await Parser.Language.load(
+    join(grammarsDir, "tree-sitter-c-sharp.wasm"),
+  );
+  return csharpLanguage;
+}
+
 // ---------------------------------------------------------------------------
 // Rust: basic entry extraction
 // ---------------------------------------------------------------------------
@@ -1242,4 +1253,37 @@ Deno.test("parseSource: TypeScript /** */ → method_definition inside a class e
     throw new Error("expected doc-comment");
   }
   assertEquals(entries[0].source.function, "myMethod");
+});
+
+// C#: basic entry extraction
+// ---------------------------------------------------------------------------
+
+Deno.test("parseSource: extracts C# /// doc comment entry", async () => {
+  const language = await getCsharpLanguage();
+  const source = `/// [SRS_BRK_0001] Sensor input debouncing
+///
+/// The sensor driver shall reject transient noise.
+///
+///     Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+///     Satisfies: SYS_BRK_0042
+///     Labels: ASIL-B
+public class BrakingSensor {}
+`;
+
+  const result = parseSource(source, {
+    file: "BrakingSensor.cs",
+    language,
+    languageId: "csharp",
+  });
+  assertEquals(result.entries.length, 1);
+  const entry = result.entries[0];
+  assertEquals(entry.displayId, "SRS_BRK_0001");
+  assertEquals(entry.title, "Sensor input debouncing");
+  assertEquals(entry.id, "01HGW2Q8MNP3RSTVWXYZABCDEF");
+  assertEquals(entry.source.kind, "doc-comment");
+  if (entry.source.kind === "doc-comment") {
+    assertEquals(entry.source.language, "csharp");
+    assertEquals(entry.source.rule, "outer-doc-comment");
+    assertEquals(entry.source.function, "BrakingSensor");
+  }
 });

--- a/packages/markspec/core/parser/source_test.ts
+++ b/packages/markspec/core/parser/source_test.ts
@@ -1287,3 +1287,134 @@ public class BrakingSensor {}
     assertEquals(entry.source.function, "BrakingSensor");
   }
 });
+
+Deno.test("parseSource: C# /// → function captures enclosing name for every item type", async () => {
+  const language = await getCsharpLanguage();
+  // One entry per node type, each carrying a distinct display ID so we
+  // can assert function-name attribution per row.
+  const source = `namespace Foo.Bar {
+    /// [REQ_0001] On namespace
+    ///
+    ///     Id: 01HGW0000000000000000001AA
+    /// dummy line so the parser stops searching for siblings on namespace
+    class _NamespaceCarrier {}
+
+    /// [REQ_0002] On class
+    ///
+    ///     Id: 01HGW0000000000000000002AA
+    public class Cls {}
+
+    /// [REQ_0003] On struct
+    ///
+    ///     Id: 01HGW0000000000000000003AA
+    public struct Strct {}
+
+    /// [REQ_0004] On interface
+    ///
+    ///     Id: 01HGW0000000000000000004AA
+    public interface IThing {}
+
+    /// [REQ_0005] On record
+    ///
+    ///     Id: 01HGW0000000000000000005AA
+    public record Rec(int X);
+
+    /// [REQ_0006] On record struct
+    ///
+    ///     Id: 01HGW0000000000000000006AA
+    public record struct RecStruct(int X);
+
+    /// [REQ_0007] On enum
+    ///
+    ///     Id: 01HGW0000000000000000007AA
+    public enum Col { Red, Green }
+
+    /// [REQ_0008] On delegate
+    ///
+    ///     Id: 01HGW0000000000000000008AA
+    public delegate void Del();
+
+    public class Holder {
+        /// [REQ_0009] On method
+        ///
+        ///     Id: 01HGW0000000000000000009AA
+        public void DoThing() {}
+
+        /// [REQ_0010] On property
+        ///
+        ///     Id: 01HGW000000000000000000AAA
+        public int Prop { get; set; }
+
+        /// [REQ_0011] On constructor
+        ///
+        ///     Id: 01HGW000000000000000000BAA
+        public Holder() {}
+
+        /// [REQ_0012] On local function
+        ///
+        ///     Id: 01HGW000000000000000000CAA
+        public void Wrapper() {
+            /// [REQ_0013] On nested local function
+            ///
+            ///     Id: 01HGW000000000000000000DAA
+            void Local() {}
+            Local();
+        }
+    }
+}
+
+/// [REQ_0014] On file-scoped namespace
+///
+///     Id: 01HGW000000000000000000EAA
+namespace Baz;
+
+class TopLevel {}
+`;
+  const { entries } = parseSource(source, {
+    file: "Coverage.cs",
+    language,
+    languageId: "csharp",
+  });
+
+  const fnByDisplayId = new Map<string, string | undefined>();
+  for (const e of entries) {
+    if (e.source.kind === "doc-comment") {
+      fnByDisplayId.set(e.displayId, e.source.function);
+    }
+  }
+  // Skip REQ_0001 (carrier-only — the next sibling after the comment
+  // is the dummy class, not the namespace itself; namespace attribution
+  // is checked separately in the traditional-namespace test below).
+  assertEquals(fnByDisplayId.get("REQ_0002"), "Cls");
+  assertEquals(fnByDisplayId.get("REQ_0003"), "Strct");
+  assertEquals(fnByDisplayId.get("REQ_0004"), "IThing");
+  assertEquals(fnByDisplayId.get("REQ_0005"), "Rec");
+  assertEquals(fnByDisplayId.get("REQ_0006"), "RecStruct");
+  assertEquals(fnByDisplayId.get("REQ_0007"), "Col");
+  assertEquals(fnByDisplayId.get("REQ_0008"), "Del");
+  assertEquals(fnByDisplayId.get("REQ_0009"), "DoThing");
+  assertEquals(fnByDisplayId.get("REQ_0010"), "Prop");
+  assertEquals(fnByDisplayId.get("REQ_0011"), "Holder");
+  assertEquals(fnByDisplayId.get("REQ_0012"), "Wrapper");
+  assertEquals(fnByDisplayId.get("REQ_0013"), "Local");
+  assertEquals(fnByDisplayId.get("REQ_0014"), "Baz");
+});
+
+Deno.test("parseSource: C# /// → function captures traditional namespace name", async () => {
+  const language = await getCsharpLanguage();
+  const source = `/// [REQ_0100] Doc on a top-level namespace
+///
+///     Id: 01HGW0000000000000000100AA
+namespace Foo.Bar {}
+`;
+  const { entries } = parseSource(source, {
+    file: "NsAttr.cs",
+    language,
+    languageId: "csharp",
+  });
+  assertEquals(entries.length, 1);
+  if (entries[0].source.kind === "doc-comment") {
+    // qualified_name; nameField returns the full `Foo.Bar` text.
+    assertEquals(entries[0].source.function, "Foo.Bar");
+  }
+});

--- a/packages/markspec/core/parser/source_test.ts
+++ b/packages/markspec/core/parser/source_test.ts
@@ -1526,3 +1526,39 @@ Deno.test("parseSource: C# multi-name field → function captures first declarat
     assertEquals(entries[0].source.function, "multi1");
   }
 });
+
+Deno.test("parseSource: C# regular // comments are not extracted", async () => {
+  const language = await getCsharpLanguage();
+  const source = `// [REQ_0400] This looks like an entry but uses // not ///
+//     Id: 01HGW0000000000000000400AA
+public class NotAnEntry {}
+`;
+  const { entries } = parseSource(source, {
+    file: "Negative.cs",
+    language,
+    languageId: "csharp",
+  });
+  assertEquals(entries.length, 0);
+});
+
+Deno.test("parseSource: C# /** */ block doc comment is recognised", async () => {
+  const language = await getCsharpLanguage();
+  const source = `/**
+ * [REQ_0401] Javadoc-style block in C#
+ *
+ *     Id: 01HGW0000000000000000401AA
+ */
+public class JavadocStyle {}
+`;
+  const { entries } = parseSource(source, {
+    file: "Javadoc.cs",
+    language,
+    languageId: "csharp",
+  });
+  assertEquals(entries.length, 1);
+  assertEquals(entries[0].displayId, "REQ_0401");
+  if (entries[0].source.kind === "doc-comment") {
+    assertEquals(entries[0].source.rule, "block-doc-comment");
+    assertEquals(entries[0].source.function, "JavadocStyle");
+  }
+});

--- a/packages/markspec/core/parser/source_test.ts
+++ b/packages/markspec/core/parser/source_test.ts
@@ -1418,3 +1418,51 @@ namespace Foo.Bar {}
     assertEquals(entries[0].source.function, "Foo.Bar");
   }
 });
+
+Deno.test("parseSource: C# destructor → function captures class name (deviates from C++)", async () => {
+  const language = await getCsharpLanguage();
+  const source = `public class Outer {
+    /// [REQ_0200] On destructor
+    ///
+    ///     Id: 01HGW0000000000000000200AA
+    ~Outer() {}
+}
+`;
+  const { entries } = parseSource(source, {
+    file: "Dtor.cs",
+    language,
+    languageId: "csharp",
+  });
+  assertEquals(entries.length, 1);
+  if (entries[0].source.kind === "doc-comment") {
+    assertEquals(entries[0].source.function, "Outer");
+  }
+});
+
+Deno.test("parseSource: C# operator and indexer → function undefined (anonymous)", async () => {
+  const language = await getCsharpLanguage();
+  const source = `public class Outer {
+    /// [REQ_0201] On operator
+    ///
+    ///     Id: 01HGW0000000000000000201AA
+    public static Outer operator +(Outer a, Outer b) => a;
+
+    /// [REQ_0202] On indexer
+    ///
+    ///     Id: 01HGW0000000000000000202AA
+    public int this[int i] => i;
+}
+`;
+  const { entries } = parseSource(source, {
+    file: "OpIdx.cs",
+    language,
+    languageId: "csharp",
+  });
+  assertEquals(entries.length, 2);
+  for (const id of ["REQ_0201", "REQ_0202"]) {
+    const e = entries.find((entry) => entry.displayId === id)!;
+    if (e.source.kind === "doc-comment") {
+      assertEquals(e.source.function, undefined, `${id} should be anonymous`);
+    }
+  }
+});

--- a/packages/markspec/core/parser/source_test.ts
+++ b/packages/markspec/core/parser/source_test.ts
@@ -1466,3 +1466,63 @@ Deno.test("parseSource: C# operator and indexer → function undefined (anonymou
     }
   }
 });
+
+Deno.test("parseSource: C# field declaration → function captures first declarator name", async () => {
+  const language = await getCsharpLanguage();
+  const source = `public class Holder {
+    /// [REQ_0300] On field
+    ///
+    ///     Id: 01HGW0000000000000000300AA
+    private int counter = 0;
+}
+`;
+  const { entries } = parseSource(source, {
+    file: "Field.cs",
+    language,
+    languageId: "csharp",
+  });
+  assertEquals(entries.length, 1);
+  if (entries[0].source.kind === "doc-comment") {
+    assertEquals(entries[0].source.function, "counter");
+  }
+});
+
+Deno.test("parseSource: C# event field declaration → function captures first declarator name", async () => {
+  const language = await getCsharpLanguage();
+  const source = `public class Holder {
+    /// [REQ_0301] On event
+    ///
+    ///     Id: 01HGW0000000000000000301AA
+    public event System.Action MyEvent;
+}
+`;
+  const { entries } = parseSource(source, {
+    file: "Event.cs",
+    language,
+    languageId: "csharp",
+  });
+  assertEquals(entries.length, 1);
+  if (entries[0].source.kind === "doc-comment") {
+    assertEquals(entries[0].source.function, "MyEvent");
+  }
+});
+
+Deno.test("parseSource: C# multi-name field → function captures first declarator only", async () => {
+  const language = await getCsharpLanguage();
+  const source = `public class Holder {
+    /// [REQ_0302] On multi-name field
+    ///
+    ///     Id: 01HGW0000000000000000302AA
+    public int multi1, multi2 = 5, multi3;
+}
+`;
+  const { entries } = parseSource(source, {
+    file: "MultiField.cs",
+    language,
+    languageId: "csharp",
+  });
+  assertEquals(entries.length, 1);
+  if (entries[0].source.kind === "doc-comment") {
+    assertEquals(entries[0].source.function, "multi1");
+  }
+});

--- a/packages/markspec/core/parser/source_test.ts
+++ b/packages/markspec/core/parser/source_test.ts
@@ -1375,6 +1375,7 @@ class TopLevel {}
     language,
     languageId: "csharp",
   });
+  assertEquals(entries.length, 14);
 
   const fnByDisplayId = new Map<string, string | undefined>();
   for (const e of entries) {
@@ -1413,6 +1414,7 @@ namespace Foo.Bar {}
     languageId: "csharp",
   });
   assertEquals(entries.length, 1);
+  assertEquals(entries[0].source.kind, "doc-comment");
   if (entries[0].source.kind === "doc-comment") {
     // qualified_name; nameField returns the full `Foo.Bar` text.
     assertEquals(entries[0].source.function, "Foo.Bar");
@@ -1434,6 +1436,7 @@ Deno.test("parseSource: C# destructor → function captures class name (deviates
     languageId: "csharp",
   });
   assertEquals(entries.length, 1);
+  assertEquals(entries[0].source.kind, "doc-comment");
   if (entries[0].source.kind === "doc-comment") {
     assertEquals(entries[0].source.function, "Outer");
   }
@@ -1461,6 +1464,11 @@ Deno.test("parseSource: C# operator and indexer → function undefined (anonymou
   assertEquals(entries.length, 2);
   for (const id of ["REQ_0201", "REQ_0202"]) {
     const e = entries.find((entry) => entry.displayId === id)!;
+    assertEquals(
+      e.source.kind,
+      "doc-comment",
+      `${id} should be a doc-comment source`,
+    );
     if (e.source.kind === "doc-comment") {
       assertEquals(e.source.function, undefined, `${id} should be anonymous`);
     }
@@ -1482,6 +1490,7 @@ Deno.test("parseSource: C# field declaration → function captures first declara
     languageId: "csharp",
   });
   assertEquals(entries.length, 1);
+  assertEquals(entries[0].source.kind, "doc-comment");
   if (entries[0].source.kind === "doc-comment") {
     assertEquals(entries[0].source.function, "counter");
   }
@@ -1502,6 +1511,7 @@ Deno.test("parseSource: C# event field declaration → function captures first d
     languageId: "csharp",
   });
   assertEquals(entries.length, 1);
+  assertEquals(entries[0].source.kind, "doc-comment");
   if (entries[0].source.kind === "doc-comment") {
     assertEquals(entries[0].source.function, "MyEvent");
   }
@@ -1522,6 +1532,7 @@ Deno.test("parseSource: C# multi-name field → function captures first declarat
     languageId: "csharp",
   });
   assertEquals(entries.length, 1);
+  assertEquals(entries[0].source.kind, "doc-comment");
   if (entries[0].source.kind === "doc-comment") {
     assertEquals(entries[0].source.function, "multi1");
   }
@@ -1557,6 +1568,7 @@ public class JavadocStyle {}
   });
   assertEquals(entries.length, 1);
   assertEquals(entries[0].displayId, "REQ_0401");
+  assertEquals(entries[0].source.kind, "doc-comment");
   if (entries[0].source.kind === "doc-comment") {
     assertEquals(entries[0].source.rule, "block-doc-comment");
     assertEquals(entries[0].source.function, "JavadocStyle");

--- a/packages/markspec/lsp/context.ts
+++ b/packages/markspec/lsp/context.ts
@@ -27,6 +27,7 @@ const SOURCE_EXTENSIONS = new Set([
   ".js",
   ".mjs",
   ".cjs",
+  ".cs",
 ]);
 
 /** Entry marker pattern: `[TYPE_XXX_NNNN]` in any context. */

--- a/scripts/fetch_grammars.ts
+++ b/scripts/fetch_grammars.ts
@@ -14,6 +14,14 @@ interface NpmGrammar {
   source: "npm";
   pkg: string;
   version: string;
+  /**
+   * Filename inside the npm package, if it differs from the on-disk
+   * name used as the GRAMMARS map key. Upstream tree-sitter-c-sharp
+   * ships its WASM as `tree-sitter-c_sharp.wasm` (C-identifier form
+   * of "c#"); we save it as `tree-sitter-c-sharp.wasm` for naming
+   * consistency with the other grammars.
+   */
+  urlFile?: string;
 }
 
 interface GithubGrammar {
@@ -81,13 +89,25 @@ const GRAMMARS: Record<string, Grammar> = {
     pkg: "tree-sitter-javascript",
     version: "0.23.1",
   },
+  "tree-sitter-c-sharp.wasm": {
+    source: "npm",
+    pkg: "tree-sitter-c-sharp",
+    version: "0.23.1",
+    // Upstream package ships its WASM with an underscore
+    // (tree-sitter-c_sharp.wasm); we save it with a hyphen to match
+    // the naming of the other grammars. Pinned to 0.23.1 because the
+    // newer 0.23.5 requires tree-sitter language ABI v15 while
+    // web-tree-sitter@0.24 only loads up to v14.
+    urlFile: "tree-sitter-c_sharp.wasm",
+  },
 };
 
 const GRAMMARS_DIR = new URL("../grammars", import.meta.url).pathname;
 
 function grammarUrl(file: string, grammar: Grammar): string {
   if (grammar.source === "npm") {
-    return `https://cdn.jsdelivr.net/npm/${grammar.pkg}@${grammar.version}/${file}`;
+    const urlFile = grammar.urlFile ?? file;
+    return `https://cdn.jsdelivr.net/npm/${grammar.pkg}@${grammar.version}/${urlFile}`;
   }
   return `https://github.com/${grammar.repo}/releases/download/${grammar.tag}/${file}`;
 }

--- a/tests/fixtures/in-code-csharp.cs
+++ b/tests/fixtures/in-code-csharp.cs
@@ -1,0 +1,11 @@
+/// [SRS_BRK_0001] Sensor input debouncing
+///
+/// The sensor driver shall reject transient noise shorter than
+/// the configured debounce window.
+///
+///     Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+///     Satisfies: SYS_BRK_0042
+///     Labels: ASIL-B
+public class BrakingSensor {
+    public void Debounce() {}
+}


### PR DESCRIPTION
## Summary

- Adds C# (`.cs`) to the source-parser dispatch via `tree-sitter-c-sharp@0.23.1`.
- Wires `csharp` through `SupportedLanguage`, `EXT_TO_GRAMMAR`, `languageIdForExtension`, `SOURCE_EXTENSIONS`, and `LANGUAGE_SPECS`.
- New `csharpItemName` extractor handles three exceptions to the simple `name`-field path: `operator_declaration` / `indexer_declaration` return undefined; `field_declaration` / `event_field_declaration` walk into the inner `variable_declarator` (first declarator wins for multi-name decls). `destructor_declaration` is intentionally NOT special-cased — the grammar exposes the class identifier as the destructor's `name` field, so `~Outer()` yields `"Outer"`.
- Fetch script gains an optional `urlFile` on `NpmGrammar` to handle the upstream package's underscore naming (`tree-sitter-c_sharp.wasm`) while keeping the on-disk hyphen-naming convention.
- 10 new unit tests in `source_test.ts` characterize: basic XML doc-line extraction, Javadoc block fallback, per-item-type happy path (14 entries covering class/struct/interface/record/record-struct/enum/delegate/method/property/constructor/local-function/nested-local-function/file-scoped-namespace), destructor returning class name, operator/indexer returning undefined, field/event-field/multi-name name extraction, and the regular `//` negative case.
- New `tests/fixtures/in-code-csharp.cs` mirrors the existing in-code Java/C++/Rust fixtures.

## Version pin rationale

`tree-sitter-c-sharp@0.23.5` (latest) is compiled against tree-sitter language ABI v15; `web-tree-sitter@^0.24` caps at v14. Pinning to **0.23.1** (newest ABI-v14 grammar). Upgrading web-tree-sitter is out of scope for this PR.

## Test plan

- [x] `just build` (lint + test + typecheck + compile)
- [x] `deno fmt --check`
- [x] `dprint check`
- [x] Full `source_test.ts` suite: 44 passed, 0 failed
- [x] Manual: `markspec validate tests/fixtures/in-code-csharp.cs` exits 0 (with expected profile-coverage warnings, same as Java/C++)

## Parallel-safe with JS-family PR

A sibling sub-project (`docs/superpowers/2026-05-25-js-family-grammars-handoff.md`) is adding TypeScript/TSX/JavaScript in parallel. Both PRs touch the same eight files (`SupportedLanguage`, `EXT_TO_GRAMMAR`, `SOURCE_EXTENSIONS`, `LANGUAGE_SPECS`, `fetch_grammars.ts`, `grammars/README.md`, `AGENTS.md`, `grammars.lock`), all additive — conflicts will be trivial. Merge order coordinated at PR time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)