### PR TITLE
feat(lsp): typl hover and completion via corpus registry (PR 7 of 8)

### DIFF
--- a/packages/markspec/lsp/server.ts
+++ b/packages/markspec/lsp/server.ts
@@ -86,6 +86,12 @@ import {
   uriToPath,
 } from "./util.ts";
 import { debugLog } from "./debug_log.ts";
+import {
+  buildDollarNameCompletions,
+  dollarNameAtPosition,
+  formatTyplHoverContent,
+  isDollarNameTrigger,
+} from "./typl.ts";
 
 // ---------------------------------------------------------------------------
 // Connection and document manager
@@ -521,6 +527,18 @@ connection.onCompletion((params): CompletionItem[] => {
     }));
   }
 
+  // Trigger 5: $Name identifier — typl binding names from the corpus registry.
+  if (isDollarNameTrigger(line)) {
+    const registry = index.getTypeRegistry();
+    const items = buildDollarNameCompletions(registry);
+    return items.map((item) => ({
+      label: item.label,
+      detail: item.detail,
+      documentation: item.documentation,
+      kind: CompletionItemKind.Variable,
+    }));
+  }
+
   return [];
 });
 
@@ -574,6 +592,16 @@ connection.onHover((params) => {
     start: { line: params.position.line, character: 0 },
     end: { line: params.position.line, character: Number.MAX_SAFE_INTEGER },
   });
+
+  // Try typl $Name token first — it takes priority over display-ID lookup.
+  const dollarName = dollarNameAtPosition(line, params.position.character);
+  if (dollarName) {
+    const registry = index.getTypeRegistry();
+    const hoverContent = formatTyplHoverContent(dollarName, registry);
+    if (hoverContent) {
+      return { contents: { kind: "markdown", value: hoverContent } };
+    }
+  }
 
   const id = displayIdAtPosition(line, params.position.character);
   if (!id) return null;

--- a/packages/markspec/lsp/typl.ts
+++ b/packages/markspec/lsp/typl.ts
@@ -1,0 +1,185 @@
+/**
+ * @module lsp/typl
+ *
+ * LSP-side typl helpers — pure functions that compute hover content
+ * and completion items for typl `$Name` identifiers and typedef
+ * references. Consume the corpus TypeRegistry from
+ * core/typl/registry.ts.
+ *
+ * See ADR-019.
+ */
+import type { Shape } from "../core/typl/mod.ts";
+import type { TypeRegistry } from "../core/typl/mod.ts";
+
+/**
+ * Return the `$Name` token at the given column on `line`, or
+ * `undefined` when the column lies on whitespace, past the line end,
+ * or outside a `$Name` token. The token starts with `$` and continues
+ * through `[A-Za-z0-9_]` characters.
+ */
+export function dollarNameAtPosition(
+  line: string,
+  column: number,
+): string | undefined {
+  if (column < 0 || column >= line.length) return undefined;
+  if (/\s/.test(line[column])) return undefined;
+
+  // Handle case where cursor is on the `$` itself.
+  if (line[column] === "$") {
+    let e = column + 1;
+    while (e < line.length && /[A-Za-z0-9_]/.test(line[e])) e++;
+    if (e - column < 2) return undefined; // bare `$` with no name
+    return line.slice(column, e);
+  }
+
+  // Cursor is on an identifier char — scan left for `$`.
+  if (!/[A-Za-z0-9_]/.test(line[column])) return undefined;
+  let start = column;
+  while (start > 0 && /[A-Za-z0-9_]/.test(line[start - 1])) start--;
+  if (start === 0 || line[start - 1] !== "$") return undefined;
+  start--; // include the `$`
+  // Scan right for token end.
+  let end = column + 1;
+  while (end < line.length && /[A-Za-z0-9_]/.test(line[end])) end++;
+  const token = line.slice(start, end);
+  if (token.length < 2) return undefined; // bare `$`
+  return token;
+}
+
+/**
+ * Format the hover content for a `$Name` from the corpus registry.
+ * Returns a short Markdown block describing the kind, the shape (if
+ * any), and the entries that declare this name.
+ *
+ * Returns `undefined` if the name isn't declared anywhere.
+ */
+export function formatTyplHoverContent(
+  name: string,
+  registry: TypeRegistry,
+): string | undefined {
+  const decls = registry.bindings.get(name);
+  if (!decls || decls.length === 0) return undefined;
+  const lines: string[] = [];
+  lines.push(`### ${name}`);
+  // Aggregate kinds — usually one, but cross-entry collisions can show
+  // multiple. The validator surfaces TYPL-002/003 separately.
+  const kinds = new Set(decls.map((d) => d.binding.kind));
+  const kindLabel = kinds.size === 1
+    ? [...kinds][0]
+    : `${[...kinds].join(" / ")} (collision)`;
+  lines.push("");
+  lines.push(`**Kind:** ${kindLabel}`);
+  // Show the first declaration's shape; if multiple shapes, note it.
+  const shapes = new Set(
+    decls.map((d) => JSON.stringify(d.binding.shape ?? null)),
+  );
+  if (shapes.size === 1) {
+    const shapeStr = formatShape(decls[0].binding.shape);
+    if (shapeStr) {
+      lines.push(`**Shape:** \`${shapeStr}\``);
+    }
+  } else {
+    lines.push(`**Shape:** _multiple, see TYPL-003_`);
+  }
+  // List declaration sites.
+  if (decls.length === 1) {
+    const d = decls[0];
+    lines.push(`**Declared in:** ${d.entryDisplayId} (${d.entryFile})`);
+  } else {
+    lines.push(`**Declared in ${decls.length} entries:**`);
+    for (const d of decls) {
+      lines.push(`- ${d.entryDisplayId} (${d.entryFile})`);
+    }
+  }
+  return lines.join("\n");
+}
+
+/**
+ * Compact one-line rendering of a typl Shape for hover and completion
+ * details. Returns undefined for absent shape.
+ */
+export function formatShape(shape: Shape | undefined): string | undefined {
+  if (!shape) return undefined;
+  switch (shape.kind) {
+    case "primitive":
+      return shape.type;
+    case "range": {
+      const lo = shape.min ?? "";
+      const hi = shape.max ?? "";
+      if (shape.exact !== undefined) return `${shape.type}[${shape.exact}]`;
+      return `${shape.type}[${lo}..${hi}]`;
+    }
+    case "length": {
+      if (shape.exact !== undefined) return `${shape.type}[${shape.exact}]`;
+      const lo = shape.min ?? "";
+      const hi = shape.max ?? "";
+      return `${shape.type}[${lo}..${hi}]`;
+    }
+    case "pattern":
+      return `/${shape.regex}/${shape.flags ?? ""}`;
+    case "array": {
+      const inner = formatShape(shape.element);
+      if (shape.exact !== undefined) return `${inner}[${shape.exact}]`;
+      if (shape.min !== undefined || shape.max !== undefined) {
+        return `${inner}[](${shape.min ?? ""}..${shape.max ?? ""})`;
+      }
+      return `${inner}[]`;
+    }
+    case "enum":
+      return shape.values.map((v) => JSON.stringify(v)).join(" | ");
+    case "record": {
+      const fields = Object.entries(shape.fields).map(([k, v]) =>
+        `${k}: ${formatShape(v)}`
+      );
+      return `{ ${fields.join(", ")} }`;
+    }
+    case "literal":
+      return JSON.stringify(shape.value);
+    case "ref":
+      return shape.name;
+    case "optional":
+      return `${formatShape(shape.inner)}?`;
+  }
+}
+
+/** Completion-item info for a `$Name` from the registry. */
+export interface TyplCompletionItem {
+  readonly label: string;
+  readonly detail: string;
+  readonly documentation: string;
+}
+
+/**
+ * Build completion items for `$Name` triggers. Returns one item per
+ * unique name in the registry. `detail` shows the kind + shape;
+ * `documentation` shows where it's declared.
+ */
+export function buildDollarNameCompletions(
+  registry: TypeRegistry,
+): readonly TyplCompletionItem[] {
+  const items: TyplCompletionItem[] = [];
+  for (const [name, decls] of registry.bindings) {
+    if (decls.length === 0) continue;
+    const first = decls[0];
+    const shape = formatShape(first.binding.shape);
+    const detail = shape
+      ? `${first.binding.kind} ${shape}`
+      : first.binding.kind;
+    const docLine = decls.length === 1
+      ? `Declared in ${first.entryDisplayId}`
+      : `Declared in ${decls.length} entries`;
+    items.push({ label: name, detail, documentation: docLine });
+  }
+  return items;
+}
+
+/**
+ * Return true when the text before the cursor ends with a `$`-prefixed
+ * partial identifier — the trigger for `$Name` completion.
+ *
+ * Matches `$` optionally followed by word characters (letters, digits,
+ * underscore). Preceded by a non-identifier char or at line start.
+ */
+export function isDollarNameTrigger(textBefore: string): boolean {
+  return /(?:^|[^A-Za-z0-9_$])\$[A-Za-z0-9_]*$/.test(textBefore);
+}

--- a/packages/markspec/lsp/typl_test.ts
+++ b/packages/markspec/lsp/typl_test.ts
@@ -1,0 +1,131 @@
+import { assertEquals } from "@std/assert";
+import {
+  buildDollarNameCompletions,
+  dollarNameAtPosition,
+  formatShape,
+  formatTyplHoverContent,
+  isDollarNameTrigger,
+} from "./typl.ts";
+import { buildTypeRegistry } from "../core/typl/mod.ts";
+import type { Entry } from "../core/model/mod.ts";
+import { makeDisplayId } from "../core/mod.ts";
+
+function entry(
+  displayId: string,
+  file: string,
+  types?: Entry["types"],
+): Entry {
+  return {
+    displayId: makeDisplayId(displayId),
+    title: "t",
+    body: "",
+    rawAttributes: [],
+    typedAttributes: new Map(),
+    id: "01HZZZ0000000000000000000A",
+    type: undefined,
+    shape: "Authored",
+    location: { file, line: 1, column: 1 },
+    source: { kind: "markdown" },
+    properties: { file: { path: file, line: 1, column: 1 } },
+    bodyTokens: [],
+    types,
+  } as unknown as Entry;
+}
+
+Deno.test("dollarNameAtPosition: detects $Name with cursor in middle", () => {
+  assertEquals(dollarNameAtPosition("The $Speed value", 5), "$Speed");
+  assertEquals(dollarNameAtPosition("The $Speed value", 8), "$Speed");
+});
+
+Deno.test("dollarNameAtPosition: returns undefined on whitespace", () => {
+  assertEquals(dollarNameAtPosition("The $Speed value", 3), undefined); // space before $
+});
+
+Deno.test("dollarNameAtPosition: returns undefined on bare $", () => {
+  assertEquals(dollarNameAtPosition("Just a $ alone", 7), undefined);
+});
+
+Deno.test("dollarNameAtPosition: detects when cursor on the $ itself", () => {
+  assertEquals(dollarNameAtPosition("$Speed", 0), "$Speed");
+});
+
+Deno.test("formatTyplHoverContent: returns undefined for unknown name", () => {
+  const r = buildTypeRegistry([]);
+  assertEquals(formatTyplHoverContent("$Unknown", r), undefined);
+});
+
+Deno.test("formatTyplHoverContent: shows kind, shape, and declaration", () => {
+  const e = entry("REQ_0001", "a.md", {
+    bindings: [{
+      statementKind: "binding",
+      name: "$Speed",
+      kind: "signal",
+      shape: { kind: "range", type: "float", min: 0, max: 300 },
+      position: { line: 5, column: 1 },
+    }],
+    typedefs: [],
+  });
+  const r = buildTypeRegistry([e]);
+  const content = formatTyplHoverContent("$Speed", r);
+  assertEquals(content?.includes("$Speed"), true);
+  assertEquals(content?.includes("signal"), true);
+  assertEquals(content?.includes("float[0..300]"), true);
+  assertEquals(content?.includes("REQ_0001"), true);
+  assertEquals(content?.includes("a.md"), true);
+});
+
+Deno.test("formatShape: range / primitive / record / enum / optional", () => {
+  assertEquals(formatShape({ kind: "primitive", type: "int" }), "int");
+  assertEquals(
+    formatShape({ kind: "range", type: "float", min: 0, max: 1 }),
+    "float[0..1]",
+  );
+  assertEquals(
+    formatShape({ kind: "enum", values: ["a", "b"] }),
+    `"a" | "b"`,
+  );
+  assertEquals(
+    formatShape({
+      kind: "optional",
+      inner: { kind: "primitive", type: "bool" },
+    }),
+    "bool?",
+  );
+});
+
+Deno.test("buildDollarNameCompletions: one item per registered name", () => {
+  const e = entry("REQ_0001", "a.md", {
+    bindings: [
+      {
+        statementKind: "binding",
+        name: "$Speed",
+        kind: "signal",
+        shape: { kind: "primitive", type: "float" },
+        position: { line: 1, column: 1 },
+      },
+      {
+        statementKind: "binding",
+        name: "$Brake",
+        kind: "command",
+        position: { line: 2, column: 1 },
+      },
+    ],
+    typedefs: [],
+  });
+  const r = buildTypeRegistry([e]);
+  const items = buildDollarNameCompletions(r);
+  assertEquals(items.length, 2);
+  const speed = items.find((i) => i.label === "$Speed");
+  assertEquals(speed?.detail, "signal float");
+});
+
+Deno.test("isDollarNameTrigger: triggers on $ and partial name", () => {
+  assertEquals(isDollarNameTrigger("The $Sp"), true);
+  assertEquals(isDollarNameTrigger("value $"), true);
+  assertEquals(isDollarNameTrigger("$Speed"), true);
+});
+
+Deno.test("isDollarNameTrigger: does not trigger on non-$ context", () => {
+  assertEquals(isDollarNameTrigger("Speed"), false);
+  assertEquals(isDollarNameTrigger("Satisfies: "), false);
+});

--- a/packages/markspec/lsp/workspace.ts
+++ b/packages/markspec/lsp/workspace.ts
@@ -13,6 +13,7 @@ import type {
   Entry,
 } from "../core/mod.ts";
 import { parseFile, suppressDeclaredAttrR010, validate } from "../core/mod.ts";
+import { buildTypeRegistry, type TypeRegistry } from "../core/typl/mod.ts";
 
 /** A display ID paired with its entry title, for completion items. */
 export interface DisplayIdEntry {
@@ -187,6 +188,18 @@ export class WorkspaceIndex {
   /** Return all tracked file paths. */
   getFilePaths(): string[] {
     return [...this.fileEntries.keys()];
+  }
+
+  /**
+   * Build the corpus type registry from all currently-indexed entries.
+   *
+   * Rebuilt on every call — no stale-cache bugs. For large projects with
+   * frequent edits this is fast enough because `getAllEntries()` is O(n)
+   * and the registry scan is O(bindings). A cached + invalidated variant
+   * can be added later when profiling shows it necessary.
+   */
+  getTypeRegistry(): TypeRegistry {
+    return buildTypeRegistry(this.getAllEntries());
   }
 
   // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

PR 7 of 8 in the typl DSL series. Adds **LSP integration** — hover and completion for typl `$Name` identifiers, powered by the corpus `TypeRegistry` from PR 6.

### What is new

- `lsp/typl.ts` (new module) — pure helpers:
  - `dollarNameAtPosition(line, column)` — extract `$Name` token under a cursor (returns undefined outside one)
  - `formatTyplHoverContent(name, registry)` — Markdown block showing kind, shape, and declaration sites for a `$Name`
  - `formatShape(shape)` — one-line shape rendering covering all 10 `Shape` variants
  - `buildDollarNameCompletions(registry)` — one completion item per registered `$Name` with kind + shape in `detail`
  - `isDollarNameTrigger(textBefore)` — context detector for the completion handler
- `lsp/workspace.ts` — added `getTypeRegistry()` method building the registry on demand from all indexed entries
- `lsp/server.ts` — two wiring points:
  - `onHover`: tries `dollarNameAtPosition` first; on match formats typl info; falls back to existing display-ID lookup
  - `onCompletion`: new trigger (#5) — when the line context matches a `$` prefix, returns typl-name completions as `CompletionItemKind.Variable`

### What is NOT in this PR

- Diagnostics: TYPL-NNN codes already flow from PR 6 through the existing core→LSP bridge — no changes required
- Docs closeout (PR 8) — language spec chapter, guide, examples
- Background indexing / cached registry — current implementation rebuilds on demand; cache + invalidation can land in a follow-up if profiling shows cost
- CHANGELOG entry — per project rule, batched at release time

### Example LSP behaviour

Hover on `$Speed` in entry prose:

```
### $Speed

**Kind:** signal
**Shape:** `float[0..300]`
**Declared in:** STK_AEB_0010 (docs/req.md)
```

Typing `$` in body text now offers completions for every `$Name` known to the corpus.

## Test plan

- [x] 10 new `lsp/typl_test.ts` unit tests covering position detection, hover formatting, shape rendering, completion building
- [x] Full LSP suite — 210 tests pass
- [x] Full `just check` — 1927 tests pass, 0 failed
- [x] `deno fmt --check`, `dprint check` — clean
- [x] `just compile` — binary builds
- [ ] Reviewer: try the LSP in the VSCode extension and confirm hover + completion render as expected
- [ ] Reviewer: confirm `getTypeRegistry()` rebuild-on-demand is acceptable for v1 (a future PR can add cache + change-driven invalidation)

Builds on:
- PR 1 (parser foundation) — #431
- PR 2 (fence adapter) — #433
- PR 3 (entry-model integration) — #437
- PR 4 (bullet glossary) — #441
- PR 5 (inline backtick) — #451
- PR 6 (validation + typeRegistry) — #457

🤖 Generated with [Claude Code](https://claude.com/claude-code)
