### PR TITLE
fix(repo): activate MarkSpec LSP on TypeScript / TSX / JavaScript files

### DIFF
--- a/docs/architecture/adr-009-core-profile-boundary.md
+++ b/docs/architecture/adr-009-core-profile-boundary.md
@@ -231,8 +231,9 @@ IDs, resolvable cross-references, well-formed `Id:` values).
 
 The core defines an **entry-source abstraction**: an interface over places
 entries come from. The Markdown parser is one implementation. Other adapters
-(tree-sitter-backed doc-comment extractors for Rust/Kotlin/C/C++/Java/etc., SBOM
-ingesters, ECAD/PLM connectors) plug in via the same interface.
+(tree-sitter-backed doc-comment extractors for Rust, Kotlin, Java, C, C++,
+TypeScript, TSX, JavaScript, etc., SBOM ingesters, ECAD/PLM connectors) plug in
+via the same interface.
 
 Once extracted, an entry is shape-indistinguishable from a Markdown-authored
 one. Provenance captures the source ("extracted from `src/foo.rs:42`", "ingested

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -659,9 +659,10 @@ defined in your profile.
 `Derived-from:`, `Verified-by:`, etc.) the server suggests all known display IDs
 in the project.
 
-**Source file context guard** — in source files (Rust, Kotlin, Java, C, C++),
-completions only activate near entry markers or trace keywords. The server won't
-interfere with your language's native LSP (rust-analyzer, kotlin-lsp, etc.).
+**Source file context guard** — in source files (Rust, Kotlin, Java, C, C++,
+TypeScript, TSX, JavaScript), completions only activate near entry markers or
+trace keywords. The server won't interfere with your language's native LSP
+(rust-analyzer, kotlin-lsp, etc.).
 
 ### VS Code
 

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -123,6 +123,10 @@ export function activate(context: ExtensionContext): void {
       { scheme: "file", language: "java" },
       { scheme: "file", language: "c" },
       { scheme: "file", language: "cpp" },
+      { scheme: "file", language: "typescript" },
+      { scheme: "file", language: "typescriptreact" },
+      { scheme: "file", language: "javascript" },
+      { scheme: "file", language: "javascriptreact" },
     ],
     synchronize: {
       fileEvents: workspace.createFileSystemWatcher("**/*.md"),


### PR DESCRIPTION
## Summary

Follow-up to #455 (JS-family grammars). That PR added TS/TSX/JS to `SupportedLanguage` and the LSP server's `SOURCE_EXTENSIONS`, so the **CLI** (`compile`, `validate`, `format`, etc.) parses doc-comment entries from `.ts/.tsx/.jsx/.js/.mjs/.cjs` files. But the VSCode extension's `documentSelector` still listed only the five original languages, so **in-editor MarkSpec features (diagnostics, completion, hover) never activated on TS/JS files** — the LSP server was ready but the client never forwarded the buffers.

This PR closes that parity gap with three small changes:

- [editors/vscode/src/extension.ts](editors/vscode/src/extension.ts) — add four selectors (`typescript`, `typescriptreact`, `javascript`, `javascriptreact`). VS Code maps `.ts → typescript`, `.tsx → typescriptreact`, `.js`/`.mjs`/`.cjs → javascript`, `.jsx → javascriptreact`, so the four selectors cover all six file extensions PR #455 added.
- [docs/guide/cli.md:662](docs/guide/cli.md#L662) — extend the "Source file context guard" language enumeration.
- [docs/architecture/adr-009-core-profile-boundary.md](docs/architecture/adr-009-core-profile-boundary.md) — extend the entry-source-pipeline language list in §9.

## Test plan

- [x] `just build` — 1948 tests pass, 0 fail; `deno compile` succeeds
- [x] `deno fmt --check` clean
- [x] `dprint check` clean
- [x] VSCode extension type-check (`npx tsc --noEmit` from `editors/vscode/`) clean
- [ ] CI runs cleanly after push

🤖 Generated with [Claude Code](https://claude.com/claude-code)