### PR TITLE
docs(repo): typl language reference, guide, and examples (PR 8 of 8 — series complete)

### DIFF
--- a/docs/architecture/adr-019-typl-type-dsl.md
+++ b/docs/architecture/adr-019-typl-type-dsl.md
@@ -43,7 +43,19 @@ v2.
 - Required named types (RIDL-style) — deferred to a strict-mode profile setting
   in v2.
 
+## Implementation status
+
+All eight implementation slices are merged:
+
+- Parser (`core/typl/`) — lexer, grammar, AST, diagnostics, validator
+- Three Markdown surfaces (fence, bullet glossary, inline) populating
+  `Entry.types`
+- Cross-entry validation and corpus `typeRegistry` in compile output
+- LSP hover, completion, and diagnostic reporting over the registry
+- Language reference, user guide, and example showcase in `docs/`
+
 ## See also
 
 - Design history: brainstorming output (not in repo — local design folder).
-- Plan: PR series of 8 incremental slices; PR 1 (this) ships the pure parser.
+- [Language reference: typl](../spec/language/typl.md)
+- [Guide: Using typl in your entries](../guide/typl.md)

--- a/docs/examples/typl-bindings.md
+++ b/docs/examples/typl-bindings.md
@@ -1,0 +1,102 @@
+# typl Bindings Showcase
+
+This document demonstrates realistic typl declarations across the three
+Markdown surfaces: fence, bullet glossary, and inline span. Each entry
+is drawn from an automotive context to show how the DSL integrates with
+genuine traceability requirements.
+
+---
+
+## Fence surface — radar tracking
+
+The fence surface is the natural choice when an entry carries several
+identifiers and at least one reusable typedef. Grouping declarations
+in a fence keeps the prose body uncluttered and lets the reader scan
+all bindings at a glance.
+
+- [SYS_RADAR_0012] Radar object-track output format
+
+  The sensor fusion module shall publish one `$Track` record per tracked
+  object at every `$CycleHz` Hz update rate. Records shall contain an object
+  identifier, range in metres, and closing velocity in metres per second.
+
+  ```typl
+  type Track = { id: int, range_m: float[0..300], velocity_ms: float[-100..100] }
+  $Track   : signal Track
+  $CycleHz : const int[10]
+  ```
+
+      Id: 01JZTYPLEXAMPLE0000RADAR001
+      Satisfies: STK_RADAR_0001
+      Labels: ASIL-B
+
+---
+
+## Bullet surface — brake controller
+
+The bullet glossary surface suits entries whose body already contains
+a list, or where the set of identifiers is small and naming them inline
+would clutter the prose. The `- $Name : kind shape` bullet sits cleanly
+at the same indent level as any other list item.
+
+- [SRS_BRAKE_0030] Brake-pedal signal debounce
+
+  The brake controller shall debounce raw pedal readings over a `$Window`
+  millisecond sliding window before emitting the `$Stable` output signal.
+  The debounce window shall be configurable at system-start time and shall
+  not exceed 50 ms.
+
+  - $Window : config int[1..50]
+  - $Stable : signal bool
+
+      Id: 01JZTYPLEXAMPLE0000BRAKE001
+      Satisfies: STK_BRAKE_0002
+      Labels: ASIL-C
+
+---
+
+## Inline surface — controller gain scheduling
+
+The inline backtick span is the lightest surface: one identifier
+declared directly in the sentence that mentions it. Use this when
+the prose would read oddly with a separate list or fence, and there is
+only one or two identifiers to annotate.
+
+- [SRS_CTRL_0005] Gain scheduling output
+
+  The controller shall apply a longitudinal gain
+  `$Gain : signal float[0.5..2.0]` selected from the active gain table
+  based on the current velocity operating mode. The gain selection shall
+  complete within one control cycle of an operating-mode transition.
+
+      Id: 01JZTYPLEXAMPLE0000CTRL001
+      Satisfies: SYS_CTRL_0003
+      Labels: ASIL-B
+
+---
+
+## Mixed surfaces — diagnostic logging
+
+When a single entry needs a shared typedef (best expressed in a fence)
+alongside a few per-signal annotations (comfortable as bullets), the
+two surfaces may coexist. All declarations in an entry share one
+namespace regardless of which surface introduces them.
+
+- [SYS_LOG_0004] Fault diagnostic record
+
+  The system shall emit a `$FaultRecord` document to the diagnostic bus
+  whenever a monitored fault is detected, and shall maintain a rolling
+  `$FaultRate` signal representing faults per second over a 10-second
+  window.
+
+  ```typl
+  type Severity  = 'info' | 'warn' | 'error' | 'fatal'
+  type FaultRecord = { ts: int, severity: Severity, code: int[0..255], msg: string[..128] }
+  ```
+
+  - $FaultRecord : document FaultRecord
+  - $FaultRate   : signal float[0..100]
+
+      Id: 01JZTYPLEXAMPLE0000DIAG001
+      Satisfies: STK_DIAG_0001
+      Labels: QM

--- a/docs/guide/SUMMARY.md
+++ b/docs/guide/SUMMARY.md
@@ -10,6 +10,7 @@
 
 - [Entry blocks](authoring.md)
 - [Profiles](profiles.md)
+- [Type declarations (typl)](typl.md)
 
 # Tools
 

--- a/docs/guide/typl.md
+++ b/docs/guide/typl.md
@@ -1,0 +1,282 @@
+# Using typl to declare identifier types
+
+typl is the MarkSpec Type Specification DSL. It gives meaning to the `$Name`
+tokens that appear in your entry bodies — by declaring their kind (signal,
+command, event, …) and their shape (float range, record, enum, …).
+
+---
+
+## When do I use typl?
+
+Use typl when an entry references `$Name` identifiers that represent typed
+quantities, and you want:
+
+- **Tooling support** — LSP hover shows the kind and shape of `$Name`; the
+  compiler reports undefined references and cross-entry collisions.
+- **Downstream codegen** — the `typeRegistry` in
+  `markspec compile --format json` maps each identifier to its shape, ready for
+  RIDL emitters or custom scripts.
+- **Verification clarity** — a tester reading the requirement sees exactly what
+  type and range `$Speed` carries, without hunting through other documents.
+
+You do not need typl if your entry bodies contain no `$Name` identifiers, or if
+the identifiers are self-explanatory from prose context alone.
+
+---
+
+## Which surface should I use?
+
+Three Markdown surfaces are available. Choose based on how many declarations you
+need and where they live relative to prose.
+
+### Fence — for dense or structured declarations
+
+Use a `` ```typl ``` `` fence when an entry carries multiple bindings and/or
+typedefs. The fence groups them visually and keeps the prose clean.
+
+````markdown
+- [SYS_RADAR_0012] Radar track output
+
+  The fusion module shall publish one `$Track` record per object at 100 ms.
+
+  ```typl
+  type Track = { id: int, range_m: float[0..300], velocity_ms: float }
+  $Track   : signal Track
+  $CycleHz : const int[10]
+  ```
+
+      Id: 01JZEXAMPLEULID000000000001
+      Satisfies: STK_RADAR_0001
+````
+
+### Bullet glossary — for sparse or annotated lists
+
+Use a `- $Name : …` bullet when the entry already contains a list and you want
+to annotate a few identifiers without adding a fence. Reads as a glossary note.
+
+```markdown
+- [SRS_BRAKE_0030] Brake pedal debounce
+
+  The controller shall debounce raw pedal readings over a `$Window` ms sliding
+  window before emitting `$Stable`.
+
+  - $Window : config int[1..50]
+  - $Stable : signal bool
+
+    Id: 01JZEXAMPLEULID000000000002
+```
+
+### Inline span — for a single identifier in prose
+
+Use a `` `$Name : shape` `` backtick span to declare one identifier directly in
+the sentence that mentions it. Keep this to one or two identifiers; use a fence
+for more.
+
+```markdown
+- [SRS_CTRL_0005] Gain scheduling
+
+  The controller shall apply a gain `$Gain : signal float[0.5..2.0]` selected
+  from the scheduled gain table.
+
+      Id: 01JZEXAMPLEULID000000000003
+```
+
+---
+
+## Common patterns
+
+### Declaring a signal
+
+A signal is a continuously observable quantity. Pair it with a range shape to
+capture the expected measurement domain.
+
+```typl
+$EngineRPM  : signal float[0..8000]
+$OilPressure: signal float[0..10.0]
+$FuelLevel  : signal int[0..100]
+```
+
+### Declaring a command with a record payload
+
+A command carries a structured payload. Define the payload shape as a typedef,
+then reference it in the binding.
+
+```typl
+type BrakeRequest = { force_N: float[0..12000], duration_ms: int[0..500] }
+$ApplyBrake : command BrakeRequest
+```
+
+### Declaring a constant
+
+A constant has a fixed value known at specification time.
+
+```typl
+$MaxRetries   : const int[3]
+$DebounceMs   : const int[10]
+$ProtocolVer  : const '2.1'
+```
+
+### Declaring an event
+
+An event is a named occurrence. The shape carries the event data, if any. Events
+with no payload omit the shape.
+
+```typl
+$CollisionAlert : event
+$PedalPressed   : event { force_N: float[0..1500], timestamp: int }
+```
+
+### Mixing surfaces in one entry
+
+All three surfaces share the same namespace within an entry. You can open a
+fence for typedefs, then use bullets for bindings, or vice versa. The compiler
+merges them.
+
+````markdown
+- [SYS_LOG_0004] Diagnostic log record
+
+  The system shall emit a `$LogRecord` document whenever a fault is detected.
+
+  ```typl
+  type Severity = 'info' | 'warn' | 'error' | 'fatal'
+  type LogRecord = { ts: int, severity: Severity, code: int[0..255], msg: string }
+  ```
+
+  - $LogRecord : document LogRecord
+  - $FaultRate : signal float[0..1.0]
+
+    Id: 01JZEXAMPLEULID000000000004
+````
+
+---
+
+## Compile output
+
+Running `markspec compile --format json` on a project that contains typl
+declarations produces two typl-specific fields in the output.
+
+**Per-entry `types` field:**
+
+```json
+{
+  "displayId": "SYS_RADAR_0012",
+  "types": {
+    "bindings": [
+      {
+        "name": "$Track",
+        "kind": "signal",
+        "shape": { "kind": "ref", "name": "Track" }
+      },
+      {
+        "name": "$CycleHz",
+        "kind": "const",
+        "shape": { "kind": "range", "type": "int", "exact": 10 }
+      }
+    ],
+    "typedefs": [
+      {
+        "name": "Track",
+        "shape": {
+          "kind": "record",
+          "fields": {
+            "id": { "kind": "primitive", "type": "int" },
+            "range_m": {
+              "kind": "range",
+              "type": "float",
+              "min": 0,
+              "max": 300
+            },
+            "velocity_ms": { "kind": "primitive", "type": "float" }
+          }
+        }
+      }
+    ]
+  }
+}
+```
+
+**Corpus-level `typeRegistry`:**
+
+At the top of the compile output, the `typeRegistry` maps every `$Name` to its
+resolved binding across the whole document set — useful for codegen scripts that
+need a flat lookup table.
+
+```json
+{
+  "typeRegistry": {
+    "$Track":   { "kind": "signal", "shape": { ... } },
+    "$CycleHz": { "kind": "const",  "shape": { ... } }
+  }
+}
+```
+
+---
+
+## Editor support
+
+The MarkSpec LSP provides two typl affordances when you open a Markdown file:
+
+- **Hover** — hovering over a `$Name` token shows its kind, shape, and which
+  entry declared it.
+- **Completion** — inside a `typl` fence or after `$`, the LSP offers names
+  already declared in the workspace as completion candidates.
+
+Both features require the `markspec lsp` server to be running. In VS Code,
+install the MarkSpec extension — it starts the server automatically.
+
+---
+
+## Common diagnostics and fixes
+
+### TYPL-005 — undefined typedef reference
+
+```
+TYPL-005: Reference to undefined typedef Track.
+```
+
+**Cause:** A binding uses `Track` as a ref shape, but no `type Track = …`
+declaration exists in the same entry.
+
+**Fix:** Add the typedef before the binding, or replace the ref with an inline
+shape.
+
+### TYPL-002 — kind collision across entries
+
+```
+TYPL-002: $Speed is declared as kind signal here and kind value in SYS_CTRL_0001:14.
+```
+
+**Cause:** Two entries declare `$Speed` with different kind keywords.
+
+**Fix:** Align the kind declaration across all entries that use `$Speed`. If the
+identifiers are genuinely different quantities, rename one of them.
+
+### TYPL-003 — shape collision across entries
+
+```
+TYPL-003: $Speed is declared with a different shape than in SYS_CTRL_0001:14.
+```
+
+**Cause:** Two entries agree on the kind but use a different shape for `$Speed`
+(e.g., `float[0..300]` in one entry, `float[0..200]` in another).
+
+**Fix:** Decide which shape is authoritative and update the other entry. If both
+ranges are intentional, use distinct names.
+
+### TYPL-001 — duplicate binding in the same entry
+
+```
+TYPL-001: Duplicate binding for $Speed in the same entry (first wins, this is a duplicate).
+```
+
+**Cause:** The same `$Name` binding appears twice within one entry (across any
+mix of surfaces).
+
+**Fix:** Remove the duplicate. The first declaration wins.
+
+---
+
+## See also
+
+- [Language reference: typl](../spec/language/typl.md)
+- [ADR-019 — typl: Type Specification DSL](../architecture/adr-019-typl-type-dsl.md)

--- a/docs/spec/language/SUMMARY.md
+++ b/docs/spec/language/SUMMARY.md
@@ -2,3 +2,4 @@
 
 - [Language](language.md)
 - [AST](ast.md)
+- [typl DSL](typl.md)

--- a/docs/spec/language/typl.md
+++ b/docs/spec/language/typl.md
@@ -1,0 +1,288 @@
+# typl — Type Specification DSL
+
+typl is the MarkSpec Type Specification DSL. It declares what `$Name`
+identifiers mean inside an entry's body — their kind (signal, event, command, …)
+and their shape (float range, record, enum, …). Every `$Name` token that appears
+in an entry body may be given a typl binding; the compiler collects all bindings
+into a per-entry `types` object and a corpus-level `typeRegistry` for downstream
+tooling such as codegen and LSP hover.
+
+---
+
+## Statement forms
+
+typl has exactly two statement forms.
+
+### Binding
+
+```
+$Name : [kind] shape
+```
+
+Declares what `$Name` represents. The kind keyword is optional and defaults to
+`value` when omitted.
+
+```
+$Speed   : signal float[0..300]
+$Enabled : bool
+$Idle    : state
+```
+
+### Typedef
+
+```
+type Name = shape
+```
+
+Declares a named shape that bindings in the same entry can reference by name.
+
+```
+type Track = { id: int, range_m: float[0..300], velocity_ms: float }
+$CurrentTrack : signal Track
+```
+
+---
+
+## Kind vocabulary
+
+The kind vocabulary is closed. Nine keywords are defined:
+
+| Kind       | Meaning                                                               |
+| ---------- | --------------------------------------------------------------------- |
+| `value`    | A plain data value with no lifecycle semantics. Default when omitted. |
+| `event`    | A named occurrence, optionally carrying a payload.                    |
+| `signal`   | A continuously observable quantity with a measurable shape.           |
+| `command`  | A request to perform an action, optionally with parameters.           |
+| `state`    | A named mode or state-machine state.                                  |
+| `const`    | A named constant whose value does not change at runtime.              |
+| `config`   | A configuration parameter supplied before system start.               |
+| `document` | A structured artefact (log record, report, notification).             |
+| `stream`   | A sequence of values produced over time.                              |
+
+---
+
+## Shape grammar
+
+A shape describes the type of the data carried by a binding. Ten shape variants
+are available.
+
+### `primitive`
+
+One of the five built-in primitive types. No constraints.
+
+```
+$Enabled  : bool
+$Payload  : bytes
+$Label    : string
+$Counter  : int
+$Ratio    : float
+```
+
+Primitive names: `int`, `float`, `bool`, `string`, `bytes`.
+
+### `range`
+
+A numeric primitive with min/max bounds or an exact value.
+
+```
+$Speed    : signal float[0..300]
+$Throttle : signal float[0..1.0]
+$Status   : int[0..255]
+$Magic    : const int[42]
+```
+
+Syntax: `int[min..max]`, `float[min..max]`, `int[exact]`, `float[exact]`. Either
+bound may be omitted (`int[0..]`, `int[..255]`).
+
+### `length`
+
+A `string` or `bytes` with a constrained length.
+
+```
+$Code    : string[3..6]
+$Hash    : bytes[32]
+$Prefix  : string[..8]
+```
+
+Syntax: `string[min..max]`, `string[exact]`, `bytes[min..max]`, `bytes[exact]`.
+
+### `pattern`
+
+A `string` constrained to a regular expression.
+
+```
+$CountryCode : pattern /^[A-Z]{3}$/
+$Ident       : pattern /^[a-z_][a-z0-9_]*$/i
+```
+
+Syntax: `/regex/` or `/regex/flags`. Supported flags: `i` (case-insensitive).
+
+### `array`
+
+An element shape repeated zero or more times, with optional length bounds.
+
+```
+$Readings  : int[]
+$Track     : signal float[](..8)
+$Waypoints : float[](1..64)
+$Matrix3x3 : float[4](9)
+```
+
+Syntax: `element[]`, `element[](min..max)`, `element[](exact)`. The element
+itself may be any shape, including a ranged type (`float[0..300][]`).
+
+### `enum`
+
+A closed set of string or numeric literals.
+
+```
+$Priority : 'low' | 'mid' | 'high'
+$State    : 0 | 1 | 2
+$Toggle   : true | false
+```
+
+Syntax: `literal | literal | …`. String literals use single quotes.
+
+### `record`
+
+A structured object with named fields.
+
+```
+type Track = { id: int, range_m: float[0..300], velocity_ms: float }
+type Log   = { ts: int, level: 'info' | 'warn' | 'error', msg: string }
+```
+
+Syntax: `{ field: shape, field: shape, … }`. Fields are comma-separated. Field
+values may be any shape, including nested records and refs.
+
+### `literal`
+
+A single fixed value.
+
+```
+$MaxRetries : const int[3]
+$Version    : const '1.0'
+$Debug      : const true
+```
+
+Literals are the `exact` form of `range`, `length`, or bare `true`/`false`. In
+practice, `int[3]` and `'fixed'` are the most common literal forms.
+
+### `ref`
+
+A bare PascalCase name referencing a typedef in the same entry.
+
+```
+type ErrorCode = int[0..127]
+$LastError : signal ErrorCode
+```
+
+Syntax: a PascalCase identifier with no punctuation. The name must resolve to a
+typedef declared in the same entry (entry-local scope — see §Scope).
+
+### `optional`
+
+A shape that may be absent.
+
+```
+$Timestamp : int?
+$Metadata  : string?
+$Extra     : bytes[32]?
+```
+
+Syntax: any shape followed by `?`. Optional wraps the innermost shape:
+`float[0..1.0]?` is valid.
+
+---
+
+## Markdown surfaces
+
+typl declarations may appear in three Markdown surfaces. All three parse to the
+same Shape AST.
+
+### Fence block
+
+Use a fenced code block tagged `typl` when an entry carries several bindings or
+typedefs. The fence collects related declarations visually.
+
+````markdown
+- [SYS_RADAR_0012] Radar track output format
+
+  The sensor fusion module shall publish one `$Track` record per tracked object
+  at every 100 ms cycle.
+
+  ```typl
+  type Track = { id: int, range_m: float[0..300], velocity_ms: float }
+  $Track   : signal Track
+  $CycleHz : const int[10]
+  ```
+
+      Id: 01JZEXAMPLEULID000000000001
+      Satisfies: STK_RADAR_0001
+````
+
+### Bullet glossary
+
+Use a bullet item with the form `- $Name : …` inside an existing bulleted list
+to annotate sparse identifiers. The bullet surface reads naturally as a glossary
+note.
+
+```markdown
+- [SRS_BRAKE_0030] Brake pedal debounce
+
+  The brake controller shall debounce raw pedal readings over a configurable
+  `$Window` millisecond sliding window before emitting `$Stable`.
+
+  - $Window : config int[1..50]
+  - $Stable : signal bool
+
+    Id: 01JZEXAMPLEULID000000000002
+```
+
+### Inline span
+
+Use a backtick span of the form `` `$Name : …` `` to annotate a single
+identifier in-prose without interrupting the surrounding text.
+
+```markdown
+- [SRS_CTRL_0005] Gain scheduling
+
+  The controller shall select a gain `$Gain : signal float[0.5..2.0]` based on
+  the current operating mode.
+
+      Id: 01JZEXAMPLEULID000000000003
+```
+
+---
+
+## Scope
+
+In v1, typl declarations are **entry-local**. A typedef declared in one entry
+cannot be referenced by name from a different entry. Cross-entry type sharing is
+deferred to a future profile-level scope mechanism.
+
+Within a single entry, all surfaces (fence, bullet, inline) share one namespace.
+A `$Name` binding or `type Name` declared in one surface is visible to the
+others in the same entry.
+
+---
+
+## Diagnostic catalogue
+
+| Code     | Severity | Description                                                              |
+| -------- | -------- | ------------------------------------------------------------------------ |
+| TYPL-001 | error    | Duplicate `$Name` binding within the same entry — first occurrence wins. |
+| TYPL-002 | error    | Same `$Name` declared with a different kind in another entry.            |
+| TYPL-003 | error    | Same `$Name` declared with a different shape in another entry.           |
+| TYPL-004 | error    | Typedef name redefined within the same entry.                            |
+| TYPL-005 | error    | Reference to an undefined typedef name.                                  |
+| TYPL-006 | error    | Malformed schema — unparseable shape expression.                         |
+| TYPL-007 | error    | Unknown kind keyword; expected one of the nine closed-vocabulary kinds.  |
+| TYPL-008 | error    | Literal value violates the declared constraint.                          |
+
+---
+
+## See also
+
+- [ADR-019 — typl: Type Specification DSL](../../architecture/adr-019-typl-type-dsl.md)
+- [Guide: Using typl in your entries](../../guide/typl.md)


### PR DESCRIPTION
## Summary

PR 8 of 8 in the typl DSL series — **documentation closeout**. Ships the language reference, user guide, and showcase examples for typl, plus updates the ADR with the merged-implementation status.

### What is new

- `docs/spec/language/typl.md` — formal language reference: both statement forms, all 9 kinds (table), all 10 shape variants with examples, the 3 Markdown surfaces with annotated code blocks, scope rules, TYPL-001..008 diagnostic catalogue
- `docs/guide/typl.md` — user-facing guide: surface selection guidance, 5 common patterns, compile-output JSON examples, editor support notes, fix instructions for TYPL-001/002/003/005
- `docs/examples/typl-bindings.md` — four realistic automotive entries showcasing each surface (radar tracking, brake debounce, gain scheduling, mixed-surface diagnostic logging)
- `docs/guide/SUMMARY.md` — links to the new typl guide
- `docs/spec/language/SUMMARY.md` — links to the new typl language reference
- `docs/architecture/adr-019-typl-type-dsl.md` — replaced the stale "PR 1 ships the pure parser" note with an "Implementation status" section listing all 8 merged slices

### What this closes

This PR completes the typl DSL series. All 8 planned slices are now shipped:

1. #431 — parser foundation (lexer, grammar, AST, diagnostics) + ADR-019
2. #433 — fence surface adapter (`extractTyplFences`)
3. #437 — entry-model integration (`Entry.types`) + compile output
4. #441 — bullet glossary surface
5. #451 — inline backtick surface
6. #457 — cross-entry validation + corpus typeRegistry
7. #462 — LSP hover + completion
8. #470 (this) — documentation closeout

## Test plan

- [x] `dprint check` — clean
- [x] `just check` — 1958 tests pass, 0 failed (docs-only, no test count change)
- [ ] Reviewer: skim the language reference for accuracy against the implementation
- [ ] Reviewer: confirm the user guide answers "when do I use typl?" clearly
- [ ] Reviewer: check `docs/examples/typl-bindings.md` renders correctly when the book is built

Builds on: PRs 1–7 (#431, #433, #437, #441, #451, #457, #462).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
