### PR TITLE
feat(core): profile extension of discipline registry (ADR-017 Slice 2)

### DIFF
--- a/docs/spec/model/annex-profile-schema.md
+++ b/docs/spec/model/annex-profile-schema.md
@@ -26,7 +26,7 @@ attributes, relations, labels).
 | `description`     | No       | string | Human-readable summary; recommended for publishing      |
 | `license`         | No       | string | SPDX identifier (e.g. `MIT`, `Apache-2.0`); recommended |
 | `extends`         | No       | string | Parent profile specifier — local path or scoped ID      |
-| `markspec-schema` | No       | string | Core schema version pin (e.g. `"1"`); see §B.7          |
+| `markspec-schema` | No       | string | Core schema version pin (e.g. `"1"`); see §B.9          |
 
 Complete example:
 
@@ -192,7 +192,98 @@ profile:
 Labels not declared in the active profile produce `MSL-L010` (unknown label
 concern).
 
-## B.7 Versioning and compatibility
+## B.7 Discipline kinds (`profile.kinds`)
+
+The optional `profile.kinds` map declares engineering disciplines that profile
+types may be assigned to. See
+[ADR-017 — Discipline Classification](../../architecture/adr-017-discipline-classification.md)
+and
+[Profiles and extensions — Discipline kinds](profiles.md#discipline-kinds-profilekinds)
+for authoring guidance.
+
+### `profile.kinds` (map)
+
+| Property | Required | Type                       | Notes                                                                          |
+| -------- | -------- | -------------------------- | ------------------------------------------------------------------------------ |
+| (key)    | —        | `^[a-z][a-z0-9-]*$`        | Kind name; must not be `mixed`; see [name rule](#kind-name-rule) below         |
+| (value)  | —        | null \| string \| KindDecl | Three legal YAML shapes; see [`profile.kinds.<name>`](#profilekindsname) below |
+
+`profile.kinds` is optional. When absent, the map is treated as empty; only
+core-declared kinds are available to type declarations in the profile.
+
+### `profile.kinds.<name>`
+
+Each map entry under `profile.kinds` declares one discipline kind. The value may
+be one of three YAML shapes:
+
+| Shape                | Example                               | Effect                                    |
+| -------------------- | ------------------------------------- | ----------------------------------------- |
+| null (bare key)      | `avionics:`                           | Kind registered; no description           |
+| string shorthand     | `mechanical: "Mechanical assemblies"` | Kind registered with inline `description` |
+| mapping (`KindDecl`) | `firmware:\n  description: "…"`       | Kind registered; description as sub-field |
+
+**`KindDecl` fields:**
+
+| Field         | Required | Type   | Notes                  |
+| ------------- | -------- | ------ | ---------------------- |
+| `description` | No       | string | Human-readable purpose |
+
+### Kind-name rule
+
+A kind name must match the pattern `^[a-z][a-z0-9-]*$` (lowercase letters,
+digits, and hyphens; must begin with a letter). The name `mixed` is reserved by
+the core engine.
+
+**Diagnostics:**
+
+| Code                     | Severity | Trigger                                                                           |
+| ------------------------ | -------- | --------------------------------------------------------------------------------- |
+| `PROFILE-DISCIPLINE-001` | error    | Kind name does not match `^[a-z][a-z0-9-]*$`                                      |
+| `PROFILE-DISCIPLINE-002` | error    | Kind name is the reserved word `mixed`                                            |
+| `PROFILE-DISCIPLINE-003` | warning  | Kind name duplicates a core-declared kind (redeclaration allowed but discouraged) |
+
+## B.8 Per-type `discipline:` field (`profile.types.<T>.discipline`)
+
+A type declaration may carry an optional `discipline:` field that assigns the
+type to a named kind:
+
+```yaml
+profile:
+  types:
+    SoftwareRequirement:
+      extends: Requirement
+      discipline: software   # must name a core or chain-declared kind
+```
+
+### Updated type fields table
+
+The full set of type fields (extending §B.3):
+
+| Field                | Required | Notes                                                                                    |
+| -------------------- | -------- | ---------------------------------------------------------------------------------------- |
+| `extends`            | Yes      | Core type name (PascalCase) or another profile type in the same chain                    |
+| `display-id-pattern` | No       | Pattern string; `{n:Nd}` is the numeric placeholder (N = minimum digits)                 |
+| `description`        | No       | Human-readable purpose shown by `markspec profile describe`                              |
+| `discipline`         | No       | Non-empty string naming a kind that exists in core-declared kinds ∪ chain-declared kinds |
+
+### Rules for `discipline:`
+
+- The value must be a non-empty string (`PROFILE-DISCIPLINE-005`).
+- The named kind must exist in the union of core kinds and all kinds declared in
+  the profile chain, including the declaring profile and all of its ancestors
+  (`PROFILE-DISCIPLINE-004`).
+- When omitted, the registry inherits the discipline by walking the `extends:`
+  chain upward; no explicit `discipline:` is needed unless the type is
+  introducing or reassigning a kind.
+
+**Diagnostics:**
+
+| Code                     | Severity | Trigger                                                                                          |
+| ------------------------ | -------- | ------------------------------------------------------------------------------------------------ |
+| `PROFILE-DISCIPLINE-004` | error    | `discipline:` names a kind not found in core-declared kinds ∪ chain-declared kinds               |
+| `PROFILE-DISCIPLINE-005` | error    | `discipline:` value is present but is not a non-empty string (empty string, null, or wrong type) |
+
+## B.9 Versioning and compatibility
 
 ### Core schema pin (`markspec-schema`)
 
@@ -222,7 +313,7 @@ A consumer project pins profile versions in `.markspec.yaml`. The toolchain
 supports the declared version only — no implicit upgrade, no downgrade. Run
 `markspec profile add <spec>@<version>` to pin explicitly.
 
-## B.8 Distribution and specifiers
+## B.10 Distribution and specifiers
 
 Profiles are referenced in `.markspec.yaml` using a specifier string:
 
@@ -237,7 +328,7 @@ Vendoring: `markspec profile add <spec>` downloads the profile and writes it
 into `profiles/` under the project root. Vendored profiles are committed to
 version control — the project owns a reproducible copy.
 
-## B.9 Extends chain and conflict resolution
+## B.11 Extends chain and conflict resolution
 
 When multiple profiles are active (the `.markspec.yaml` `profiles:` list), they
 are merged into a single **effective profile**. Resolution order: later entries
@@ -263,7 +354,7 @@ Conflict rules:
 | Relations  | Child relation overrides parent relation of same `key`   |
 | Labels     | Union; duplicate `name` keeps child `description`        |
 
-## B.10 Validation and publishing
+## B.12 Validation and publishing
 
 Validate a profile manifest before distributing it:
 

--- a/docs/spec/model/profiles.md
+++ b/docs/spec/model/profiles.md
@@ -128,6 +128,82 @@ A project with no `.markspec.yaml` (or an empty profiles list) runs in
 Core-only mode is useful for generic documentation where full traceability
 tooling is not needed.
 
+## Discipline kinds (`profile.kinds`)
+
+A **kind** is a named engineering discipline — such as `software`, `hardware`,
+or `mechanical` — used to classify entries for discipline-aware filtering,
+reporting, and export. Kinds are declared in the `profile.kinds` map and
+referenced from individual type declarations via a `discipline:` field.
+
+See
+[ADR-017 — Discipline Classification](../../architecture/adr-017-discipline-classification.md)
+for the rationale and the full classification channel algorithm.
+
+### Kind declaration syntax
+
+Each entry in `profile.kinds` maps a kind name to one of three YAML shapes:
+
+```yaml
+profile:
+  kinds:
+    firmware:
+      description: Embedded firmware modules
+    mechanical: "Mechanical components and assemblies"
+    avionics:
+
+  types:
+    SoftwareRequirement:
+      extends: Requirement
+      discipline: software
+
+    FirmwareUnit:
+      extends: SoftwareUnit
+      # inherits 'software' from SoftwareUnit
+```
+
+| Shape                              | Meaning                                               |
+| ---------------------------------- | ----------------------------------------------------- |
+| `<name>:` (null value)             | Kind exists; no description                           |
+| `<name>: "string"`                 | Kind exists; bare string is the description shorthand |
+| `<name>:\n  description: "string"` | Kind exists; description as a sub-field               |
+
+### Kind-name lexical rule
+
+Kind names must match `^[a-z][a-z0-9-]*$`: lowercase letters, digits, and
+hyphens, starting with a letter. The name `mixed` is reserved by the core engine
+and may not be declared in a profile.
+
+### Per-type `discipline:` field
+
+A type declaration may carry a `discipline:` field naming the kind that the type
+belongs to:
+
+```yaml
+profile:
+  types:
+    SoftwareRequirement:
+      extends: Requirement
+      discipline: software
+```
+
+The named kind must exist in the union of core-declared kinds and all
+chain-declared kinds; referencing an unknown kind is `PROFILE-DISCIPLINE-004`.
+
+**Auto-inheritance.** When a type does not carry `discipline:` explicitly, the
+registry is built at compile time from the merged profile chain: the engine
+walks the `extends:` chain upward until it finds a type with an explicit
+`discipline:` assignment, or reaches a core type. Concretely, a type only needs
+`discipline:` when it is either introducing a new kind or reassigning the kind
+inherited from its parent.
+
+### Redeclaring core kinds
+
+The core engine ships with three built-in kinds: `system`, `software`, and
+`hardware`. Declaring one of these names in a profile does not change their
+semantics but produces a `PROFILE-DISCIPLINE-003` warning (the declaration is
+idempotent and ignored). Declare a new kind name to introduce additional
+disciplines such as `firmware`, `mechanical`, or `avionics`.
+
 ## What profiles cannot change
 
 Profiles extend core — they cannot weaken or redefine it:

--- a/packages/markspec/core/compiler/inverses_test.ts
+++ b/packages/markspec/core/compiler/inverses_test.ts
@@ -76,6 +76,7 @@ function makeProfile(
         description: { value: undefined, origin: "test-profile" },
         attrDescriptions: new Map(),
         relationDescriptions: new Map(),
+        discipline: { value: undefined, origin: "test-profile" },
       },
       origin: "test-profile",
     });
@@ -87,6 +88,7 @@ function makeProfile(
     conventions: new Map(),
     types,
     documents: { types: new Map(), frontMatter: new Map() },
+    kinds: new Map(),
     prose: {
       lexicons: {
         "capitalized-allow": { value: [], origin: "" },

--- a/packages/markspec/core/compiler/mod.ts
+++ b/packages/markspec/core/compiler/mod.ts
@@ -23,7 +23,7 @@ import {
   validate,
 } from "../validator/mod.ts";
 import { type TypeRegistry, validateTypl } from "../typl/mod.ts";
-import { CORE_DISCIPLINE_REGISTRY } from "../model/mod.ts";
+import { buildEffectiveDisciplineRegistry } from "../profile/discipline_registry.ts";
 import { ATTR_TO_LINK_KIND } from "./constants.ts";
 import { classifyDiscipline } from "./discipline_classifier.ts";
 import { generateInverses } from "./inverses.ts";
@@ -321,16 +321,13 @@ export async function compile(
 
   // Phase 4: Classify each entry's discipline per ADR-017 Invariant 1
   // (channels 3 + 4 + default — override and freeze ship in Slice 3).
-  // Mutates the `entries` map by replacing each Entry with a remapped
-  // copy that carries `derivedDiscipline`.
+  // The effective registry is built once per compile() from the active
+  // profile chain; null falls back to the core seed.
   {
+    const registry = buildEffectiveDisciplineRegistry(options.profile ?? null);
     const classified: Entry[] = [];
     for (const entry of entries.values()) {
-      const discipline = classifyDiscipline(
-        entry,
-        entries,
-        CORE_DISCIPLINE_REGISTRY,
-      );
+      const discipline = classifyDiscipline(entry, entries, registry);
       classified.push({ ...entry, derivedDiscipline: discipline });
     }
     entries.clear();

--- a/packages/markspec/core/compiler/mod_test.ts
+++ b/packages/markspec/core/compiler/mod_test.ts
@@ -8,7 +8,7 @@
 import { assertEquals, assertExists } from "@std/assert";
 import { compile } from "./mod.ts";
 import { makeDisplayId } from "../model/mod.ts";
-import type { EffectiveProfile } from "../model/mod.ts";
+import type { EffectiveProfile, EffectiveTypeDef } from "../model/mod.ts";
 
 const ULID_A = "01HGW2Q8MNP3RSTVWXYZABCDEF";
 const ULID_B = "01HGW2Q8MNP3RSTVWXYZABCDEG";
@@ -488,6 +488,7 @@ function profileWithFoo(): EffectiveProfile {
     colors: new Map(),
     types: new Map(),
     documents: { types: new Map(), frontMatter: new Map() },
+    kinds: new Map(),
     prose: {
       lexicons: {
         "capitalized-allow": { value: [], origin: "" },
@@ -652,4 +653,61 @@ Deno.test("compile: typeRegistry collects $Name bindings from typl fences", asyn
   assertEquals(Array.isArray(speedDecls), true);
   assertEquals(speedDecls?.length, 1);
   assertEquals(speedDecls?.[0].binding.kind, "signal");
+});
+
+// ---------------------------------------------------------------------------
+// Phase 4: Profile-extended registry classification
+// ---------------------------------------------------------------------------
+
+function syntheticProfile(): EffectiveProfile {
+  const td: EffectiveTypeDef = {
+    name: "SoftwareRequirement",
+    extends: "Requirement",
+    displayIdPattern: { value: "SWR_{NNNN}", origin: "p" },
+    displayIdPatternEnforcement: { value: "off", origin: "p" },
+    color: { value: undefined, origin: "p" },
+    required: { value: [], origin: "p" },
+    attributes: new Map(),
+    traceability: new Map(),
+    description: { value: undefined, origin: "p" },
+    attrDescriptions: new Map(),
+    relationDescriptions: new Map(),
+    discipline: { value: "software", origin: "p" },
+  };
+  // deno-lint-ignore no-explicit-any
+  const types = new Map() as any;
+  types.set("SoftwareRequirement", { value: td, origin: "p" });
+  return {
+    attributes: new Map(),
+    labels: new Map(),
+    conventions: new Map(),
+    colors: new Map(),
+    types,
+    documents: { types: new Map(), frontMatter: new Map() },
+    kinds: new Map(),
+    prose: {
+      lexicons: {
+        "capitalized-allow": { value: [], origin: "" },
+        "sentence-abbrev": { value: [], origin: "" },
+      },
+    },
+  };
+}
+
+Deno.test("compile: profile-extended registry classifies SoftwareRequirement entries", async () => {
+  const files: Record<string, string> = {
+    "/r.md": `
+- [SWR_0001] SW requirement
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      Type: SoftwareRequirement
+`,
+  };
+  const result = await compile(["/r.md"], {
+    readFile: reader(files),
+    profile: syntheticProfile(),
+  });
+  const swr = result.entries.get(makeDisplayId("SWR_0001"));
+  if (!swr) throw new Error("SWR_0001 missing from compile output");
+  assertEquals(swr.derivedDiscipline, "software");
 });

--- a/packages/markspec/core/mod.ts
+++ b/packages/markspec/core/mod.ts
@@ -46,6 +46,7 @@ export type {
   EntrySource,
   ExtractorRule,
   InlineRef,
+  KindDecl,
   LabelConcern,
   LabelConcernKind,
   LabelValue,
@@ -139,6 +140,7 @@ export type {
   RunGitResult,
 } from "./profile/mod.ts";
 
+export { buildEffectiveDisciplineRegistry } from "./profile/mod.ts";
 export { buildProfileIntrospection } from "./profile/mod.ts";
 export type {
   AttributeDetail,

--- a/packages/markspec/core/mod_test.ts
+++ b/packages/markspec/core/mod_test.ts
@@ -183,3 +183,17 @@ Deno.test("report produces traceability output", () => {
   // Should at least contain the header row
   assertEquals(output.includes("ID"), true);
 });
+
+// ---------------------------------------------------------------------------
+// ADR-017 Slice 2 public-API surface
+// ---------------------------------------------------------------------------
+
+import { buildEffectiveDisciplineRegistry, type KindDecl } from "./mod.ts";
+
+Deno.test("core/mod.ts re-exports Slice 2 surface", () => {
+  // buildEffectiveDisciplineRegistry: callable with null.
+  const reg = buildEffectiveDisciplineRegistry(null);
+  assertEquals(reg.get("SoftwareComponent"), "software");
+  // KindDecl: type-level only (compile-time check).
+  const _kd: KindDecl = { description: "test" };
+});

--- a/packages/markspec/core/model/mod.ts
+++ b/packages/markspec/core/model/mod.ts
@@ -856,6 +856,7 @@ export type {
   EffectiveTypeDef,
   EnforcementMode,
   InverseDecl,
+  KindDecl,
   LabelConcern,
   LabelConcernKind,
   LabelValue,

--- a/packages/markspec/core/model/mod_test.ts
+++ b/packages/markspec/core/model/mod_test.ts
@@ -5,7 +5,16 @@
  */
 
 import { assertEquals } from "@std/assert";
-import type { BodyToken, BodyTokenKind, Entry } from "./mod.ts";
+import type {
+  BodyToken,
+  BodyTokenKind,
+  EffectiveProfile,
+  EffectiveTypeDef,
+  Entry,
+  KindDecl,
+  ProfileManifest,
+  TypeDef,
+} from "./mod.ts";
 import { makeDisplayId } from "./mod.ts";
 
 Deno.test("BodyToken: discriminated union exhaustiveness", () => {
@@ -60,4 +69,74 @@ Deno.test("Entry type allows derivedDiscipline to be omitted (optional field)", 
     bodyTokens: [],
   };
   if (entry.derivedDiscipline !== undefined) throw new Error("unreachable");
+});
+
+Deno.test("Slice 2 model: KindDecl + kinds/discipline fields type-check", () => {
+  // KindDecl is a tiny record with an optional description.
+  const kd: KindDecl = { description: "Embedded firmware modules" };
+  if (kd.description !== "Embedded firmware modules") {
+    throw new Error("unreachable");
+  }
+
+  // ProfileManifest gains a kinds map.
+  const manifest: ProfileManifest = {
+    id: "x",
+    version: "0",
+    universalAttributes: [],
+    labels: [],
+    conventions: [],
+    colors: new Map(),
+    types: new Map(),
+    documents: { types: [], frontMatter: [] },
+    kinds: new Map<string, KindDecl>([["firmware", {}]]),
+    prose: { lexicons: { "capitalized-allow": [], "sentence-abbrev": [] } },
+  };
+  if (!manifest.kinds.has("firmware")) throw new Error("unreachable");
+
+  // TypeDef gains an optional discipline string.
+  const td: TypeDef = {
+    name: "SoftwareRequirement",
+    extends: "Requirement",
+    displayIdPatternEnforcement: "off",
+    required: [],
+    attributes: [],
+    traceability: new Map(),
+    discipline: "software",
+  };
+  if (td.discipline !== "software") throw new Error("unreachable");
+
+  // EffectiveProfile gains a provenanced kinds map.
+  const ep: EffectiveProfile = {
+    attributes: new Map(),
+    labels: new Map(),
+    conventions: new Map(),
+    colors: new Map(),
+    types: new Map(),
+    documents: { types: new Map(), frontMatter: new Map() },
+    kinds: new Map(),
+    prose: {
+      lexicons: {
+        "capitalized-allow": { value: [], origin: "x" },
+        "sentence-abbrev": { value: [], origin: "x" },
+      },
+    },
+  };
+  if (ep.kinds.size !== 0) throw new Error("unreachable");
+
+  // EffectiveTypeDef gains a provenanced discipline value.
+  const etd: EffectiveTypeDef = {
+    name: "SoftwareRequirement",
+    extends: "Requirement",
+    displayIdPattern: { value: undefined, origin: "x" },
+    displayIdPatternEnforcement: { value: "off", origin: "x" },
+    color: { value: undefined, origin: "x" },
+    required: { value: [], origin: "x" },
+    attributes: new Map(),
+    traceability: new Map(),
+    description: { value: undefined, origin: "x" },
+    attrDescriptions: new Map(),
+    relationDescriptions: new Map(),
+    discipline: { value: "software", origin: "x" },
+  };
+  if (etd.discipline.value !== "software") throw new Error("unreachable");
 });

--- a/packages/markspec/core/model/profile.ts
+++ b/packages/markspec/core/model/profile.ts
@@ -112,6 +112,15 @@ export interface ProfileConvention {
 }
 
 // ---------------------------------------------------------------------------
+// Discipline kind declaration
+// ---------------------------------------------------------------------------
+
+/** A profile-declared discipline kind. */
+export interface KindDecl {
+  readonly description?: string;
+}
+
+// ---------------------------------------------------------------------------
 // Type definition
 // ---------------------------------------------------------------------------
 
@@ -129,6 +138,12 @@ export interface TypeDef {
   /** Optional semantic color-role name (key into `ProfileManifest.colors`). */
   readonly color?: string;
   readonly description?: string;
+  /**
+   * Discipline kind explicitly assigned to this type. When absent, the
+   * effective discipline registry auto-inherits from the type's `extends:`
+   * ancestor (see core/profile/discipline_registry.ts).
+   */
+  readonly discipline?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -192,6 +207,13 @@ export interface ProfileManifest {
     readonly types: readonly DocTypeDef[];
     readonly frontMatter: readonly AttrDecl[];
   };
+
+  /**
+   * Profile-declared discipline kinds (ADR-017 Invariant 2). Maps kind
+   * name → declaration metadata. Empty when the manifest does not declare
+   * `profile.kinds:`.
+   */
+  readonly kinds: ReadonlyMap<string, KindDecl>;
 
   /**
    * Prose-analysis configuration. All lexicon lists are additive across
@@ -282,6 +304,12 @@ export interface EffectiveTypeDef {
   readonly description: ProvenancedValue<string | undefined>;
   readonly attrDescriptions: ProvenancedMap<string>;
   readonly relationDescriptions: ProvenancedMap<string>;
+  /**
+   * Discipline kind explicitly assigned to this type by some tier of the
+   * profile chain. `value` is `undefined` when no tier assigned one — the
+   * registry builder then walks the `extends:` chain to resolve.
+   */
+  readonly discipline: ProvenancedValue<string | undefined>;
 }
 
 /**
@@ -299,6 +327,8 @@ export interface EffectiveProfile {
     readonly types: ProvenancedMap<DocTypeDef>;
     readonly frontMatter: ProvenancedMap<AttrDecl>;
   };
+  /** Discipline kinds declared across the profile chain (ADR-017). */
+  readonly kinds: ProvenancedMap<KindDecl>;
   /**
    * Prose-analysis configuration merged across the chain. Each lexicon list
    * is list-additive: parent entries first, child entries appended, duplicates

--- a/packages/markspec/core/profile/chain.ts
+++ b/packages/markspec/core/profile/chain.ts
@@ -275,6 +275,7 @@ function buildPlaceholderEffective(
     colors: new Map(),
     types: new Map(),
     documents: { types: new Map(), frontMatter: new Map() },
+    kinds: new Map(),
     prose: {
       lexicons: {
         "capitalized-allow": { value: [], origin: "" },

--- a/packages/markspec/core/profile/colors_test.ts
+++ b/packages/markspec/core/profile/colors_test.ts
@@ -52,6 +52,7 @@ function makeProfile(
         description: { value: undefined, origin: "test" },
         attrDescriptions: new Map(),
         relationDescriptions: new Map(),
+        discipline: { value: undefined, origin: "test" },
       },
       origin: "test",
     }]),
@@ -63,6 +64,7 @@ function makeProfile(
     colors: colorsMap,
     types: typesMap,
     documents: { types: new Map(), frontMatter: new Map() },
+    kinds: new Map(),
     prose: {
       lexicons: {
         "capitalized-allow": { value: [], origin: "" },

--- a/packages/markspec/core/profile/discipline_registry.ts
+++ b/packages/markspec/core/profile/discipline_registry.ts
@@ -1,0 +1,75 @@
+/**
+ * @module core/profile/discipline_registry
+ *
+ * Build an effective discipline registry from a merged
+ * {@linkcode EffectiveProfile}. Per ADR-017 Slice 2: the registry is
+ * the core seed plus every profile-declared type whose discipline
+ * resolves — either directly (an explicit `discipline:` field) or
+ * via auto-inheritance walking the `extends:` chain to a registered
+ * ancestor.
+ *
+ * The current manifest parser only allows profile-declared types to
+ * extend **core** types (see `parseTypeDef` in `manifest.ts`), so the
+ * inheritance walk is one step in practice. The implementation below
+ * loops defensively so future relaxation of that constraint doesn't
+ * silently break inheritance through profile-declared intermediates.
+ * Cycles are currently impossible because the parser rejects any
+ * `extends` value that is not a recognised core type (PROFILE-TYPE-002),
+ * guaranteeing the fixed-point loop terminates in exactly one pass
+ * today.
+ *
+ * @see docs/architecture/adr-017-discipline-classification.md (Invariant 2)
+ */
+
+import {
+  CORE_DISCIPLINE_REGISTRY,
+  type Discipline,
+  type DisciplineRegistry,
+  type EffectiveProfile,
+} from "../model/mod.ts";
+
+/**
+ * Build the effective discipline registry for a given (merged) profile.
+ * When `effective` is `null` (CLI run without a profile), the core seed
+ * is returned verbatim.
+ *
+ * Algorithm:
+ *   1. Start with a mutable copy of {@linkcode CORE_DISCIPLINE_REGISTRY}.
+ *   2. For each profile-declared type, resolve its discipline:
+ *      - Use the explicit `discipline.value` when present.
+ *      - Otherwise walk `extends:` one hop at a time, stopping at the
+ *        first ancestor that resolves (core registry or already-resolved
+ *        profile type).
+ *   3. Iterate until no new entries are added (handles arbitrary
+ *      declaration order). Bounded by the number of profile types, so
+ *      worst-case O(n²); n is small for realistic profiles.
+ */
+export function buildEffectiveDisciplineRegistry(
+  effective: EffectiveProfile | null,
+): DisciplineRegistry {
+  const out = new Map<string, Discipline>(CORE_DISCIPLINE_REGISTRY);
+  if (!effective) return out;
+
+  // Resolve in fixed-point fashion so order-of-declaration doesn't matter.
+  // Each pass attempts every unresolved type; if any type resolves, do
+  // another pass.
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const [typeName, entry] of effective.types) {
+      if (out.has(typeName)) continue;
+      const explicit = entry.value.discipline.value;
+      if (explicit !== undefined) {
+        out.set(typeName, explicit);
+        changed = true;
+        continue;
+      }
+      const inherited = out.get(entry.value.extends);
+      if (inherited !== undefined) {
+        out.set(typeName, inherited);
+        changed = true;
+      }
+    }
+  }
+  return out;
+}

--- a/packages/markspec/core/profile/discipline_registry_test.ts
+++ b/packages/markspec/core/profile/discipline_registry_test.ts
@@ -1,0 +1,117 @@
+// packages/markspec/core/profile/discipline_registry_test.ts
+
+import { assertEquals } from "@std/assert";
+import {
+  CORE_DISCIPLINE_REGISTRY,
+  type EffectiveTypeDef,
+} from "../model/mod.ts";
+import { buildEffectiveDisciplineRegistry } from "./discipline_registry.ts";
+
+// NOTE: no test exercises multi-pass fixed-point resolution because the
+// current manifest parser rejects `extends` values that aren't core
+// types (PROFILE-TYPE-002), so profile→profile inheritance chains are
+// unreachable. Add a multi-pass test if that constraint is ever relaxed.
+
+// deno-lint-ignore no-explicit-any
+function emptyEffective(): any {
+  return {
+    attributes: new Map(),
+    labels: new Map(),
+    conventions: new Map(),
+    colors: new Map(),
+    types: new Map(),
+    documents: { types: new Map(), frontMatter: new Map() },
+    kinds: new Map(),
+    prose: {
+      lexicons: {
+        "capitalized-allow": { value: [], origin: "" },
+        "sentence-abbrev": { value: [], origin: "" },
+      },
+    },
+  };
+}
+
+function typeEntry(
+  name: string,
+  extendsBase: string,
+  discipline: string | undefined,
+): EffectiveTypeDef {
+  return {
+    name,
+    extends: extendsBase,
+    displayIdPattern: { value: undefined, origin: "p" },
+    displayIdPatternEnforcement: { value: "off", origin: "p" },
+    color: { value: undefined, origin: "p" },
+    required: { value: [], origin: "p" },
+    attributes: new Map(),
+    traceability: new Map(),
+    description: { value: undefined, origin: "p" },
+    attrDescriptions: new Map(),
+    relationDescriptions: new Map(),
+    discipline: { value: discipline, origin: "p" },
+  };
+}
+
+Deno.test("registry: null effective profile → core seed unchanged", () => {
+  const reg = buildEffectiveDisciplineRegistry(null);
+  assertEquals(reg.get("SoftwareComponent"), "software");
+  assertEquals(reg.get("HardwareComponent"), "hardware");
+  // Same size as core seed; no extra entries.
+  assertEquals(reg.size, CORE_DISCIPLINE_REGISTRY.size);
+});
+
+Deno.test("registry: profile-declared type with explicit discipline", () => {
+  const ep = emptyEffective();
+  ep.types.set("SoftwareRequirement", {
+    value: typeEntry("SoftwareRequirement", "Requirement", "software"),
+    origin: "p",
+  });
+  const reg = buildEffectiveDisciplineRegistry(ep);
+  assertEquals(reg.get("SoftwareRequirement"), "software");
+});
+
+Deno.test("registry: profile-declared type auto-inherits from core ancestor", () => {
+  // FirmwareUnit extends SoftwareUnit, no explicit discipline → inherit 'software'.
+  const ep = emptyEffective();
+  ep.types.set("FirmwareUnit", {
+    value: typeEntry("FirmwareUnit", "SoftwareUnit", undefined),
+    origin: "p",
+  });
+  const reg = buildEffectiveDisciplineRegistry(ep);
+  assertEquals(reg.get("FirmwareUnit"), "software");
+});
+
+Deno.test("registry: explicit discipline overrides ancestor inheritance", () => {
+  const ep = emptyEffective();
+  ep.kinds.set("firmware", { value: {}, origin: "p" });
+  ep.types.set("EmbeddedFirmwareUnit", {
+    value: typeEntry("EmbeddedFirmwareUnit", "SoftwareUnit", "firmware"),
+    origin: "p",
+  });
+  const reg = buildEffectiveDisciplineRegistry(ep);
+  assertEquals(reg.get("EmbeddedFirmwareUnit"), "firmware");
+});
+
+Deno.test("registry: type with no ancestor in registry is skipped", () => {
+  const ep = emptyEffective();
+  ep.types.set("LooseType", {
+    value: typeEntry("LooseType", "Requirement", undefined),
+    origin: "p",
+  });
+  const reg = buildEffectiveDisciplineRegistry(ep);
+  // Requirement is not discipline-bearing; LooseType inherits nothing.
+  assertEquals(reg.has("LooseType"), false);
+});
+
+Deno.test("registry: core entries are preserved", () => {
+  const ep = emptyEffective();
+  ep.types.set("MyType", {
+    value: typeEntry("MyType", "Requirement", "system"),
+    origin: "p",
+  });
+  const reg = buildEffectiveDisciplineRegistry(ep);
+  // Core SW/HW Component/Interface/Unit subtypes still in registry.
+  assertEquals(reg.get("SoftwareComponent"), "software");
+  assertEquals(reg.get("HardwareInterface"), "hardware");
+  assertEquals(reg.get("MyType"), "system");
+});

--- a/packages/markspec/core/profile/manifest.ts
+++ b/packages/markspec/core/profile/manifest.ts
@@ -12,13 +12,16 @@ import {
   type AttrDecl,
   type Cardinality,
   COLOR_NAME_RE,
+  CORE_KINDS,
   CORE_TYPES,
   type DocTypeDef,
   type EnforcementMode,
+  type KindDecl,
   type LabelConcern,
   type LabelConcernKind,
   type LabelValue,
   LIST_VALUE_TYPES,
+  MIXED_DISCIPLINE,
   PALETTE_HUES,
   type ProfileConvention,
   type ProfileSpecifier,
@@ -48,6 +51,7 @@ const ALLOWED_PROFILE_KEYS = new Set([
   "conventions",
   "types",
   "documents",
+  "kinds",
   "prose",
 ]);
 
@@ -60,6 +64,7 @@ const ALLOWED_TYPE_KEYS = new Set([
   "attributes",
   "traceability",
   "color",
+  "discipline",
 ]);
 
 const ALLOWED_DOC_TYPE_KEYS = new Set(["id", "contains", "description"]);
@@ -617,6 +622,104 @@ function parseColorsMap(
   return out;
 }
 
+/**
+ * Parse the `profile.kinds:` block. Each key must match COLOR_NAME_RE
+ * (the same lexical rule used for color names — lowercase letters,
+ * digits, hyphens, starting with a letter). Values may be:
+ *   - `null` / `undefined` — declare the kind with no description.
+ *   - a bare string — treated as the description shorthand.
+ *   - a mapping with optional `description:`.
+ *
+ * Validation:
+ *   - PROFILE-DISCIPLINE-001 (error): name fails the regex.
+ *   - PROFILE-DISCIPLINE-002 (error): name is the reserved sentinel
+ *     `MIXED_DISCIPLINE` ("mixed").
+ *   - PROFILE-DISCIPLINE-003 (warning): name shadows a core kind
+ *     (`system`/`software`/`hardware`).
+ */
+function parseKindsMap(
+  raw: unknown,
+  sourcePath: string,
+  diagnostics: Diagnostic[],
+): Map<string, KindDecl> {
+  const out = new Map<string, KindDecl>();
+  if (raw === undefined) return out;
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+    diagnostics.push({
+      code: "PROFILE-LOAD-003",
+      severity: "error",
+      message: "profile.kinds: must be a mapping",
+      location: { file: sourcePath, line: 1, column: 1 },
+    });
+    return out;
+  }
+  for (
+    const [name, value] of Object.entries(raw as Record<string, unknown>)
+  ) {
+    if (name === MIXED_DISCIPLINE) {
+      diagnostics.push({
+        code: "PROFILE-DISCIPLINE-002",
+        severity: "error",
+        message:
+          `profile.kinds: '${name}' is a reserved sentinel name; choose a different kind name`,
+        location: { file: sourcePath, line: 1, column: 1 },
+      });
+      continue;
+    }
+    if (!COLOR_NAME_RE.test(name)) {
+      diagnostics.push({
+        code: "PROFILE-DISCIPLINE-001",
+        severity: "error",
+        message:
+          `profile.kinds: '${name}' is not a valid kind name (lowercase letters, digits, hyphens; must start with a letter)`,
+        location: { file: sourcePath, line: 1, column: 1 },
+      });
+      continue;
+    }
+    if (CORE_KINDS.has(name)) {
+      diagnostics.push({
+        code: "PROFILE-DISCIPLINE-003",
+        severity: "warning",
+        message:
+          `profile.kinds: '${name}' redeclares a core kind (already shipped by markspec core); the declaration is idempotent and will be ignored`,
+        location: { file: sourcePath, line: 1, column: 1 },
+      });
+      continue;
+    }
+    let description: string | undefined;
+    if (value === null || value === undefined) {
+      // declaration only
+    } else if (typeof value === "string") {
+      description = value;
+    } else if (typeof value === "object" && !Array.isArray(value)) {
+      const r = value as Record<string, unknown>;
+      if (r.description !== undefined && typeof r.description !== "string") {
+        diagnostics.push({
+          code: "PROFILE-LOAD-003",
+          severity: "error",
+          message: `profile.kinds.${name}: 'description' must be a string`,
+          location: { file: sourcePath, line: 1, column: 1 },
+        });
+        continue;
+      }
+      description = typeof r.description === "string"
+        ? r.description
+        : undefined;
+    } else {
+      diagnostics.push({
+        code: "PROFILE-LOAD-003",
+        severity: "error",
+        message:
+          `profile.kinds.${name}: value must be null, a string, or a mapping with 'description'`,
+        location: { file: sourcePath, line: 1, column: 1 },
+      });
+      continue;
+    }
+    out.set(name, description !== undefined ? { description } : {});
+  }
+  return out;
+}
+
 const KNOWN_CONVENTIONS = new Set(["modal-keywords"]);
 const MODAL_KEYWORDS_CASING_VALUES = new Set(["rfc2119", "iso", "preserve"]);
 
@@ -995,6 +1098,21 @@ function parseTypeDef(
     color = r.color;
   }
 
+  // PROFILE-DISCIPLINE-005 (error): value is not a non-empty string.
+  let discipline: string | undefined;
+  if (r.discipline !== undefined) {
+    if (typeof r.discipline !== "string" || r.discipline.length === 0) {
+      diagnostics.push({
+        code: "PROFILE-DISCIPLINE-005",
+        severity: "error",
+        message: `${ctx}: 'discipline' must be a non-empty string`,
+        location: { file: sourcePath, line: 1, column: 1 },
+      });
+      return undefined;
+    }
+    discipline = r.discipline;
+  }
+
   const description = typeof r.description === "string"
     ? r.description
     : undefined;
@@ -1028,6 +1146,7 @@ function parseTypeDef(
     traceability,
     color,
     description,
+    discipline,
   };
 }
 
@@ -1281,6 +1400,11 @@ export function parseManifest(
     sourcePath,
     diagnostics,
   );
+  const kinds = parseKindsMap(
+    profileSection.kinds,
+    sourcePath,
+    diagnostics,
+  );
   const conventions = parseConventions(
     profileSection.conventions,
     sourcePath,
@@ -1337,6 +1461,7 @@ export function parseManifest(
     colors,
     types: types,
     documents: documents,
+    kinds,
     prose,
   };
 

--- a/packages/markspec/core/profile/manifest_test.ts
+++ b/packages/markspec/core/profile/manifest_test.ts
@@ -1076,3 +1076,177 @@ profile:
     true,
   );
 });
+
+Deno.test("manifest: parses kinds: mapping with mixed forms", () => {
+  const yaml = `id: t
+version: "0"
+markspec-schema: "1"
+profile:
+  kinds:
+    firmware:
+      description: Embedded firmware modules
+    mechanical: "Mechanical components"
+    avionics:
+`;
+  const { manifest, diagnostics } = parseManifest(yaml);
+  assertEquals(diagnostics.filter((d) => d.severity === "error").length, 0);
+  assertEquals(manifest?.kinds.size, 3);
+  assertEquals(
+    manifest?.kinds.get("firmware")?.description,
+    "Embedded firmware modules",
+  );
+  assertEquals(
+    manifest?.kinds.get("mechanical")?.description,
+    "Mechanical components",
+  );
+  assertEquals(manifest?.kinds.get("avionics")?.description, undefined);
+});
+
+Deno.test("manifest: PROFILE-DISCIPLINE-001 on invalid kind-name format", () => {
+  const yaml = `id: t
+version: "0"
+markspec-schema: "1"
+profile:
+  kinds:
+    BadName:
+      description: starts with uppercase
+`;
+  const { manifest, diagnostics } = parseManifest(yaml);
+  assertEquals(manifest, null);
+  assertEquals(
+    diagnostics.some((d) => d.code === "PROFILE-DISCIPLINE-001"),
+    true,
+  );
+});
+
+Deno.test("manifest: PROFILE-DISCIPLINE-002 on reserved 'mixed' kind name", () => {
+  const yaml = `id: t
+version: "0"
+markspec-schema: "1"
+profile:
+  kinds:
+    mixed:
+      description: should be rejected
+`;
+  const { manifest, diagnostics } = parseManifest(yaml);
+  assertEquals(manifest, null);
+  assertEquals(
+    diagnostics.some((d) => d.code === "PROFILE-DISCIPLINE-002"),
+    true,
+  );
+});
+
+Deno.test("manifest: PROFILE-DISCIPLINE-003 warning on redeclaring a core kind", () => {
+  const yaml = `id: t
+version: "0"
+markspec-schema: "1"
+profile:
+  kinds:
+    software:
+      description: redundant
+`;
+  const { manifest, diagnostics } = parseManifest(yaml);
+  // Warning, not error — manifest still parses.
+  assertEquals(manifest !== null, true);
+  const warns = diagnostics.filter((d) => d.code === "PROFILE-DISCIPLINE-003");
+  assertEquals(warns.length, 1);
+  assertEquals(warns[0].severity, "warning");
+  // Suppression behaviour: the redeclared core kind must NOT appear in the manifest's map.
+  assertEquals(manifest?.kinds.size, 0);
+});
+
+Deno.test("manifest: kinds block can be absent (default to empty map)", () => {
+  const yaml = `id: t
+version: "0"
+markspec-schema: "1"
+profile: {}
+`;
+  const { manifest, diagnostics } = parseManifest(yaml);
+  assertEquals(diagnostics.filter((d) => d.severity === "error").length, 0);
+  assertEquals(manifest?.kinds.size, 0);
+});
+
+Deno.test("manifest: PROFILE-LOAD-003 when kinds: is not a mapping", () => {
+  const yaml = `id: t
+version: "0"
+markspec-schema: "1"
+profile:
+  kinds: not-a-map
+`;
+  const { manifest, diagnostics } = parseManifest(yaml);
+  assertEquals(manifest, null);
+  assertEquals(
+    diagnostics.some((d) =>
+      d.code === "PROFILE-LOAD-003" &&
+      d.message.includes("profile.kinds")
+    ),
+    true,
+  );
+});
+
+Deno.test("manifest: parses per-type discipline: as a string", () => {
+  const yaml = `id: t
+version: "0"
+markspec-schema: "1"
+profile:
+  types:
+    SoftwareRequirement:
+      extends: Requirement
+      discipline: software
+`;
+  const { manifest, diagnostics } = parseManifest(yaml);
+  assertEquals(diagnostics.filter((d) => d.severity === "error").length, 0);
+  const td = manifest?.types.get("SoftwareRequirement");
+  assertEquals(td?.discipline, "software");
+});
+
+Deno.test("manifest: PROFILE-DISCIPLINE-005 when discipline: is not a string", () => {
+  const yaml = `id: t
+version: "0"
+markspec-schema: "1"
+profile:
+  types:
+    BadType:
+      extends: Requirement
+      discipline: 42
+`;
+  const { manifest, diagnostics } = parseManifest(yaml);
+  assertEquals(manifest, null);
+  assertEquals(
+    diagnostics.some((d) => d.code === "PROFILE-DISCIPLINE-005"),
+    true,
+  );
+});
+
+Deno.test("manifest: PROFILE-DISCIPLINE-005 when discipline: is an empty string", () => {
+  const yaml = `id: t
+version: "0"
+markspec-schema: "1"
+profile:
+  types:
+    BadType:
+      extends: Requirement
+      discipline: ""
+`;
+  const { manifest, diagnostics } = parseManifest(yaml);
+  assertEquals(manifest, null);
+  assertEquals(
+    diagnostics.some((d) => d.code === "PROFILE-DISCIPLINE-005"),
+    true,
+  );
+});
+
+Deno.test("manifest: discipline: is optional on a type", () => {
+  const yaml = `id: t
+version: "0"
+markspec-schema: "1"
+profile:
+  types:
+    SomeType:
+      extends: Requirement
+`;
+  const { manifest, diagnostics } = parseManifest(yaml);
+  assertEquals(diagnostics.filter((d) => d.severity === "error").length, 0);
+  const td = manifest?.types.get("SomeType");
+  assertEquals(td?.discipline, undefined);
+});

--- a/packages/markspec/core/profile/merge.ts
+++ b/packages/markspec/core/profile/merge.ts
@@ -8,12 +8,14 @@
  * Merge happens once at load. Callers should not call `mergeChain` lazily.
  */
 
+import { CORE_KINDS } from "../model/mod.ts";
 import type {
   AttrDecl,
   Diagnostic,
   DocTypeDef,
   EffectiveProfile,
   EffectiveTypeDef,
+  KindDecl,
   LabelConcern,
   LoadedProfile,
   ProfileChain,
@@ -82,6 +84,11 @@ export function mergeChain(chain: ProfileChain): MergeResult {
     diagnostics,
     tiers[tiers.length - 1].sourcePath,
   );
+  validateTypeDisciplines(
+    effective,
+    diagnostics,
+    tiers[tiers.length - 1].sourcePath,
+  );
 
   // If any merge error was recorded, drop the effective profile.
   const hasError = diagnostics.some((d) => d.severity === "error");
@@ -120,6 +127,9 @@ function foldTier(
   // Colors map: last-write-wins per key, additive across tiers.
   const colors = unionColorsMap(base.colors, m.colors, origin);
 
+  // Kinds map: additive across tiers, child wins on description.
+  const kinds = unionKindsMap(base.kinds, m.kinds, origin);
+
   // Types — add new types, fold existing ones.
   const types = new Map(base.types);
   for (const [name, td] of m.types) {
@@ -141,6 +151,7 @@ function foldTier(
         description: { value: td.description, origin },
         attrDescriptions: mapFromAttrDescriptions(td.attributes, origin),
         relationDescriptions: mapFromTraceDescriptions(td.traceability, origin),
+        discipline: { value: td.discipline, origin },
       };
       types.set(name, { value: eff, origin });
     } else {
@@ -194,6 +205,7 @@ function foldTier(
       types: docTypes,
       frontMatter,
     },
+    kinds,
     prose: {
       lexicons: {
         "capitalized-allow": capAllow,
@@ -257,6 +269,33 @@ function validateTypeColors(
         location: { file: fallbackFile, line: 1, column: 1 },
       });
     }
+  }
+}
+
+/**
+ * After the full chain folds, verify each type's `discipline.value` (when
+ * set) names a kind that is in the merged `effective.kinds` map ∪
+ * CORE_KINDS. Emits PROFILE-DISCIPLINE-004 for each violation. Runs after
+ * the merge because a parent tier's kind must be visible to a child
+ * tier's type.
+ */
+function validateTypeDisciplines(
+  effective: EffectiveProfile,
+  diagnostics: Diagnostic[],
+  fallbackFile: string,
+): void {
+  for (const [typeName, entry] of effective.types) {
+    const value = entry.value.discipline.value;
+    if (value === undefined) continue;
+    if (CORE_KINDS.has(value)) continue;
+    if (effective.kinds.has(value)) continue;
+    diagnostics.push({
+      code: "PROFILE-DISCIPLINE-004",
+      severity: "error",
+      message:
+        `type '${typeName}' references unknown discipline kind '${value}' (declare it under profile.kinds: in this profile or a parent)`,
+      location: { file: fallbackFile, line: 1, column: 1 },
+    });
   }
 }
 
@@ -513,6 +552,12 @@ function tightenType(
       ? { value: child.description, origin: childOrigin }
       : effExisting.description;
 
+  // Discipline: child wins when set; otherwise parent stays.
+  const discipline: ProvenancedValue<string | undefined> =
+    child.discipline !== undefined
+      ? { value: child.discipline, origin: childOrigin }
+      : effExisting.discipline;
+
   const attrDescriptions = mergeDescriptionMap(
     effExisting.attrDescriptions,
     child.attributes.map((a) => ({ name: a.name, desc: a.description })),
@@ -540,6 +585,7 @@ function tightenType(
     description,
     attrDescriptions,
     relationDescriptions,
+    discipline,
   };
   const overrides = [
     ...(existing.overrides ?? []),
@@ -717,6 +763,7 @@ function seedFromTier(tier: LoadedProfile): EffectiveProfile {
       types: mapFromDocTypes(m.documents.types, origin),
       frontMatter: mapFromAttrList(m.documents.frontMatter, origin),
     },
+    kinds: mapFromKinds(m.kinds, origin),
     prose: {
       lexicons: {
         "capitalized-allow": {
@@ -739,6 +786,40 @@ function mapFromColors(
   const out = new Map<string, ProvenancedMapEntry<string>>();
   for (const [name, hue] of colors) {
     out.set(name, { value: hue, origin });
+  }
+  return out;
+}
+
+/**
+ * Union of `kinds:` maps across tiers. Additive: every tier's kinds are
+ * carried. When two tiers declare the same kind, the child wins on
+ * description and `overrides` records the displaced parent.
+ */
+function unionKindsMap(
+  parent: ProvenancedMap<KindDecl>,
+  childKinds: ReadonlyMap<string, KindDecl>,
+  childOrigin: ProfileId,
+): ProvenancedMap<KindDecl> {
+  if (childKinds.size === 0) return parent;
+  const out = new Map(parent);
+  for (const [name, kd] of childKinds) {
+    const prior = out.get(name);
+    out.set(name, {
+      value: kd,
+      origin: childOrigin,
+      overrides: prior ? [...(prior.overrides ?? []), prior.origin] : undefined,
+    });
+  }
+  return out;
+}
+
+function mapFromKinds(
+  kinds: ReadonlyMap<string, KindDecl>,
+  origin: ProfileId,
+): ProvenancedMap<KindDecl> {
+  const out = new Map<string, ProvenancedMapEntry<KindDecl>>();
+  for (const [name, kd] of kinds) {
+    out.set(name, { value: kd, origin });
   }
   return out;
 }
@@ -922,6 +1003,7 @@ function mapFromTypes(
       description: { value: td.description, origin },
       attrDescriptions: mapFromAttrDescriptions(td.attributes, origin),
       relationDescriptions: mapFromTraceDescriptions(td.traceability, origin),
+      discipline: { value: td.discipline, origin },
     };
     out.set(name, { value: eff, origin });
   }

--- a/packages/markspec/core/profile/merge_test.ts
+++ b/packages/markspec/core/profile/merge_test.ts
@@ -38,6 +38,7 @@ function singleTierChain(yaml: string): ProfileChain {
       colors: new Map(),
       types: new Map(),
       documents: { types: new Map(), frontMatter: new Map() },
+      kinds: new Map(),
       prose: {
         lexicons: {
           "capitalized-allow": { value: [], origin: "" },
@@ -142,6 +143,7 @@ function multiTierChain(yamls: readonly string[]): ProfileChain {
       colors: new Map(),
       types: new Map(),
       documents: { types: new Map(), frontMatter: new Map() },
+      kinds: new Map(),
       prose: {
         lexicons: {
           "capitalized-allow": { value: [], origin: "" },
@@ -1193,4 +1195,221 @@ version: 1.0.0
   const eff = result.effective!;
   assertEquals(eff.prose.lexicons["capitalized-allow"].value, []);
   assertEquals(eff.prose.lexicons["sentence-abbrev"].value, []);
+});
+
+Deno.test("merge: kinds from a single tier are seeded with provenance", () => {
+  const chain = singleTierChain(`id: p1
+version: "0"
+markspec-schema: "1"
+profile:
+  kinds:
+    firmware:
+      description: Embedded firmware
+`);
+  const { effective, diagnostics } = mergeChain(chain);
+  assertEquals(diagnostics.filter((d) => d.severity === "error").length, 0);
+  const fw = effective!.kinds.get("firmware");
+  assertEquals(fw?.value.description, "Embedded firmware");
+  assertEquals(fw?.origin, "p1");
+});
+
+Deno.test("merge: kinds union across tiers; child wins on description (provenance preserved)", () => {
+  const chain = multiTierChain([
+    `id: p1
+version: "0"
+markspec-schema: "1"
+profile:
+  kinds:
+    firmware:
+      description: from parent
+`,
+    `id: p2
+version: "0"
+markspec-schema: "1"
+profile:
+  kinds:
+    firmware:
+      description: from child
+    mechanical:
+      description: child only
+`,
+  ]);
+  const { effective } = mergeChain(chain);
+  const fw = effective!.kinds.get("firmware");
+  assertEquals(fw?.value.description, "from child");
+  assertEquals(fw?.origin, "p2");
+  // `overrides` records the parent that lost the description battle.
+  assertEquals(fw?.overrides, ["p1"]);
+  const mech = effective!.kinds.get("mechanical");
+  assertEquals(mech?.origin, "p2");
+  // `mech` is an additive-only kind (no parent); no overrides chain.
+  assertEquals(mech?.overrides, undefined);
+});
+
+Deno.test("merge: per-type discipline is seeded from a single tier", () => {
+  const chain = singleTierChain(`id: p1
+version: "0"
+markspec-schema: "1"
+profile:
+  types:
+    SoftwareRequirement:
+      extends: Requirement
+      discipline: software
+`);
+  const { effective } = mergeChain(chain);
+  const td = effective?.types.get("SoftwareRequirement")?.value;
+  assertEquals(td?.discipline.value, "software");
+  assertEquals(td?.discipline.origin, "p1");
+});
+
+Deno.test("merge: child tier reassigning a type's discipline wins (LWW with provenance)", () => {
+  const chain = multiTierChain([
+    `id: p1
+version: "0"
+markspec-schema: "1"
+profile:
+  types:
+    MyType:
+      extends: Requirement
+      discipline: software
+`,
+    `id: p2
+version: "0"
+markspec-schema: "1"
+profile:
+  types:
+    MyType:
+      extends: Requirement
+      discipline: hardware
+`,
+  ]);
+  const { effective } = mergeChain(chain);
+  const td = effective?.types.get("MyType")?.value;
+  assertEquals(td?.discipline.value, "hardware");
+  assertEquals(td?.discipline.origin, "p2");
+});
+
+Deno.test("merge: child adds discipline where parent had none", () => {
+  const chain = multiTierChain([
+    `id: p1
+version: "0"
+markspec-schema: "1"
+profile:
+  types:
+    MyType:
+      extends: Requirement
+`,
+    `id: p2
+version: "0"
+markspec-schema: "1"
+profile:
+  types:
+    MyType:
+      extends: Requirement
+      discipline: software
+`,
+  ]);
+  const { effective } = mergeChain(chain);
+  const td = effective?.types.get("MyType")?.value;
+  assertEquals(td?.discipline.value, "software");
+  assertEquals(td?.discipline.origin, "p2");
+});
+
+Deno.test("merge: parent's discipline is preserved when child omits it", () => {
+  const chain = multiTierChain([
+    `id: p1
+version: "0"
+markspec-schema: "1"
+profile:
+  types:
+    MyType:
+      extends: Requirement
+      discipline: software
+`,
+    `id: p2
+version: "0"
+markspec-schema: "1"
+profile:
+  types:
+    MyType:
+      extends: Requirement
+      # no discipline — parent's value should survive
+`,
+  ]);
+  const { effective } = mergeChain(chain);
+  const td = effective?.types.get("MyType")?.value;
+  assertEquals(td?.discipline.value, "software");
+  assertEquals(td?.discipline.origin, "p1");
+});
+
+Deno.test("merge: PROFILE-DISCIPLINE-004 when discipline references unknown kind", () => {
+  const chain = singleTierChain(`id: p1
+version: "0"
+markspec-schema: "1"
+profile:
+  types:
+    BadType:
+      extends: Requirement
+      discipline: nonsense
+`);
+  const { effective, diagnostics } = mergeChain(chain);
+  assertEquals(effective, null);
+  const d = diagnostics.find((d) => d.code === "PROFILE-DISCIPLINE-004");
+  assertEquals(d?.severity, "error");
+  assertEquals(d?.message.includes("nonsense"), true);
+  assertEquals(d?.message.includes("BadType"), true);
+});
+
+Deno.test("merge: PROFILE-DISCIPLINE-004 accepts profile-declared kinds", () => {
+  // Parent declares the kind; child references it. Order matters because
+  // validation runs after the full chain folds.
+  const chain = multiTierChain([
+    `id: p1
+version: "0"
+markspec-schema: "1"
+profile:
+  kinds:
+    firmware:
+      description: embedded
+`,
+    `id: p2
+version: "0"
+markspec-schema: "1"
+profile:
+  types:
+    MyType:
+      extends: Requirement
+      discipline: firmware
+`,
+  ]);
+  const { effective, diagnostics } = mergeChain(chain);
+  assertEquals(
+    diagnostics.filter((d) => d.code === "PROFILE-DISCIPLINE-004").length,
+    0,
+  );
+  assertEquals(
+    effective?.types.get("MyType")?.value.discipline.value,
+    "firmware",
+  );
+});
+
+Deno.test("merge: PROFILE-DISCIPLINE-004 accepts core kinds (software/hardware/system)", () => {
+  const chain = singleTierChain(`id: p1
+version: "0"
+markspec-schema: "1"
+profile:
+  types:
+    MyType:
+      extends: Requirement
+      discipline: software
+`);
+  const { effective, diagnostics } = mergeChain(chain);
+  assertEquals(
+    diagnostics.filter((d) => d.code === "PROFILE-DISCIPLINE-004").length,
+    0,
+  );
+  assertEquals(
+    effective?.types.get("MyType")?.value.discipline.value,
+    "software",
+  );
 });

--- a/packages/markspec/core/profile/mod.ts
+++ b/packages/markspec/core/profile/mod.ts
@@ -42,6 +42,8 @@ export type { MergeResult } from "./merge.ts";
 
 export { resolveEntryColor } from "./colors.ts";
 
+export { buildEffectiveDisciplineRegistry } from "./discipline_registry.ts";
+
 export { buildProfileIntrospection } from "./introspect.ts";
 export type {
   AttributeDetail,

--- a/packages/markspec/core/validator/attributes_test.ts
+++ b/packages/markspec/core/validator/attributes_test.ts
@@ -45,6 +45,7 @@ function typeDef(opts: {
       description: { value: undefined, origin: ORIGIN },
       attrDescriptions: new Map(),
       relationDescriptions: new Map(),
+      discipline: { value: undefined, origin: ORIGIN },
     },
   };
 }
@@ -62,6 +63,7 @@ function profile(opts: {
     conventions: new Map(),
     types: typesMap,
     documents: { types: new Map(), frontMatter: new Map() },
+    kinds: new Map(),
     prose: {
       lexicons: {
         "capitalized-allow": { value: [], origin: "" },
@@ -461,10 +463,12 @@ Deno.test("effectiveScope: trace rule without explicit attribute declaration syn
           description: { value: undefined, origin },
           attrDescriptions: new Map(),
           relationDescriptions: new Map(),
+          discipline: { value: undefined, origin },
         },
       }],
     ]),
     documents: { types: new Map(), frontMatter: new Map() },
+    kinds: new Map(),
     prose: {
       lexicons: {
         "capitalized-allow": { value: [], origin: "" },
@@ -521,10 +525,12 @@ Deno.test("effectiveScope: explicit attribute declaration wins over trace-rule s
           description: { value: undefined, origin },
           attrDescriptions: new Map(),
           relationDescriptions: new Map(),
+          discipline: { value: undefined, origin },
         },
       }],
     ]),
     documents: { types: new Map(), frontMatter: new Map() },
+    kinds: new Map(),
     prose: {
       lexicons: {
         "capitalized-allow": { value: [], origin: "" },

--- a/packages/markspec/core/validator/normalize_test.ts
+++ b/packages/markspec/core/validator/normalize_test.ts
@@ -35,6 +35,7 @@ function profile(opts: {
     conventions: new Map(),
     types: new Map(),
     documents: { types: new Map(), frontMatter: new Map() },
+    kinds: new Map(),
     prose: {
       lexicons: {
         "capitalized-allow": { value: [], origin: "" },
@@ -215,11 +216,13 @@ Deno.test("normalizeListValues: type-scope declarations are considered", () => {
           description: { value: undefined, origin },
           attrDescriptions: new Map(),
           relationDescriptions: new Map(),
+          discipline: { value: undefined, origin },
         },
         origin,
       }],
     ]),
     documents: { types: new Map(), frontMatter: new Map() },
+    kinds: new Map(),
     prose: {
       lexicons: {
         "capitalized-allow": { value: [], origin: "" },

--- a/packages/markspec/core/validator/pipeline_test.ts
+++ b/packages/markspec/core/validator/pipeline_test.ts
@@ -57,6 +57,7 @@ function buildProfileWithRequirement(): EffectiveProfile {
       description: { value: undefined, origin },
       attrDescriptions: new Map(),
       relationDescriptions: new Map(),
+      discipline: { value: undefined, origin },
     },
     origin,
   };
@@ -67,6 +68,7 @@ function buildProfileWithRequirement(): EffectiveProfile {
     colors: new Map(),
     types: new Map([["requirement", reqType]]),
     documents: { types: new Map(), frontMatter: new Map() },
+    kinds: new Map(),
     prose: {
       lexicons: {
         "capitalized-allow": { value: [], origin: "" },
@@ -163,6 +165,7 @@ Deno.test("runPipeline: Stage 3 checks attributes of classified entries", () => 
       description: { value: undefined, origin },
       attrDescriptions: new Map(),
       relationDescriptions: new Map(),
+      discipline: { value: undefined, origin },
     },
   };
   const profile: EffectiveProfile = {
@@ -172,6 +175,7 @@ Deno.test("runPipeline: Stage 3 checks attributes of classified entries", () => 
     colors: new Map(),
     types: new Map([["requirement", reqType]]),
     documents: { types: new Map(), frontMatter: new Map() },
+    kinds: new Map(),
     prose: {
       lexicons: {
         "capitalized-allow": { value: [], origin: "" },
@@ -223,6 +227,7 @@ Deno.test("runPipeline: MSL-R010 suppressed for profile-declared attributes", ()
     colors: new Map(),
     types: new Map(),
     documents: { types: new Map(), frontMatter: new Map() },
+    kinds: new Map(),
     prose: {
       lexicons: {
         "capitalized-allow": { value: [], origin: "" },
@@ -267,6 +272,7 @@ Deno.test("runPipeline: profile with zero types runs Stage 2 permissively", () =
     colors: new Map(),
     types: new Map(),
     documents: { types: new Map(), frontMatter: new Map() },
+    kinds: new Map(),
     prose: {
       lexicons: {
         "capitalized-allow": { value: [], origin: "" },
@@ -306,6 +312,7 @@ Deno.test("runPipeline: Stage 4 catches required link missing", () => {
       description: { value: undefined, origin },
       attrDescriptions: new Map(),
       relationDescriptions: new Map(),
+      discipline: { value: undefined, origin },
     },
   };
   const profile: EffectiveProfile = {
@@ -315,6 +322,7 @@ Deno.test("runPipeline: Stage 4 catches required link missing", () => {
     colors: new Map(),
     types: new Map([["test", reqType]]),
     documents: { types: new Map(), frontMatter: new Map() },
+    kinds: new Map(),
     prose: {
       lexicons: {
         "capitalized-allow": { value: [], origin: "" },
@@ -367,6 +375,7 @@ Deno.test("runPipeline: Stage 2.5 normalization splits comma-separated id-list v
     colors: new Map(),
     types: new Map(),
     documents: { types: new Map(), frontMatter: new Map() },
+    kinds: new Map(),
     prose: {
       lexicons: {
         "capitalized-allow": { value: [], origin: "" },

--- a/packages/markspec/core/validator/traceability_test.ts
+++ b/packages/markspec/core/validator/traceability_test.ts
@@ -50,6 +50,7 @@ function typeDef(opts: {
       description: { value: undefined, origin: ORIGIN },
       attrDescriptions: new Map(),
       relationDescriptions: new Map(),
+      discipline: { value: undefined, origin: ORIGIN },
     },
   };
 }
@@ -66,6 +67,7 @@ function profile(opts: {
     conventions: new Map(),
     types: typesMap,
     documents: { types: new Map(), frontMatter: new Map() },
+    kinds: new Map(),
     prose: {
       lexicons: {
         "capitalized-allow": { value: [], origin: "" },

--- a/packages/markspec/core/validator/type_resolution_test.ts
+++ b/packages/markspec/core/validator/type_resolution_test.ts
@@ -284,6 +284,7 @@ Deno.test("resolvedCoreType: profile type resolves to its core parent via extend
       description: { value: undefined, origin },
       attrDescriptions: new Map(),
       relationDescriptions: new Map(),
+      discipline: { value: undefined, origin },
     },
     origin,
   };
@@ -294,6 +295,7 @@ Deno.test("resolvedCoreType: profile type resolves to its core parent via extend
     colors: new Map(),
     types: new Map([["system-requirement", sysReq]]),
     documents: { types: new Map(), frontMatter: new Map() },
+    kinds: new Map(),
     prose: {
       lexicons: {
         "capitalized-allow": { value: [], origin: "" },

--- a/packages/markspec/core/validator/types_test.ts
+++ b/packages/markspec/core/validator/types_test.ts
@@ -61,6 +61,7 @@ function buildType(opts: {
       description: { value: undefined, origin },
       attrDescriptions: new Map(),
       relationDescriptions: new Map(),
+      discipline: { value: undefined, origin },
     },
     origin,
   };
@@ -78,6 +79,7 @@ function buildProfile(
     conventions: new Map(),
     types: typesMap,
     documents: { types: new Map(), frontMatter: new Map() },
+    kinds: new Map(),
     prose: {
       lexicons: {
         "capitalized-allow": { value: [], origin: "" },

--- a/packages/markspec/lsp/workspace_test.ts
+++ b/packages/markspec/lsp/workspace_test.ts
@@ -243,6 +243,7 @@ Deno.test("WorkspaceIndex: validateAll suppresses MSL-R010 for profile-declared 
     colors: new Map(),
     types: new Map(),
     documents: { types: new Map(), frontMatter: new Map() },
+    kinds: new Map(),
     prose: {
       lexicons: {
         "capitalized-allow": { value: [], origin: "" },

--- a/tests/e2e/discipline_profile_extension_test.ts
+++ b/tests/e2e/discipline_profile_extension_test.ts
@@ -1,0 +1,162 @@
+/**
+ * @module tests/e2e/discipline_profile_extension_test
+ *
+ * E2E tests for profile extension of the discipline registry (ADR-017 Slice 2).
+ */
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { markspec } from "./helpers.ts";
+
+const TIERED_PROFILE = {
+  files: {
+    "project.yaml": `name: tiered-test\nversion: 0.1.0\n`,
+    ".markspec.yaml": `profiles:\n  - ./profiles/tiered\n`,
+    "profiles/tiered/markspec.yaml": `id: tiered
+version: 0.0.1
+markspec-schema: "1"
+profile:
+  types:
+    SoftwareRequirement:
+      extends: Requirement
+      display-id-pattern: "SWR_{NNNN}"
+      discipline: software
+    HardwareRequirement:
+      extends: Requirement
+      display-id-pattern: "HWR_{NNNN}"
+      discipline: hardware
+`,
+    "requirements.md": `# Requirements
+
+- [SWR_0001] Brake controller debounces pedal input
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      Type: SoftwareRequirement
+
+- [HWR_0001] Brake actuator delivers force within 12kN
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEG
+      Type: HardwareRequirement
+`,
+  },
+};
+
+const FIRMWARE_PROFILE = {
+  files: {
+    "project.yaml": `name: firmware-test\nversion: 0.1.0\n`,
+    ".markspec.yaml": `profiles:\n  - ./profiles/firmware\n`,
+    "profiles/firmware/markspec.yaml": `id: firmware-test
+version: 0.0.1
+markspec-schema: "1"
+profile:
+  kinds:
+    firmware:
+      description: Embedded firmware modules
+  types:
+    FirmwareUnit:
+      extends: SoftwareUnit
+      display-id-pattern: "FWU_{NNNN}"
+      discipline: firmware
+    InheritedSwUnit:
+      extends: SoftwareUnit
+      display-id-pattern: "INH_{NNNN}"
+      # no discipline — auto-inherits 'software' from SoftwareUnit
+`,
+    "units.md": `# Units
+
+- [FWU_0001] Bootloader firmware
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEH
+      Type: FirmwareUnit
+
+- [INH_0001] Auto-inherited software unit
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEI
+      Type: InheritedSwUnit
+`,
+  },
+};
+
+const UNKNOWN_KIND_PROFILE = {
+  files: {
+    "project.yaml": `name: bad-test\nversion: 0.1.0\n`,
+    ".markspec.yaml": `profiles:\n  - ./profiles/bad\n`,
+    "profiles/bad/markspec.yaml": `id: bad
+version: 0.0.1
+markspec-schema: "1"
+profile:
+  types:
+    BadType:
+      extends: Requirement
+      display-id-pattern: "BAD_{NNNN}"
+      discipline: nonsense
+`,
+    "empty.md": `# Placeholder\n`,
+  },
+};
+
+const RESERVED_KIND_PROFILE = {
+  files: {
+    "project.yaml": `name: reserved-test\nversion: 0.1.0\n`,
+    ".markspec.yaml": `profiles:\n  - ./profiles/reserved\n`,
+    "profiles/reserved/markspec.yaml": `id: reserved
+version: 0.0.1
+markspec-schema: "1"
+profile:
+  kinds:
+    mixed:
+      description: reserved sentinel
+`,
+    "empty.md": `# Placeholder\n`,
+  },
+};
+
+Deno.test("Slice 2 E2E: tiered profile drives channel-3 classification via discipline:", async () => {
+  const { code, stdout } = await markspec(
+    ["compile", "--format", "json", "requirements.md"],
+    TIERED_PROFILE,
+  );
+  assertEquals(code, 0);
+  const compiled = JSON.parse(stdout);
+  const byId = compiled.entries as Record<
+    string,
+    { derivedDiscipline?: string }
+  >;
+  assertEquals(byId["SWR_0001"]?.derivedDiscipline, "software");
+  assertEquals(byId["HWR_0001"]?.derivedDiscipline, "hardware");
+});
+
+Deno.test("Slice 2 E2E: profile-declared kinds and auto-inheritance", async () => {
+  const { code, stdout } = await markspec(
+    ["compile", "--format", "json", "units.md"],
+    FIRMWARE_PROFILE,
+  );
+  assertEquals(code, 0);
+  const compiled = JSON.parse(stdout);
+  const byId = compiled.entries as Record<
+    string,
+    { derivedDiscipline?: string }
+  >;
+  // Profile-declared kind + explicit discipline:
+  assertEquals(byId["FWU_0001"]?.derivedDiscipline, "firmware");
+  // Auto-inheritance: no explicit discipline → inherits 'software' from SoftwareUnit.
+  assertEquals(byId["INH_0001"]?.derivedDiscipline, "software");
+});
+
+Deno.test("Slice 2 E2E: unknown kind referenced by discipline: fails the load", async () => {
+  const { code, stderr } = await markspec(
+    ["compile", "--format", "json", "empty.md"],
+    UNKNOWN_KIND_PROFILE,
+  );
+  assertEquals(code, 1);
+  assertStringIncludes(stderr, "PROFILE-DISCIPLINE-004");
+  assertStringIncludes(stderr, "nonsense");
+});
+
+Deno.test("Slice 2 E2E: reserved kind name 'mixed' fails the load", async () => {
+  const { code, stderr } = await markspec(
+    ["compile", "--format", "json", "empty.md"],
+    RESERVED_KIND_PROFILE,
+  );
+  assertEquals(code, 1);
+  assertStringIncludes(stderr, "PROFILE-DISCIPLINE-002");
+});


### PR DESCRIPTION
## Summary

Implements Slice 2 of ADR-017 Implementation backlog — profiles can now extend the core discipline registry via a `profile.kinds:` block and per-type `discipline:` field. The compiler Phase 4 classifier consumes the profile-extended registry; bare runs without a profile still use the core seed.

## What this enables

- **Use case A (tiered profiles, ASPICE/ISO 26262):** profile declares `SoftwareRequirement → software` and `HardwareRequirement → hardware`; channel 3 fires on entries authored as those types, no `Allocated-to` required.
- **Use case C (extensible kinds, non-automotive domains):** profile declares `kinds: { firmware: ... }` plus subtypes that register against it (`FirmwareUnit: firmware`), and the classifier returns the profile-declared kind.
- **Auto-inheritance** at registry-build time: a profile-declared type that extends a discipline-bearing core type (e.g. `FirmwareUnit extends SoftwareUnit`) inherits the ancestor discipline without needing an explicit `discipline:` field.

## New diagnostics

- `PROFILE-DISCIPLINE-001` — invalid kind-name format.
- `PROFILE-DISCIPLINE-002` — reserved kind name `mixed`.
- `PROFILE-DISCIPLINE-003` — warning: redeclaring a core kind (idempotent).
- `PROFILE-DISCIPLINE-004` — type discipline references unknown kind (post-merge check).
- `PROFILE-DISCIPLINE-005` — `discipline:` field is not a non-empty string.

## Out of scope (later slices)

- `Discipline:` override and `Discipline-frozen:` freeze attributes (Slice 3).
- Mixed-allocation validator error rule (Slice 4).
- Reporter `--group-by discipline` flag (Slice 4).
- `discipline_mode` flag (Slice 5).

## Test plan

- [ ] Unit tests in `core/profile/manifest_test.ts` (kinds + per-type discipline parsing) pass.
- [ ] Unit tests in `core/profile/merge_test.ts` (kinds union, discipline LWW, PROFILE-DISCIPLINE-004) pass.
- [ ] Unit tests in `core/profile/discipline_registry_test.ts` (builder + auto-inheritance) pass.
- [ ] Compiler-level test in `core/compiler/mod_test.ts` confirms Phase 4 consumes the profile-extended registry.
- [ ] E2E test in `tests/e2e/discipline_profile_extension_test.ts` confirms all four scenarios behave as designed.
- [ ] Reviewer verifies no snapshot drift beyond expected `discipline` additions on `EffectiveTypeDef` serialisations.
- [ ] Reviewer confirms no CHANGELOG entry (per project policy: release-time only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
