### PR TITLE
perf(core): avoid double mdast parse in body_tokens.ts

### DIFF
--- a/packages/markspec/core/ast/build.ts
+++ b/packages/markspec/core/ast/build.ts
@@ -599,13 +599,26 @@ function mapMdastNode(node: RootContent, body: string): BodyBlock {
  *   only for single-line paragraphs.
  */
 export function buildBodyAst(body: string): BodyBlock[] {
+  return buildBodyAstWithTree(body).blocks;
+}
+
+/**
+ * Like {@linkcode buildBodyAst} but also returns the intermediate mdast
+ * `Root` so callers that need it (e.g. body-token extraction) avoid
+ * re-parsing.
+ */
+export function buildBodyAstWithTree(
+  body: string,
+): { blocks: BodyBlock[]; tree: Root } {
   // Line-ending normalisation is a §3.4 spec-permitted transformation:
   // every AST is built from LF-canonical text so `\r` never reaches a
   // node's text or markers. Without this, `buildBodyAst("a\r\nb")` and
   // `buildBodyAst("a\nb")` would produce different ASTs, breaking the
   // build/render/format contract for CRLF-bearing inputs.
   const normalised = normalizeLineEndings(body);
-  if (!normalised.trim()) return [];
+  if (!normalised.trim()) {
+    return { blocks: [], tree: { type: "root", children: [] } };
+  }
 
   const tree = processor.parse(normalised) as Root;
   const blocks: BodyBlock[] = tree.children.map((node) =>
@@ -613,5 +626,5 @@ export function buildBodyAst(body: string): BodyBlock[] {
   );
 
   // Post-pass: assign caption positions
-  return assignCaptionPositions(blocks);
+  return { blocks: assignCaptionPositions(blocks), tree };
 }

--- a/packages/markspec/core/parser/body_tokens.ts
+++ b/packages/markspec/core/parser/body_tokens.ts
@@ -150,12 +150,11 @@ function emitGherkin(
  * to body-relative line/column.
  */
 function emitInlineCode(
-  body: string,
+  tree: Root,
   out: BodyToken[],
   baseLocation: SourceLocation,
   columnOffset: number,
 ): void {
-  const tree = processor.parse(body) as Root;
   const visit = (node: RootContent | Root): void => {
     if (
       node.type === "inlineCode" && node.position &&
@@ -201,6 +200,7 @@ export function extractBodyTokens(
   bodyAst: readonly BodyBlock[],
   baseLocation: SourceLocation,
   columnOffset = 0,
+  mdastTree?: Root,
 ): readonly BodyToken[] {
   const tokens: BodyToken[] = [];
   const verbatimLines = collectVerbatimLines(bodyAst);
@@ -262,7 +262,8 @@ export function extractBodyTokens(
   }
 
   emitGherkin(bodyAst, tokens, baseLocation, columnOffset);
-  emitInlineCode(body, tokens, baseLocation, columnOffset);
+  const tree = mdastTree ?? processor.parse(body) as Root;
+  emitInlineCode(tree, tokens, baseLocation, columnOffset);
 
   tokens.sort((a, b) =>
     a.location.line !== b.location.line

--- a/packages/markspec/core/parser/markdown.ts
+++ b/packages/markspec/core/parser/markdown.ts
@@ -16,7 +16,7 @@ import {
 } from "./attributes.ts";
 import { extractBodyTokens } from "./body_tokens.ts";
 import { processor } from "./remark.ts";
-import { buildBodyAst } from "../ast/build.ts";
+import { buildBodyAstWithTree } from "../ast/build.ts";
 import type { LineMap } from "./line_map.ts";
 import { translateEntryLocations } from "./translate.ts";
 import {
@@ -304,7 +304,7 @@ function extractEntry(
   const bodyContent = extractBodyContent(item, markdownLines);
   const [body, attrLines] = splitBodyAndAttributes(bodyContent);
   const attributes = parseAttributes(attrLines);
-  const bodyAst = buildBodyAst(body);
+  const { blocks: bodyAst, tree: mdastTree } = buildBodyAstWithTree(body);
 
   const entryLine = item.position?.start.line ?? 1;
 
@@ -532,11 +532,17 @@ function extractEntry(
   const bodyStartLine = hasLineMap
     ? (item.children[1]?.position?.start.line ?? (line + 1))
     : line + 1;
-  const bodyTokens = extractBodyTokens(body, bodyAst, {
-    file,
-    line: bodyStartLine,
-    column: 1,
-  }, bodyIndent);
+  const bodyTokens = extractBodyTokens(
+    body,
+    bodyAst,
+    {
+      file,
+      line: bodyStartLine,
+      column: 1,
+    },
+    bodyIndent,
+    mdastTree,
+  );
 
   // Extract typl declarations from all three surfaces in the body:
   // (1) ```typl fences, (2) bullet-glossary items, (3) inline code spans.

--- a/packages/markspec/core/typl/grammar.ts
+++ b/packages/markspec/core/typl/grammar.ts
@@ -307,10 +307,12 @@ class Parser {
         );
       }
     }
-    const out: Shape = { kind: "range", type };
-    if (min !== undefined) (out as Record<string, unknown>).min = min;
-    if (max !== undefined) (out as Record<string, unknown>).max = max;
-    return out;
+    return {
+      kind: "range",
+      type,
+      ...(min !== undefined && { min }),
+      ...(max !== undefined && { max }),
+    };
   }
 
   private parseLengthBody(type: "string" | "bytes"): Shape | undefined {
@@ -339,10 +341,12 @@ class Parser {
     this.advance();
     if (this.peek().kind === "NUMBER") max = Number(this.advance().value);
     if (!this.expect("RBRACKET")) return undefined;
-    const out: Shape = { kind: "length", type };
-    if (min !== undefined) (out as Record<string, unknown>).min = min;
-    if (max !== undefined) (out as Record<string, unknown>).max = max;
-    return out;
+    return {
+      kind: "length",
+      type,
+      ...(min !== undefined && { min }),
+      ...(max !== undefined && { max }),
+    };
   }
 
   private parseRecord(): Shape | undefined {


### PR DESCRIPTION
Fixes #450

`emitInlineCode` was re-parsing the body to find inline-code spans. Now threads the already-parsed mdast tree from `buildBodyAst`, eliminating the redundant parse.