### PR TITLE
refactor(core): replace unsafe casts and JSON.stringify in typl module

### DIFF
--- a/packages/markspec/core/typl/grammar.ts
+++ b/packages/markspec/core/typl/grammar.ts
@@ -307,10 +307,12 @@ class Parser {
         );
       }
     }
-    const out: Shape = { kind: "range", type };
-    if (min !== undefined) (out as Record<string, unknown>).min = min;
-    if (max !== undefined) (out as Record<string, unknown>).max = max;
-    return out;
+    return {
+      kind: "range",
+      type,
+      ...(min !== undefined ? { min } : {}),
+      ...(max !== undefined ? { max } : {}),
+    };
   }
 
   private parseLengthBody(type: "string" | "bytes"): Shape | undefined {
@@ -339,10 +341,12 @@ class Parser {
     this.advance();
     if (this.peek().kind === "NUMBER") max = Number(this.advance().value);
     if (!this.expect("RBRACKET")) return undefined;
-    const out: Shape = { kind: "length", type };
-    if (min !== undefined) (out as Record<string, unknown>).min = min;
-    if (max !== undefined) (out as Record<string, unknown>).max = max;
-    return out;
+    return {
+      kind: "length",
+      type,
+      ...(min !== undefined ? { min } : {}),
+      ...(max !== undefined ? { max } : {}),
+    };
   }
 
   private parseRecord(): Shape | undefined {

--- a/packages/markspec/core/typl/validator.ts
+++ b/packages/markspec/core/typl/validator.ts
@@ -147,7 +147,48 @@ function shapesEqual(
 ): boolean {
   if (a === b) return true;
   if (!a || !b) return false;
-  return JSON.stringify(a) === JSON.stringify(b);
+  if (a.kind !== b.kind) return false;
+  switch (a.kind) {
+    case "primitive":
+      return a.type === (b as typeof a).type;
+    case "range":
+      return a.type === (b as typeof a).type &&
+        a.exact === (b as typeof a).exact &&
+        a.min === (b as typeof a).min &&
+        a.max === (b as typeof a).max;
+    case "length":
+      return a.type === (b as typeof a).type &&
+        a.exact === (b as typeof a).exact &&
+        a.min === (b as typeof a).min &&
+        a.max === (b as typeof a).max;
+    case "pattern":
+      return a.regex === (b as typeof a).regex &&
+        a.flags === (b as typeof a).flags;
+    case "literal":
+      return a.value === (b as typeof a).value;
+    case "enum":
+      return a.values.length === (b as typeof a).values.length &&
+        a.values.every((v, i) => v === (b as typeof a).values[i]);
+    case "array":
+      return a.exact === (b as typeof a).exact &&
+        a.min === (b as typeof a).min &&
+        a.max === (b as typeof a).max &&
+        shapesEqual(a.element, (b as typeof a).element);
+    case "optional":
+      return shapesEqual(a.inner, (b as typeof a).inner);
+    case "record": {
+      const aKeys = Object.keys(a.fields).sort();
+      const bKeys = Object.keys((b as typeof a).fields).sort();
+      if (aKeys.length !== bKeys.length) return false;
+      return aKeys.every((k, i) =>
+        k === bKeys[i] && shapesEqual(a.fields[k], (b as typeof a).fields[k])
+      );
+    }
+    case "ref":
+      return a.name === (b as typeof a).name;
+    default:
+      return false;
+  }
 }
 
 // Re-export Binding for consumers that import from this module.


### PR DESCRIPTION
Fixes #448
Fixes #460

- Replaces unsafe `as Record<string, unknown>` casts in grammar.ts with spread operators
- Replaces order-sensitive `JSON.stringify` in `shapesEqual` with deep structural comparison