### PR TITLE
fix(core): emit TYPL-006 diagnostic for unterminated regex literal

### DIFF
--- a/packages/markspec/core/typl/grammar.ts
+++ b/packages/markspec/core/typl/grammar.ts
@@ -523,6 +523,8 @@ class Parser {
 export function parseTyplBlock(
   source: string,
 ): { ast: TyplBlock; diagnostics: readonly TyplDiagnostic[] } {
-  const tokens = tokenize(source);
-  return new Parser(tokens).parseBlock();
+  const { tokens, diagnostics: lexDiagnostics } = tokenize(source);
+  const { ast, diagnostics: parseDiagnostics } = new Parser(tokens)
+    .parseBlock();
+  return { ast, diagnostics: [...lexDiagnostics, ...parseDiagnostics] };
 }

--- a/packages/markspec/core/typl/lexer.ts
+++ b/packages/markspec/core/typl/lexer.ts
@@ -13,6 +13,7 @@
  */
 
 import type { Position } from "./ast.ts";
+import { type TyplDiagnostic, typlDiagnostic } from "./diagnostics.ts";
 
 /** All token kinds produced by the typl tokenizer. */
 export type TokenKind =
@@ -80,8 +81,11 @@ const DIGIT_RE = /[0-9]/;
  * 1-based (line 1, column 1 is the first character of the source). The
  * stream always ends with exactly one `EOF` token.
  */
-export function tokenize(source: string): Token[] {
+export function tokenize(
+  source: string,
+): { tokens: Token[]; diagnostics: TyplDiagnostic[] } {
   const tokens: Token[] = [];
+  const diagnostics: TyplDiagnostic[] = [];
   let line = 1;
   let column = 1;
   let i = 0;
@@ -161,6 +165,14 @@ export function tokenize(source: string): Token[] {
       if (i < source.length && source[i] === "/") {
         i++;
         column++;
+      } else {
+        diagnostics.push(
+          typlDiagnostic(
+            "TYPL-006",
+            { detail: "unterminated regex literal" },
+            { line, column: startCol },
+          ),
+        );
       }
       push("REGEX", regex, startCol);
       // Optional flags after the closing `/`.
@@ -278,5 +290,5 @@ export function tokenize(source: string): Token[] {
   }
 
   tokens.push({ kind: "EOF", value: "", position: { line, column } });
-  return tokens;
+  return { tokens, diagnostics };
 }

--- a/packages/markspec/core/typl/lexer_test.ts
+++ b/packages/markspec/core/typl/lexer_test.ts
@@ -2,9 +2,14 @@
 import { assertEquals } from "@std/assert";
 import { tokenize } from "./lexer.ts";
 
+/** Helper: extract just the token array from tokenize result. */
+function toks(source: string) {
+  return tokenize(source).tokens;
+}
+
 Deno.test("tokenize: binding with explicit kind + range", () => {
-  const tokens = tokenize("$Speed : signal float[0..300]");
-  assertEquals(tokens.map((t) => t.kind), [
+  const t = toks("$Speed : signal float[0..300]");
+  assertEquals(t.map((x) => x.kind), [
     "DOLLAR_IDENT", // $Speed
     "COLON", // :
     "IDENT", // signal
@@ -19,8 +24,8 @@ Deno.test("tokenize: binding with explicit kind + range", () => {
 });
 
 Deno.test("tokenize: typedef line", () => {
-  const tokens = tokenize("type BrakeReq = { force_N: float[0..12000] }");
-  assertEquals(tokens.map((t) => t.kind), [
+  const t = toks("type BrakeReq = { force_N: float[0..12000] }");
+  assertEquals(t.map((x) => x.kind), [
     "TYPE",
     "IDENT",
     "EQUALS",
@@ -39,42 +44,54 @@ Deno.test("tokenize: typedef line", () => {
 });
 
 Deno.test("tokenize: regex pattern keeps body intact", () => {
-  const tokens = tokenize("$VIN : /^[A-Z]{17}$/i");
-  const regex = tokens.find((t) => t.kind === "REGEX");
+  const t = toks("$VIN : /^[A-Z]{17}$/i");
+  const regex = t.find((x) => x.kind === "REGEX");
   assertEquals(regex?.value, "^[A-Z]{17}$");
-  const flags = tokens.find((t) => t.kind === "REGEX_FLAGS");
+  const flags = t.find((x) => x.kind === "REGEX_FLAGS");
   assertEquals(flags?.value, "i");
 });
 
 Deno.test("tokenize: comment line", () => {
-  const tokens = tokenize("# this is ignored");
-  assertEquals(tokens.map((t) => t.kind), ["COMMENT", "EOF"]);
+  const t = toks("# this is ignored");
+  assertEquals(t.map((x) => x.kind), ["COMMENT", "EOF"]);
 });
 
 Deno.test("tokenize: positions are 1-based; line increments on \\n", () => {
-  const tokens = tokenize("$X\n$Y");
+  const t = toks("$X\n$Y");
   // $X on line 1 col 1, $Y on line 2 col 1
-  assertEquals(tokens[0].position, { line: 1, column: 1 });
-  assertEquals(tokens[1].position, { line: 2, column: 1 });
+  assertEquals(t[0].position, { line: 1, column: 1 });
+  assertEquals(t[1].position, { line: 2, column: 1 });
 });
 
 Deno.test("tokenize: empty source emits only EOF at line 1 col 1", () => {
-  const tokens = tokenize("");
-  assertEquals(tokens.length, 1);
-  assertEquals(tokens[0].kind, "EOF");
-  assertEquals(tokens[0].position, { line: 1, column: 1 });
+  const t = toks("");
+  assertEquals(t.length, 1);
+  assertEquals(t[0].kind, "EOF");
+  assertEquals(t[0].position, { line: 1, column: 1 });
 });
 
 Deno.test("tokenize: REGEX_FLAGS position points at the flags, not the opening /", () => {
-  const tokens = tokenize("/abc/i");
-  const flags = tokens.find((t) => t.kind === "REGEX_FLAGS");
+  const t = toks("/abc/i");
+  const flags = t.find((x) => x.kind === "REGEX_FLAGS");
   // Opening / is at col 1; pattern abc is cols 2-4; closing / at col 5; flag i at col 6
   assertEquals(flags?.position, { line: 1, column: 6 });
 });
 
 Deno.test("tokenize: string with escape preserves the escaped char (backslash stripped)", () => {
-  const tokens = tokenize("'\\n'");
-  const str = tokens.find((t) => t.kind === "STRING");
+  const t = toks("'\\n'");
+  const str = t.find((x) => x.kind === "STRING");
   // Documents the design: backslash is consumed, next char taken verbatim
   assertEquals(str?.value, "n");
+});
+
+Deno.test("tokenize: unterminated regex emits TYPL-006 diagnostic", () => {
+  const { tokens, diagnostics } = tokenize("/abc");
+  assertEquals(tokens.find((t) => t.kind === "REGEX")?.value, "abc");
+  assertEquals(diagnostics.length, 1);
+  assertEquals(diagnostics[0].code, "TYPL-006");
+  assertEquals(
+    diagnostics[0].message,
+    "Malformed schema: unterminated regex literal.",
+  );
+  assertEquals(diagnostics[0].position, { line: 1, column: 1 });
 });


### PR DESCRIPTION
Fixes #449

When a regex literal is missing its closing `/`, the lexer now emits a TYPL-006 diagnostic pointing to the opening `/` instead of silently consuming to EOF.