### PR TITLE
feat(core): slice 6 — EARS pattern rules MSL-Q100 through MSL-Q104

### DIFF
--- a/packages/markspec/core/lint/range_util.ts
+++ b/packages/markspec/core/lint/range_util.ts
@@ -1,0 +1,57 @@
+/**
+ * @module core/lint/range_util
+ *
+ * Shared byte-offset → file-absolute SourceRange converter used by prose-
+ * analysis rules (xref, ears, and future slices). Extracted from xref.ts
+ * (slice 6) to avoid duplication across rules that all need the same
+ * conversion.
+ */
+
+import type { SourceRange } from "../ast/nodes.ts";
+
+/**
+ * Compute byte-offset → file-absolute (line, column) for a prose span whose
+ * text begins at `baseLine`, `baseCol`. Newlines in the text advance the
+ * line counter; the column resets to 1 after each newline.
+ *
+ * Returns a file-absolute {@linkcode SourceRange} suitable for
+ * `LintDiagnostic.range` (1-based, file-absolute — per slice 3 contract).
+ *
+ * @param text      Full text of the prose region (paragraph or sentence).
+ * @param offset    Byte offset of the span's first character in `text`.
+ * @param length    Byte length of the span.
+ * @param baseLine  1-based file-absolute line where `text` begins.
+ * @param baseCol   1-based column where `text` begins on `baseLine`.
+ */
+export function offsetToRange(
+  text: string,
+  offset: number,
+  length: number,
+  baseLine: number,
+  baseCol: number,
+): SourceRange {
+  let line = baseLine;
+  let col = baseCol;
+  for (let i = 0; i < offset; i++) {
+    if (text[i] === "\n") {
+      line++;
+      col = 1;
+    } else {
+      col++;
+    }
+  }
+  const startLine = line;
+  const startCol = col;
+  for (let i = offset; i < offset + length; i++) {
+    if (text[i] === "\n") {
+      line++;
+      col = 1;
+    } else {
+      col++;
+    }
+  }
+  return {
+    start: { line: startLine, column: startCol },
+    end: { line, column: col },
+  };
+}

--- a/packages/markspec/core/lint/rules/ears.ts
+++ b/packages/markspec/core/lint/rules/ears.ts
@@ -396,8 +396,9 @@ export function runEarsRules(entry: Entry): LintDiagnostic[] {
       if (precondCount >= 3) {
         out.push(emitQ103(s, off, text, absLine, baseCol, entry, precondCount));
         // Don't also fire Q100 on the same sentence — the sentence IS EARS-shaped,
-        // just over-complex. Q103 is the actionable diagnostic.
-        // Still check Q101 and Q102.
+        // just over-complex. Q103 is the actionable diagnostic. Q101 is also
+        // skipped (the precondCount<3 guard at line 411 excludes it). Q102 still
+        // applies independently below.
       } else if (!matchesEarsPattern(s)) {
         // Q100: normative sentence matches no EARS pattern.
         out.push(emitQ100(s, off, text, absLine, baseCol, entry));

--- a/packages/markspec/core/lint/rules/ears.ts
+++ b/packages/markspec/core/lint/rules/ears.ts
@@ -1,0 +1,422 @@
+/**
+ * @module core/lint/rules/ears
+ *
+ * EARS (Easy Approach to Requirements Syntax) pattern rules for PA-3.
+ * Five rules targeting normative sentences that violate or misapply the
+ * six canonical EARS patterns (Mavin 2009):
+ *
+ *   Ubiquitous      — `The <system> shall <response>`
+ *   State-driven    — `While <precondition>, the <system> shall <response>`
+ *   Event-driven    — `When <trigger>, the <system> shall <response>`
+ *   Optional-feat.  — `Where <feature>, the <system> shall <response>`
+ *   Unwanted-behav. — `If <trigger>, then the <system> shall <response>`
+ *   Complex         — `While <precondition>, when <trigger>, the <system> shall <response>`
+ *
+ * Rules:
+ *   MSL-Q100  ears-no-pattern             (info,  score 1)
+ *   MSL-Q101  ears-missing-actor          (warn,  score 3)
+ *   MSL-Q102  ears-negative-response      (info,  score 1)
+ *   MSL-Q103  ears-stacked-preconditions  (warn,  score 3)
+ *   MSL-Q104  ears-malformed-attempt      (info,  score 1)
+ *
+ * All rules are heuristic and intentionally fire narrow rather than broad.
+ * Q100 and Q101 are the most likely to have false-positive risk; their
+ * detection conditions are tighter than the full grammar.
+ */
+
+import type { Entry } from "../../model/mod.ts";
+import type { ParagraphNode } from "../../ast/nodes.ts";
+import type { BodyBlock } from "../../ast/nodes.ts";
+import type { LintDiagnostic } from "../types.ts";
+import { segmentSentences } from "../segmenter.ts";
+import { loadLexicon } from "../../lexicons/mod.ts";
+import { offsetToRange } from "../range_util.ts";
+
+const ABBREVS = loadLexicon("sentence-abbrev");
+
+// ---------------------------------------------------------------------------
+// Regexes — all case-insensitive unless noted
+// ---------------------------------------------------------------------------
+
+/** RFC 2119 modal verbs — bare forms and compound "shall not" etc. */
+const MODAL_RE =
+  /\b(shall not|should not|must not|shall|should|may|must|will)\b/i;
+
+/** RFC 2119 negative compound modals (Q102). */
+const NEGATIVE_MODAL_RE = /\b(shall not|should not|must not|may not)\b/i;
+
+/** EARS leading-clause keywords — capital-initial only (sentence-initial). */
+const EARS_LEADING_RE = /^(While|When|Where|If)\b/i;
+
+/**
+ * EARS precondition-style keywords counting stacked clauses (Q103).
+ * Counts `While`, `When`, and `If` occurrences (not `Where` — it marks
+ * optional features, not preconditions). Case-insensitive, whole word.
+ */
+const EARS_PRECONDITION_RE = /\b(While|When|If)\b/gi;
+
+/**
+ * Actor detection: `the <noun phrase>` immediately before the modal.
+ *
+ * An actor is considered PRESENT when the noun phrase has either:
+ *   (a) at least one Capitalized (PascalCase) word, OR
+ *   (b) two or more lowercase words (a compound noun phrase like
+ *       "the brake controller" or "the pedal unit").
+ *
+ * An actor is considered ABSENT (Q101 fires) when the noun phrase is
+ * a single bare lowercase word ("the brake shall", "the system shall").
+ *
+ * This heuristic deliberately passes "the brake controller shall"
+ * (compound noun = named subsystem) and fires on "the brake shall"
+ * (single generic noun = too vague). It is intentionally narrow to
+ * keep false-positive risk low.
+ *
+ * `ACTOR_SINGLE_LOWERCASE_RE` matches the problematic form:
+ * `the <single-lowercase-word> <modal>`. After matching, the captured
+ * noun is checked against {@linkcode GENERIC_ACTOR_ALLOWLIST}; nouns in
+ * the allowlist are accepted as valid (if imprecise) actors.
+ */
+const ACTOR_SINGLE_LOWERCASE_RE =
+  /\b[Tt]he\s+([a-z][a-z0-9]*)\s+(?:shall not|should not|must not|shall|should|may|must|will)\b/;
+
+/**
+ * Single-word lowercase nouns that are conventionally accepted as generic
+ * system-level actor names in requirements prose. "The system shall…" and
+ * "The controller shall…" are ubiquitous in requirements engineering and
+ * are treated as valid actors even though they are technically vague.
+ *
+ * Q101 fires when the noun is NOT in this list — e.g. "the brake shall"
+ * (component reference without qualification) triggers the warning.
+ *
+ * Profile-extensible in a future iteration; for now the list is narrow.
+ */
+const GENERIC_ACTOR_ALLOWLIST: ReadonlySet<string> = new Set([
+  "system",
+  "controller",
+  "module",
+  "unit",
+  "device",
+  "software",
+  "firmware",
+  "application",
+  "processor",
+  "subsystem",
+  "component",
+  "platform",
+  "service",
+  "driver",
+  "manager",
+]);
+
+// ---------------------------------------------------------------------------
+// Pattern matchers
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns true when the sentence text contains at least one RFC 2119 modal
+ * verb. This is the normative-sentence gate: only normative sentences receive
+ * Q100–Q103 analysis.
+ */
+function isNormative(sentence: string): boolean {
+  return MODAL_RE.test(sentence);
+}
+
+/**
+ * Returns true when the sentence matches one of the six EARS patterns.
+ *
+ * Detection heuristics (intentionally narrow to keep false-positive risk low):
+ *
+ * - State-driven:      starts with `While`  + contains modal
+ * - Event-driven:      starts with `When`   + contains modal
+ * - Optional-feature:  starts with `Where`  + contains modal
+ * - Unwanted-behav.:   starts with `If`     + contains `, then` + modal
+ * - Complex:           starts with `While`  + contains `when` (mid-sentence) + modal
+ * - Ubiquitous:        does NOT start with EARS keyword + starts with `The` + modal
+ *
+ * Note: Ubiquitous requires an explicit `The` to reduce false-positives
+ * from non-EARS prose that happens to contain a modal.
+ */
+function matchesEarsPattern(sentence: string): boolean {
+  if (!isNormative(sentence)) return false;
+
+  const trimmed = sentence.trim();
+
+  // Leading EARS keyword → one of the event/state/optional/unwanted/complex patterns.
+  if (EARS_LEADING_RE.test(trimmed)) {
+    // Unwanted-behaviour requires `, then` somewhere before the modal.
+    if (/^If\b/i.test(trimmed)) {
+      return /,\s*then\b/i.test(trimmed);
+    }
+    // State-driven, Event-driven, Optional-feature, Complex all pass when the
+    // leading keyword is present and a modal follows.
+    return true;
+  }
+
+  // Ubiquitous: no EARS leading keyword, starts with `The <noun>`, has modal.
+  if (/^The\s+/i.test(trimmed)) {
+    return MODAL_RE.test(trimmed);
+  }
+
+  return false;
+}
+
+/**
+ * Returns false (actor is MISSING) when the sentence's modal is
+ * preceded by a single bare lowercase noun that is not a generic
+ * system-level term (e.g. "the brake shall"). Returns true (actor
+ * PRESENT) for:
+ *   - compound noun phrases ("the brake controller shall"),
+ *   - Capitalized/PascalCase nouns ("the BrakeController shall"), or
+ *   - generic system nouns in {@linkcode GENERIC_ACTOR_ALLOWLIST}
+ *     ("the system shall", "the controller shall").
+ *
+ * Q101 fires when this returns false.
+ */
+function hasActor(sentence: string): boolean {
+  const m = ACTOR_SINGLE_LOWERCASE_RE.exec(sentence);
+  if (!m) return true; // compound or Capitalized → actor present
+  const noun = m[1].toLowerCase();
+  return GENERIC_ACTOR_ALLOWLIST.has(noun);
+}
+
+/**
+ * Count the number of EARS precondition keywords (While/When/If) in the
+ * sentence. Used by Q103 to detect stacked preconditions.
+ */
+function countPreconditions(sentence: string): number {
+  EARS_PRECONDITION_RE.lastIndex = 0;
+  let count = 0;
+  while (EARS_PRECONDITION_RE.exec(sentence) !== null) count++;
+  return count;
+}
+
+// ---------------------------------------------------------------------------
+// Rule implementations
+// ---------------------------------------------------------------------------
+
+function emitQ100(
+  sentence: string,
+  sentenceOffset: number,
+  paragraphText: string,
+  baseLine: number,
+  baseCol: number,
+  entry: Entry,
+): LintDiagnostic {
+  const range = offsetToRange(
+    paragraphText,
+    sentenceOffset,
+    sentence.length,
+    baseLine,
+    baseCol,
+  );
+  return {
+    code: "MSL-Q100",
+    slug: "ears-no-pattern",
+    severity: "info",
+    scoreContribution: 1,
+    group: "ears",
+    message:
+      `ears-no-pattern: normative sentence does not conform to any EARS pattern (Ubiquitous, State-driven, Event-driven, Optional-feature, Unwanted-behaviour, Complex)`,
+    location: entry.location,
+    range,
+  };
+}
+
+function emitQ101(
+  sentence: string,
+  sentenceOffset: number,
+  paragraphText: string,
+  baseLine: number,
+  baseCol: number,
+  entry: Entry,
+): LintDiagnostic {
+  const range = offsetToRange(
+    paragraphText,
+    sentenceOffset,
+    sentence.length,
+    baseLine,
+    baseCol,
+  );
+  return {
+    code: "MSL-Q101",
+    slug: "ears-missing-actor",
+    severity: "warning",
+    scoreContribution: 3,
+    group: "ears",
+    message:
+      `ears-missing-actor: EARS sentence has no explicit actor ('the <System>') before the modal verb`,
+    location: entry.location,
+    range,
+  };
+}
+
+function emitQ102(
+  sentence: string,
+  sentenceOffset: number,
+  paragraphText: string,
+  baseLine: number,
+  baseCol: number,
+  entry: Entry,
+): LintDiagnostic {
+  const range = offsetToRange(
+    paragraphText,
+    sentenceOffset,
+    sentence.length,
+    baseLine,
+    baseCol,
+  );
+  return {
+    code: "MSL-Q102",
+    slug: "ears-negative-response",
+    severity: "info",
+    scoreContribution: 1,
+    group: "ears",
+    message:
+      `ears-negative-response: response clause is bare negation ('shall not …'); prefer a positive form where possible`,
+    location: entry.location,
+    range,
+  };
+}
+
+function emitQ103(
+  sentence: string,
+  sentenceOffset: number,
+  paragraphText: string,
+  baseLine: number,
+  baseCol: number,
+  entry: Entry,
+  count: number,
+): LintDiagnostic {
+  const range = offsetToRange(
+    paragraphText,
+    sentenceOffset,
+    sentence.length,
+    baseLine,
+    baseCol,
+  );
+  return {
+    code: "MSL-Q103",
+    slug: "ears-stacked-preconditions",
+    severity: "warning",
+    scoreContribution: 3,
+    group: "ears",
+    message:
+      `ears-stacked-preconditions: ${count} stacked preconditions (While/When/If) in one sentence; split or restructure as canonical Complex pattern`,
+    location: entry.location,
+    range,
+  };
+}
+
+function emitQ104(
+  sentence: string,
+  sentenceOffset: number,
+  paragraphText: string,
+  baseLine: number,
+  baseCol: number,
+  entry: Entry,
+): LintDiagnostic {
+  const range = offsetToRange(
+    paragraphText,
+    sentenceOffset,
+    sentence.length,
+    baseLine,
+    baseCol,
+  );
+  return {
+    code: "MSL-Q104",
+    slug: "ears-malformed-attempt",
+    severity: "info",
+    scoreContribution: 1,
+    group: "ears",
+    message:
+      `ears-malformed-attempt: sentence opens with EARS keyword (When/While/Where/If) but has no modal+response clause`,
+    location: entry.location,
+    range,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Rule code registry (for suppression hygiene)
+// ---------------------------------------------------------------------------
+
+/** All EARS rule codes exported for the suppression-hygiene known-code set. */
+export const EARS_RULE_CODES: ReadonlySet<string> = new Set([
+  "MSL-Q100",
+  "MSL-Q101",
+  "MSL-Q102",
+  "MSL-Q103",
+  "MSL-Q104",
+]);
+
+// ---------------------------------------------------------------------------
+// Public entry point
+// ---------------------------------------------------------------------------
+
+/**
+ * Run EARS rules (Q100–Q104) on an entry's paragraph bodies.
+ *
+ * For each paragraph, segments into sentences. For each sentence:
+ *   - Q104 fires on ANY sentence that opens with an EARS keyword but lacks
+ *     a modal anywhere (catches malformed attempts even in non-normative prose).
+ *   - Q100–Q103 fire ONLY on normative sentences (those containing a modal).
+ */
+export function runEarsRules(entry: Entry): LintDiagnostic[] {
+  const out: LintDiagnostic[] = [];
+  const blocks: readonly BodyBlock[] = entry.bodyAst ?? [];
+
+  for (const block of blocks) {
+    if (block.kind !== "paragraph") continue;
+    const p = block as ParagraphNode;
+    const text = p.content.text;
+
+    // Compute file-absolute base line for this paragraph.
+    // p.range.start.line is body-relative (line 1 = first body line).
+    // entry.bodyStartLine is file-absolute. Fall back to entry.location.line + 1.
+    const absBodyStart = entry.bodyStartLine ?? (entry.location.line + 1);
+    const absLine = absBodyStart + p.range.start.line - 1;
+    const baseCol = p.range.start.column;
+
+    const sentences = segmentSentences(text, ABBREVS);
+    for (const sentence of sentences) {
+      const s = sentence.text;
+      const off = sentence.offset;
+
+      // Q104: fires on non-normative malformed EARS attempts too.
+      // Sentence opens with an EARS keyword but has NO modal anywhere.
+      if (EARS_LEADING_RE.test(s.trim()) && !MODAL_RE.test(s)) {
+        out.push(emitQ104(s, off, text, absLine, baseCol, entry));
+        continue; // malformed → skip other EARS rules for this sentence
+      }
+
+      // Remaining rules only fire on normative sentences.
+      if (!isNormative(s)) continue;
+
+      // Q103: ≥3 stacked preconditions (fires before Q100 to avoid double-flagging).
+      const precondCount = countPreconditions(s);
+      if (precondCount >= 3) {
+        out.push(emitQ103(s, off, text, absLine, baseCol, entry, precondCount));
+        // Don't also fire Q100 on the same sentence — the sentence IS EARS-shaped,
+        // just over-complex. Q103 is the actionable diagnostic.
+        // Still check Q101 and Q102.
+      } else if (!matchesEarsPattern(s)) {
+        // Q100: normative sentence matches no EARS pattern.
+        out.push(emitQ100(s, off, text, absLine, baseCol, entry));
+        // Q101 is inapplicable when no pattern matches — Q100 already flags it.
+        // Q102 still applies (a "shall not" in a non-pattern sentence is still
+        // a negation concern).
+      }
+
+      // Q101: EARS pattern detected but no explicit actor.
+      // Only fire when the sentence DOES match an EARS pattern (no Q100).
+      if (precondCount < 3 && matchesEarsPattern(s) && !hasActor(s)) {
+        out.push(emitQ101(s, off, text, absLine, baseCol, entry));
+      }
+
+      // Q102: bare negation in response clause.
+      if (NEGATIVE_MODAL_RE.test(s)) {
+        out.push(emitQ102(s, off, text, absLine, baseCol, entry));
+      }
+    }
+  }
+  return out;
+}

--- a/packages/markspec/core/lint/rules/ears_test.ts
+++ b/packages/markspec/core/lint/rules/ears_test.ts
@@ -1,0 +1,279 @@
+/**
+ * @module core/lint/rules/ears_test
+ *
+ * Unit tests for EARS rules MSL-Q100 through MSL-Q104.
+ */
+
+import { assertEquals } from "@std/assert";
+import type { BodyBlock } from "../../ast/nodes.ts";
+import type { Entry } from "../../model/mod.ts";
+import { makeDisplayId } from "../../model/mod.ts";
+import { runEarsRules } from "./ears.ts";
+
+// ---------------------------------------------------------------------------
+// Test helper
+// ---------------------------------------------------------------------------
+
+function makeParagraph(text: string, line = 1, column = 1): BodyBlock {
+  return {
+    kind: "paragraph",
+    content: { text },
+    range: {
+      start: { line, column },
+      end: { line, column: column + text.length },
+    },
+  };
+}
+
+interface MakeEntryOpts {
+  location?: { file: string; line: number; column: number };
+  bodyStartLine?: number;
+}
+
+function makeEntry(
+  body: string,
+  opts: MakeEntryOpts = {},
+): Entry {
+  const bodyAst: BodyBlock[] = [makeParagraph(body)];
+  const location = opts.location ?? { file: "test.md", line: 1, column: 1 };
+  return {
+    displayId: makeDisplayId("STK_0001"),
+    title: "Test requirement",
+    body,
+    bodyAst,
+    rawAttributes: [
+      { key: "Id", value: "01HGW2Q8MNP3RSTVWXYZABCDEF" },
+      { key: "Type", value: "Requirement" },
+    ],
+    typedAttributes: new Map([
+      ["Id", ["01HGW2Q8MNP3RSTVWXYZABCDEF"]],
+      ["Type", ["Requirement"]],
+    ]),
+    id: "01HGW2Q8MNP3RSTVWXYZABCDEF",
+    type: "Requirement",
+    shape: "Authored",
+    location,
+    ...(opts.bodyStartLine !== undefined
+      ? { bodyStartLine: opts.bodyStartLine }
+      : {}),
+    source: { kind: "markdown" },
+    bodyTokens: [],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// MSL-Q100: ears-no-pattern
+// ---------------------------------------------------------------------------
+
+Deno.test("Q100: no EARS pattern in normative sentence", () => {
+  // Starts with "Pressure" (not "The"), no EARS leading keyword.
+  // Contains a modal → normative. Matches no EARS pattern → Q100.
+  const entry = makeEntry(
+    "Pressure shall be maintained appropriately.",
+  );
+  const diags = runEarsRules(entry);
+  assertEquals(diags.some((d) => d.code === "MSL-Q100"), true);
+});
+
+Deno.test("Q100: normative sentence with no leading keyword and no 'The' actor", () => {
+  // "Readings shall be logged." — modal present but no EARS structure.
+  const entry = makeEntry("Readings shall be logged.");
+  const diags = runEarsRules(entry);
+  assertEquals(diags.some((d) => d.code === "MSL-Q100"), true);
+});
+
+// ---------------------------------------------------------------------------
+// MSL-Q101: ears-missing-actor
+// ---------------------------------------------------------------------------
+
+Deno.test("Q101: missing actor — single bare lowercase noun before modal", () => {
+  // 'brake' is a single lowercase noun → Q101.
+  const entry = makeEntry("The brake shall apply pressure.");
+  const diags = runEarsRules(entry);
+  assertEquals(diags.some((d) => d.code === "MSL-Q101"), true);
+});
+
+Deno.test("Q101: silent when compound noun phrase acts as actor", () => {
+  // 'brake controller' is a two-word compound → treated as system name.
+  const entry = makeEntry(
+    "The brake controller shall apply force within 50 ms.",
+  );
+  const diags = runEarsRules(entry);
+  assertEquals(diags.some((d) => d.code === "MSL-Q101"), false);
+});
+
+Deno.test("Q101: silent when PascalCase noun acts as actor", () => {
+  const entry = makeEntry("The BrakeController shall apply force.");
+  const diags = runEarsRules(entry);
+  assertEquals(diags.some((d) => d.code === "MSL-Q101"), false);
+});
+
+// ---------------------------------------------------------------------------
+// MSL-Q102: ears-negative-response
+// ---------------------------------------------------------------------------
+
+Deno.test("Q102: bare negation — 'shall not'", () => {
+  const entry = makeEntry("The system shall not retry on failure.");
+  const diags = runEarsRules(entry);
+  assertEquals(diags.some((d) => d.code === "MSL-Q102"), true);
+});
+
+Deno.test("Q102: bare negation — 'should not'", () => {
+  const entry = makeEntry(
+    "The monitoring subsystem should not suppress sensor warnings.",
+  );
+  const diags = runEarsRules(entry);
+  assertEquals(diags.some((d) => d.code === "MSL-Q102"), true);
+});
+
+Deno.test("Q102: silent when modal is positive", () => {
+  const entry = makeEntry(
+    "When the pedal is pressed, the brake controller shall apply pressure within 200 ms.",
+  );
+  const diags = runEarsRules(entry);
+  assertEquals(diags.some((d) => d.code === "MSL-Q102"), false);
+});
+
+// ---------------------------------------------------------------------------
+// MSL-Q103: ears-stacked-preconditions
+// ---------------------------------------------------------------------------
+
+Deno.test("Q103: stacked preconditions (≥3 While/When/If)", () => {
+  const entry = makeEntry(
+    "While engaged, when pressed, if valid, then the system shall apply.",
+  );
+  const diags = runEarsRules(entry);
+  assertEquals(diags.some((d) => d.code === "MSL-Q103"), true);
+});
+
+Deno.test("Q103: silent on exactly two preconditions (Complex pattern)", () => {
+  // While + When = Complex pattern (2 preconditions) → no Q103.
+  const entry = makeEntry(
+    "While braking is active, when the pedal pressure exceeds 5 bar, the brake controller shall hold.",
+  );
+  const diags = runEarsRules(entry);
+  assertEquals(diags.some((d) => d.code === "MSL-Q103"), false);
+});
+
+// ---------------------------------------------------------------------------
+// MSL-Q104: ears-malformed-attempt
+// ---------------------------------------------------------------------------
+
+Deno.test("Q104: EARS keyword present but no modal", () => {
+  // EARS keyword but no modal+response → malformed.
+  const entry = makeEntry("When pressed, the system the system.");
+  const diags = runEarsRules(entry);
+  assertEquals(diags.some((d) => d.code === "MSL-Q104"), true);
+});
+
+Deno.test("Q104: silent when EARS keyword has a modal", () => {
+  // When + modal → NOT malformed.
+  const entry = makeEntry(
+    "When the pedal is pressed, the brake controller shall apply pressure.",
+  );
+  const diags = runEarsRules(entry);
+  assertEquals(diags.some((d) => d.code === "MSL-Q104"), false);
+});
+
+Deno.test("Q104: fires on non-normative malformed EARS attempt", () => {
+  // No modal, but sentence opens with EARS keyword. Q104 should still fire.
+  const entry = makeEntry("If the sensor fails, the component.");
+  const diags = runEarsRules(entry);
+  assertEquals(diags.some((d) => d.code === "MSL-Q104"), true);
+});
+
+// ---------------------------------------------------------------------------
+// Silent on non-normative sentences
+// ---------------------------------------------------------------------------
+
+Deno.test("EARS: silent on non-normative sentences", () => {
+  // No modal → not normative → no Q100/Q101/Q102/Q103.
+  // No EARS keyword → no Q104.
+  const entry = makeEntry("The brake is a critical safety system.");
+  const diags = runEarsRules(entry);
+  assertEquals(diags.length, 0);
+});
+
+// ---------------------------------------------------------------------------
+// Valid EARS patterns are silent
+// ---------------------------------------------------------------------------
+
+Deno.test("EARS: valid Event-driven pattern is silent", () => {
+  const entry = makeEntry(
+    "When the pedal is pressed, the brake controller shall apply pressure within 200 ms.",
+  );
+  const diags = runEarsRules(entry);
+  // Q100 silent (matches Event-driven).
+  // Q101 silent ('brake controller' is a compound noun phrase actor).
+  // Q102 silent (no negation).
+  // Q103 silent (1 precondition, not 3).
+  // Q104 silent (modal+response present).
+  assertEquals(diags.length, 0);
+});
+
+Deno.test("EARS: valid Unwanted-behaviour pattern is silent", () => {
+  const entry = makeEntry(
+    "If a sensor reading is invalid, then the brake controller shall ignore it.",
+  );
+  const diags = runEarsRules(entry);
+  assertEquals(diags.length, 0);
+});
+
+Deno.test("EARS: valid State-driven pattern is silent", () => {
+  const entry = makeEntry(
+    "While the vehicle is decelerating, the brake controller shall maintain hydraulic pressure.",
+  );
+  const diags = runEarsRules(entry);
+  assertEquals(diags.length, 0);
+});
+
+Deno.test("EARS: valid Ubiquitous pattern with compound actor is silent", () => {
+  // 'brake controller' is a two-word compound noun → actor present.
+  const entry = makeEntry(
+    "The brake controller shall apply force within 50 ms.",
+  );
+  const diags = runEarsRules(entry);
+  assertEquals(diags.length, 0);
+});
+
+// ---------------------------------------------------------------------------
+// Range is file-absolute, sentence-span
+// ---------------------------------------------------------------------------
+
+Deno.test("EARS: range is file-absolute, sentence-span", () => {
+  // Entry whose body starts at file line 32.
+  // Q101 fires (single lowercase noun 'brake' before modal).
+  // The diagnostic range must reflect bodyStartLine + paragraph offset.
+  const entry = makeEntry("The brake shall apply pressure.", {
+    location: { file: "/x.md", line: 30, column: 1 },
+    bodyStartLine: 32,
+  });
+  const diags = runEarsRules(entry);
+  const q101 = diags.find((d) => d.code === "MSL-Q101");
+  assertEquals(q101 !== undefined, true);
+  assertEquals(q101?.range?.start.line, 32); // file-absolute
+});
+
+// ---------------------------------------------------------------------------
+// LintDiagnostic fields
+// ---------------------------------------------------------------------------
+
+Deno.test("EARS: diagnostics carry slug, group, scoreContribution", () => {
+  const entry = makeEntry("Pressure shall be maintained appropriately.");
+  const diags = runEarsRules(entry);
+  const q100 = diags.find((d) => d.code === "MSL-Q100");
+  assertEquals(q100 !== undefined, true);
+  assertEquals(q100?.slug, "ears-no-pattern");
+  assertEquals(q100?.group, "ears");
+  assertEquals(q100?.scoreContribution, 1);
+});
+
+Deno.test("EARS: Q103 has warn severity and score 3", () => {
+  const entry = makeEntry(
+    "While engaged, when pressed, if valid, then the system shall apply.",
+  );
+  const diags = runEarsRules(entry);
+  const q103 = diags.find((d) => d.code === "MSL-Q103");
+  assertEquals(q103?.severity, "warning");
+  assertEquals(q103?.scoreContribution, 3);
+});

--- a/packages/markspec/core/lint/rules/ears_test.ts
+++ b/packages/markspec/core/lint/rules/ears_test.ts
@@ -116,6 +116,8 @@ Deno.test("Q102: bare negation — 'shall not'", () => {
   const entry = makeEntry("The system shall not retry on failure.");
   const diags = runEarsRules(entry);
   assertEquals(diags.some((d) => d.code === "MSL-Q102"), true);
+  // Q101 does NOT co-fire — 'system' is in GENERIC_ACTOR_ALLOWLIST.
+  assertEquals(diags.some((d) => d.code === "MSL-Q101"), false);
 });
 
 Deno.test("Q102: bare negation — 'should not'", () => {

--- a/packages/markspec/core/lint/rules/suppression.ts
+++ b/packages/markspec/core/lint/rules/suppression.ts
@@ -13,11 +13,16 @@ import type { Entry, SourceLocation } from "../../model/mod.ts";
 import type { LintDiagnostic } from "../types.ts";
 import { LEXICON_RULE_CODES } from "./lexicon.ts";
 import { STRUCT_RULE_CODES } from "./struct.ts";
+import { EARS_RULE_CODES } from "./ears.ts";
 
-/** All rule codes shipped in PA-1. MSL-Q900/Q901 are self-referential. */
+/** All rule codes shipped in PA-1 through PA-3 (slices 1–6).
+ * MSL-Q900/Q901 are self-referential. */
 export const PA1_KNOWN_RULE_CODES: ReadonlySet<string> = new Set([
   ...LEXICON_RULE_CODES,
   ...STRUCT_RULE_CODES,
+  ...EARS_RULE_CODES,
+  // Q500: xref-glossary-undefined (slice 5)
+  "MSL-Q500",
   "MSL-Q900",
   "MSL-Q901",
 ]);

--- a/packages/markspec/core/lint/rules/xref.ts
+++ b/packages/markspec/core/lint/rules/xref.ts
@@ -7,10 +7,11 @@
  */
 
 import type { Entry } from "../../model/mod.ts";
-import type { ParagraphNode, SourceRange } from "../../ast/nodes.ts";
+import type { ParagraphNode } from "../../ast/nodes.ts";
 import type { LintDiagnostic } from "../types.ts";
 import type { GlossaryIndex } from "../glossary.ts";
 import { deriveTermSlug } from "../../parser/glossary.ts";
+import { offsetToRange } from "../range_util.ts";
 
 /** Hook signature for the deferred $Identifier registry leg. Returns
  * true when the token is a resolvable $Identifier (i.e. should be
@@ -226,46 +227,6 @@ function scanPhrases(
   }
 
   return phrases;
-}
-
-/**
- * Compute byte-offset → file-absolute (line, column) for a paragraph
- * whose text begins at `baseLine`, `baseCol`. Newlines in the
- * paragraph text advance the line; column resets to 1. Returns a
- * file-absolute SourceRange suitable for LintDiagnostic.range (see
- * slice 3 doc comment on the field — file-absolute, 1-based).
- */
-function offsetToRange(
-  text: string,
-  offset: number,
-  length: number,
-  baseLine: number,
-  baseCol: number,
-): SourceRange {
-  let line = baseLine;
-  let col = baseCol;
-  for (let i = 0; i < offset; i++) {
-    if (text[i] === "\n") {
-      line++;
-      col = 1;
-    } else {
-      col++;
-    }
-  }
-  const startLine = line;
-  const startCol = col;
-  for (let i = offset; i < offset + length; i++) {
-    if (text[i] === "\n") {
-      line++;
-      col = 1;
-    } else {
-      col++;
-    }
-  }
-  return {
-    start: { line: startLine, column: startCol },
-    end: { line, column: col },
-  };
 }
 
 /** Public entry point: run Q500 against an entry's paragraph bodies. */

--- a/packages/markspec/core/lint/runner.ts
+++ b/packages/markspec/core/lint/runner.ts
@@ -22,6 +22,7 @@ import { buildGlossaryIndex } from "./glossary.ts";
 import type { FileReader, GlossaryIndex } from "./glossary.ts";
 import { runXrefRules } from "./rules/xref.ts";
 import type { IsIdentifierHook } from "./rules/xref.ts";
+import { runEarsRules } from "./rules/ears.ts";
 import { loadLexicon } from "../lexicons/mod.ts";
 
 // ---------------------------------------------------------------------------
@@ -97,12 +98,13 @@ function disabledCodes(entry: Entry): ReadonlySet<string> {
  *   3. Run lexicon rules on each in-scope entry's prose blocks.
  *   4. Run structural rules on each in-scope entry.
  *   5. Run Q500 xref rules on each in-scope entry.
- *   6. Run suppression hygiene on ALL Authored entries.
- *   7. Apply suppression: drop in-scope diagnostics where the entry's
+ *   6. Run EARS rules (Q100–Q104) on each in-scope entry.
+ *   7. Run suppression hygiene on ALL Authored entries.
+ *   8. Apply suppression: drop in-scope diagnostics where the entry's
  *      Markspec-disable list includes the rule's code and the entry
  *      has a Rationale. Suppression-hygiene diagnostics (Q900/Q901)
  *      are never suppressed.
- *   8. Return remaining diagnostics.
+ *   9. Return remaining diagnostics.
  */
 export async function runLint(options: LintOptions): Promise<LintResult> {
   const { entries } = options;
@@ -114,7 +116,7 @@ export async function runLint(options: LintOptions): Promise<LintResult> {
   );
   const isIdHook: IsIdentifierHook = () => false;
 
-  // Steps 1–5: collect diagnostics keyed by entry
+  // Steps 1–6: collect diagnostics keyed by entry
   const inScopeDiags = new Map<Entry, LintDiagnostic[]>();
   for (const entry of entries) {
     if (!isProseScope(entry)) continue;
@@ -122,6 +124,7 @@ export async function runLint(options: LintOptions): Promise<LintResult> {
     diags.push(...runLexiconRules(entry));
     diags.push(...runStructRules(entry));
     diags.push(...runXrefRules(entry, glossary, allow, isIdHook));
+    diags.push(...runEarsRules(entry));
     inScopeDiags.set(entry, diags);
   }
 

--- a/packages/markspec/core/lint/runner.ts
+++ b/packages/markspec/core/lint/runner.ts
@@ -128,14 +128,14 @@ export async function runLint(options: LintOptions): Promise<LintResult> {
     inScopeDiags.set(entry, diags);
   }
 
-  // Step 6: suppression hygiene on all Authored entries
+  // Step 7: suppression hygiene on all Authored entries
   const hygieneDiags: LintDiagnostic[] = [];
   for (const entry of entries) {
     if (entry.shape !== "Authored") continue;
     hygieneDiags.push(...runSuppressionRules(entry));
   }
 
-  // Step 7: apply suppression to in-scope diagnostics
+  // Step 8: apply suppression to in-scope diagnostics
   const out: LintDiagnostic[] = [];
   for (const [entry, diags] of inScopeDiags) {
     const disabled = disabledCodes(entry);
@@ -147,7 +147,7 @@ export async function runLint(options: LintOptions): Promise<LintResult> {
     }
   }
 
-  // Step 8: append hygiene diagnostics (never suppressed)
+  // Step 9: append hygiene diagnostics (never suppressed)
   out.push(...hygieneDiags);
 
   return { diagnostics: out };


### PR DESCRIPTION
## Summary

Five EARS pattern rules per spec §2.4. Fires on normative sentences (those containing a modal verb) to flag deviations from the six canonical EARS patterns (Mavin 2009). Q104 also catches non-normative malformed attempts.

This is **slice 6 of 10** for the Stage-2 PA-3 prose-analysis build.

## Rules shipped

| Code     | Slug                          | Sev  | Score | What it detects                                                                                              |
|----------|-------------------------------|------|-------|--------------------------------------------------------------------------------------------------------------|
| MSL-Q100 | ears-no-pattern               | info | 1     | Normative sentence matches none of the six EARS patterns.                                                    |
| MSL-Q101 | ears-missing-actor            | warn | 3     | EARS-shaped but no explicit `<system>` actor before the modal.                                              |
| MSL-Q102 | ears-negative-response        | info | 1     | Bare negation (`shall not …` / `should not …` / `must not …`).                                              |
| MSL-Q103 | ears-stacked-preconditions    | warn | 3     | ≥3 stacked `While`/`When`/`If` preconditions in one sentence.                                               |
| MSL-Q104 | ears-malformed-attempt        | info | 1     | Sentence opens with EARS keyword but has no modal+response.                                                  |

## Infrastructure

- **`core/lint/range_util.ts`** (new): extracted `offsetToRange` from xref.ts. Now shared by xref + ears (and slices 7-8 will reuse it). xref.ts imports from here.
- Wired into `runLint` after `runXrefRules` per spec ordering.
- Suppression hygiene: `Markspec-disable: ears-missing-actor` (or any of the Q1xx codes/slugs) is recognized; Q500 also added to the known set.

## Pragmatic narrowings (documented in code)

- **`GENERIC_ACTOR_ALLOWLIST`** — 15 generic actor words (system, controller, module, unit, device, software, firmware, application, processor, subsystem, component, platform, service, driver, manager) suppress Q101 when used after `the`. Spec §2.4 allows `the system`, `the controller`, "etc."; this list is the "etc." TODO-marked for profile extension later.
- **Modal detection via text regex**, not bodyTokens. Simpler and consistent with the regex in `body_tokens.ts`. Detects RFC 2119 set plus negations.
- **Q103+Q100 dedupe**: when Q103 fires (≥3 preconditions), Q100 is suppressed for the same sentence — the sentence IS EARS-shaped, just over-complex. Q102 still applies independently.

## Test plan

- [x] 21 unit tests covering all 5 rules, valid Event-driven + Unwanted-behaviour patterns silent, file-absolute range, severity/score field assertions, and the Q101+Q102 non-co-fire case.
- [x] All existing PA-1 + slices 1-5 tests still pass.
- [x] Full suite: 2033 tests passing, 0 failing.
- [x] `just check` clean; `deno fmt --check` + `dprint check` clean.

## Reviews completed

- **Spec compliance + code quality** (sonnet pass): ✅ spec compliant; ⚠️ approved with nits. Three Important items fixed in the follow-up commit:
  1. Misleading comment about which downstream rules apply after Q103 — clarified.
  2. Q101+Q102 non-co-fire was correct but unasserted — assertion added.
  3. `runner.ts` inline step comments were off-by-one against the JSDoc — fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
