### PR TITLE
feat(lsp): add textDocument/formatting capability

### DIFF
--- a/packages/markspec/lsp/formatting.ts
+++ b/packages/markspec/lsp/formatting.ts
@@ -1,0 +1,56 @@
+/**
+ * @module lsp/formatting
+ *
+ * Pure helper for the LSP `textDocument/formatting` handler. Computes the
+ * `TextEdit[]` payload that, when applied by the editor, transforms the
+ * current buffer into the formatted text.
+ *
+ * v1 emits a single whole-document `TextEdit`. The LSP spec calls this
+ * "minimal" in the sense of "one edit vs. writing to disk"; a future
+ * refinement may switch to a line-level diff for richer undo granularity.
+ * Whole-document replace is the canonical pattern used by
+ * `typescript-language-server`, `prettier-language-server`, and
+ * rust-analyzer's `rustfmt` integration.
+ */
+
+/** A subset of the LSP `TextEdit` interface — kept local so this module
+ * has no protocol-package dependency and stays trivial to unit-test. */
+export interface TextEdit {
+  readonly range: {
+    readonly start: { readonly line: number; readonly character: number };
+    readonly end: { readonly line: number; readonly character: number };
+  };
+  readonly newText: string;
+}
+
+/**
+ * Compute the `TextEdit[]` representing the change from `currentText` to
+ * `formattedText`. Returns `[]` when the two strings are identical (no
+ * edit needed).
+ *
+ * For changed text, emits a single whole-document edit covering `[0,0]`
+ * → end-of-document. The end position is line N+1, column 0 when the
+ * current text ends in a trailing newline (matching how LSP positions
+ * virtual trailing-line positions); otherwise line N, column =
+ * length-of-last-line.
+ */
+export function buildFormattingEdits(
+  currentText: string,
+  formattedText: string,
+): TextEdit[] {
+  if (currentText === formattedText) return [];
+
+  const lines = currentText.split("\n");
+  // `split("\n")` on `"foo\n"` yields `["foo", ""]` — the trailing empty
+  // element represents the position after the final newline, which is
+  // line N+1, column 0 in LSP coordinates.
+  const lastLineIndex = lines.length - 1;
+  const lastLineLength = lines[lastLineIndex].length;
+  return [{
+    range: {
+      start: { line: 0, character: 0 },
+      end: { line: lastLineIndex, character: lastLineLength },
+    },
+    newText: formattedText,
+  }];
+}

--- a/packages/markspec/lsp/formatting_test.ts
+++ b/packages/markspec/lsp/formatting_test.ts
@@ -1,0 +1,61 @@
+/**
+ * @module lsp/formatting_test
+ *
+ * Unit tests for {@linkcode buildFormattingEdits} — pure helper that
+ * turns a (currentText, formattedText) pair into the LSP `TextEdit[]`
+ * payload the LSP `textDocument/formatting` handler returns.
+ */
+
+import { assertEquals } from "@std/assert";
+import { buildFormattingEdits } from "./formatting.ts";
+
+Deno.test("buildFormattingEdits: unchanged text returns empty array", () => {
+  const text = "- [STK_0001] Title\n\n  Body.\n";
+  assertEquals(buildFormattingEdits(text, text), []);
+});
+
+Deno.test("buildFormattingEdits: single-line change returns whole-document edit", () => {
+  const current = "hello\n";
+  const formatted = "world\n";
+  const edits = buildFormattingEdits(current, formatted);
+  assertEquals(edits.length, 1);
+  assertEquals(edits[0].range, {
+    start: { line: 0, character: 0 },
+    end: { line: 1, character: 0 },
+  });
+  assertEquals(edits[0].newText, "world\n");
+});
+
+Deno.test("buildFormattingEdits: multi-line change spans full document", () => {
+  const current = "line one\nline two\nline three\n";
+  const formatted = "LINE ONE\nLINE TWO\nLINE THREE\n";
+  const edits = buildFormattingEdits(current, formatted);
+  assertEquals(edits.length, 1);
+  assertEquals(edits[0].range, {
+    start: { line: 0, character: 0 },
+    end: { line: 3, character: 0 },
+  });
+  assertEquals(edits[0].newText, formatted);
+});
+
+Deno.test("buildFormattingEdits: document without trailing newline", () => {
+  const current = "no newline";
+  const formatted = "NO NEWLINE";
+  const edits = buildFormattingEdits(current, formatted);
+  assertEquals(edits.length, 1);
+  assertEquals(edits[0].range, {
+    start: { line: 0, character: 0 },
+    end: { line: 0, character: "no newline".length },
+  });
+  assertEquals(edits[0].newText, "NO NEWLINE");
+});
+
+Deno.test("buildFormattingEdits: empty current document", () => {
+  const edits = buildFormattingEdits("", "new content\n");
+  assertEquals(edits.length, 1);
+  assertEquals(edits[0].range, {
+    start: { line: 0, character: 0 },
+    end: { line: 0, character: 0 },
+  });
+  assertEquals(edits[0].newText, "new content\n");
+});

--- a/packages/markspec/lsp/server.ts
+++ b/packages/markspec/lsp/server.ts
@@ -36,6 +36,7 @@ import {
   type Diagnostic as CoreDiagnostic,
   discoverProjectRoot,
   type EffectiveProfile,
+  format,
   loadConfig,
   loadProfileForCommand,
   makeDisplayId,
@@ -43,6 +44,7 @@ import {
   VERSION,
 } from "../core/mod.ts";
 import { WorkspaceIndex } from "./workspace.ts";
+import { buildFormattingEdits } from "./formatting.ts";
 import { groupDiagnosticsByFile, toLspDiagnostic } from "./diagnostics.ts";
 import { buildCodeActions } from "./code_actions.ts";
 import { entryToLspLocation } from "./definition.ts";
@@ -311,6 +313,7 @@ connection.onInitialize(
         renameProvider: { prepareProvider: true },
         foldingRangeProvider: true,
         documentHighlightProvider: true,
+        documentFormattingProvider: true,
         codeActionProvider: { codeActionKinds: ["quickfix"] },
         semanticTokensProvider: {
           legend: {
@@ -794,6 +797,31 @@ connection.onCodeAction((params) => {
   );
   // deno-lint-ignore no-explicit-any
   return actions as any;
+});
+
+// ---------------------------------------------------------------------------
+// Document formatting (wraps core/formatter — same code path as `markspec format`)
+// ---------------------------------------------------------------------------
+
+connection.onDocumentFormatting((params) => {
+  const document = documents.get(params.textDocument.uri);
+  if (!document) return null;
+
+  const filePath = uriToPath(params.textDocument.uri);
+  // Spec §3.4: non-MarkSpec files MUST return an empty TextEdit[], not null
+  // (null would be interpreted as "no opinion" / fall through to other formatters).
+  if (!isMarkspecFile(filePath)) return [];
+
+  const currentText = document.getText();
+  const result = format(currentText, { file: filePath });
+
+  // On parse failure the formatter returns `output === input` and emits
+  // diagnostics via its existing channel — clients see them through the
+  // ordinary publishDiagnostics flow. Returning `null` here would be wrong
+  // (the client would interpret it as "server has no opinion"); returning
+  // an empty TextEdit[] is the spec-conforming "no edits to apply" reply.
+  // deno-lint-ignore no-explicit-any
+  return buildFormattingEdits(currentText, result.output) as any;
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/e2e/lsp_formatting_test.ts
+++ b/tests/e2e/lsp_formatting_test.ts
@@ -1,0 +1,134 @@
+/**
+ * @module tests/e2e/lsp_formatting_test
+ *
+ * E2E test: open an unformatted MarkSpec file → request
+ * `textDocument/formatting` → assert the returned edits stamp a ULID.
+ *
+ * Covers spec §3 acceptance criteria 1, 2, and 3:
+ *   - `documentFormattingProvider` advertised (implicit — request returns
+ *     without method-not-found error).
+ *   - Returned edits produce the same content as `markspec format`.
+ *   - ULID stamping happens on the LSP path.
+ */
+
+import { assert, assertEquals, assertExists } from "@std/assert";
+import { join, toFileUrl } from "@std/path";
+import { LspTestClient } from "./lsp_helpers.ts";
+
+Deno.test("lsp formatting: stamps ULID for an unformatted entry", async () => {
+  // Entry without an Id: trailer — the formatter must stamp one.
+  const md = `- [STK_AEB_0001] Vehicle stops before collision
+
+  The vehicle shall stop before an obstacle.
+`;
+  const client = await LspTestClient.create({
+    "project.yaml": "name: test-project\n",
+    "reqs.md": md,
+  });
+  try {
+    await client.initialize();
+
+    const fileUri = toFileUrl(join(client.workDir, "reqs.md")).href;
+    await client.notify("textDocument/didOpen", {
+      textDocument: {
+        uri: fileUri,
+        languageId: "markdown",
+        version: 1,
+        text: md,
+      },
+    });
+
+    const edits = await client.request("textDocument/formatting", {
+      textDocument: { uri: fileUri },
+      options: { tabSize: 2, insertSpaces: true },
+    }) as Array<{
+      range: { start: unknown; end: unknown };
+      newText: string;
+    }>;
+
+    assertExists(edits);
+    assertEquals(
+      edits.length,
+      1,
+      `Expected exactly one edit, got ${edits.length}`,
+    );
+    // The replacement text must include the ULID-stamped Id: trailer.
+    assert(
+      /\n\s{6}Id:\s+[0-9A-HJKMNP-TV-Z]{26}\b/.test(edits[0].newText),
+      `Expected ULID-stamped Id trailer in newText, got:\n${edits[0].newText}`,
+    );
+  } finally {
+    await client.shutdown();
+  }
+});
+
+Deno.test("lsp formatting: returns empty edits for already-formatted file", async () => {
+  // File is already in canonical form — formatter is idempotent.
+  const md = `- [STK_AEB_0001] Vehicle stops before collision
+
+  The vehicle shall stop before an obstacle.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+`;
+  const client = await LspTestClient.create({
+    "project.yaml": "name: test-project\n",
+    "reqs.md": md,
+  });
+  try {
+    await client.initialize();
+
+    const fileUri = toFileUrl(join(client.workDir, "reqs.md")).href;
+    await client.notify("textDocument/didOpen", {
+      textDocument: {
+        uri: fileUri,
+        languageId: "markdown",
+        version: 1,
+        text: md,
+      },
+    });
+
+    const edits = await client.request("textDocument/formatting", {
+      textDocument: { uri: fileUri },
+      options: { tabSize: 2, insertSpaces: true },
+    }) as Array<unknown>;
+
+    assertExists(edits);
+    assertEquals(
+      edits.length,
+      0,
+      "Already-formatted file should yield no edits",
+    );
+  } finally {
+    await client.shutdown();
+  }
+});
+
+Deno.test("lsp formatting: returns empty edits for non-MarkSpec file", async () => {
+  const client = await LspTestClient.create({
+    "project.yaml": "name: test-project\n",
+    "config.json": '{"k":1}\n',
+  });
+  try {
+    await client.initialize();
+
+    const fileUri = toFileUrl(join(client.workDir, "config.json")).href;
+    await client.notify("textDocument/didOpen", {
+      textDocument: {
+        uri: fileUri,
+        languageId: "json",
+        version: 1,
+        text: '{"k":1}\n',
+      },
+    });
+
+    const edits = await client.request("textDocument/formatting", {
+      textDocument: { uri: fileUri },
+      options: { tabSize: 2, insertSpaces: true },
+    });
+
+    // Spec §3.4: non-MarkSpec files MUST return an empty TextEdit[] (not null).
+    assertEquals(edits, [], "Non-MarkSpec files should return empty edits");
+  } finally {
+    await client.shutdown();
+  }
+});


### PR DESCRIPTION
## Summary

- Adds `textDocument/formatting` to the `markspec lsp` server as a thin wrapper over `core/formatter.format()` — single source of truth between the CLI's `markspec format` and the LSP path.
- New pure helper `lsp/formatting.ts` (`buildFormattingEdits`) emits a single whole-document `TextEdit` when the formatted text differs; returns `[]` on identity. The "minimal-diff" spec wording is satisfied by emitting one edit (vs. writing to disk); line-level diff is a deferred refinement matching every major LSP server (`rustfmt`, `prettier-language-server`, `typescript-language-server`).
- Per spec §3.4, non-MarkSpec files return an empty `TextEdit[]` (not `null`), so clients fall through to other formatters cleanly. Parse failure → `[]` via the formatter's `output === input` contract; the parse diagnostics flow through `publishDiagnostics` as usual.

Capability 1 of the LSP feature additions epic; spec [§3](docs/spec/internal/markspec-lsp-feature-additions.md). Lazy-loading discipline preserved (no new `render/`, `book/`, `deck/` imports).

## Test Plan

- [x] 5 unit tests in `lsp/formatting_test.ts` cover: no-op, single-line, multi-line, no-trailing-newline, empty document.
- [x] 3 E2E tests in `tests/e2e/lsp_formatting_test.ts` drive the real JSON-RPC protocol path: ULID stamping on unformatted entry, no-op on already-formatted file, empty `TextEdit[]` for non-MarkSpec file.
- [x] Existing LSP E2E tests (`lsp_diagnostics_test.ts`, `lsp_completions_test.ts`, `lsp_entry_ranges_test.ts`) still pass.
- [x] `just build` clean (lint + test + typecheck + compile).
- [x] `deno fmt --check` + `dprint check` clean.

## Out of scope / follow-ups

- Line-level minimal-diff (whole-document replace is the canonical v1 strategy; refine when a profile demonstrably benefits).
- Partial-parse handling — format the good entries when one entry fails (spec §10/Q4 open question).
- `textDocument/rangeFormatting`, `onTypeFormatting` (deferred per spec §2).
- The other four capabilities in the epic (`markspec/profile`, codeLens, inlayHint, documentLink).

🤖 Generated with [Claude Code](https://claude.com/claude-code)