### PR TITLE
feat(core): slice 7 — modal sentence rules MSL-Q200 and MSL-Q201

### DIFF
--- a/packages/markspec/core/lint/rules/modal_sentence.ts
+++ b/packages/markspec/core/lint/rules/modal_sentence.ts
@@ -1,0 +1,198 @@
+/**
+ * @module core/lint/rules/modal_sentence
+ *
+ * Modal sentence rules for PA-3:
+ *
+ *   MSL-Q200  modal-multiple           (warn, score 3)
+ *   MSL-Q201  modal-soft-in-normative  (info, score 1)
+ *
+ * Q200: ≥2 normative modals in one sentence — a compound requirement.
+ * Q201: `should`/`may` (with or without `not`) in a Requirement-rooted entry.
+ *
+ * Q202 (modal-prohibited) is NOT in scope for this slice — deferred per
+ * ADR-021 Decision 6 (needs profile config plumbing not yet in core).
+ *
+ * Both rules operate on paragraph-kind body blocks only. Gherkin DocStrings
+ * live in `feature` blocks (not paragraph-kind) and are excluded by design.
+ */
+
+import type { Entry } from "../../model/mod.ts";
+import type { BodyBlock, ParagraphNode } from "../../ast/nodes.ts";
+import type { LintDiagnostic } from "../types.ts";
+import { segmentSentences } from "../segmenter.ts";
+import { loadLexicon } from "../../lexicons/mod.ts";
+import { offsetToRange } from "../range_util.ts";
+import { resolvedCoreType } from "../../validator/type_resolution.ts";
+
+const ABBREVS = loadLexicon("sentence-abbrev");
+
+// ---------------------------------------------------------------------------
+// Regexes
+// ---------------------------------------------------------------------------
+
+/**
+ * RFC 2119 modal verbs — compound negations FIRST so `shall not` is
+ * captured as a single token rather than `shall` + `not`. The `gi`
+ * flags enable case-insensitive matching and allow `exec`-loop reuse
+ * after resetting `lastIndex`.
+ *
+ * `will` is intentionally excluded — it is not a normative modal per
+ * RFC 2119 and its presence is handled by the Q202 rule (deferred).
+ */
+const MODAL_COMPOUND_RE =
+  /\b(shall not|should not|must not|may not|shall|should|must|may)\b/gi;
+
+/**
+ * Soft modal check — `should`/`may` with or without `not`. Used by
+ * Q201 to detect hedge modals in Requirement-typed entries. Stateless
+ * (no `g` flag); reset not required.
+ */
+const SOFT_MODAL_RE = /\b(should not|may not|should|may)\b/i;
+
+// ---------------------------------------------------------------------------
+// Rule code registry
+// ---------------------------------------------------------------------------
+
+/** All modal-sentence rule codes exported for the suppression-hygiene set. */
+export const MODAL_SENTENCE_RULE_CODES: ReadonlySet<string> = new Set([
+  "MSL-Q200",
+  "MSL-Q201",
+]);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Count the number of modal occurrences in `text`.
+ *
+ * Compound negations (`shall not`, `should not`, `must not`, `may not`) each
+ * count as ONE modal, not two — they are single rhetorical tokens. The regex
+ * places compound forms before bare forms so greedy matching handles the
+ * `not` suffix as part of the token.
+ */
+function countModals(text: string): number {
+  MODAL_COMPOUND_RE.lastIndex = 0;
+  let count = 0;
+  while (MODAL_COMPOUND_RE.exec(text) !== null) count++;
+  return count;
+}
+
+// ---------------------------------------------------------------------------
+// Emit helpers
+// ---------------------------------------------------------------------------
+
+function emitQ200(
+  sentence: string,
+  sentenceOffset: number,
+  paragraphText: string,
+  baseLine: number,
+  baseCol: number,
+  entry: Entry,
+  modalCount: number,
+): LintDiagnostic {
+  const range = offsetToRange(
+    paragraphText,
+    sentenceOffset,
+    sentence.length,
+    baseLine,
+    baseCol,
+  );
+  return {
+    code: "MSL-Q200",
+    slug: "modal-multiple",
+    severity: "warning",
+    scoreContribution: 3,
+    group: "modal",
+    message:
+      `modal-multiple: ${modalCount} modal verbs in one sentence; split into separate single-obligation requirements`,
+    location: entry.location,
+    range,
+  };
+}
+
+function emitQ201(
+  sentence: string,
+  sentenceOffset: number,
+  paragraphText: string,
+  baseLine: number,
+  baseCol: number,
+  entry: Entry,
+): LintDiagnostic {
+  const range = offsetToRange(
+    paragraphText,
+    sentenceOffset,
+    sentence.length,
+    baseLine,
+    baseCol,
+  );
+  return {
+    code: "MSL-Q201",
+    slug: "modal-soft-in-normative",
+    severity: "info",
+    scoreContribution: 1,
+    group: "modal",
+    message:
+      `modal-soft-in-normative: 'should'/'may' in a Requirement entry is a hedge, not an obligation; use 'shall' or 'must' instead`,
+    location: entry.location,
+    range,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Public entry point
+// ---------------------------------------------------------------------------
+
+/**
+ * Run modal sentence rules (Q200–Q201) on an entry's paragraph bodies.
+ *
+ * For each paragraph, segments into sentences. For each sentence:
+ *   - Q200 fires when ≥2 modal verbs appear in the same sentence
+ *     (compound requirement).
+ *   - Q201 fires when a soft modal (`should`/`may`) appears in a sentence
+ *     of a Requirement-typed entry.
+ *
+ * One Q200 diagnostic is emitted per offending sentence regardless of how
+ * many modals (≥2) the sentence contains. Q201 similarly emits once per
+ * offending sentence.
+ */
+export function runModalSentenceRules(entry: Entry): LintDiagnostic[] {
+  const out: LintDiagnostic[] = [];
+  const blocks: readonly BodyBlock[] = entry.bodyAst ?? [];
+
+  // Q201 only fires for Requirement-rooted entries. Conservatively skip when
+  // the core type is unresolved (profile-less project or unknown display-ID).
+  const isRequirement = resolvedCoreType(entry) === "Requirement";
+
+  for (const block of blocks) {
+    if (block.kind !== "paragraph") continue;
+    const p = block as ParagraphNode;
+    const text = p.content.text;
+
+    // Compute file-absolute base line for this paragraph.
+    // p.range.start.line is body-relative (line 1 = first body line).
+    // entry.bodyStartLine is file-absolute. Fall back to entry.location.line + 1.
+    const absBodyStart = entry.bodyStartLine ?? (entry.location.line + 1);
+    const absLine = absBodyStart + p.range.start.line - 1;
+    const baseCol = p.range.start.column;
+
+    const sentences = segmentSentences(text, ABBREVS);
+    for (const sentence of sentences) {
+      const s = sentence.text;
+      const off = sentence.offset;
+
+      // Q200: ≥2 modals in a single sentence.
+      const modalCount = countModals(s);
+      if (modalCount >= 2) {
+        out.push(emitQ200(s, off, text, absLine, baseCol, entry, modalCount));
+      }
+
+      // Q201: soft modal in a Requirement-typed entry.
+      if (isRequirement && SOFT_MODAL_RE.test(s)) {
+        out.push(emitQ201(s, off, text, absLine, baseCol, entry));
+      }
+    }
+  }
+
+  return out;
+}

--- a/packages/markspec/core/lint/rules/modal_sentence_test.ts
+++ b/packages/markspec/core/lint/rules/modal_sentence_test.ts
@@ -1,0 +1,231 @@
+/**
+ * @module core/lint/rules/modal_sentence_test
+ *
+ * Unit tests for modal sentence rules MSL-Q200 and MSL-Q201.
+ */
+
+import { assertEquals } from "@std/assert";
+import type { BodyBlock } from "../../ast/nodes.ts";
+import type { Entry } from "../../model/mod.ts";
+import { makeDisplayId } from "../../model/mod.ts";
+import { runModalSentenceRules } from "./modal_sentence.ts";
+
+// ---------------------------------------------------------------------------
+// Test helper
+// ---------------------------------------------------------------------------
+
+function makeParagraph(text: string, line = 1, column = 1): BodyBlock {
+  return {
+    kind: "paragraph",
+    content: { text },
+    range: {
+      start: { line, column },
+      end: { line, column: column + text.length },
+    },
+  };
+}
+
+interface MakeEntryOpts {
+  /** Resolved core type string (e.g. "Requirement", "Test"). */
+  type?: string;
+  location?: { file: string; line: number; column: number };
+  bodyStartLine?: number;
+}
+
+function makeEntry(
+  body: string,
+  opts: MakeEntryOpts = {},
+): Entry {
+  const bodyAst: BodyBlock[] = [makeParagraph(body)];
+  const location = opts.location ?? { file: "test.md", line: 1, column: 1 };
+  const entryType = opts.type;
+  return {
+    displayId: makeDisplayId("STK_0001"),
+    title: "Test requirement",
+    body,
+    bodyAst,
+    rawAttributes: [
+      { key: "Id", value: "01HGW2Q8MNP3RSTVWXYZABCDEF" },
+      ...(entryType ? [{ key: "Type", value: entryType }] : []),
+    ],
+    typedAttributes: new Map([
+      ["Id", ["01HGW2Q8MNP3RSTVWXYZABCDEF"]],
+      ...(entryType ? [["Type", [entryType]] as [string, string[]]] : []),
+    ]),
+    id: "01HGW2Q8MNP3RSTVWXYZABCDEF",
+    type: entryType,
+    shape: "Authored",
+    location,
+    ...(opts.bodyStartLine !== undefined
+      ? { bodyStartLine: opts.bodyStartLine }
+      : {}),
+    source: { kind: "markdown" },
+    bodyTokens: [],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// MSL-Q200: modal-multiple
+// ---------------------------------------------------------------------------
+
+Deno.test("Q200: fires when ≥2 modals in one sentence", () => {
+  const entry = makeEntry(
+    "The system shall apply pressure and shall log the event.",
+  );
+  const diags = runModalSentenceRules(entry);
+  assertEquals(diags.some((d) => d.code === "MSL-Q200"), true);
+});
+
+Deno.test("Q200: silent when modals split across sentences", () => {
+  const entry = makeEntry("The system shall apply. The logger shall record.");
+  const diags = runModalSentenceRules(entry);
+  assertEquals(diags.some((d) => d.code === "MSL-Q200"), false);
+});
+
+Deno.test("Q200: silent on single modal", () => {
+  const entry = makeEntry("The system shall apply pressure.");
+  const diags = runModalSentenceRules(entry);
+  assertEquals(diags.some((d) => d.code === "MSL-Q200"), false);
+});
+
+Deno.test("Q200: 3 modals in one sentence still fires once", () => {
+  const entry = makeEntry(
+    "The brake shall apply, shall log, and shall release.",
+  );
+  const diags = runModalSentenceRules(entry);
+  const q200 = diags.filter((d) => d.code === "MSL-Q200");
+  assertEquals(q200.length, 1); // one diagnostic per offending sentence
+});
+
+Deno.test("Q200: 'shall not' counts as one modal, not two", () => {
+  const entry = makeEntry(
+    "The system shall not retry on failure.",
+  );
+  const diags = runModalSentenceRules(entry);
+  assertEquals(diags.some((d) => d.code === "MSL-Q200"), false);
+});
+
+Deno.test("Q200: 'shall not' + 'shall' counts as two modals", () => {
+  // Two distinct modal tokens: "shall not" and "shall".
+  const entry = makeEntry(
+    "The system shall not retry on failure and shall log the event.",
+  );
+  const diags = runModalSentenceRules(entry);
+  assertEquals(diags.some((d) => d.code === "MSL-Q200"), true);
+});
+
+// ---------------------------------------------------------------------------
+// MSL-Q201: modal-soft-in-normative
+// ---------------------------------------------------------------------------
+
+Deno.test("Q201: fires for 'should' in Requirement-typed entry", () => {
+  const entry = makeEntry("The system should retry on failure.", {
+    type: "Requirement",
+  });
+  const diags = runModalSentenceRules(entry);
+  assertEquals(diags.some((d) => d.code === "MSL-Q201"), true);
+});
+
+Deno.test("Q201: fires for 'may' in Requirement-typed entry", () => {
+  const entry = makeEntry("The driver may override the alert.", {
+    type: "Requirement",
+  });
+  const diags = runModalSentenceRules(entry);
+  assertEquals(diags.some((d) => d.code === "MSL-Q201"), true);
+});
+
+Deno.test("Q201: silent for 'shall' in Requirement-typed entry", () => {
+  const entry = makeEntry("The system shall retry on failure.", {
+    type: "Requirement",
+  });
+  const diags = runModalSentenceRules(entry);
+  assertEquals(diags.some((d) => d.code === "MSL-Q201"), false);
+});
+
+Deno.test("Q201: silent for 'should' in a non-Requirement entry (e.g. Test)", () => {
+  const entry = makeEntry("The test should verify the brake actuation.", {
+    type: "Test",
+  });
+  const diags = runModalSentenceRules(entry);
+  assertEquals(diags.some((d) => d.code === "MSL-Q201"), false);
+});
+
+Deno.test("Q201: silent for 'should' in entry with no resolved type", () => {
+  // Profile-less project: entry type is undefined. Q201 conservatively skips.
+  const entry = makeEntry("The system should retry on failure.");
+  const diags = runModalSentenceRules(entry);
+  assertEquals(diags.some((d) => d.code === "MSL-Q201"), false);
+});
+
+// ---------------------------------------------------------------------------
+// Co-firing
+// ---------------------------------------------------------------------------
+
+Deno.test("Q200+Q201: can co-fire on 'The system should retry and should log.' in Requirement", () => {
+  // Both: ≥2 modals (Q200) AND soft modal in Requirement (Q201).
+  const entry = makeEntry(
+    "The system should retry and should log.",
+    { type: "Requirement" },
+  );
+  const diags = runModalSentenceRules(entry);
+  assertEquals(diags.some((d) => d.code === "MSL-Q200"), true);
+  assertEquals(diags.some((d) => d.code === "MSL-Q201"), true);
+});
+
+// ---------------------------------------------------------------------------
+// File-absolute range
+// ---------------------------------------------------------------------------
+
+Deno.test("Q200: range is file-absolute, sentence-span", () => {
+  // Use bodyStartLine to verify file-absolute emission.
+  const entry = makeEntry(
+    "The system shall apply and shall log.",
+    {
+      location: { file: "/x.md", line: 30, column: 1 },
+      bodyStartLine: 32,
+    },
+  );
+  const diags = runModalSentenceRules(entry);
+  const q200 = diags.find((d) => d.code === "MSL-Q200");
+  assertEquals(q200?.range?.start.line, 32);
+});
+
+// ---------------------------------------------------------------------------
+// Metadata fields
+// ---------------------------------------------------------------------------
+
+Deno.test("Q200: carries correct slug, group, scoreContribution, severity", () => {
+  const entry = makeEntry(
+    "The system shall apply pressure and shall log the event.",
+  );
+  const diags = runModalSentenceRules(entry);
+  const q200 = diags.find((d) => d.code === "MSL-Q200");
+  assertEquals(q200?.slug, "modal-multiple");
+  assertEquals(q200?.group, "modal");
+  assertEquals(q200?.scoreContribution, 3);
+  assertEquals(q200?.severity, "warning");
+});
+
+Deno.test("Q201: carries correct slug, group, scoreContribution, severity", () => {
+  const entry = makeEntry("The system should retry on failure.", {
+    type: "Requirement",
+  });
+  const diags = runModalSentenceRules(entry);
+  const q201 = diags.find((d) => d.code === "MSL-Q201");
+  assertEquals(q201?.slug, "modal-soft-in-normative");
+  assertEquals(q201?.group, "modal");
+  assertEquals(q201?.scoreContribution, 1);
+  assertEquals(q201?.severity, "info");
+});
+
+// ---------------------------------------------------------------------------
+// Silent on non-normative sentences (no modals)
+// ---------------------------------------------------------------------------
+
+Deno.test("modal: silent on non-normative sentences", () => {
+  const entry = makeEntry("The brake is a critical safety component.", {
+    type: "Requirement",
+  });
+  const diags = runModalSentenceRules(entry);
+  assertEquals(diags.length, 0);
+});

--- a/packages/markspec/core/lint/rules/suppression.ts
+++ b/packages/markspec/core/lint/rules/suppression.ts
@@ -14,13 +14,15 @@ import type { LintDiagnostic } from "../types.ts";
 import { LEXICON_RULE_CODES } from "./lexicon.ts";
 import { STRUCT_RULE_CODES } from "./struct.ts";
 import { EARS_RULE_CODES } from "./ears.ts";
+import { MODAL_SENTENCE_RULE_CODES } from "./modal_sentence.ts";
 
-/** All rule codes shipped in PA-1 through PA-3 (slices 1–6).
+/** All rule codes shipped in PA-1 through PA-3 (slices 1–7).
  * MSL-Q900/Q901 are self-referential. */
 export const PA1_KNOWN_RULE_CODES: ReadonlySet<string> = new Set([
   ...LEXICON_RULE_CODES,
   ...STRUCT_RULE_CODES,
   ...EARS_RULE_CODES,
+  ...MODAL_SENTENCE_RULE_CODES,
   // Q500: xref-glossary-undefined (slice 5)
   "MSL-Q500",
   "MSL-Q900",

--- a/packages/markspec/core/lint/runner.ts
+++ b/packages/markspec/core/lint/runner.ts
@@ -23,6 +23,7 @@ import type { FileReader, GlossaryIndex } from "./glossary.ts";
 import { runXrefRules } from "./rules/xref.ts";
 import type { IsIdentifierHook } from "./rules/xref.ts";
 import { runEarsRules } from "./rules/ears.ts";
+import { runModalSentenceRules } from "./rules/modal_sentence.ts";
 import { loadLexicon } from "../lexicons/mod.ts";
 
 // ---------------------------------------------------------------------------
@@ -99,12 +100,13 @@ function disabledCodes(entry: Entry): ReadonlySet<string> {
  *   4. Run structural rules on each in-scope entry.
  *   5. Run Q500 xref rules on each in-scope entry.
  *   6. Run EARS rules (Q100–Q104) on each in-scope entry.
- *   7. Run suppression hygiene on ALL Authored entries.
- *   8. Apply suppression: drop in-scope diagnostics where the entry's
+ *   7. Run modal sentence rules (Q200–Q201) on each in-scope entry.
+ *   8. Run suppression hygiene on ALL Authored entries.
+ *   9. Apply suppression: drop in-scope diagnostics where the entry's
  *      Markspec-disable list includes the rule's code and the entry
  *      has a Rationale. Suppression-hygiene diagnostics (Q900/Q901)
  *      are never suppressed.
- *   9. Return remaining diagnostics.
+ *  10. Return remaining diagnostics.
  */
 export async function runLint(options: LintOptions): Promise<LintResult> {
   const { entries } = options;
@@ -116,7 +118,7 @@ export async function runLint(options: LintOptions): Promise<LintResult> {
   );
   const isIdHook: IsIdentifierHook = () => false;
 
-  // Steps 1–6: collect diagnostics keyed by entry
+  // Steps 1–7: collect diagnostics keyed by entry
   const inScopeDiags = new Map<Entry, LintDiagnostic[]>();
   for (const entry of entries) {
     if (!isProseScope(entry)) continue;
@@ -125,17 +127,18 @@ export async function runLint(options: LintOptions): Promise<LintResult> {
     diags.push(...runStructRules(entry));
     diags.push(...runXrefRules(entry, glossary, allow, isIdHook));
     diags.push(...runEarsRules(entry));
+    diags.push(...runModalSentenceRules(entry));
     inScopeDiags.set(entry, diags);
   }
 
-  // Step 7: suppression hygiene on all Authored entries
+  // Step 8: suppression hygiene on all Authored entries
   const hygieneDiags: LintDiagnostic[] = [];
   for (const entry of entries) {
     if (entry.shape !== "Authored") continue;
     hygieneDiags.push(...runSuppressionRules(entry));
   }
 
-  // Step 8: apply suppression to in-scope diagnostics
+  // Step 9: apply suppression to in-scope diagnostics
   const out: LintDiagnostic[] = [];
   for (const [entry, diags] of inScopeDiags) {
     const disabled = disabledCodes(entry);
@@ -147,7 +150,7 @@ export async function runLint(options: LintOptions): Promise<LintResult> {
     }
   }
 
-  // Step 9: append hygiene diagnostics (never suppressed)
+  // Step 10: append hygiene diagnostics (never suppressed)
   out.push(...hygieneDiags);
 
   return { diagnostics: out };


### PR DESCRIPTION
## Summary

Two modal-verb misuse rules per spec §2.5:

| Code     | Slug                       | Sev  | Score | Fires when                                                                                                |
|----------|----------------------------|------|-------|-----------------------------------------------------------------------------------------------------------|
| MSL-Q200 | modal-multiple             | warn | 3     | ≥2 RFC 2119 modals in one sentence — a compound requirement.                                              |
| MSL-Q201 | modal-soft-in-normative    | info | 1     | `should`/`may` (±`not`) in a Requirement-rooted entry — a hedge, not an obligation.                       |

This is **slice 7 of 10** for the Stage-2 PA-3 prose-analysis build.

## Behaviour pinned by tests

- `shall not` counts as **1 modal**, not 2 — the regex consumes compound forms before bare. Test in `modal_sentence_test.ts`.
- `shall not + shall` in one sentence = 2 modals → Q200 fires.
- Q200 emits **one diagnostic per offending sentence**, even when 3+ modals are present.
- Q201 only fires when `resolvedCoreType(entry) === "Requirement"`. Profile-less entries (no resolved type) skip silently — conservative.
- `will` is **not** counted as a normative modal (excluded from RFC 2119 scope; belongs to the deferred Q202 modal-prohibited).
- Q200 + Q201 co-fire correctly on `"The system should retry and should log."` in a Requirement.
- Ranges are file-absolute, sentence-span (via `range_util.offsetToRange`).

## Q202 status

**Deferred** per ADR-021 Decision 6 — needs profile config plumbing (severity promotion, prohibited-modal lists per type). Not in scope for this slice or this epic.

## Test plan

- [x] 16 unit tests (13 spec-mandated + 3 extras).
- [x] All existing PA-1 + slices 1-6 tests still pass.
- [x] Full suite: 2111 tests passing, 0 failing.
- [x] `just check` clean; `deno fmt --check` + `dprint check` clean.

## Reviews completed

- **Spec compliance + code quality** (sonnet pass): ✅ spec compliant; ⚠️ approved with nits. No critical issues, no Important issues blocking merge.
- One observation worth noting: the normative-modal regex is now duplicated between `ears.ts` and `modal_sentence.ts`. Both files use slightly different forms (ears has `will`, modal_sentence has `may not`) because they serve different purposes. Extracting a shared modal-token utility is a candidate refactor for slice 8 or a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
