### PR TITLE
feat(cli): vscode lsp install — verify-and-report, drop `code --install-extension`

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -22,6 +22,7 @@
     "@std/assert": "jsr:@std/assert@^1",
     "@std/cli": "jsr:@std/cli@^1",
     "@std/fs": "jsr:@std/fs@^1",
+    "@std/jsonc": "jsr:@std/jsonc@^1",
     "@std/testing": "jsr:@std/testing@^1",
     "@std/ulid": "jsr:@std/ulid@^1",
     "@std/yaml": "jsr:@std/yaml@^1",

--- a/deno.lock
+++ b/deno.lock
@@ -9,7 +9,7 @@
     "jsr:@db/sqlite@0.13": "0.13.0",
     "jsr:@deno/dnt@~0.42.3": "0.42.3",
     "jsr:@denosaurs/plug@1": "1.1.0",
-    "jsr:@std/assert@1": "1.0.13",
+    "jsr:@std/assert@1": "1.0.19",
     "jsr:@std/assert@^1.0.19": "1.0.19",
     "jsr:@std/cli@1": "1.0.28",
     "jsr:@std/encoding@1": "1.0.10",
@@ -20,6 +20,8 @@
     "jsr:@std/internal@^1.0.12": "1.0.13",
     "jsr:@std/internal@^1.0.13": "1.0.13",
     "jsr:@std/internal@^1.0.6": "1.0.12",
+    "jsr:@std/json@^1.0.2": "1.1.0",
+    "jsr:@std/jsonc@1": "1.0.2",
     "jsr:@std/path@1": "1.1.4",
     "jsr:@std/path@1.0": "1.0.9",
     "jsr:@std/path@^1.1.0": "1.1.0",
@@ -154,6 +156,15 @@
     },
     "@std/internal@1.0.13": {
       "integrity": "2f9546691d4ac2d32859c82dff284aaeac980ddeca38430d07941e7e288725c0"
+    },
+    "@std/json@1.1.0": {
+      "integrity": "93330d3ed4054d6b1ffe54b075432c80a5f671be77277b978931e018014cb1cc"
+    },
+    "@std/jsonc@1.0.2": {
+      "integrity": "909605dae3af22bd75b1cbda8d64a32cf1fd2cf6efa3f9e224aba6d22c0f44c7",
+      "dependencies": [
+        "jsr:@std/json"
+      ]
     },
     "@std/path@1.0.9": {
       "integrity": "260a49f11edd3db93dd38350bf9cd1b4d1366afa98e81b86167b4e3dd750129e"
@@ -1423,6 +1434,7 @@
       "jsr:@std/assert@1",
       "jsr:@std/cli@1",
       "jsr:@std/fs@1",
+      "jsr:@std/jsonc@1",
       "jsr:@std/path@1",
       "jsr:@std/testing@1",
       "jsr:@std/ulid@1",

--- a/packages/markspec/cli/install/lsp_adapters.ts
+++ b/packages/markspec/cli/install/lsp_adapters.ts
@@ -87,38 +87,235 @@ export const neovimDescriptor: LspAdapter = {
   },
 };
 
-/**
- * VS Code adapter — verify-only.
- * The markspec-ide extension manages the LSP server; no config needed.
- */
-export async function vscodeAdapter(): Promise<AdapterResult> {
-  const extensionId = "driftsys.markspec-ide";
-  let installed = false;
-  try {
-    const cmd = new Deno.Command("code", {
-      args: ["--list-extensions"],
-      stdout: "piped",
-      stderr: "null",
-    });
-    const result = await cmd.output();
-    const output = new TextDecoder().decode(result.stdout);
-    installed = output.includes(extensionId);
-  } catch {
-    // `code` not on PATH — treat as not installed
-  }
+// ---------------------------------------------------------------------------
+// VS Code adapter — verify-and-report
+// ---------------------------------------------------------------------------
 
-  if (installed) {
+/** Marketplace extension ID for the bundled VS Code client. */
+const VSCODE_EXTENSION_ID = "driftsys.markspec-ide";
+
+/** Marketplace listing URL printed when the extension is missing. */
+const VSCODE_MARKETPLACE_URL =
+  "https://marketplace.visualstudio.com/items?itemName=driftsys.markspec-ide";
+
+/** Settings.json key the markspec-ide extension reads at startup. */
+const VSCODE_SERVER_PATH_KEY = "markspec.server.path";
+
+/**
+ * Injectable seams for {@linkcode vscodeAdapter}. Production callers omit
+ * `env` and let the orchestrator dispatch through {@linkcode defaultVscodeEnv}
+ * (which shells out to `code --list-extensions` and reads the platform's
+ * settings.json from disk). Tests pass a fully fake env so no host I/O occurs.
+ */
+export interface VscodeAdapterEnv {
+  readonly platform: "darwin" | "linux" | "win32";
+  readonly home: string;
+  /**
+   * `%APPDATA%` equivalent on Windows. Only consulted when
+   * {@linkcode platform} is `"win32"`; safe to omit on POSIX.
+   */
+  readonly appData?: string;
+  /**
+   * List installed VS Code extension IDs. Resolve to `undefined` when the
+   * `code` CLI is absent on `$PATH` — that's "extension status unknown",
+   * not "extension absent".
+   */
+  readonly listExtensions: () => Promise<readonly string[] | undefined>;
+  /**
+   * Read VS Code's settings.json at `path`. Resolve to `undefined` when the
+   * file does not exist. The returned string is JSONC — comments are
+   * tolerated by the adapter's parser.
+   */
+  readonly readSettings: (path: string) => Promise<string | undefined>;
+}
+
+/** Inputs accepted by {@linkcode vscodeAdapter}. */
+export interface VscodeAdapterOptions {
+  /**
+   * Absolute path to the running `markspec` binary. Compared against
+   * the `markspec.server.path` value in VS Code's settings.json.
+   * The orchestrator threads its `--binary-path` flag here.
+   */
+  readonly binaryPath: string;
+  /** Test-only seam — defaults to {@linkcode defaultVscodeEnv}. */
+  readonly env?: VscodeAdapterEnv;
+}
+
+/**
+ * Default `VscodeAdapterEnv` wired to real Deno APIs. Spawns `code
+ * --list-extensions` for detection and reads the platform's user
+ * settings.json from disk.
+ */
+export function defaultVscodeEnv(): VscodeAdapterEnv {
+  const platform: VscodeAdapterEnv["platform"] = Deno.build.os === "windows"
+    ? "win32"
+    : Deno.build.os === "darwin"
+    ? "darwin"
+    : "linux";
+  return {
+    platform,
+    home: Deno.env.get(platform === "win32" ? "USERPROFILE" : "HOME") ?? "",
+    appData: Deno.env.get("APPDATA") ?? undefined,
+    listExtensions: async () => {
+      try {
+        const cmd = new Deno.Command("code", {
+          args: ["--list-extensions"],
+          stdout: "piped",
+          stderr: "null",
+        });
+        const out = await cmd.output();
+        if (!out.success) return undefined;
+        return new TextDecoder().decode(out.stdout)
+          .split("\n")
+          .map((s) => s.trim())
+          .filter((s) => s.length > 0);
+      } catch {
+        return undefined;
+      }
+    },
+    readSettings: async (path) => {
+      try {
+        return await Deno.readTextFile(path);
+      } catch {
+        return undefined;
+      }
+    },
+  };
+}
+
+/**
+ * Resolve the user-scope settings.json path per platform — same locations
+ * VS Code itself reads from at startup.
+ */
+function userSettingsPath(env: VscodeAdapterEnv): string {
+  if (env.platform === "darwin") {
+    return join(
+      env.home,
+      "Library",
+      "Application Support",
+      "Code",
+      "User",
+      "settings.json",
+    );
+  }
+  if (env.platform === "win32") {
+    // APPDATA is the canonical location; fall back to HOME-derived path if absent.
+    const base = env.appData ?? join(env.home, "AppData", "Roaming");
+    return join(base, "Code", "User", "settings.json");
+  }
+  return join(env.home, ".config", "Code", "User", "settings.json");
+}
+
+/** Build the remediation snippet shown when settings.json needs an edit. */
+function remediationSnippet(binaryPath: string, settingsPath: string): string {
+  const escaped = JSON.stringify(binaryPath);
+  return [
+    `Add this to ${settingsPath}:`,
+    "",
+    "  {",
+    `    "${VSCODE_SERVER_PATH_KEY}": ${escaped}`,
+    "  }",
+  ].join("\n");
+}
+
+/**
+ * VS Code adapter — verify-and-report. Per spec §4.3 this adapter never
+ * writes config; it inspects the installed extension and VS Code's
+ * settings.json and prints either a success line or a remediation snippet.
+ *
+ * Per spec §8 Q5 it MUST NOT suggest `code --install-extension`. When the
+ * extension is absent, the only call-to-action is the marketplace URL.
+ */
+export async function vscodeAdapter(
+  options: VscodeAdapterOptions,
+): Promise<AdapterResult> {
+  const env = options.env ?? defaultVscodeEnv();
+  const extensions = await env.listExtensions();
+  const installed = extensions !== undefined &&
+    extensions.includes(VSCODE_EXTENSION_ID);
+
+  // Branch 1: extension absent (or status unknown because `code` is missing).
+  // Both paths point at the marketplace URL — the user installs from there.
+  if (!installed) {
+    const reason = extensions === undefined
+      ? `VS Code 'code' CLI not found on PATH; cannot verify extension. ` +
+        `Install the markspec-ide extension from:`
+      : `VS Code extension ${VSCODE_EXTENSION_ID} is not installed. ` +
+        `Install it from:`;
     return {
       stdout: "",
-      stderr:
-        `VS Code extension ${extensionId} is installed. The LSP server is launched automatically by the extension. No additional configuration needed.`,
+      stderr: `${reason}\n  ${VSCODE_MARKETPLACE_URL}`,
       exitCode: 0,
     };
   }
+
+  // Branch 2: extension installed — verify markspec.server.path in settings.json.
+  const settingsPath = userSettingsPath(env);
+  const raw = await env.readSettings(settingsPath);
+
+  if (raw === undefined) {
+    return {
+      stdout: "",
+      stderr: [
+        `VS Code extension ${VSCODE_EXTENSION_ID} is installed but ${settingsPath} does not exist.`,
+        remediationSnippet(options.binaryPath, settingsPath),
+      ].join("\n"),
+      exitCode: 0,
+    };
+  }
+
+  // Tolerate JSONC. Lazy-import keeps the dep out of code paths that
+  // never hit this adapter (the orchestrator only loads it on
+  // --editor=vscode).
+  const { parse } = await import("@std/jsonc");
+  let parsed: unknown;
+  try {
+    parsed = parse(raw);
+  } catch (err) {
+    return {
+      stdout: "",
+      stderr:
+        `VS Code extension ${VSCODE_EXTENSION_ID} is installed but ${settingsPath} is not valid JSONC: ${
+          (err as Error).message
+        }\nFix the file by hand, then re-run.`,
+      exitCode: 0,
+    };
+  }
+  const configured = isJsonObject(parsed)
+    ? parsed[VSCODE_SERVER_PATH_KEY]
+    : undefined;
+
+  if (typeof configured !== "string" || configured.length === 0) {
+    return {
+      stdout: "",
+      stderr: [
+        `VS Code extension ${VSCODE_EXTENSION_ID} is installed but ${VSCODE_SERVER_PATH_KEY} is not set in ${settingsPath}.`,
+        remediationSnippet(options.binaryPath, settingsPath),
+      ].join("\n"),
+      exitCode: 0,
+    };
+  }
+
+  if (configured !== options.binaryPath) {
+    return {
+      stdout: "",
+      stderr: [
+        `VS Code extension ${VSCODE_EXTENSION_ID} is installed but ${VSCODE_SERVER_PATH_KEY} in ${settingsPath} points at ${configured}, not ${options.binaryPath}.`,
+        remediationSnippet(options.binaryPath, settingsPath),
+      ].join("\n"),
+      exitCode: 0,
+    };
+  }
+
   return {
     stdout: "",
     stderr:
-      `VS Code extension ${extensionId} is not installed.\nInstall it from the VS Code Marketplace or run:\n  code --install-extension ${extensionId}`,
+      `VS Code extension ${VSCODE_EXTENSION_ID} is installed and ${VSCODE_SERVER_PATH_KEY} in ${settingsPath} matches ${options.binaryPath}. No action needed.`,
     exitCode: 0,
   };
+}
+
+/** Type guard for a plain JSON object — narrows `unknown` for property access. */
+function isJsonObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }

--- a/packages/markspec/cli/install/lsp_adapters_test.ts
+++ b/packages/markspec/cli/install/lsp_adapters_test.ts
@@ -1,5 +1,213 @@
 import { assert, assertEquals, assertStringIncludes } from "@std/assert";
-import { neovimAdapter, neovimDescriptor, zedAdapter } from "./lsp_adapters.ts";
+import {
+  neovimAdapter,
+  neovimDescriptor,
+  vscodeAdapter,
+  type VscodeAdapterEnv,
+  zedAdapter,
+} from "./lsp_adapters.ts";
+
+// ---------------------------------------------------------------------------
+// vscodeAdapter — Slice B verify-and-report rework (spec §4.3, §8 Q5)
+// ---------------------------------------------------------------------------
+
+const MARKETPLACE_URL =
+  "https://marketplace.visualstudio.com/items?itemName=driftsys.markspec-ide";
+const EXTENSION_ID = "driftsys.markspec-ide";
+
+/** Build a VscodeAdapterEnv with sensible defaults that tests can override. */
+function fakeEnv(overrides: Partial<VscodeAdapterEnv> = {}): VscodeAdapterEnv {
+  return {
+    platform: "darwin",
+    home: "/Users/test",
+    appData: undefined,
+    listExtensions: () => Promise.resolve([]),
+    readSettings: () => Promise.resolve(undefined),
+    ...overrides,
+  };
+}
+
+Deno.test("vscodeAdapter: extension not installed → marketplace URL, no `code --install-extension`", async () => {
+  const r = await vscodeAdapter({
+    binaryPath: "/opt/markspec/markspec",
+    env: fakeEnv({ listExtensions: () => Promise.resolve(["other.ext"]) }),
+  });
+  assertEquals(r.exitCode, 0);
+  assertStringIncludes(r.stderr, MARKETPLACE_URL);
+  assertEquals(
+    r.stderr.includes("code --install-extension"),
+    false,
+    "stderr must not suggest `code --install-extension` (spec §8 Q5)",
+  );
+});
+
+Deno.test("vscodeAdapter: `code` CLI absent → marketplace URL, no `code --install-extension`", async () => {
+  const r = await vscodeAdapter({
+    binaryPath: "/opt/markspec/markspec",
+    env: fakeEnv({ listExtensions: () => Promise.resolve(undefined) }),
+  });
+  assertEquals(r.exitCode, 0);
+  assertStringIncludes(r.stderr, MARKETPLACE_URL);
+  assertEquals(r.stderr.includes("code --install-extension"), false);
+});
+
+Deno.test("vscodeAdapter: extension installed + path matches → success, no remediation", async () => {
+  const settings = JSON.stringify({
+    "markspec.server.path": "/opt/markspec/markspec",
+  });
+  const r = await vscodeAdapter({
+    binaryPath: "/opt/markspec/markspec",
+    env: fakeEnv({
+      listExtensions: () => Promise.resolve([EXTENSION_ID]),
+      readSettings: () => Promise.resolve(settings),
+    }),
+  });
+  assertEquals(r.exitCode, 0);
+  // Success path mentions the extension is wired up correctly.
+  assertStringIncludes(r.stderr, EXTENSION_ID);
+  assertStringIncludes(r.stderr, "/opt/markspec/markspec");
+  // No remediation snippet on the success path.
+  assertEquals(r.stderr.includes("markspec.server.path"), true);
+  assertEquals(r.stderr.includes("code --install-extension"), false);
+});
+
+Deno.test("vscodeAdapter: extension installed + path mismatch → remediation snippet", async () => {
+  const settings = JSON.stringify({
+    "markspec.server.path": "/old/path/markspec",
+  });
+  const r = await vscodeAdapter({
+    binaryPath: "/opt/markspec/markspec",
+    env: fakeEnv({
+      listExtensions: () => Promise.resolve([EXTENSION_ID]),
+      readSettings: () => Promise.resolve(settings),
+    }),
+  });
+  assertEquals(r.exitCode, 0);
+  // Remediation lists both the stale and the expected paths.
+  assertStringIncludes(r.stderr, "/old/path/markspec");
+  assertStringIncludes(r.stderr, "/opt/markspec/markspec");
+  assertStringIncludes(r.stderr, "markspec.server.path");
+  assertEquals(r.stderr.includes("code --install-extension"), false);
+});
+
+Deno.test("vscodeAdapter: extension installed + key missing → remediation snippet", async () => {
+  // settings.json exists but markspec.server.path is unset.
+  const settings = JSON.stringify({ "editor.fontSize": 14 });
+  const r = await vscodeAdapter({
+    binaryPath: "/opt/markspec/markspec",
+    env: fakeEnv({
+      listExtensions: () => Promise.resolve([EXTENSION_ID]),
+      readSettings: () => Promise.resolve(settings),
+    }),
+  });
+  assertEquals(r.exitCode, 0);
+  assertStringIncludes(r.stderr, "markspec.server.path");
+  assertStringIncludes(r.stderr, "/opt/markspec/markspec");
+  assertEquals(r.stderr.includes("code --install-extension"), false);
+});
+
+Deno.test("vscodeAdapter: extension installed + settings.json missing → remediation snippet", async () => {
+  const r = await vscodeAdapter({
+    binaryPath: "/opt/markspec/markspec",
+    env: fakeEnv({
+      listExtensions: () => Promise.resolve([EXTENSION_ID]),
+      readSettings: () => Promise.resolve(undefined),
+    }),
+  });
+  assertEquals(r.exitCode, 0);
+  assertStringIncludes(r.stderr, "markspec.server.path");
+  assertStringIncludes(r.stderr, "/opt/markspec/markspec");
+  assertEquals(r.stderr.includes("code --install-extension"), false);
+});
+
+Deno.test("vscodeAdapter: JSONC settings with line + block comments parses correctly", async () => {
+  // VS Code's real settings.json is JSONC. The adapter must tolerate
+  // `//` line comments and `/* … */` block comments.
+  const settings = `{
+  // Line comment
+  "markspec.server.path": "/opt/markspec/markspec",
+  /* Block comment */
+  "editor.fontSize": 14
+}`;
+  const r = await vscodeAdapter({
+    binaryPath: "/opt/markspec/markspec",
+    env: fakeEnv({
+      listExtensions: () => Promise.resolve([EXTENSION_ID]),
+      readSettings: () => Promise.resolve(settings),
+    }),
+  });
+  assertEquals(r.exitCode, 0);
+  assertStringIncludes(r.stderr, "/opt/markspec/markspec");
+  // Must hit the "match" branch, not the remediation branch.
+  assertEquals(
+    r.stderr.includes("/old/"),
+    false,
+    "must parse JSONC and pick up the matching path",
+  );
+});
+
+Deno.test("vscodeAdapter: macOS resolves settings.json under Library/Application Support", async () => {
+  // The platform-specific path resolution is observable through the
+  // path argument passed to readSettings. Capture it.
+  let observedPath: string | undefined;
+  await vscodeAdapter({
+    binaryPath: "/opt/markspec/markspec",
+    env: fakeEnv({
+      platform: "darwin",
+      home: "/Users/test",
+      listExtensions: () => Promise.resolve([EXTENSION_ID]),
+      readSettings: (path: string) => {
+        observedPath = path;
+        return Promise.resolve(undefined);
+      },
+    }),
+  });
+  assertEquals(
+    observedPath?.replaceAll("\\", "/"),
+    "/Users/test/Library/Application Support/Code/User/settings.json",
+  );
+});
+
+Deno.test("vscodeAdapter: Linux resolves settings.json under .config/Code/User", async () => {
+  let observedPath: string | undefined;
+  await vscodeAdapter({
+    binaryPath: "/opt/markspec/markspec",
+    env: fakeEnv({
+      platform: "linux",
+      home: "/home/test",
+      listExtensions: () => Promise.resolve([EXTENSION_ID]),
+      readSettings: (path: string) => {
+        observedPath = path;
+        return Promise.resolve(undefined);
+      },
+    }),
+  });
+  assertEquals(
+    observedPath?.replaceAll("\\", "/"),
+    "/home/test/.config/Code/User/settings.json",
+  );
+});
+
+Deno.test("vscodeAdapter: Windows resolves settings.json under APPDATA/Code/User", async () => {
+  let observedPath: string | undefined;
+  await vscodeAdapter({
+    binaryPath: "C:\\Program Files\\markspec\\markspec.exe",
+    env: fakeEnv({
+      platform: "win32",
+      home: "C:\\Users\\test",
+      appData: "C:\\Users\\test\\AppData\\Roaming",
+      listExtensions: () => Promise.resolve([EXTENSION_ID]),
+      readSettings: (path: string) => {
+        observedPath = path;
+        return Promise.resolve(undefined);
+      },
+    }),
+  });
+  assertEquals(
+    observedPath?.replaceAll("\\", "/"),
+    "C:/Users/test/AppData/Roaming/Code/User/settings.json",
+  );
+});
 
 Deno.test("neovim adapter: output contains lsp and --stdio args", () => {
   const { stdout } = neovimAdapter();

--- a/packages/markspec/cli/install/orchestrator.ts
+++ b/packages/markspec/cli/install/orchestrator.ts
@@ -84,15 +84,17 @@ export async function runLspInstall(
   }
   const editorId = options.editor as LspEditorId;
 
-  // 2. Legacy print-only fallback for vscode/zed (Slice B/C migrates them).
+  // 2. VS Code — verify-and-report (Slice B). Reads the user settings.json
+  //    and compares `markspec.server.path` against the supplied binary path.
   if (editorId === "vscode") {
-    const r = await vscodeAdapter();
+    const r = await vscodeAdapter({ binaryPath: options.binaryPath });
     return {
       stdout: r.stdout ? `${r.stdout}\n` : "",
       stderr: r.stderr ? `${r.stderr}\n` : "",
       exitCode: r.exitCode,
     };
   }
+  // Legacy print-only fallback for zed (Slice C migrates it).
   if (editorId === "zed") {
     const r = zedAdapter();
     return {

--- a/tests/e2e/lsp_install_test.ts
+++ b/tests/e2e/lsp_install_test.ts
@@ -153,6 +153,34 @@ Deno.test(
 );
 
 Deno.test(
+  "lsp install vscode: never suggests `code --install-extension` (spec §8 Q5)",
+  async () => {
+    // The vscode adapter is verify-only and branches on whether the `code`
+    // CLI is on PATH and the markspec-ide extension is installed. Only one
+    // assertion is universally true across every branch — and it is the
+    // load-bearing one: §8 Q5 forbids any `code --install-extension`
+    // suggestion in any branch. Branch-specific message shapes are
+    // covered by the unit tests in lsp_adapters_test.ts.
+    const { code, stderr } = await markspec(
+      [
+        "lsp",
+        "install",
+        "--editor=vscode",
+        "--binary-path=/opt/markspec/markspec",
+      ],
+      { permissions: ["--allow-env", "--allow-run"] },
+    );
+    assertEquals(code, 0);
+    assertStringIncludes(stderr, "driftsys.markspec-ide");
+    assertEquals(
+      stderr.includes("code --install-extension"),
+      false,
+      "stderr must never suggest `code --install-extension`",
+    );
+  },
+);
+
+Deno.test(
   "lsp install neovim: --remove with no existing block → exit 0 already-removed",
   async () => {
     const { code, stderr } = await markspec(


### PR DESCRIPTION
## Summary

Reworks `markspec lsp install --editor=vscode` from print-only to **verify-and-report** per spec §4.3, and removes the `code --install-extension` suggestion per §8 Q5 resolution.

- New adapter detects the markspec-ide extension, reads VS Code's user `settings.json` (JSONC via `@std/jsonc`), and either confirms `markspec.server.path` matches the bundled binary or prints a remediation snippet — never writes the settings file.
- Adapter takes an injected `VscodeAdapterEnv` (platform, home, extension lister, settings reader) so the 9 new unit tests run fully offline.
- One e2e test pins the universal `code --install-extension` absence rule across all branches.
- Adds `@std/jsonc@^1` to workspace imports.

Implements Toolchain Tier 3 Closeout — **Slice B** (`docs/superpowers/2026-05-25-tier3-closeout-handoff.md`).
Spec: `docs/spec/internal/markspec-toolchain-distribution.md` §4.3, §8 Q5.

## Behavior

| Scenario | Output |
| --- | --- |
| `code` CLI missing from PATH | Marketplace URL; no suggestion to install via `code` |
| Extension not installed | Marketplace URL; no suggestion to install via `code` |
| Extension installed, key missing or settings.json missing | Remediation snippet showing the JSON to add |
| Extension installed, key points at a different binary | Remediation snippet listing both stale and expected paths |
| Extension installed, key matches | One-line confirmation |

Exit code is always 0 — verification is informational, not a failure mode.

## Test plan

- [x] 9 new unit tests cover all branches + JSONC parsing + per-platform settings.json paths (Darwin / Linux / Win32)
- [x] New e2e test pins `code --install-extension` absence in any branch
- [x] Existing 16 adapter tests + 7 install e2e tests still pass
- [x] Full suite: `just build` (2131 passed, 0 failed, 2 ignored)
- [x] Format gates: `deno fmt --check` + `dprint check`
- [x] Compiled binary smoke-tested against real `~/Library/Application Support/Code/User/settings.json` — correctly emits the remediation snippet, exit 0, no `code --install-extension` mention

## Notes

- `--scope=workspace` is intentionally ignored for vscode — the markspec-ide extension auto-loads from any open VS Code workspace, so workspace-scope `.vscode/settings.json` isn't load-bearing. If a follow-up needs it, the adapter has the seam to support both.
- The 235-line growth in `lsp_adapters.ts` is mostly platform-resolution + doc comments; the algorithmic code is ~80 LOC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
