### PR TITLE
feat(core): slice 8 — INCOSE sentence rules Q306-Q312 + Q402

### DIFF
--- a/packages/markspec/core/lint/rules/incose_sentence.ts
+++ b/packages/markspec/core/lint/rules/incose_sentence.ts
@@ -78,12 +78,19 @@ const PRONOUN_RE = /\b(it|this|that|they|them)\b/gi;
  * pattern (comma + EARS keyword). Heuristic: "When X, it shall…" is a
  * common shorthand and should not fire.
  *
- * Detection: `it` preceded (with optional whitespace) by `,` and then
- * the EARS keyword — covers ", it" after a preceding conditional clause.
- * We match just the comma-space-it sequence since the EARS keyword can
- * be at variable distance.
+ * Detection: the SPECIFIC `it` occurrence at position `idx` is preceded
+ * (after stripping leading whitespace from `idx`) by a `,`. Checked
+ * per-occurrence — not sentence-wide — so a sentence like
+ * "When X, it shall log and then it shall store it." correctly flags
+ * the second and third `it` while exempting the first.
  */
-const IT_AFTER_COMMA_RE = /,\s*it\b/i;
+function isItAfterComma(sentence: string, idx: number): boolean {
+  // Walk back from idx skipping whitespace; the first non-space char
+  // must be a comma.
+  let k = idx - 1;
+  while (k >= 0 && sentence[k] === " ") k--;
+  return k >= 0 && sentence[k] === ",";
+}
 
 /**
  * Q309 — `that` exception: `that` acting as a relative-clause introducer
@@ -282,7 +289,10 @@ function checkQ306(
   // Only normative sentences.
   if (countModals(sentence) === 0) return undefined;
   const condCount = countConditionKeywords(sentence);
-  // Q306 fires on exactly 2 conditions. ≥3 is Q103 territory — defer to EARS.
+  // Q306 fires on exactly 2 conditions. ≥3 is Q103 territory for
+  // When/While/If — defer to EARS. Note: Q103 does NOT count `where`,
+  // so ≥3 stacked `where` clauses fall through both rules silently —
+  // an accepted gap for that rare construction.
   if (condCount !== 2) return undefined;
   return emit(
     "MSL-Q306",
@@ -386,7 +396,8 @@ function checkQ309(
     const idx = m.index;
 
     // Exception 1: `it` after a comma (EARS conditional lead-in like "When X, it shall").
-    if (pronoun === "it" && IT_AFTER_COMMA_RE.test(sentence)) continue;
+    // Per-occurrence check, not sentence-wide — see isItAfterComma JSDoc.
+    if (pronoun === "it" && isItAfterComma(sentence, idx)) continue;
 
     // Exception 2: `that` as a relative-clause introducer.
     if (pronoun === "that" && hasThatRelativeClause(sentence, idx)) continue;

--- a/packages/markspec/core/lint/rules/incose_sentence.ts
+++ b/packages/markspec/core/lint/rules/incose_sentence.ts
@@ -1,0 +1,587 @@
+/**
+ * @module core/lint/rules/incose_sentence
+ *
+ * INCOSE sentence-level rules for PA-3 plus the entry-level Q402:
+ *
+ *   MSL-Q306  incose-r11-separate-clauses   (info, score 1)
+ *   MSL-Q307  incose-r18-single-thought      (warn, score 3)
+ *   MSL-Q308  incose-r19-combinator          (info, score 1)
+ *   MSL-Q309  incose-r24-pronouns            (info, score 1)
+ *   MSL-Q311  incose-r27-explicit-conditions (info, score 1)
+ *   MSL-Q312  incose-r33-range-of-values     (info, score 1)
+ *   MSL-Q402  struct-multiple-shall          (warn, score 3)
+ *
+ * Q300 (passive voice) and Q301 (subject-verb) are deferred to slice 10
+ * due to heuristic complexity.
+ *
+ * All rules are heuristic. Default to `info` severity to avoid training
+ * authors to ignore the catalog. Q307 and Q402 are `warn` because they
+ * indicate multi-obligation requirements — structural issues, not style.
+ *
+ * Q402 is entry-level: it fires when ≥2 normative modals appear across
+ * the whole body but no single sentence already triggered Q200 (the
+ * per-sentence modal-multiple rule). This catches requirements where
+ * obligations are spread across separate sentences/paragraphs rather
+ * than concentrated in one.
+ */
+
+import type { Entry } from "../../model/mod.ts";
+import type { BodyBlock, ParagraphNode } from "../../ast/nodes.ts";
+import type { LintDiagnostic } from "../types.ts";
+import { segmentSentences } from "../segmenter.ts";
+import { loadLexicon } from "../../lexicons/mod.ts";
+import { offsetToRange } from "../range_util.ts";
+// Re-use MODAL_COMPOUND_RE from modal_sentence to avoid further duplication.
+// Importing it avoids a separate modal_tokens.ts extraction (option b) while
+// keeping option c (copy/paste) off the table.
+import { MODAL_COMPOUND_RE } from "./modal_sentence.ts";
+
+const ABBREVS = loadLexicon("sentence-abbrev");
+
+// ---------------------------------------------------------------------------
+// Regexes
+// ---------------------------------------------------------------------------
+
+/**
+ * EARS condition keywords counted by Q306 (2 conditions triggers Q306;
+ * ≥3 is Q103 territory). Same set as EARS_PRECONDITION_RE in ears.ts
+ * but this counts `where` too — Q306 is about clause-packing, not just
+ * preconditions.
+ */
+const CONDITION_KEYWORD_RE = /\b(when|while|if|where)\b/gi;
+
+/**
+ * Q307 — single thought: detect `and` joining two independent clauses
+ * each with their own modal verb. Fires when a sentence contains `and`
+ * and ≥2 modal occurrences.
+ */
+const AND_RE = /\band\b/i;
+
+/**
+ * Q308 — combinator: `however`, `whereas`, `meanwhile`, `but`, `unless`
+ * joining clauses that should be separate. These are discourse connectives
+ * that signal the sentence contains multiple thoughts.
+ */
+const COMBINATOR_RE = /\b(however|whereas|meanwhile|but|unless)\b/i;
+
+/**
+ * Q309 — pronouns: personal/indefinite pronouns heuristically indicating
+ * a missing antecedent. Whole-word, case-insensitive.
+ *
+ * `that` is included here but filtered separately by the relative-clause
+ * heuristic — see {@linkcode hasThatRelativeClause}.
+ */
+const PRONOUN_RE = /\b(it|this|that|they|them)\b/gi;
+
+/**
+ * Q309 — `it` exception: `it` immediately after an EARS leading-clause
+ * pattern (comma + EARS keyword). Heuristic: "When X, it shall…" is a
+ * common shorthand and should not fire.
+ *
+ * Detection: `it` preceded (with optional whitespace) by `,` and then
+ * the EARS keyword — covers ", it" after a preceding conditional clause.
+ * We match just the comma-space-it sequence since the EARS keyword can
+ * be at variable distance.
+ */
+const IT_AFTER_COMMA_RE = /,\s*it\b/i;
+
+/**
+ * Q309 — `that` exception: `that` acting as a relative-clause introducer
+ * rather than a demonstrative pronoun. Heuristic: `that` followed by a
+ * word character (a verb/adjective in the relative clause) is acceptable.
+ * `that` at end-of-clause or followed by punctuation signals a
+ * demonstrative use.
+ *
+ * Conservative approach: treat `that` followed by `\w` as a relative
+ * clause (skip). Only flag `that` NOT followed by `\w`.
+ */
+function hasThatRelativeClause(sentence: string, thatIdx: number): boolean {
+  // Skip any whitespace after "that"
+  const afterThat = thatIdx + 4; // length of "that"
+  let k = afterThat;
+  while (k < sentence.length && sentence[k] === " ") k++;
+  if (k >= sentence.length) return false;
+  return /\w/.test(sentence[k]);
+}
+
+/**
+ * Q311 — implicit condition phrases. A normative sentence containing one of
+ * these vague applicability phrases fires Q311, unless the sentence
+ * starts with an explicit EARS leading clause (When/While/Where/If).
+ *
+ * Profile-extensible in a future iteration; for now the set is narrow and
+ * documented here for reference.
+ */
+const IMPLICIT_CONDITION_PHRASES: readonly string[] = [
+  "when applicable",
+  "as appropriate",
+  "in some cases",
+  "where relevant",
+  "if necessary",
+  "as needed",
+];
+
+/** Pre-compiled phrase regexes for Q311. */
+const IMPLICIT_CONDITION_RES: readonly RegExp[] = IMPLICIT_CONDITION_PHRASES
+  .map((p) => new RegExp(`\\b${p.replace(/\s+/g, "\\s+")}\\b`, "i"));
+
+/**
+ * Q311 — EARS explicit condition guard: sentence starts with a leading
+ * EARS keyword (When/While/Where/If), indicating the condition is already
+ * stated explicitly. Q311 should skip such sentences.
+ */
+const EARS_LEADING_EXPLICIT_RE = /^\s*(When|While|Where|If)\b/i;
+
+/**
+ * Q312 — bare numeric quantity with unit but without a tolerance marker.
+ *
+ * The unit set covers common engineering domains. Deliberately narrow to
+ * avoid false positives on plain numbers (version numbers, counts, etc.).
+ * Profile-extensible in a future iteration.
+ *
+ * Units (case-sensitive to avoid `A` matching article "a"):
+ *   Force:       N, kN
+ *   Length:      m, mm, cm, km
+ *   Time:        s, ms, μs, us
+ *   Temperature: °C, °F, K (uppercase only — avoid "k" as suffix)
+ *   Electrical:  V, A, W, kW (uppercase — avoid "v" = verb)
+ *   Frequency:   Hz, kHz, MHz, GHz
+ *   Percentage:  %
+ *   Angle:       °
+ *   Mass:        kg, g (but NOT bare "g" after digits — too many false positives)
+ *
+ * The pattern requires a digit before the unit and uses word-boundary or
+ * end-of-token anchors to avoid partial matches.
+ *
+ * Note: `kg` is included; bare `g` is excluded (too many false positives
+ * from abbreviations). `K` (Kelvin) is included as capital-K only.
+ */
+const QUANTITY_WITH_UNIT_RE =
+  /\b(\d+(?:\.\d+)?)\s*(kN|kHz|MHz|GHz|kW|ms|μs|us|mm|cm|km|°C|°F|Hz|N|m|s|V|A|W|K|kg|%|°)\b/g;
+
+/**
+ * Q312 — tolerance markers in the same sentence. If any of these patterns
+ * appear, the quantity is considered to carry a tolerance and Q312 is
+ * suppressed.
+ *
+ * Covers: ±, +/-, "within ±", "between X and Y" (via \bbetween\b),
+ * comparison operators ≤, ≥, <, >, "tolerance of", "up to", "at most",
+ * "at least".
+ */
+const TOLERANCE_MARKER_RE =
+  /±|\+\s*\/\s*-|tolerance\s+of|\bbetween\b|≤|≥|[<>]|\bup\s+to\b|\bat\s+most\b|\bat\s+least\b|\bno\s+more\s+than\b|\bno\s+less\s+than\b/i;
+
+// ---------------------------------------------------------------------------
+// Rule code registry
+// ---------------------------------------------------------------------------
+
+/** All INCOSE sentence rule codes exported for suppression-hygiene set. */
+export const INCOSE_SENTENCE_RULE_CODES: ReadonlySet<string> = new Set([
+  "MSL-Q306",
+  "MSL-Q307",
+  "MSL-Q308",
+  "MSL-Q309",
+  "MSL-Q311",
+  "MSL-Q312",
+  "MSL-Q402",
+]);
+
+// ---------------------------------------------------------------------------
+// Modal counting helper (reusing MODAL_COMPOUND_RE from modal_sentence.ts)
+// ---------------------------------------------------------------------------
+
+/**
+ * Count the number of modal occurrences in `text`. Resets `MODAL_COMPOUND_RE`
+ * lastIndex before every call to prevent state leakage across uses.
+ */
+function countModals(text: string): number {
+  MODAL_COMPOUND_RE.lastIndex = 0;
+  let count = 0;
+  while (MODAL_COMPOUND_RE.exec(text) !== null) count++;
+  return count;
+}
+
+// ---------------------------------------------------------------------------
+// Emit helpers
+// ---------------------------------------------------------------------------
+
+function emit(
+  code: string,
+  slug: string,
+  severity: "info" | "warning",
+  scoreContribution: number,
+  message: string,
+  sentence: string,
+  sentenceOffset: number,
+  paragraphText: string,
+  baseLine: number,
+  baseCol: number,
+  entry: Entry,
+): LintDiagnostic {
+  const range = offsetToRange(
+    paragraphText,
+    sentenceOffset,
+    sentence.length,
+    baseLine,
+    baseCol,
+  );
+  return {
+    code,
+    slug,
+    severity,
+    scoreContribution,
+    group: "incose",
+    message,
+    location: entry.location,
+    range,
+  };
+}
+
+function emitEntryLevel(
+  code: string,
+  slug: string,
+  severity: "info" | "warning",
+  scoreContribution: number,
+  message: string,
+  entry: Entry,
+): LintDiagnostic {
+  return {
+    code,
+    slug,
+    severity,
+    scoreContribution,
+    group: "incose",
+    message,
+    location: entry.location,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Q306 — incose-r11-separate-clauses
+// ---------------------------------------------------------------------------
+
+/**
+ * Count EARS condition keywords (when/while/if/where) in `text`. Used by
+ * Q306 (fires on 2 conditions) and the Q103-overlap guard (skip when ≥3).
+ */
+function countConditionKeywords(text: string): number {
+  CONDITION_KEYWORD_RE.lastIndex = 0;
+  let count = 0;
+  while (CONDITION_KEYWORD_RE.exec(text) !== null) count++;
+  return count;
+}
+
+function checkQ306(
+  sentence: string,
+  sentenceOffset: number,
+  paragraphText: string,
+  baseLine: number,
+  baseCol: number,
+  entry: Entry,
+): LintDiagnostic | undefined {
+  // Only normative sentences.
+  if (countModals(sentence) === 0) return undefined;
+  const condCount = countConditionKeywords(sentence);
+  // Q306 fires on exactly 2 conditions. ≥3 is Q103 territory — defer to EARS.
+  if (condCount !== 2) return undefined;
+  return emit(
+    "MSL-Q306",
+    "incose-r11-separate-clauses",
+    "info",
+    1,
+    `incose-r11-separate-clauses: normative sentence packs ${condCount} conditions into one clause; consider splitting into separate requirements`,
+    sentence,
+    sentenceOffset,
+    paragraphText,
+    baseLine,
+    baseCol,
+    entry,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Q307 — incose-r18-single-thought
+// ---------------------------------------------------------------------------
+
+function checkQ307(
+  sentence: string,
+  sentenceOffset: number,
+  paragraphText: string,
+  baseLine: number,
+  baseCol: number,
+  entry: Entry,
+): LintDiagnostic | undefined {
+  // Fire when the sentence contains `and` AND ≥2 modal verbs.
+  // This is broader than Q200 (which fires on any ≥2 modals) but Q307
+  // specifically targets the "and joining two obligations" smell.
+  // Both Q200 and Q307 may co-fire — both are valid signals.
+  if (!AND_RE.test(sentence)) return undefined;
+  if (countModals(sentence) < 2) return undefined;
+  return emit(
+    "MSL-Q307",
+    "incose-r18-single-thought",
+    "warning",
+    3,
+    `incose-r18-single-thought: sentence carries more than one obligation joined by 'and'; split into separate single-obligation requirements`,
+    sentence,
+    sentenceOffset,
+    paragraphText,
+    baseLine,
+    baseCol,
+    entry,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Q308 — incose-r19-combinator
+// ---------------------------------------------------------------------------
+
+function checkQ308(
+  sentence: string,
+  sentenceOffset: number,
+  paragraphText: string,
+  baseLine: number,
+  baseCol: number,
+  entry: Entry,
+): LintDiagnostic | undefined {
+  // Only normative sentences.
+  if (countModals(sentence) === 0) return undefined;
+  const m = COMBINATOR_RE.exec(sentence);
+  if (!m) return undefined;
+  const word = m[1].toLowerCase();
+  return emit(
+    "MSL-Q308",
+    "incose-r19-combinator",
+    "info",
+    1,
+    `incose-r19-combinator: discourse combinator '${word}' joins clauses that should be separate requirements`,
+    sentence,
+    sentenceOffset,
+    paragraphText,
+    baseLine,
+    baseCol,
+    entry,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Q309 — incose-r24-pronouns
+// ---------------------------------------------------------------------------
+
+function checkQ309(
+  sentence: string,
+  sentenceOffset: number,
+  paragraphText: string,
+  baseLine: number,
+  baseCol: number,
+  entry: Entry,
+): LintDiagnostic | undefined {
+  // Only normative sentences.
+  if (countModals(sentence) === 0) return undefined;
+
+  PRONOUN_RE.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = PRONOUN_RE.exec(sentence)) !== null) {
+    const pronoun = m[0].toLowerCase();
+    const idx = m.index;
+
+    // Exception 1: `it` after a comma (EARS conditional lead-in like "When X, it shall").
+    if (pronoun === "it" && IT_AFTER_COMMA_RE.test(sentence)) continue;
+
+    // Exception 2: `that` as a relative-clause introducer.
+    if (pronoun === "that" && hasThatRelativeClause(sentence, idx)) continue;
+
+    return emit(
+      "MSL-Q309",
+      "incose-r24-pronouns",
+      "info",
+      1,
+      `incose-r24-pronouns: pronoun '${pronoun}' may lack an explicit antecedent; replace with the noun it refers to`,
+      sentence,
+      sentenceOffset,
+      paragraphText,
+      baseLine,
+      baseCol,
+      entry,
+    );
+  }
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Q311 — incose-r27-explicit-conditions
+// ---------------------------------------------------------------------------
+
+function checkQ311(
+  sentence: string,
+  sentenceOffset: number,
+  paragraphText: string,
+  baseLine: number,
+  baseCol: number,
+  entry: Entry,
+): LintDiagnostic | undefined {
+  // Only normative sentences.
+  if (countModals(sentence) === 0) return undefined;
+  // If the sentence starts with an explicit EARS condition, the applicability
+  // IS stated; skip Q311.
+  if (EARS_LEADING_EXPLICIT_RE.test(sentence)) return undefined;
+  for (const re of IMPLICIT_CONDITION_RES) {
+    if (re.test(sentence)) {
+      return emit(
+        "MSL-Q311",
+        "incose-r27-explicit-conditions",
+        "info",
+        1,
+        `incose-r27-explicit-conditions: sentence uses a vague applicability phrase; state the condition explicitly using an EARS leading clause (When/While/Where/If)`,
+        sentence,
+        sentenceOffset,
+        paragraphText,
+        baseLine,
+        baseCol,
+        entry,
+      );
+    }
+  }
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Q312 — incose-r33-range-of-values
+// ---------------------------------------------------------------------------
+
+function checkQ312(
+  sentence: string,
+  sentenceOffset: number,
+  paragraphText: string,
+  baseLine: number,
+  baseCol: number,
+  entry: Entry,
+): LintDiagnostic | undefined {
+  // Only normative sentences.
+  if (countModals(sentence) === 0) return undefined;
+  // If any tolerance marker appears in the sentence, all quantities are
+  // considered covered. This is intentionally conservative — a sentence
+  // with one tolerance marker and one bare quantity still passes because
+  // the marker signals the author is aware of tolerances.
+  if (TOLERANCE_MARKER_RE.test(sentence)) return undefined;
+  // Check for at least one bare quantity with a unit.
+  QUANTITY_WITH_UNIT_RE.lastIndex = 0;
+  if (QUANTITY_WITH_UNIT_RE.exec(sentence) !== null) {
+    return emit(
+      "MSL-Q312",
+      "incose-r33-range-of-values",
+      "info",
+      1,
+      `incose-r33-range-of-values: numeric quantity appears without a tolerance or range; add ±, between…and, ≤/≥, or a tolerance clause`,
+      sentence,
+      sentenceOffset,
+      paragraphText,
+      baseLine,
+      baseCol,
+      entry,
+    );
+  }
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Q402 — struct-multiple-shall (entry-level)
+// ---------------------------------------------------------------------------
+
+/**
+ * Entry-level check: fire when the whole body contains ≥2 modal
+ * occurrences but no single sentence contains ≥2 (which would be Q200
+ * territory). The two checks are performed over `entry.bodyAst` so that
+ * paragraph-boundary-spanning counts are correct.
+ */
+function checkQ402(
+  entry: Entry,
+  totalBodyModals: number,
+  anysentenceHasTwoModals: boolean,
+): LintDiagnostic | undefined {
+  if (totalBodyModals < 2) return undefined;
+  // Defer to Q200 when any single sentence already concentrates ≥2 modals.
+  if (anysentenceHasTwoModals) return undefined;
+  return emitEntryLevel(
+    "MSL-Q402",
+    "struct-multiple-shall",
+    "warning",
+    3,
+    `struct-multiple-shall: body contains ${totalBodyModals} normative modal verbs across separate sentences; consider splitting into ${totalBodyModals} single-obligation requirements`,
+    entry,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Public entry point
+// ---------------------------------------------------------------------------
+
+/**
+ * Run INCOSE sentence rules (Q306–Q312) and entry-level Q402.
+ *
+ * For each paragraph, segments into sentences. For each normative sentence:
+ *   - Q306 fires on exactly 2 EARS condition keywords (separate-clauses).
+ *   - Q307 fires when `and` joins ≥2 modal verbs (single-thought).
+ *   - Q308 fires on discourse combinators (however/whereas/meanwhile/but/unless).
+ *   - Q309 fires on personal/indefinite pronouns without explicit antecedent.
+ *   - Q311 fires on vague applicability phrases when no EARS leading clause.
+ *   - Q312 fires on bare numeric quantities without a tolerance marker.
+ *
+ * Entry-level Q402 fires when the whole body has ≥2 modals but no single
+ * sentence concentrated them (which would be Q200 territory).
+ */
+export function runIncoseSentenceRules(entry: Entry): LintDiagnostic[] {
+  const out: LintDiagnostic[] = [];
+  const blocks: readonly BodyBlock[] = entry.bodyAst ?? [];
+
+  // Q402 tracking across the whole entry body.
+  let totalBodyModals = 0;
+  let anysentenceHasTwoModals = false;
+
+  for (const block of blocks) {
+    if (block.kind !== "paragraph") continue;
+    const p = block as ParagraphNode;
+    const text = p.content.text;
+
+    // Compute file-absolute base line for this paragraph.
+    // p.range.start.line is body-relative (line 1 = first body line).
+    // entry.bodyStartLine is file-absolute. Fall back to entry.location.line + 1.
+    const absBodyStart = entry.bodyStartLine ?? (entry.location.line + 1);
+    const absLine = absBodyStart + p.range.start.line - 1;
+    const baseCol = p.range.start.column;
+
+    const sentences = segmentSentences(text, ABBREVS);
+    for (const sentence of sentences) {
+      const s = sentence.text;
+      const off = sentence.offset;
+
+      const modalsInSentence = countModals(s);
+      totalBodyModals += modalsInSentence;
+      if (modalsInSentence >= 2) anysentenceHasTwoModals = true;
+
+      const q306 = checkQ306(s, off, text, absLine, baseCol, entry);
+      if (q306) out.push(q306);
+
+      const q307 = checkQ307(s, off, text, absLine, baseCol, entry);
+      if (q307) out.push(q307);
+
+      const q308 = checkQ308(s, off, text, absLine, baseCol, entry);
+      if (q308) out.push(q308);
+
+      const q309 = checkQ309(s, off, text, absLine, baseCol, entry);
+      if (q309) out.push(q309);
+
+      const q311 = checkQ311(s, off, text, absLine, baseCol, entry);
+      if (q311) out.push(q311);
+
+      const q312 = checkQ312(s, off, text, absLine, baseCol, entry);
+      if (q312) out.push(q312);
+    }
+  }
+
+  // Entry-level Q402.
+  const q402 = checkQ402(entry, totalBodyModals, anysentenceHasTwoModals);
+  if (q402) out.push(q402);
+
+  return out;
+}

--- a/packages/markspec/core/lint/rules/incose_sentence_test.ts
+++ b/packages/markspec/core/lint/rules/incose_sentence_test.ts
@@ -1,0 +1,469 @@
+/**
+ * @module core/lint/rules/incose_sentence_test
+ *
+ * Unit tests for INCOSE sentence rules MSL-Q306 through MSL-Q312
+ * and entry-level MSL-Q402.
+ */
+
+import { assertEquals } from "@std/assert";
+import type { BodyBlock } from "../../ast/nodes.ts";
+import type { Entry } from "../../model/mod.ts";
+import { makeDisplayId } from "../../model/mod.ts";
+import { runIncoseSentenceRules } from "./incose_sentence.ts";
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function makeParagraph(text: string, line = 1, column = 1): BodyBlock {
+  return {
+    kind: "paragraph",
+    content: { text },
+    range: {
+      start: { line, column },
+      end: { line, column: column + text.length },
+    },
+  };
+}
+
+interface MakeEntryOpts {
+  location?: { file: string; line: number; column: number };
+  bodyStartLine?: number;
+}
+
+/**
+ * Build a minimal Authored entry for testing. Supports multi-paragraph bodies
+ * (separate text blocks with `\n\n` in `body`) — the body is split on `\n\n`
+ * and each chunk becomes its own `paragraph` BodyBlock. Line numbers for
+ * subsequent paragraphs are approximated by offset from the first paragraph.
+ */
+function makeEntry(
+  body: string,
+  opts: MakeEntryOpts = {},
+): Entry {
+  const paragraphs = body.split(/\n\n+/);
+  const bodyAst: BodyBlock[] = [];
+  let lineOffset = 1;
+  for (const para of paragraphs) {
+    if (para.trim().length === 0) continue;
+    bodyAst.push(makeParagraph(para.trim(), lineOffset));
+    // Advance line offset: count newlines in para + 2 for the separator.
+    lineOffset += (para.match(/\n/g)?.length ?? 0) + 2;
+  }
+  const location = opts.location ?? { file: "test.md", line: 1, column: 1 };
+  return {
+    displayId: makeDisplayId("STK_0001"),
+    title: "Test requirement",
+    body,
+    bodyAst,
+    rawAttributes: [
+      { key: "Id", value: "01HGW2Q8MNP3RSTVWXYZABCDEF" },
+      { key: "Type", value: "Requirement" },
+    ],
+    typedAttributes: new Map([
+      ["Id", ["01HGW2Q8MNP3RSTVWXYZABCDEF"]],
+      ["Type", ["Requirement"]],
+    ]),
+    id: "01HGW2Q8MNP3RSTVWXYZABCDEF",
+    type: "Requirement",
+    shape: "Authored",
+    location,
+    ...(opts.bodyStartLine !== undefined
+      ? { bodyStartLine: opts.bodyStartLine }
+      : {}),
+    source: { kind: "markdown" },
+    bodyTokens: [],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// MSL-Q306: incose-r11-separate-clauses
+// ---------------------------------------------------------------------------
+
+Deno.test("Q306: separate clauses (≥2 conditions, <3)", () => {
+  const entry = makeEntry(
+    "The system, when X and when Y, shall apply.",
+  );
+  const diags = runIncoseSentenceRules(entry);
+  assertEquals(diags.some((d) => d.code === "MSL-Q306"), true);
+});
+
+Deno.test("Q306: silent when Q103 already fires (≥3 conditions)", () => {
+  // Slice 6's Q103 covers this case; Q306 must NOT also fire here.
+  const entry = makeEntry(
+    "When X, when Y, when Z, the system shall apply.",
+  );
+  const diags = runIncoseSentenceRules(entry);
+  assertEquals(diags.some((d) => d.code === "MSL-Q306"), false);
+});
+
+Deno.test("Q306: silent on exactly 1 condition keyword", () => {
+  const entry = makeEntry(
+    "When the pedal is pressed, the brake controller shall apply pressure.",
+  );
+  const diags = runIncoseSentenceRules(entry);
+  assertEquals(diags.some((d) => d.code === "MSL-Q306"), false);
+});
+
+Deno.test("Q306: silent on non-normative sentences (no modal)", () => {
+  const entry = makeEntry("The system, when X and when Y, is configured.");
+  const diags = runIncoseSentenceRules(entry);
+  assertEquals(diags.some((d) => d.code === "MSL-Q306"), false);
+});
+
+Deno.test("Q306: carries correct metadata", () => {
+  const entry = makeEntry(
+    "The system, when X and when Y, shall apply.",
+  );
+  const diags = runIncoseSentenceRules(entry);
+  const q306 = diags.find((d) => d.code === "MSL-Q306");
+  assertEquals(q306?.slug, "incose-r11-separate-clauses");
+  assertEquals(q306?.group, "incose");
+  assertEquals(q306?.scoreContribution, 1);
+  assertEquals(q306?.severity, "info");
+});
+
+// ---------------------------------------------------------------------------
+// MSL-Q307: incose-r18-single-thought
+// ---------------------------------------------------------------------------
+
+Deno.test("Q307: single thought — two obligations with 'and'", () => {
+  const entry = makeEntry("The brake shall apply and the engine shall stop.");
+  const diags = runIncoseSentenceRules(entry);
+  assertEquals(diags.some((d) => d.code === "MSL-Q307"), true);
+});
+
+Deno.test("Q307: silent when only one modal (no compound)", () => {
+  const entry = makeEntry(
+    "The brake controller shall apply pressure and release gradually.",
+  );
+  const diags = runIncoseSentenceRules(entry);
+  assertEquals(diags.some((d) => d.code === "MSL-Q307"), false);
+});
+
+Deno.test("Q307: silent when no 'and' linking two modals", () => {
+  const entry = makeEntry("The system shall apply and log.");
+  // Only 1 modal verb (`shall`); 'and' joins two verbs to the same modal.
+  const diags = runIncoseSentenceRules(entry);
+  assertEquals(diags.some((d) => d.code === "MSL-Q307"), false);
+});
+
+Deno.test("Q307: carries correct metadata", () => {
+  const entry = makeEntry("The brake shall apply and the engine shall stop.");
+  const diags = runIncoseSentenceRules(entry);
+  const q307 = diags.find((d) => d.code === "MSL-Q307");
+  assertEquals(q307?.slug, "incose-r18-single-thought");
+  assertEquals(q307?.group, "incose");
+  assertEquals(q307?.scoreContribution, 3);
+  assertEquals(q307?.severity, "warning");
+});
+
+// ---------------------------------------------------------------------------
+// MSL-Q308: incose-r19-combinator
+// ---------------------------------------------------------------------------
+
+Deno.test("Q308: combinator 'however' joining clauses", () => {
+  const entry = makeEntry(
+    "The system shall log, however the logger shall rotate files.",
+  );
+  const diags = runIncoseSentenceRules(entry);
+  assertEquals(diags.some((d) => d.code === "MSL-Q308"), true);
+});
+
+Deno.test("Q308: combinator 'whereas' joining clauses", () => {
+  const entry = makeEntry(
+    "The system shall apply force, whereas the safety unit shall limit torque.",
+  );
+  const diags = runIncoseSentenceRules(entry);
+  assertEquals(diags.some((d) => d.code === "MSL-Q308"), true);
+});
+
+Deno.test("Q308: combinator 'but' in normative sentence", () => {
+  const entry = makeEntry(
+    "The system shall apply force, but the controller shall limit it.",
+  );
+  const diags = runIncoseSentenceRules(entry);
+  assertEquals(diags.some((d) => d.code === "MSL-Q308"), true);
+});
+
+Deno.test("Q308: silent in non-normative sentence", () => {
+  // No modal → not normative → Q308 skips.
+  const entry = makeEntry(
+    "The component is designed to respond quickly, however it is not required.",
+  );
+  const diags = runIncoseSentenceRules(entry);
+  assertEquals(diags.some((d) => d.code === "MSL-Q308"), false);
+});
+
+Deno.test("Q308: carries correct metadata", () => {
+  const entry = makeEntry(
+    "The system shall log, however the logger shall rotate files.",
+  );
+  const diags = runIncoseSentenceRules(entry);
+  const q308 = diags.find((d) => d.code === "MSL-Q308");
+  assertEquals(q308?.slug, "incose-r19-combinator");
+  assertEquals(q308?.group, "incose");
+  assertEquals(q308?.scoreContribution, 1);
+  assertEquals(q308?.severity, "info");
+});
+
+// ---------------------------------------------------------------------------
+// MSL-Q309: incose-r24-pronouns
+// ---------------------------------------------------------------------------
+
+Deno.test("Q309: pronoun without antecedent ('it')", () => {
+  const entry = makeEntry("The brake controller shall apply it.");
+  const diags = runIncoseSentenceRules(entry);
+  assertEquals(diags.some((d) => d.code === "MSL-Q309"), true);
+});
+
+Deno.test("Q309: pronoun 'this' in normative sentence", () => {
+  const entry = makeEntry("The system shall validate this before processing.");
+  const diags = runIncoseSentenceRules(entry);
+  assertEquals(diags.some((d) => d.code === "MSL-Q309"), true);
+});
+
+Deno.test("Q309: pronoun 'they' in normative sentence", () => {
+  const entry = makeEntry("The sensors shall report when they detect a fault.");
+  const diags = runIncoseSentenceRules(entry);
+  assertEquals(diags.some((d) => d.code === "MSL-Q309"), true);
+});
+
+Deno.test("Q309: silent when 'that' is a relative clause", () => {
+  const entry = makeEntry(
+    "The brake controller shall apply pressure that exceeds 100N.",
+  );
+  const diags = runIncoseSentenceRules(entry);
+  assertEquals(diags.some((d) => d.code === "MSL-Q309"), false);
+});
+
+Deno.test("Q309: silent in non-normative sentence", () => {
+  // No modal → not normative → Q309 skips.
+  const entry = makeEntry("The brake is a component, and it is critical.");
+  const diags = runIncoseSentenceRules(entry);
+  assertEquals(diags.some((d) => d.code === "MSL-Q309"), false);
+});
+
+Deno.test("Q309: carries correct metadata", () => {
+  const entry = makeEntry("The brake controller shall apply it.");
+  const diags = runIncoseSentenceRules(entry);
+  const q309 = diags.find((d) => d.code === "MSL-Q309");
+  assertEquals(q309?.slug, "incose-r24-pronouns");
+  assertEquals(q309?.group, "incose");
+  assertEquals(q309?.scoreContribution, 1);
+  assertEquals(q309?.severity, "info");
+});
+
+// ---------------------------------------------------------------------------
+// MSL-Q311: incose-r27-explicit-conditions
+// ---------------------------------------------------------------------------
+
+Deno.test("Q311: implicit condition 'where relevant'", () => {
+  const entry = makeEntry(
+    "The system shall, where relevant, log warnings.",
+  );
+  const diags = runIncoseSentenceRules(entry);
+  assertEquals(diags.some((d) => d.code === "MSL-Q311"), true);
+});
+
+Deno.test("Q311: implicit condition 'when applicable'", () => {
+  const entry = makeEntry(
+    "The system shall, when applicable, engage the safety mode.",
+  );
+  const diags = runIncoseSentenceRules(entry);
+  assertEquals(diags.some((d) => d.code === "MSL-Q311"), true);
+});
+
+Deno.test("Q311: implicit condition 'as appropriate'", () => {
+  const entry = makeEntry(
+    "The module shall apply corrections as appropriate.",
+  );
+  const diags = runIncoseSentenceRules(entry);
+  assertEquals(diags.some((d) => d.code === "MSL-Q311"), true);
+});
+
+Deno.test("Q311: silent when condition is explicit (EARS leading clause)", () => {
+  const entry = makeEntry(
+    "Where logging is enabled, the system shall log warnings.",
+  );
+  const diags = runIncoseSentenceRules(entry);
+  assertEquals(diags.some((d) => d.code === "MSL-Q311"), false);
+});
+
+Deno.test("Q311: silent when EARS 'When' starts the sentence", () => {
+  const entry = makeEntry(
+    "When applicable, the system shall engage the safety mode.",
+  );
+  const diags = runIncoseSentenceRules(entry);
+  assertEquals(diags.some((d) => d.code === "MSL-Q311"), false);
+});
+
+Deno.test("Q311: silent in non-normative sentence", () => {
+  // No modal → not normative.
+  const entry = makeEntry("The system is, where relevant, audited by QA.");
+  const diags = runIncoseSentenceRules(entry);
+  assertEquals(diags.some((d) => d.code === "MSL-Q311"), false);
+});
+
+Deno.test("Q311: carries correct metadata", () => {
+  const entry = makeEntry(
+    "The system shall, where relevant, log warnings.",
+  );
+  const diags = runIncoseSentenceRules(entry);
+  const q311 = diags.find((d) => d.code === "MSL-Q311");
+  assertEquals(q311?.slug, "incose-r27-explicit-conditions");
+  assertEquals(q311?.group, "incose");
+  assertEquals(q311?.scoreContribution, 1);
+  assertEquals(q311?.severity, "info");
+});
+
+// ---------------------------------------------------------------------------
+// MSL-Q312: incose-r33-range-of-values
+// ---------------------------------------------------------------------------
+
+Deno.test("Q312: bare quantity without tolerance ('200N')", () => {
+  const entry = makeEntry("The brake shall apply 200N within 200 ms.");
+  const diags = runIncoseSentenceRules(entry);
+  assertEquals(diags.some((d) => d.code === "MSL-Q312"), true);
+});
+
+Deno.test("Q312: silent with explicit tolerance ('± 5N')", () => {
+  const entry = makeEntry(
+    "The brake shall apply 200N ± 5N within 200 ms ± 10 ms.",
+  );
+  const diags = runIncoseSentenceRules(entry);
+  assertEquals(diags.some((d) => d.code === "MSL-Q312"), false);
+});
+
+Deno.test("Q312: silent on plain numbers without units", () => {
+  // "5 entries" / "version 1" — no unit, so not a measurable quantity.
+  const entry = makeEntry("The system shall log 5 entries at version 1.");
+  const diags = runIncoseSentenceRules(entry);
+  assertEquals(diags.some((d) => d.code === "MSL-Q312"), false);
+});
+
+Deno.test("Q312: silent when 'between ... and ...' tolerance present", () => {
+  const entry = makeEntry(
+    "The system shall apply between 150N and 250N force.",
+  );
+  const diags = runIncoseSentenceRules(entry);
+  assertEquals(diags.some((d) => d.code === "MSL-Q312"), false);
+});
+
+Deno.test("Q312: fires on time unit (ms) without tolerance", () => {
+  const entry = makeEntry(
+    "The system shall respond within 500 ms from sensor input.",
+  );
+  // "within" here is not a tolerance marker by the current heuristic;
+  // however Q312 fires on bare 500 ms. This is an accepted false positive
+  // (the author should add ± or use ≤ to be precise).
+  // NOTE: "within" is NOT in TOLERANCE_MARKER_RE; only "up to"/"at most"/"≤" etc. are.
+  const diags = runIncoseSentenceRules(entry);
+  assertEquals(diags.some((d) => d.code === "MSL-Q312"), true);
+});
+
+Deno.test("Q312: silent when ≤ comparison operator acts as tolerance", () => {
+  const entry = makeEntry(
+    "The system shall respond in ≤ 500 ms from sensor input.",
+  );
+  const diags = runIncoseSentenceRules(entry);
+  assertEquals(diags.some((d) => d.code === "MSL-Q312"), false);
+});
+
+Deno.test("Q312: silent in non-normative sentence", () => {
+  // No modal → not normative.
+  const entry = makeEntry("The sensor measures 200N force at the brake pad.");
+  const diags = runIncoseSentenceRules(entry);
+  assertEquals(diags.some((d) => d.code === "MSL-Q312"), false);
+});
+
+Deno.test("Q312: carries correct metadata", () => {
+  const entry = makeEntry("The brake shall apply 200N of force.");
+  const diags = runIncoseSentenceRules(entry);
+  const q312 = diags.find((d) => d.code === "MSL-Q312");
+  assertEquals(q312?.slug, "incose-r33-range-of-values");
+  assertEquals(q312?.group, "incose");
+  assertEquals(q312?.scoreContribution, 1);
+  assertEquals(q312?.severity, "info");
+});
+
+// ---------------------------------------------------------------------------
+// MSL-Q402: struct-multiple-shall (entry-level)
+// ---------------------------------------------------------------------------
+
+Deno.test("Q402: entry-level multiple shall, no Q200 overlap", () => {
+  // Two paragraphs, two modals, one per sentence — no Q200.
+  const entry = makeEntry(
+    "The system shall apply.\n\nThe system shall log.",
+  );
+  const diags = runIncoseSentenceRules(entry);
+  assertEquals(diags.some((d) => d.code === "MSL-Q402"), true);
+  assertEquals(diags.some((d) => d.code === "MSL-Q200"), false);
+});
+
+Deno.test("Q402: silent when Q200 fires (single sentence ≥2 modals)", () => {
+  // Single sentence with 2 modals → Q402 must defer (Q200 territory).
+  const entry = makeEntry("The system shall apply and shall log.");
+  const diags = runIncoseSentenceRules(entry);
+  assertEquals(diags.some((d) => d.code === "MSL-Q402"), false);
+});
+
+Deno.test("Q402: silent on single modal", () => {
+  const entry = makeEntry("The system shall apply pressure.");
+  const diags = runIncoseSentenceRules(entry);
+  assertEquals(diags.some((d) => d.code === "MSL-Q402"), false);
+});
+
+Deno.test("Q402: fires across two sentences in the same paragraph", () => {
+  // Two sentences with one modal each — both in the same paragraph block.
+  const entry = makeEntry(
+    "The system shall apply. The system shall log.",
+  );
+  const diags = runIncoseSentenceRules(entry);
+  assertEquals(diags.some((d) => d.code === "MSL-Q402"), true);
+});
+
+Deno.test("Q402: carries correct metadata", () => {
+  const entry = makeEntry(
+    "The system shall apply.\n\nThe system shall log.",
+  );
+  const diags = runIncoseSentenceRules(entry);
+  const q402 = diags.find((d) => d.code === "MSL-Q402");
+  assertEquals(q402?.slug, "struct-multiple-shall");
+  assertEquals(q402?.group, "incose");
+  assertEquals(q402?.scoreContribution, 3);
+  assertEquals(q402?.severity, "warning");
+});
+
+// ---------------------------------------------------------------------------
+// Range emission: file-absolute, sentence-span
+// ---------------------------------------------------------------------------
+
+Deno.test("Range emission: file-absolute, sentence-span", () => {
+  const entry = makeEntry(
+    "The brake controller shall apply it.",
+    {
+      location: { file: "/x.md", line: 30, column: 1 },
+      bodyStartLine: 32,
+    },
+  );
+  const diags = runIncoseSentenceRules(entry);
+  const q309 = diags.find((d) => d.code === "MSL-Q309");
+  assertEquals(q309?.range?.start.line, 32);
+});
+
+// ---------------------------------------------------------------------------
+// Silent on non-normative sentences (no modals at all)
+// ---------------------------------------------------------------------------
+
+Deno.test("INCOSE: all rules silent on non-normative sentences", () => {
+  // No modal → not normative → no sentence-level rules fire.
+  // Also no Q402 since total modals = 0.
+  const entry = makeEntry(
+    "The brake is a critical safety system, when relevant.",
+  );
+  const diags = runIncoseSentenceRules(entry);
+  // Only sentence-level incose rules; Q402 also silent (0 modals < 2).
+  assertEquals(diags.filter((d) => d.code.startsWith("MSL-Q3")).length, 0);
+  assertEquals(diags.some((d) => d.code === "MSL-Q402"), false);
+});

--- a/packages/markspec/core/lint/rules/incose_sentence_test.ts
+++ b/packages/markspec/core/lint/rules/incose_sentence_test.ts
@@ -467,3 +467,32 @@ Deno.test("INCOSE: all rules silent on non-normative sentences", () => {
   assertEquals(diags.filter((d) => d.code.startsWith("MSL-Q3")).length, 0);
   assertEquals(diags.some((d) => d.code === "MSL-Q402"), false);
 });
+
+Deno.test("Q309: per-occurrence comma exception ('When X, it ... it ...')", () => {
+  // The first `it` is exempted (after a comma — EARS lead-in). The
+  // subsequent `it` is NOT after a comma and MUST fire Q309. Previously
+  // a sentence-wide regex check incorrectly exempted both occurrences.
+  const entry = makeEntry(
+    "When the pedal is pressed, it shall log and then it shall store it.",
+  );
+  const diags = runIncoseSentenceRules(entry);
+  const q309 = diags.filter((d) => d.code === "MSL-Q309");
+  // At least one Q309 fires (for the second/third `it`, not the first).
+  assertEquals(q309.length >= 1, true);
+});
+
+Deno.test("Q307: can co-fire with modal-multiple territory", () => {
+  // Q307 fires on `and`-joined dual-modal sentence; the same construct
+  // would also trigger Q200 (slice 7) when run through the full pipeline.
+  // We test Q307 in isolation here — runner-level integration confirms
+  // both fire together (slice 7 wired Q200; this slice wired Q307).
+  const entry = makeEntry(
+    "The brake shall apply and the engine shall stop.",
+  );
+  const diags = runIncoseSentenceRules(entry);
+  assertEquals(diags.some((d) => d.code === "MSL-Q307"), true);
+  // Q200 is in modal_sentence.ts, not incose_sentence.ts — verify it
+  // is NOT emitted by THIS rule module (cross-module dedupe via the
+  // runner, not via these rules).
+  assertEquals(diags.some((d) => d.code === "MSL-Q200"), false);
+});

--- a/packages/markspec/core/lint/rules/modal_sentence.ts
+++ b/packages/markspec/core/lint/rules/modal_sentence.ts
@@ -39,7 +39,7 @@ const ABBREVS = loadLexicon("sentence-abbrev");
  * `will` is intentionally excluded — it is not a normative modal per
  * RFC 2119 and its presence is handled by the Q202 rule (deferred).
  */
-const MODAL_COMPOUND_RE =
+export const MODAL_COMPOUND_RE =
   /\b(shall not|should not|must not|may not|shall|should|must|may)\b/gi;
 
 /**

--- a/packages/markspec/core/lint/rules/suppression.ts
+++ b/packages/markspec/core/lint/rules/suppression.ts
@@ -15,14 +15,16 @@ import { LEXICON_RULE_CODES } from "./lexicon.ts";
 import { STRUCT_RULE_CODES } from "./struct.ts";
 import { EARS_RULE_CODES } from "./ears.ts";
 import { MODAL_SENTENCE_RULE_CODES } from "./modal_sentence.ts";
+import { INCOSE_SENTENCE_RULE_CODES } from "./incose_sentence.ts";
 
-/** All rule codes shipped in PA-1 through PA-3 (slices 1–7).
+/** All rule codes shipped in PA-1 through PA-3 (slices 1–8).
  * MSL-Q900/Q901 are self-referential. */
 export const PA1_KNOWN_RULE_CODES: ReadonlySet<string> = new Set([
   ...LEXICON_RULE_CODES,
   ...STRUCT_RULE_CODES,
   ...EARS_RULE_CODES,
   ...MODAL_SENTENCE_RULE_CODES,
+  ...INCOSE_SENTENCE_RULE_CODES,
   // Q500: xref-glossary-undefined (slice 5)
   "MSL-Q500",
   "MSL-Q900",

--- a/packages/markspec/core/lint/runner.ts
+++ b/packages/markspec/core/lint/runner.ts
@@ -24,6 +24,7 @@ import { runXrefRules } from "./rules/xref.ts";
 import type { IsIdentifierHook } from "./rules/xref.ts";
 import { runEarsRules } from "./rules/ears.ts";
 import { runModalSentenceRules } from "./rules/modal_sentence.ts";
+import { runIncoseSentenceRules } from "./rules/incose_sentence.ts";
 import { loadLexicon } from "../lexicons/mod.ts";
 
 // ---------------------------------------------------------------------------
@@ -101,12 +102,13 @@ function disabledCodes(entry: Entry): ReadonlySet<string> {
  *   5. Run Q500 xref rules on each in-scope entry.
  *   6. Run EARS rules (Q100–Q104) on each in-scope entry.
  *   7. Run modal sentence rules (Q200–Q201) on each in-scope entry.
- *   8. Run suppression hygiene on ALL Authored entries.
- *   9. Apply suppression: drop in-scope diagnostics where the entry's
+ *   8. Run INCOSE sentence rules (Q306–Q312, Q402) on each in-scope entry.
+ *   9. Run suppression hygiene on ALL Authored entries.
+ *  10. Apply suppression: drop in-scope diagnostics where the entry's
  *      Markspec-disable list includes the rule's code and the entry
  *      has a Rationale. Suppression-hygiene diagnostics (Q900/Q901)
  *      are never suppressed.
- *  10. Return remaining diagnostics.
+ *  11. Return remaining diagnostics.
  */
 export async function runLint(options: LintOptions): Promise<LintResult> {
   const { entries } = options;
@@ -118,7 +120,7 @@ export async function runLint(options: LintOptions): Promise<LintResult> {
   );
   const isIdHook: IsIdentifierHook = () => false;
 
-  // Steps 1–7: collect diagnostics keyed by entry
+  // Steps 1–8: collect diagnostics keyed by entry
   const inScopeDiags = new Map<Entry, LintDiagnostic[]>();
   for (const entry of entries) {
     if (!isProseScope(entry)) continue;
@@ -128,17 +130,19 @@ export async function runLint(options: LintOptions): Promise<LintResult> {
     diags.push(...runXrefRules(entry, glossary, allow, isIdHook));
     diags.push(...runEarsRules(entry));
     diags.push(...runModalSentenceRules(entry));
+    // Step 8: INCOSE sentence rules (Q306–Q312, Q402)
+    diags.push(...runIncoseSentenceRules(entry));
     inScopeDiags.set(entry, diags);
   }
 
-  // Step 8: suppression hygiene on all Authored entries
+  // Step 9: suppression hygiene on all Authored entries
   const hygieneDiags: LintDiagnostic[] = [];
   for (const entry of entries) {
     if (entry.shape !== "Authored") continue;
     hygieneDiags.push(...runSuppressionRules(entry));
   }
 
-  // Step 9: apply suppression to in-scope diagnostics
+  // Step 10: apply suppression to in-scope diagnostics
   const out: LintDiagnostic[] = [];
   for (const [entry, diags] of inScopeDiags) {
     const disabled = disabledCodes(entry);
@@ -150,7 +154,7 @@ export async function runLint(options: LintOptions): Promise<LintResult> {
     }
   }
 
-  // Step 10: append hygiene diagnostics (never suppressed)
+  // Step 11: append hygiene diagnostics (never suppressed)
   out.push(...hygieneDiags);
 
   return { diagnostics: out };


### PR DESCRIPTION
## Summary

Six INCOSE sentence-level rules plus the entry-level Q402 multi-shall:

| Code     | Slug                              | Sev  | Score | Fires when                                                                                              |
|----------|-----------------------------------|------|-------|---------------------------------------------------------------------------------------------------------|
| MSL-Q306 | incose-r11-separate-clauses       | info | 1     | Normative sentence with exactly 2 EARS condition keywords. Defers to Q103 at ≥3.                       |
| MSL-Q307 | incose-r18-single-thought         | warn | 3     | Normative sentence with `and` joining ≥2 modal verbs.                                                  |
| MSL-Q308 | incose-r19-combinator             | info | 1     | Normative sentence with `however`/`whereas`/`meanwhile`/`but`/`unless`.                                |
| MSL-Q309 | incose-r24-pronouns               | info | 1     | `it`/`this`/`that`/`they`/`them` in normative sentence (with per-occurrence exceptions for `, it` and relative-clause `that`). |
| MSL-Q311 | incose-r27-explicit-conditions    | info | 1     | Vague applicability phrases without explicit EARS leading clause.                                       |
| MSL-Q312 | incose-r33-range-of-values        | info | 1     | Bare numeric quantity with engineering unit + no tolerance marker.                                      |
| MSL-Q402 | struct-multiple-shall             | warn | 3     | **Entry-level:** total modals ≥2 across body AND no single sentence already triggered Q200.            |

This is **slice 8 of 10** for the Stage-2 PA-3 prose-analysis build.

## Modal regex deduplication

`MODAL_COMPOUND_RE` is now exported from `core/lint/rules/modal_sentence.ts` (slice 7) and imported here. No duplication. The slice-7 review's noted future concern is addressed.

## Dedupe logic

- **Q306 ↔ Q103:** Q306 fires at exactly 2 condition keywords; defers at ≥3 (Q103's territory). Documented gap: `where` is counted by Q306 but not Q103, so ≥3 stacked `where` clauses silently fall through both — accepted given rarity.
- **Q402 ↔ Q200:** entry-level Q402 only fires when no sentence already had ≥2 modals. Tracked via an `anysentenceHasTwoModals` accumulator during the sentence walk.

## What's deferred

- **Q300 (passive voice)** and **Q301 (subject-verb)** deferred to slice 10 per the plan — heuristic complexity warrants separate slice.

## Test plan

- [x] 44 unit tests covering all 7 rules, all dedupe paths, and the two regression cases added during code review.
- [x] All existing PA-1 + slices 1-7 tests still pass.
- [x] Full suite: 2162 tests passing, 0 failing.
- [x] `just check` clean; `deno fmt --check` + `dprint check` clean.

## Reviews completed

- **Spec compliance + code quality** (sonnet pass): ✅ spec compliant; ⚠️ approved with nits. Three Important issues fixed in the follow-up commit:
  1. **Q309's `it` exception was sentence-wide** — any `, it` in the sentence exempted ALL `it` occurrences. Replaced with per-occurrence `isItAfterComma(sentence, idx)` that walks back from the specific match position. Regression test pins the bug.
  2. **Q306 deferral comment misleading** — Q103 doesn't count `where`, so ≥3 stacked `where` clauses fall through. Inline comment documents the accepted gap.
  3. **Q307 co-fire scenario untested** — explicit test added asserting Q307 fires on `and`-joined dual-modal sentences (cross-module dedupe with Q200 happens at runner level).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
