### PR TITLE
fix(core): emit warning for empty CSV elements in attribute values

### DIFF
--- a/packages/markspec/core/model/attributes_test.ts
+++ b/packages/markspec/core/model/attributes_test.ts
@@ -1,0 +1,117 @@
+/**
+ * Property-based invariant tests for ATTRIBUTE_CATALOG.
+ *
+ * Walks all 31 entries and asserts structural invariants that must hold
+ * for every attribute specification in the catalog.
+ *
+ * Partially addresses #215.
+ */
+
+import { assertEquals, assertNotEquals } from "@std/assert";
+import { assert } from "@std/assert/assert";
+import { ATTRIBUTE_CATALOG } from "./attributes.ts";
+
+// ---------------------------------------------------------------------------
+// Invariant: no duplicate keys
+// ---------------------------------------------------------------------------
+
+Deno.test("ATTRIBUTE_CATALOG: no duplicate keys", () => {
+  const keys = ATTRIBUTE_CATALOG.map((s) => s.key);
+  const unique = new Set(keys);
+  assertEquals(
+    keys.length,
+    unique.size,
+    `Duplicate keys found: ${
+      keys.filter((k, i) => keys.indexOf(k) !== i).join(", ")
+    }`,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Per-entry shape invariants
+// ---------------------------------------------------------------------------
+
+for (const spec of ATTRIBUTE_CATALOG) {
+  Deno.test(`ATTRIBUTE_CATALOG[${spec.key}]: key is non-empty Title-Case string`, () => {
+    assert(spec.key.length > 0, "key must be non-empty");
+    // Title-Case: first character is uppercase
+    assertEquals(
+      spec.key[0],
+      spec.key[0].toUpperCase(),
+      `key "${spec.key}" must start with uppercase`,
+    );
+    // No whitespace
+    assertEquals(
+      spec.key,
+      spec.key.trim(),
+      "key must not have surrounding whitespace",
+    );
+    assert(
+      !/\s/.test(spec.key),
+      `key "${spec.key}" must not contain whitespace`,
+    );
+  });
+
+  Deno.test(`ATTRIBUTE_CATALOG[${spec.key}]: shapes is a non-empty array`, () => {
+    assert(Array.isArray(spec.shapes), "shapes must be an array");
+    assertNotEquals(spec.shapes.length, 0, "shapes must not be empty");
+    for (const shape of spec.shapes) {
+      assert(
+        shape === "Authored" || shape === "Reference",
+        `Invalid shape "${shape}" on ${spec.key}`,
+      );
+    }
+  });
+
+  Deno.test(`ATTRIBUTE_CATALOG[${spec.key}]: enum attributes have enumValues or are profile-delegated`, () => {
+    if (spec.type === "enum") {
+      // Open enums (e.g., Type) delegate their vocabulary to profiles;
+      // closed enums (e.g., Origin) must declare enumValues.
+      if (spec.enumValues !== undefined) {
+        assert(
+          spec.enumValues.length > 0,
+          `Enum attribute "${spec.key}" has empty enumValues array`,
+        );
+      }
+      // Either way, enumValues must not be an empty array
+    }
+  });
+
+  Deno.test(`ATTRIBUTE_CATALOG[${spec.key}]: identity attribute is required`, () => {
+    if (spec.type === "id" && spec.key === "Id") {
+      assert(
+        spec.required,
+        `Identity attribute "${spec.key}" must be required`,
+      );
+    }
+  });
+
+  Deno.test(`ATTRIBUTE_CATALOG[${spec.key}]: generated attributes are not required`, () => {
+    if (spec.origin === "generated") {
+      assertEquals(
+        spec.required,
+        false,
+        `Generated attribute "${spec.key}" must not be required`,
+      );
+    }
+  });
+
+  Deno.test(`ATTRIBUTE_CATALOG[${spec.key}]: has valid origin`, () => {
+    assert(
+      spec.origin === "authored" || spec.origin === "assigned" ||
+        spec.origin === "generated",
+      `Invalid origin "${spec.origin}" on ${spec.key}`,
+    );
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Aggregate invariant: catalog is non-trivial
+// ---------------------------------------------------------------------------
+
+Deno.test("ATTRIBUTE_CATALOG: has at least 25 entries", () => {
+  assert(
+    ATTRIBUTE_CATALOG.length >= 25,
+    `Expected >=25 entries, got ${ATTRIBUTE_CATALOG.length}`,
+  );
+});

--- a/packages/markspec/core/validator/mod.ts
+++ b/packages/markspec/core/validator/mod.ts
@@ -18,6 +18,7 @@ import type { Attribute, Diagnostic, Entry } from "../model/mod.ts";
 import {
   attributeSpec,
   CORE_TYPE_SCOPED_ATTRS,
+  CSV_SPLITTABLE_TYPES,
   IDENTITY_KEY,
   ULID_RE,
   UNIVERSAL_ATTRIBUTE_KEYS,
@@ -406,6 +407,25 @@ function checkStructural(
             `${entry.displayId}: unknown attribute '${attr.key}' (not in core universal set; profile-declared attributes are permitted when a profile is loaded)`,
           location: entry.location,
         });
+      }
+
+      // MSL-A006: empty element in CSV attribute value (e.g. "A,,B").
+      const csvSpec = attributeSpec(attr.key);
+      if (
+        csvSpec && CSV_SPLITTABLE_TYPES.has(csvSpec.type) &&
+        attr.value.includes(",")
+      ) {
+        const parts = attr.value.split(",").map((s) => s.trim());
+        const emptyCount = parts.filter((s) => s.length === 0).length;
+        if (emptyCount > 0) {
+          diagnostics.push({
+            code: "MSL-A006",
+            severity: "warning",
+            message:
+              `${entry.displayId}: attribute '${attr.key}' contains ${emptyCount} empty element(s) in CSV value "${attr.value}"`,
+            location: entry.location,
+          });
+        }
       }
     }
   }

--- a/packages/markspec/core/validator/mod_test.ts
+++ b/packages/markspec/core/validator/mod_test.ts
@@ -402,3 +402,36 @@ Deno.test("validate: $Name with different kinds across entries → TYPL-002", ()
   assertEquals(typl002.length, 1);
   assertEquals(result.valid, false);
 });
+
+// ---------------------------------------------------------------------------
+// MSL-A006: empty CSV element warning
+// ---------------------------------------------------------------------------
+
+Deno.test("validate: CSV attribute with empty element emits MSL-A006", () => {
+  const e = entry({
+    displayId: "STK_0001",
+    rawAttributes: [
+      { key: "Id", value: "01HGW2Q8MNP3RSTVWXYZABCDEF" },
+      { key: "Labels", value: "ASIL-B,,Safety" },
+    ],
+    id: "01HGW2Q8MNP3RSTVWXYZABCDEF",
+  });
+  const result = validate([e]);
+  const a006 = result.diagnostics.filter((d) => d.code === "MSL-A006");
+  assertEquals(a006.length, 1);
+  assertEquals(a006[0].severity, "warning");
+});
+
+Deno.test("validate: CSV attribute without empty element does not emit MSL-A006", () => {
+  const e = entry({
+    displayId: "STK_0002",
+    rawAttributes: [
+      { key: "Id", value: "01HGW2Q8MNP3RSTVWXYZABCDEG" },
+      { key: "Labels", value: "ASIL-B, Safety" },
+    ],
+    id: "01HGW2Q8MNP3RSTVWXYZABCDEG",
+  });
+  const result = validate([e]);
+  const a006 = result.diagnostics.filter((d) => d.code === "MSL-A006");
+  assertEquals(a006.length, 0);
+});


### PR DESCRIPTION
Adds MSL-A006 warning diagnostic when a CSV-splittable attribute (Labels, Satisfies, etc.) contains empty elements (e.g. `"A,,B"`).

Previously, both `collateAttributes` and `expandCsvValues` silently dropped empty slots via `.filter(s => s.length > 0)`. Now the validator emits a warning so authors are aware of the malformed value.

Partially addresses #215.