### PR TITLE
fix(deps): bump web-tree-sitter to ^0.25 for ABI v15 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,10 +131,6 @@
   projection that stripped emphasis; the new scanner runs on the raw body.
   Authors using emphasis around modal verbs will not get the lint warning.
   Plain `SHALL` and `MUST NOT` are detected correctly.
-- **grammars:** The bundled `grammars/tree-sitter-c.wasm` is compiled against
-  tree-sitter ABI v15 while the installed `web-tree-sitter` accepts v13–v14.
-  C source files therefore fail to load grammars at runtime — independent
-  of #409 and tracked separately.
 
 ## [0.5.3] (2026-05-23)
 

--- a/deno.lock
+++ b/deno.lock
@@ -6,51 +6,42 @@
     "jsr:@cliffy/internal@1.0.0": "1.0.0",
     "jsr:@cliffy/table@1.0.0": "1.0.0",
     "jsr:@david/code-block-writer@^13.0.3": "13.0.3",
-    "jsr:@db/sqlite@0.13": "0.13.0",
     "jsr:@deno/dnt@~0.42.3": "0.42.3",
-    "jsr:@denosaurs/plug@1": "1.1.0",
     "jsr:@std/assert@1": "1.0.19",
     "jsr:@std/assert@^1.0.19": "1.0.19",
+    "jsr:@std/async@^1.3.0": "1.3.0",
     "jsr:@std/cli@1": "1.0.28",
     "jsr:@std/collections@^1.1.3": "1.1.7",
-    "jsr:@std/encoding@1": "1.0.10",
+    "jsr:@std/data-structures@^1.0.11": "1.0.11",
     "jsr:@std/fmt@1": "1.0.9",
     "jsr:@std/fmt@^1.0.9": "1.0.9",
     "jsr:@std/fs@1": "1.0.23",
     "jsr:@std/fs@^1.0.23": "1.0.23",
     "jsr:@std/internal@^1.0.12": "1.0.13",
     "jsr:@std/internal@^1.0.13": "1.0.13",
-    "jsr:@std/internal@^1.0.6": "1.0.12",
     "jsr:@std/json@^1.0.2": "1.1.0",
     "jsr:@std/jsonc@1": "1.0.2",
     "jsr:@std/path@1": "1.1.4",
-    "jsr:@std/path@1.0": "1.0.9",
-    "jsr:@std/path@^1.1.0": "1.1.0",
     "jsr:@std/path@^1.1.4": "1.1.4",
     "jsr:@std/semver@^1.0.8": "1.0.8",
     "jsr:@std/testing@1": "1.0.18",
     "jsr:@std/text@^1.0.17": "1.0.17",
     "jsr:@std/toml@1": "1.0.11",
     "jsr:@std/ulid@1": "1.0.0",
-    "jsr:@std/yaml@1": "1.0.12",
+    "jsr:@std/yaml@1": "1.1.0",
     "jsr:@ts-morph/bootstrap@0.27": "0.27.0",
     "jsr:@ts-morph/common@0.27": "0.27.0",
-    "npm:@modelcontextprotocol/sdk@*": "1.29.0_zod@4.4.3",
     "npm:@modelcontextprotocol/sdk@1": "1.29.0_zod@4.4.3",
     "npm:@myriaddreamin/typst-ts-node-compiler@0.6": "0.6.0",
     "npm:@types/mdast@4": "4.0.4",
     "npm:rehype-stringify@10": "10.0.1",
-    "npm:remark-gfm@*": "4.0.1",
     "npm:remark-gfm@4": "4.0.1",
-    "npm:remark-parse@*": "11.0.0",
     "npm:remark-parse@11": "11.0.0",
     "npm:remark-rehype@11": "11.1.2",
-    "npm:unified@*": "11.0.5",
     "npm:unified@11": "11.0.5",
     "npm:vscode-languageserver-textdocument@1": "1.0.12",
-    "npm:vscode-languageserver@*": "9.0.1",
     "npm:vscode-languageserver@9": "9.0.1",
-    "npm:web-tree-sitter@0.24": "0.24.7"
+    "npm:web-tree-sitter@0.25": "0.25.10"
   },
   "jsr": {
     "@cliffy/command@1.0.0": {
@@ -83,13 +74,6 @@
     "@david/code-block-writer@13.0.3": {
       "integrity": "f98c77d320f5957899a61bfb7a9bead7c6d83ad1515daee92dbacc861e13bb7f"
     },
-    "@db/sqlite@0.13.0": {
-      "integrity": "4545c635e0b3d4ddfdc0f2240f932f24b8ad0178e9c2e3a0f9403e7b18ae2fb5",
-      "dependencies": [
-        "jsr:@denosaurs/plug",
-        "jsr:@std/path@1.0"
-      ]
-    },
     "@deno/dnt@0.42.3": {
       "integrity": "62a917a0492f3c8af002dce90605bb0d41f7d29debc06aca40dba72ab65d8ae3",
       "dependencies": [
@@ -100,26 +84,14 @@
         "jsr:@ts-morph/bootstrap"
       ]
     },
-    "@denosaurs/plug@1.1.0": {
-      "integrity": "eb2f0b7546c7bca2000d8b0282c54d50d91cf6d75cb26a80df25a6de8c4bc044",
-      "dependencies": [
-        "jsr:@std/encoding",
-        "jsr:@std/fmt@1",
-        "jsr:@std/fs@1",
-        "jsr:@std/path@1"
-      ]
-    },
-    "@std/assert@1.0.13": {
-      "integrity": "ae0d31e41919b12c656c742b22522c32fb26ed0cba32975cb0de2a273cb68b29",
-      "dependencies": [
-        "jsr:@std/internal@^1.0.6"
-      ]
-    },
     "@std/assert@1.0.19": {
       "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
       "dependencies": [
         "jsr:@std/internal@^1.0.12"
       ]
+    },
+    "@std/async@1.3.0": {
+      "integrity": "80485538a4f7baaa46bfe2246168069e02ed142b9f9079cd164f43bb060ad9e9"
     },
     "@std/cli@1.0.28": {
       "integrity": "74ef9b976db59ca6b23a5283469c9072be6276853807a83ec6c7ce412135c70a",
@@ -131,20 +103,11 @@
     "@std/collections@1.1.7": {
       "integrity": "56f659d011218a69740b12829cf5ea2c9b70bbed0af02597e27dc1eb5e69e208"
     },
-    "@std/encoding@1.0.10": {
-      "integrity": "8783c6384a2d13abd5e9e87a7ae0520a30e9f56aeeaa3bdf910a3eaaf5c811a1"
-    },
-    "@std/fmt@1.0.8": {
-      "integrity": "71e1fc498787e4434d213647a6e43e794af4fd393ef8f52062246e06f7e372b7"
+    "@std/data-structures@1.0.11": {
+      "integrity": "53b98ed7efa61f107dfc14244bd2ec5557f7f7ee0bbaef6d449d7937facacb89"
     },
     "@std/fmt@1.0.9": {
       "integrity": "2487343e8899fb2be5d0e3d35013e54477ada198854e52dd05ed0422eddcabe0"
-    },
-    "@std/fs@1.0.18": {
-      "integrity": "24bcad99eab1af4fde75e05da6e9ed0e0dce5edb71b7e34baacf86ffe3969f3a",
-      "dependencies": [
-        "jsr:@std/path@^1.1.0"
-      ]
     },
     "@std/fs@1.0.23": {
       "integrity": "3ecbae4ce4fee03b180fa710caff36bb5adb66631c46a6460aaad49515565a37",
@@ -152,12 +115,6 @@
         "jsr:@std/internal@^1.0.12",
         "jsr:@std/path@^1.1.4"
       ]
-    },
-    "@std/internal@1.0.7": {
-      "integrity": "39eeb5265190a7bc5d5591c9ff019490bd1f2c3907c044a11b0d545796158a0f"
-    },
-    "@std/internal@1.0.12": {
-      "integrity": "972a634fd5bc34b242024402972cd5143eac68d8dffaca5eaa4dba30ce17b027"
     },
     "@std/internal@1.0.13": {
       "integrity": "2f9546691d4ac2d32859c82dff284aaeac980ddeca38430d07941e7e288725c0"
@@ -170,12 +127,6 @@
       "dependencies": [
         "jsr:@std/json"
       ]
-    },
-    "@std/path@1.0.9": {
-      "integrity": "260a49f11edd3db93dd38350bf9cd1b4d1366afa98e81b86167b4e3dd750129e"
-    },
-    "@std/path@1.1.0": {
-      "integrity": "ddc94f8e3c275627281cbc23341df6b8bcc874d70374f75fec2533521e3d6886"
     },
     "@std/path@1.1.4": {
       "integrity": "1d2d43f39efb1b42f0b1882a25486647cb851481862dc7313390b2bb044314b5",
@@ -190,6 +141,8 @@
       "integrity": "d3152f57b11666bf6358d0e127c7e3488e91178b0c2d8fbf0793e1c53cd13cb1",
       "dependencies": [
         "jsr:@std/assert@^1.0.19",
+        "jsr:@std/async",
+        "jsr:@std/data-structures",
         "jsr:@std/fs@^1.0.23",
         "jsr:@std/internal@^1.0.13",
         "jsr:@std/path@^1.1.4"
@@ -207,8 +160,8 @@
     "@std/ulid@1.0.0": {
       "integrity": "d41c3d27a907714413649fee864b7cde8d42ee68437d22b79d5de4f81d808780"
     },
-    "@std/yaml@1.0.12": {
-      "integrity": "7deabca4545bcedd07c5f69ea53acea71b8b4c67562f224e17b90d75944cb20c"
+    "@std/yaml@1.1.0": {
+      "integrity": "fc1c5c63e05c4c5eb6118355f557958035d41940d6c29d35b306ef7155d6edb0"
     },
     "@ts-morph/bootstrap@0.27.0": {
       "integrity": "b8d7bc8f7942ce853dde4161b28f9aa96769cef3d8eebafb379a81800b9e2448",
@@ -225,7 +178,7 @@
     }
   },
   "npm": {
-    "@hono/node-server@1.19.14_hono@4.12.18": {
+    "@hono/node-server@1.19.14_hono@4.12.23": {
       "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
       "dependencies": [
         "hono"
@@ -237,7 +190,7 @@
         "@hono/node-server",
         "ajv",
         "ajv-formats",
-        "content-type",
+        "content-type@1.0.5",
         "cors",
         "cross-spawn",
         "eventsource",
@@ -348,9 +301,8 @@
     "@types/unist@3.0.3": {
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="
     },
-    "@ungap/structured-clone@1.3.0": {
-      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
-      "deprecated": true
+    "@ungap/structured-clone@1.3.1": {
+      "integrity": "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ=="
     },
     "accepts@2.0.0": {
       "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
@@ -359,7 +311,7 @@
         "negotiator"
       ]
     },
-    "ajv-formats@3.0.1_ajv@8.17.1": {
+    "ajv-formats@3.0.1_ajv@8.20.0": {
       "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
       "dependencies": [
         "ajv"
@@ -368,8 +320,8 @@
         "ajv"
       ]
     },
-    "ajv@8.17.1": {
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+    "ajv@8.20.0": {
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dependencies": [
         "fast-deep-equal",
         "fast-uri",
@@ -384,7 +336,7 @@
       "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
       "dependencies": [
         "bytes",
-        "content-type",
+        "content-type@1.0.5",
         "debug",
         "http-errors",
         "iconv-lite",
@@ -431,6 +383,9 @@
     },
     "content-type@1.0.5": {
       "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="
+    },
+    "content-type@2.0.0": {
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="
     },
     "cookie-signature@1.2.2": {
       "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="
@@ -497,8 +452,8 @@
     "es-errors@1.3.0": {
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="
     },
-    "es-object-atoms@1.1.1": {
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+    "es-object-atoms@1.1.2": {
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "dependencies": [
         "es-errors"
       ]
@@ -521,8 +476,8 @@
         "eventsource-parser"
       ]
     },
-    "express-rate-limit@8.5.1_express@5.2.1": {
-      "integrity": "sha512-5O6KYmyJEpuPJV5hNTXKbAHWRqrzyu+OI3vUnSd2kXFubIVpG7ezpgxQy76Zo5GQZtrQBg86hF+CM/NX+cioiQ==",
+    "express-rate-limit@8.5.2_express@5.2.1": {
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
       "dependencies": [
         "express",
         "ip-address"
@@ -534,7 +489,7 @@
         "accepts",
         "body-parser",
         "content-disposition",
-        "content-type",
+        "content-type@1.0.5",
         "cookie",
         "cookie-signature",
         "debug",
@@ -567,8 +522,8 @@
     "fast-deep-equal@3.1.3": {
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
-    "fast-uri@3.0.6": {
-      "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw=="
+    "fast-uri@3.1.2": {
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ=="
     },
     "finalhandler@2.1.1": {
       "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
@@ -618,8 +573,8 @@
     "has-symbols@1.1.0": {
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="
     },
-    "hasown@2.0.2": {
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+    "hasown@2.0.3": {
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
       "dependencies": [
         "function-bind"
       ]
@@ -646,8 +601,8 @@
         "@types/hast"
       ]
     },
-    "hono@4.12.18": {
-      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ=="
+    "hono@4.12.23": {
+      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA=="
     },
     "html-void-elements@3.0.0": {
       "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg=="
@@ -1132,8 +1087,8 @@
         "ipaddr.js"
       ]
     },
-    "qs@6.15.1": {
-      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+    "qs@6.15.2": {
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "dependencies": [
         "side-channel"
       ]
@@ -1307,10 +1262,10 @@
     "trough@2.2.0": {
       "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw=="
     },
-    "type-is@2.0.1": {
-      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+    "type-is@2.1.0": {
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "dependencies": [
-        "content-type",
+        "content-type@2.0.0",
         "media-typer",
         "mime-types"
       ]
@@ -1403,8 +1358,8 @@
       ],
       "bin": true
     },
-    "web-tree-sitter@0.24.7": {
-      "integrity": "sha512-CdC/TqVFbXqR+C51v38hv6wOPatKEUGxa39scAeFSm98wIhZxAYonhRQPSMmfZ2w7JDI0zQDdzdmgtNk06/krQ=="
+    "web-tree-sitter@0.25.10": {
+      "integrity": "sha512-Y09sF44/13XvgVKgO2cNDw5rGk6s26MgoZPXLESvMXeefBf7i6/73eFurre0IsTW6E14Y0ArIzhUMmjoc7xyzA=="
     },
     "which@2.0.2": {
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
@@ -1428,17 +1383,6 @@
     "zwitch@2.0.4": {
       "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="
     }
-  },
-  "remote": {
-    "https://deno.land/x/sqlite@v3.9.1/build/sqlite.js": "2afc7875c7b9c85d89730c4a311ab3a304e5d1bf761fbadd8c07bbdf130f5f9b",
-    "https://deno.land/x/sqlite@v3.9.1/build/vfs.js": "7f7778a9fe499cd10738d6e43867340b50b67d3e39142b0065acd51a84cd2e03",
-    "https://deno.land/x/sqlite@v3.9.1/mod.ts": "e09fc79d8065fe222578114b109b1fd60077bff1bb75448532077f784f4d6a83",
-    "https://deno.land/x/sqlite@v3.9.1/src/constants.ts": "90f3be047ec0a89bcb5d6fc30db121685fc82cb00b1c476124ff47a4b0472aa9",
-    "https://deno.land/x/sqlite@v3.9.1/src/db.ts": "03d0c860957496eadedd86e51a6e650670764630e64f56df0092e86c90752401",
-    "https://deno.land/x/sqlite@v3.9.1/src/error.ts": "f7a15cb00d7c3797da1aefee3cf86d23e0ae92e73f0ba3165496c3816ab9503a",
-    "https://deno.land/x/sqlite@v3.9.1/src/function.ts": "bc778cab7a6d771f690afa27264c524d22fcb96f1bb61959ade7922c15a4ab8d",
-    "https://deno.land/x/sqlite@v3.9.1/src/query.ts": "d58abda928f6582d77bad685ecf551b1be8a15e8e38403e293ec38522e030cad",
-    "https://deno.land/x/sqlite@v3.9.1/src/wasm.ts": "e79d0baa6e42423257fb3c7cc98091c54399254867e0f34a09b5bdef37bd9487"
   },
   "workspace": {
     "dependencies": [
@@ -1468,7 +1412,7 @@
           "npm:unified@11",
           "npm:vscode-languageserver-textdocument@1",
           "npm:vscode-languageserver@9",
-          "npm:web-tree-sitter@0.24"
+          "npm:web-tree-sitter@0.25"
         ]
       }
     }

--- a/packages/markspec/core/formatter/source.ts
+++ b/packages/markspec/core/formatter/source.ts
@@ -6,8 +6,8 @@
  * with appropriate comment prefixes.
  */
 
-import type { SyntaxNode } from "web-tree-sitter";
-import Parser from "web-tree-sitter";
+import type { Node as SyntaxNode } from "web-tree-sitter";
+import { type Language, Parser } from "web-tree-sitter";
 import { format } from "./mod.ts";
 import type { FormatOptions } from "./mod.ts";
 import {
@@ -19,7 +19,7 @@ import {
 /** Options for {@linkcode formatSource}. */
 export interface FormatSourceOptions extends FormatOptions {
   /** Pre-loaded tree-sitter language grammar. */
-  readonly language: Parser.Language;
+  readonly language: Language;
 }
 
 /** Result of a source file format operation. */
@@ -63,11 +63,12 @@ export interface DocCommentBlockInfo {
  */
 export function extractDocCommentBlocks(
   content: string,
-  language: Parser.Language,
+  language: Language,
 ): DocCommentBlockInfo[] {
   const parser = new Parser();
   parser.setLanguage(language);
   const tree = parser.parse(content);
+  if (!tree) return [];
 
   const blocks: DocCommentBlockInfo[] = [];
   walkForDocCommentInfo(tree.rootNode, blocks);

--- a/packages/markspec/core/parser/grammars.ts
+++ b/packages/markspec/core/parser/grammars.ts
@@ -5,7 +5,7 @@
  * grammar WASM files and caches loaded languages for reuse.
  */
 
-import Parser from "web-tree-sitter";
+import { Language, Parser } from "web-tree-sitter";
 import { join } from "@std/path";
 
 /** Map file extensions to grammar WASM file names. */
@@ -41,7 +41,7 @@ const GRAMMARS_DIR = join(
 );
 
 let initialized = false;
-const cache = new Map<string, Promise<Parser.Language>>();
+const cache = new Map<string, Promise<Language>>();
 
 /** Check whether a file extension has a supported grammar. */
 export function isSupportedExtension(ext: string): boolean {
@@ -53,13 +53,13 @@ export function isSupportedExtension(ext: string): boolean {
  *
  * Initializes the Parser WASM runtime on first call. Grammar languages
  * are cached — repeated calls with the same extension return the
- * same `Parser.Language` instance. Concurrent-safe: stores the loading
+ * same `Language` instance. Concurrent-safe: stores the loading
  * promise so parallel calls await the same load.
  *
  * @param ext - File extension including the dot (e.g., `.rs`, `.java`)
  * @throws If the extension is unsupported or the WASM file cannot be loaded
  */
-export function loadGrammar(ext: string): Promise<Parser.Language> {
+export function loadGrammar(ext: string): Promise<Language> {
   const grammarName = EXT_TO_GRAMMAR[ext];
   if (!grammarName) {
     throw new Error(`unsupported file extension: ${ext}`);
@@ -73,7 +73,7 @@ export function loadGrammar(ext: string): Promise<Parser.Language> {
   return pending;
 }
 
-async function doLoad(grammarName: string): Promise<Parser.Language> {
+async function doLoad(grammarName: string): Promise<Language> {
   if (!initialized) {
     await Parser.init();
     initialized = true;
@@ -84,9 +84,9 @@ async function doLoad(grammarName: string): Promise<Parser.Language> {
   const binPath = join(GRAMMARS_DIR, `${grammarName}.wasm.bin`);
   try {
     await Deno.stat(binPath);
-    return Parser.Language.load(binPath);
+    return Language.load(binPath);
   } catch {
-    return Parser.Language.load(join(GRAMMARS_DIR, `${grammarName}.wasm`));
+    return Language.load(join(GRAMMARS_DIR, `${grammarName}.wasm`));
   }
 }
 

--- a/packages/markspec/core/parser/language_spec.ts
+++ b/packages/markspec/core/parser/language_spec.ts
@@ -11,7 +11,7 @@
  * {@linkcode languageIdForExtension}.
  */
 
-import type { SyntaxNode } from "web-tree-sitter";
+import type { Node as SyntaxNode } from "web-tree-sitter";
 import type { SupportedLanguage } from "../model/mod.ts";
 export type { SupportedLanguage }; // re-export for parser-internal consumers
 

--- a/packages/markspec/core/parser/source.ts
+++ b/packages/markspec/core/parser/source.ts
@@ -6,8 +6,8 @@
  * content to the markdown parser for entry extraction.
  */
 
-import type { SyntaxNode } from "web-tree-sitter";
-import Parser from "web-tree-sitter";
+import type { Node as SyntaxNode } from "web-tree-sitter";
+import { type Language, Parser } from "web-tree-sitter";
 import type { Entry, ExtractorRule } from "../model/mod.ts";
 import { parseMarkdown } from "./markdown.ts";
 import { buildBlockLineMap } from "./line_map.ts";
@@ -22,7 +22,7 @@ export interface ParseSourceOptions {
   /** File path used in source locations. */
   readonly file?: string;
   /** Pre-loaded tree-sitter language grammar. */
-  readonly language: Parser.Language;
+  readonly language: Language;
   /**
    * Language id for the active grammar — used by the walker to look up
    * the doc-comment dispatch row in `LANGUAGE_SPECS`. The caller maps
@@ -77,6 +77,7 @@ export function parseSource(
   const parser = new Parser();
   parser.setLanguage(options.language);
   const tree = parser.parse(content);
+  if (!tree) return { entries: [] };
 
   const blocks: DocCommentBlock[] = [];
   walkForDocComments(tree.rootNode, blocks, spec);

--- a/packages/markspec/core/parser/source_test.ts
+++ b/packages/markspec/core/parser/source_test.ts
@@ -5,7 +5,7 @@
  */
 
 import { assertEquals, assertStringIncludes } from "@std/assert";
-import Parser from "web-tree-sitter";
+import { Language, Parser } from "web-tree-sitter";
 import { join } from "@std/path";
 import { parseSource } from "./source.ts";
 
@@ -21,89 +21,89 @@ const grammarsDir = join(
   "..",
   "grammars",
 );
-let rustLanguage: Parser.Language;
+let rustLanguage: Language;
 
-async function getRustLanguage(): Promise<Parser.Language> {
+async function getRustLanguage(): Promise<Language> {
   if (rustLanguage) return rustLanguage;
   await Parser.init();
-  rustLanguage = await Parser.Language.load(
+  rustLanguage = await Language.load(
     join(grammarsDir, "tree-sitter-rust.wasm"),
   );
   return rustLanguage;
 }
 
-let javaLanguage: Parser.Language;
+let javaLanguage: Language;
 
-async function getJavaLanguage(): Promise<Parser.Language> {
+async function getJavaLanguage(): Promise<Language> {
   if (javaLanguage) return javaLanguage;
   await Parser.init();
-  javaLanguage = await Parser.Language.load(
+  javaLanguage = await Language.load(
     join(grammarsDir, "tree-sitter-java.wasm"),
   );
   return javaLanguage;
 }
 
-let kotlinLanguage: Parser.Language;
+let kotlinLanguage: Language;
 
-async function getKotlinLanguage(): Promise<Parser.Language> {
+async function getKotlinLanguage(): Promise<Language> {
   if (kotlinLanguage) return kotlinLanguage;
   await Parser.init();
-  kotlinLanguage = await Parser.Language.load(
+  kotlinLanguage = await Language.load(
     join(grammarsDir, "tree-sitter-kotlin.wasm"),
   );
   return kotlinLanguage;
 }
 
-let cppLanguage: Parser.Language;
+let cppLanguage: Language;
 
-async function getCppLanguage(): Promise<Parser.Language> {
+async function getCppLanguage(): Promise<Language> {
   if (cppLanguage) return cppLanguage;
   await Parser.init();
-  cppLanguage = await Parser.Language.load(
+  cppLanguage = await Language.load(
     join(grammarsDir, "tree-sitter-cpp.wasm"),
   );
   return cppLanguage;
 }
 
-let typescriptLanguage: Parser.Language;
+let typescriptLanguage: Language;
 
-async function getTypescriptLanguage(): Promise<Parser.Language> {
+async function getTypescriptLanguage(): Promise<Language> {
   if (typescriptLanguage) return typescriptLanguage;
   await Parser.init();
-  typescriptLanguage = await Parser.Language.load(
+  typescriptLanguage = await Language.load(
     join(grammarsDir, "tree-sitter-typescript.wasm"),
   );
   return typescriptLanguage;
 }
 
-let tsxLanguage: Parser.Language;
+let tsxLanguage: Language;
 
-async function getTsxLanguage(): Promise<Parser.Language> {
+async function getTsxLanguage(): Promise<Language> {
   if (tsxLanguage) return tsxLanguage;
   await Parser.init();
-  tsxLanguage = await Parser.Language.load(
+  tsxLanguage = await Language.load(
     join(grammarsDir, "tree-sitter-tsx.wasm"),
   );
   return tsxLanguage;
 }
 
-let javascriptLanguage: Parser.Language;
+let javascriptLanguage: Language;
 
-async function getJavascriptLanguage(): Promise<Parser.Language> {
+async function getJavascriptLanguage(): Promise<Language> {
   if (javascriptLanguage) return javascriptLanguage;
   await Parser.init();
-  javascriptLanguage = await Parser.Language.load(
+  javascriptLanguage = await Language.load(
     join(grammarsDir, "tree-sitter-javascript.wasm"),
   );
   return javascriptLanguage;
 }
 
-let csharpLanguage: Parser.Language;
+let csharpLanguage: Language;
 
-async function getCsharpLanguage(): Promise<Parser.Language> {
+async function getCsharpLanguage(): Promise<Language> {
   if (csharpLanguage) return csharpLanguage;
   await Parser.init();
-  csharpLanguage = await Parser.Language.load(
+  csharpLanguage = await Language.load(
     join(grammarsDir, "tree-sitter-c-sharp.wasm"),
   );
   return csharpLanguage;

--- a/packages/markspec/deno.json
+++ b/packages/markspec/deno.json
@@ -17,7 +17,7 @@
     "remark-rehype": "npm:remark-rehype@^11",
     "rehype-stringify": "npm:rehype-stringify@^10",
     "mdast": "npm:@types/mdast@^4",
-    "web-tree-sitter": "npm:web-tree-sitter@^0.24",
+    "web-tree-sitter": "npm:web-tree-sitter@^0.25",
     "typst-ts-node-compiler": "npm:@myriaddreamin/typst-ts-node-compiler@^0.6",
     "vscode-languageserver/node": "npm:vscode-languageserver@^9/node.js",
     "vscode-languageserver-textdocument": "npm:vscode-languageserver-textdocument@^1"


### PR DESCRIPTION
The bundled `grammars/tree-sitter-c.wasm` is compiled against tree-sitter ABI v15 which `web-tree-sitter` 0.24.x rejected (compatibility range 13–14). This bumps to 0.25.x which accepts ABI v15.

## Changes

- **packages/markspec/deno.json**: `^0.24` → `^0.25`
- **core/parser/source.ts, grammars.ts, language_spec.ts, source_test.ts, formatter/source.ts**: Update imports for breaking 0.25 API changes (named exports, `Node` rename, nullable `parse()`)
- **deno.lock**: Regenerated
- **CHANGELOG.md**: Remove C grammar known limitation

## Breaking API changes in web-tree-sitter 0.25

- Default export removed → named `{ Language, Parser }`
- `Parser.Language` → top-level `Language` class
- `SyntaxNode` → `Node`
- `parser.parse()` returns `Tree | null`

## Verification

All 5 grammars load successfully:
- C (ABI v15) ✓
- C++ (ABI v14) ✓
- Rust (ABI v14) ✓
- Kotlin (ABI v14) ✓
- Java (ABI v14) ✓

Full test suite: 2347 passed, 0 failed.

Fixes #427