### PR TITLE
feat(lsp): add markspec/profile request and profileChanged notification

### DIFF
--- a/packages/markspec/core/mod.ts
+++ b/packages/markspec/core/mod.ts
@@ -52,6 +52,7 @@ export type {
   LabelValue,
   Link,
   LinkKind,
+  LoadedProfile,
   ModalCase,
   PaletteHue,
   ProfileChain,

--- a/packages/markspec/lsp/profile_request.ts
+++ b/packages/markspec/lsp/profile_request.ts
@@ -1,0 +1,136 @@
+/**
+ * @module lsp/profile_request
+ *
+ * Pure helper for the LSP `markspec/profile` custom request. Derives the
+ * wire-shape response from `core/profile`'s in-memory model:
+ *
+ *   - Strips `{NNNN}` placeholder from `displayIdPattern` to compute
+ *     `prefix`.
+ *   - Resolves the type's color role (e.g. "primary") through
+ *     `EffectiveProfile.colors` to a palette hue name ("blue" | ...).
+ *   - Validates the hue against `PALETTE_HUES`; returns `null` on any
+ *     failure path (no role declared, role not in colors map, value
+ *     outside palette).
+ *
+ * No file I/O, no LSP types — testable from a unit test with synthetic
+ * profile inputs.
+ *
+ * See `docs/superpowers/specs/2026-05-25-lsp-profile-request-design.md` §3
+ * for the response shape and §5 for the edge-case decisions.
+ */
+
+import type {
+  EffectiveProfile,
+  PaletteHue,
+  ProfileChain,
+} from "../core/mod.ts";
+import { PALETTE_HUES } from "../core/mod.ts";
+
+/** A single tier in the profile chain. */
+export interface ProfileLayer {
+  /** Manifest `id`, e.g. "markspec/default". */
+  readonly name: string;
+  /** Resolved source — file path or package specifier. */
+  readonly source: string;
+}
+
+/** Per-type metadata exposed to clients. */
+export interface ProfileTypeInfo {
+  /** Type name, e.g. "stakeholder-requirement". */
+  readonly name: string;
+  /** Display-ID prefix derived from `displayIdPattern` (placeholder stripped). Empty string when no pattern. */
+  readonly prefix: string;
+  /** Palette hue name, or `null` when no color resolves. */
+  readonly color: PaletteHue | null;
+}
+
+/** Effective profile view returned by `markspec/profile`. */
+export interface EffectiveProfileInfo {
+  /** Innermost (child-most) tier's id, or "(none)" when no profile is loaded. */
+  readonly name: string;
+  readonly types: ReadonlyArray<ProfileTypeInfo>;
+}
+
+/** Top-level response shape. */
+export interface MarkspecProfileResponse {
+  readonly chain: ReadonlyArray<ProfileLayer>;
+  readonly effective: EffectiveProfileInfo;
+}
+
+/**
+ * Empty response shape — returned when no profile is loaded (file-local
+ * mode). Exported so both the helper's empty-shape branch and the server's
+ * cache initializer reference one literal, avoiding drift.
+ */
+export const EMPTY_PROFILE_RESPONSE: MarkspecProfileResponse = {
+  chain: [],
+  effective: { name: "(none)", types: [] },
+};
+
+/**
+ * Compute the LSP wire response from the loaded chain + effective profile.
+ *
+ * Returns the empty shape (`chain: []`, `effective.name: "(none)"`,
+ * `effective.types: []`) when `chain` is `null` or `effective` is
+ * `undefined` — the file-local mode.
+ */
+export function buildProfileResponse(
+  chain: ProfileChain | null,
+  effective: EffectiveProfile | undefined,
+): MarkspecProfileResponse {
+  if (!chain || !effective) {
+    return EMPTY_PROFILE_RESPONSE;
+  }
+
+  const layers: ProfileLayer[] = chain.tiers.map((tier) => ({
+    name: tier.id,
+    source: tier.sourcePath,
+  }));
+
+  const effectiveName = chain.tiers.length > 0
+    ? chain.tiers[chain.tiers.length - 1].id
+    : "(none)";
+
+  const types: ProfileTypeInfo[] = [];
+  for (const [name, entry] of effective.types) {
+    const typeDef = entry.value;
+    types.push({
+      name,
+      prefix: derivePrefix(typeDef.displayIdPattern.value),
+      color: resolveHue(typeDef.color.value, effective),
+    });
+  }
+
+  return { chain: layers, effective: { name: effectiveName, types } };
+}
+
+/**
+ * Strip the `{...}` placeholder from a display-ID pattern to yield the
+ * fixed prefix. Returns the empty string when no placeholder is present
+ * or the pattern is undefined.
+ */
+function derivePrefix(pattern: string | undefined): string {
+  if (!pattern) return "";
+  const idx = pattern.indexOf("{");
+  if (idx < 0) return "";
+  return pattern.slice(0, idx);
+}
+
+/**
+ * Resolve a type's color role through the profile's `colors` map to a
+ * palette hue name. Returns `null` when:
+ *   - the type declares no color role,
+ *   - the role is not bound in `effective.colors`, or
+ *   - the bound value is not a member of {@linkcode PALETTE_HUES}.
+ */
+function resolveHue(
+  roleName: string | undefined,
+  effective: EffectiveProfile,
+): PaletteHue | null {
+  if (!roleName) return null;
+  const bound = effective.colors.get(roleName);
+  if (!bound) return null;
+  const hue = bound.value;
+  if (!(PALETTE_HUES as readonly string[]).includes(hue)) return null;
+  return hue as PaletteHue;
+}

--- a/packages/markspec/lsp/profile_request_test.ts
+++ b/packages/markspec/lsp/profile_request_test.ts
@@ -1,0 +1,208 @@
+/**
+ * @module lsp/profile_request_test
+ *
+ * Unit tests for {@linkcode buildProfileResponse} — pure helper that turns a
+ * (chain, effective) pair into the wire shape returned by the
+ * `markspec/profile` LSP request.
+ */
+
+import { assertEquals } from "@std/assert";
+import { buildProfileResponse } from "./profile_request.ts";
+import type {
+  EffectiveProfile,
+  EffectiveTypeDef,
+  LoadedProfile,
+  ProfileChain,
+  ProvenancedMapEntry,
+  ProvenancedValue,
+} from "../core/mod.ts";
+
+/** Provenanced-value helper — origin doesn't matter for the LSP wire shape. */
+function pv<T>(value: T): ProvenancedValue<T> {
+  return { value, origin: "test" };
+}
+
+/** Provenanced-map-entry helper. */
+function pe<V>(value: V): ProvenancedMapEntry<V> {
+  return { value, origin: "test" };
+}
+
+/** Minimal `EffectiveTypeDef` with only the fields the helper reads. */
+function fakeTypeDef(opts: {
+  name: string;
+  displayIdPattern?: string;
+  color?: string;
+}): EffectiveTypeDef {
+  return {
+    name: opts.name,
+    extends: "requirement",
+    displayIdPattern: pv(opts.displayIdPattern),
+    displayIdPatternEnforcement: pv("warn"),
+    color: pv(opts.color),
+    required: pv([]),
+    attributes: new Map(),
+    traceability: new Map(),
+    description: pv(undefined),
+    attrDescriptions: new Map(),
+    relationDescriptions: new Map(),
+    discipline: pv(undefined),
+  };
+}
+
+/** Minimal `EffectiveProfile` with only the fields the helper reads. */
+function fakeEffective(
+  types: ReadonlyArray<EffectiveTypeDef>,
+  colors: ReadonlyMap<string, string> = new Map(),
+): EffectiveProfile {
+  const typesMap = new Map<string, ProvenancedMapEntry<EffectiveTypeDef>>();
+  for (const t of types) typesMap.set(t.name, pe(t));
+  const colorsMap = new Map<string, ProvenancedMapEntry<string>>();
+  for (const [k, v] of colors) colorsMap.set(k, pe(v));
+  return {
+    attributes: new Map(),
+    labels: new Map(),
+    conventions: new Map(),
+    colors: colorsMap,
+    types: typesMap,
+    documents: { types: new Map(), frontMatter: new Map() },
+    kinds: new Map(),
+    prose: {
+      lexicons: {
+        "capitalized-allow": pv([]),
+        "sentence-abbrev": pv([]),
+      },
+    },
+  };
+}
+
+/** Minimal `LoadedProfile` exposing only the fields the helper reads. */
+function fakeLoaded(id: string, sourcePath: string): LoadedProfile {
+  return {
+    id,
+    version: "0.0.0",
+    // deno-lint-ignore no-explicit-any
+    specifier: { kind: "local", path: sourcePath } as any,
+    // deno-lint-ignore no-explicit-any
+    manifest: {} as any,
+    sourcePath,
+    baseDir: sourcePath.replace(/\/[^/]+$/, ""),
+  };
+}
+
+function fakeChain(
+  tiers: ReadonlyArray<LoadedProfile>,
+  effective: EffectiveProfile,
+): ProfileChain {
+  return { tiers, effective };
+}
+
+Deno.test("buildProfileResponse: no profile loaded returns empty shape", () => {
+  const result = buildProfileResponse(null, undefined);
+  assertEquals(result, {
+    chain: [],
+    effective: { name: "(none)", types: [] },
+  });
+});
+
+Deno.test("buildProfileResponse: single-tier chain with hue-resolved type", () => {
+  const stkType = fakeTypeDef({
+    name: "stakeholder-requirement",
+    displayIdPattern: "STK_{NNNN}",
+    color: "primary",
+  });
+  const effective = fakeEffective([stkType], new Map([["primary", "blue"]]));
+  const chain = fakeChain(
+    [fakeLoaded("markspec/default", "/proj/.markspec.yaml")],
+    effective,
+  );
+
+  const result = buildProfileResponse(chain, effective);
+
+  assertEquals(result.chain, [{
+    name: "markspec/default",
+    source: "/proj/.markspec.yaml",
+  }]);
+  assertEquals(result.effective.name, "markspec/default");
+  assertEquals(result.effective.types, [{
+    name: "stakeholder-requirement",
+    prefix: "STK_",
+    color: "blue",
+  }]);
+});
+
+Deno.test("buildProfileResponse: multi-tier chain, child tier's id wins for effective.name", () => {
+  const t = fakeTypeDef({
+    name: "stakeholder-requirement",
+    displayIdPattern: "STK_AEB_{NNNN}",
+    color: "primary",
+  });
+  const effective = fakeEffective([t], new Map([["primary", "orange"]]));
+  const chain = fakeChain(
+    [
+      fakeLoaded("markspec/default", "/proj/.markspec.yaml"),
+      fakeLoaded("acme/aeb", "/proj/acme-profile.yaml"),
+    ],
+    effective,
+  );
+
+  const result = buildProfileResponse(chain, effective);
+
+  assertEquals(result.chain.map((l) => l.name), [
+    "markspec/default",
+    "acme/aeb",
+  ]);
+  assertEquals(result.effective.name, "acme/aeb");
+  assertEquals(result.effective.types[0].prefix, "STK_AEB_");
+  assertEquals(result.effective.types[0].color, "orange");
+});
+
+Deno.test("buildProfileResponse: type without color declared returns null color", () => {
+  const t = fakeTypeDef({
+    name: "memo",
+    displayIdPattern: "MEMO_{NNNN}",
+  });
+  const effective = fakeEffective([t]);
+  const chain = fakeChain(
+    [fakeLoaded("markspec/default", "/proj/.markspec.yaml")],
+    effective,
+  );
+
+  const result = buildProfileResponse(chain, effective);
+
+  assertEquals(result.effective.types[0].color, null);
+});
+
+Deno.test("buildProfileResponse: type with displayIdPattern absent returns empty prefix", () => {
+  const t = fakeTypeDef({
+    name: "memo",
+  });
+  const effective = fakeEffective([t]);
+  const chain = fakeChain(
+    [fakeLoaded("markspec/default", "/proj/.markspec.yaml")],
+    effective,
+  );
+
+  const result = buildProfileResponse(chain, effective);
+
+  assertEquals(result.effective.types[0].prefix, "");
+});
+
+Deno.test("buildProfileResponse: invalid hue value returns null color", () => {
+  const t = fakeTypeDef({
+    name: "stakeholder-requirement",
+    displayIdPattern: "STK_{NNNN}",
+    color: "primary",
+  });
+  const effective = fakeEffective(
+    [t],
+    new Map([["primary", "not-a-hue"]]),
+  );
+  const chain = fakeChain(
+    [fakeLoaded("markspec/default", "/proj/.markspec.yaml")],
+    effective,
+  );
+
+  const result = buildProfileResponse(chain, effective);
+
+  assertEquals(result.effective.types[0].color, null);
+});

--- a/packages/markspec/lsp/server.ts
+++ b/packages/markspec/lsp/server.ts
@@ -16,6 +16,8 @@ import {
   CompletionItemKind,
   createConnection,
   type Diagnostic as LspDiagnosticType,
+  DidChangeWatchedFilesNotification,
+  type FileEvent,
   type InitializeParams,
   type InitializeResult,
   InsertTextFormat,
@@ -25,6 +27,7 @@ import {
   TextDocuments,
   TextDocumentSyncKind,
   type TextEdit as LspTextEdit,
+  WatchKind,
 } from "vscode-languageserver/node";
 import { TextDocument } from "vscode-languageserver-textdocument";
 import process from "node:process";
@@ -53,6 +56,11 @@ import { entryToLspLocation } from "./definition.ts";
 import { displayIdAtPosition, formatHoverContent } from "./hover.ts";
 import { entriesToFoldingRanges } from "./folding.ts";
 import { findOccurrencesInFile } from "./highlights.ts";
+import {
+  buildProfileResponse,
+  EMPTY_PROFILE_RESPONSE,
+  type MarkspecProfileResponse,
+} from "./profile_request.ts";
 import { findReferencingEntries } from "./references.ts";
 import { findIdOccurrencesInFile, prepareRenameRange } from "./rename.ts";
 import {
@@ -136,6 +144,7 @@ globalThis.addEventListener("error", (e) => {
 let projectRoot: string | undefined;
 let _config: ProjectConfig = DEFAULT_PROJECT_CONFIG;
 let profile: EffectiveProfile | undefined;
+let cachedProfileResponse: MarkspecProfileResponse = EMPTY_PROFILE_RESPONSE;
 let lockfile: Lockfile | undefined;
 const index = new WorkspaceIndex();
 // Cached cross-file validation result. Updated by publishAllDiagnostics
@@ -305,6 +314,10 @@ connection.onInitialize(
         if (profileResult.chain) {
           profile = profileResult.chain.effective;
         }
+        cachedProfileResponse = buildProfileResponse(
+          profileResult.chain,
+          profile,
+        );
       } catch {
         connection.console.warn("Failed to load profile");
       }
@@ -370,6 +383,34 @@ connection.onInitialize(
 );
 
 // ---------------------------------------------------------------------------
+// Profile reload — fires `markspec/profileChanged` after watched profile files
+// change. Debounced 500ms so rapid-fire saves coalesce into one reload.
+// ---------------------------------------------------------------------------
+
+async function reloadProfile(): Promise<void> {
+  if (!projectRoot) return;
+  try {
+    const profileResult = await loadProfileForCommand(projectRoot, readFile);
+    profile = profileResult.chain?.effective;
+    cachedProfileResponse = buildProfileResponse(
+      profileResult.chain,
+      profile,
+    );
+    connection.sendNotification(
+      "markspec/profileChanged",
+      cachedProfileResponse,
+    );
+    // Profile changes can flip MSL-R010 suppression and other
+    // attribute-validity decisions — republish cross-file diagnostics.
+    publishAllDiagnostics();
+  } catch (err) {
+    connection.console.warn(`Failed to reload profile: ${err}`);
+  }
+}
+
+const debouncedReloadProfile = debounce(reloadProfile, 500);
+
+// ---------------------------------------------------------------------------
 // Initialized — build the workspace index
 // ---------------------------------------------------------------------------
 
@@ -419,11 +460,49 @@ connection.onInitialized(async () => {
       release: VERSION,
       coreSchemaVersion: CORE_SCHEMA_VERSION,
     });
+
+    // Register the profile-file watcher. We do this even when no profile
+    // is currently loaded so a later `.markspec.yaml` creation triggers
+    // a reload. See design doc §4 step 2.
+    if (projectRoot) {
+      try {
+        await connection.client.register(
+          DidChangeWatchedFilesNotification.type,
+          {
+            watchers: [
+              {
+                globPattern: "**/.markspec.yaml",
+                kind: WatchKind.Create | WatchKind.Change | WatchKind.Delete,
+              },
+              {
+                globPattern: "**/project.yaml",
+                kind: WatchKind.Create | WatchKind.Change | WatchKind.Delete,
+              },
+            ],
+          },
+        );
+      } catch (err) {
+        connection.console.warn(
+          `Failed to register profile-file watcher: ${err}`,
+        );
+      }
+    }
   } catch (err) {
     connection.console.error(`Indexing failed: ${err}`);
     debugLog(`onInitialized: indexing failed: ${err}`);
   }
   debugLog("onInitialized: end");
+});
+
+// ---------------------------------------------------------------------------
+// onDidChangeWatchedFiles — profile-file edits debounce → reload
+// ---------------------------------------------------------------------------
+
+connection.onDidChangeWatchedFiles((params: { changes: FileEvent[] }) => {
+  // We only watch `.markspec.yaml` + `project.yaml`, so any change here
+  // affects the profile chain. Debounce 500ms — see design doc §4.1.
+  if (params.changes.length === 0) return;
+  debouncedReloadProfile();
 });
 
 // ---------------------------------------------------------------------------
@@ -918,6 +997,19 @@ connection.languages.semanticTokens.on((params) => {
 });
 
 // ---------------------------------------------------------------------------
+// markspec/profile — custom request: active profile metadata for client coloring
+// ---------------------------------------------------------------------------
+
+connection.onRequest(
+  "markspec/profile",
+  (_params: { uri?: string }): MarkspecProfileResponse => {
+    // `_params.uri` is accepted for forward compatibility but ignored in v1;
+    // the server uses its rootUri. See design doc §3.1.
+    return cachedProfileResponse;
+  },
+);
+
+// ---------------------------------------------------------------------------
 // markspec/entryRanges — custom request driving VS Code decorations
 // ---------------------------------------------------------------------------
 
@@ -946,6 +1038,7 @@ connection.onRequest(
 connection.onShutdown(() => {
   debugLog("onShutdown");
   debouncedValidateAll.cancel();
+  debouncedReloadProfile.cancel();
 });
 
 connection.onExit(() => {

--- a/tests/e2e/lsp_profile_request_test.ts
+++ b/tests/e2e/lsp_profile_request_test.ts
@@ -1,0 +1,136 @@
+/**
+ * @module tests/e2e/lsp_profile_request_test
+ *
+ * E2E tests for the `markspec/profile` custom request and
+ * `markspec/profileChanged` notification.
+ *
+ * Covers design doc §7.2:
+ *   - populated response when a profile is loaded;
+ *   - empty shape when no profile is configured;
+ *   - notification fires after a `workspace/didChangeWatchedFiles` event.
+ */
+
+import { assert, assertEquals, assertExists } from "@std/assert";
+import { join, toFileUrl } from "@std/path";
+import { LspTestClient } from "./lsp_helpers.ts";
+
+interface ProfileLayer {
+  name: string;
+  source: string;
+}
+interface ProfileType {
+  name: string;
+  prefix: string;
+  color: string | null;
+}
+interface MarkspecProfileResponse {
+  chain: ProfileLayer[];
+  effective: { name: string; types: ProfileType[] };
+}
+
+Deno.test("lsp markspec/profile: returns populated response with loaded profile", async () => {
+  // Minimal project.yaml + .markspec.yaml that activates the bundled default
+  // profile. The default profile declares the 16 core type names — the
+  // exact membership is verified by core/profile tests, not here. We
+  // only assert structural shape.
+  const client = await LspTestClient.create({
+    "project.yaml": "name: test-project\n",
+    ".markspec.yaml": "profiles: []\n",
+  });
+  try {
+    await client.initialize();
+
+    const result = await client.request(
+      "markspec/profile",
+      {},
+    ) as MarkspecProfileResponse;
+
+    assertExists(result);
+    assertExists(result.chain);
+    assertExists(result.effective);
+    // Default profile yields a non-empty chain.
+    assert(
+      result.chain.length >= 1,
+      `Expected non-empty chain, got: ${JSON.stringify(result.chain)}`,
+    );
+    // Effective name should not be "(none)" when a profile is loaded.
+    assert(
+      result.effective.name !== "(none)",
+      `Expected loaded profile, got "(none)"`,
+    );
+    // Types array is present (may be non-empty with default profile).
+    assertExists(result.effective.types);
+    // Every type carries the expected shape.
+    for (const t of result.effective.types) {
+      assertEquals(typeof t.name, "string");
+      assertEquals(typeof t.prefix, "string");
+      assert(
+        t.color === null || typeof t.color === "string",
+        `color must be string|null, got ${typeof t.color}`,
+      );
+    }
+  } finally {
+    await client.shutdown();
+  }
+});
+
+Deno.test("lsp markspec/profile: returns empty shape when no profile is configured", async () => {
+  // `.markspec.yaml` with `default-profile: false` is the documented
+  // opt-out per `core/profile/load.ts:35-38`.
+  const client = await LspTestClient.create({
+    "project.yaml": "name: test-project\n",
+    ".markspec.yaml": "default-profile: false\nprofiles: []\n",
+  });
+  try {
+    await client.initialize();
+
+    const result = await client.request(
+      "markspec/profile",
+      {},
+    ) as MarkspecProfileResponse;
+
+    assertEquals(result.chain, []);
+    assertEquals(result.effective.name, "(none)");
+    assertEquals(result.effective.types, []);
+  } finally {
+    await client.shutdown();
+  }
+});
+
+Deno.test("lsp markspec/profile: notification fires after watched-file change", async () => {
+  const client = await LspTestClient.create({
+    "project.yaml": "name: test-project\n",
+    ".markspec.yaml": "profiles: []\n",
+  });
+  try {
+    await client.initialize();
+
+    // Sanity: initial response is populated.
+    const before = await client.request(
+      "markspec/profile",
+      {},
+    ) as MarkspecProfileResponse;
+    assert(before.chain.length >= 1);
+
+    // Simulate the client sending a watched-file change. The server
+    // debounces 500ms; we wait up to 3000ms for the notification
+    // (generous to absorb slow-disk CI environments).
+    const filePath = join(client.workDir, ".markspec.yaml");
+    await client.notify("workspace/didChangeWatchedFiles", {
+      changes: [
+        { uri: toFileUrl(filePath).href, type: 2 /* Changed */ },
+      ],
+    });
+
+    const notif = await client.waitForNotification(
+      "markspec/profileChanged",
+      3000,
+    );
+    assertExists(notif.params);
+    const payload = notif.params as MarkspecProfileResponse;
+    assertExists(payload.chain);
+    assertExists(payload.effective);
+  } finally {
+    await client.shutdown();
+  }
+});


### PR DESCRIPTION
## Summary

- Adds the `markspec/profile` custom LSP request to the `markspec lsp` server. Returns the active profile chain and per-type metadata (name, display-ID prefix, palette hue) so editors can render profile-aware entry coloring. Pure helper `buildProfileResponse` derives the wire shape from the existing `core/profile` model; no new core dependencies.
- Adds a dynamic `workspace/didChangeWatchedFiles` registration for `**/.markspec.yaml` + `**/project.yaml`, debounced 500ms server-side. On change, fires `markspec/profileChanged` notification with the new payload and republishes cross-file diagnostics so MSL-R010 suppression and type-validity decisions stay in sync.
- Capability 2 of the LSP feature additions epic (Capability 1 / `textDocument/formatting` landed as PR #482). 5 unit tests + 3 E2E tests; no regressions in existing LSP E2E suite.

## Spec divergence (intentional)

This PR diverges from the merged spec at `docs/spec/internal/markspec-lsp-feature-additions.md` §4.3:

- Drops the `category: string` bucket field. The legacy prefix→bucket mapping in CLAUDE.md is being retired per ADR-011; there is no profile-declared category field yet to build on.
- Replaces `color: { print: string; screen: string }` (hex pairs) with `color: PaletteHue | null` (single hue name). The VS Code extension already owns hex via `package.json` `contributes.colors` + `theme/markspec.css`; the LSP only needs to surface a key per type.

Rationale captured in [docs/superpowers/specs/2026-05-25-lsp-profile-request-design.md](docs/superpowers/specs/2026-05-25-lsp-profile-request-design.md) §1, §3.4. A doc-only spec-amendment PR will follow this one (design doc §8).

## Test Plan

- [x] 6 unit tests in `lsp/profile_request_test.ts` cover: no profile, single-tier chain, multi-tier override, type without color, type without `displayIdPattern`, invalid hue → null.
- [x] 3 E2E tests in `tests/e2e/lsp_profile_request_test.ts` drive the real JSON-RPC path: populated response with bundled default profile, empty shape with `default-profile: false` opt-out, `markspec/profileChanged` notification fires after a simulated `workspace/didChangeWatchedFiles` event.
- [x] Existing LSP E2E suite (`lsp_diagnostics_test.ts`, `lsp_completions_test.ts`, `lsp_formatting_test.ts`, `lsp_entry_ranges_test.ts`) still passes.
- [x] `just build` clean (lint + test + typecheck + compile).
- [x] `deno fmt --check` + `dprint check` clean.

## Out of scope / follow-ups

- Doc-only spec amendment PR to `markspec-lsp-feature-additions.md` §4.3 + `markspec-vscode-authoring.md` §4.4 (CSS variable convention change to `--markspec-color-{hue}`).
- Optional `role?: string` field on `ProfileTypeInfo` — additive future change when an MCP-style consumer needs the semantic role.
- Multi-workspace support via `MarkspecProfileParams.uri`.
- Equality-skip on `markspec/profileChanged` (suppress no-op refreshes) — flagged by the final reviewer; defer until a profile consumer demonstrates the churn.
- Routing `loadProfileForCommand` diagnostics into `publishAllDiagnostics` so profile-syntax errors surface in the editor — pre-existing gap, not a regression.
- Capabilities 3-5 of the epic (`textDocument/codeLens`, `inlayHint`, `documentLink`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
