### PR TITLE
feat(core): Discipline: override + Discipline-frozen: attributes (ADR-017 Slice 3)

### DIFF
--- a/docs/spec/language/language.md
+++ b/docs/spec/language/language.md
@@ -579,14 +579,16 @@ no TYPE vocabulary and no family enum.
 
 The following attributes apply to every family:
 
-| Attribute       | Type          | Required | Description                                   |
-| --------------- | ------------- | -------- | --------------------------------------------- |
-| `Labels`        | `tag-list`    | no       | Classification tags (includes `DRAFT` marker) |
-| `References`    | `citation`    | no       | External reference citations with locator     |
-| `External-id`   | `external-id` | no       | Cross-system identifier(s)                    |
-| `Supersedes`    | `id`          | no       | Same-shape entry this one replaces            |
-| `Superseded-by` | `id`          | —        | Generated inverse of `Supersedes`             |
-| `Deprecated`    | `string`      | no       | Retirement reason (non-replacement case)      |
+| Attribute           | Type          | Required | Description                                                                                                                                                                  |
+| ------------------- | ------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Labels`            | `tag-list`    | no       | Classification tags (includes `DRAFT` marker)                                                                                                                                |
+| `Discipline`        | `text`        | no       | ADR-017 Slice 3 — author-asserted discipline kind. Value matches `/^[a-z][a-z0-9-]*$/`. Takes precedence over the classifier's type/allocation channels. Single-cardinality. |
+| `Discipline-frozen` | `text`        | no       | ADR-017 Slice 3 — cached snapshot of a past derivation: `<kind>` or `<kind> @ <YYYY-MM-DD>`. The formatter stamps today's UTC date when written bare. Single-cardinality.    |
+| `References`        | `citation`    | no       | External reference citations with locator                                                                                                                                    |
+| `External-id`       | `external-id` | no       | Cross-system identifier(s)                                                                                                                                                   |
+| `Supersedes`        | `id`          | no       | Same-shape entry this one replaces                                                                                                                                           |
+| `Superseded-by`     | `id`          | —        | Generated inverse of `Supersedes`                                                                                                                                            |
+| `Deprecated`        | `string`      | no       | Retirement reason (non-replacement case)                                                                                                                                     |
 
 **Draft state** is carried by the `DRAFT` label — a plain universal tag with no
 exclusive-group semantics. Authors set `Labels: DRAFT` on entries that are
@@ -1514,13 +1516,20 @@ carrying an `Id:` attribute.
 
 Type resolution and per-type attribute validation (spec §1.3, §1.6):
 
-| ID         | Severity | Rule                                                                                                                           |
-| ---------- | -------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| `MSL-T020` | error    | `Type:` value is neither a core type nor a profile-declared type.                                                              |
-| `MSL-T021` | warning  | Core type inferred (display-ID prefix, URI scheme, or discriminating attribute); declare `Type:` explicitly to silence.        |
-| `MSL-T022` | warning  | Attribute is core-known but not valid on the entry's resolved type.                                                            |
-| `MSL-T023` | error    | `Type:` value looks like a profile-declared type but no profile is loaded (core-only mode).                                    |
-| `MSL-T024` | warning  | Entry carries a type-specific attribute but its core type could not be resolved (no `Type:`, no profile, no inferable signal). |
+| ID         | Severity | Rule                                                                                                                                                       |
+| ---------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `MSL-T020` | error    | `Type:` value is neither a core type nor a profile-declared type.                                                                                          |
+| `MSL-T021` | warning  | Core type inferred (display-ID prefix, URI scheme, or discriminating attribute); declare `Type:` explicitly to silence.                                    |
+| `MSL-T022` | warning  | Attribute is core-known but not valid on the entry's resolved type.                                                                                        |
+| `MSL-T023` | error    | `Type:` value looks like a profile-declared type but no profile is loaded (core-only mode).                                                                |
+| `MSL-T024` | warning  | Entry carries a type-specific attribute but its core type could not be resolved (no `Type:`, no profile, no inferable signal).                             |
+| `MSL-T025` | error    | `Discipline:` value is not a known kind (core or profile-declared) — ADR-017 Slice 3.                                                                      |
+| `MSL-T026` | error    | `Discipline-frozen:` value is malformed (expected `<kind>` or `<kind> @ YYYY-MM-DD`, calendar-valid date) — ADR-017 Slice 3.                               |
+| `MSL-T027` | error    | `Discipline-frozen:` parses but its kind is not in the effective kind set — ADR-017 Slice 3.                                                               |
+| `MSL-T028` | warning  | `Discipline:` override conflicts with the type-based derivation (channel 3) — ADR-017 Slice 3.                                                             |
+| `MSL-T029` | warning  | `Discipline:` override conflicts with the allocation-based derivation (channel 4) — ADR-017 Slice 3.                                                       |
+| `MSL-T030` | warning  | `Discipline-frozen:` kind differs from the current channels-3/4 derivation. Not suppressed when current derivation defaults to `system` — ADR-017 Slice 3. |
+| `MSL-T031` | warning  | `Discipline:` and `Discipline-frozen:` both well-formed and reference known kinds, but disagree — ADR-017 Slice 3.                                         |
 
 Profile-declared enum attributes (e.g., `ASIL`, `Test-level`, `Element-kind`)
 are validated against the vocabulary declared in the active profile's manifest.

--- a/docs/spec/model/profiles.md
+++ b/docs/spec/model/profiles.md
@@ -204,6 +204,20 @@ semantics but produces a `PROFILE-DISCIPLINE-003` warning (the declaration is
 idempotent and ignored). Declare a new kind name to introduce additional
 disciplines such as `firmware`, `mechanical`, or `avionics`.
 
+### Discipline override and freeze
+
+Profiles that declare additional kinds via `profile.kinds:` extend the
+**effective kind set** consulted by the universal `Discipline:` and
+`Discipline-frozen:` attributes (see ADR-017 Implementation backlog items 4 and
+5). When an author writes `Discipline: firmware` on an entry, the classifier
+accepts the value (channel 1, lenient) and the validator
+([MSL-T025](../language/language.md#section-8)) succeeds when `firmware` is in
+the effective kind set — i.e., declared by the active profile chain or one of
+the core `system` / `software` / `hardware` kinds.
+
+The freeze attribute follows the same rule for its kind component; see ADR-017
+for the full lexical grammar and validator interaction matrix.
+
 ## What profiles cannot change
 
 Profiles extend core — they cannot weaken or redefine it:

--- a/packages/markspec/core/compiler/discipline_classifier.ts
+++ b/packages/markspec/core/compiler/discipline_classifier.ts
@@ -1,14 +1,15 @@
 /**
  * @module core/compiler/discipline_classifier
  *
- * Pure-function classifier implementing channels 3 (type-based) and 4
- * (allocation-based) of the four-channel discipline resolution from
- * ADR-017 Invariant 1, plus the default fallback to `"system"`.
+ * Pure-function classifier implementing the four-channel discipline
+ * resolution from ADR-017 Invariant 1, plus the default fallback to
+ * `"system"`. Channels in precedence order:
  *
- * **Channels 1 (override) and 2 (freeze) are not implemented in this
- * slice.** They ship in Slice 3 (`Discipline:` and `Discipline-frozen:`
- * attributes). When those land, the classifier will read them first;
- * for now the function jumps straight to channel 3.
+ *   1. Override — `Discipline:` attribute (lenient; emits value verbatim)
+ *   2. Freeze   — `Discipline-frozen:` attribute (strict; falls through
+ *                 to channel 3 on parse failure)
+ *   3. Type-based — `entry.type` looked up in the registry
+ *   4. Allocation-based — `Allocated-to` targets' types looked up
  *
  * @see docs/architecture/adr-017-discipline-classification.md (Invariant 1)
  * @see docs/architecture/adr-018-core-discipline-ssot.md (R3)
@@ -21,6 +22,51 @@ import type {
   DisplayId,
   Entry,
 } from "../mod.ts";
+
+/**
+ * Read the first non-empty value of a single-cardinality attribute from an
+ * entry's raw attributes. Returns `undefined` when absent or empty. Used
+ * by channels 1 and 2.
+ */
+function singleAttrValue(entry: Entry, key: string): string | undefined {
+  for (const attr of entry.rawAttributes) {
+    if (attr.key === key) {
+      const trimmed = attr.value.trim();
+      if (trimmed.length > 0) return trimmed;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Parse a `Discipline-frozen:` value. Accepts `<kind>` or `<kind> @
+ * <YYYY-MM-DD>` with optional whitespace around `@`. The date component,
+ * when present, must be calendar-valid (rejects `2026-02-30`, etc.).
+ *
+ * Returns `{ kind }` on success or `undefined` when the value doesn't
+ * match the grammar. The classifier uses this in channel 2 (strict — a
+ * malformed value falls through to channel 3 rather than emitting
+ * garbage). The validator uses the same parse to decide MSL-T026.
+ */
+export function parseFrozenValue(
+  value: string,
+): { readonly kind: string; readonly date?: string } | undefined {
+  const m = /^([a-z][a-z0-9-]*)(?:\s*@\s*(\d{4}-\d{2}-\d{2}))?\s*$/.exec(
+    value.trim(),
+  );
+  if (!m) return undefined;
+  const kind = m[1];
+  const date = m[2];
+  if (date !== undefined) {
+    // Calendar-validity round-trip: parsing and reformatting must yield
+    // the exact same string. Rejects 2026-02-30 / 2026-13-99 / 2026-00-15.
+    const d = new Date(`${date}T00:00:00Z`);
+    if (isNaN(d.getTime())) return undefined;
+    const round = d.toISOString().slice(0, 10);
+    if (round !== date) return undefined;
+  }
+  return date !== undefined ? { kind, date } : { kind };
+}
 
 /**
  * Resolve an entry's type, falling back to the `Type:` raw attribute when
@@ -43,9 +89,10 @@ function resolvedType(entry: Entry): string | undefined {
 }
 
 /**
- * Resolve the discipline of `entry` against `registry`, using channels
- * 3 (type-based) and 4 (allocation-based) in precedence order, defaulting
- * to `"system"` when neither channel yields a kind.
+ * Resolve the discipline of `entry` against `registry`, using all four
+ * channels in precedence order (1 override > 2 freeze > 3 type-based >
+ * 4 allocation-based), defaulting to `"system"` when no channel yields
+ * a kind.
  *
  * @param entry The entry to classify.
  * @param entriesByDisplayId Lookup map used by channel 4 to resolve
@@ -59,6 +106,19 @@ export function classifyDiscipline(
   entriesByDisplayId: ReadonlyMap<DisplayId, Entry>,
   registry: DisciplineRegistry,
 ): Discipline {
+  // Channel 1: override (lenient on unknown kinds — emit verbatim).
+  const override = singleAttrValue(entry, "Discipline");
+  if (override !== undefined) return override;
+
+  // Channel 2: freeze (strict on malformed values — fall through on parse
+  // failure). The validator (MSL-T026) emits the error separately.
+  const frozen = singleAttrValue(entry, "Discipline-frozen");
+  if (frozen !== undefined) {
+    const parsed = parseFrozenValue(frozen);
+    if (parsed !== undefined) return parsed.kind;
+    // fall through to channel 3
+  }
+
   // Channel 3: type-based.
   const type = resolvedType(entry);
   if (type !== undefined) {
@@ -90,5 +150,48 @@ export function classifyDiscipline(
   if (seen.size > 1) return MIXED_DISCIPLINE;
 
   // Default.
+  return "system";
+}
+
+/**
+ * Run channels 3 + 4 + default only — skip channels 1 (override) and 2
+ * (freeze). Used by the validator (Slice 3) to compute "what would the
+ * derivation be without the author's override?" so it can detect
+ * MSL-T028 (override vs type-based) and MSL-T029 (override vs
+ * allocation-based) conflicts and MSL-T030 (freeze divergence) without
+ * the override / freeze masking the channel-3/4 result.
+ */
+export function classifyDerivationOnly(
+  entry: Entry,
+  entriesByDisplayId: ReadonlyMap<DisplayId, Entry>,
+  registry: DisciplineRegistry,
+): Discipline {
+  // Channel 3: type-based.
+  const type = resolvedType(entry);
+  if (type !== undefined) {
+    const kind = registry.get(type);
+    if (kind !== undefined) return kind;
+  }
+
+  // Channel 4: allocation-based.
+  const seen = new Set<Discipline>();
+  for (const attr of entry.rawAttributes) {
+    if (attr.key !== "Allocated-to") continue;
+    for (const raw of attr.value.split(",")) {
+      const token = raw.trim();
+      if (token.length === 0) continue;
+      const target = entriesByDisplayId.get(makeDisplayId(token));
+      if (!target) continue;
+      const targetType = resolvedType(target);
+      if (targetType === undefined) continue;
+      const kind = registry.get(targetType);
+      if (kind !== undefined) seen.add(kind);
+    }
+  }
+  if (seen.size === 1) {
+    for (const kind of seen) return kind;
+  }
+  if (seen.size > 1) return MIXED_DISCIPLINE;
+
   return "system";
 }

--- a/packages/markspec/core/compiler/discipline_classifier_test.ts
+++ b/packages/markspec/core/compiler/discipline_classifier_test.ts
@@ -14,7 +14,17 @@ import {
   makeDisplayId,
   MIXED_DISCIPLINE,
 } from "../mod.ts";
-import { classifyDiscipline } from "./discipline_classifier.ts";
+import {
+  classifyDerivationOnly,
+  classifyDiscipline,
+} from "./discipline_classifier.ts";
+
+const TEST_REGISTRY = new Map<string, Discipline>([
+  ["SoftwareComponent", "software"],
+  ["HardwareComponent", "hardware"],
+  ["SoftwareRequirement", "software"],
+  ["HardwareRequirement", "hardware"],
+]);
 
 function fixture(overrides: Partial<Entry>): Entry {
   return {
@@ -260,5 +270,176 @@ Deno.test(
       classifyDiscipline(req, map, extendedRegistry),
       "software",
     );
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Slice 3: channels 1 (override) and 2 (freeze)
+// ---------------------------------------------------------------------------
+
+Deno.test(
+  "Slice 3 classifier: channel 1 (override) beats channel 3 (type-based)",
+  () => {
+    const e = fixture({
+      displayId: makeDisplayId("REQ_001"),
+      type: "SoftwareRequirement",
+      rawAttributes: [{ key: "Discipline", value: "hardware" }],
+    });
+    const d = classifyDiscipline(
+      e,
+      new Map<DisplayId, Entry>(),
+      TEST_REGISTRY,
+    );
+    assertEquals(d, "hardware");
+  },
+);
+
+Deno.test(
+  "Slice 3 classifier: channel 1 (override) beats channel 4 (allocation-based)",
+  () => {
+    const sw = fixture({
+      displayId: makeDisplayId("COMP_SW"),
+      type: "SoftwareComponent",
+    });
+    const e = fixture({
+      displayId: makeDisplayId("REQ_001"),
+      rawAttributes: [
+        { key: "Allocated-to", value: "COMP_SW" },
+        { key: "Discipline", value: "hardware" },
+      ],
+    });
+    const map = new Map<DisplayId, Entry>([[sw.displayId, sw]]);
+    const d = classifyDiscipline(e, map, TEST_REGISTRY);
+    assertEquals(d, "hardware");
+  },
+);
+
+Deno.test(
+  "Slice 3 classifier: channel 1 with unknown kind is lenient (emits value verbatim)",
+  () => {
+    const e = fixture({
+      displayId: makeDisplayId("REQ_001"),
+      type: "SoftwareRequirement",
+      rawAttributes: [{ key: "Discipline", value: "firmware" }],
+    });
+    const d = classifyDiscipline(
+      e,
+      new Map<DisplayId, Entry>(),
+      TEST_REGISTRY,
+    );
+    assertEquals(d, "firmware");
+  },
+);
+
+Deno.test(
+  "Slice 3 classifier: channel 2 (freeze) beats channel 3 (type-based)",
+  () => {
+    const e = fixture({
+      displayId: makeDisplayId("REQ_001"),
+      type: "SoftwareRequirement",
+      rawAttributes: [
+        { key: "Discipline-frozen", value: "hardware @ 2026-01-15" },
+      ],
+    });
+    const d = classifyDiscipline(
+      e,
+      new Map<DisplayId, Entry>(),
+      TEST_REGISTRY,
+    );
+    assertEquals(d, "hardware");
+  },
+);
+
+Deno.test(
+  "Slice 3 classifier: channel 2 (freeze) beats channel 4 (allocation-based)",
+  () => {
+    const sw = fixture({
+      displayId: makeDisplayId("COMP_SW"),
+      type: "SoftwareComponent",
+    });
+    const e = fixture({
+      displayId: makeDisplayId("REQ_001"),
+      rawAttributes: [
+        { key: "Allocated-to", value: "COMP_SW" },
+        { key: "Discipline-frozen", value: "hardware @ 2026-01-15" },
+      ],
+    });
+    const map = new Map<DisplayId, Entry>([[sw.displayId, sw]]);
+    const d = classifyDiscipline(e, map, TEST_REGISTRY);
+    assertEquals(d, "hardware");
+  },
+);
+
+Deno.test(
+  "Slice 3 classifier: channel 1 (override) beats channel 2 (freeze)",
+  () => {
+    const e = fixture({
+      displayId: makeDisplayId("REQ_001"),
+      rawAttributes: [
+        { key: "Discipline", value: "software" },
+        { key: "Discipline-frozen", value: "hardware @ 2026-01-15" },
+      ],
+    });
+    const d = classifyDiscipline(
+      e,
+      new Map<DisplayId, Entry>(),
+      TEST_REGISTRY,
+    );
+    assertEquals(d, "software");
+  },
+);
+
+Deno.test(
+  "Slice 3 classifier: channel 2 with bare-kind form parses correctly",
+  () => {
+    const e = fixture({
+      displayId: makeDisplayId("REQ_001"),
+      rawAttributes: [{ key: "Discipline-frozen", value: "software" }],
+    });
+    const d = classifyDiscipline(
+      e,
+      new Map<DisplayId, Entry>(),
+      TEST_REGISTRY,
+    );
+    assertEquals(d, "software");
+  },
+);
+
+Deno.test(
+  "Slice 3 classifier: channel 2 with malformed value falls through to channel 3",
+  () => {
+    const e = fixture({
+      displayId: makeDisplayId("REQ_001"),
+      type: "SoftwareRequirement",
+      rawAttributes: [
+        { key: "Discipline-frozen", value: "GARBAGE @ not-a-date" },
+      ],
+    });
+    const d = classifyDiscipline(
+      e,
+      new Map<DisplayId, Entry>(),
+      TEST_REGISTRY,
+    );
+    assertEquals(d, "software");
+  },
+);
+
+Deno.test(
+  "Slice 3 classifier: classifyDerivationOnly skips channels 1 + 2",
+  () => {
+    const e = fixture({
+      displayId: makeDisplayId("REQ_001"),
+      type: "SoftwareRequirement",
+      rawAttributes: [
+        { key: "Discipline", value: "hardware" },
+        { key: "Discipline-frozen", value: "hardware @ 2026-01-15" },
+      ],
+    });
+    const d = classifyDerivationOnly(
+      e,
+      new Map<DisplayId, Entry>(),
+      TEST_REGISTRY,
+    );
+    assertEquals(d, "software");
   },
 );

--- a/packages/markspec/core/formatter/mod.ts
+++ b/packages/markspec/core/formatter/mod.ts
@@ -326,6 +326,12 @@ export interface FormatOptions {
   readonly file?: string;
   /** ULID generator override (for testing). */
   readonly generateUlid?: () => string;
+  /**
+   * Override the "today" date used by the Discipline-frozen: stamper.
+   * Returned value must be a `YYYY-MM-DD` string in UTC. Default: today.
+   * Injectable for deterministic tests.
+   */
+  readonly today?: () => string;
 }
 
 /** Result of a format operation. */
@@ -336,6 +342,31 @@ export interface FormatResult {
   readonly diagnostics: readonly Diagnostic[];
   /** Whether any changes were made. */
   readonly changed: boolean;
+}
+
+/**
+ * UTC `YYYY-MM-DD` for today. Used as the default for the
+ * Discipline-frozen: stamper.
+ */
+function todayUtc(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+/**
+ * If `value` is a bare discipline kind (no `@`), return
+ * `<kind> @ <today>`. Otherwise return the value unchanged. Used by
+ * `format()` to auto-stamp `Discipline-frozen:` lines per ADR-017 Slice 3.
+ *
+ * The bare-kind regex deliberately matches the same shape the validator
+ * accepts in {@linkcode parseFrozenValue}; anything that doesn't match
+ * (e.g. uppercase kinds, already-dated forms) is left alone — the
+ * validator handles malformed values via MSL-T026.
+ */
+function stampDisciplineFrozen(value: string, today: string): string {
+  if (/^[a-z][a-z0-9-]*\s*$/.test(value)) {
+    return `${value.trim()} @ ${today}`;
+  }
+  return value;
 }
 
 /**
@@ -432,6 +463,32 @@ export function format(
         message: `assigned Id: ${newId} to ${entry.displayId}`,
         location: entry.location,
       });
+    }
+
+    // Discipline-frozen: date stamping (ADR-017 Slice 3). Walk attrs;
+    // if any Discipline-frozen: value is a bare kind, rewrite it with
+    // today's UTC date. Idempotent on already-dated values.
+    const todayFn = options?.today ?? todayUtc;
+    const todayStr = todayFn();
+    let stampedCount = 0;
+    attrs = attrs.map((a) => {
+      if (a.key !== "Discipline-frozen") return a;
+      const newValue = stampDisciplineFrozen(a.value, todayStr);
+      if (newValue !== a.value) {
+        stampedCount++;
+        return { key: a.key, value: newValue };
+      }
+      return a;
+    });
+    if (stampedCount > 0) {
+      diagnostics.push({
+        code: "MSL-F001",
+        severity: "info",
+        message:
+          `stamped Discipline-frozen: with ${todayStr} on ${entry.displayId}`,
+        location: entry.location,
+      });
+      changed = true;
     }
 
     if (attrs.length === 0) continue;

--- a/packages/markspec/core/formatter/mod_test.ts
+++ b/packages/markspec/core/formatter/mod_test.ts
@@ -475,3 +475,55 @@ Deno.test("format: mixed multi-entry doc is idempotent across the AST cutover", 
   assertFalse(once.includes("MUST debounce"));
   assertStringIncludes(once, "must debounce");
 });
+
+Deno.test("Slice 3 formatter: stamps today's date when Discipline-frozen: is bare kind", () => {
+  const input = `# Test
+
+- [REQ_001] Title
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      Discipline-frozen: software
+`;
+  const { output, changed } = format(input, {
+    today: () => "2026-05-25",
+  });
+  assertEquals(changed, true);
+  assertEquals(
+    output.includes("Discipline-frozen: software @ 2026-05-25"),
+    true,
+  );
+});
+
+Deno.test("Slice 3 formatter: leaves already-dated Discipline-frozen: alone (idempotent)", () => {
+  const input = `# Test
+
+- [REQ_001] Title
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      Discipline-frozen: software @ 2026-03-12
+`;
+  const { output } = format(input, {
+    today: () => "2026-05-25",
+  });
+  assertEquals(
+    output.includes("Discipline-frozen: software @ 2026-03-12"),
+    true,
+  );
+  assertEquals(output.includes("2026-05-25"), false);
+});
+
+Deno.test("Slice 3 formatter: malformed Discipline-frozen: value is untouched (validator handles it)", () => {
+  const input = `# Test
+
+- [REQ_001] Title
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      Discipline-frozen: Software
+`;
+  const { output } = format(input, {
+    today: () => "2026-05-25",
+  });
+  // Uppercase 'S' — doesn't match the bare-kind regex; formatter punts.
+  assertEquals(output.includes("Discipline-frozen: Software"), true);
+  assertEquals(output.includes("@ 2026-05-25"), false);
+});

--- a/packages/markspec/core/model/attributes.ts
+++ b/packages/markspec/core/model/attributes.ts
@@ -278,6 +278,34 @@ export const ATTRIBUTE_CATALOG: readonly AttributeSpec[] = [
     shapes: BOTH_SHAPES,
     required: false,
   },
+
+  // Discipline classification per ADR-017 Slice 3.
+  // - `Discipline:` is an author-asserted kind that takes precedence over
+  //   the classifier's type-based and allocation-based channels.
+  //   Lenient on unknown kinds — the value is emitted verbatim and
+  //   MSL-T025 warns separately.
+  // - `Discipline-frozen:` is a dated snapshot of a past derivation in
+  //   the form `<kind>` or `<kind> @ <YYYY-MM-DD>`. The formatter stamps
+  //   today's UTC date when only `<kind>` is written. MSL-T026 catches
+  //   malformed values; MSL-T030 warns when the freeze diverges from the
+  //   current derivation.
+  // Both are text-typed (the value space is dynamic — kinds come from the
+  // effective registry built per ADR-017 Slice 2). Single-cardinality
+  // follows automatically because `text` is not in `REPEATABLE_VALUE_TYPES`.
+  {
+    key: "Discipline",
+    type: "text",
+    origin: "authored",
+    shapes: BOTH_SHAPES,
+    required: false,
+  },
+  {
+    key: "Discipline-frozen",
+    type: "text",
+    origin: "authored",
+    shapes: BOTH_SHAPES,
+    required: false,
+  },
 ];
 
 /** Canonical Title-Case attribute keys the core recognizes. */

--- a/packages/markspec/core/model/mod_test.ts
+++ b/packages/markspec/core/model/mod_test.ts
@@ -15,7 +15,11 @@ import type {
   ProfileManifest,
   TypeDef,
 } from "./mod.ts";
-import { makeDisplayId } from "./mod.ts";
+import {
+  attributeSpec,
+  makeDisplayId,
+  UNIVERSAL_ATTRIBUTE_KEYS,
+} from "./mod.ts";
 
 Deno.test("BodyToken: discriminated union exhaustiveness", () => {
   const modal: BodyToken = {
@@ -139,4 +143,21 @@ Deno.test("Slice 2 model: KindDecl + kinds/discipline fields type-check", () => 
     discipline: { value: "software", origin: "x" },
   };
   if (etd.discipline.value !== "software") throw new Error("unreachable");
+});
+
+Deno.test("Slice 3 model: Discipline and Discipline-frozen are in the universal catalog", () => {
+  assertEquals(UNIVERSAL_ATTRIBUTE_KEYS.includes("Discipline"), true);
+  assertEquals(UNIVERSAL_ATTRIBUTE_KEYS.includes("Discipline-frozen"), true);
+
+  const d = attributeSpec("Discipline");
+  assertEquals(d?.type, "text");
+  assertEquals(d?.origin, "authored");
+  assertEquals(d?.required, false);
+  assertEquals(d?.shapes.length, 2); // both shapes
+
+  const df = attributeSpec("Discipline-frozen");
+  assertEquals(df?.type, "text");
+  assertEquals(df?.origin, "authored");
+  assertEquals(df?.required, false);
+  assertEquals(df?.shapes.length, 2);
 });

--- a/packages/markspec/core/validator/discipline.ts
+++ b/packages/markspec/core/validator/discipline.ts
@@ -1,0 +1,245 @@
+/**
+ * @module core/validator/discipline
+ *
+ * Discipline-attribute validator per ADR-017 Slice 3. Emits seven codes:
+ *
+ *   - MSL-T025 — `Discipline:` value not in the effective kind set (error)
+ *   - MSL-T026 — `Discipline-frozen:` value malformed (error)
+ *   - MSL-T027 — `Discipline-frozen:` kind not in the effective set (error)
+ *   - MSL-T028 — `Discipline:` conflicts with channel-3 derivation (warning)
+ *   - MSL-T029 — `Discipline:` conflicts with channel-4 derivation (warning)
+ *   - MSL-T030 — `Discipline-frozen:` differs from current derivation (warning)
+ *   - MSL-T031 — `Discipline:` and `Discipline-frozen:` disagree (warning)
+ *
+ * The effective kind set used by T025/T027 is `CORE_KINDS` plus any kinds
+ * the active profile chain declared via `profile.kinds:` (Slice 2's
+ * effective registry).
+ *
+ * Tasks 5–8 of the plan add T026–T031 incrementally on top of this skeleton.
+ */
+
+import type {
+  Diagnostic,
+  DisciplineRegistry,
+  DisplayId,
+  Entry,
+} from "../model/mod.ts";
+import { CORE_KINDS, makeDisplayId, MIXED_DISCIPLINE } from "../model/mod.ts";
+import {
+  classifyDerivationOnly,
+  parseFrozenValue,
+} from "../compiler/discipline_classifier.ts";
+
+/**
+ * Read the first non-empty value of a single-cardinality attribute. Mirrors
+ * the helper in the classifier so the validator doesn't need to import it.
+ */
+function singleAttrValue(entry: Entry, key: string): string | undefined {
+  for (const attr of entry.rawAttributes) {
+    if (attr.key === key) {
+      const trimmed = attr.value.trim();
+      if (trimmed.length > 0) return trimmed;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Build the effective kind set from `CORE_KINDS` plus every type → kind
+ * value the registry contains.
+ */
+function effectiveKindSet(registry: DisciplineRegistry): Set<string> {
+  const set = new Set<string>(CORE_KINDS);
+  for (const kind of registry.values()) set.add(kind);
+  return set;
+}
+
+/**
+ * Compute channel-3 alone for an entry — what the type-based registry
+ * lookup would yield. Returns `undefined` when no type or unknown type.
+ */
+function channel3Kind(
+  entry: Entry,
+  registry: DisciplineRegistry,
+): string | undefined {
+  if (entry.type === undefined) {
+    // Fallback: look at the raw Type: attribute (mirrors resolvedType()
+    // in the classifier so the validator works in core-only mode).
+    for (const attr of entry.rawAttributes) {
+      if (attr.key === "Type") {
+        const trimmed = attr.value.trim();
+        if (trimmed.length > 0) return registry.get(trimmed);
+      }
+    }
+    return undefined;
+  }
+  return registry.get(entry.type);
+}
+
+/**
+ * Compute channel-4 alone for an entry — walk Allocated-to targets,
+ * return the unique discipline if one, MIXED_DISCIPLINE if many,
+ * `undefined` if none.
+ */
+function channel4Kind(
+  entry: Entry,
+  entriesByDisplayId: ReadonlyMap<DisplayId, Entry>,
+  registry: DisciplineRegistry,
+): string | undefined {
+  const seen = new Set<string>();
+  for (const attr of entry.rawAttributes) {
+    if (attr.key !== "Allocated-to") continue;
+    for (const raw of attr.value.split(",")) {
+      const token = raw.trim();
+      if (token.length === 0) continue;
+      const target = entriesByDisplayId.get(makeDisplayId(token));
+      if (!target) continue;
+      const targetType = target.type ??
+        target.rawAttributes.find((a) => a.key === "Type")?.value.trim();
+      if (!targetType) continue;
+      const kind = registry.get(targetType);
+      if (kind !== undefined) seen.add(kind);
+    }
+  }
+  if (seen.size === 0) return undefined;
+  if (seen.size === 1) return [...seen][0];
+  return MIXED_DISCIPLINE;
+}
+
+/**
+ * Validate the `Discipline:` and `Discipline-frozen:` attributes across
+ * every entry. Pure function: takes the entries, a lookup map (used by
+ * later tasks for channel-4 derivation), and the effective registry.
+ *
+ * @param entries Entries to walk.
+ * @param entriesByDisplayId Lookup map for channel-4 derivation. Tasks 5–8
+ *   will use this; Task 4 ignores it but keeps the parameter to fix the
+ *   signature now.
+ * @param registry Effective discipline registry from Slice 2's
+ *   `buildEffectiveDisciplineRegistry()`, or `CORE_DISCIPLINE_REGISTRY` in
+ *   core-only mode.
+ */
+export function validateDiscipline(
+  entries: readonly Entry[],
+  entriesByDisplayId: ReadonlyMap<DisplayId, Entry>,
+  registry: DisciplineRegistry,
+): Diagnostic[] {
+  const out: Diagnostic[] = [];
+  const knownKinds = effectiveKindSet(registry);
+
+  for (const entry of entries) {
+    const override = singleAttrValue(entry, "Discipline");
+    if (override !== undefined && !knownKinds.has(override)) {
+      out.push({
+        code: "MSL-T025",
+        severity: "error",
+        message:
+          `${entry.displayId}: Discipline: '${override}' is not a known kind (declare it under profile.kinds: or use a core kind: ${
+            [...CORE_KINDS].join(" / ")
+          })`,
+        location: entry.location,
+      });
+    }
+
+    const frozen = singleAttrValue(entry, "Discipline-frozen");
+    if (frozen !== undefined) {
+      const parsed = parseFrozenValue(frozen);
+      if (parsed === undefined) {
+        out.push({
+          code: "MSL-T026",
+          severity: "error",
+          message:
+            `${entry.displayId}: Discipline-frozen: '${frozen}' is malformed (expected '<kind>' or '<kind> @ YYYY-MM-DD'; kind must match /^[a-z][a-z0-9-]*$/; date must be calendar-valid)`,
+          location: entry.location,
+        });
+      } else if (!knownKinds.has(parsed.kind)) {
+        out.push({
+          code: "MSL-T027",
+          severity: "error",
+          message:
+            `${entry.displayId}: Discipline-frozen: kind '${parsed.kind}' is not a known kind (declare it under profile.kinds: or use a core kind: ${
+              [...CORE_KINDS].join(" / ")
+            })`,
+          location: entry.location,
+        });
+      }
+    }
+
+    // T028 / T029: override vs channel-3 / channel-4 conflicts. Only run
+    // when the override is well-formed (suppressed by T025) and a channel
+    // actually produced a kind (default-system suppression).
+    if (override !== undefined && knownKinds.has(override)) {
+      const c3 = channel3Kind(entry, registry);
+      if (c3 !== undefined && c3 !== override) {
+        out.push({
+          code: "MSL-T028",
+          severity: "warning",
+          message:
+            `${entry.displayId}: Discipline: '${override}' conflicts with type-based derivation '${c3}' (from Type: ${
+              entry.type ?? "(raw)"
+            })`,
+          location: entry.location,
+        });
+      }
+      const c4 = channel4Kind(entry, entriesByDisplayId, registry);
+      if (c4 !== undefined && c4 !== override) {
+        out.push({
+          code: "MSL-T029",
+          severity: "warning",
+          message:
+            `${entry.displayId}: Discipline: '${override}' conflicts with allocation-based derivation '${c4}' (via Allocated-to)`,
+          location: entry.location,
+        });
+      }
+    }
+
+    // T030: freeze divergence. Runs whenever the freeze is well-formed
+    // and references a known kind — NOT suppressed by default-system
+    // derivation (drift from a known kind to default-system is exactly
+    // what freeze is designed to surface).
+    if (frozen !== undefined) {
+      const parsedF = parseFrozenValue(frozen);
+      if (parsedF !== undefined && knownKinds.has(parsedF.kind)) {
+        const current = classifyDerivationOnly(
+          entry,
+          entriesByDisplayId,
+          registry,
+        );
+        if (current !== parsedF.kind) {
+          out.push({
+            code: "MSL-T030",
+            severity: "warning",
+            message:
+              `${entry.displayId}: Discipline-frozen: '${parsedF.kind}' differs from current derivation '${current}' (something changed since the freeze on ${
+                parsedF.date ?? "(no date)"
+              })`,
+            location: entry.location,
+          });
+        }
+      }
+    }
+
+    // T031: override vs freeze disagreement. Both must be well-formed
+    // and reference known kinds — otherwise upstream errors (T025/T026/T027)
+    // handle the case.
+    if (
+      override !== undefined &&
+      knownKinds.has(override) &&
+      frozen !== undefined
+    ) {
+      const parsedF = parseFrozenValue(frozen);
+      if (parsedF !== undefined && knownKinds.has(parsedF.kind)) {
+        if (override !== parsedF.kind) {
+          out.push({
+            code: "MSL-T031",
+            severity: "warning",
+            message:
+              `${entry.displayId}: Discipline: '${override}' disagrees with Discipline-frozen: '${parsedF.kind}' (the override wins for derivedDiscipline; remove or update the freeze if the override is intentional)`,
+            location: entry.location,
+          });
+        }
+      }
+    }
+  }
+  return out;
+}

--- a/packages/markspec/core/validator/discipline_test.ts
+++ b/packages/markspec/core/validator/discipline_test.ts
@@ -1,0 +1,513 @@
+/**
+ * @module core/validator/discipline_test
+ *
+ * Unit tests for {@linkcode validateDiscipline} — ADR-017 Slice 3, Task 4.
+ * Covers MSL-T025 (unknown override kind) only; Tasks 5–8 will add tests
+ * for MSL-T026 through MSL-T031.
+ */
+
+import { assertEquals } from "@std/assert";
+import {
+  CORE_DISCIPLINE_REGISTRY,
+  type DisplayId,
+  type Entry,
+  makeDisplayId,
+} from "../mod.ts";
+import { validateDiscipline } from "./discipline.ts";
+
+function fixture(overrides: Partial<Entry>): Entry {
+  return {
+    displayId: makeDisplayId("X_0001"),
+    title: "Fixture",
+    body: "",
+    rawAttributes: [],
+    typedAttributes: new Map(),
+    shape: "Authored",
+    location: { file: "t.md", line: 1, column: 1 },
+    source: { kind: "markdown" },
+    bodyTokens: [],
+    derivedDiscipline: "system",
+    ...overrides,
+  };
+}
+
+Deno.test("MSL-T025: unknown override kind emits error", () => {
+  const e = fixture({
+    displayId: makeDisplayId("REQ_001"),
+    rawAttributes: [{ key: "Discipline", value: "nonsense" }],
+  });
+  const diags = validateDiscipline(
+    [e],
+    new Map<DisplayId, Entry>(),
+    CORE_DISCIPLINE_REGISTRY,
+  );
+  const t025 = diags.find((d) => d.code === "MSL-T025");
+  assertEquals(t025?.severity, "error");
+  assertEquals(t025?.message.includes("nonsense"), true);
+});
+
+Deno.test("MSL-T025: known core kind override is silent", () => {
+  const e = fixture({
+    displayId: makeDisplayId("REQ_001"),
+    rawAttributes: [{ key: "Discipline", value: "software" }],
+  });
+  const diags = validateDiscipline(
+    [e],
+    new Map<DisplayId, Entry>(),
+    CORE_DISCIPLINE_REGISTRY,
+  );
+  assertEquals(diags.some((d) => d.code === "MSL-T025"), false);
+});
+
+Deno.test("MSL-T025: empty override value is silent (no false positive)", () => {
+  const e = fixture({
+    displayId: makeDisplayId("REQ_001"),
+    rawAttributes: [{ key: "Discipline", value: "" }],
+  });
+  const diags = validateDiscipline(
+    [e],
+    new Map<DisplayId, Entry>(),
+    CORE_DISCIPLINE_REGISTRY,
+  );
+  assertEquals(diags.some((d) => d.code === "MSL-T025"), false);
+});
+
+Deno.test("MSL-T026: missing kind ('@ 2026-01-15' with no leading kind) emits error", () => {
+  const e = fixture({
+    displayId: makeDisplayId("REQ_001"),
+    rawAttributes: [{ key: "Discipline-frozen", value: "@ 2026-01-15" }],
+  });
+  const diags = validateDiscipline(
+    [e],
+    new Map<DisplayId, Entry>(),
+    CORE_DISCIPLINE_REGISTRY,
+  );
+  assertEquals(diags.some((d) => d.code === "MSL-T026"), true);
+});
+
+Deno.test("MSL-T026: uppercase kind ('Software') emits error", () => {
+  const e = fixture({
+    displayId: makeDisplayId("REQ_001"),
+    rawAttributes: [{ key: "Discipline-frozen", value: "Software" }],
+  });
+  const diags = validateDiscipline(
+    [e],
+    new Map<DisplayId, Entry>(),
+    CORE_DISCIPLINE_REGISTRY,
+  );
+  assertEquals(diags.some((d) => d.code === "MSL-T026"), true);
+});
+
+Deno.test("MSL-T026: invalid month (2026-13-99) emits error", () => {
+  const e = fixture({
+    displayId: makeDisplayId("REQ_001"),
+    rawAttributes: [{
+      key: "Discipline-frozen",
+      value: "software @ 2026-13-99",
+    }],
+  });
+  const diags = validateDiscipline(
+    [e],
+    new Map<DisplayId, Entry>(),
+    CORE_DISCIPLINE_REGISTRY,
+  );
+  assertEquals(diags.some((d) => d.code === "MSL-T026"), true);
+});
+
+Deno.test("MSL-T026: invalid Feb 30 emits error", () => {
+  const e = fixture({
+    displayId: makeDisplayId("REQ_001"),
+    rawAttributes: [{
+      key: "Discipline-frozen",
+      value: "software @ 2026-02-30",
+    }],
+  });
+  const diags = validateDiscipline(
+    [e],
+    new Map<DisplayId, Entry>(),
+    CORE_DISCIPLINE_REGISTRY,
+  );
+  assertEquals(diags.some((d) => d.code === "MSL-T026"), true);
+});
+
+Deno.test("MSL-T026: bare kind ('software') is silent", () => {
+  const e = fixture({
+    displayId: makeDisplayId("REQ_001"),
+    rawAttributes: [{ key: "Discipline-frozen", value: "software" }],
+  });
+  const diags = validateDiscipline(
+    [e],
+    new Map<DisplayId, Entry>(),
+    CORE_DISCIPLINE_REGISTRY,
+  );
+  assertEquals(diags.some((d) => d.code === "MSL-T026"), false);
+});
+
+Deno.test("MSL-T026: kind + valid date ('software @ 2026-05-25') is silent", () => {
+  const e = fixture({
+    displayId: makeDisplayId("REQ_001"),
+    rawAttributes: [{
+      key: "Discipline-frozen",
+      value: "software @ 2026-05-25",
+    }],
+  });
+  const diags = validateDiscipline(
+    [e],
+    new Map<DisplayId, Entry>(),
+    CORE_DISCIPLINE_REGISTRY,
+  );
+  assertEquals(diags.some((d) => d.code === "MSL-T026"), false);
+});
+
+Deno.test("MSL-T027: well-formed freeze with unknown kind emits error", () => {
+  const e = fixture({
+    displayId: makeDisplayId("REQ_001"),
+    rawAttributes: [{
+      key: "Discipline-frozen",
+      value: "nonsense @ 2026-01-15",
+    }],
+  });
+  const diags = validateDiscipline(
+    [e],
+    new Map<DisplayId, Entry>(),
+    CORE_DISCIPLINE_REGISTRY,
+  );
+  assertEquals(diags.some((d) => d.code === "MSL-T027"), true);
+});
+
+Deno.test("MSL-T026 suppresses MSL-T027: malformed value never reaches the kind check", () => {
+  const e = fixture({
+    displayId: makeDisplayId("REQ_001"),
+    rawAttributes: [{
+      key: "Discipline-frozen",
+      value: "Software @ 2026-01-15",
+    }],
+  });
+  const diags = validateDiscipline(
+    [e],
+    new Map<DisplayId, Entry>(),
+    CORE_DISCIPLINE_REGISTRY,
+  );
+  assertEquals(diags.some((d) => d.code === "MSL-T026"), true);
+  assertEquals(diags.some((d) => d.code === "MSL-T027"), false);
+});
+
+const TEST_REGISTRY_T028 = new Map<string, string>([
+  ["SoftwareRequirement", "software"],
+  ["HardwareRequirement", "hardware"],
+  ["SoftwareComponent", "software"],
+  ["HardwareComponent", "hardware"],
+]);
+
+Deno.test("MSL-T028: override 'hardware' on SoftwareRequirement-typed entry emits warning", () => {
+  const e = fixture({
+    displayId: makeDisplayId("REQ_001"),
+    type: "SoftwareRequirement",
+    rawAttributes: [{ key: "Discipline", value: "hardware" }],
+  });
+  const diags = validateDiscipline(
+    [e],
+    new Map<DisplayId, Entry>(),
+    TEST_REGISTRY_T028,
+  );
+  const t = diags.find((d) => d.code === "MSL-T028");
+  assertEquals(t?.severity, "warning");
+});
+
+Deno.test("MSL-T028: override 'software' matching type derivation is silent", () => {
+  const e = fixture({
+    displayId: makeDisplayId("REQ_001"),
+    type: "SoftwareRequirement",
+    rawAttributes: [{ key: "Discipline", value: "software" }],
+  });
+  const diags = validateDiscipline(
+    [e],
+    new Map<DisplayId, Entry>(),
+    TEST_REGISTRY_T028,
+  );
+  assertEquals(diags.some((d) => d.code === "MSL-T028"), false);
+});
+
+Deno.test("MSL-T028: suppressed when entry type is not in the registry (default-system suppression)", () => {
+  const e = fixture({
+    displayId: makeDisplayId("REQ_001"),
+    type: "Requirement", // not in TEST_REGISTRY_T028 → channel 3 yields undefined
+    rawAttributes: [{ key: "Discipline", value: "software" }],
+  });
+  const diags = validateDiscipline(
+    [e],
+    new Map<DisplayId, Entry>(),
+    TEST_REGISTRY_T028,
+  );
+  assertEquals(diags.some((d) => d.code === "MSL-T028"), false);
+});
+
+Deno.test("MSL-T029: override 'hardware' on entry allocated to SoftwareComponent emits warning", () => {
+  const sw = fixture({
+    displayId: makeDisplayId("COMP_SW"),
+    type: "SoftwareComponent",
+  });
+  const e = fixture({
+    displayId: makeDisplayId("REQ_001"),
+    rawAttributes: [
+      { key: "Allocated-to", value: "COMP_SW" },
+      { key: "Discipline", value: "hardware" },
+    ],
+  });
+  const map = new Map<DisplayId, Entry>([[sw.displayId, sw]]);
+  const diags = validateDiscipline([e], map, TEST_REGISTRY_T028);
+  const t = diags.find((d) => d.code === "MSL-T029");
+  assertEquals(t?.severity, "warning");
+});
+
+Deno.test("MSL-T029: matching allocation is silent", () => {
+  const sw = fixture({
+    displayId: makeDisplayId("COMP_SW"),
+    type: "SoftwareComponent",
+  });
+  const e = fixture({
+    displayId: makeDisplayId("REQ_001"),
+    rawAttributes: [
+      { key: "Allocated-to", value: "COMP_SW" },
+      { key: "Discipline", value: "software" },
+    ],
+  });
+  const map = new Map<DisplayId, Entry>([[sw.displayId, sw]]);
+  const diags = validateDiscipline([e], map, TEST_REGISTRY_T028);
+  assertEquals(diags.some((d) => d.code === "MSL-T029"), false);
+});
+
+Deno.test("MSL-T029: suppressed when no allocation targets resolve (default-system suppression)", () => {
+  const e = fixture({
+    displayId: makeDisplayId("REQ_001"),
+    rawAttributes: [{ key: "Discipline", value: "software" }],
+  });
+  const diags = validateDiscipline(
+    [e],
+    new Map<DisplayId, Entry>(),
+    TEST_REGISTRY_T028,
+  );
+  assertEquals(diags.some((d) => d.code === "MSL-T029"), false);
+});
+
+Deno.test("MSL-T028 + MSL-T029 can both fire on the same entry", () => {
+  const sw = fixture({
+    displayId: makeDisplayId("COMP_SW"),
+    type: "SoftwareComponent",
+  });
+  const e = fixture({
+    displayId: makeDisplayId("REQ_001"),
+    type: "SoftwareRequirement",
+    rawAttributes: [
+      { key: "Allocated-to", value: "COMP_SW" },
+      { key: "Discipline", value: "hardware" },
+    ],
+  });
+  const map = new Map<DisplayId, Entry>([[sw.displayId, sw]]);
+  const diags = validateDiscipline([e], map, TEST_REGISTRY_T028);
+  assertEquals(diags.some((d) => d.code === "MSL-T028"), true);
+  assertEquals(diags.some((d) => d.code === "MSL-T029"), true);
+});
+
+Deno.test("MSL-T025 suppresses MSL-T028 and T029 (unknown kind, nothing to compare)", () => {
+  const e = fixture({
+    displayId: makeDisplayId("REQ_001"),
+    type: "SoftwareRequirement",
+    rawAttributes: [{ key: "Discipline", value: "nonsense" }],
+  });
+  const diags = validateDiscipline(
+    [e],
+    new Map<DisplayId, Entry>(),
+    TEST_REGISTRY_T028,
+  );
+  assertEquals(diags.some((d) => d.code === "MSL-T025"), true);
+  assertEquals(diags.some((d) => d.code === "MSL-T028"), false);
+  assertEquals(diags.some((d) => d.code === "MSL-T029"), false);
+});
+
+Deno.test("MSL-T030: freeze 'software' on hardware-typed entry emits warning", () => {
+  const e = fixture({
+    displayId: makeDisplayId("REQ_001"),
+    type: "HardwareRequirement",
+    rawAttributes: [{
+      key: "Discipline-frozen",
+      value: "software @ 2026-01-15",
+    }],
+  });
+  const diags = validateDiscipline(
+    [e],
+    new Map<DisplayId, Entry>(),
+    TEST_REGISTRY_T028,
+  );
+  const t = diags.find((d) => d.code === "MSL-T030");
+  assertEquals(t?.severity, "warning");
+});
+
+Deno.test("MSL-T030: freeze matching current derivation is silent", () => {
+  const e = fixture({
+    displayId: makeDisplayId("REQ_001"),
+    type: "SoftwareRequirement",
+    rawAttributes: [{
+      key: "Discipline-frozen",
+      value: "software @ 2026-01-15",
+    }],
+  });
+  const diags = validateDiscipline(
+    [e],
+    new Map<DisplayId, Entry>(),
+    TEST_REGISTRY_T028,
+  );
+  assertEquals(diags.some((d) => d.code === "MSL-T030"), false);
+});
+
+Deno.test("MSL-T030 fires when derivation defaults to system (NOT suppressed)", () => {
+  // Entry has no Type in registry and no Allocated-to → derivation = system.
+  // Freeze captured 'software'. Drift from 'software' → 'system' is meaningful.
+  const e = fixture({
+    displayId: makeDisplayId("REQ_001"),
+    type: "Requirement",
+    rawAttributes: [{
+      key: "Discipline-frozen",
+      value: "software @ 2026-01-15",
+    }],
+  });
+  const diags = validateDiscipline(
+    [e],
+    new Map<DisplayId, Entry>(),
+    TEST_REGISTRY_T028,
+  );
+  assertEquals(diags.some((d) => d.code === "MSL-T030"), true);
+});
+
+Deno.test("MSL-T030: freeze 'system' matching default-system derivation is silent", () => {
+  const e = fixture({
+    displayId: makeDisplayId("REQ_001"),
+    type: "Requirement",
+    rawAttributes: [{
+      key: "Discipline-frozen",
+      value: "system @ 2026-01-15",
+    }],
+  });
+  const diags = validateDiscipline(
+    [e],
+    new Map<DisplayId, Entry>(),
+    TEST_REGISTRY_T028,
+  );
+  assertEquals(diags.some((d) => d.code === "MSL-T030"), false);
+});
+
+Deno.test("MSL-T026 suppresses MSL-T030: malformed freeze → no divergence comparison", () => {
+  const e = fixture({
+    displayId: makeDisplayId("REQ_001"),
+    type: "SoftwareRequirement",
+    rawAttributes: [{ key: "Discipline-frozen", value: "Software" }],
+  });
+  const diags = validateDiscipline(
+    [e],
+    new Map<DisplayId, Entry>(),
+    TEST_REGISTRY_T028,
+  );
+  assertEquals(diags.some((d) => d.code === "MSL-T026"), true);
+  assertEquals(diags.some((d) => d.code === "MSL-T030"), false);
+});
+
+Deno.test("MSL-T030 fires alongside T028/T029 — they are independent signals", () => {
+  const sw = fixture({
+    displayId: makeDisplayId("COMP_SW"),
+    type: "SoftwareComponent",
+  });
+  const e = fixture({
+    displayId: makeDisplayId("REQ_001"),
+    type: "SoftwareRequirement",
+    rawAttributes: [
+      { key: "Allocated-to", value: "COMP_SW" },
+      { key: "Discipline", value: "hardware" },
+      { key: "Discipline-frozen", value: "hardware @ 2026-01-15" },
+    ],
+  });
+  const map = new Map<DisplayId, Entry>([[sw.displayId, sw]]);
+  const diags = validateDiscipline([e], map, TEST_REGISTRY_T028);
+  assertEquals(diags.some((d) => d.code === "MSL-T028"), true); // override vs type
+  assertEquals(diags.some((d) => d.code === "MSL-T029"), true); // override vs allocation
+  assertEquals(diags.some((d) => d.code === "MSL-T030"), true); // freeze vs derivation
+});
+
+Deno.test("MSL-T031: override 'software' + freeze 'hardware' (both known) emits warning", () => {
+  const e = fixture({
+    displayId: makeDisplayId("REQ_001"),
+    rawAttributes: [
+      { key: "Discipline", value: "software" },
+      { key: "Discipline-frozen", value: "hardware @ 2026-01-15" },
+    ],
+  });
+  const diags = validateDiscipline(
+    [e],
+    new Map<DisplayId, Entry>(),
+    CORE_DISCIPLINE_REGISTRY,
+  );
+  const t = diags.find((d) => d.code === "MSL-T031");
+  assertEquals(t?.severity, "warning");
+});
+
+Deno.test("MSL-T031: override and freeze agreeing is silent", () => {
+  const e = fixture({
+    displayId: makeDisplayId("REQ_001"),
+    rawAttributes: [
+      { key: "Discipline", value: "software" },
+      { key: "Discipline-frozen", value: "software @ 2026-01-15" },
+    ],
+  });
+  const diags = validateDiscipline(
+    [e],
+    new Map<DisplayId, Entry>(),
+    CORE_DISCIPLINE_REGISTRY,
+  );
+  assertEquals(diags.some((d) => d.code === "MSL-T031"), false);
+});
+
+Deno.test("MSL-T025 suppresses MSL-T031: unknown override → no comparison", () => {
+  const e = fixture({
+    displayId: makeDisplayId("REQ_001"),
+    rawAttributes: [
+      { key: "Discipline", value: "nonsense" },
+      { key: "Discipline-frozen", value: "software @ 2026-01-15" },
+    ],
+  });
+  const diags = validateDiscipline(
+    [e],
+    new Map<DisplayId, Entry>(),
+    CORE_DISCIPLINE_REGISTRY,
+  );
+  assertEquals(diags.some((d) => d.code === "MSL-T025"), true);
+  assertEquals(diags.some((d) => d.code === "MSL-T031"), false);
+});
+
+Deno.test("MSL-T026 suppresses MSL-T031: malformed freeze → no comparison", () => {
+  const e = fixture({
+    displayId: makeDisplayId("REQ_001"),
+    rawAttributes: [
+      { key: "Discipline", value: "software" },
+      { key: "Discipline-frozen", value: "Software" }, // uppercase → malformed
+    ],
+  });
+  const diags = validateDiscipline(
+    [e],
+    new Map<DisplayId, Entry>(),
+    CORE_DISCIPLINE_REGISTRY,
+  );
+  assertEquals(diags.some((d) => d.code === "MSL-T026"), true);
+  assertEquals(diags.some((d) => d.code === "MSL-T031"), false);
+});
+
+Deno.test("MSL-T031: only override present → no warning", () => {
+  const e = fixture({
+    displayId: makeDisplayId("REQ_001"),
+    rawAttributes: [{ key: "Discipline", value: "software" }],
+  });
+  const diags = validateDiscipline(
+    [e],
+    new Map<DisplayId, Entry>(),
+    CORE_DISCIPLINE_REGISTRY,
+  );
+  assertEquals(diags.some((d) => d.code === "MSL-T031"), false);
+});

--- a/packages/markspec/core/validator/pipeline.ts
+++ b/packages/markspec/core/validator/pipeline.ts
@@ -14,6 +14,7 @@ import type {
   EffectiveProfile,
   Entry,
 } from "../model/mod.ts";
+import { CORE_DISCIPLINE_REGISTRY, makeDisplayId } from "../model/mod.ts";
 import { validate } from "./mod.ts";
 import {
   classifyEntriesStage,
@@ -31,6 +32,8 @@ import { normalizeListValues } from "./normalize.ts";
 import { validateTraceabilityForEntry } from "./traceability.ts";
 import { validateFeatureAc } from "./feature_ac.ts";
 import { validateCaptionConvention } from "./caption_convention.ts";
+import { validateDiscipline } from "./discipline.ts";
+import { buildEffectiveDisciplineRegistry } from "../profile/discipline_registry.ts";
 
 /** Result of running the full validator pipeline. */
 export interface PipelineResult {
@@ -90,6 +93,20 @@ export function runPipeline(
   // Runs project-wide because targets may live in any entry; needs the
   // whole batch indexed.
   diagnostics.push(...validateTraceTargetTypes(entries));
+
+  // Stage 1.7 — discipline attribute validation (ADR-017 Slice 3).
+  // Runs in both core-only and profile modes. In core-only mode the
+  // registry is CORE_DISCIPLINE_REGISTRY (kinds: system/software/hardware
+  // only) so T025/T027 only accept core kinds.
+  const disciplineRegistry = profile !== null
+    ? buildEffectiveDisciplineRegistry(profile)
+    : CORE_DISCIPLINE_REGISTRY;
+  const entriesByDisplayId = new Map(
+    entries.map((e) => [makeDisplayId(e.displayId), e] as const),
+  );
+  diagnostics.push(
+    ...validateDiscipline(entries, entriesByDisplayId, disciplineRegistry),
+  );
 
   // Stage 2 — classification (only when a profile is loaded).
   let finalEntries: readonly Entry[] = entries;

--- a/packages/markspec/core/validator/pipeline_test.ts
+++ b/packages/markspec/core/validator/pipeline_test.ts
@@ -358,6 +358,29 @@ Deno.test("runPipeline: Stage 4 catches required link missing", () => {
   assertEquals(result.valid, false);
 });
 
+Deno.test("Slice 3 pipeline: validateDiscipline runs and emits MSL-T025 on unknown override", () => {
+  const entry: Entry = {
+    shape: "Authored",
+    displayId: makeDisplayId("REQ_001"),
+    title: "x",
+    body: "",
+    rawAttributes: [
+      { key: "Id", value: "01HGW2Q8MNP3RSTVWXYZABCDEF" },
+      { key: "Discipline", value: "nonsense" },
+    ],
+    typedAttributes: new Map(),
+    type: undefined,
+    id: "01HGW2Q8MNP3RSTVWXYZABCDEF",
+    location: { file: "x.md", line: 1, column: 1 },
+    bodyTokens: [],
+    source: { kind: "markdown" as const },
+    derivedDiscipline: "system",
+  };
+
+  const { diagnostics } = runPipeline([entry], null);
+  assertEquals(diagnostics.some((d) => d.code === "MSL-T025"), true);
+});
+
 Deno.test("runPipeline: Stage 2.5 normalization splits comma-separated id-list values before Stage 3", () => {
   const origin = "@test/p";
   const verifiesAttr = {

--- a/packages/markspec/lsp/context.ts
+++ b/packages/markspec/lsp/context.ts
@@ -35,7 +35,7 @@ const ENTRY_MARKER_RE = /\[[A-Z]{2,}_[A-Z0-9_]+\]/;
 
 /** Trace attribute keywords that indicate a MarkSpec context. */
 const TRACE_KEYWORDS_RE =
-  /\b(Id|Satisfies|Derived-from|Verified-by|References|Tests|Depends-on|Part-of|Allocated-to|Realizes|Generated-from|Supersedes|Labels)\s*:/;
+  /\b(Id|Satisfies|Derived-from|Verified-by|References|Tests|Depends-on|Part-of|Allocated-to|Realizes|Generated-from|Supersedes|Labels|Discipline-frozen|Discipline)\s*:/;
 
 /**
  * Check whether a file path has a MarkSpec-relevant extension.

--- a/packages/markspec/lsp/context_test.ts
+++ b/packages/markspec/lsp/context_test.ts
@@ -90,3 +90,13 @@ Deno.test("isDocCommentContext: returns false for plain code", () => {
   ];
   assertEquals(isDocCommentContext(lines, 1), false);
 });
+
+Deno.test("Slice 3 LSP context: Discipline: keyword triggers doc-comment context", () => {
+  const lines = ["/// Some prose", "/// Discipline: software"];
+  assertEquals(isDocCommentContext(lines, 1), true);
+});
+
+Deno.test("Slice 3 LSP context: Discipline-frozen: keyword triggers doc-comment context", () => {
+  const lines = ["/// Some prose", "/// Discipline-frozen: software"];
+  assertEquals(isDocCommentContext(lines, 1), true);
+});

--- a/tests/e2e/discipline_format_test.ts
+++ b/tests/e2e/discipline_format_test.ts
@@ -1,0 +1,19 @@
+// tests/e2e/discipline_format_test.ts
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { markspec } from "./helpers.ts";
+
+Deno.test("Slice 3 E2E format: bare Discipline-frozen: stamps today's date", async () => {
+  const input = `# Test
+
+- [REQ_001] Title
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      Discipline-frozen: software
+`;
+  const r1 = await markspec(["format", "requirements.md"], {
+    "requirements.md": input,
+  });
+  assertEquals(r1.code, 0);
+  assertStringIncludes(r1.stderr, "stamped Discipline-frozen:");
+});

--- a/tests/e2e/discipline_override_freeze_test.ts
+++ b/tests/e2e/discipline_override_freeze_test.ts
@@ -1,0 +1,128 @@
+// tests/e2e/discipline_override_freeze_test.ts
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { markspec } from "./helpers.ts";
+
+const TIERED_PROFILE = {
+  files: {
+    "project.yaml": `name: slice3-tiered\nversion: 0.1.0\n`,
+    ".markspec.yaml": `profiles:\n  - ./profiles/tiered\n`,
+    "profiles/tiered/markspec.yaml": `id: slice3-tiered
+version: 0.0.1
+markspec-schema: "1"
+profile:
+  types:
+    SoftwareRequirement:
+      extends: Requirement
+      display-id-pattern: "SWR_{NNNN}"
+      discipline: software
+    HardwareRequirement:
+      extends: Requirement
+      display-id-pattern: "HWR_{NNNN}"
+      discipline: hardware
+`,
+  },
+};
+
+function withRequirements(body: string): Record<string, string> {
+  return { ...TIERED_PROFILE.files, "requirements.md": body };
+}
+
+Deno.test("Slice 3 E2E: Discipline: override beats type-based and shows in derivedDiscipline", async () => {
+  const { code, stdout } = await markspec(
+    ["compile", "--format", "json", "requirements.md"],
+    withRequirements(`# Requirements
+
+- [SWR_0001] Should be software but author asserts hardware
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      Type: SoftwareRequirement
+      Discipline: hardware
+`),
+  );
+  // Exit 0 because the conflict is a warning, not an error.
+  assertEquals(code, 0, "compile should exit 0 (warning only)");
+  const compiled = JSON.parse(stdout);
+  const entry = compiled.entries["SWR_0001"];
+  // Override wins for derivedDiscipline (channel 1 precedence).
+  assertEquals(entry.derivedDiscipline, "hardware");
+});
+
+Deno.test("Slice 3 E2E: Discipline: override-vs-type conflict surfaces MSL-T028", async () => {
+  const { stderr } = await markspec(
+    ["validate", "requirements.md"],
+    withRequirements(`# Requirements
+
+- [SWR_0001] Mismatched override
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      Type: SoftwareRequirement
+      Discipline: hardware
+`),
+  );
+  assertStringIncludes(stderr, "MSL-T028");
+});
+
+Deno.test("Slice 3 E2E: Discipline: unknown kind fails with MSL-T025", async () => {
+  const { code, stderr } = await markspec(
+    ["validate", "requirements.md"],
+    withRequirements(`# Requirements
+
+- [SWR_0001] Unknown kind asserted
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      Type: SoftwareRequirement
+      Discipline: nonsense
+`),
+  );
+  assertEquals(code, 1);
+  assertStringIncludes(stderr, "MSL-T025");
+  assertStringIncludes(stderr, "nonsense");
+});
+
+Deno.test("Slice 3 E2E: Discipline-frozen: malformed value fails with MSL-T026", async () => {
+  const { code, stderr } = await markspec(
+    ["validate", "requirements.md"],
+    withRequirements(`# Requirements
+
+- [SWR_0001] Malformed freeze
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      Type: SoftwareRequirement
+      Discipline-frozen: software @ 2026-02-30
+`),
+  );
+  assertEquals(code, 1);
+  assertStringIncludes(stderr, "MSL-T026");
+});
+
+Deno.test("Slice 3 E2E: Discipline-frozen: divergence from current derivation surfaces MSL-T030", async () => {
+  const { stderr } = await markspec(
+    ["validate", "requirements.md"],
+    withRequirements(`# Requirements
+
+- [SWR_0001] Frozen as hardware but currently classifies as software
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      Type: SoftwareRequirement
+      Discipline-frozen: hardware @ 2026-01-15
+`),
+  );
+  assertStringIncludes(stderr, "MSL-T030");
+});
+
+Deno.test("Slice 3 E2E: Discipline: and Discipline-frozen: disagreement surfaces MSL-T031", async () => {
+  const { stderr } = await markspec(
+    ["validate", "requirements.md"],
+    withRequirements(`# Requirements
+
+- [SWR_0001] Override software, freeze hardware
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      Type: SoftwareRequirement
+      Discipline: software
+      Discipline-frozen: hardware @ 2026-01-15
+`),
+  );
+  assertStringIncludes(stderr, "MSL-T031");
+});


### PR DESCRIPTION
## Summary

- Adds `Discipline:` and `Discipline-frozen:` as core text-typed universal attributes.
- Extends `classifyDiscipline()` with channels 1 (override, lenient on unknown kinds) and 2 (freeze, strict on malformed values), preserving the function signature.
- Ships seven new validator codes (MSL-T025..T031) covering value validity and conflict warnings, including the spec-corrected interaction where default-`system` derivation suppresses T028/T029 but NOT T030.
- Adds one formatter rule that auto-stamps today's UTC date on bare `Discipline-frozen:` values (parallels `Id:` ULID stamping; idempotent).
- LSP source-file context regex recognises both new keywords.

Implements ADR-017 Implementation backlog items 4 and 5.

Spec: `docs/superpowers/specs/2026-05-25-discipline-override-freeze-attributes-design.md` (local working doc).

## Test plan

- [x] `just check` exit 0 (2489 tests, 3 ignored).
- [x] `tests/e2e/discipline_override_freeze_test.ts` — 6 sub-tests cover override-wins-in-derivedDiscipline, override-vs-type (MSL-T028), unknown kind (MSL-T025), malformed freeze (MSL-T026), freeze divergence (MSL-T030), override-vs-freeze disagreement (MSL-T031).
- [x] `tests/e2e/discipline_format_test.ts` — stamping rule end-to-end via the CLI.
- [x] `deno fmt --check && dprint check` clean.
- [x] Pre-push hook (`just check`) re-ran green on the squashed commit.

## Implementation chain

Built via 12 TDD task commits in a worktree, then rebased onto `origin/main` (which moved 5 commits during the slice) and squashed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
