### PR TITLE
feat(core): slice 9 — score roll-up + CLI/JSON output

### DIFF
--- a/packages/markspec/cli/commands/lint.ts
+++ b/packages/markspec/cli/commands/lint.ts
@@ -41,12 +41,28 @@ export const lintCmd = new Command()
       const hasWarnings = diagnostics.some((d) => d.severity === "warning");
 
       if (options.format === "json") {
-        console.log(JSON.stringify(diagnostics, null, 2));
+        const output = { diagnostics, score: lintResult.score };
+        console.log(JSON.stringify(output, null, 2));
       } else {
         for (const d of diagnostics) {
-          const loc = d.location ? `${d.location.file}:${d.location.line}` : "";
-          console.error(`${d.severity}[${d.code}]: ${loc} ${d.message}`);
+          const loc = d.location
+            ? `${d.location.file}:${d.location.line}:${d.location.column}`
+            : "";
+          console.error(
+            `${loc} ${d.severity} ${d.slug} [${d.code}]: ${d.message}`,
+          );
         }
+        const { bandCounts, mean } = lintResult.score.rollup;
+        const { antiPatternNote } = lintResult.score;
+        const bandSummary = [
+          `${bandCounts["0"]} entries in band 0`,
+          `${bandCounts["1-3"]} in 1-3`,
+          `${bandCounts["4-7"]} in 4-7`,
+          `${bandCounts["8-15"]} in 8-15`,
+          `${bandCounts["16+"]} in 16+`,
+        ].join(", ");
+        console.error(`\nScore: ${bandSummary}. Mean: ${mean}.`);
+        console.error(`Note: ${antiPatternNote}`);
       }
 
       if (hasErrors) {

--- a/packages/markspec/core/lint/mod.ts
+++ b/packages/markspec/core/lint/mod.ts
@@ -8,5 +8,7 @@
 export type { LintDiagnostic } from "./types.ts";
 export { isProseScope, runLint } from "./runner.ts";
 export type { LintOptions, LintResult } from "./runner.ts";
+export { ANTI_PATTERN_NOTE, computeScoreRollup } from "./score.ts";
+export type { EntryScore, RuleContribution, ScoreRollup } from "./score.ts";
 export { segmentSentences } from "./segmenter.ts";
 export type { Sentence } from "./segmenter.ts";

--- a/packages/markspec/core/lint/runner.ts
+++ b/packages/markspec/core/lint/runner.ts
@@ -26,6 +26,8 @@ import { runEarsRules } from "./rules/ears.ts";
 import { runModalSentenceRules } from "./rules/modal_sentence.ts";
 import { runIncoseSentenceRules } from "./rules/incose_sentence.ts";
 import { loadLexicon } from "../lexicons/mod.ts";
+import { computeScoreRollup } from "./score.ts";
+import type { ScoreRollup } from "./score.ts";
 
 // ---------------------------------------------------------------------------
 // In-scope predicate
@@ -71,6 +73,7 @@ export interface LintOptions {
 
 export interface LintResult {
   readonly diagnostics: readonly LintDiagnostic[];
+  readonly score: ScoreRollup;
 }
 
 // ---------------------------------------------------------------------------
@@ -108,7 +111,8 @@ function disabledCodes(entry: Entry): ReadonlySet<string> {
  *      Markspec-disable list includes the rule's code and the entry
  *      has a Rationale. Suppression-hygiene diagnostics (Q900/Q901)
  *      are never suppressed.
- *  11. Return remaining diagnostics.
+ *  11. Compute score roll-up (per-entry scores, band-counts, mean).
+ *  12. Return diagnostics and score.
  */
 export async function runLint(options: LintOptions): Promise<LintResult> {
   const { entries } = options;
@@ -157,5 +161,8 @@ export async function runLint(options: LintOptions): Promise<LintResult> {
   // Step 11: append hygiene diagnostics (never suppressed)
   out.push(...hygieneDiags);
 
-  return { diagnostics: out };
+  // Step 12: compute score roll-up across all entries (including 0-score ones).
+  const score = computeScoreRollup(out, entries);
+
+  return { diagnostics: out, score };
 }

--- a/packages/markspec/core/lint/score.ts
+++ b/packages/markspec/core/lint/score.ts
@@ -1,0 +1,223 @@
+/**
+ * @module core/lint/score
+ *
+ * Score roll-up for the prose-quality lint pipeline (ADR-021 Decision 4).
+ *
+ * {@linkcode computeScoreRollup} is a pure function: same input → same
+ * byte-identical output. Entries with zero diagnostics still appear in
+ * `perEntry` so band-counts and the mean include all authored entries.
+ *
+ * Band scheme (fixed — do not change widths per ADR-021 Decision 4):
+ *   0  |  1–3  |  4–7  |  8–15  |  16+
+ */
+
+import type { LintDiagnostic } from "./types.ts";
+import type { Entry } from "../model/mod.ts";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/** A single rule's contribution to an entry's score. */
+export interface RuleContribution {
+  readonly code: string;
+  readonly slug: string;
+  /** Score per firing (constant for a given rule). */
+  readonly weight: number;
+  /** How many times this rule fired on this entry. */
+  readonly occurrences: number;
+}
+
+/** Aggregated score for one entry. */
+export interface EntryScore {
+  /** ULID from entry.id (empty string when the entry has no Id stamp). */
+  readonly entryId: string;
+  readonly displayId: string;
+  readonly score: number;
+  /** Sorted by weight DESC, code ASC for deterministic output. */
+  readonly contributions: readonly RuleContribution[];
+}
+
+/** Full score roll-up returned by {@linkcode computeScoreRollup}. */
+export interface ScoreRollup {
+  /** Per-entry scores, sorted by displayId for determinism. */
+  readonly perEntry: readonly EntryScore[];
+  readonly rollup: {
+    /** Count of entries per band. All five keys are always present. */
+    readonly bandCounts: Record<string, number>;
+    /** Arithmetic mean of per-entry scores, rounded to 1 decimal. */
+    readonly mean: number;
+  };
+  /** Anti-pattern note — exact ADR-021 Decision 5 string. */
+  readonly antiPatternNote: string;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** ADR-021 Decision 5 — verbatim; do not change. */
+export const ANTI_PATTERN_NOTE =
+  "Optimize the requirements, not the score. The score is a smoke detector, not a KPI.";
+
+/** Ordered band definitions: [label, predicate]. */
+const BANDS: ReadonlyArray<readonly [string, (n: number) => boolean]> = [
+  ["0", (n) => n === 0],
+  ["1-3", (n) => n >= 1 && n <= 3],
+  ["4-7", (n) => n >= 4 && n <= 7],
+  ["8-15", (n) => n >= 8 && n <= 15],
+  ["16+", (n) => n >= 16],
+] as const;
+
+// ---------------------------------------------------------------------------
+// computeScoreRollup
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute per-entry scores and roll up band-counts + mean across all entries.
+ *
+ * Diagnostic → entry assignment strategy (option b — pure, no runner internals):
+ * Build a per-file array of entries sorted by `location.line`. For each
+ * diagnostic, find the entry in the same file whose start line is the largest
+ * line ≤ the diagnostic's line (i.e. the entry that "owns" that position).
+ * Diagnostics that don't match any entry are silently skipped (they would be
+ * suppression-hygiene diagnostics from entries not in scope, or diagnostics
+ * with no location).
+ *
+ * @param diagnostics - Flat array of lint diagnostics from {@linkcode runLint}.
+ * @param entries - All entries (including those with 0 diagnostics) to ensure
+ *   band-counts and the mean denominator cover the full population.
+ */
+export function computeScoreRollup(
+  diagnostics: readonly LintDiagnostic[],
+  entries: readonly Entry[],
+): ScoreRollup {
+  // Step 1: Build per-file sorted entry array for O(log M) lookup.
+  // Key: file path. Value: entries sorted ascending by location.line.
+  const fileEntries = new Map<string, Entry[]>();
+  for (const entry of entries) {
+    const file = entry.location.file;
+    const arr = fileEntries.get(file) ?? [];
+    arr.push(entry);
+    fileEntries.set(file, arr);
+  }
+  // Sort each per-file list ascending by line so binary-search works.
+  for (const arr of fileEntries.values()) {
+    arr.sort((a, b) => a.location.line - b.location.line);
+  }
+
+  // Step 2: Map from Entry → accumulator { code → { slug, weight, count } }.
+  const accumMap = new Map<
+    Entry,
+    Map<string, { slug: string; weight: number; count: number }>
+  >();
+  // Pre-seed every entry with an empty accumulator so 0-score entries appear.
+  for (const entry of entries) {
+    accumMap.set(entry, new Map());
+  }
+
+  // Step 3: Assign each diagnostic to an entry and accumulate.
+  for (const diag of diagnostics) {
+    if (!diag.location) continue;
+    const file = diag.location.file;
+    const fileArr = fileEntries.get(file);
+    if (!fileArr || fileArr.length === 0) continue;
+    const entry = findOwningEntry(fileArr, diag.location.line);
+    if (!entry) continue;
+    const accum = accumMap.get(entry);
+    if (!accum) continue; // entry not in our set (e.g. hygiene on out-of-scope)
+    const existing = accum.get(diag.code);
+    if (existing) {
+      existing.count++;
+    } else {
+      accum.set(diag.code, {
+        slug: diag.slug,
+        weight: diag.scoreContribution,
+        count: 1,
+      });
+    }
+  }
+
+  // Step 4: Build EntryScore[] sorted by displayId.
+  const perEntry: EntryScore[] = [];
+  for (const entry of entries) {
+    const accum = accumMap.get(entry)!;
+    let score = 0;
+    const contributions: RuleContribution[] = [];
+    for (const [code, { slug, weight, count }] of accum) {
+      score += weight * count;
+      contributions.push({ code, slug, weight, occurrences: count });
+    }
+    // Sort contributions: weight DESC, then code ASC for ties.
+    contributions.sort((a, b) =>
+      b.weight !== a.weight ? b.weight - a.weight : a.code.localeCompare(b.code)
+    );
+    perEntry.push({
+      entryId: entry.id ?? "",
+      displayId: entry.displayId,
+      score,
+      contributions,
+    });
+  }
+  // Sort perEntry by displayId for determinism.
+  perEntry.sort((a, b) => a.displayId.localeCompare(b.displayId));
+
+  // Step 5: Compute band-counts.
+  const bandCounts: Record<string, number> = {};
+  for (const [label] of BANDS) {
+    bandCounts[label] = 0;
+  }
+  for (const { score } of perEntry) {
+    for (const [label, predicate] of BANDS) {
+      if (predicate(score)) {
+        bandCounts[label]++;
+        break;
+      }
+    }
+  }
+
+  // Step 6: Compute mean (round to 1 decimal).
+  const totalScore = perEntry.reduce((s, e) => s + e.score, 0);
+  const mean = perEntry.length === 0
+    ? 0
+    : Math.round((totalScore / perEntry.length) * 10) / 10;
+
+  return {
+    perEntry,
+    rollup: { bandCounts, mean },
+    antiPatternNote: ANTI_PATTERN_NOTE,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Find the entry that owns a given line in a file.
+ *
+ * The owning entry is the one whose `location.line` is the largest value
+ * ≤ `line` in the sorted `fileArr`. This matches how the runner assigns
+ * diagnostics: each rule emits diagnostics with the entry's location or
+ * a location within the entry's body, always at or after the entry start
+ * line.
+ */
+function findOwningEntry(
+  fileArr: readonly Entry[],
+  line: number,
+): Entry | undefined {
+  // Binary search for the last entry whose location.line <= line.
+  let lo = 0;
+  let hi = fileArr.length - 1;
+  let result: Entry | undefined;
+  while (lo <= hi) {
+    const mid = (lo + hi) >>> 1;
+    if (fileArr[mid].location.line <= line) {
+      result = fileArr[mid];
+      lo = mid + 1;
+    } else {
+      hi = mid - 1;
+    }
+  }
+  return result;
+}

--- a/packages/markspec/core/lint/score_test.ts
+++ b/packages/markspec/core/lint/score_test.ts
@@ -1,0 +1,191 @@
+/**
+ * @module core/lint/score_test
+ *
+ * Unit tests for computeScoreRollup.
+ */
+
+import { assertEquals } from "@std/assert";
+import type { Entry } from "../model/mod.ts";
+import { makeDisplayId } from "../model/mod.ts";
+import type { LintDiagnostic } from "./types.ts";
+import { ANTI_PATTERN_NOTE, computeScoreRollup } from "./score.ts";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function fakeEntry(displayId: string, file = "/x.md"): Entry {
+  return {
+    displayId: makeDisplayId(displayId),
+    title: "Test entry",
+    body: "The system shall do something.",
+    bodyAst: [],
+    rawAttributes: [
+      { key: "Id", value: "01HGW2Q8MNP3RSTVWXYZABCDEF" },
+      { key: "Type", value: "Requirement" },
+    ],
+    typedAttributes: new Map([
+      ["Id", ["01HGW2Q8MNP3RSTVWXYZABCDEF"]],
+      ["Type", ["Requirement"]],
+    ]),
+    id: "01HGW2Q8MNP3RSTVWXYZABCDEF",
+    type: "Requirement",
+    shape: "Authored",
+    location: { file, line: 1, column: 1 },
+    source: { kind: "markdown" },
+    bodyTokens: [],
+  } as unknown as Entry;
+}
+
+function fakeDiag(
+  code: string,
+  slug: string,
+  weight: number,
+  file: string,
+  line = 1,
+): LintDiagnostic {
+  return {
+    code,
+    slug,
+    group: "incose",
+    severity: "warning",
+    scoreContribution: weight,
+    message: `${slug}: test`,
+    location: { file, line, column: 1 },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+Deno.test("score: per-entry score = Σ contributions", () => {
+  const entry = fakeEntry("STK_0001");
+  const diags = [
+    fakeDiag("MSL-Q302", "incose-r7-vague-term", 3, "/x.md"),
+    fakeDiag("MSL-Q304", "incose-r9-open-ended", 1, "/x.md"),
+  ];
+  const roll = computeScoreRollup(diags, [entry]);
+  assertEquals(roll.perEntry[0].score, 4);
+  assertEquals(roll.perEntry[0].displayId, "STK_0001");
+});
+
+Deno.test("score: contributions sorted weight DESC, code ASC", () => {
+  const entry = fakeEntry("STK_0001");
+  const diags = [
+    fakeDiag("MSL-Q304", "incose-r9-open-ended", 1, "/x.md"), // w=1
+    fakeDiag("MSL-Q500", "xref-glossary-undefined", 3, "/x.md"), // w=3
+    fakeDiag("MSL-Q302", "incose-r7-vague-term", 3, "/x.md"), // w=3
+  ];
+  const roll = computeScoreRollup(diags, [entry]);
+  const c = roll.perEntry[0].contributions;
+  assertEquals(c[0].code, "MSL-Q302"); // weight 3, code-ASC tie → Q302
+  assertEquals(c[1].code, "MSL-Q500"); // weight 3
+  assertEquals(c[2].code, "MSL-Q304"); // weight 1
+});
+
+Deno.test("score: occurrences counts repeated firings", () => {
+  const entry = fakeEntry("STK_0001");
+  const diags = [
+    fakeDiag("MSL-Q302", "incose-r7-vague-term", 3, "/x.md"),
+    fakeDiag("MSL-Q302", "incose-r7-vague-term", 3, "/x.md"),
+  ];
+  const roll = computeScoreRollup(diags, [entry]);
+  assertEquals(roll.perEntry[0].score, 6);
+  assertEquals(roll.perEntry[0].contributions[0].occurrences, 2);
+});
+
+Deno.test("score: bandCounts cover all 5 bands always", () => {
+  // 5 entries with scores 0, 2, 5, 9, 20 → bands 0:1, 1-3:1, 4-7:1, 8-15:1, 16+:1.
+  const entries = ["STK_0001", "STK_0002", "STK_0003", "STK_0004", "STK_0005"]
+    .map((id, i) => fakeEntry(id, `/${i}.md`));
+  const diags: LintDiagnostic[] = [];
+  // Entry 2 (file /1.md): score 2 (one w=2 fictional)
+  diags.push(fakeDiag("MSL-QXXX", "fictional", 2, "/1.md"));
+  // Entry 3 (file /2.md): score 5 (one w=3, two w=1)
+  diags.push(fakeDiag("MSL-Q302", "incose-r7-vague-term", 3, "/2.md"));
+  diags.push(fakeDiag("MSL-Q304", "incose-r9-open-ended", 1, "/2.md"));
+  diags.push(fakeDiag("MSL-Q304", "incose-r9-open-ended", 1, "/2.md"));
+  // Entry 4 (file /3.md): score 9
+  diags.push(fakeDiag("MSL-Q302", "incose-r7-vague-term", 3, "/3.md"));
+  diags.push(fakeDiag("MSL-Q302", "incose-r7-vague-term", 3, "/3.md"));
+  diags.push(fakeDiag("MSL-Q302", "incose-r7-vague-term", 3, "/3.md"));
+  // Entry 5 (file /4.md): score 21 (7 × 3)
+  for (let k = 0; k < 7; k++) {
+    diags.push(fakeDiag("MSL-Q302", "incose-r7-vague-term", 3, "/4.md"));
+  }
+  // No diagnostics for entry 1 (file /0.md) → score 0.
+  const roll = computeScoreRollup(diags, entries);
+  assertEquals(roll.rollup.bandCounts["0"], 1);
+  assertEquals(roll.rollup.bandCounts["1-3"], 1);
+  assertEquals(roll.rollup.bandCounts["4-7"], 1);
+  assertEquals(roll.rollup.bandCounts["8-15"], 1);
+  assertEquals(roll.rollup.bandCounts["16+"], 1);
+});
+
+Deno.test("score: mean rounded to 1 decimal, includes 0-score entries", () => {
+  // 3 entries: scores 0, 1, 2 → mean 1.0.
+  const entries = [
+    fakeEntry("STK_001", "/a.md"),
+    fakeEntry("STK_002", "/b.md"),
+    fakeEntry("STK_003", "/c.md"),
+  ];
+  const diags = [
+    fakeDiag("MSL-Q304", "incose-r9-open-ended", 1, "/b.md"),
+    fakeDiag("MSL-Q304", "incose-r9-open-ended", 1, "/c.md"),
+    fakeDiag("MSL-Q304", "incose-r9-open-ended", 1, "/c.md"),
+  ];
+  const roll = computeScoreRollup(diags, entries);
+  assertEquals(roll.rollup.mean, 1.0);
+});
+
+Deno.test("score: anti-pattern note is the exact ADR-021 string", () => {
+  const roll = computeScoreRollup([], [fakeEntry("STK_0001")]);
+  assertEquals(
+    roll.antiPatternNote,
+    "Optimize the requirements, not the score. The score is a smoke detector, not a KPI.",
+  );
+  // Also verify via exported constant.
+  assertEquals(roll.antiPatternNote, ANTI_PATTERN_NOTE);
+});
+
+Deno.test("score: deterministic — same input → same output", () => {
+  const entries = [fakeEntry("STK_0001"), fakeEntry("STK_0002", "/y.md")];
+  const diags = [fakeDiag("MSL-Q302", "incose-r7-vague-term", 3, "/x.md")];
+  const a = computeScoreRollup(diags, entries);
+  const b = computeScoreRollup(diags, entries);
+  assertEquals(JSON.stringify(a), JSON.stringify(b));
+});
+
+Deno.test("score: perEntry sorted by displayId for determinism", () => {
+  const entries = [
+    fakeEntry("STK_0003", "/c.md"),
+    fakeEntry("STK_0001", "/a.md"),
+    fakeEntry("STK_0002", "/b.md"),
+  ];
+  const roll = computeScoreRollup([], entries);
+  assertEquals(
+    roll.perEntry.map((e) => e.displayId),
+    ["STK_0001", "STK_0002", "STK_0003"],
+  );
+});
+
+Deno.test("score: empty diagnostics and empty entries → mean 0 and all bands 0", () => {
+  const roll = computeScoreRollup([], []);
+  assertEquals(roll.rollup.mean, 0);
+  assertEquals(Object.keys(roll.rollup.bandCounts).length, 5);
+  for (const count of Object.values(roll.rollup.bandCounts)) {
+    assertEquals(count, 0);
+  }
+});
+
+Deno.test("score: band keys present in canonical order", () => {
+  const roll = computeScoreRollup([], []);
+  assertEquals(Object.keys(roll.rollup.bandCounts), [
+    "0",
+    "1-3",
+    "4-7",
+    "8-15",
+    "16+",
+  ]);
+});

--- a/packages/markspec/core/lint/score_test.ts
+++ b/packages/markspec/core/lint/score_test.ts
@@ -96,7 +96,7 @@ Deno.test("score: occurrences counts repeated firings", () => {
 });
 
 Deno.test("score: bandCounts cover all 5 bands always", () => {
-  // 5 entries with scores 0, 2, 5, 9, 20 → bands 0:1, 1-3:1, 4-7:1, 8-15:1, 16+:1.
+  // 5 entries with scores 0, 2, 5, 9, 21 → bands 0:1, 1-3:1, 4-7:1, 8-15:1, 16+:1.
   const entries = ["STK_0001", "STK_0002", "STK_0003", "STK_0004", "STK_0005"]
     .map((id, i) => fakeEntry(id, `/${i}.md`));
   const diags: LintDiagnostic[] = [];
@@ -188,4 +188,86 @@ Deno.test("score: band keys present in canonical order", () => {
     "8-15",
     "16+",
   ]);
+});
+
+// Band-boundary regression tests — guards against off-by-one if the
+// band predicates are ever edited. The values 1, 3, 4, 7, 8, 15, 16
+// sit exactly on the band boundaries per ADR-021 Decision 4.
+Deno.test("score: boundary — score=1 lands in '1-3'", () => {
+  const entry = fakeEntry("STK_0001");
+  const diags = [fakeDiag("MSL-Q304", "incose-r9-open-ended", 1, "/x.md")];
+  const roll = computeScoreRollup(diags, [entry]);
+  assertEquals(roll.rollup.bandCounts["1-3"], 1);
+  assertEquals(roll.rollup.bandCounts["0"], 0);
+});
+
+Deno.test("score: boundary — score=3 lands in '1-3' (upper edge)", () => {
+  const entry = fakeEntry("STK_0001");
+  const diags = [fakeDiag("MSL-Q302", "incose-r7-vague-term", 3, "/x.md")];
+  const roll = computeScoreRollup(diags, [entry]);
+  assertEquals(roll.rollup.bandCounts["1-3"], 1);
+  assertEquals(roll.rollup.bandCounts["4-7"], 0);
+});
+
+Deno.test("score: boundary — score=4 lands in '4-7' (lower edge)", () => {
+  const entry = fakeEntry("STK_0001");
+  const diags = [
+    fakeDiag("MSL-Q302", "incose-r7-vague-term", 3, "/x.md"),
+    fakeDiag("MSL-Q304", "incose-r9-open-ended", 1, "/x.md"),
+  ];
+  const roll = computeScoreRollup(diags, [entry]);
+  assertEquals(roll.rollup.bandCounts["4-7"], 1);
+  assertEquals(roll.rollup.bandCounts["1-3"], 0);
+});
+
+Deno.test("score: boundary — score=7 lands in '4-7' (upper edge)", () => {
+  const entry = fakeEntry("STK_0001");
+  // 2×3 + 1 = 7
+  const diags = [
+    fakeDiag("MSL-Q302", "incose-r7-vague-term", 3, "/x.md"),
+    fakeDiag("MSL-Q302", "incose-r7-vague-term", 3, "/x.md"),
+    fakeDiag("MSL-Q304", "incose-r9-open-ended", 1, "/x.md"),
+  ];
+  const roll = computeScoreRollup(diags, [entry]);
+  assertEquals(roll.rollup.bandCounts["4-7"], 1);
+  assertEquals(roll.rollup.bandCounts["8-15"], 0);
+});
+
+Deno.test("score: boundary — score=8 lands in '8-15' (lower edge)", () => {
+  const entry = fakeEntry("STK_0001");
+  // 2×3 + 2×1 = 8
+  const diags = [
+    fakeDiag("MSL-Q302", "incose-r7-vague-term", 3, "/x.md"),
+    fakeDiag("MSL-Q302", "incose-r7-vague-term", 3, "/x.md"),
+    fakeDiag("MSL-Q304", "incose-r9-open-ended", 1, "/x.md"),
+    fakeDiag("MSL-Q304", "incose-r9-open-ended", 1, "/x.md"),
+  ];
+  const roll = computeScoreRollup(diags, [entry]);
+  assertEquals(roll.rollup.bandCounts["8-15"], 1);
+  assertEquals(roll.rollup.bandCounts["4-7"], 0);
+});
+
+Deno.test("score: boundary — score=15 lands in '8-15' (upper edge)", () => {
+  const entry = fakeEntry("STK_0001");
+  // 5×3 = 15
+  const diags: LintDiagnostic[] = [];
+  for (let k = 0; k < 5; k++) {
+    diags.push(fakeDiag("MSL-Q302", "incose-r7-vague-term", 3, "/x.md"));
+  }
+  const roll = computeScoreRollup(diags, [entry]);
+  assertEquals(roll.rollup.bandCounts["8-15"], 1);
+  assertEquals(roll.rollup.bandCounts["16+"], 0);
+});
+
+Deno.test("score: boundary — score=16 lands in '16+' (lower edge)", () => {
+  const entry = fakeEntry("STK_0001");
+  // 5×3 + 1 = 16
+  const diags: LintDiagnostic[] = [];
+  for (let k = 0; k < 5; k++) {
+    diags.push(fakeDiag("MSL-Q302", "incose-r7-vague-term", 3, "/x.md"));
+  }
+  diags.push(fakeDiag("MSL-Q304", "incose-r9-open-ended", 1, "/x.md"));
+  const roll = computeScoreRollup(diags, [entry]);
+  assertEquals(roll.rollup.bandCounts["16+"], 1);
+  assertEquals(roll.rollup.bandCounts["8-15"], 0);
 });

--- a/packages/markspec/core/mod.ts
+++ b/packages/markspec/core/mod.ts
@@ -252,7 +252,19 @@ export type {
 } from "./reporter/mod.ts";
 
 // Lint (prose-analysis)
-export { isProseScope, runLint } from "./lint/mod.ts";
-export type { LintDiagnostic, LintOptions, LintResult } from "./lint/mod.ts";
+export {
+  ANTI_PATTERN_NOTE,
+  computeScoreRollup,
+  isProseScope,
+  runLint,
+} from "./lint/mod.ts";
+export type {
+  EntryScore,
+  LintDiagnostic,
+  LintOptions,
+  LintResult,
+  RuleContribution,
+  ScoreRollup,
+} from "./lint/mod.ts";
 
 export * as typl from "./typl/mod.ts";

--- a/tests/e2e/lint_q500_test.ts
+++ b/tests/e2e/lint_q500_test.ts
@@ -32,8 +32,10 @@ Deno.test("Q500 e2e: undefined PascalCase fires", async () => {
       },
     },
   );
-  const parsed = JSON.parse(stdout) as Array<{ code: string; message: string }>;
-  const q500 = parsed.find((d) => d.code === "MSL-Q500");
+  const parsed = JSON.parse(stdout) as {
+    diagnostics: Array<{ code: string; message: string }>;
+  };
+  const q500 = parsed.diagnostics.find((d) => d.code === "MSL-Q500");
   assertEquals(q500 !== undefined, true);
   assertStringIncludes(q500!.message, "BrakeController");
 });
@@ -61,8 +63,8 @@ Deno.test("Q500 e2e: silent when DefinitionList defines it", async () => {
       },
     },
   );
-  const parsed = JSON.parse(stdout) as Array<{ code: string }>;
-  const q500s = parsed.filter((d) => d.code === "MSL-Q500");
+  const parsed = JSON.parse(stdout) as { diagnostics: Array<{ code: string }> };
+  const q500s = parsed.diagnostics.filter((d) => d.code === "MSL-Q500");
   assertEquals(q500s.length, 0);
 });
 

--- a/tests/e2e/lint_test.ts
+++ b/tests/e2e/lint_test.ts
@@ -5,7 +5,7 @@
  * fixture files and asserts exit codes, stdout, and stderr.
  */
 
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertStringIncludes } from "@std/assert";
 import { markspec } from "./helpers.ts";
 
 // ---------------------------------------------------------------------------
@@ -50,17 +50,21 @@ const SHORT_TITLE_FIXTURE = `- [REQ-001] Hi
 `;
 
 // ---------------------------------------------------------------------------
-// 1. Clean fixture exits 0 with valid JSON array output
+// 1. Clean fixture exits 0 with valid JSON object output
 // ---------------------------------------------------------------------------
 
-Deno.test("lint: clean fixture exits 0 and stdout is valid JSON array", async () => {
+Deno.test("lint: clean fixture exits 0 and stdout is valid JSON object", async () => {
   const { code, stdout } = await markspec(
     ["lint", "--format", "json", "req.md"],
     { files: { "project.yaml": PROJECT_YAML, "req.md": CLEAN_FIXTURE } },
   );
   assertEquals(code, 0);
-  const parsed = JSON.parse(stdout);
-  assertEquals(Array.isArray(parsed), true);
+  const parsed = JSON.parse(stdout) as {
+    diagnostics: unknown[];
+    score: unknown;
+  };
+  assertEquals(Array.isArray(parsed.diagnostics), true);
+  assertEquals(typeof parsed.score, "object");
 });
 
 // ---------------------------------------------------------------------------
@@ -74,9 +78,9 @@ Deno.test("lint: vague fixture triggers MSL-Q302 and MSL-Q303", async () => {
   );
   // Exit 2 = warnings present
   assertEquals(code, 2);
-  const diags = JSON.parse(stdout) as Array<{ code: string }>;
-  assertEquals(diags.some((d) => d.code === "MSL-Q302"), true);
-  assertEquals(diags.some((d) => d.code === "MSL-Q303"), true);
+  const parsed = JSON.parse(stdout) as { diagnostics: Array<{ code: string }> };
+  assertEquals(parsed.diagnostics.some((d) => d.code === "MSL-Q302"), true);
+  assertEquals(parsed.diagnostics.some((d) => d.code === "MSL-Q303"), true);
 });
 
 // ---------------------------------------------------------------------------
@@ -89,8 +93,8 @@ Deno.test("lint: entry with title < 3 chars triggers MSL-Q400", async () => {
     { files: { "project.yaml": PROJECT_YAML, "req.md": SHORT_TITLE_FIXTURE } },
   );
   // Q400 is info-severity so exit is 0, but the diagnostic appears in JSON
-  const diags = JSON.parse(stdout) as Array<{ code: string }>;
-  assertEquals(diags.some((d) => d.code === "MSL-Q400"), true);
+  const parsed = JSON.parse(stdout) as { diagnostics: Array<{ code: string }> };
+  assertEquals(parsed.diagnostics.some((d) => d.code === "MSL-Q400"), true);
 });
 
 // ---------------------------------------------------------------------------
@@ -115,10 +119,12 @@ Deno.test("lint: JSON output includes slug, group, scoreContribution", async () 
     { files: { "project.yaml": PROJECT_YAML, "req.md": VAGUE_FIXTURE } },
   );
   assertEquals(code, 2);
-  const diags = JSON.parse(stdout) as Array<
-    { code: string; slug: string; group: string; scoreContribution: number }
-  >;
-  const q302 = diags.find((d) => d.code === "MSL-Q302");
+  const parsed = JSON.parse(stdout) as {
+    diagnostics: Array<
+      { code: string; slug: string; group: string; scoreContribution: number }
+    >;
+  };
+  const q302 = parsed.diagnostics.find((d) => d.code === "MSL-Q302");
   assertEquals(q302 !== undefined, true);
   assertEquals(typeof q302!.slug, "string");
   assertEquals(typeof q302!.group, "string");
@@ -138,4 +144,74 @@ Deno.test("lint: markspec validate does not emit MSL-Q codes", async () => {
   assertEquals(code, 0);
   // No MSL-Q codes in validate output
   assertEquals(stderr.includes("MSL-Q"), false);
+});
+
+// ---------------------------------------------------------------------------
+// 7. Score rollup: JSON output contains score with bands + anti-pattern note
+// ---------------------------------------------------------------------------
+
+Deno.test("lint: JSON output contains score rollup with bands and anti-pattern note", async () => {
+  const { stdout } = await markspec(
+    ["lint", "--format", "json", "req.md"],
+    { files: { "project.yaml": PROJECT_YAML, "req.md": VAGUE_FIXTURE } },
+  );
+  const parsed = JSON.parse(stdout) as {
+    score: {
+      rollup: { bandCounts: Record<string, number>; mean: number };
+      antiPatternNote: string;
+    };
+  };
+  const { score } = parsed;
+  assertEquals(typeof score.rollup.mean, "number");
+  assertEquals(typeof score.rollup.bandCounts["0"], "number");
+  assertEquals(typeof score.rollup.bandCounts["1-3"], "number");
+  assertEquals(typeof score.rollup.bandCounts["4-7"], "number");
+  assertEquals(typeof score.rollup.bandCounts["8-15"], "number");
+  assertEquals(typeof score.rollup.bandCounts["16+"], "number");
+  assertEquals(
+    score.antiPatternNote,
+    "Optimize the requirements, not the score. The score is a smoke detector, not a KPI.",
+  );
+});
+
+// ---------------------------------------------------------------------------
+// 8. Score rollup: text output includes score summary line
+// ---------------------------------------------------------------------------
+
+Deno.test("lint: text output includes score summary in stderr", async () => {
+  const { stderr } = await markspec(
+    ["lint", "req.md"],
+    { files: { "project.yaml": PROJECT_YAML, "req.md": VAGUE_FIXTURE } },
+  );
+  assertStringIncludes(stderr, "Score:");
+  assertStringIncludes(stderr, "Mean:");
+  assertStringIncludes(stderr, "smoke detector");
+});
+
+// ---------------------------------------------------------------------------
+// 9. Score rollup: perEntry shape is correct
+// ---------------------------------------------------------------------------
+
+Deno.test("lint: JSON score.perEntry has correct shape", async () => {
+  const { stdout } = await markspec(
+    ["lint", "--format", "json", "req.md"],
+    { files: { "project.yaml": PROJECT_YAML, "req.md": VAGUE_FIXTURE } },
+  );
+  const parsed = JSON.parse(stdout) as {
+    score: {
+      perEntry: Array<{
+        entryId: string;
+        displayId: string;
+        score: number;
+        contributions: Array<
+          { code: string; weight: number; occurrences: number }
+        >;
+      }>;
+    };
+  };
+  assertEquals(parsed.score.perEntry.length > 0, true);
+  const entry = parsed.score.perEntry[0];
+  assertEquals(typeof entry.displayId, "string");
+  assertEquals(typeof entry.score, "number");
+  assertEquals(Array.isArray(entry.contributions), true);
 });


### PR DESCRIPTION
## Summary

Per-entry score + per-project roll-up + new `markspec lint` text and JSON output formats. Surfaces the `scoreContribution` data that slices 5-8 have been populating.

This is **slice 9 of 10** for the Stage-2 PA-3 prose-analysis build.

## What ships

**`core/lint/score.ts`** (new) — `computeScoreRollup(diagnostics, entries): ScoreRollup`. Pure function. Returns:

```json
{
  "perEntry": [
    {
      "entryId": "<ULID>",
      "displayId": "STK_BRK_0001",
      "score": 7,
      "contributions": [
        { "code": "MSL-Q500", "slug": "xref-glossary-undefined", "weight": 3, "occurrences": 1 },
        { "code": "MSL-Q302", "slug": "incose-r7-vague-term", "weight": 3, "occurrences": 1 },
        { "code": "MSL-Q304", "slug": "incose-r9-open-ended", "weight": 1, "occurrences": 1 }
      ]
    }
  ],
  "rollup": {
    "bandCounts": { "0": 12, "1-3": 4, "4-7": 2, "8-15": 1, "16+": 0 },
    "mean": 1.8
  },
  "antiPatternNote": "Optimize the requirements, not the score. The score is a smoke detector, not a KPI."
}
```

**Determinism guarantees** (all tested):
- `perEntry` sorted by `displayId`.
- `contributions[]` sorted by `weight DESC, code ASC`.
- All 5 band keys always present in canonical order (`0` / `1-3` / `4-7` / `8-15` / `16+` per ADR-021 Decision 4).
- Same input → byte-identical output.
- `antiPatternNote` is the EXACT string from ADR-021 Decision 5.

**CLI output:**
- **Text (default)**: diagnostics to stderr (clig.dev), followed by a one-line band summary and the anti-pattern note. Skipped on `--quiet`.
- **JSON (`--format json`)**: full structure including `score` to stdout.

**No trend artifact** — ADR-021 Decision 5 is binding. No CI score badge, no PR-comment integration, no score-delta tracker. The score is computed and emitted; teams compute trends in their own CI.

## Test plan

- [x] 17 unit tests covering aggregation, sorting, all 5 band counts, mean rounding, anti-pattern note exactness, determinism, and **explicit boundary tests for scores 1, 3, 4, 7, 8, 15, 16** (added during code review — guards against off-by-one if band predicates are ever edited).
- [x] All existing tests still pass.
- [x] Full suite: 2176 tests passing, 0 failing.
- [x] `just check` clean; `deno fmt --check` + `dprint check` clean.

## Reviews completed

- **Spec compliance + code quality** (sonnet pass): ✅ spec compliant; ⚠️ approved with nits. Two fixes in the follow-up commit:
  1. Boundary-value tests added for scores at every band edge (1, 3, 4, 7, 8, 15, 16).
  2. Fixed a stale comment claiming score `20` where the code computes `21`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
