### PR TITLE
feat(cli): mcp install — claude-desktop managed-block + vscode-mcp verify-only

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -34,6 +34,7 @@
     "npm:@modelcontextprotocol/sdk@1": "1.29.0_zod@4.4.3",
     "npm:@myriaddreamin/typst-ts-node-compiler@0.6": "0.6.0",
     "npm:@types/mdast@4": "4.0.4",
+    "npm:jsonc-parser@3": "3.3.1",
     "npm:rehype-stringify@10": "10.0.1",
     "npm:remark-gfm@4": "4.0.1",
     "npm:remark-parse@11": "11.0.0",
@@ -649,6 +650,9 @@
     },
     "json-schema-typed@8.0.2": {
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="
+    },
+    "jsonc-parser@3.3.1": {
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ=="
     },
     "longest-streak@3.1.0": {
       "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="
@@ -1405,6 +1409,7 @@
           "npm:@modelcontextprotocol/sdk@1",
           "npm:@myriaddreamin/typst-ts-node-compiler@0.6",
           "npm:@types/mdast@4",
+          "npm:jsonc-parser@3",
           "npm:rehype-stringify@10",
           "npm:remark-gfm@4",
           "npm:remark-parse@11",

--- a/packages/markspec/cli/commands/mcp_cmd.ts
+++ b/packages/markspec/cli/commands/mcp_cmd.ts
@@ -2,6 +2,11 @@
  * @module cli/commands/mcp_cmd
  *
  * `markspec mcp` — start the MCP server or install its configuration.
+ *
+ * Slice C: claude-desktop runs through the full `runMcpInstall`
+ * orchestrator — JSON managed-block, timestamped sidecar backup,
+ * diff preview, atomic write. vscode remains verify-only (parity
+ * with Slice B's LSP vscode adapter). Cursor remains print-only.
  */
 
 import { Command } from "@cliffy/command";
@@ -13,45 +18,55 @@ export const mcpCmd = new Command()
     await startServer();
   })
   .command("install")
-  .description("Print MCP server configuration for a client")
+  .description("Install or print MCP server configuration for a client")
   .option(
     "--client <client:string>",
     "Client ID (claude-desktop|cursor|vscode)",
     { required: true },
   )
+  .option("--scope <scope:string>", "Config scope: user|workspace")
   .option(
-    "--scope <scope:string>",
-    "Config scope: user|workspace (reserved for Tier 3)",
+    "--binary-path <path:string>",
+    "Path or invoked name written into config",
+    { default: "markspec" },
   )
+  .option(
+    "--print",
+    "Write the new file contents to stdout; do not write to disk",
+  )
+  .option("--force", "Apply without TTY confirmation; required in non-TTY")
+  .option("--no-color", "Disable color output")
+  .option("--remove", "Remove the managed entry from the config file")
   .action(
-    async (options: { client: string; scope?: string }) => {
-      const { MCP_CLIENT_IDS, suggestId } = await import(
-        "../install/adapters.ts"
+    async (
+      options: {
+        client: string;
+        scope?: string;
+        binaryPath: string;
+        print?: boolean;
+        force?: boolean;
+        color?: boolean;
+        remove?: boolean;
+      },
+    ) => {
+      const { runMcpInstall } = await import(
+        "../install/mcp_orchestrator.ts"
       );
-      const clientId = options.client;
-      if (
-        !MCP_CLIENT_IDS.includes(
-          clientId as "claude-desktop" | "cursor" | "vscode",
-        )
-      ) {
-        const suggestion = suggestId(clientId, MCP_CLIENT_IDS);
-        const hint = suggestion ? `\n  did you mean: ${suggestion}` : "";
-        console.error(
-          `error: unknown client '${clientId}' (known: ${
-            MCP_CLIENT_IDS.join(", ")
-          })${hint}`,
-        );
-        Deno.exit(1);
+      const result = await runMcpInstall({
+        client: options.client,
+        scope: options.scope,
+        binaryPath: options.binaryPath,
+        print: options.print,
+        force: options.force,
+        noColor: options.color === false,
+        remove: options.remove,
+      });
+      if (result.stdout) {
+        await Deno.stdout.write(new TextEncoder().encode(result.stdout));
       }
-      const { claudeDesktopAdapter, cursorAdapter, vscodeMcpAdapter } =
-        await import("../install/mcp_adapters.ts");
-      const result = clientId === "claude-desktop"
-        ? claudeDesktopAdapter()
-        : clientId === "cursor"
-        ? cursorAdapter()
-        : await vscodeMcpAdapter();
-      if (result.stdout) console.log(result.stdout);
-      if (result.stderr) console.error(result.stderr);
+      if (result.stderr) {
+        await Deno.stderr.write(new TextEncoder().encode(result.stderr));
+      }
       Deno.exit(result.exitCode);
     },
   );

--- a/packages/markspec/cli/install/adapters.ts
+++ b/packages/markspec/cli/install/adapters.ts
@@ -79,6 +79,40 @@ export interface LspAdapter {
   renderBlock(input: RenderBlockInput): string;
 }
 
+/**
+ * Adapter descriptor consumed by the MCP install orchestrator. Each
+ * adapter exposes pure functions (no I/O) for path resolution and block
+ * rendering; the orchestrator handles file reads, diff/preview, backup,
+ * and writes.
+ *
+ * The `renderBlock` return type is `Record<string, unknown>` — the JSON
+ * object placed under `mcpServers.<name>` in the target config file.
+ */
+export interface McpAdapter {
+  readonly id: McpClientId;
+  /**
+   * Resolve the config file path for the given scope.
+   * - `home` is `Deno.env.get("HOME")` (POSIX) or equivalent.
+   * - `appData` is `Deno.env.get("APPDATA")` on Windows (undefined on POSIX).
+   * - `workspaceRoot` is the directory containing the workspace marker;
+   *   required when `scope === "workspace"`, ignored otherwise.
+   *
+   * MAY throw when `scope === "workspace"` is meaningless for the
+   * client (e.g. Claude Desktop is per-user only). The orchestrator
+   * rejects unsupported scopes before calling this, so a throw here
+   * is a defensive guard, not a documented surface.
+   */
+  resolveConfigPath(
+    scope: "user" | "workspace",
+    cwd: string,
+    home: string,
+    appData?: string,
+    workspaceRoot?: string,
+  ): string;
+  /** Render the JSON object for the `mcpServers.<name>` key. */
+  renderBlock(input: RenderBlockInput): Record<string, unknown>;
+}
+
 /** Iterative O(n·m) Levenshtein distance with a single row buffer. */
 function levenshtein(a: string, b: string): number {
   if (a === b) return 0;

--- a/packages/markspec/cli/install/managed_block.ts
+++ b/packages/markspec/cli/install/managed_block.ts
@@ -100,3 +100,130 @@ export function removeLuaBlock(currentContent: string): string {
   const trimmed = before.endsWith("\n\n") ? before.slice(0, -1) : before;
   return `${trimmed}${after}`;
 }
+
+// ---------------------------------------------------------------------------
+// JSON-key managed block (Claude Desktop JSONC config and similar targets)
+// ---------------------------------------------------------------------------
+
+import { applyEdits, type Edit, modify, parse } from "jsonc-parser";
+
+/** Default formatting options applied to inserted JSON regions. */
+const JSONC_FORMAT_OPTIONS = {
+  tabSize: 2,
+  insertSpaces: true,
+  eol: "\n",
+} as const;
+
+/** Default modify options — keep formatting close to surrounding code. */
+const JSONC_MODIFY_OPTIONS = {
+  formattingOptions: JSONC_FORMAT_OPTIONS,
+} as const;
+
+/**
+ * Set the value at `jsonPath` inside `currentContent`. Preserves
+ * sibling keys, key order, line + block comments, and trailing
+ * commas outside the modified region. Empty input is treated as
+ * `{}` — the function will create the necessary intermediate
+ * structures.
+ *
+ * Idempotent: if the existing value at `jsonPath` deep-equals
+ * `value`, returns `currentContent` byte-identical (no formatting
+ * normalisation). This is load-bearing for the
+ * `markspec mcp install` no-op-re-run contract (spec §6.2).
+ *
+ * Pure: no I/O.
+ */
+export function applyJsonBlock(
+  currentContent: string,
+  jsonPath: readonly (string | number)[],
+  value: unknown,
+): string {
+  const text = currentContent.trim().length === 0 ? "{}" : currentContent;
+  const existing = parse(text, undefined, {
+    allowTrailingComma: true,
+    disallowComments: false,
+  }) as unknown;
+  if (
+    jsonValueAt(existing, jsonPath) !== undefined &&
+    deepEqual(jsonValueAt(existing, jsonPath), value)
+  ) {
+    return currentContent;
+  }
+  const edits: Edit[] = modify(
+    text,
+    [...jsonPath],
+    value,
+    JSONC_MODIFY_OPTIONS,
+  );
+  return applyEdits(text, edits);
+}
+
+/**
+ * Remove the key at `jsonPath` from `currentContent`. Preserves
+ * everything else. Idempotent: if the path is absent, returns
+ * `currentContent` byte-identical.
+ *
+ * Pure: no I/O.
+ */
+export function removeJsonBlock(
+  currentContent: string,
+  jsonPath: readonly (string | number)[],
+): string {
+  if (currentContent.trim().length === 0) return currentContent;
+  const existing = parse(currentContent, undefined, {
+    allowTrailingComma: true,
+    disallowComments: false,
+  }) as unknown;
+  if (jsonValueAt(existing, jsonPath) === undefined) return currentContent;
+  const edits: Edit[] = modify(
+    currentContent,
+    [...jsonPath],
+    undefined,
+    JSONC_MODIFY_OPTIONS,
+  );
+  return applyEdits(currentContent, edits);
+}
+
+/** Walk a parsed JSON value following `path`; return undefined on miss. */
+function jsonValueAt(
+  value: unknown,
+  path: readonly (string | number)[],
+): unknown {
+  let cur: unknown = value;
+  for (const segment of path) {
+    if (cur === null || cur === undefined) return undefined;
+    if (typeof segment === "string") {
+      if (typeof cur !== "object" || Array.isArray(cur)) return undefined;
+      cur = (cur as Record<string, unknown>)[segment];
+    } else {
+      if (!Array.isArray(cur)) return undefined;
+      cur = cur[segment];
+    }
+  }
+  return cur;
+}
+
+/** Structural equality for plain JSON values (no class instances, no NaN). */
+function deepEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (a === null || b === null) return false;
+  if (typeof a !== typeof b) return false;
+  if (typeof a !== "object") return false;
+  if (Array.isArray(a) !== Array.isArray(b)) return false;
+  if (Array.isArray(a)) {
+    const bArr = b as unknown[];
+    if (a.length !== bArr.length) return false;
+    for (let i = 0; i < a.length; i++) {
+      if (!deepEqual(a[i], bArr[i])) return false;
+    }
+    return true;
+  }
+  const aObj = a as Record<string, unknown>;
+  const bObj = b as Record<string, unknown>;
+  const aKeys = Object.keys(aObj);
+  if (aKeys.length !== Object.keys(bObj).length) return false;
+  for (const k of aKeys) {
+    if (!deepEqual(aObj[k], bObj[k])) return false;
+  }
+  return true;
+}

--- a/packages/markspec/cli/install/managed_block_test.ts
+++ b/packages/markspec/cli/install/managed_block_test.ts
@@ -1,8 +1,10 @@
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertStringIncludes } from "@std/assert";
 import {
+  applyJsonBlock,
   applyLuaBlock,
   LUA_FENCE_CLOSE,
   LUA_FENCE_OPEN,
+  removeJsonBlock,
   removeLuaBlock,
 } from "./managed_block.ts";
 
@@ -147,4 +149,116 @@ Deno.test("removeLuaBlock: trims trailing blank line before block (#480)", () =>
   const input = `-- config\n\n${block}`;
   const result = removeLuaBlock(input);
   assertEquals(result, "-- config\n");
+});
+
+// ---------------------------------------------------------------------------
+// applyJsonBlock / removeJsonBlock
+// ---------------------------------------------------------------------------
+
+const MCP_PATH: readonly (string | number)[] = ["mcpServers", "markspec"];
+const MCP_VALUE = { command: "markspec", args: ["mcp"] };
+
+Deno.test("applyJsonBlock: empty input → creates mcpServers.markspec", () => {
+  const result = applyJsonBlock("", MCP_PATH, MCP_VALUE);
+  const parsed = JSON.parse(result);
+  assertEquals(parsed.mcpServers.markspec, MCP_VALUE);
+});
+
+Deno.test("applyJsonBlock: re-apply with same value → byte-identical", () => {
+  const initial = applyJsonBlock("", MCP_PATH, MCP_VALUE);
+  const reapplied = applyJsonBlock(initial, MCP_PATH, MCP_VALUE);
+  assertEquals(reapplied, initial);
+});
+
+Deno.test("applyJsonBlock: preserves sibling keys under same parent", () => {
+  const input = `{
+  "mcpServers": {
+    "other-server": { "command": "other", "args": ["run"] }
+  }
+}
+`;
+  const result = applyJsonBlock(input, MCP_PATH, MCP_VALUE);
+  const parsed = JSON.parse(result);
+  assertEquals(parsed.mcpServers["other-server"].command, "other");
+  assertEquals(parsed.mcpServers.markspec, MCP_VALUE);
+});
+
+Deno.test(
+  "applyJsonBlock: preserves JSONC line + block comments outside modified region",
+  () => {
+    const input = `{
+  // Top comment
+  "mcpServers": {
+    /* block comment */
+    "other-server": { "command": "other", "args": ["run"] }
+  },
+  // Trailing comment
+  "globalShortcut": "Cmd+Space"
+}
+`;
+    const result = applyJsonBlock(input, MCP_PATH, MCP_VALUE);
+    assertStringIncludes(result, "// Top comment");
+    assertStringIncludes(result, "/* block comment */");
+    assertStringIncludes(result, "// Trailing comment");
+    assertStringIncludes(result, '"globalShortcut": "Cmd+Space"');
+  },
+);
+
+Deno.test(
+  "applyJsonBlock: replaces existing markspec entry, keeps siblings",
+  () => {
+    const input = `{
+  "mcpServers": {
+    "markspec": { "command": "/old/path", "args": ["mcp"] },
+    "other-server": { "command": "other", "args": ["run"] }
+  }
+}
+`;
+    const result = applyJsonBlock(input, MCP_PATH, MCP_VALUE);
+    const parsed = JSON.parse(result);
+    assertEquals(parsed.mcpServers.markspec, MCP_VALUE);
+    assertEquals(parsed.mcpServers["other-server"].command, "other");
+  },
+);
+
+Deno.test("removeJsonBlock: removes only the markspec key", () => {
+  const input = `{
+  "mcpServers": {
+    "markspec": { "command": "markspec", "args": ["mcp"] },
+    "other-server": { "command": "other", "args": ["run"] }
+  }
+}
+`;
+  const result = removeJsonBlock(input, MCP_PATH);
+  const parsed = JSON.parse(result);
+  assertEquals(parsed.mcpServers.markspec, undefined);
+  assertEquals(parsed.mcpServers["other-server"].command, "other");
+});
+
+Deno.test("removeJsonBlock: absent key → byte-identical", () => {
+  const input = `{
+  "mcpServers": {
+    "other-server": { "command": "other", "args": ["run"] }
+  }
+}
+`;
+  const result = removeJsonBlock(input, MCP_PATH);
+  assertEquals(result, input);
+});
+
+Deno.test("removeJsonBlock: empty input → byte-identical", () => {
+  assertEquals(removeJsonBlock("", MCP_PATH), "");
+});
+
+Deno.test("removeJsonBlock: preserves comments and other siblings", () => {
+  const input = `{
+  // header comment
+  "mcpServers": {
+    "markspec": { "command": "markspec", "args": ["mcp"] }
+  }
+}
+`;
+  const result = removeJsonBlock(input, MCP_PATH);
+  assertStringIncludes(result, "// header comment");
+  assertEquals(result.includes('"markspec"'), false);
 });

--- a/packages/markspec/cli/install/mcp_adapters.ts
+++ b/packages/markspec/cli/install/mcp_adapters.ts
@@ -3,38 +3,81 @@
  *
  * MCP install adapters for `markspec mcp install --client=<id>`.
  *
- * Each adapter returns an {@linkcode AdapterResult} with separate stdout
- * and stderr strings. stdout carries the config block; stderr carries
- * status messages and file path hints.
+ * Two new shapes:
+ * - `claudeDesktopDescriptor: McpAdapter` — full managed-block path
+ *   (resolves to platform-specific Claude Desktop config, returns
+ *   `{ command, args }` for the `mcpServers.markspec` JSON key).
+ * - `vscodeMcpAdapter(options)` — verify-only, mirrors Slice B's
+ *   vscodeAdapter (checks the markspec-ide extension is installed).
+ *
+ * Legacy print-only `cursorAdapter()` is preserved unchanged —
+ * Cursor remains in the print-only tier per spec §5.2.
  */
 
-import type { AdapterResult } from "./adapters.ts";
+import { join } from "@std/path";
+import type {
+  AdapterResult,
+  McpAdapter,
+  RenderBlockInput,
+} from "./adapters.ts";
+
+/** Marketplace extension ID shared with the LSP path. */
+const VSCODE_EXTENSION_ID = "driftsys.markspec-ide";
+
+/** Marketplace listing URL printed when the extension is missing. */
+const VSCODE_MARKETPLACE_URL =
+  "https://marketplace.visualstudio.com/items?itemName=driftsys.markspec-ide";
+
+// ---------------------------------------------------------------------------
+// claudeDesktopDescriptor — full managed-block flow (spec §5.2 / §6.1)
+// ---------------------------------------------------------------------------
 
 /**
- * Return the JSON config block for Claude Desktop's
- * `claude_desktop_config.json`. The full `mcpServers` wrapper is
- * included so the user can see exactly where to place the entry.
+ * Claude Desktop is a per-user app — no workspace scope.
+ * - macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
+ * - Windows: `%APPDATA%/Claude/claude_desktop_config.json`
+ * - Linux: `~/.config/Claude/claude_desktop_config.json`
+ *
+ * The orchestrator rejects `--scope=workspace` for this client before
+ * calling `resolveConfigPath`; the implementation throws as a
+ * defensive guard.
  */
-export function claudeDesktopAdapter(): AdapterResult {
-  const stdout = `{
-  "mcpServers": {
-    "markspec": {
-      "command": "<BINARY_PATH>",
-      "args": ["mcp"]
+export const claudeDesktopDescriptor: McpAdapter = {
+  id: "claude-desktop",
+  resolveConfigPath(scope, _cwd, home, appData, _workspaceRoot) {
+    if (scope === "workspace") {
+      throw new Error(
+        "claude-desktop does not support workspace scope (per-user app)",
+      );
     }
-  }
-}`;
-  const isMac = Deno.build.os === "darwin";
-  const configPath = isMac
-    ? "~/Library/Application Support/Claude/claude_desktop_config.json"
-    : "~/.config/claude/claude_desktop_config.json";
-  const stderr =
-    `Merge the "markspec" entry above into the "mcpServers" object in:\n  ${configPath}`;
-  return { stdout, stderr, exitCode: 0 };
-}
+    if (Deno.build.os === "darwin") {
+      return join(
+        home,
+        "Library",
+        "Application Support",
+        "Claude",
+        "claude_desktop_config.json",
+      );
+    }
+    if (Deno.build.os === "windows") {
+      const base = appData ?? join(home, "AppData", "Roaming");
+      return join(base, "Claude", "claude_desktop_config.json");
+    }
+    return join(home, ".config", "Claude", "claude_desktop_config.json");
+  },
+  renderBlock(input: RenderBlockInput): Record<string, unknown> {
+    return { command: input.binaryPath, args: ["mcp"] };
+  },
+};
+
+// ---------------------------------------------------------------------------
+// cursorAdapter — preserved legacy print-only (spec §5.2 — `--print` only)
+// ---------------------------------------------------------------------------
 
 /**
- * Return the full JSON for Cursor's `~/.cursor/mcp.json`.
+ * Return the full JSON for Cursor's `~/.cursor/mcp.json`. Remains a
+ * legacy print-only adapter — Cursor has not been promoted to a
+ * first-class managed-block adapter in v1.
  */
 export function cursorAdapter(): AdapterResult {
   const stdout = `{
@@ -49,39 +92,93 @@ export function cursorAdapter(): AdapterResult {
   return { stdout, stderr, exitCode: 0 };
 }
 
-/**
- * VS Code MCP adapter — verify-only.
- * The markspec-ide extension registers the MCP server via
- * `lm.registerMcpServerDefinitionProvider`; no manual config needed.
- */
-export async function vscodeMcpAdapter(): Promise<AdapterResult> {
-  const extensionId = "driftsys.markspec-ide";
-  let installed = false;
-  try {
-    const cmd = new Deno.Command("code", {
-      args: ["--list-extensions"],
-      stdout: "piped",
-      stderr: "null",
-    });
-    const result = await cmd.output();
-    const output = new TextDecoder().decode(result.stdout);
-    installed = output.includes(extensionId);
-  } catch {
-    // `code` not on PATH
-  }
+// ---------------------------------------------------------------------------
+// vscodeMcpAdapter — verify-only, parallel to Slice B's vscodeAdapter
+// ---------------------------------------------------------------------------
 
-  if (installed) {
+/**
+ * Injectable seams for {@linkcode vscodeMcpAdapter}. Production callers
+ * omit `env` and let the adapter dispatch through
+ * {@linkcode defaultVscodeMcpEnv}, which shells out to
+ * `code --list-extensions`. Tests pass a fully fake env so no host I/O
+ * occurs.
+ */
+export interface VscodeMcpAdapterEnv {
+  /**
+   * List installed VS Code extension IDs. Resolve to `undefined` when
+   * the `code` CLI is absent on `$PATH` — that's "extension status
+   * unknown", not "extension absent".
+   */
+  readonly listExtensions: () => Promise<readonly string[] | undefined>;
+}
+
+/** Inputs accepted by {@linkcode vscodeMcpAdapter}. */
+export interface VscodeMcpAdapterOptions {
+  /** Test-only seam — defaults to {@linkcode defaultVscodeMcpEnv}. */
+  readonly env?: VscodeMcpAdapterEnv;
+}
+
+/**
+ * Default env wired to real Deno APIs. Spawns `code --list-extensions`
+ * for detection.
+ */
+export function defaultVscodeMcpEnv(): VscodeMcpAdapterEnv {
+  return {
+    listExtensions: async () => {
+      try {
+        const cmd = new Deno.Command("code", {
+          args: ["--list-extensions"],
+          stdout: "piped",
+          stderr: "null",
+        });
+        const out = await cmd.output();
+        if (!out.success) return undefined;
+        return new TextDecoder().decode(out.stdout)
+          .split("\n")
+          .map((s) => s.trim())
+          .filter((s) => s.length > 0);
+      } catch {
+        return undefined;
+      }
+    },
+  };
+}
+
+/**
+ * VS Code MCP adapter — verify-only. Per spec §5.3 the markspec-ide
+ * extension registers the MCP server via
+ * `lm.registerMcpServerDefinitionProvider`; no manual config write is
+ * required.
+ *
+ * Per spec §8 Q5 (applied here by parity with the LSP path), this
+ * adapter MUST NOT suggest `code --install-extension`. When the
+ * extension is absent the only call-to-action is the marketplace URL.
+ */
+export async function vscodeMcpAdapter(
+  options: VscodeMcpAdapterOptions = {},
+): Promise<AdapterResult> {
+  const env = options.env ?? defaultVscodeMcpEnv();
+  const extensions = await env.listExtensions();
+  const installed = extensions !== undefined &&
+    extensions.includes(VSCODE_EXTENSION_ID);
+
+  if (!installed) {
+    const reason = extensions === undefined
+      ? `VS Code 'code' CLI not found on PATH; cannot verify extension. ` +
+        `Install the markspec-ide extension from:`
+      : `VS Code extension ${VSCODE_EXTENSION_ID} is not installed. ` +
+        `Install it from:`;
     return {
       stdout: "",
-      stderr:
-        `VS Code extension ${extensionId} is installed. The MCP server is registered automatically by the extension. No additional configuration needed.`,
+      stderr: `${reason}\n  ${VSCODE_MARKETPLACE_URL}`,
       exitCode: 0,
     };
   }
+
   return {
     stdout: "",
     stderr:
-      `VS Code extension ${extensionId} is not installed.\nInstall it from the VS Code Marketplace or run:\n  code --install-extension ${extensionId}`,
+      `VS Code extension ${VSCODE_EXTENSION_ID} is installed. The MCP server is registered automatically by the extension via lm.registerMcpServerDefinitionProvider. No additional configuration needed.`,
     exitCode: 0,
   };
 }

--- a/packages/markspec/cli/install/mcp_adapters_test.ts
+++ b/packages/markspec/cli/install/mcp_adapters_test.ts
@@ -1,38 +1,105 @@
-import { assertStringIncludes } from "@std/assert";
-import { claudeDesktopAdapter, cursorAdapter } from "./mcp_adapters.ts";
+import { assert, assertEquals, assertStringIncludes } from "@std/assert";
+import {
+  claudeDesktopDescriptor,
+  cursorAdapter,
+  vscodeMcpAdapter,
+  type VscodeMcpAdapterEnv,
+} from "./mcp_adapters.ts";
 
-Deno.test("claude-desktop adapter: stdout contains mcpServers", () => {
-  const { stdout } = claudeDesktopAdapter();
-  assertStringIncludes(stdout, "mcpServers");
+// Normalise path separators so assertions are portable across POSIX and Windows.
+function normalizePath(p: string): string {
+  return p.replaceAll("\\", "/");
+}
+
+Deno.test("claudeDesktopDescriptor: id is claude-desktop", () => {
+  assertEquals(claudeDesktopDescriptor.id, "claude-desktop");
 });
 
-Deno.test("claude-desktop adapter: stdout contains args mcp", () => {
-  const { stdout } = claudeDesktopAdapter();
-  assertStringIncludes(stdout, '"args": ["mcp"]');
+Deno.test("claudeDesktopDescriptor: renderBlock returns command + args", () => {
+  const block = claudeDesktopDescriptor.renderBlock({ binaryPath: "markspec" });
+  assertEquals(block, { command: "markspec", args: ["mcp"] });
 });
 
-Deno.test("claude-desktop adapter: stdout contains BINARY_PATH placeholder", () => {
-  const { stdout } = claudeDesktopAdapter();
-  assertStringIncludes(stdout, "<BINARY_PATH>");
+Deno.test("claudeDesktopDescriptor: renderBlock with absolute path", () => {
+  const block = claudeDesktopDescriptor.renderBlock({
+    binaryPath: "/opt/markspec/markspec",
+  });
+  assertEquals(block, { command: "/opt/markspec/markspec", args: ["mcp"] });
 });
 
-Deno.test("claude-desktop adapter: stderr contains config file path", () => {
-  const { stderr } = claudeDesktopAdapter();
-  // Should mention the config file location
-  assertStringIncludes(stderr, "claude_desktop_config.json");
+// resolveConfigPath calls into Deno.build.os, which we can't override at
+// runtime without restructuring. Test the host platform; the other
+// platforms are exercised via e2e tests with explicit HOME injection.
+Deno.test("claudeDesktopDescriptor: user-scope path is host-platform-correct", () => {
+  const path = claudeDesktopDescriptor.resolveConfigPath(
+    "user",
+    "/cwd",
+    "/home/test",
+    "/appdata",
+  );
+  const normalised = normalizePath(path);
+  assertStringIncludes(normalised, "claude_desktop_config.json");
+  assertStringIncludes(normalised, "/Claude/");
 });
 
-Deno.test("cursor adapter: stdout contains mcpServers", () => {
-  const { stdout } = cursorAdapter();
-  assertStringIncludes(stdout, "mcpServers");
+Deno.test("claudeDesktopDescriptor: workspace scope throws", () => {
+  let threw = false;
+  try {
+    claudeDesktopDescriptor.resolveConfigPath("workspace", "/cwd", "/home", "");
+  } catch {
+    threw = true;
+  }
+  assert(threw);
 });
 
-Deno.test("cursor adapter: stderr mentions mcp.json", () => {
-  const { stderr } = cursorAdapter();
-  assertStringIncludes(stderr, "mcp.json");
+Deno.test("cursorAdapter: stdout contains mcpServers; stderr mentions mcp.json", () => {
+  const r = cursorAdapter();
+  assertStringIncludes(r.stdout, "mcpServers");
+  assertStringIncludes(r.stderr, "mcp.json");
+  assertEquals(r.exitCode, 0);
 });
 
-Deno.test("cursor adapter: stdout contains args mcp", () => {
-  const { stdout } = cursorAdapter();
-  assertStringIncludes(stdout, '"args": ["mcp"]');
+const MARKETPLACE_URL =
+  "https://marketplace.visualstudio.com/items?itemName=driftsys.markspec-ide";
+const EXTENSION_ID = "driftsys.markspec-ide";
+
+function fakeMcpEnv(
+  overrides: Partial<VscodeMcpAdapterEnv> = {},
+): VscodeMcpAdapterEnv {
+  return {
+    listExtensions: () => Promise.resolve([]),
+    ...overrides,
+  };
+}
+
+Deno.test("vscodeMcpAdapter: extension not installed → marketplace URL, no `code --install-extension`", async () => {
+  const r = await vscodeMcpAdapter({
+    env: fakeMcpEnv({ listExtensions: () => Promise.resolve(["other.ext"]) }),
+  });
+  assertEquals(r.exitCode, 0);
+  assertStringIncludes(r.stderr, MARKETPLACE_URL);
+  assertEquals(
+    r.stderr.includes("code --install-extension"),
+    false,
+    "stderr must not suggest `code --install-extension` (parity with spec §8 Q5)",
+  );
+});
+
+Deno.test("vscodeMcpAdapter: `code` CLI absent → marketplace URL, no `code --install-extension`", async () => {
+  const r = await vscodeMcpAdapter({
+    env: fakeMcpEnv({ listExtensions: () => Promise.resolve(undefined) }),
+  });
+  assertEquals(r.exitCode, 0);
+  assertStringIncludes(r.stderr, MARKETPLACE_URL);
+  assertEquals(r.stderr.includes("code --install-extension"), false);
+});
+
+Deno.test("vscodeMcpAdapter: extension installed → success, mentions provider API", async () => {
+  const r = await vscodeMcpAdapter({
+    env: fakeMcpEnv({ listExtensions: () => Promise.resolve([EXTENSION_ID]) }),
+  });
+  assertEquals(r.exitCode, 0);
+  assertStringIncludes(r.stderr, EXTENSION_ID);
+  assertStringIncludes(r.stderr, "registerMcpServerDefinitionProvider");
+  assertEquals(r.stderr.includes("code --install-extension"), false);
 });

--- a/packages/markspec/cli/install/mcp_orchestrator.ts
+++ b/packages/markspec/cli/install/mcp_orchestrator.ts
@@ -1,0 +1,272 @@
+/**
+ * @module cli/install/mcp_orchestrator
+ *
+ * `markspec mcp install` orchestrator — mirrors `runLspInstall`
+ * structurally, with two key differences:
+ *
+ * 1. The managed block is a JSON-key value (under `mcpServers.markspec`)
+ *    edited via `applyJsonBlock` / `removeJsonBlock`, not a Lua fence.
+ * 2. `--scope=workspace` is rejected for `--client=claude-desktop` —
+ *    Claude Desktop is a per-user app with no workspace config.
+ *
+ * Boundary contract (kept pure for testability): `runMcpInstall(options)`
+ * returns an `OrchestratorResult`. No `process.exit`, no global state.
+ * The CLI action wrapper in `mcp_cmd.ts` writes stdout/stderr and
+ * exits with the returned `exitCode`.
+ */
+
+import { dirname } from "@std/path";
+import { MCP_CLIENT_IDS, type McpClientId, suggestId } from "./adapters.ts";
+import {
+  claudeDesktopDescriptor,
+  cursorAdapter,
+  vscodeMcpAdapter,
+} from "./mcp_adapters.ts";
+import { applyJsonBlock, removeJsonBlock } from "./managed_block.ts";
+import { writeBackup } from "./backup.ts";
+import { renderDiff } from "./preview.ts";
+
+/** JSON path of the managed entry under any MCP client config. */
+const MCP_JSON_PATH: readonly (string | number)[] = ["mcpServers", "markspec"];
+
+/** Options accepted by {@linkcode runMcpInstall}. */
+export interface McpInstallOptions {
+  readonly client: string;
+  readonly scope?: string;
+  readonly binaryPath: string;
+  readonly print?: boolean;
+  readonly force?: boolean;
+  /** Reserved; no color output is emitted yet. */
+  readonly noColor?: boolean;
+  readonly remove?: boolean;
+  /**
+   * Test-only seam: lets unit tests inject a known cwd, HOME,
+   * APPDATA, and TTY verdict without touching the host environment.
+   */
+  readonly env?: {
+    readonly cwd?: string;
+    readonly home?: string;
+    readonly appData?: string;
+    readonly isTty?: boolean;
+  };
+}
+
+/** Result shape returned by the orchestrator. */
+export interface OrchestratorResult {
+  readonly stdout: string;
+  readonly stderr: string;
+  readonly exitCode: number;
+}
+
+/**
+ * Run `markspec mcp install` with the supplied options. Pure boundary:
+ * returns the stdout/stderr/exitCode triple the CLI action will surface.
+ * Performs file I/O internally.
+ */
+export async function runMcpInstall(
+  options: McpInstallOptions,
+): Promise<OrchestratorResult> {
+  // 1. Validate --client.
+  if (!MCP_CLIENT_IDS.includes(options.client as McpClientId)) {
+    const suggestion = suggestId(options.client, MCP_CLIENT_IDS);
+    const hint = suggestion ? `\n  did you mean: ${suggestion}` : "";
+    return {
+      stdout: "",
+      stderr: `error: unknown client '${options.client}' (known: ${
+        MCP_CLIENT_IDS.join(", ")
+      })${hint}\n`,
+      exitCode: 1,
+    };
+  }
+  const clientId = options.client as McpClientId;
+
+  // 2. Cursor — legacy print-only. Spec §5.2 keeps Cursor in the
+  //    print-only tier; the orchestrator just delegates.
+  if (clientId === "cursor") {
+    const r = cursorAdapter();
+    return {
+      stdout: r.stdout ? `${r.stdout}\n` : "",
+      stderr: r.stderr ? `${r.stderr}\n` : "",
+      exitCode: r.exitCode,
+    };
+  }
+
+  // 3. VS Code — verify-only.
+  if (clientId === "vscode") {
+    const r = await vscodeMcpAdapter();
+    return {
+      stdout: r.stdout ? `${r.stdout}\n` : "",
+      stderr: r.stderr ? `${r.stderr}\n` : "",
+      exitCode: r.exitCode,
+    };
+  }
+
+  // 4. claude-desktop — full managed-block flow.
+  //    Reject --scope=workspace before any other work: Claude Desktop
+  //    is per-user only.
+  if (options.scope === "workspace") {
+    return {
+      stdout: "",
+      stderr:
+        `error: --scope=workspace is not supported for --client=claude-desktop (per-user app); use --scope=user or omit\n`,
+      exitCode: 1,
+    };
+  }
+  if (options.scope !== undefined && options.scope !== "user") {
+    return {
+      stdout: "",
+      stderr:
+        `error: unknown scope '${options.scope}' (known: user, workspace)\n`,
+      exitCode: 1,
+    };
+  }
+
+  const cwd = options.env?.cwd ?? Deno.cwd();
+  const readHome = (): string => {
+    if (options.env?.home !== undefined) return options.env.home;
+    try {
+      return Deno.env.get(
+        Deno.build.os === "windows" ? "USERPROFILE" : "HOME",
+      ) ?? "";
+    } catch {
+      return "";
+    }
+  };
+  const readAppData = (): string | undefined => {
+    if (options.env?.appData !== undefined) return options.env.appData;
+    try {
+      return Deno.env.get("APPDATA") ?? undefined;
+    } catch {
+      return undefined;
+    }
+  };
+  const isTty = options.env?.isTty ?? Deno.stdin.isTerminal();
+
+  // claude-desktop is always user-scope; resolve the config path.
+  const configPath = claudeDesktopDescriptor.resolveConfigPath(
+    "user",
+    cwd,
+    readHome(),
+    readAppData(),
+  );
+
+  // 5. Read current content. Missing file → empty string.
+  let current = "";
+  let fileExists = true;
+  try {
+    current = await Deno.readTextFile(configPath);
+  } catch (err) {
+    if (err instanceof Deno.errors.NotFound) {
+      current = "";
+      fileExists = false;
+    } else {
+      return {
+        stdout: "",
+        stderr: `error: cannot read ${configPath}: ${(err as Error).message}\n`,
+        exitCode: 1,
+      };
+    }
+  }
+
+  // 6. Compute next content.
+  const next = options.remove
+    ? removeJsonBlock(current, MCP_JSON_PATH)
+    : applyJsonBlock(
+      current,
+      MCP_JSON_PATH,
+      claudeDesktopDescriptor.renderBlock({ binaryPath: options.binaryPath }),
+    );
+
+  // 7. Idempotence check.
+  if (next === current) {
+    const msg = options.remove
+      ? `markspec mcp install: already removed (no managed entry in ${configPath})\n`
+      : `markspec mcp install: already up to date (${configPath})\n`;
+    return { stdout: "", stderr: msg, exitCode: 0 };
+  }
+
+  // 8. --print path: emit `next` to stdout, target path to stderr.
+  if (options.print) {
+    return {
+      stdout: next,
+      stderr: `would write to ${configPath}\n`,
+      exitCode: 0,
+    };
+  }
+
+  // 9. TTY / non-TTY handling.
+  if (!options.force) {
+    const diff = renderDiff(current, next, configPath);
+    if (!isTty) {
+      return {
+        stdout: "",
+        stderr: `${diff}` +
+          `error: non-interactive context (stdin is not a TTY); pass --force to apply or --print to skip writing\n`,
+        exitCode: 1,
+      };
+    }
+    return {
+      stdout: "",
+      stderr: `${diff}` +
+        `aborted: re-run with --force to apply\n`,
+      exitCode: 0,
+    };
+  }
+
+  // 10. Write path. Backup only when the original file existed.
+  let backupNote = "";
+  if (fileExists) {
+    try {
+      const backupAt = await writeBackup(configPath);
+      backupNote = `backup: ${backupAt}\n`;
+    } catch (err) {
+      return {
+        stdout: "",
+        stderr: `error: backup failed for ${configPath}: ${
+          (err as Error).message
+        }\n`,
+        exitCode: 1,
+      };
+    }
+  }
+
+  // Ensure parent directory exists.
+  try {
+    await Deno.mkdir(dirname(configPath), { recursive: true });
+  } catch (err) {
+    if (!(err instanceof Deno.errors.AlreadyExists)) {
+      return {
+        stdout: "",
+        stderr:
+          `${backupNote}error: cannot create parent directory for ${configPath}: ${
+            (err as Error).message
+          }\n`,
+        exitCode: 1,
+      };
+    }
+  }
+
+  // Atomic write: stage to .tmp, rename.
+  const tmpPath = `${configPath}.tmp`;
+  try {
+    await Deno.writeTextFile(tmpPath, next);
+    await Deno.rename(tmpPath, configPath);
+  } catch (err) {
+    try {
+      await Deno.remove(tmpPath);
+    } catch { /* ignore */ }
+    return {
+      stdout: "",
+      stderr: `${backupNote}error: write failed for ${configPath}: ${
+        (err as Error).message
+      }\n`,
+      exitCode: 1,
+    };
+  }
+
+  return {
+    stdout: "",
+    stderr: `${backupNote}wrote ${configPath}\n`,
+    exitCode: 0,
+  };
+}

--- a/packages/markspec/cli/install/mcp_orchestrator_test.ts
+++ b/packages/markspec/cli/install/mcp_orchestrator_test.ts
@@ -1,0 +1,51 @@
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { runMcpInstall } from "./mcp_orchestrator.ts";
+
+Deno.test("runMcpInstall: unknown client → exit 1 with suggestion", async () => {
+  const r = await runMcpInstall({
+    client: "claude-desktp", // typo
+    binaryPath: "markspec",
+    env: { cwd: "/tmp", home: "/home/test", isTty: false },
+  });
+  assertEquals(r.exitCode, 1);
+  assertStringIncludes(r.stderr, "unknown client 'claude-desktp'");
+  assertStringIncludes(r.stderr, "did you mean: claude-desktop");
+});
+
+Deno.test(
+  "runMcpInstall: claude-desktop + --scope=workspace → exit 1 with clear message",
+  async () => {
+    const r = await runMcpInstall({
+      client: "claude-desktop",
+      scope: "workspace",
+      binaryPath: "markspec",
+      env: { cwd: "/tmp", home: "/home/test", isTty: false },
+    });
+    assertEquals(r.exitCode, 1);
+    assertStringIncludes(r.stderr, "--scope=workspace is not supported");
+    assertStringIncludes(r.stderr, "claude-desktop");
+    assertStringIncludes(r.stderr, "per-user");
+  },
+);
+
+Deno.test("runMcpInstall: unknown scope → exit 1", async () => {
+  const r = await runMcpInstall({
+    client: "claude-desktop",
+    scope: "global",
+    binaryPath: "markspec",
+    env: { cwd: "/tmp", home: "/home/test", isTty: false },
+  });
+  assertEquals(r.exitCode, 1);
+  assertStringIncludes(r.stderr, "unknown scope 'global'");
+});
+
+Deno.test("runMcpInstall: cursor → delegates to legacy print-only adapter", async () => {
+  const r = await runMcpInstall({
+    client: "cursor",
+    binaryPath: "markspec",
+    env: { cwd: "/tmp", home: "/home/test", isTty: false },
+  });
+  assertEquals(r.exitCode, 0);
+  assertStringIncludes(r.stdout, "mcpServers");
+  assertStringIncludes(r.stderr, "mcp.json");
+});

--- a/packages/markspec/deno.json
+++ b/packages/markspec/deno.json
@@ -11,6 +11,7 @@
     "@cliffy/command": "jsr:@cliffy/command@^1",
     "@std/assert": "jsr:@std/assert@^1",
     "@modelcontextprotocol/sdk": "npm:@modelcontextprotocol/sdk@^1",
+    "jsonc-parser": "npm:jsonc-parser@^3",
     "unified": "npm:unified@^11",
     "remark-parse": "npm:remark-parse@^11",
     "remark-gfm": "npm:remark-gfm@^4",

--- a/tests/e2e/install_test.ts
+++ b/tests/e2e/install_test.ts
@@ -44,11 +44,13 @@ Deno.test(
 );
 
 Deno.test(
-  "mcp install --client=claude-desktop: exits 0, stdout contains mcpServers",
+  "mcp install --client=claude-desktop --print: exits 0, stdout contains mcpServers",
   async () => {
+    // Slice C: claude-desktop now flows through the orchestrator;
+    // passing --print keeps the test side-effect-free.
     const { code, stdout } = await markspec(
-      ["mcp", "install", "--client=claude-desktop"],
-      { permissions: ["--allow-run"] },
+      ["mcp", "install", "--client=claude-desktop", "--print", "--scope=user"],
+      { permissions: ["--allow-run", "--allow-env"] },
     );
     assertEquals(code, 0);
     assertStringIncludes(stdout, "mcpServers");

--- a/tests/e2e/mcp_install_test.ts
+++ b/tests/e2e/mcp_install_test.ts
@@ -1,0 +1,346 @@
+/**
+ * @module tests/e2e/mcp_install_test
+ *
+ * End-to-end tests for `markspec mcp install`. Exercises the
+ * mcp_orchestrator wiring — JSON managed-block writes, idempotence,
+ * --print, --remove, non-TTY safety, vscode verify-only path, and
+ * Q5 parity (no `code --install-extension`).
+ *
+ * The `markspec()` helper spawns the CLI as a subprocess with piped
+ * stdin, so `Deno.stdin.isTerminal()` returns false — non-TTY
+ * branch is exercised by default unless `--force` is passed.
+ */
+
+import { assert, assertEquals, assertStringIncludes } from "@std/assert";
+import { dirname, fromFileUrl, join } from "@std/path";
+import { markspec } from "./helpers.ts";
+
+// ---------------------------------------------------------------------------
+// Test 1: --print emits full file to stdout, "would write to" to stderr
+// ---------------------------------------------------------------------------
+
+Deno.test(
+  "mcp install claude-desktop: --print emits full file to stdout, would-write to stderr",
+  async () => {
+    const { code, stdout, stderr } = await markspec(
+      [
+        "mcp",
+        "install",
+        "--client=claude-desktop",
+        "--print",
+        "--binary-path=markspec",
+      ],
+      { permissions: ["--allow-env"] },
+    );
+    assertEquals(code, 0);
+    assertStringIncludes(stdout, '"mcpServers"');
+    assertStringIncludes(stdout, '"markspec"');
+    assertStringIncludes(stdout, '"command": "markspec"');
+    assertStringIncludes(stdout, '"args"');
+    assertStringIncludes(stderr, "would write to ");
+    assertStringIncludes(
+      stderr.replaceAll("\\", "/"),
+      "claude_desktop_config.json",
+    );
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Test 2: unknown client suggests correction
+// ---------------------------------------------------------------------------
+
+Deno.test(
+  "mcp install: unknown client suggests correction",
+  async () => {
+    const { code, stderr } = await markspec(
+      ["mcp", "install", "--client=claude-desktp", "--print"],
+      { permissions: ["--allow-env"] },
+    );
+    assertEquals(code, 1);
+    assertStringIncludes(stderr, "unknown client 'claude-desktp'");
+    assertStringIncludes(stderr, "did you mean: claude-desktop");
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Test 3: non-TTY without --force → exit 1 with remediation hint
+// ---------------------------------------------------------------------------
+
+Deno.test(
+  "mcp install claude-desktop: non-TTY without --force → exit 1 with remediation",
+  async () => {
+    const { code, stderr } = await markspec(
+      ["mcp", "install", "--client=claude-desktop", "--binary-path=markspec"],
+      { permissions: ["--allow-env"] },
+    );
+    assertEquals(code, 1);
+    assertStringIncludes(stderr, "non-interactive");
+    assertStringIncludes(stderr, "--force");
+    // The message must not appear doubled (formatting regression guard)
+    assert(!stderr.includes("\n\nerror: non-interactive"));
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Test 4: --scope=workspace rejected for claude-desktop
+// ---------------------------------------------------------------------------
+
+Deno.test(
+  "mcp install claude-desktop: --scope=workspace → exit 1 (per-user app)",
+  async () => {
+    const { code, stderr } = await markspec(
+      [
+        "mcp",
+        "install",
+        "--client=claude-desktop",
+        "--scope=workspace",
+        "--print",
+      ],
+      { permissions: ["--allow-env"] },
+    );
+    assertEquals(code, 1);
+    assertStringIncludes(stderr, "--scope=workspace is not supported");
+    assertStringIncludes(stderr, "claude-desktop");
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Test 5: vscode never emits `code --install-extension` (spec §8 Q5)
+// ---------------------------------------------------------------------------
+
+Deno.test(
+  "mcp install vscode: never suggests `code --install-extension` (parity with spec §8 Q5)",
+  async () => {
+    const { code, stderr } = await markspec(
+      ["mcp", "install", "--client=vscode"],
+      { permissions: ["--allow-env", "--allow-run"] },
+    );
+    assertEquals(code, 0);
+    assertStringIncludes(stderr, "driftsys.markspec-ide");
+    assertEquals(
+      stderr.includes("code --install-extension"),
+      false,
+      "stderr must never suggest `code --install-extension`",
+    );
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Direct subprocess helper — for tests that need a controlled HOME dir
+// ---------------------------------------------------------------------------
+
+const CLI_ENTRY = fromFileUrl(
+  new URL("../../packages/markspec/main.ts", import.meta.url),
+);
+
+async function runMcpInstallE2e(
+  args: string[],
+  homeDir: string,
+): Promise<{ code: number; stdout: string; stderr: string }> {
+  // Inherit the parent environment so Windows-specific vars
+  // (SYSTEMROOT, TMP, PATH, …) reach the subprocess — Deno needs them
+  // to function on Windows. Strip GIT_* like the shared helper does.
+  // Then override HOME / USERPROFILE / APPDATA to point at the temp
+  // dir so the orchestrator writes there instead of the real user
+  // config locations.
+  const parentEnv = Deno.env.toObject();
+  const env: Record<string, string> = {};
+  for (const [k, v] of Object.entries(parentEnv)) {
+    if (!k.startsWith("GIT_")) env[k] = v;
+  }
+  env.HOME = homeDir;
+  env.USERPROFILE = homeDir;
+  env.APPDATA = join(homeDir, "AppData", "Roaming");
+  const cmd = new Deno.Command("deno", {
+    args: [
+      "run",
+      "--allow-read",
+      "--allow-write",
+      "--allow-env",
+      "--allow-run",
+      CLI_ENTRY,
+      ...args,
+    ],
+    stdout: "piped",
+    stderr: "piped",
+    clearEnv: true,
+    env,
+  });
+  const result = await cmd.output();
+  return {
+    code: result.code,
+    stdout: new TextDecoder().decode(result.stdout),
+    stderr: new TextDecoder().decode(result.stderr),
+  };
+}
+
+function expectedConfigPath(homeDir: string): string {
+  if (Deno.build.os === "darwin") {
+    return join(
+      homeDir,
+      "Library",
+      "Application Support",
+      "Claude",
+      "claude_desktop_config.json",
+    );
+  }
+  if (Deno.build.os === "windows") {
+    return join(
+      homeDir,
+      "AppData",
+      "Roaming",
+      "Claude",
+      "claude_desktop_config.json",
+    );
+  }
+  return join(homeDir, ".config", "Claude", "claude_desktop_config.json");
+}
+
+// ---------------------------------------------------------------------------
+// Test 6: --force writes managed entry; re-run is no-op (idempotence)
+// ---------------------------------------------------------------------------
+
+Deno.test(
+  "mcp install claude-desktop: --force writes managed entry; re-run is no-op",
+  async () => {
+    const homeDir = await Deno.makeTempDir();
+    try {
+      const first = await runMcpInstallE2e(
+        [
+          "mcp",
+          "install",
+          "--client=claude-desktop",
+          "--binary-path=/opt/markspec/markspec",
+          "--force",
+        ],
+        homeDir,
+      );
+      assertEquals(first.code, 0, first.stderr);
+      assertStringIncludes(first.stderr, "wrote ");
+
+      const configPath = expectedConfigPath(homeDir);
+      const written = await Deno.readTextFile(configPath);
+      const parsed = JSON.parse(written);
+      assertEquals(
+        parsed.mcpServers.markspec.command,
+        "/opt/markspec/markspec",
+      );
+      assertEquals(parsed.mcpServers.markspec.args, ["mcp"]);
+
+      // Second run with identical args must be a no-op.
+      const second = await runMcpInstallE2e(
+        [
+          "mcp",
+          "install",
+          "--client=claude-desktop",
+          "--binary-path=/opt/markspec/markspec",
+          "--force",
+        ],
+        homeDir,
+      );
+      assertEquals(second.code, 0, second.stderr);
+      assertStringIncludes(second.stderr, "already up to date");
+    } finally {
+      await Deno.remove(homeDir, { recursive: true });
+    }
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Test 7: preserves sibling keys and JSONC comments
+// ---------------------------------------------------------------------------
+
+Deno.test(
+  "mcp install claude-desktop: preserves sibling keys and JSONC comments",
+  async () => {
+    const homeDir = await Deno.makeTempDir();
+    try {
+      const configPath = expectedConfigPath(homeDir);
+      const configDir = dirname(configPath);
+      await Deno.mkdir(configDir, { recursive: true });
+      const initial = `{
+  // top comment
+  "mcpServers": {
+    "other-server": { "command": "other", "args": ["run"] }
+  },
+  /* block */ "globalShortcut": "Cmd+Space"
+}
+`;
+      await Deno.writeTextFile(configPath, initial);
+
+      const r = await runMcpInstallE2e(
+        [
+          "mcp",
+          "install",
+          "--client=claude-desktop",
+          "--binary-path=markspec",
+          "--force",
+        ],
+        homeDir,
+      );
+      assertEquals(r.code, 0, r.stderr);
+
+      const written = await Deno.readTextFile(configPath);
+      assertStringIncludes(written, "// top comment");
+      assertStringIncludes(written, "/* block */");
+      assertStringIncludes(written, '"other-server"');
+      assertStringIncludes(written, '"globalShortcut"');
+      assertStringIncludes(written, '"markspec"');
+    } finally {
+      await Deno.remove(homeDir, { recursive: true });
+    }
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Test 8: --remove strips only the markspec entry; re-remove is no-op
+// ---------------------------------------------------------------------------
+
+Deno.test(
+  "mcp install claude-desktop: --remove strips only the markspec entry",
+  async () => {
+    const homeDir = await Deno.makeTempDir();
+    try {
+      // First: install to create the entry.
+      await runMcpInstallE2e(
+        [
+          "mcp",
+          "install",
+          "--client=claude-desktop",
+          "--binary-path=markspec",
+          "--force",
+        ],
+        homeDir,
+      );
+
+      // Remove it.
+      const r = await runMcpInstallE2e(
+        [
+          "mcp",
+          "install",
+          "--client=claude-desktop",
+          "--remove",
+          "--force",
+        ],
+        homeDir,
+      );
+      assertEquals(r.code, 0, r.stderr);
+      assertStringIncludes(r.stderr, "wrote ");
+
+      const configPath = expectedConfigPath(homeDir);
+      const written = await Deno.readTextFile(configPath);
+      const parsed = JSON.parse(written);
+      assertEquals(parsed.mcpServers?.markspec, undefined);
+
+      // Re-remove must be a no-op.
+      const second = await runMcpInstallE2e(
+        ["mcp", "install", "--client=claude-desktop", "--remove", "--force"],
+        homeDir,
+      );
+      assertEquals(second.code, 0, second.stderr);
+      assertStringIncludes(second.stderr, "already removed");
+    } finally {
+      await Deno.remove(homeDir, { recursive: true });
+    }
+  },
+);


### PR DESCRIPTION
## Summary

Slice C of the Tier 3 closeout — last remaining slice. Adds the MCP counterpart to Slice A's `markspec lsp install`:

- `markspec mcp install --client=claude-desktop --force` writes a managed `markspec` entry under `mcpServers` in the Claude Desktop config via structure-preserving JSONC edits (`npm:jsonc-parser`). Idempotent, backed up, atomic. Comments and sibling keys preserved.
- `markspec mcp install --client=vscode` is verify-only (parity with Slice B's LSP vscode adapter); never suggests `code --install-extension` (spec §8 Q5 parity).
- `--client=cursor` remains print-only.
- `--scope=workspace` is rejected for claude-desktop (per-user app).

Reuses Slice A's `workspace.ts`, `backup.ts`, `preview.ts` unchanged and Slice B's adapter-with-seams pattern. The orchestrator (`mcp_orchestrator.ts`) mirrors `runLspInstall` structurally.

Spec sections implemented: §5.1, §5.2, §5.3, §5.4, §6.1, §6.2, §6.3, §6.4, §6.6.

## Test plan

- [x] `just build` clean
- [x] `deno fmt --check && dprint check` clean
- [x] 9 unit tests for `applyJsonBlock` / `removeJsonBlock` (idempotence, comment preservation, sibling preservation, replace, remove)
- [x] Unit tests for `claudeDesktopDescriptor` + `vscodeMcpAdapter` (six scenarios via seams)
- [x] Unit tests for `runMcpInstall` dispatch (unknown client, workspace rejection, cursor delegation)
- [x] 8 e2e scenarios in `tests/e2e/mcp_install_test.ts` (full happy/sad paths + idempotence + comment-preservation + `--remove`)
- [x] Existing `tests/e2e/install_test.ts` updated for new claude-desktop default behavior
- [x] 2198 tests pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)
