### PR TITLE
fix(core): hash only viewed bytes in sha256Bytes

### DIFF
--- a/packages/markspec/core/lock/hash.ts
+++ b/packages/markspec/core/lock/hash.ts
@@ -19,10 +19,16 @@ export async function sha256Bytes(bytes: Uint8Array): Promise<string> {
   // Copy into a fresh ArrayBuffer so the argument satisfies the strict
   // BufferSource overload (Uint8Array<ArrayBufferLike> includes
   // SharedArrayBuffer which Web Crypto does not accept).
-  const plain: ArrayBuffer = bytes.buffer instanceof ArrayBuffer
-    ? bytes.buffer
-    : new Uint8Array(bytes).buffer;
-  const buf = await crypto.subtle.digest("SHA-256", plain);
+  // Slice only the viewed portion — bytes.buffer may be a larger backing store
+  // when bytes is a sub-buffer view. The copy also satisfies the strict
+  // BufferSource overload (excludes SharedArrayBuffer).
+  const plain = bytes.buffer instanceof ArrayBuffer
+    ? new Uint8Array(bytes.buffer, bytes.byteOffset, bytes.byteLength)
+    : new Uint8Array(bytes);
+  const buf = await crypto.subtle.digest(
+    "SHA-256",
+    plain as Uint8Array<ArrayBuffer>,
+  );
   return "sha256:" + toHex(new Uint8Array(buf));
 }
 

--- a/packages/markspec/core/lock/hash_test.ts
+++ b/packages/markspec/core/lock/hash_test.ts
@@ -18,6 +18,14 @@ Deno.test("sha256String: 'abc' has known hash", async () => {
   );
 });
 
+Deno.test("sha256Bytes: sub-buffer view hashes only the viewed slice", async () => {
+  const full = new TextEncoder().encode("XXXabcYYY");
+  const view = full.subarray(3, 6); // "abc"
+  const fromView = await sha256Bytes(view);
+  const fromDirect = await sha256Bytes(new TextEncoder().encode("abc"));
+  assertEquals(fromView, fromDirect);
+});
+
 Deno.test("sha256Bytes: deterministic across calls", async () => {
   const a = await sha256Bytes(new TextEncoder().encode("hello world"));
   const b = await sha256Bytes(new TextEncoder().encode("hello world"));


### PR DESCRIPTION
Fixes #492

When `bytes` is a sub-buffer view, `bytes.buffer` is the entire backing ArrayBuffer. Now uses `byteOffset`/`byteLength` to hash only the viewed slice.