### PR TITLE
docs(spec): align LSP feature additions §4 with implementation

### DIFF
--- a/docs/spec/internal/markspec-lsp-feature-additions.md
+++ b/docs/spec/internal/markspec-lsp-feature-additions.md
@@ -207,23 +207,36 @@ interface ProfileType {
   /** Type name (e.g. "stakeholder-requirement", "software-architecture-description"). */
   readonly name: string;
 
-  /** Display-ID prefix (e.g. "STK_AEB_", "SAD_"). */
+  /** Display-ID prefix derived from the type's `displayIdPattern`
+   * (placeholder stripped). Empty string when no pattern is declared. */
   readonly prefix: string;
 
-  /** Category bucket for coloring — "req" / "spec" / "test" / etc. */
-  readonly category: string;
-
-  /** Color metadata, per palette. */
-  readonly color: {
-    readonly print: string;  // hex e.g. "#4477AA"
-    readonly screen: string; // hex e.g. "#0077BB"
-  };
+  /** Palette hue name resolved from the type's color role through
+   * `EffectiveProfile.colors`. `null` when no role is declared or the
+   * value is not a member of `PALETTE_HUES`. */
+  readonly color: PaletteHue | null;
 }
+
+type PaletteHue =
+  | "blue" | "cyan" | "teal" | "orange" | "red" | "purple" | "grey";
 ```
 
-The shapes match the existing `EffectiveProfile` returned by
-`core/profile/mod.ts`. The LSP wrapper serializes the in-memory representation
-to JSON; no additional metadata.
+The shape derives directly from `core/profile`'s in-memory model: `prefix` comes
+from `EffectiveTypeDef.displayIdPattern` with the `{...}` placeholder stripped,
+and `color` resolves the type's role through `EffectiveProfile.colors` to a
+palette hue.
+
+**Hex / category derivation: out of scope for v1.** Clients map hue → hex
+through their own design-token bundle (the VS Code extension already ships
+`theme/markspec.css` + `package.json` `contributes.colors`). The legacy
+prefix→bucket mapping in CLAUDE.md is being retired per ADR-011; profile-
+declared category buckets land in a follow-up once ADR-011 ships. A future
+additive `role?: string` field on `ProfileType` can surface the profile's
+semantic color role when a consumer needs it — clients ignore unknown fields.
+
+See `docs/superpowers/specs/2026-05-25-lsp-profile-request-design.md` §1, §3.4
+for the resolution rationale and `packages/markspec/lsp/profile_request.ts` for
+the implementation.
 
 ### 4.4 Caching and invalidation
 
@@ -231,8 +244,8 @@ The server caches the response from the last `core/profile` load. It MUST
 invalidate the cache when:
 
 - The profile chain changes (`.markspec.yaml` or `project.yaml` modified —
-  detected via `workspace/didChangeWatchedFiles` or the existing periodic
-  reload).
+  detected via the server's dynamic `workspace/didChangeWatchedFiles`
+  registration, debounced 500ms server-side).
 - The workspace root changes (typically only on editor restart).
 
 On cache invalidation, the server fires a `markspec/profileChanged` notification

--- a/docs/spec/internal/markspec-vscode-authoring.md
+++ b/docs/spec/internal/markspec-vscode-authoring.md
@@ -338,9 +338,15 @@ Mechanism:
 - The extension generates a CSS rule per type, e.g.:
   ```css
   .markspec-type-stakeholder-requirement {
-    border-left-color: var(--markspec-color-req, #4477AA);
+    border-left-color: var(--markspec-color-blue, #4477AA);
   }
   ```
+  The variable is keyed by the **palette hue** the LSP returns for the type
+  (`"blue" | "cyan" | "teal" | "orange" | "red" | "purple" | "grey"`). The
+  extension provides `--markspec-color-{hue}` definitions through its bundled
+  `theme/markspec.css`; the inline hex fallback covers the bootstrap window
+  before the stylesheet loads. The same `--markspec-color-{hue}` convention
+  powers the published HTML book — single rendering path.
 - The extension injects this stylesheet into the preview via the markdown
   preview's `addContent` hook (or via a dynamic stylesheet contribution if VS
   Code's API allows; otherwise via `data:` URI in the markdown-it output).


### PR DESCRIPTION
## Summary

PR #491 shipped `markspec/profile` with a hue-name `color` field instead of the hex pair + `category` bucket the spec originally described. This PR updates the spec to match what is actually implemented (the spec is `Status: Draft`, so amend-after-implement is appropriate). Three small edits, all in §4 — no source code touched.

## What changed

### `markspec-lsp-feature-additions.md` §4.3 — ProfileType shape

- Drop `category: string`. The legacy prefix→bucket mapping in CLAUDE.md is being retired per ADR-011; no profile-declared bucket exists yet to surface.
- Replace `color: { print: string; screen: string }` (hex pairs) with `color: PaletteHue | null` where `PaletteHue` is the 7-name palette union from `core/model/palette.ts`.
- Add a rationale paragraph: clients map hue → hex through their own design-token bundle (the VS Code extension already ships `theme/markspec.css` + `package.json` `contributes.colors`). A future additive `role?: string` field can surface the profile's semantic role when a consumer needs it — clients ignore unknown fields.

### `markspec-lsp-feature-additions.md` §4.4 — caching invalidation trigger

- Replace "detected via `workspace/didChangeWatchedFiles` or the existing periodic reload" (the periodic reload never existed) with "detected via the server's dynamic `workspace/didChangeWatchedFiles` registration, debounced 500ms server-side". Matches the actual PR #491 implementation.

### `markspec-vscode-authoring.md` §4.4 — CSS example

- Change `var(--markspec-color-req, ...)` to `var(--markspec-color-blue, ...)` — keyed by palette hue, not bucket name.
- Add note that the extension provides `--markspec-color-{hue}` via its bundled `theme/markspec.css`; the inline hex is a bootstrap fallback. Same convention powers the published HTML book.

## Test Plan

- [x] `dprint check` clean.
- [x] `deno fmt --check` clean (no TypeScript touched).
- [x] No code changes — pre-commit hook passed `deno check`, `deno lint`, and `git std lint` regardless.

## Out of scope

- Re-evaluating §4.3 once ADR-011 lands the profile-declared bucket model; an additive `category?: string` field can land then without breaking the v1 shape.
- The optional `role?: string` field is sketched in the rationale paragraph but not added to the v1 interface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
