### PR TITLE
feat(core): slice 10 (final) — Q300/Q301 passive + Q902 disable-unused

### DIFF
--- a/packages/markspec/core/lint/rules/passive.ts
+++ b/packages/markspec/core/lint/rules/passive.ts
@@ -1,0 +1,322 @@
+/**
+ * @module core/lint/rules/passive
+ *
+ * Passive-voice and subject-verb rules for PA-3 (slice 10):
+ *
+ *   MSL-Q300  incose-r2-active-voice  (warn, score 3)
+ *   MSL-Q301  incose-r3-subject-verb  (info, score 1)
+ *
+ * Q300 — passive voice construction in a normative sentence.
+ *
+ *   Detection heuristic: be-verb immediately before a past-participial
+ *   form in the same sentence AND the sentence contains a normative modal.
+ *
+ *   Two surface forms are detected:
+ *     (a) Modal + "be" + past-participial word:
+ *         "shall be applied", "should be processed", "must be done"
+ *     (b) Copular be-verb (is/are/was/were) + past-participial word in a
+ *         normative sentence:
+ *         "Pressure is applied within 200 ms." with a modal elsewhere in
+ *         the sentence.
+ *
+ *   Past-participial heuristic: word ending in `-ed` (regular) OR a
+ *   known irregular list. Words ending in `-ed` that are NOT passive
+ *   participials (e.g. "needed", "provided") are intentionally included
+ *   — false-positive risk is acknowledged and the `warn` severity is
+ *   calibrated for it. Adjectives like "ready", "busy", "free" do NOT
+ *   end in `-ed` and are therefore NOT flagged. "shall be ready" does
+ *   NOT trigger Q300 — the heuristic correctly skips it because "ready"
+ *   is not past-participial shaped.
+ *
+ *   Known limit: "shall be based on" is a borderline case — "based" is
+ *   past-participial, so Q300 fires. Authors should rewrite as "shall
+ *   derive from" or suppress with Markspec-disable + Rationale.
+ *
+ * Q301 — subject/verb appropriateness heuristic.
+ *
+ *   Two narrow sub-patterns:
+ *     (a) Pronoun subject: sentence starts with It/This/That + modal.
+ *         "It shall be possible to …" is a common non-actor construction.
+ *     (b) Existential-there construction: sentence starts with
+ *         "There shall/should/must …".
+ *
+ *   Both patterns indicate the sentence lacks a clear actor and are
+ *   captured by the incose-r3 guidance. Q309 (pronouns) may co-fire
+ *   with (a) — both are valid; they fire for different reasons.
+ *
+ * All rules operate on paragraph-kind body blocks only.
+ */
+
+import type { Entry } from "../../model/mod.ts";
+import type { BodyBlock, ParagraphNode } from "../../ast/nodes.ts";
+import type { LintDiagnostic } from "../types.ts";
+import { segmentSentences } from "../segmenter.ts";
+import { loadLexicon } from "../../lexicons/mod.ts";
+import { offsetToRange } from "../range_util.ts";
+import { MODAL_COMPOUND_RE } from "./modal_sentence.ts";
+
+const ABBREVS = loadLexicon("sentence-abbrev");
+
+// ---------------------------------------------------------------------------
+// Regexes
+// ---------------------------------------------------------------------------
+
+/**
+ * Be-verb set used in passive detection. Covers all finite and non-finite
+ * forms of "be". Compound negations with `not` are included so "shall not
+ * be applied" is also caught.
+ */
+const BE_VERB_RE =
+  /\b(is|are|was|were|be|been|being|is not|are not|was not|were not)\b/i;
+
+/**
+ * Known irregular past participials. These words do not end in `-ed`
+ * but are unambiguously past participials in a passive construction
+ * (e.g. "shall be done", "shall be made", "shall be seen").
+ *
+ * Kept deliberately narrow. Words like "known" and "given" are omitted
+ * because they function as adjectives most of the time in requirements
+ * prose ("a given condition", "a known limit").
+ */
+const IRREGULAR_PARTICIPIALS: ReadonlySet<string> = new Set([
+  "done",
+  "made",
+  "seen",
+  "held",
+  "built",
+  "sent",
+  "set",
+  "put",
+  "run",
+  "cut",
+  "read",
+  "fed",
+  "led",
+  "met",
+  "kept",
+  "left",
+  "lost",
+  "shown",
+  "found",
+  "bound",
+  "born",
+  "brought",
+  "bought",
+  "caught",
+  "drawn",
+  "driven",
+  "eaten",
+  "fallen",
+  "flown",
+  "forgotten",
+  "frozen",
+  "gotten",
+  "given",
+  "grown",
+  "hidden",
+  "hit",
+  "hung",
+  "known",
+  "laid",
+  "lain",
+  "paid",
+  "proven",
+  "ridden",
+  "risen",
+  "said",
+  "spoken",
+  "stolen",
+  "taken",
+  "thrown",
+  "told",
+  "understood",
+  "woken",
+  "worn",
+  "written",
+]);
+
+/**
+ * Returns true when `word` looks like a past participial:
+ *   - ends in `-ed` (regular), OR
+ *   - is in the irregular list.
+ */
+function isPastParticipial(word: string): boolean {
+  const lower = word.toLowerCase();
+  if (lower.endsWith("ed")) return true;
+  return IRREGULAR_PARTICIPIALS.has(lower);
+}
+
+/**
+ * Detect a passive construction in a sentence.
+ *
+ * Strategy: scan for a be-verb. If found, look at the next non-whitespace
+ * word after it. If that word is past-participial shaped, it is a passive
+ * construction.
+ *
+ * The scan is greedy — we check each be-verb occurrence and report passive
+ * on the first match.
+ *
+ * Handles:
+ *   - "shall be applied" — modal before be-verb (be + applied)
+ *   - "is required" — copular be + required
+ *   - "shall be fully processed" — adverb between be and participial
+ *     (NOT detected by this heuristic — the "next word" check would
+ *     see "fully" and stop. Accepted limitation.)
+ */
+function detectPassive(sentence: string): boolean {
+  // Reset before each use — BE_VERB_RE has no `g` flag, but for safety
+  // we use a fresh exec each call.
+  const beMatch = BE_VERB_RE.exec(sentence);
+  if (!beMatch) return false;
+  // Look at the word immediately after the be-verb match.
+  const afterBe = sentence.slice(beMatch.index + beMatch[0].length);
+  // Skip leading whitespace.
+  const trimmed = afterBe.trimStart();
+  if (trimmed.length === 0) return false;
+  // Extract the first word.
+  const wordMatch = /^([a-zA-Z]+)/.exec(trimmed);
+  if (!wordMatch) return false;
+  return isPastParticipial(wordMatch[1]);
+}
+
+/**
+ * Q301 pronoun-subject heuristic: sentence starts with It/This/That
+ * (case-insensitive after initial capital) followed by whitespace and a
+ * modal verb somewhere in the sentence.
+ */
+const PRONOUN_SUBJECT_RE = /^(it|this|that|there)\s/i;
+
+/**
+ * Detect a pronoun or existential-there sentence subject.
+ * Fires when the sentence starts with It/This/That/There and the
+ * sentence is normative (already checked before calling).
+ */
+function detectPronounSubject(sentence: string): boolean {
+  return PRONOUN_SUBJECT_RE.test(sentence.trim());
+}
+
+// ---------------------------------------------------------------------------
+// Rule code registry
+// ---------------------------------------------------------------------------
+
+/** All passive-voice rule codes exported for the suppression-hygiene set. */
+export const PASSIVE_RULE_CODES: ReadonlySet<string> = new Set([
+  "MSL-Q300",
+  "MSL-Q301",
+]);
+
+// ---------------------------------------------------------------------------
+// Emit helpers
+// ---------------------------------------------------------------------------
+
+function emitQ300(
+  sentence: string,
+  sentenceOffset: number,
+  paragraphText: string,
+  baseLine: number,
+  baseCol: number,
+  entry: Entry,
+): LintDiagnostic {
+  const range = offsetToRange(
+    paragraphText,
+    sentenceOffset,
+    sentence.length,
+    baseLine,
+    baseCol,
+  );
+  return {
+    code: "MSL-Q300",
+    slug: "incose-r2-active-voice",
+    severity: "warning",
+    scoreContribution: 3,
+    group: "incose",
+    message:
+      `incose-r2-active-voice: passive construction detected in normative sentence; rewrite in active voice`,
+    location: entry.location,
+    range,
+  };
+}
+
+function emitQ301(
+  sentence: string,
+  sentenceOffset: number,
+  paragraphText: string,
+  baseLine: number,
+  baseCol: number,
+  entry: Entry,
+): LintDiagnostic {
+  const range = offsetToRange(
+    paragraphText,
+    sentenceOffset,
+    sentence.length,
+    baseLine,
+    baseCol,
+  );
+  return {
+    code: "MSL-Q301",
+    slug: "incose-r3-subject-verb",
+    severity: "info",
+    scoreContribution: 1,
+    group: "incose",
+    message:
+      `incose-r3-subject-verb: sentence subject is a pronoun or existential 'there'; replace with the explicit actor`,
+    location: entry.location,
+    range,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Public entry point
+// ---------------------------------------------------------------------------
+
+/**
+ * Run passive-voice rules (Q300–Q301) on an entry's paragraph bodies.
+ *
+ * For each paragraph, segments into sentences. For each normative sentence
+ * (one containing a modal verb):
+ *   - Q300 fires when a passive construction is detected (be-verb +
+ *     past-participial word).
+ *   - Q301 fires when the sentence subject is a pronoun (It/This/That)
+ *     or existential-there construction.
+ */
+export function runPassiveRules(entry: Entry): LintDiagnostic[] {
+  const out: LintDiagnostic[] = [];
+  const blocks: readonly BodyBlock[] = entry.bodyAst ?? [];
+
+  for (const block of blocks) {
+    if (block.kind !== "paragraph") continue;
+    const p = block as ParagraphNode;
+    const text = p.content.text;
+
+    // Compute file-absolute base line for this paragraph.
+    // p.range.start.line is body-relative (line 1 = first body line).
+    // entry.bodyStartLine is file-absolute. Fall back to entry.location.line + 1.
+    const absBodyStart = entry.bodyStartLine ?? (entry.location.line + 1);
+    const absLine = absBodyStart + p.range.start.line - 1;
+    const baseCol = p.range.start.column;
+
+    const sentences = segmentSentences(text, ABBREVS);
+    for (const sentence of sentences) {
+      const s = sentence.text;
+      const off = sentence.offset;
+
+      // Only normative sentences (containing a modal verb).
+      MODAL_COMPOUND_RE.lastIndex = 0;
+      const isNormative = MODAL_COMPOUND_RE.test(s);
+      MODAL_COMPOUND_RE.lastIndex = 0;
+      if (!isNormative) continue;
+
+      // Q300: passive voice detection (be-verb + past participial).
+      if (detectPassive(s)) {
+        out.push(emitQ300(s, off, text, absLine, baseCol, entry));
+      }
+
+      // Q301: pronoun or existential-there subject.
+      if (detectPronounSubject(s)) {
+        out.push(emitQ301(s, off, text, absLine, baseCol, entry));
+      }
+    }
+  }
+
+  return out;
+}

--- a/packages/markspec/core/lint/rules/passive.ts
+++ b/packages/markspec/core/lint/rules/passive.ts
@@ -66,8 +66,13 @@ const ABBREVS = loadLexicon("sentence-abbrev");
  * forms of "be". Compound negations with `not` are included so "shall not
  * be applied" is also caught.
  */
-const BE_VERB_RE =
-  /\b(is|are|was|were|be|been|being|is not|are not|was not|were not)\b/i;
+// Bare be-verb forms only. Listing `is not`/`are not`/etc. as additional
+// alternatives would be dead code — left-to-right alternation would match
+// the bare form first. Accepted limitation: `"is not applied"` is NOT
+// detected as passive (the post-be-verb scan in `detectPassive` finds
+// `not` and stops). Negated passive through a modal (`"shall not be
+// applied"`) IS detected because the be-verb matched is `be`, not `is`.
+const BE_VERB_RE = /\b(is|are|was|were|be|been|being)\b/i;
 
 /**
  * Known irregular past participials. These words do not end in `-ed`
@@ -111,12 +116,12 @@ const IRREGULAR_PARTICIPIALS: ReadonlySet<string> = new Set([
   "forgotten",
   "frozen",
   "gotten",
-  "given",
+  // 'given' deliberately omitted — adjective-ambiguous ("a given condition").
   "grown",
   "hidden",
   "hit",
   "hung",
-  "known",
+  // 'known' deliberately omitted — adjective-ambiguous ("a known limit").
   "laid",
   "lain",
   "paid",
@@ -153,8 +158,11 @@ function isPastParticipial(word: string): boolean {
  * word after it. If that word is past-participial shaped, it is a passive
  * construction.
  *
- * The scan is greedy — we check each be-verb occurrence and report passive
- * on the first match.
+ * First-match scan — only the first be-verb in the sentence is inspected.
+ * A sentence with `is critical and shall be applied` is detected via the
+ * `be applied` pair (the first be-verb `is` would be followed by `critical`
+ * which isn't past-participial; the regex finds the first be-verb only, so
+ * this sentence WON'T detect — accepted limitation, narrow heuristic).
  *
  * Handles:
  *   - "shall be applied" — modal before be-verb (be + applied)

--- a/packages/markspec/core/lint/rules/passive_test.ts
+++ b/packages/markspec/core/lint/rules/passive_test.ts
@@ -1,0 +1,280 @@
+/**
+ * @module core/lint/rules/passive_test
+ *
+ * Unit tests for MSL-Q300 (incose-r2-active-voice) and
+ * MSL-Q301 (incose-r3-subject-verb).
+ */
+
+import { assertEquals } from "@std/assert";
+import type { BodyBlock } from "../../ast/nodes.ts";
+import type { Entry } from "../../model/mod.ts";
+import { makeDisplayId } from "../../model/mod.ts";
+import { runPassiveRules } from "./passive.ts";
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function makeParagraph(text: string, line = 1, column = 1): BodyBlock {
+  return {
+    kind: "paragraph",
+    content: { text },
+    range: {
+      start: { line, column },
+      end: { line, column: column + text.length },
+    },
+  };
+}
+
+function makeEntry(body: string): Entry {
+  return {
+    displayId: makeDisplayId("STK_0001"),
+    title: "Test requirement",
+    body,
+    bodyAst: [makeParagraph(body)],
+    rawAttributes: [
+      { key: "Id", value: "01HGW2Q8MNP3RSTVWXYZABCDEF" },
+      { key: "Type", value: "Requirement" },
+    ],
+    typedAttributes: new Map([
+      ["Id", ["01HGW2Q8MNP3RSTVWXYZABCDEF"]],
+      ["Type", ["Requirement"]],
+    ]),
+    id: "01HGW2Q8MNP3RSTVWXYZABCDEF",
+    type: "Requirement",
+    shape: "Authored",
+    location: { file: "test.md", line: 1, column: 1 },
+    source: { kind: "markdown" },
+    bodyTokens: [],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// MSL-Q300: incose-r2-active-voice
+// ---------------------------------------------------------------------------
+
+Deno.test("Q300: fires on 'shall be applied' (modal + be + -ed)", () => {
+  const entry = makeEntry("Pressure shall be applied within 200 ms.");
+  const diags = runPassiveRules(entry);
+  assertEquals(diags.some((d) => d.code === "MSL-Q300"), true);
+});
+
+Deno.test("Q300: fires on 'shall be processed' (regular -ed)", () => {
+  const entry = makeEntry("The signal shall be processed by the controller.");
+  const diags = runPassiveRules(entry);
+  assertEquals(diags.some((d) => d.code === "MSL-Q300"), true);
+});
+
+Deno.test("Q300: fires on 'should be initialized' (should + be + -ed)", () => {
+  const entry = makeEntry(
+    "The module should be initialized before use.",
+  );
+  const diags = runPassiveRules(entry);
+  assertEquals(diags.some((d) => d.code === "MSL-Q300"), true);
+});
+
+Deno.test("Q300: fires on 'must be done' (irregular participial)", () => {
+  const entry = makeEntry("The calibration must be done before shipment.");
+  const diags = runPassiveRules(entry);
+  assertEquals(diags.some((d) => d.code === "MSL-Q300"), true);
+});
+
+Deno.test("Q300: fires on 'shall be written' (irregular participial)", () => {
+  const entry = makeEntry("The report shall be written by the engineer.");
+  const diags = runPassiveRules(entry);
+  assertEquals(diags.some((d) => d.code === "MSL-Q300"), true);
+});
+
+Deno.test("Q300: fires on 'shall be taken' (irregular participial)", () => {
+  const entry = makeEntry("Action shall be taken within 5 s of detection.");
+  const diags = runPassiveRules(entry);
+  assertEquals(diags.some((d) => d.code === "MSL-Q300"), true);
+});
+
+Deno.test("Q300: silent on active form 'shall apply'", () => {
+  const entry = makeEntry("The brake shall apply pressure within 200 ms.");
+  const diags = runPassiveRules(entry);
+  assertEquals(diags.some((d) => d.code === "MSL-Q300"), false);
+});
+
+Deno.test("Q300: silent on 'shall be ready' (adjective, not participial)", () => {
+  // "ready" does not end in -ed and is not in the irregular list.
+  const entry = makeEntry(
+    "The system shall be ready to receive commands within 100 ms.",
+  );
+  const diags = runPassiveRules(entry);
+  assertEquals(diags.some((d) => d.code === "MSL-Q300"), false);
+});
+
+Deno.test("Q300: silent on 'shall be able' (adjective phrase)", () => {
+  const entry = makeEntry(
+    "The operator shall be able to override the alert.",
+  );
+  const diags = runPassiveRules(entry);
+  assertEquals(diags.some((d) => d.code === "MSL-Q300"), false);
+});
+
+Deno.test("Q300: silent on non-normative sentence (no modal)", () => {
+  const entry = makeEntry("The data is transferred to the archive.");
+  const diags = runPassiveRules(entry);
+  assertEquals(diags.some((d) => d.code === "MSL-Q300"), false);
+});
+
+Deno.test("Q300: silent on empty bodyAst", () => {
+  const entry: Entry = {
+    displayId: makeDisplayId("STK_0001"),
+    title: "Test requirement",
+    body: "",
+    bodyAst: [],
+    rawAttributes: [{ key: "Id", value: "01HGW2Q8MNP3RSTVWXYZABCDEF" }],
+    typedAttributes: new Map(),
+    id: "01HGW2Q8MNP3RSTVWXYZABCDEF",
+    type: "Requirement",
+    shape: "Authored",
+    location: { file: "test.md", line: 1, column: 1 },
+    source: { kind: "markdown" },
+    bodyTokens: [],
+  };
+  const diags = runPassiveRules(entry);
+  assertEquals(diags.length, 0);
+});
+
+Deno.test("Q300: diagnostic carries correct code, slug, group, severity", () => {
+  const entry = makeEntry("The sensor shall be calibrated annually.");
+  const diags = runPassiveRules(entry);
+  const d = diags.find((x) => x.code === "MSL-Q300");
+  assertEquals(d !== undefined, true);
+  assertEquals(d!.slug, "incose-r2-active-voice");
+  assertEquals(d!.group, "incose");
+  assertEquals(d!.severity, "warning");
+  assertEquals(d!.scoreContribution, 3);
+});
+
+Deno.test("Q300: diagnostic has a range", () => {
+  const entry = makeEntry("The sensor shall be calibrated annually.");
+  const diags = runPassiveRules(entry);
+  const d = diags.find((x) => x.code === "MSL-Q300");
+  assertEquals(d?.range !== undefined, true);
+  assertEquals(typeof d!.range!.start.line, "number");
+  assertEquals(typeof d!.range!.start.column, "number");
+});
+
+Deno.test("Q300: fires on 'shall not be applied' (negated modal + passive)", () => {
+  const entry = makeEntry(
+    "Voltage shall not be applied during initialization.",
+  );
+  const diags = runPassiveRules(entry);
+  assertEquals(diags.some((d) => d.code === "MSL-Q300"), true);
+});
+
+// ---------------------------------------------------------------------------
+// MSL-Q301: incose-r3-subject-verb
+// ---------------------------------------------------------------------------
+
+Deno.test("Q301: fires on 'It shall' (pronoun subject)", () => {
+  const entry = makeEntry("It shall be possible to override the alert.");
+  const diags = runPassiveRules(entry);
+  assertEquals(diags.some((d) => d.code === "MSL-Q301"), true);
+});
+
+Deno.test("Q301: fires on 'This shall' (pronoun subject)", () => {
+  const entry = makeEntry("This shall be confirmed within 10 s.");
+  const diags = runPassiveRules(entry);
+  assertEquals(diags.some((d) => d.code === "MSL-Q301"), true);
+});
+
+Deno.test("Q301: fires on 'That shall' (pronoun subject)", () => {
+  const entry = makeEntry("That shall be logged in the event journal.");
+  const diags = runPassiveRules(entry);
+  assertEquals(diags.some((d) => d.code === "MSL-Q301"), true);
+});
+
+Deno.test("Q301: fires on 'There shall' (existential-there)", () => {
+  const entry = makeEntry(
+    "There shall be no false activations during normal operation.",
+  );
+  const diags = runPassiveRules(entry);
+  assertEquals(diags.some((d) => d.code === "MSL-Q301"), true);
+});
+
+Deno.test("Q301: silent on clear actor subject", () => {
+  const entry = makeEntry("The brake controller shall apply pressure.");
+  const diags = runPassiveRules(entry);
+  assertEquals(diags.some((d) => d.code === "MSL-Q301"), false);
+});
+
+Deno.test("Q301: silent on 'The system shall'", () => {
+  const entry = makeEntry("The system shall detect obstacles within 100 ms.");
+  const diags = runPassiveRules(entry);
+  assertEquals(diags.some((d) => d.code === "MSL-Q301"), false);
+});
+
+Deno.test("Q301: silent on non-normative sentence", () => {
+  const entry = makeEntry("It is a critical system component.");
+  const diags = runPassiveRules(entry);
+  assertEquals(diags.some((d) => d.code === "MSL-Q301"), false);
+});
+
+Deno.test("Q301: diagnostic carries correct code, slug, group, severity", () => {
+  const entry = makeEntry("It shall be possible to configure the threshold.");
+  const diags = runPassiveRules(entry);
+  const d = diags.find((x) => x.code === "MSL-Q301");
+  assertEquals(d !== undefined, true);
+  assertEquals(d!.slug, "incose-r3-subject-verb");
+  assertEquals(d!.group, "incose");
+  assertEquals(d!.severity, "info");
+  assertEquals(d!.scoreContribution, 1);
+});
+
+Deno.test("Q301: diagnostic has a range", () => {
+  const entry = makeEntry("It shall be possible to configure the threshold.");
+  const diags = runPassiveRules(entry);
+  const d = diags.find((x) => x.code === "MSL-Q301");
+  assertEquals(d?.range !== undefined, true);
+});
+
+// ---------------------------------------------------------------------------
+// Co-firing: Q300 and Q301 may both fire on same sentence
+// ---------------------------------------------------------------------------
+
+Deno.test("Q300 and Q301 may co-fire: 'It shall be applied'", () => {
+  const entry = makeEntry("It shall be applied within 200 ms.");
+  const diags = runPassiveRules(entry);
+  // Both fire: pronoun subject (Q301) + passive construction (Q300)
+  assertEquals(diags.some((d) => d.code === "MSL-Q300"), true);
+  assertEquals(diags.some((d) => d.code === "MSL-Q301"), true);
+});
+
+// ---------------------------------------------------------------------------
+// File-absolute range: bodyStartLine respected
+// ---------------------------------------------------------------------------
+
+Deno.test("Q300: range uses file-absolute line from bodyStartLine", () => {
+  const body = "The sensor shall be calibrated annually.";
+  const entry: Entry = {
+    displayId: makeDisplayId("STK_0001"),
+    title: "Test requirement",
+    body,
+    bodyAst: [makeParagraph(body, 1, 1)],
+    rawAttributes: [
+      { key: "Id", value: "01HGW2Q8MNP3RSTVWXYZABCDEF" },
+      { key: "Type", value: "Requirement" },
+    ],
+    typedAttributes: new Map([
+      ["Id", ["01HGW2Q8MNP3RSTVWXYZABCDEF"]],
+      ["Type", ["Requirement"]],
+    ]),
+    id: "01HGW2Q8MNP3RSTVWXYZABCDEF",
+    type: "Requirement",
+    shape: "Authored",
+    location: { file: "test.md", line: 5, column: 1 },
+    bodyStartLine: 7,
+    source: { kind: "markdown" },
+    bodyTokens: [],
+  };
+  const diags = runPassiveRules(entry);
+  const d = diags.find((x) => x.code === "MSL-Q300");
+  assertEquals(d !== undefined, true);
+  // bodyStartLine=7, paragraph on line 1 (body-relative) → abs line = 7 + 1 - 1 = 7
+  assertEquals(d!.range!.start.line, 7);
+});

--- a/packages/markspec/core/lint/rules/suppression.ts
+++ b/packages/markspec/core/lint/rules/suppression.ts
@@ -97,6 +97,11 @@ export function runUnusedSuppressionCheck(
   const out: LintDiagnostic[] = [];
   const location: SourceLocation = ctx.entry.location;
   for (const code of ctx.disabledCodes) {
+    // Skip codes Q901 already flagged as unknown — Q902 is for
+    // "known code listed but didn't match", not "unknown code listed".
+    // Without this gate, every malformed `Markspec-disable:` token
+    // would fire both Q901 and Q902.
+    if (!PA1_KNOWN_RULE_CODES.has(code)) continue;
     if (!ctx.matchedCodes.has(code)) {
       out.push({
         code: "MSL-Q902",

--- a/packages/markspec/core/lint/rules/suppression.ts
+++ b/packages/markspec/core/lint/rules/suppression.ts
@@ -1,12 +1,19 @@
 /**
  * @module core/lint/rules/suppression
  *
- * Two suppression-hygiene rules for PA-1:
+ * Three suppression-hygiene rules for PA-1 through PA-3:
  *   MSL-Q900  disable-without-rationale  (warn, score 3)
  *   MSL-Q901  disable-unknown-rule       (warn, score 3)
+ *   MSL-Q902  disable-unused             (info, score 0)
  *
- * These run on every Authored entry (not just in-scope ones) because
+ * Q900/Q901 run on every Authored entry (not just in-scope ones) because
  * suppression hygiene applies to any entry that uses Markspec-disable.
+ *
+ * Q902 is runner-level: it is emitted by the runner after the suppression
+ * filter, once we know which codes actually matched a diagnostic. The
+ * {@linkcode runUnusedSuppressionCheck} helper is called from the runner
+ * after the filter step — it compares the set of disabled codes to the
+ * set of codes that were actually suppressed.
  */
 
 import type { Entry, SourceLocation } from "../../model/mod.ts";
@@ -16,19 +23,22 @@ import { STRUCT_RULE_CODES } from "./struct.ts";
 import { EARS_RULE_CODES } from "./ears.ts";
 import { MODAL_SENTENCE_RULE_CODES } from "./modal_sentence.ts";
 import { INCOSE_SENTENCE_RULE_CODES } from "./incose_sentence.ts";
+import { PASSIVE_RULE_CODES } from "./passive.ts";
 
-/** All rule codes shipped in PA-1 through PA-3 (slices 1–8).
- * MSL-Q900/Q901 are self-referential. */
+/** All rule codes shipped in PA-1 through PA-3 (slices 1–10).
+ * MSL-Q900/Q901/Q902 are self-referential. */
 export const PA1_KNOWN_RULE_CODES: ReadonlySet<string> = new Set([
   ...LEXICON_RULE_CODES,
   ...STRUCT_RULE_CODES,
   ...EARS_RULE_CODES,
   ...MODAL_SENTENCE_RULE_CODES,
   ...INCOSE_SENTENCE_RULE_CODES,
+  ...PASSIVE_RULE_CODES,
   // Q500: xref-glossary-undefined (slice 5)
   "MSL-Q500",
   "MSL-Q900",
   "MSL-Q901",
+  "MSL-Q902",
 ]);
 
 /** Parse the Markspec-disable attribute value into individual rule tokens. */
@@ -50,6 +60,57 @@ export function hasRationale(entry: Entry): boolean {
     if (attr.key === "Rationale" && attr.value.trim().length > 0) return true;
   }
   return false;
+}
+
+// ---------------------------------------------------------------------------
+// Q902 — disable-unused (runner integration)
+// ---------------------------------------------------------------------------
+
+/**
+ * Context supplied by the runner after the suppression filter step.
+ * Carries both the full set of disabled codes/slugs from the entry's
+ * `Markspec-disable:` attribute and the subset that actually matched
+ * (i.e., suppressed) a diagnostic during this run.
+ */
+export interface UnusedSuppressionContext {
+  readonly entry: Entry;
+  /** Codes/slugs listed in `Markspec-disable:`. */
+  readonly disabledCodes: ReadonlySet<string>;
+  /** Codes that matched at least one diagnostic (were actually suppressed). */
+  readonly matchedCodes: ReadonlySet<string>;
+}
+
+/**
+ * Emit MSL-Q902 for each disabled code/slug that did not match any
+ * diagnostic during this run (stale escape hatch).
+ *
+ * One Q902 is emitted per unused code, not per entry. Emitted at the
+ * entry location (entry-level range — no sentence span).
+ *
+ * Suppression-hygiene diagnostics (Q900/Q901/Q902 themselves) are never
+ * suppressed, so unused checks for Q900/Q901/Q902 are intentionally
+ * allowed to fire — they serve as documentation of over-suppression.
+ */
+export function runUnusedSuppressionCheck(
+  ctx: UnusedSuppressionContext,
+): LintDiagnostic[] {
+  const out: LintDiagnostic[] = [];
+  const location: SourceLocation = ctx.entry.location;
+  for (const code of ctx.disabledCodes) {
+    if (!ctx.matchedCodes.has(code)) {
+      out.push({
+        code: "MSL-Q902",
+        slug: "disable-unused",
+        severity: "info",
+        scoreContribution: 0,
+        group: "disable",
+        message:
+          `disable-unused: '${code}' is listed in 'Markspec-disable' but no matching diagnostic was emitted for this entry`,
+        location,
+      });
+    }
+  }
+  return out;
 }
 
 /** Run MSL-Q900 and MSL-Q901 on an entry. Safe to call on all Authored entries. */

--- a/packages/markspec/core/lint/runner.ts
+++ b/packages/markspec/core/lint/runner.ts
@@ -17,6 +17,7 @@ import {
   hasRationale,
   parseDisableValue,
   runSuppressionRules,
+  runUnusedSuppressionCheck,
 } from "./rules/suppression.ts";
 import { buildGlossaryIndex } from "./glossary.ts";
 import type { FileReader, GlossaryIndex } from "./glossary.ts";
@@ -25,6 +26,7 @@ import type { IsIdentifierHook } from "./rules/xref.ts";
 import { runEarsRules } from "./rules/ears.ts";
 import { runModalSentenceRules } from "./rules/modal_sentence.ts";
 import { runIncoseSentenceRules } from "./rules/incose_sentence.ts";
+import { runPassiveRules } from "./rules/passive.ts";
 import { loadLexicon } from "../lexicons/mod.ts";
 import { computeScoreRollup } from "./score.ts";
 import type { ScoreRollup } from "./score.ts";
@@ -106,13 +108,17 @@ function disabledCodes(entry: Entry): ReadonlySet<string> {
  *   6. Run EARS rules (Q100–Q104) on each in-scope entry.
  *   7. Run modal sentence rules (Q200–Q201) on each in-scope entry.
  *   8. Run INCOSE sentence rules (Q306–Q312, Q402) on each in-scope entry.
- *   9. Run suppression hygiene on ALL Authored entries.
- *  10. Apply suppression: drop in-scope diagnostics where the entry's
+ *   9. Run passive-voice rules (Q300–Q301) on each in-scope entry.
+ *  10. Run suppression hygiene on ALL Authored entries.
+ *  11. Apply suppression: drop in-scope diagnostics where the entry's
  *      Markspec-disable list includes the rule's code and the entry
- *      has a Rationale. Suppression-hygiene diagnostics (Q900/Q901)
- *      are never suppressed.
- *  11. Compute score roll-up (per-entry scores, band-counts, mean).
- *  12. Return diagnostics and score.
+ *      has a Rationale. Track which codes were actually suppressed.
+ *      Suppression-hygiene diagnostics (Q900/Q901/Q902) are never
+ *      suppressed.
+ *  12. Run Q902 (disable-unused): emit one info diagnostic per disabled
+ *      code that did not match any diagnostic this run (stale escape hatch).
+ *  13. Compute score roll-up (per-entry scores, band-counts, mean).
+ *  14. Return diagnostics and score.
  */
 export async function runLint(options: LintOptions): Promise<LintResult> {
   const { entries } = options;
@@ -124,44 +130,67 @@ export async function runLint(options: LintOptions): Promise<LintResult> {
   );
   const isIdHook: IsIdentifierHook = () => false;
 
-  // Steps 1–8: collect diagnostics keyed by entry
+  // Steps 1–9: collect diagnostics keyed by entry
   const inScopeDiags = new Map<Entry, LintDiagnostic[]>();
   for (const entry of entries) {
     if (!isProseScope(entry)) continue;
     const diags: LintDiagnostic[] = [];
+    // Step 3: lexicon rules
     diags.push(...runLexiconRules(entry));
+    // Step 4: structural rules
     diags.push(...runStructRules(entry));
+    // Step 5: xref rules (Q500)
     diags.push(...runXrefRules(entry, glossary, allow, isIdHook));
+    // Step 6: EARS rules (Q100–Q104)
     diags.push(...runEarsRules(entry));
+    // Step 7: modal sentence rules (Q200–Q201)
     diags.push(...runModalSentenceRules(entry));
     // Step 8: INCOSE sentence rules (Q306–Q312, Q402)
     diags.push(...runIncoseSentenceRules(entry));
+    // Step 9: passive-voice rules (Q300–Q301)
+    diags.push(...runPassiveRules(entry));
     inScopeDiags.set(entry, diags);
   }
 
-  // Step 9: suppression hygiene on all Authored entries
+  // Step 10: suppression hygiene on all Authored entries
   const hygieneDiags: LintDiagnostic[] = [];
   for (const entry of entries) {
     if (entry.shape !== "Authored") continue;
     hygieneDiags.push(...runSuppressionRules(entry));
   }
 
-  // Step 10: apply suppression to in-scope diagnostics
+  // Step 11: apply suppression to in-scope diagnostics; track matched codes
+  // per entry so Step 12 can detect unused suppressions (Q902).
   const out: LintDiagnostic[] = [];
   for (const [entry, diags] of inScopeDiags) {
     const disabled = disabledCodes(entry);
     const entryHasRationale = hasRationale(entry);
+    const matched = new Set<string>();
     for (const diag of diags) {
       // Suppression requires both a matching code AND a Rationale.
-      if (entryHasRationale && disabled.has(diag.code)) continue;
+      if (entryHasRationale && disabled.has(diag.code)) {
+        matched.add(diag.code);
+        continue;
+      }
       out.push(diag);
+    }
+    // Step 12: Q902 — emit one info diagnostic per disabled code that
+    // did not suppress any diagnostic during this run.
+    if (disabled.size > 0) {
+      out.push(
+        ...runUnusedSuppressionCheck({
+          entry,
+          disabledCodes: disabled,
+          matchedCodes: matched,
+        }),
+      );
     }
   }
 
-  // Step 11: append hygiene diagnostics (never suppressed)
+  // Append hygiene diagnostics (Q900/Q901 — never suppressed)
   out.push(...hygieneDiags);
 
-  // Step 12: compute score roll-up across all entries (including 0-score ones).
+  // Step 13: compute score roll-up across all entries (including 0-score ones).
   const score = computeScoreRollup(out, entries);
 
   return { diagnostics: out, score };

--- a/packages/markspec/core/lint/runner_test.ts
+++ b/packages/markspec/core/lint/runner_test.ts
@@ -311,3 +311,167 @@ Deno.test("runLint: output is deterministic for same input", async () => {
     r2.diagnostics.map((d) => d.code),
   );
 });
+
+// ---------------------------------------------------------------------------
+// Q902: disable-unused (runner integration)
+// ---------------------------------------------------------------------------
+
+Deno.test("runLint: MSL-Q902 fires when Markspec-disable code did not match any diagnostic", async () => {
+  // "incose-r7-vague-term" → MSL-Q302 (vague-term). Body has no vague term → Q302 won't fire.
+  const text = "The system shall process the request within 200 ms.";
+  const entry = makeEntry({
+    body: text,
+    bodyAst: [
+      {
+        kind: "paragraph",
+        content: { text },
+        range: {
+          start: { line: 1, column: 1 },
+          end: { line: 1, column: text.length },
+        },
+      },
+    ],
+    rawAttributes: [
+      { key: "Id", value: "01HGW2Q8MNP3RSTVWXYZABCDEF" },
+      { key: "Type", value: "Requirement" },
+      { key: "Markspec-disable", value: "MSL-Q302" },
+      { key: "Rationale", value: "Reviewed and accepted." },
+    ],
+    typedAttributes: new Map([
+      ["Id", ["01HGW2Q8MNP3RSTVWXYZABCDEF"]],
+      ["Type", ["Requirement"]],
+      ["Markspec-disable", ["MSL-Q302"]],
+      ["Rationale", ["Reviewed and accepted."]],
+    ]),
+  });
+  const result = await runLint({ entries: [entry] });
+  const codes = result.diagnostics.map((d) => d.code);
+  assertEquals(codes.includes("MSL-Q902"), true);
+});
+
+Deno.test("runLint: MSL-Q902 silent when Markspec-disable code did match a suppressed diagnostic", async () => {
+  // Body contains "some" → Q302 fires, gets suppressed → no Q902.
+  const text = "The system should use some processing mechanism.";
+  const entry = makeEntry({
+    body: text,
+    bodyAst: [
+      {
+        kind: "paragraph",
+        content: { text },
+        range: {
+          start: { line: 1, column: 1 },
+          end: { line: 1, column: text.length },
+        },
+      },
+    ],
+    rawAttributes: [
+      { key: "Id", value: "01HGW2Q8MNP3RSTVWXYZABCDEF" },
+      { key: "Type", value: "Requirement" },
+      { key: "Markspec-disable", value: "MSL-Q302" },
+      { key: "Rationale", value: "Reviewed and accepted." },
+    ],
+    typedAttributes: new Map([
+      ["Id", ["01HGW2Q8MNP3RSTVWXYZABCDEF"]],
+      ["Type", ["Requirement"]],
+      ["Markspec-disable", ["MSL-Q302"]],
+      ["Rationale", ["Reviewed and accepted."]],
+    ]),
+  });
+  const result = await runLint({ entries: [entry] });
+  const codes = result.diagnostics.map((d) => d.code);
+  // Q302 was suppressed and actually matched → Q902 must NOT fire.
+  assertEquals(codes.includes("MSL-Q902"), false);
+  // Q302 itself must not appear (it was suppressed).
+  assertEquals(codes.includes("MSL-Q302"), false);
+});
+
+Deno.test("runLint: MSL-Q902 silent when entry has no Markspec-disable", async () => {
+  const text = "The system shall process the request within 200 ms.";
+  const entry = makeEntry({
+    body: text,
+    bodyAst: [
+      {
+        kind: "paragraph",
+        content: { text },
+        range: {
+          start: { line: 1, column: 1 },
+          end: { line: 1, column: text.length },
+        },
+      },
+    ],
+  });
+  const result = await runLint({ entries: [entry] });
+  const codes = result.diagnostics.map((d) => d.code);
+  assertEquals(codes.includes("MSL-Q902"), false);
+});
+
+Deno.test("runLint: MSL-Q902 emits one diagnostic per unused code", async () => {
+  // Disable three codes; body triggers none of them.
+  const text = "The system shall process the request within 200 ms.";
+  const entry = makeEntry({
+    body: text,
+    bodyAst: [
+      {
+        kind: "paragraph",
+        content: { text },
+        range: {
+          start: { line: 1, column: 1 },
+          end: { line: 1, column: text.length },
+        },
+      },
+    ],
+    rawAttributes: [
+      { key: "Id", value: "01HGW2Q8MNP3RSTVWXYZABCDEF" },
+      { key: "Type", value: "Requirement" },
+      // Q302 (vague-term), Q303 (subjective), Q304 (weak-imperative) — none fire on this body.
+      { key: "Markspec-disable", value: "MSL-Q302, MSL-Q303, MSL-Q304" },
+      { key: "Rationale", value: "Reviewed and accepted." },
+    ],
+    typedAttributes: new Map([
+      ["Id", ["01HGW2Q8MNP3RSTVWXYZABCDEF"]],
+      ["Type", ["Requirement"]],
+      ["Markspec-disable", ["MSL-Q302", "MSL-Q303", "MSL-Q304"]],
+      ["Rationale", ["Reviewed and accepted."]],
+    ]),
+  });
+  const result = await runLint({ entries: [entry] });
+  const q902s = result.diagnostics.filter((d) => d.code === "MSL-Q902");
+  // One Q902 per unused code → 3 total.
+  assertEquals(q902s.length, 3);
+});
+
+Deno.test("runLint: MSL-Q902 has correct fields (info, score 0, group disable)", async () => {
+  const text = "The system shall process the request within 200 ms.";
+  const entry = makeEntry({
+    body: text,
+    bodyAst: [
+      {
+        kind: "paragraph",
+        content: { text },
+        range: {
+          start: { line: 1, column: 1 },
+          end: { line: 1, column: text.length },
+        },
+      },
+    ],
+    rawAttributes: [
+      { key: "Id", value: "01HGW2Q8MNP3RSTVWXYZABCDEF" },
+      { key: "Type", value: "Requirement" },
+      { key: "Markspec-disable", value: "MSL-Q302" },
+      { key: "Rationale", value: "Reviewed and accepted." },
+    ],
+    typedAttributes: new Map([
+      ["Id", ["01HGW2Q8MNP3RSTVWXYZABCDEF"]],
+      ["Type", ["Requirement"]],
+      ["Markspec-disable", ["MSL-Q302"]],
+      ["Rationale", ["Reviewed and accepted."]],
+    ]),
+  });
+  const result = await runLint({ entries: [entry] });
+  const d = result.diagnostics.find((x) => x.code === "MSL-Q902");
+  assertEquals(d !== undefined, true);
+  assertEquals(d!.severity, "info");
+  assertEquals(d!.scoreContribution, 0);
+  assertEquals(d!.group, "disable");
+  assertEquals(d!.slug, "disable-unused");
+});

--- a/packages/markspec/core/lint/runner_test.ts
+++ b/packages/markspec/core/lint/runner_test.ts
@@ -475,3 +475,46 @@ Deno.test("runLint: MSL-Q902 has correct fields (info, score 0, group disable)",
   assertEquals(d!.group, "disable");
   assertEquals(d!.slug, "disable-unused");
 });
+
+Deno.test("runLint: MSL-Q902 does NOT fire for unknown codes (Q901's territory)", async () => {
+  // Unknown code 'MSL-ZZZZ' triggers Q901 (unknown-rule). Q902 must NOT
+  // ALSO fire on the same token — that would double-diagnose every
+  // malformed disable entry.
+  const text = "The system shall process the request within 200 ms.";
+  const entry = makeEntry({
+    body: text,
+    bodyAst: [
+      {
+        kind: "paragraph",
+        content: { text },
+        range: {
+          start: { line: 1, column: 1 },
+          end: { line: 1, column: text.length },
+        },
+      },
+    ],
+    rawAttributes: [
+      { key: "Id", value: "01HGW2Q8MNP3RSTVWXYZABCDEF" },
+      { key: "Type", value: "Requirement" },
+      { key: "Markspec-disable", value: "MSL-ZZZZ" },
+      { key: "Rationale", value: "Reviewed and accepted." },
+    ],
+    typedAttributes: new Map([
+      ["Id", ["01HGW2Q8MNP3RSTVWXYZABCDEF"]],
+      ["Type", ["Requirement"]],
+      ["Markspec-disable", ["MSL-ZZZZ"]],
+      ["Rationale", ["Reviewed and accepted."]],
+    ]),
+  });
+  const result = await runLint({ entries: [entry] });
+  // Q901 fires (unknown rule).
+  assertEquals(
+    result.diagnostics.some((d) => d.code === "MSL-Q901"),
+    true,
+  );
+  // Q902 does NOT also fire on the same token.
+  assertEquals(
+    result.diagnostics.some((d) => d.code === "MSL-Q902"),
+    false,
+  );
+});


### PR DESCRIPTION
## Summary

**The final slice of the PA-3 epic.** Three rules: MSL-Q902 (`disable-unused`) with runner integration, MSL-Q300 (`incose-r2-active-voice` passive voice), and MSL-Q301 (`incose-r3-subject-verb` pronoun subject).

This is **slice 10 of 10**. After this PR merges, all 16 PA-3 rules are on main and the Stage-2 PA-3 prose-analysis epic is **complete**.

## Rules shipped

| Code     | Slug                                       | Sev   | Score | Fires when                                                                                       |
|----------|--------------------------------------------|-------|-------|--------------------------------------------------------------------------------------------------|
| MSL-Q902 | `disable-unused`                           | info  | 0     | A `Markspec-disable:` directive lists a code that didn't suppress any diagnostic this run.       |
| MSL-Q300 | `incose-r2-active-voice` (alias `struct-passive-voice`) | warn  | 3     | Normative sentence with be-verb + past participle (passive voice).                              |
| MSL-Q301 | `incose-r3-subject-verb`                   | info  | 1     | Normative sentence whose subject is a pronoun (`It`/`This`/`That`/`There`).                     |

## Q902 runner integration

`runLint` now tracks `matchedCodes: Set<string>` per entry during the suppression filter step. After filtering, `runUnusedSuppressionCheck` walks each entry's `Markspec-disable:` list and emits one Q902 per code that didn't suppress anything.

**Correct mutual exclusion with Q901:** Q901 (unknown rule) fires when a code isn't in `PA1_KNOWN_RULE_CODES`. Q902 explicitly gates on the same set — so a malformed code like `MSL-ZZZZ` triggers Q901 only, never both. This was caught in code review (initial implementation double-diagnosed). Regression test pins the behavior.

## Pragmatic narrowing

- **Q300** uses a closed set of irregular participials plus `-ed`-shape detection. Skips adjectives like `ready`/`able`/`given`/`known` to avoid false positives on "shall be ready" / "a given condition" / "a known limit".
- **Q300 limitation (documented):** bare-be-verb passives without a modal (`"is not applied"`) aren't detected because the first be-verb match in the sentence is consumed and the next word is `not`. Modal-form negated passive (`"shall not be applied"`) IS detected.
- **Q301** is narrow: sentence-initial `It`/`This`/`That`/`There` only. Will co-fire with Q300 on `"It shall be applied"` (intentional — both flags are valid signals).

## Test plan

- [x] 25 unit tests in `passive_test.ts` (Q300 + Q301).
- [x] 6 Q902 integration tests in `runner_test.ts` (including the regression test for Q901/Q902 mutual exclusion).
- [x] All existing tests still pass.
- [x] Full suite: 2540+ tests passing, 0 failing.
- [x] `just check` clean; `deno fmt --check` + `dprint check` clean.

## Reviews completed

- **Spec compliance + code quality** (sonnet pass, extra-strict on Q902 because the suppression filter is in the runner critical path): ✅ spec compliant after fix; ⚠️ approved with nits.
- **One critical bug fixed in the follow-up commit on this branch:** Q902 was firing on unknown codes that also triggered Q901 — double-diagnostic for every malformed disable token. Now gated on `PA1_KNOWN_RULE_CODES`.
- Two important comment/code-honesty fixes: `given`/`known` removed from the irregular-participial set (the doc comment said they were excluded; they were actually included); dead `is not`/`are not` regex alternatives removed (left-to-right alternation made them unreachable).

## Epic summary

**All 16 PA-3 rules are now in MarkSpec:**

| Group       | Rules (slice number)                                              |
|-------------|-------------------------------------------------------------------|
| lexicon     | Q302, Q303, Q304, Q305, Q310, Q313 (PA-1)                         |
| struct      | Q400, Q401 (PA-1), Q402 (slice 8)                                 |
| suppression | Q900, Q901 (PA-1), Q902 (slice 10)                                |
| xref        | **Q500 — flagship** (slice 5)                                     |
| ears        | Q100, Q101, Q102, Q103, Q104 (slice 6)                            |
| modal       | Q200, Q201 (slice 7); Q202 deferred (needs profile config epic)   |
| incose      | Q300, Q301 (slice 10), Q306, Q307, Q308, Q309, Q311, Q312 (slice 8) |

Plus: rule-based sentence segmenter (slice 2), file-absolute diagnostic ranges (slice 3), glossary-only resolver (slice 4), score roll-up with band-counts + mean (slice 9), `markspec lint` text + JSON output, suppression hygiene with rationale enforcement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
