### PR TITLE
docs(spec): align LSP feature additions §5.1 codeLens label with implementation

### DIFF
--- a/docs/spec/internal/markspec-lsp-feature-additions.md
+++ b/docs/spec/internal/markspec-lsp-feature-additions.md
@@ -287,7 +287,7 @@ title line:
 | Lens                      | Displayed              | Click action                                   |
 | ------------------------- | ---------------------- | ---------------------------------------------- |
 | `↑ N dependents`          | when N > 0             | Opens the LSP `references` view for the entry. |
-| `↓ Satisfies: ID (Title)` | per `Satisfies:` value | Opens the LSP `definition` for the target.     |
+| `↓ Satisfies: ID — Title` | per `Satisfies:` value | Opens the LSP `definition` for the target.     |
 
 Backing: the server already has the workspace index (`lsp/workspace.ts`).
 Dependent counts are computed via the same scan that powers


### PR DESCRIPTION
## Summary

Capability 3 (PR #505) shipped the Satisfies codeLens with title `↓ Satisfies: ID — Title` (em-dash separator) to match the house style established by `lsp/hover.ts:64` and `lsp/symbols.ts:114`. The spec §5.1 table still read `↓ Satisfies: ID (Title)` with parens. Update the spec to match the implementation + sibling features.

One-character change: `(` and `)` → ` — `.

Same amend-after-implement pattern as PR #498 (the Capability 2 spec amendment).

## Test Plan

- [x] `dprint check` clean.
- [x] No code changes — pre-commit hook still ran `deno fmt --check`, `deno check`, and `git std lint` because the hooks are unconditional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
