### PR TITLE
feat(lsp): add textDocument/inlayHint capability

### DIFF
--- a/packages/markspec/lsp/code_lens.ts
+++ b/packages/markspec/lsp/code_lens.ts
@@ -19,6 +19,7 @@
  */
 
 import type { DisplayId, Entry } from "../core/mod.ts";
+import { buildIncomingCount } from "./incoming_index.ts";
 
 /** A subset of the LSP `Command` interface. */
 export interface Command {
@@ -58,22 +59,7 @@ export function buildCodeLenses(
 ): CodeLens[] {
   if (entries.length === 0) return [];
 
-  // Build per-target incoming-edge counts in one O(n) pass.
-  const incomingCount = new Map<DisplayId, number>();
-  for (const e of allEntries) {
-    for (const attr of e.rawAttributes) {
-      if (attr.key === "Id") continue;
-      const tokens = attr.value.split(TOKEN_SEPARATORS_RE);
-      for (const tok of tokens) {
-        if (tok.length === 0) continue;
-        if (tok === e.displayId) continue;
-        incomingCount.set(
-          tok as DisplayId,
-          (incomingCount.get(tok as DisplayId) ?? 0) + 1,
-        );
-      }
-    }
-  }
+  const incomingCount = buildIncomingCount(allEntries);
 
   // Index targets by displayId so `Satisfies:` titles resolve in O(1).
   const byDisplayId = new Map<DisplayId, Entry>();

--- a/packages/markspec/lsp/incoming_index.ts
+++ b/packages/markspec/lsp/incoming_index.ts
@@ -1,0 +1,51 @@
+/**
+ * @module lsp/incoming_index
+ *
+ * Shared incoming-edge index for LSP helpers (codeLens, inlayHint).
+ *
+ * Builds a per-target `Map<DisplayId, number>` in one O(N × A × T) pass
+ * over all entries, where N is entry count, A is average attributes per
+ * entry, and T is average tokens per attribute value. The walk skips the
+ * `Id` attribute (which carries the entry's own identifier, not an
+ * incoming reference) and skips self-references (`STK_001` in
+ * `STK_001`'s own `Satisfies:`).
+ *
+ * Same splitter (`[\s,]+`) and skip rules as `lsp/references.ts:findReferencingEntries`
+ * so the count matches the references list shown when the corresponding
+ * codeLens / hint is clicked.
+ */
+
+import type { DisplayId, Entry } from "../core/mod.ts";
+
+/** Whitespace + comma splitter for attribute value lists. */
+const TOKEN_SEPARATORS_RE = /[\s,]+/;
+
+/**
+ * Build `Map<DisplayId, number>` of incoming attribute references over
+ * the entire workspace.
+ *
+ * Tokens come from splitting each `rawAttributes[].value` on `[\s,]+`.
+ * The `Id` attribute is skipped (it declares the entry, not a reference).
+ * Self-references (`e.displayId` appearing in `e`'s own attributes) are
+ * skipped to match `findReferencingEntries`' semantics.
+ */
+export function buildIncomingCount(
+  allEntries: readonly Entry[],
+): Map<DisplayId, number> {
+  const count = new Map<DisplayId, number>();
+  for (const e of allEntries) {
+    for (const attr of e.rawAttributes) {
+      if (attr.key === "Id") continue;
+      const tokens = attr.value.split(TOKEN_SEPARATORS_RE);
+      for (const tok of tokens) {
+        if (tok.length === 0) continue;
+        if (tok === e.displayId) continue;
+        count.set(
+          tok as DisplayId,
+          (count.get(tok as DisplayId) ?? 0) + 1,
+        );
+      }
+    }
+  }
+  return count;
+}

--- a/packages/markspec/lsp/incoming_index_test.ts
+++ b/packages/markspec/lsp/incoming_index_test.ts
@@ -1,0 +1,84 @@
+/**
+ * @module lsp/incoming_index_test
+ *
+ * Unit tests for {@linkcode buildIncomingCount} — pure helper that counts
+ * incoming attribute references per display ID across the workspace.
+ */
+
+import { assertEquals } from "@std/assert";
+import { buildIncomingCount } from "./incoming_index.ts";
+import type { Attribute, DisplayId, Entry, Ulid } from "../core/mod.ts";
+
+function fakeEntry(opts: {
+  displayId: string;
+  file?: string;
+  line?: number;
+  attrs?: Array<{ key: string; value: string }>;
+}): Entry {
+  const attrs: Attribute[] = (opts.attrs ?? []).map((a) => ({
+    key: a.key,
+    value: a.value,
+  }));
+  return {
+    shape: "Authored",
+    displayId: opts.displayId as DisplayId,
+    title: "T",
+    id: "01HGW2Q8MNP3RSTVWXYZABCDEF" as Ulid,
+    body: "",
+    rawAttributes: attrs,
+    typedAttributes: new Map(),
+    type: undefined,
+    location: {
+      file: opts.file ?? "/proj/r.md",
+      line: opts.line ?? 1,
+      column: 1,
+    },
+    labels: [],
+    // deno-lint-ignore no-explicit-any
+  } as any;
+}
+
+Deno.test("buildIncomingCount: empty input returns empty map", () => {
+  const count = buildIncomingCount([]);
+  assertEquals(count.size, 0);
+});
+
+Deno.test("buildIncomingCount: counts incoming refs, skips self-reference and Id", () => {
+  const target = fakeEntry({ displayId: "STK_001" });
+  const child1 = fakeEntry({
+    displayId: "SAD_A",
+    attrs: [{ key: "Satisfies", value: "STK_001" }],
+  });
+  const child2 = fakeEntry({
+    displayId: "SAD_B",
+    attrs: [{ key: "Satisfies", value: "STK_001" }],
+  });
+  // Self-reference: STK_001's own Satisfies value lists itself.
+  // The skip rule ensures this doesn't inflate its own count.
+  const selfRef = fakeEntry({
+    displayId: "STK_001",
+    attrs: [{ key: "Satisfies", value: "STK_001" }],
+  });
+  // Id attribute shouldn't contribute even if the value matches a display ID.
+  const idAttr = fakeEntry({
+    displayId: "OTHER",
+    attrs: [{ key: "Id", value: "STK_001" }],
+  });
+
+  const count = buildIncomingCount([target, child1, child2, selfRef, idAttr]);
+
+  assertEquals(count.get("STK_001" as DisplayId), 2);
+});
+
+Deno.test("buildIncomingCount: counts across multiple targets", () => {
+  const child = fakeEntry({
+    displayId: "SAD_001",
+    attrs: [
+      { key: "Satisfies", value: "STK_A, STK_B" },
+      { key: "Derived-from", value: "STK_A" },
+    ],
+  });
+  const count = buildIncomingCount([child]);
+  assertEquals(count.get("STK_A" as DisplayId), 2);
+  assertEquals(count.get("STK_B" as DisplayId), 1);
+});

--- a/packages/markspec/lsp/inlay_hint.ts
+++ b/packages/markspec/lsp/inlay_hint.ts
@@ -1,0 +1,100 @@
+/**
+ * @module lsp/inlay_hint
+ *
+ * Pure helper for the LSP `textDocument/inlayHint` handler. Emits two
+ * kinds of hints per entry, positioned at the end of the title line:
+ *
+ *   - `: <type>` (`InlayHintKind.Type` = 1) — when the entry has no
+ *     explicit `Type:` attribute and the parser resolved one from the
+ *     display-ID prefix. Suppressing this when an explicit `Type:` is
+ *     present avoids duplicating visible information.
+ *
+ *   - `(N dependents)` (`InlayHintKind.Parameter` = 2) — when N > 0.
+ *     Per spec §5.2, the server emits this unconditionally; the client
+ *     decides whether to render it (suppress when the dependents-codeLens
+ *     is on, per `markspec.lsp.codeLens.dependents` setting in VS Code).
+ *
+ * Both hints render at end-of-title-line. The caller supplies a
+ * `lineLength(line: number) => number` callback (1-based input) so the
+ * helper stays decoupled from `@std/path` and the document text.
+ *
+ * Uses the shared {@linkcode buildIncomingCount} index — same source of
+ * truth as `code_lens.ts`'s dependent count.
+ *
+ * Spec: `docs/spec/internal/markspec-lsp-feature-additions.md` §5.2.
+ */
+
+import type { Entry } from "../core/mod.ts";
+import { buildIncomingCount } from "./incoming_index.ts";
+
+/** LSP `InlayHintKind` numeric constants per spec 3.17. */
+export const InlayHintKindType = 1;
+export const InlayHintKindParameter = 2;
+
+/** A subset of the LSP `InlayHint` interface. */
+export interface InlayHint {
+  readonly position: {
+    readonly line: number;
+    readonly character: number;
+  };
+  readonly label: string;
+  readonly kind?: number;
+  readonly paddingLeft?: boolean;
+  readonly paddingRight?: boolean;
+}
+
+/**
+ * Build the `InlayHint[]` for a document's entries.
+ *
+ * @param entries — entries declared in the document the client requested
+ *   hints for.
+ * @param allEntries — every entry in the workspace, used to compute
+ *   dependent counts.
+ * @param lineLength — `(line: number) => number` callback returning the
+ *   character length of the given **1-based** line. Used to position the
+ *   hint at the end of the entry's title line. Returns 0 if the line is
+ *   out of range; the helper handles that by emitting at column 0.
+ */
+export function buildInlayHints(
+  entries: readonly Entry[],
+  allEntries: readonly Entry[],
+  lineLength: (line: number) => number,
+): InlayHint[] {
+  if (entries.length === 0) return [];
+
+  const incomingCount = buildIncomingCount(allEntries);
+
+  const out: InlayHint[] = [];
+  for (const entry of entries) {
+    const lspLine = Math.max(0, entry.location.line - 1);
+    const character = Math.max(0, lineLength(entry.location.line));
+    const position = { line: lspLine, character };
+
+    // Type hint: only when parser inferred a type AND no explicit
+    // `Type:` raw attribute is present (would duplicate visible info).
+    if (entry.type !== undefined) {
+      const hasExplicitType = entry.rawAttributes.some((a) => a.key === "Type");
+      if (!hasExplicitType) {
+        out.push({
+          position,
+          label: `: ${entry.type}`,
+          kind: InlayHintKindType,
+          paddingLeft: true,
+        });
+      }
+    }
+
+    // Dependents hint: server emits unconditionally; client decides
+    // whether to render (suppress when codeLens shows the same info).
+    const depCount = incomingCount.get(entry.displayId) ?? 0;
+    if (depCount > 0) {
+      out.push({
+        position,
+        label: depCount === 1 ? "(1 dependent)" : `(${depCount} dependents)`,
+        kind: InlayHintKindParameter,
+        paddingLeft: true,
+      });
+    }
+  }
+  return out;
+}

--- a/packages/markspec/lsp/inlay_hint_test.ts
+++ b/packages/markspec/lsp/inlay_hint_test.ts
@@ -1,0 +1,125 @@
+/**
+ * @module lsp/inlay_hint_test
+ *
+ * Unit tests for {@linkcode buildInlayHints} — pure helper that emits
+ * inline hints (`: <type>` and `(N dependents)`) for `textDocument/inlayHint`.
+ */
+
+import { assertEquals } from "@std/assert";
+import { buildInlayHints } from "./inlay_hint.ts";
+import type { Attribute, DisplayId, Entry, Ulid } from "../core/mod.ts";
+
+function fakeEntry(opts: {
+  displayId: string;
+  title?: string;
+  line?: number;
+  file?: string;
+  type?: string;
+  attrs?: Array<{ key: string; value: string }>;
+}): Entry {
+  const attrs: Attribute[] = (opts.attrs ?? []).map((a) => ({
+    key: a.key,
+    value: a.value,
+  }));
+  return {
+    shape: "Authored",
+    displayId: opts.displayId as DisplayId,
+    title: opts.title ?? "T",
+    id: "01HGW2Q8MNP3RSTVWXYZABCDEF" as Ulid,
+    body: "",
+    rawAttributes: attrs,
+    typedAttributes: new Map(),
+    type: opts.type,
+    location: {
+      file: opts.file ?? "/proj/r.md",
+      line: opts.line ?? 1,
+      column: 1,
+    },
+    labels: [],
+    // deno-lint-ignore no-explicit-any
+  } as any;
+}
+
+/** Stub lineLength: every line is 80 chars wide. */
+const stubLineLength = (_line: number): number => 80;
+
+Deno.test("buildInlayHints: empty input returns empty array", () => {
+  assertEquals(buildInlayHints([], [], stubLineLength), []);
+});
+
+Deno.test("buildInlayHints: entry with no type and no dependents yields no hints", () => {
+  const entry = fakeEntry({ displayId: "STK_001" });
+  assertEquals(buildInlayHints([entry], [entry], stubLineLength), []);
+});
+
+Deno.test("buildInlayHints: prefix-inferred type yields ': <type>' hint", () => {
+  const entry = fakeEntry({
+    displayId: "STK_001",
+    type: "stakeholder-requirement",
+  });
+  const hints = buildInlayHints([entry], [entry], stubLineLength);
+  const typeHint = hints.find((h) => h.label.startsWith(":"));
+  assertEquals(typeHint?.label, ": stakeholder-requirement");
+  assertEquals(typeHint?.position, { line: 0, character: 80 });
+  assertEquals(typeHint?.kind, 1);
+  assertEquals(typeHint?.paddingLeft, true);
+});
+
+Deno.test("buildInlayHints: explicit Type: attribute suppresses ': <type>' hint", () => {
+  const entry = fakeEntry({
+    displayId: "STK_001",
+    type: "stakeholder-requirement",
+    attrs: [{ key: "Type", value: "stakeholder-requirement" }],
+  });
+  const hints = buildInlayHints([entry], [entry], stubLineLength);
+  const typeHint = hints.find((h) => h.label.startsWith(":"));
+  assertEquals(typeHint, undefined);
+});
+
+Deno.test("buildInlayHints: entry with dependents yields '(N dependents)' hint", () => {
+  const target = fakeEntry({ displayId: "STK_001" });
+  const child1 = fakeEntry({
+    displayId: "SAD_A",
+    attrs: [{ key: "Satisfies", value: "STK_001" }],
+  });
+  const child2 = fakeEntry({
+    displayId: "SAD_B",
+    attrs: [{ key: "Satisfies", value: "STK_001" }],
+  });
+  const hints = buildInlayHints(
+    [target],
+    [target, child1, child2],
+    stubLineLength,
+  );
+  const depHint = hints.find((h) => h.label.startsWith("("));
+  assertEquals(depHint?.label, "(2 dependents)");
+  assertEquals(depHint?.position, { line: 0, character: 80 });
+  assertEquals(depHint?.kind, 2);
+});
+
+Deno.test("buildInlayHints: singular dependent uses singular form", () => {
+  const target = fakeEntry({ displayId: "STK_001" });
+  const child = fakeEntry({
+    displayId: "SAD_A",
+    attrs: [{ key: "Satisfies", value: "STK_001" }],
+  });
+  const hints = buildInlayHints([target], [target, child], stubLineLength);
+  const depHint = hints.find((h) => h.label.startsWith("("));
+  assertEquals(depHint?.label, "(1 dependent)");
+});
+
+Deno.test("buildInlayHints: type + dependents both emitted on the same entry", () => {
+  const target = fakeEntry({
+    displayId: "STK_001",
+    type: "stakeholder-requirement",
+  });
+  const child = fakeEntry({
+    displayId: "SAD_A",
+    attrs: [{ key: "Satisfies", value: "STK_001" }],
+  });
+  const hints = buildInlayHints([target], [target, child], stubLineLength);
+  assertEquals(hints.length, 2);
+  // Order: type hint first, then dependents.
+  assertEquals(hints[0].label, ": stakeholder-requirement");
+  assertEquals(hints[1].label, "(1 dependent)");
+});

--- a/packages/markspec/lsp/server.ts
+++ b/packages/markspec/lsp/server.ts
@@ -57,6 +57,7 @@ import { entryToLspLocation } from "./definition.ts";
 import { displayIdAtPosition, formatHoverContent } from "./hover.ts";
 import { entriesToFoldingRanges } from "./folding.ts";
 import { findOccurrencesInFile } from "./highlights.ts";
+import { buildInlayHints } from "./inlay_hint.ts";
 import {
   buildProfileResponse,
   EMPTY_PROFILE_RESPONSE,
@@ -366,6 +367,7 @@ connection.onInitialize(
         documentHighlightProvider: true,
         documentFormattingProvider: true,
         codeLensProvider: { resolveProvider: false },
+        inlayHintProvider: { resolveProvider: false },
         codeActionProvider: { codeActionKinds: ["quickfix"] },
         semanticTokensProvider: {
           legend: {
@@ -953,6 +955,23 @@ connection.onCodeLens((params) => {
   const allEntries = index.getAllEntries();
   // deno-lint-ignore no-explicit-any
   return buildCodeLenses(entries, allEntries, pathToUri) as any;
+});
+
+// ---------------------------------------------------------------------------
+// Inlay hints — ": <type>" and "(N dependents)" per entry (spec §5.2)
+// ---------------------------------------------------------------------------
+
+connection.languages.inlayHint.on((params) => {
+  const filePath = uriToPath(params.textDocument.uri);
+  if (!isMarkspecFile(filePath)) return [];
+  const document = documents.get(params.textDocument.uri);
+  if (!document) return [];
+  const entries = index.getEntriesForFile(filePath);
+  const allEntries = index.getAllEntries();
+  const lines = document.getText().split("\n");
+  const lineLength = (line: number): number => lines[line - 1]?.length ?? 0;
+  // deno-lint-ignore no-explicit-any
+  return buildInlayHints(entries, allEntries, lineLength) as any;
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/e2e/lsp_inlay_hint_test.ts
+++ b/tests/e2e/lsp_inlay_hint_test.ts
@@ -1,0 +1,150 @@
+// tests/e2e/lsp_inlay_hint_test.ts
+
+/**
+ * @module tests/e2e/lsp_inlay_hint_test
+ *
+ * E2E test for `textDocument/inlayHint` — drives the LSP via JSON-RPC
+ * and verifies hint emission for the two kinds defined by spec §5.2.
+ */
+
+import { assert, assertEquals, assertExists } from "@std/assert";
+import { join, toFileUrl } from "@std/path";
+import { LspTestClient } from "./lsp_helpers.ts";
+
+interface InlayHint {
+  position: { line: number; character: number };
+  label: string;
+  kind?: number;
+  paddingLeft?: boolean;
+  paddingRight?: boolean;
+}
+
+Deno.test("lsp inlayHint: dependents hint appears for referenced entry", async () => {
+  const md = `- [STK_AEB_0001] Target requirement
+
+  Body.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+
+- [SAD_AEB_0001] Child architecture item
+
+  Body.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEG
+      Satisfies: STK_AEB_0001
+`;
+  const client = await LspTestClient.create({
+    "project.yaml": "name: test-project\n",
+    "reqs.md": md,
+  });
+  try {
+    await client.initialize();
+
+    const fileUri = toFileUrl(join(client.workDir, "reqs.md")).href;
+    await client.notify("textDocument/didOpen", {
+      textDocument: {
+        uri: fileUri,
+        languageId: "markdown",
+        version: 1,
+        text: md,
+      },
+    });
+    await new Promise((r) => setTimeout(r, 500));
+
+    const hints = await client.request("textDocument/inlayHint", {
+      textDocument: { uri: fileUri },
+      range: {
+        start: { line: 0, character: 0 },
+        end: { line: 100, character: 0 },
+      },
+    }) as InlayHint[];
+
+    assertExists(hints);
+    const depHint = hints.find((h) =>
+      h.label.startsWith("(") && h.label.includes("dependent")
+    );
+    assert(
+      depHint !== undefined,
+      `Expected a dependents hint, got: ${
+        JSON.stringify(hints.map((h) => h.label))
+      }`,
+    );
+    assertEquals(depHint?.label, "(1 dependent)");
+  } finally {
+    await client.shutdown();
+  }
+});
+
+Deno.test("lsp inlayHint: returns empty array for non-MarkSpec file", async () => {
+  const client = await LspTestClient.create({
+    "project.yaml": "name: test-project\n",
+    "config.json": '{"k":1}\n',
+  });
+  try {
+    await client.initialize();
+
+    const fileUri = toFileUrl(join(client.workDir, "config.json")).href;
+    await client.notify("textDocument/didOpen", {
+      textDocument: {
+        uri: fileUri,
+        languageId: "json",
+        version: 1,
+        text: '{"k":1}\n',
+      },
+    });
+
+    const hints = await client.request("textDocument/inlayHint", {
+      textDocument: { uri: fileUri },
+      range: {
+        start: { line: 0, character: 0 },
+        end: { line: 100, character: 0 },
+      },
+    }) as InlayHint[];
+
+    assertEquals(hints, []);
+  } finally {
+    await client.shutdown();
+  }
+});
+
+Deno.test("lsp inlayHint: isolated entry yields no hints", async () => {
+  // Single entry, no Satisfies refs, default-profile opted out → no
+  // type inference, no dependents.
+  const md = `- [STK_AEB_0001] Isolated requirement
+
+  Body.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+`;
+  const client = await LspTestClient.create({
+    "project.yaml": "name: test-project\n",
+    ".markspec.yaml": "default-profile: false\nprofiles: []\n",
+    "reqs.md": md,
+  });
+  try {
+    await client.initialize();
+
+    const fileUri = toFileUrl(join(client.workDir, "reqs.md")).href;
+    await client.notify("textDocument/didOpen", {
+      textDocument: {
+        uri: fileUri,
+        languageId: "markdown",
+        version: 1,
+        text: md,
+      },
+    });
+    await new Promise((r) => setTimeout(r, 500));
+
+    const hints = await client.request("textDocument/inlayHint", {
+      textDocument: { uri: fileUri },
+      range: {
+        start: { line: 0, character: 0 },
+        end: { line: 100, character: 0 },
+      },
+    }) as InlayHint[];
+
+    assertEquals(hints, []);
+  } finally {
+    await client.shutdown();
+  }
+});


### PR DESCRIPTION
## Summary

- Adds `textDocument/inlayHint` to the MarkSpec LSP server. Each entry receives up to two inline hints at end-of-title-line: a `: <type>` hint (kind=Type) when the parser inferred the type from the display-ID prefix and no explicit `Type:` attribute is present, and a `(N dependents)` hint (kind=Parameter, singular/plural correct) when N > 0.
- Per spec §5.2 Open Question #2, the dependents-hint coordination with codeLens is **client-side**: server emits both unconditionally; the client suppresses whichever it doesn't want via its own settings (in VS Code: `markspec.lsp.codeLens.dependents`).
- Extracts `buildIncomingCount` from `code_lens.ts` into the new shared module `lsp/incoming_index.ts`, per the explicit recommendation of the Capability 3 final reviewer. The extraction is behaviour-preserving — `buildCodeLenses` keeps its public signature and all 8 codeLens unit tests still pass.
- Capability 4 of the LSP feature additions epic (Capabilities 1-3 shipped as PRs #482, #491, #505).

## Test Plan

- [x] 3 unit tests in `lsp/incoming_index_test.ts` cover: empty input, self-reference + Id skip combined, multiple targets.
- [x] 7 unit tests in `lsp/inlay_hint_test.ts` cover: empty input, no-hint entry, prefix-inferred type, explicit-`Type:` suppression, dependents singular/plural, type + dependents on the same entry.
- [x] 3 E2E tests in `tests/e2e/lsp_inlay_hint_test.ts` drive the real JSON-RPC path: dependents hint emission, non-MarkSpec file → `[]`, isolated entry (default-profile opt-out) → `[]`.
- [x] All 8 existing `lsp/code_lens_test.ts` tests still pass — refactor is behaviour-preserving.
- [x] Existing LSP E2E suites (formatting, profile_request, code_lens, diagnostics, completions) still pass. **33 LSP tests pass total**.
- [x] `just build` clean.
- [x] `deno fmt --check` + `dprint check` clean.

## Follow-ups (out of scope)

- **Spec amendment:** spec §10 Open Question #2 should be marked "resolved (client-side suppression)" in a doc-only follow-up PR — the current commit body records the architectural call but the spec still lists it as open. Same amend-after-implement pattern as PRs #498 and #506.
- Memoising `buildIncomingCount` per `WorkspaceIndex` epoch — same future-perf note already present on `getTypeRegistry`.
- Settings-driven per-hint-kind opt-out — owned by the VS Code extension settings layer (`editors/vscode/`).
- Capability 5 — `textDocument/documentLink` for `Verified-by:` paths — separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
