### PR TITLE
feat(lsp): add textDocument/documentLink for Verified-by file paths

### DIFF
--- a/packages/markspec/lsp/document_links.ts
+++ b/packages/markspec/lsp/document_links.ts
@@ -1,0 +1,198 @@
+/**
+ * @module lsp/document_links
+ *
+ * Pure helper for the LSP `textDocument/documentLink` handler. Walks
+ * each entry's source lines, finds `Verified-by:` trailer lines, and
+ * emits one `DocumentLink` per value whose path portion ends in a
+ * recognized source-file extension.
+ *
+ * The link **range** covers only the path substring (not the optional
+ * `:test_name` or `:line[:col]` suffix); the link **target** is the
+ * file URI returned by `resolveTarget`, plus the `#L<line>` fragment
+ * applied by the caller when a numeric suffix is present.
+ *
+ * Spec: `docs/spec/internal/markspec-lsp-feature-additions.md` §5.3.
+ */
+
+import type { Entry } from "../core/mod.ts";
+
+/** Source-file extensions recognized as document-link candidates.
+ * Superset of `lsp/context.ts`'s `SOURCE_EXTENSIONS` — spec §5.3 also
+ * calls out `.py` and `.go` even though MarkSpec's tree-sitter parser
+ * doesn't yet load grammars for them. */
+export const DOCUMENT_LINK_EXTENSIONS: ReadonlySet<string> = new Set([
+  ".rs",
+  ".kt",
+  ".kts",
+  ".java",
+  ".c",
+  ".h",
+  ".cpp",
+  ".cc",
+  ".cxx",
+  ".hpp",
+  ".hxx",
+  ".ts",
+  ".tsx",
+  ".jsx",
+  ".js",
+  ".mjs",
+  ".cjs",
+  ".cs",
+  ".py",
+  ".go",
+]);
+
+/** A subset of the LSP `DocumentLink` interface. */
+export interface DocumentLink {
+  readonly range: {
+    readonly start: { readonly line: number; readonly character: number };
+    readonly end: { readonly line: number; readonly character: number };
+  };
+  readonly target: string;
+}
+
+/**
+ * Matches a trailer-indented `Verified-by:` line, capturing the
+ * leading indent + key + ": " prefix in group 1 so callers can
+ * compute the value's starting column.
+ *
+ * Trailer indent is ≥4 spaces per the parser; the formatter
+ * canonicalises to 6.
+ */
+const VERIFIED_BY_LINE_RE = /^(\s{4,}Verified-by\s*:\s*)(.*)$/;
+
+/**
+ * Match a single value token: `<path>` with an optional
+ * `:line[:col]` or `:identifier` suffix. Group 1 captures the path
+ * portion (which the link range covers); group 2 captures the
+ * numeric line suffix when present (which the resolver consumes).
+ *
+ * Path characters: anything except whitespace, comma, and colon —
+ * keeps the boundary between path and `:suffix` unambiguous.
+ */
+const VALUE_TOKEN_RE =
+  /^([^\s,:]+)(?::(\d+)(?::\d+)?|:[A-Za-z_][A-Za-z0-9_]*)?$/;
+
+/** Return the extension (including the dot) for a path, lowercased. */
+function extOf(p: string): string {
+  const i = p.lastIndexOf(".");
+  if (i < 0) return "";
+  // Reject if the dot is in a directory segment (no slash after the dot).
+  if (p.indexOf("/", i) >= 0) return "";
+  if (p.indexOf("\\", i) >= 0) return "";
+  return p.slice(i).toLowerCase();
+}
+
+/** Top-level comma split — Verified-by paths never contain `[...]`
+ * citation locators, so simple comma split is sufficient. */
+function splitCsv(value: string): string[] {
+  return value.split(",");
+}
+
+/**
+ * Build the `DocumentLink[]` for a document.
+ *
+ * @param entries — entries declared in the document the client requested
+ *   links for. Each entry's `location.line` (1-based) anchors the search;
+ *   the helper scans lines from that entry's start up to either the next
+ *   entry's start − 1 or the end of `text`.
+ * @param text — the full text of the document. Used to locate the path
+ *   substring's column within each `Verified-by:` line.
+ * @param resolveTarget — `(relPath, lineSuffix?) => uri | undefined`.
+ *   Resolves a value's path portion to a `file://` URI. Returns
+ *   `undefined` to suppress emission (e.g., when the caller cannot
+ *   determine a project root). When `lineSuffix` is a number, the
+ *   caller-side implementation appends `#L<lineSuffix>` to the URI;
+ *   when it is `undefined`, no fragment is appended. Keeping the
+ *   resolver injected makes the helper platform-neutral and
+ *   unit-testable without `@std/path` or filesystem access.
+ */
+export function buildDocumentLinks(
+  entries: readonly Entry[],
+  text: string,
+  resolveTarget: (
+    relPath: string,
+    lineSuffix: number | undefined,
+  ) => string | undefined,
+): DocumentLink[] {
+  if (entries.length === 0) return [];
+
+  const lines = text.split("\n");
+  const sorted = [...entries].sort(
+    (a, b) => a.location.line - b.location.line,
+  );
+
+  const out: DocumentLink[] = [];
+
+  for (let i = 0; i < sorted.length; i++) {
+    const entry = sorted[i];
+    // 1-based inclusive start; 1-based inclusive end.
+    const startLine = entry.location.line;
+    const endLine = i + 1 < sorted.length
+      ? sorted[i + 1].location.line - 1
+      : lines.length;
+
+    for (let lineNo = startLine; lineNo <= endLine; lineNo++) {
+      const line = lines[lineNo - 1];
+      if (line === undefined) continue;
+      const m = VERIFIED_BY_LINE_RE.exec(line);
+      if (!m) continue;
+
+      const prefixLen = m[1].length;
+      const value = m[2];
+
+      // Walk comma-separated tokens, tracking the column of each
+      // token's start within the source line so we can emit an
+      // accurate range. `cursor` is the column of the next character
+      // to examine; `csvParts` are the raw split chunks (each
+      // potentially leading/trailing whitespace).
+      let cursor = prefixLen;
+      const csvParts = splitCsv(value);
+      for (let p = 0; p < csvParts.length; p++) {
+        const part = csvParts[p];
+        // Skip leading whitespace inside the part to find token start.
+        let tokenStart = 0;
+        while (tokenStart < part.length && /\s/.test(part[tokenStart])) {
+          tokenStart++;
+        }
+        // Find token end (until trailing whitespace).
+        let tokenEnd = part.length;
+        while (tokenEnd > tokenStart && /\s/.test(part[tokenEnd - 1])) {
+          tokenEnd--;
+        }
+        const token = part.slice(tokenStart, tokenEnd);
+
+        // Absolute column where the token begins.
+        const tokenColumn = cursor + tokenStart;
+
+        // Advance `cursor` past this part and the comma separator
+        // (except for the last part).
+        cursor += part.length;
+        if (p < csvParts.length - 1) cursor += 1; // the comma
+
+        if (token.length === 0) continue;
+
+        const vm = VALUE_TOKEN_RE.exec(token);
+        if (!vm) continue;
+        const pathPart = vm[1];
+        const numericLine = vm[2] !== undefined ? Number(vm[2]) : undefined;
+
+        if (!DOCUMENT_LINK_EXTENSIONS.has(extOf(pathPart))) continue;
+
+        const target = resolveTarget(pathPart, numericLine);
+        if (target === undefined) continue;
+
+        const lspLine = lineNo - 1;
+        out.push({
+          range: {
+            start: { line: lspLine, character: tokenColumn },
+            end: { line: lspLine, character: tokenColumn + pathPart.length },
+          },
+          target,
+        });
+      }
+    }
+  }
+  return out;
+}

--- a/packages/markspec/lsp/document_links_test.ts
+++ b/packages/markspec/lsp/document_links_test.ts
@@ -1,0 +1,234 @@
+/**
+ * @module lsp/document_links_test
+ */
+
+import { assertEquals } from "@std/assert";
+import type { Entry } from "../core/mod.ts";
+import { buildDocumentLinks } from "./document_links.ts";
+
+function fakeEntry(line: number, title: string): Entry {
+  // Minimal Entry stub — only the fields buildDocumentLinks reads.
+  return {
+    displayId: "STK_0001",
+    title,
+    body: "",
+    rawAttributes: [],
+    typedAttributes: new Map(),
+    labels: [],
+    location: { file: "/proj/reqs.md", line, column: 1 },
+    type: undefined,
+    id: undefined,
+  } as unknown as Entry;
+}
+
+// Identity resolver: passes the path through unchanged and appends
+// `#L<n>` when a line suffix is supplied. Mirrors the server-side
+// resolver but stays platform-neutral.
+const idResolver = (
+  relPath: string,
+  lineSuffix: number | undefined,
+): string | undefined =>
+  lineSuffix === undefined
+    ? `file:///proj/${relPath}`
+    : `file:///proj/${relPath}#L${lineSuffix}`;
+
+Deno.test("buildDocumentLinks: empty entries returns []", () => {
+  assertEquals(buildDocumentLinks([], "", idResolver), []);
+});
+
+Deno.test("buildDocumentLinks: no Verified-by attribute returns []", () => {
+  const text = `- [STK_0001] T
+
+  Body.
+
+      Id: 01HABC
+`;
+  assertEquals(
+    buildDocumentLinks([fakeEntry(1, "T")], text, idResolver),
+    [],
+  );
+});
+
+Deno.test("buildDocumentLinks: path-only value matched", () => {
+  const text = `- [STK_0001] T
+
+      Id: 01HABC
+      Verified-by: tests/sit_bar.rs
+`;
+  const links = buildDocumentLinks(
+    [fakeEntry(1, "T")],
+    text,
+    idResolver,
+  );
+  assertEquals(links.length, 1);
+  assertEquals(links[0].target, "file:///proj/tests/sit_bar.rs");
+  // Range covers `tests/sit_bar.rs` — line 4 (0-based 3), starting after
+  // `      Verified-by: ` which is 19 chars wide.
+  assertEquals(links[0].range, {
+    start: { line: 3, character: 19 },
+    end: { line: 3, character: 19 + "tests/sit_bar.rs".length },
+  });
+});
+
+Deno.test("buildDocumentLinks: numeric :line suffix produces #L fragment", () => {
+  const text = `- [STK_0001] T
+
+      Id: 01HABC
+      Verified-by: src/foo.rs:42
+`;
+  const links = buildDocumentLinks(
+    [fakeEntry(1, "T")],
+    text,
+    idResolver,
+  );
+  assertEquals(links.length, 1);
+  assertEquals(links[0].target, "file:///proj/src/foo.rs#L42");
+  // Range covers only `src/foo.rs` (the path), not the `:42` suffix.
+  assertEquals(links[0].range.end.character, 19 + "src/foo.rs".length);
+});
+
+Deno.test("buildDocumentLinks: numeric :line:col suffix produces #L fragment", () => {
+  const text = `- [STK_0001] T
+
+      Id: 01HABC
+      Verified-by: src/foo.rs:42:5
+`;
+  const links = buildDocumentLinks(
+    [fakeEntry(1, "T")],
+    text,
+    idResolver,
+  );
+  assertEquals(links.length, 1);
+  assertEquals(links[0].target, "file:///proj/src/foo.rs#L42");
+});
+
+Deno.test("buildDocumentLinks: identifier (test-name) suffix — no fragment", () => {
+  const text = `- [STK_0001] T
+
+      Id: 01HABC
+      Verified-by: src/foo.rs:test_name
+`;
+  const links = buildDocumentLinks(
+    [fakeEntry(1, "T")],
+    text,
+    idResolver,
+  );
+  assertEquals(links.length, 1);
+  // No fragment because the suffix is not numeric.
+  assertEquals(links[0].target, "file:///proj/src/foo.rs");
+  // Range still covers only `src/foo.rs`.
+  assertEquals(links[0].range.end.character, 19 + "src/foo.rs".length);
+});
+
+Deno.test("buildDocumentLinks: display ID is not linkified", () => {
+  const text = `- [STK_0001] T
+
+      Id: 01HABC
+      Verified-by: STK_AEB_0001
+`;
+  assertEquals(
+    buildDocumentLinks([fakeEntry(1, "T")], text, idResolver),
+    [],
+  );
+});
+
+Deno.test("buildDocumentLinks: unknown extension is not linkified", () => {
+  const text = `- [STK_0001] T
+
+      Id: 01HABC
+      Verified-by: report.pdf
+`;
+  assertEquals(
+    buildDocumentLinks([fakeEntry(1, "T")], text, idResolver),
+    [],
+  );
+});
+
+Deno.test("buildDocumentLinks: multiple comma-separated values on one line", () => {
+  const text = `- [STK_0001] T
+
+      Id: 01HABC
+      Verified-by: a.rs, b.kt:10
+`;
+  const links = buildDocumentLinks(
+    [fakeEntry(1, "T")],
+    text,
+    idResolver,
+  );
+  assertEquals(links.length, 2);
+  assertEquals(links[0].target, "file:///proj/a.rs");
+  assertEquals(links[1].target, "file:///proj/b.kt#L10");
+  // Ranges must not overlap and must reflect each path's column.
+  const valuesStart = "      Verified-by: ".length;
+  assertEquals(links[0].range.start.character, valuesStart);
+  assertEquals(links[0].range.end.character, valuesStart + "a.rs".length);
+  // `b.kt` follows `a.rs, ` — i.e. ", " of length 2.
+  const bStart = valuesStart + "a.rs".length + ", ".length;
+  assertEquals(links[1].range.start.character, bStart);
+  assertEquals(links[1].range.end.character, bStart + "b.kt".length);
+});
+
+Deno.test("buildDocumentLinks: multiple Verified-by lines under one entry", () => {
+  const text = `- [STK_0001] T
+
+      Id: 01HABC
+      Verified-by: a.rs
+      Verified-by: b.go
+`;
+  const links = buildDocumentLinks(
+    [fakeEntry(1, "T")],
+    text,
+    idResolver,
+  );
+  assertEquals(links.length, 2);
+  assertEquals(links[0].target, "file:///proj/a.rs");
+  assertEquals(links[0].range.start.line, 3);
+  assertEquals(links[1].target, "file:///proj/b.go");
+  assertEquals(links[1].range.start.line, 4);
+});
+
+Deno.test("buildDocumentLinks: links scoped to entry range — Verified-by outside any entry ignored", () => {
+  const text = `prose line — Verified-by: rogue.rs is not a real attribute
+
+- [STK_0001] T
+
+      Id: 01HABC
+      Verified-by: real.rs
+`;
+  const links = buildDocumentLinks(
+    [fakeEntry(3, "T")],
+    text,
+    idResolver,
+  );
+  assertEquals(links.length, 1);
+  assertEquals(links[0].target, "file:///proj/real.rs");
+});
+
+Deno.test("buildDocumentLinks: resolveTarget returning undefined suppresses link", () => {
+  const text = `- [STK_0001] T
+
+      Id: 01HABC
+      Verified-by: src/foo.rs
+`;
+  const links = buildDocumentLinks(
+    [fakeEntry(1, "T")],
+    text,
+    () => undefined,
+  );
+  assertEquals(links, []);
+});
+
+Deno.test("buildDocumentLinks: mixed display-ID + path on one line", () => {
+  const text = `- [STK_0001] T
+
+      Id: 01HABC
+      Verified-by: STK_AEB_0002, tests/foo.rs:7
+`;
+  const links = buildDocumentLinks(
+    [fakeEntry(1, "T")],
+    text,
+    idResolver,
+  );
+  assertEquals(links.length, 1);
+  assertEquals(links[0].target, "file:///proj/tests/foo.rs#L7");
+});

--- a/packages/markspec/lsp/server.ts
+++ b/packages/markspec/lsp/server.ts
@@ -31,7 +31,7 @@ import {
 } from "vscode-languageserver/node";
 import { TextDocument } from "vscode-languageserver-textdocument";
 import process from "node:process";
-import { join } from "@std/path";
+import { isAbsolute, join } from "@std/path";
 import { ulid } from "@std/ulid";
 import {
   CORE_SCHEMA_VERSION,
@@ -50,6 +50,7 @@ import {
 } from "../core/mod.ts";
 import { WorkspaceIndex } from "./workspace.ts";
 import { buildCodeLenses } from "./code_lens.ts";
+import { buildDocumentLinks } from "./document_links.ts";
 import { buildFormattingEdits } from "./formatting.ts";
 import { groupDiagnosticsByFile, toLspDiagnostic } from "./diagnostics.ts";
 import { buildCodeActions } from "./code_actions.ts";
@@ -369,6 +370,7 @@ connection.onInitialize(
         codeLensProvider: { resolveProvider: false },
         inlayHintProvider: { resolveProvider: false },
         codeActionProvider: { codeActionKinds: ["quickfix"] },
+        documentLinkProvider: { resolveProvider: false },
         semanticTokensProvider: {
           legend: {
             tokenTypes: [...SEMANTIC_TOKEN_LEGEND.tokenTypes],
@@ -917,6 +919,32 @@ connection.onCodeAction((params) => {
   );
   // deno-lint-ignore no-explicit-any
   return actions as any;
+});
+
+// ---------------------------------------------------------------------------
+// Document links — clickable `Verified-by:` file-path values (§5.3)
+// ---------------------------------------------------------------------------
+
+connection.onDocumentLinks((params) => {
+  const document = documents.get(params.textDocument.uri);
+  if (!document) return [];
+  const filePath = uriToPath(params.textDocument.uri);
+  if (!isMarkspecFile(filePath)) return [];
+  if (!projectRoot) return [];
+
+  const entries = index.getEntriesForFile(filePath);
+  const root = projectRoot;
+  const resolveTarget = (
+    relPath: string,
+    lineSuffix: number | undefined,
+  ): string | undefined => {
+    const absPath = isAbsolute(relPath) ? relPath : join(root, relPath);
+    const baseUri = pathToUri(absPath);
+    return lineSuffix === undefined ? baseUri : `${baseUri}#L${lineSuffix}`;
+  };
+
+  // deno-lint-ignore no-explicit-any
+  return buildDocumentLinks(entries, document.getText(), resolveTarget) as any;
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/e2e/lsp_document_link_test.ts
+++ b/tests/e2e/lsp_document_link_test.ts
@@ -1,0 +1,161 @@
+// tests/e2e/lsp_document_link_test.ts
+
+/**
+ * @module tests/e2e/lsp_document_link_test
+ *
+ * E2E test for `textDocument/documentLink` — drives the LSP via
+ * JSON-RPC and verifies link emission for `Verified-by:` file-path
+ * values per spec §5.3.
+ */
+
+import { assertEquals, assertExists } from "@std/assert";
+import { join, toFileUrl } from "@std/path";
+import { LspTestClient } from "./lsp_helpers.ts";
+
+interface DocumentLink {
+  range: {
+    start: { line: number; character: number };
+    end: { line: number; character: number };
+  };
+  target: string;
+}
+
+Deno.test("lsp documentLink: path-only Verified-by value produces a link", async () => {
+  const md = `- [STK_AEB_0001] Requirement with file-path Verified-by
+
+  Body.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      Verified-by: tests/sit_bar.rs
+`;
+  const client = await LspTestClient.create({
+    "project.yaml": "name: test-project\n",
+    "reqs.md": md,
+  });
+  try {
+    await client.initialize();
+    const fileUri = toFileUrl(join(client.workDir, "reqs.md")).href;
+    await client.notify("textDocument/didOpen", {
+      textDocument: {
+        uri: fileUri,
+        languageId: "markdown",
+        version: 1,
+        text: md,
+      },
+    });
+    await new Promise((r) => setTimeout(r, 500));
+
+    const links = await client.request("textDocument/documentLink", {
+      textDocument: { uri: fileUri },
+    }) as DocumentLink[];
+
+    assertExists(links);
+    assertEquals(links.length, 1);
+    const expectedTarget =
+      toFileUrl(join(client.workDir, "tests/sit_bar.rs")).href;
+    assertEquals(links[0].target, expectedTarget);
+  } finally {
+    await client.shutdown();
+  }
+});
+
+Deno.test("lsp documentLink: numeric :line suffix produces #L fragment", async () => {
+  const md = `- [STK_AEB_0001] Requirement with line-suffixed Verified-by
+
+  Body.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      Verified-by: src/foo.rs:42
+`;
+  const client = await LspTestClient.create({
+    "project.yaml": "name: test-project\n",
+    "reqs.md": md,
+  });
+  try {
+    await client.initialize();
+    const fileUri = toFileUrl(join(client.workDir, "reqs.md")).href;
+    await client.notify("textDocument/didOpen", {
+      textDocument: {
+        uri: fileUri,
+        languageId: "markdown",
+        version: 1,
+        text: md,
+      },
+    });
+    await new Promise((r) => setTimeout(r, 500));
+
+    const links = await client.request("textDocument/documentLink", {
+      textDocument: { uri: fileUri },
+    }) as DocumentLink[];
+
+    assertEquals(links.length, 1);
+    const expectedBase = toFileUrl(join(client.workDir, "src/foo.rs")).href;
+    assertEquals(links[0].target, `${expectedBase}#L42`);
+  } finally {
+    await client.shutdown();
+  }
+});
+
+Deno.test("lsp documentLink: display-ID Verified-by value is not linkified", async () => {
+  const md = `- [STK_AEB_0001] Target
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+
+- [STK_AEB_0002] Verifies via display ID
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEG
+      Verified-by: STK_AEB_0001
+`;
+  const client = await LspTestClient.create({
+    "project.yaml": "name: test-project\n",
+    "reqs.md": md,
+  });
+  try {
+    await client.initialize();
+    const fileUri = toFileUrl(join(client.workDir, "reqs.md")).href;
+    await client.notify("textDocument/didOpen", {
+      textDocument: {
+        uri: fileUri,
+        languageId: "markdown",
+        version: 1,
+        text: md,
+      },
+    });
+    await new Promise((r) => setTimeout(r, 500));
+
+    const links = await client.request("textDocument/documentLink", {
+      textDocument: { uri: fileUri },
+    }) as DocumentLink[];
+
+    assertEquals(links, []);
+  } finally {
+    await client.shutdown();
+  }
+});
+
+Deno.test("lsp documentLink: returns empty array for non-MarkSpec file", async () => {
+  const client = await LspTestClient.create({
+    "project.yaml": "name: test-project\n",
+    "config.json": '{"k":1}\n',
+  });
+  try {
+    await client.initialize();
+    const fileUri = toFileUrl(join(client.workDir, "config.json")).href;
+    await client.notify("textDocument/didOpen", {
+      textDocument: {
+        uri: fileUri,
+        languageId: "json",
+        version: 1,
+        text: '{"k":1}\n',
+      },
+    });
+
+    const links = await client.request("textDocument/documentLink", {
+      textDocument: { uri: fileUri },
+    }) as DocumentLink[];
+
+    assertEquals(links, []);
+  } finally {
+    await client.shutdown();
+  }
+});


### PR DESCRIPTION
## Summary

- Implements LSP `textDocument/documentLink` per spec §5.3 — `Verified-by:` values whose path portion ends in a recognized source-file extension become clickable file links.
- Numeric `:line[:col]` suffixes produce a `file://path#L<line>` fragment (VS Code convention). Identifier suffixes (`:test_name`) are recognised but emit no fragment.
- The pure helper (`lsp/document_links.ts`) takes a `resolveTarget` callback so the platform-specific path → URI conversion stays in `server.ts` and the helper stays unit-testable.
- Non-MarkSpec files and missing `projectRoot` return `[]`.

Spec: `docs/spec/internal/markspec-lsp-feature-additions.md` §5.3.

This is the 5th and final capability in the LSP Feature Additions epic (handoff: `docs/superpowers/2026-05-26-lsp-feature-additions-status.md`).

## Test plan

- [x] `just build` clean
- [x] `deno fmt --check && dprint check` clean
- [x] 13 new unit tests in `packages/markspec/lsp/document_links_test.ts` pass
- [x] 4 new E2E tests in `tests/e2e/lsp_document_link_test.ts` pass
- [x] Existing LSP E2E suite (`lsp_code_lens_test.ts`, `lsp_inlay_hint_test.ts`, …) unchanged — 2616 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
