### PR TITLE
docs(release): prep 0.6.0 — refresh stale CLI / spec / guide content

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -220,26 +220,31 @@ pass. `CHANGELOG.md` and `docs/examples/` are excluded from dprint.
 
 ### Implemented
 
-| Command                               | Module                              | Purpose                                                                     |
-| ------------------------------------- | ----------------------------------- | --------------------------------------------------------------------------- |
-| `markspec format [...files]`          | `core/formatter`                    | Stamp ULIDs, fix indentation, normalize attributes. Pre-commit hook.        |
-| `markspec validate [...files]`        | `core/validator`                    | Check broken refs, missing Ids, malformed entries, duplicates.              |
-| `markspec compile <paths...>`         | `core/compiler`                     | Parse all files, build traceability graph, output compiled JSON.            |
-| `markspec show <id> <paths...>`       | `core/compiler`                     | Show details of a single entry by display ID or ULID.                       |
-| `markspec context <id> <paths...>`    | `core/compiler`                     | Walk the Satisfies chain upward from an entry.                              |
-| `markspec dependents <id> <paths...>` | `core/compiler`                     | List all entries that depend on a given entry.                              |
-| `markspec report <kind> <paths...>`   | `core/reporter`                     | Generate traceability matrix or coverage report.                            |
-| `markspec profile show`               | `core/profile`                      | Show the active profile chain and effective configuration.                  |
-| `markspec doctor`                     | `core/profile` + `core/validator`   | Project health check: profile, config, and validation summary.              |
-| `markspec next-id <type> <paths...>`  | `core/compiler` + `core/profile`    | Print the next available display ID for a profile-declared type.            |
-| `markspec create <type> <paths...>`   | `core/compiler` + `core/profile`    | Scaffold a new entry block for a profile-declared type (stdout).            |
-| `markspec insert <type> <file>`       | `core/compiler` + `core/profile`    | Append a scaffolded entry block to the file (agent write path).             |
-| `markspec export <format> <paths...>` | `core/compiler`                     | Emit the compiled traceability graph as json, yaml, or csv (reqif pending). |
-| `markspec hook [...files]`            | `core/formatter` + `core/validator` | Pre-commit hook: run format --check + validate on the given files.          |
-| `markspec doc build <file>`           | `render/typst`                      | Single document → PDF via Typst WASM.                                       |
-| `markspec book build`                 | `book/site`                         | Multi-chapter → static HTML site.                                           |
-| `markspec lsp`                        | `lsp/server`                        | LSP server for editor integration (stdio JSON-RPC).                         |
-| `markspec mcp`                        | `mcp/server`                        | MCP server for AI agent integration (stdio JSON-RPC).                       |
+| Command                               | Module                              | Purpose                                                                       |
+| ------------------------------------- | ----------------------------------- | ----------------------------------------------------------------------------- |
+| `markspec format [...files]`          | `core/formatter`                    | Stamp ULIDs, fix indentation, normalize attributes. Pre-commit hook.          |
+| `markspec validate [...files]`        | `core/validator`                    | Check broken refs, missing Ids, malformed entries, duplicates.                |
+| `markspec compile <paths...>`         | `core/compiler`                     | Parse all files, build traceability graph, output compiled JSON.              |
+| `markspec show <id> <paths...>`       | `core/compiler`                     | Show details of a single entry by display ID or ULID.                         |
+| `markspec context <id> <paths...>`    | `core/compiler`                     | Walk the Satisfies chain upward from an entry.                                |
+| `markspec dependents <id> <paths...>` | `core/compiler`                     | List all entries that depend on a given entry.                                |
+| `markspec report <kind> <paths...>`   | `core/reporter`                     | Generate traceability matrix or coverage report.                              |
+| `markspec profile show`               | `core/profile`                      | Show the active profile chain and effective configuration.                    |
+| `markspec doctor`                     | `core/profile` + `core/validator`   | Project health check: profile, config, and validation summary.                |
+| `markspec next-id <type> <paths...>`  | `core/compiler` + `core/profile`    | Print the next available display ID for a profile-declared type.              |
+| `markspec create <type> <paths...>`   | `core/compiler` + `core/profile`    | Scaffold a new entry block for a profile-declared type (stdout).              |
+| `markspec insert <type> <file>`       | `core/compiler` + `core/profile`    | Append a scaffolded entry block to the file (agent write path).               |
+| `markspec export <format> <paths...>` | `core/compiler`                     | Emit the compiled traceability graph as json, yaml, or csv (reqif pending).   |
+| `markspec hook [...files]`            | `core/formatter` + `core/validator` | Pre-commit hook: run format --check + validate on the given files.            |
+| `markspec lint [...paths]`            | `core/lint`                         | Prose-analysis lint (modal verbs, EARS, passive voice, INCOSE, flagship).     |
+| `markspec lock`                       | `core/lock`                         | Generate or refresh `markspec.lock` (upstream pins, sync mappings).           |
+| `markspec sync {status\|log\|show}`   | `core/sync`                         | Read-only surface over lockfile + per-system sync log (NDJSON).               |
+| `markspec doc build <file>`           | `render/typst`                      | Single document → PDF via Typst WASM.                                         |
+| `markspec book build`                 | `book/site`                         | Multi-chapter → static HTML site.                                             |
+| `markspec lsp`                        | `lsp/server`                        | LSP server for editor integration (stdio JSON-RPC).                           |
+| `markspec lsp install`                | `lsp/server`                        | Print LSP server configuration for an editor (vscode, neovim, zed).           |
+| `markspec mcp`                        | `mcp/server`                        | MCP server for AI agent integration (stdio JSON-RPC).                         |
+| `markspec mcp install`                | `mcp/server`                        | Print MCP server configuration for a client (claude-desktop, cursor, vscode). |
 
 ### Not yet implemented
 
@@ -393,6 +398,23 @@ docs/
   `$Identifier` entity refs and inline code; supersedes ADR-014's
   `InlineContent.markers`; `LineMap` carries file-relative positions through
   source-file doc-comment parsing
+- `adr-017-discipline-classification.md` — derive SW/HW discipline from the
+  Allocated-to graph; introduces `Entry.derivedDiscipline?`; ships in slices
+  (registry + channels + default + mixed + `discipline_mode`)
+- `adr-018-core-discipline-ssot.md` — single source of truth for SW/HW
+  discipline lives in core (R3 / Path A++); profile extends, never overrides
+- `adr-019-typl-type-dsl.md` — typl Type Specification DSL for inline
+  constraint/type declarations on entry attributes; parser + three surfaces
+  (inline, bullet, fenced) + validation + corpus type registry
+- `adr-020-sqlite-indexing-eval.md` — evaluation scope for on-demand SQLite
+  indexing as Phase 1 of the background-indexing epic (no FS watcher, surgical
+  invalidation, lockfile-pinned federated cache)
+- `adr-021-prose-analysis-flagship-build.md` — Stage-2 prose-analysis design: 16
+  active MSL-Q rules + flagship `xref-glossary-undefined` + band-count score
+  roll-up; deliberate non-feature: no trend artifacts in core
+- `adr-022-lockfile-and-external-sync.md` — `markspec.lock` format for upstream
+  version pinning + sync state tracking (`markspec lock`,
+  `markspec sync status|log|show`)
 - `overview.md` — narrative architecture tour
 
 See [docs/architecture/overview.md](docs/architecture/overview.md) for a reading

--- a/README.md
+++ b/README.md
@@ -9,30 +9,77 @@
 A Markdown flavor for traceable industrial documentation, and a CLI toolchain
 that processes it.
 
-> Early development. The
-> [language specification](docs/spec/language/language.md) is under active
-> revision to match ADR-009 (core/profile boundary). Tooling is not yet
-> functional.
+> Pre-1.0. The toolchain is functional end-to-end for authoring, validation,
+> traceability, rendering, and editor / agent integration. The
+> [language specification](docs/spec/language/language.md) and wire formats
+> (compile-output JSON, lockfile) may still change without
+> backward-compatibility shims until 1.0.
 
 ## Tools
 
+**Authoring and validation**
+
 ```text
-markspec format          # stamp ULIDs, normalize attributes
-markspec validate        # check broken refs, missing Ids
-markspec compile <paths> # build traceability graph → JSON
-                         # (ingests deps via SBOM tooling if configured)
-markspec export          # JSON → csv, reqif, yaml
-markspec insert          # scaffold entry block
-markspec profile         # add / publish / manage profiles
+markspec format             # stamp ULIDs, normalize attributes
+markspec validate           # check broken refs, missing Ids, duplicates
+markspec lint               # prose analysis (modal verbs, EARS, passive, …)
+markspec hook               # pre-commit gate: format --check + validate
+markspec insert <type>      # append a scaffolded entry to a file
+markspec create <type>      # scaffold a new entry block (stdout)
+markspec next-id <type>     # next available display ID for a type
+```
 
-markspec doc build       # document PDF
-markspec book build      # PDF + HTML book
-markspec book dev        # live preview
-markspec deck build      # presentation PDF
-markspec deck dev        # live preview
+**Traceability and querying**
 
-markspec lsp             # LSP server
-markspec mcp             # MCP server
+```text
+markspec compile <paths>    # build traceability graph → JSON
+markspec show <id>          # show one entry by display ID or ULID
+markspec context <id>       # walk the Satisfies chain upward
+markspec dependents <id>    # list entries that depend on an entry
+markspec report <kind>      # traceability matrix or coverage report
+markspec export <format>    # compile-graph → json, yaml, csv
+```
+
+**Lockfile and external sync**
+
+```text
+markspec lock               # generate or refresh markspec.lock
+markspec sync status        # group bound entries by remote_state
+markspec sync log           # tail per-system sync log (NDJSON)
+markspec sync show <id>     # full sync state for one bound entry
+```
+
+**Profiles and diagnostics**
+
+```text
+markspec profile show       # show active profile chain
+markspec doctor             # project health check
+```
+
+**Rendering**
+
+```text
+markspec doc build          # single document → PDF (Typst WASM)
+markspec book build         # multi-chapter → static HTML site
+```
+
+**Editor and agent integration**
+
+```text
+markspec lsp                # LSP server (stdio JSON-RPC)
+markspec lsp install        # print LSP config for vscode, neovim, zed
+markspec mcp                # MCP server (stdio JSON-RPC)
+markspec mcp install        # print MCP config for claude-desktop,
+                            #   cursor, vscode
+```
+
+**Not yet implemented** (registered but exit with an error):
+
+```text
+markspec export reqif       # ReqIF XML export
+markspec book dev           # live preview with hot reload
+markspec deck build         # slides → PDF via Touying/Typst
+markspec deck dev           # live slide preview
 ```
 
 ## Modules

--- a/docs/guide/ai-agents.md
+++ b/docs/guide/ai-agents.md
@@ -47,10 +47,19 @@ Generate the snippet automatically:
 markspec mcp install --client claude-desktop
 ```
 
+Pin a specific binary path (useful when the binary is not on `PATH` or when
+package-manager upgrades would change the install location):
+
+```sh
+markspec mcp install --client claude-desktop \
+  --binary-path /opt/markspec/bin/markspec
+```
+
 ### Cursor
 
 ```sh
 markspec mcp install --client cursor
+markspec mcp install --client cursor --binary-path /opt/markspec/bin/markspec
 ```
 
 ### VS Code (Copilot / Claude)

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -380,6 +380,78 @@ formatting or has validation errors.
 
 See [Pre-commit hook](recipes/git-hooks.md) for setup instructions.
 
+### Lockfile and external sync
+
+#### lock
+
+Generate or refresh `markspec.lock`. The lockfile pins upstream profile and
+language-pack versions, and records the sync mappings discovered from
+`project.yaml`. See
+[ADR-022](../architecture/adr-022-lockfile-and-external-sync.md).
+
+```sh
+markspec lock
+```
+
+| Flag       | Type   | Default | Description                                            |
+| ---------- | ------ | ------- | ------------------------------------------------------ |
+| `--check`  | bool   | false   | CI mode: read-only, exit `1` on drift.                 |
+| `--update` | string | —       | Force re-resolve all upstreams, or one by `id`/`slug`. |
+| `--format` | string | `text`  | Output format: `json`, `text`.                         |
+
+**Examples:**
+
+```sh
+markspec lock                      # write or refresh markspec.lock
+markspec lock --check              # CI gate: fail if lockfile is stale
+markspec lock --update             # force re-resolve every upstream
+markspec lock --update github-foo  # force re-resolve one upstream
+```
+
+#### sync
+
+Read-only commands surfacing bound-entry state from `markspec.lock` and the
+per-system NDJSON sync log under `.markspec/sync/<system>/log.ndjson`. `push` /
+`pull` / `resolve` / `init` are connector-side and ship in per-tool ADRs.
+
+```sh
+markspec sync status [system]
+markspec sync log    [system]
+markspec sync show   <displayId>
+```
+
+**`sync status`** — group bound entries by `remote_state`:
+
+| Flag       | Type   | Default | Description                                                                                                       |
+| ---------- | ------ | ------- | ----------------------------------------------------------------------------------------------------------------- |
+| `--state`  | string | —       | Filter to one `remote_state` (`ok`, `behind`, `ahead`, `conflict`, `unreachable`, `deleted-upstream`, `unbound`). |
+| `--format` | string | `text`  | Output format: `json`, `text`.                                                                                    |
+
+**`sync log`** — tail the per-system sync log (NDJSON):
+
+| Flag       | Type   | Default | Description                                              |
+| ---------- | ------ | ------- | -------------------------------------------------------- |
+| `--tail`   | number | `20`    | Number of lines from the end.                            |
+| `--op`     | string | —       | Filter to one op: `push`, `pull`, `conflict`, `resolve`. |
+| `--since`  | string | —       | Filter to entries at or after this RFC 3339 timestamp.   |
+| `--format` | string | `text`  | Output format: `json`, `text`.                           |
+
+**`sync show`** — full sync state for one bound entry:
+
+| Flag       | Type   | Default | Description                    |
+| ---------- | ------ | ------- | ------------------------------ |
+| `--format` | string | `text`  | Output format: `json`, `text`. |
+
+**Examples:**
+
+```sh
+markspec sync status                     # all systems, grouped by state
+markspec sync status jira                # one system
+markspec sync status --state conflict    # only conflicting entries
+markspec sync log jira --tail 50 --op conflict
+markspec sync show STK_BRK_0001
+```
+
 ### Documents
 
 #### doc build
@@ -593,33 +665,49 @@ a re-read after an edit returns up-to-date content.
 
 #### mcp install
 
-Print MCP server configuration for a client.
+Print MCP server configuration for a client. The output is the client's native
+config snippet — pipe it to the client's settings file or copy-paste it.
 
 ```sh
 markspec mcp install --client <client>
 ```
 
-Supported clients: `claude-desktop`, `cursor`, `vscode`.
+| Flag            | Type   | Default             | Description                                                                                                                |
+| --------------- | ------ | ------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `--client`      | string | —                   | Client ID: `claude-desktop`, `cursor`, `vscode`.                                                                           |
+| `--binary-path` | string | invoked binary name | Explicit path to the `markspec` binary. Default writes the invoked name (resolves via `PATH`, surviving package upgrades). |
+
+**Examples:**
 
 ```sh
 markspec mcp install --client claude-desktop
 markspec mcp install --client cursor
 markspec mcp install --client vscode
+markspec mcp install --client claude-desktop --binary-path /opt/markspec/bin/markspec
 ```
 
 #### lsp install
 
-Print LSP server configuration for an editor.
+Print LSP server configuration for an editor. The output is the editor's native
+config snippet (JSON for VS Code, Lua for Neovim, JSON for Zed) — pipe it to the
+editor's settings file or copy-paste it.
 
 ```sh
 markspec lsp install --editor <editor>
 ```
 
-Supported editors: `vscode`, `neovim`, `zed`.
+| Flag            | Type   | Default             | Description                                                                                                                |
+| --------------- | ------ | ------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `--editor`      | string | —                   | Editor ID: `vscode`, `neovim`, `zed`.                                                                                      |
+| `--binary-path` | string | invoked binary name | Explicit path to the `markspec` binary. Default writes the invoked name (resolves via `PATH`, surviving package upgrades). |
+
+**Examples:**
 
 ```sh
+markspec lsp install --editor vscode
 markspec lsp install --editor neovim
 markspec lsp install --editor zed
+markspec lsp install --editor vscode --binary-path /opt/markspec/bin/markspec
 ```
 
 ### Not yet implemented

--- a/docs/guide/editor-vscode.md
+++ b/docs/guide/editor-vscode.md
@@ -7,21 +7,26 @@ use on the command line.
 
 ## Features
 
-| Feature                  | Description                                                                         |
-| ------------------------ | ----------------------------------------------------------------------------------- |
-| Real-time diagnostics    | Validation errors and warnings inline as you type                                   |
-| Entry block completions  | `- [` → full block scaffold with display ID and attribute skeleton                  |
-| ID reference completions | `Satisfies:` → pick from all display IDs in the workspace                           |
-| Type completions         | `Type:` → core types + profile-declared types                                       |
-| Hover                    | Hover any display ID to preview the entry's title, type, and body                   |
-| Go-to-definition         | `F12` on a display ID jumps to the entry's source location                          |
-| Find all references      | `Shift+F12` lists every file that references a display ID                           |
-| Workspace rename         | `F2` renames a display ID across the entire workspace                               |
-| Document outline         | Outline view lists every entry in the file                                          |
-| Workspace symbol search  | `Ctrl+T` fuzzy-searches entries by display ID or title                              |
-| Folding                  | Each entry block is collapsible                                                     |
-| Document highlights      | Cursor on a display ID highlights every occurrence in the file                      |
-| Quick fixes              | One-click fixes for MSL-M060 (uppercase modal), MSL-A030 (generated attr), and more |
+| Feature                  | Description                                                                            |
+| ------------------------ | -------------------------------------------------------------------------------------- |
+| Real-time diagnostics    | Validation errors and warnings inline as you type                                      |
+| Entry block completions  | `- [` → full block scaffold with display ID and attribute skeleton                     |
+| ID reference completions | `Satisfies:` → pick from all display IDs in the workspace                              |
+| Type completions         | `Type:` → core types + profile-declared types                                          |
+| Hover                    | Hover any display ID to preview the entry's title, type, and body                      |
+| Go-to-definition         | `F12` on a display ID jumps to the entry's source location                             |
+| Find all references      | `Shift+F12` lists every file that references a display ID                              |
+| Workspace rename         | `F2` renames a display ID across the entire workspace                                  |
+| Document outline         | Outline view lists every entry in the file                                             |
+| Workspace symbol search  | `Ctrl+T` fuzzy-searches entries by display ID or title                                 |
+| Folding                  | Each entry block is collapsible                                                        |
+| Document highlights      | Cursor on a display ID highlights every occurrence in the file                         |
+| Code lens                | Per-entry inline lenses: "↑ N dependents" and "↓ Satisfies: ID — Title"                |
+| Inlay hints              | Per-entry inline hints: resolved `: <type>` and `(N dependents)` counters              |
+| Document links           | `Verified-by:` file-path values are clickable links to the test source                 |
+| Document formatting      | `Shift+Alt+F` runs the same code path as `markspec format` on the buffer               |
+| Semantic tokens          | Display IDs, ULIDs, modal verbs, EARS triggers, and typl tokens are syntax-highlighted |
+| Quick fixes              | One-click fixes for MSL-M060 (uppercase modal), MSL-A030 (generated attr), and more    |
 
 ## Install
 
@@ -77,6 +82,13 @@ Generate the full configuration snippet for your editor:
 markspec lsp install --editor neovim
 markspec lsp install --editor zed
 markspec lsp install --editor vscode   # prints JSON config block
+```
+
+Pin a specific binary path (default writes the invoked binary name, which
+resolves via `PATH` and survives package-manager upgrades):
+
+```sh
+markspec lsp install --editor neovim --binary-path /opt/markspec/bin/markspec
 ```
 
 ## Troubleshooting

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -116,7 +116,7 @@ deno run jsr:@driftsys/markspec --help
 
 ```sh
 markspec --version
-# markspec 0.5.0 (core-schema 1)
+# markspec 0.6.0 (core-schema 1)
 ```
 
 ## AI assistant skillset (upskill)

--- a/docs/guide/profiles.md
+++ b/docs/guide/profiles.md
@@ -86,6 +86,35 @@ This creates a `my-profile/` directory with a `markspec.yaml` manifest and a
 
 ---
 
+## Discipline classification (SW / HW)
+
+MarkSpec derives a software-or-hardware **discipline** for each requirement by
+walking the `Allocated-to` graph upward from concrete components to the abstract
+requirement, and tagging the requirement with the union of disciplines reached.
+The result lands on `Entry.derivedDiscipline?` in compile output and flows into
+reports.
+
+See [ADR-017](../architecture/adr-017-discipline-classification.md) and
+[ADR-018](../architecture/adr-018-core-discipline-ssot.md) for the design. Three
+modes ship out of the box, selectable via the profile's `discipline-mode:`
+field:
+
+| Mode     | Behavior                                                                                   |
+| -------- | ------------------------------------------------------------------------------------------ |
+| `none`   | No discipline derivation. Recommended for projects that do not separate SW from HW.        |
+| `flat`   | One `software-requirement` / `hardware-requirement` bucket per discipline. Default.        |
+| `tiered` | Profile may declare per-discipline subtypes (e.g. `swe.software-requirement`). Compliance. |
+
+Authors can override the derived value with the `Discipline:` trailer attribute,
+and freeze the override with `Discipline-frozen: true`. Frozen overrides are
+excluded from re-derivation.
+
+The set of components recognized as the discipline source-of-truth lives in core
+(`Item.discipline`); profiles may **extend** the vocabulary with new components
+but cannot reclassify existing core components.
+
+---
+
 ## Coming in a future release
 
 - **ASPICE / ISO 26262 mapping** — how profile types correspond to process work

--- a/docs/guide/recipes/ci.md
+++ b/docs/guide/recipes/ci.md
@@ -115,5 +115,5 @@ Cache `~/.local/bin/markspec` between runs to avoid downloading on every job:
 - uses: actions/cache@v4
   with:
     path: ~/.local/bin/markspec
-    key: markspec-${{ runner.os }}-0.5.0
+    key: markspec-${{ runner.os }}-0.6.0
 ```

--- a/docs/spec/model/annex-compile-output.md
+++ b/docs/spec/model/annex-compile-output.md
@@ -49,7 +49,7 @@ edge data.
   "markspecSchemaVersion": 1,
   "generator": {
     "name": "markspec",
-    "version": "0.5.0"
+    "version": "0.6.0"
   },
   "project": {
     "name": "my-project",
@@ -107,6 +107,11 @@ Each entry record appears as one JSON object — either as a line in
   "type": "requirement",
   "title": "Sensor debouncing",
   "body": "The sensor driver shall debounce raw inputs to eliminate noise.",
+  "bodyTokens": [
+    { "kind": "modal", "value": "shall", "line": 42, "column": 22 }
+  ],
+  "derivedDiscipline": ["software"],
+  "source": { "kind": "markdown" },
   "rawAttributes": [
     { "key": "Id", "value": "01HGW2Q8MNP3RSTVWXYZABCDEF" },
     { "key": "Type", "value": "requirement" },
@@ -118,22 +123,40 @@ Each entry record appears as one JSON object — either as a line in
     "file.path": "docs/requirements.md",
     "file.mtime": "2026-05-19T07:00:00Z",
     "git.sha": "a88ba34",
-    "git.author": "Alice <alice@example.com>"
+    "git.author": "Alice <alice@example.com>",
+    "source.type": "markdown"
   }
 }
 ```
 
-| Field           | Type                          | Notes                                      |
-| --------------- | ----------------------------- | ------------------------------------------ |
-| `displayId`     | string                        | Human-readable ID, e.g. `SRS_BRK_0107`     |
-| `id`            | string \| null                | ULID or URI; `null` if no `Id:` trailer    |
-| `shape`         | `"Authored"` \| `"Reference"` | Determined by `Id:` format                 |
-| `type`          | string \| null                | Resolved type name; `null` if unresolved   |
-| `title`         | string                        | Entry title text                           |
-| `body`          | string                        | Entry body text (trimmed)                  |
-| `rawAttributes` | `{key, value}[]`              | All trailer attributes in source order     |
-| `location`      | `{file, line, column}`        | Source file path, 1-based line and column  |
-| `properties`    | object                        | Observed facts (see Properties namespaces) |
+For an in-source entry (Rust `///`, Kotlin `/**`, etc.), `source` is the
+`doc-comment` variant:
+
+```json
+{
+  "source": {
+    "kind": "doc-comment",
+    "language": "rust",
+    "function": "swt_brk_0001_debounce_filters_noise",
+    "rule": "outer-doc-comment"
+  }
+}
+```
+
+| Field               | Type                          | Notes                                                                                                                |
+| ------------------- | ----------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `displayId`         | string                        | Human-readable ID, e.g. `SRS_BRK_0107`                                                                               |
+| `id`                | string \| null                | ULID or URI; `null` if no `Id:` trailer                                                                              |
+| `shape`             | `"Authored"` \| `"Reference"` | Determined by `Id:` format                                                                                           |
+| `type`              | string \| null                | Resolved type name; `null` if unresolved                                                                             |
+| `title`             | string                        | Entry title text                                                                                                     |
+| `body`              | string                        | Entry body text (trimmed)                                                                                            |
+| `bodyTokens`        | `BodyToken[]`                 | Flat token stream — modal verbs, EARS triggers, Gherkin keywords, `$Identifier` entity refs, inline code. ADR-016.   |
+| `derivedDiscipline` | string[] \| undefined         | Disciplines reached by walking `Allocated-to` edges. ADR-017.                                                        |
+| `source`            | `EntrySource`                 | Tagged union: `{kind:"markdown"}` or `{kind:"doc-comment", language, function, rule}`. Pre-0.6.0 was a plain string. |
+| `rawAttributes`     | `{key, value}[]`              | All trailer attributes in source order                                                                               |
+| `location`          | `{file, line, column}`        | Source file path, 1-based line and column                                                                            |
+| `properties`        | object                        | Observed facts (see Properties namespaces)                                                                           |
 
 ## Properties namespaces
 

--- a/docs/spec/model/attributes.md
+++ b/docs/spec/model/attributes.md
@@ -10,16 +10,18 @@ active profile.
 These attributes apply to every entry regardless of type. They are defined by
 core and are always available, even in core-only mode (no profile configured).
 
-| Attribute       | Required | Cardinality | Value                                                           |
-| --------------- | -------- | ----------- | --------------------------------------------------------------- |
-| `Id`            | Yes      | Single      | Bare ULID (Authored shape) or URI with scheme (Reference shape) |
-| `Type`          | No       | Single      | Core or profile-declared type name                              |
-| `Labels`        | No       | Multi       | Free-form tags; one `Labels:` line per tag                      |
-| `References`    | No       | Multi       | Display ID, optionally followed by a locator in `[…]`           |
-| `External-id`   | No       | Single      | Cross-system identifier (Jira, DOORS, …)                        |
-| `Supersedes`    | No       | Single      | Display ID of the predecessor entry (Authored only)             |
-| `Superseded-by` | —        | Generated   | Inverse of `Supersedes`; written by `markspec format`           |
-| `Deprecated`    | No       | Single      | Quoted retirement reason string                                 |
+| Attribute           | Required | Cardinality | Value                                                                                                                  |
+| ------------------- | -------- | ----------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `Id`                | Yes      | Single      | Bare ULID (Authored shape) or URI with scheme (Reference shape)                                                        |
+| `Type`              | No       | Single      | Core or profile-declared type name                                                                                     |
+| `Labels`            | No       | Multi       | Free-form tags; one `Labels:` line per tag                                                                             |
+| `Discipline`        | No       | Single      | ADR-017 — author-asserted discipline kind (`software`, `hardware`, …). Overrides the classifier's derivation channels. |
+| `Discipline-frozen` | No       | Single      | ADR-017 — cached snapshot of a past derivation: `<kind>` or `<kind> @ <YYYY-MM-DD>`. Excluded from re-derivation.      |
+| `References`        | No       | Multi       | Display ID, optionally followed by a locator in `[…]`                                                                  |
+| `External-id`       | No       | Single      | Cross-system identifier (Jira, DOORS, …)                                                                               |
+| `Supersedes`        | No       | Single      | Display ID of the predecessor entry (Authored only)                                                                    |
+| `Superseded-by`     | —        | Generated   | Inverse of `Supersedes`; written by `markspec format`                                                                  |
+| `Deprecated`        | No       | Single      | Quoted retirement reason string                                                                                        |
 
 ### Id
 

--- a/docs/spec/model/compile-output.md
+++ b/docs/spec/model/compile-output.md
@@ -29,7 +29,7 @@ data:
 ```json
 {
   "markspecSchemaVersion": 1,
-  "generator": { "name": "markspec", "version": "0.5.0" },
+  "generator": { "name": "markspec", "version": "0.6.0" },
   "project": { "name": "my-project", "version": "1.0.0" },
   "counts": { "entries": 1234, "edges": 456 },
   "entries": { "format": "ndjson", "file": "entries.ndjson" },
@@ -44,17 +44,20 @@ data:
 
 Each entry record (in `compiled.json` or `entries.ndjson`) contains:
 
-| Field           | Type                          | Notes                                              |
-| --------------- | ----------------------------- | -------------------------------------------------- |
-| `displayId`     | string                        | Human-readable identifier, e.g. `SRS_BRK_0107`     |
-| `id`            | string \| null                | ULID or URI; null for entries without `Id:`        |
-| `shape`         | `"Authored"` \| `"Reference"` | Determined by `Id:` format                         |
-| `type`          | string \| null                | Resolved type, e.g. `requirement` or `Requirement` |
-| `title`         | string                        | Entry title (first line of list item)              |
-| `body`          | string                        | Entry body text                                    |
-| `rawAttributes` | `{key, value}[]`              | All trailer attributes as parsed                   |
-| `location`      | `{file, line, column}`        | Source location                                    |
-| `properties`    | object                        | Observed facts: `file.*`, `git.*`, `source.*`      |
+| Field               | Type                          | Notes                                                                                                                       |
+| ------------------- | ----------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `displayId`         | string                        | Human-readable identifier, e.g. `SRS_BRK_0107`                                                                              |
+| `id`                | string \| null                | ULID or URI; null for entries without `Id:`                                                                                 |
+| `shape`             | `"Authored"` \| `"Reference"` | Determined by `Id:` format                                                                                                  |
+| `type`              | string \| null                | Resolved type, e.g. `requirement` or `Requirement`                                                                          |
+| `title`             | string                        | Entry title (first line of list item)                                                                                       |
+| `body`              | string                        | Entry body text                                                                                                             |
+| `bodyTokens`        | `BodyToken[]`                 | Flat token stream (modal verbs, EARS triggers, Gherkin keywords, `$Identifier` entity refs, inline code). See ADR-016.      |
+| `derivedDiscipline` | string[] \| undefined         | Disciplines reached by walking `Allocated-to`. ADR-017.                                                                     |
+| `source`            | `EntrySource`                 | Tagged union: `{kind:"markdown"}` or `{kind:"doc-comment", language, function, rule}`. Replaces the pre-0.6.0 string field. |
+| `rawAttributes`     | `{key, value}[]`              | All trailer attributes as parsed                                                                                            |
+| `location`          | `{file, line, column}`        | Source location                                                                                                             |
+| `properties`        | object                        | Observed facts: `file.*`, `git.*`, `source.*`                                                                               |
 
 ## Privacy
 

--- a/docs/spec/model/entry-format.md
+++ b/docs/spec/model/entry-format.md
@@ -102,6 +102,19 @@ Rules:
 - Attribute order within the trailer is not significant for semantics, but
   `markspec format` normalizes it: `Id` first, then `Type`, then relations, then
   `Labels`, then any remaining attributes.
+- The `Discipline:` and `Discipline-frozen:` attributes are author overrides of
+  the discipline derivation pass (see
+  [Type taxonomy → Discipline classification](types.md#discipline-classification)).
+  `Discipline:` is single-valued and matches `/^[a-z][a-z0-9-]*$/`;
+  `Discipline-frozen:` carries a `<kind>` or `<kind> @ <YYYY-MM-DD>` snapshot
+  that is excluded from re-derivation.
+
+**Computed fields.** The parser emits `Entry.bodyTokens` — a flat
+position-sorted token stream covering modal verbs, EARS triggers, Gherkin
+keywords, `$Identifier` entity refs and inline code (ADR-016). These tokens are
+not author-editable; they are recomputed on every parse and surface in the
+compile-output entry record. After the discipline pass, an entry may also carry
+`Entry.derivedDiscipline` (set of disciplines reached via `Allocated-to`).
 
 ## The two shapes
 

--- a/docs/spec/model/prose-analysis.md
+++ b/docs/spec/model/prose-analysis.md
@@ -23,6 +23,48 @@ descriptions and glossary entries follow different writing conventions.
 Suppression-hygiene rules (`MSL-Q9xx`) run on **all** authored entries
 regardless of type.
 
+## All active rules
+
+The Stage-2 prose-analysis build (ADR-021) ships the rules below. Severity and
+score contribution drive the project-level roll-up surfaced by
+`markspec lint --format json` (band counts + mean; no trend artifact in core, by
+design — see
+[ADR-021](../../architecture/adr-021-prose-analysis-flagship-build.md)).
+
+| Code     | Slug                              | Surface             | Severity | Score |
+| -------- | --------------------------------- | ------------------- | -------- | ----- |
+| MSL-Q100 | ears-no-pattern                   | EARS                | info     | 1     |
+| MSL-Q101 | ears-missing-actor                | EARS                | warning  | 3     |
+| MSL-Q102 | ears-negative-response            | EARS                | info     | 1     |
+| MSL-Q103 | ears-stacked-preconditions        | EARS                | warning  | 3     |
+| MSL-Q104 | ears-malformed-attempt            | EARS                | info     | 1     |
+| MSL-Q200 | modal-multiple                    | Modal sentence      | warning  | 3     |
+| MSL-Q201 | modal-soft-in-normative           | Modal sentence      | info     | 1     |
+| MSL-Q300 | incose-r2-active-voice            | Passive voice       | warning  | 3     |
+| MSL-Q301 | incose-r3-subject-verb            | Passive voice       | info     | 1     |
+| MSL-Q302 | incose-r7-vague-term              | INCOSE lexicon      | warning  | 3     |
+| MSL-Q303 | incose-r8-escape-clause           | INCOSE lexicon      | warning  | 3     |
+| MSL-Q304 | incose-r9-open-ended              | INCOSE lexicon      | info     | 1     |
+| MSL-Q305 | incose-r10-superfluous-infinitive | INCOSE lexicon      | info     | 1     |
+| MSL-Q310 | incose-r26-absolute               | INCOSE lexicon      | info     | 1     |
+| MSL-Q313 | incose-r16-not                    | INCOSE lexicon      | info     | 1     |
+| MSL-Q400 | struct-title-length               | Structural          | info     | 1     |
+| MSL-Q401 | struct-body-length                | Structural          | info     | 1     |
+| MSL-Q500 | xref-glossary-undefined           | Flagship cross-ref  | warning  | 3     |
+| MSL-Q900 | disable-without-rationale         | Suppression hygiene | warning  | —     |
+| MSL-Q901 | disable-unknown-rule              | Suppression hygiene | warning  | —     |
+| MSL-Q902 | disable-unused                    | Suppression hygiene | info     | —     |
+
+The flagship rule **MSL-Q500 `xref-glossary-undefined`** flags capitalized
+proper-noun usage in normative prose that has no corresponding `Definition`
+entry in the glossary. It ships with a glossary-only subset resolver
+(`$Identifier` / RIDL rules degrade-to-silent until ADR-016 marker pass lands).
+The default severity is `warning`, and core ships an English-baseline allowlist
+of universally-true capitalized words (calendar / geography / languages) at
+`packages/markspec/core/lexicons/capitalized-allow.txt` — list-additive across
+profile tiers, capped, and explicitly excludes domain vocabulary and
+standards-body acronyms.
+
 ## Modal keyword analysis
 
 Modal keywords signal the obligation level of a requirement. MarkSpec enforces
@@ -175,8 +217,11 @@ A rule can be silenced for a specific entry by adding two trailer attributes:
 
 Both `Markspec-disable` and `Rationale` must be present; a suppression without a
 rationale fires **MSL-Q900** (disable-without-rationale). Citing an unknown rule
-code fires **MSL-Q901** (disable-unknown-rule). These two hygiene rules run on
-all authored entries regardless of type and cannot themselves be suppressed.
+code fires **MSL-Q901** (disable-unknown-rule). A disable that did not match any
+diagnostic during a run fires **MSL-Q902** (disable-unused) — one diagnostic per
+unused code at the entry's location — so stale escape hatches get pruned. These
+three hygiene rules run on all authored entries regardless of type and cannot
+themselves be suppressed.
 
 ## Running prose analysis
 

--- a/docs/spec/model/relations.md
+++ b/docs/spec/model/relations.md
@@ -72,6 +72,14 @@ Note: `Supersedes` / `Superseded-by` are **universal attributes** (not relation
 attributes) — they are part of core and are available without any profile. See
 the [Attributes](attributes.md) chapter.
 
+**`Allocated-to` drives discipline classification.** Per
+[ADR-017](../../architecture/adr-017-discipline-classification.md) the toolchain
+walks `Allocated-to` edges from a requirement to the components it is allocated
+to and tags the requirement with each reached discipline. The result lands on
+`Entry.derivedDiscipline?` in compile output. Authors override the derived value
+with the `Discipline:` trailer attribute and freeze it with
+`Discipline-frozen:`.
+
 ## Cross-shape relations
 
 Both Authored and Reference entries can appear as relation sources or targets. A

--- a/docs/spec/model/types.md
+++ b/docs/spec/model/types.md
@@ -296,3 +296,18 @@ Profile subtypes appear in the type-resolution chain at step 1 (when used
 explicitly as the `Type:` value) and step 2 (when matched by their display-ID
 pattern). They cannot shadow core type names — attempting to declare a profile
 type named `Requirement` raises `MSL-A040`.
+
+## Discipline classification
+
+Per [ADR-017](../../architecture/adr-017-discipline-classification.md) and
+[ADR-018](../../architecture/adr-018-core-discipline-ssot.md), the toolchain
+derives a software-or-hardware discipline for each `Requirement` by walking the
+`Allocated-to` graph upward from concrete `Component` and `Unit` types. The
+result lands on `Entry.derivedDiscipline?` in compile output.
+
+The set of components recognized as the discipline source-of-truth lives in core
+(`Item.discipline`); profiles may **extend** the vocabulary with new components
+but cannot reclassify existing core components. Three modes are available via
+the profile's `discipline-mode:` field — `none`, `flat`, `tiered`. See the
+[Profile guide](../../guide/profiles.md#discipline-classification-sw--hw) for
+selection criteria.


### PR DESCRIPTION
## Summary

Doc-only sweep ahead of the v0.6.0 release. README, AGENTS.md, the user guide,
and the spec reference (docs/spec/model/) had drifted behind features merged
since v0.5.3 — lockfile + sync, LSP code lens / inlay hints / document links,
discipline classification (ADR-017/018), prose-analysis Stage-2, typl
(ADR-019). This brings them back in sync.

- **README**: drop the "Tooling is not yet functional" banner; reorganize the
  Tools section by capability group (authoring, traceability, lockfile,
  profiles, rendering, integration) and call out the still-unimplemented
  commands explicitly.
- **AGENTS.md**: add `lock`, `sync`, `lsp install`, `mcp install`, `lint`
  rows to the Implemented command table; extend the ADR list to cover
  ADR-017 through ADR-022.
- **docs/guide/cli.md**: document `markspec lock`, `markspec sync
  {status|log|show}`, and the new `--binary-path` flag on `lsp install` /
  `mcp install`.
- **docs/guide/ai-agents.md**, **editor-vscode.md**: thread
  `--binary-path` through the install examples; document the new LSP
  capabilities (code lens, inlay hints, document links, formatting,
  semantic tokens).
- **docs/guide/profiles.md**: cover the discipline-mode flag (none / flat
  / tiered) and the role of `Allocated-to` per ADR-017 / ADR-018.
- **docs/guide/installation.md**, **recipes/ci.md**: bump version pin
  `0.5.0` → `0.6.0`.
- **docs/spec/model/**: add `Discipline:` / `Discipline-frozen:` to the
  universal attribute table; document `Entry.bodyTokens` and the
  `EntrySource` tagged union in compile output; note `Allocated-to`
  drives discipline derivation; cross-link the discipline-classification
  pass from `types.md`; expand `prose-analysis.md` with the full active
  rule set (21 codes including flagship MSL-Q500 `xref-glossary-undefined`)
  and MSL-Q902 `disable-unused` hygiene rule.

Per repo memory, CHANGELOG entries remain batched and are not touched here.

## Test plan

- [x] `just lint` — `deno lint` + `dprint check` pass.
- [x] `deno fmt --check` passes.
- [x] `just check` (lint + type-check + 2645 tests) passes locally.
- [ ] CI green on GitHub Actions before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)