### PR TITLE
fix(parser): correct body token positions for markdown files

### DIFF
--- a/packages/markspec/core/parser/markdown.ts
+++ b/packages/markspec/core/parser/markdown.ts
@@ -177,7 +177,7 @@ function extractEntry(
   definitions: Set<string>,
   isReferencesDoc: boolean,
   diagnostics: Diagnostic[],
-  hasLineMap = false,
+  _hasLineMap = false,
 ): Entry | undefined {
   // Task list items (remark-gfm sets checked to true/false) are not entries.
   if (item.checked != null) return undefined;
@@ -511,27 +511,17 @@ function extractEntry(
   // Inline-construct tokens (ADR-016). Reuses the already-built bodyAst to
   // avoid a redundant mdast parse.
   //
-  // bodyStartLine: when a lineMap is present (source-file path), use the
-  // mdast position of the second child (the body paragraph) — the actual
-  // buffer line where the body starts. CommonMark loose lists have a blank
-  // line between title and body, so the body is at (entry_line + 2), not
-  // (entry_line + 1). Without a lineMap we keep the legacy (entry_line + 1)
-  // behaviour to avoid shifting existing markdown-file token locations.
+  // bodyStartLine: use the mdast position of the second child (the body
+  // paragraph) — the actual buffer line where the body starts. CommonMark
+  // loose lists have a blank line between title and body, so the body is at
+  // (entry_line + 2), not (entry_line + 1).
   //
-  // columnOffset: when a lineMap is present, body text has been stripped of
-  // the list-item indent (e.g., "  " for column-1 items), so each token
-  // column must be bumped by that indent width for the LineMap to translate
-  // to the correct source column. Without a lineMap, no offset is applied
-  // (legacy behaviour unchanged).
-  const bodyIndent = hasLineMap
-    // + 2 = the "  " continuation indent prepended by wrapAsListItem to
-    // every non-title line. Mirrors the indent computation in
-    // extractBodyContent below.
-    ? (item.position?.start.column ?? 1) - 1 + 2
-    : 0;
-  const bodyStartLine = hasLineMap
-    ? (item.children[1]?.position?.start.line ?? (line + 1))
-    : line + 1;
+  // columnOffset: body text has been stripped of the list-item indent (e.g.,
+  // "  " for column-1 items), so each token column must be bumped by that
+  // indent width. The + 2 accounts for the "  " continuation indent
+  // prepended by wrapAsListItem to every non-title line.
+  const bodyIndent = (item.position?.start.column ?? 1) - 1 + 2;
+  const bodyStartLine = item.children[1]?.position?.start.line ?? (line + 1);
   const bodyTokens = extractBodyTokens(
     body,
     bodyAst,

--- a/packages/markspec/core/parser/markdown_test.ts
+++ b/packages/markspec/core/parser/markdown_test.ts
@@ -354,6 +354,90 @@ Deno.test("parseMarkdown: populates Entry.bodyTokens", () => {
   assertEquals(kinds.includes("entity-ref"), true);
 });
 
+Deno.test("parseMarkdown: bodyToken positions are file-accurate", () => {
+  // Regression test for #514: body token locations must match the actual
+  // file content — line and column point to the token text in the source.
+  const md = [
+    "- [REQ-1] Title",
+    "",
+    "  The driver shall debounce $Sensor inputs.",
+    "",
+    `      Id: ${ULID}`,
+  ].join("\n") + "\n";
+  const lines = md.split("\n");
+  const { entries } = parseMarkdown(md, { file: "test.md" });
+  const tokens = entries[0].bodyTokens;
+
+  // Every token's location must slice back to its text in the source.
+  for (const t of tokens) {
+    const fileLine = lines[t.location.line - 1];
+    const actual = fileLine.slice(
+      t.location.column - 1,
+      t.location.column - 1 + t.text.length,
+    );
+    assertEquals(
+      actual,
+      t.text,
+      `Token "${t.text}" at L${t.location.line}:${t.location.column} ` +
+        `does not match file content "${actual}"`,
+    );
+  }
+
+  // Spot-check specific positions:
+  const modal = tokens.find((t) => t.kind === "modal")!;
+  // "shall" is on line 3 (body paragraph), column 14 ("  The driver " = 13 chars)
+  assertEquals(modal.location.line, 3);
+  assertEquals(modal.location.column, 14);
+
+  const entityRef = tokens.find((t) => t.kind === "entity-ref")!;
+  // "$Sensor" starts at column 29 on line 3 ("  The driver shall debounce " = 29 chars)
+  assertEquals(entityRef.location.line, 3);
+  assertEquals(entityRef.location.column, 29);
+});
+
+Deno.test("parseMarkdown: gherkin bodyToken positions are file-accurate", () => {
+  // Regression test for #514: gherkin tokens inside ```gherkin fences must
+  // have file-accurate positions accounting for list-item indent.
+  const md = [
+    "- [REQ-1] Filter acceptance",
+    "",
+    "  The filter shall pass:",
+    "",
+    "  ```gherkin",
+    "  Scenario: Spike rejection",
+    "    Given a stable reading of 500",
+    "    When a spike occurs",
+    "    Then the output shall remain 500",
+    "  ```",
+    "",
+    `      Id: ${ULID}`,
+  ].join("\n") + "\n";
+  const lines = md.split("\n");
+  const { entries } = parseMarkdown(md, { file: "test.md" });
+  const gherkinTokens = entries[0].bodyTokens.filter(
+    (t) => t.kind === "gherkin-section" || t.kind === "gherkin-step",
+  );
+
+  // Every gherkin token must align with file content.
+  for (const t of gherkinTokens) {
+    const fileLine = lines[t.location.line - 1];
+    const actual = fileLine.slice(
+      t.location.column - 1,
+      t.location.column - 1 + t.text.length,
+    );
+    assertEquals(
+      actual,
+      t.text,
+      `Gherkin token "${t.text}" at L${t.location.line}:${t.location.column} ` +
+        `does not match file content "${actual}"`,
+    );
+  }
+
+  // At least one section and one step token should exist.
+  assertEquals(gherkinTokens.some((t) => t.kind === "gherkin-section"), true);
+  assertEquals(gherkinTokens.some((t) => t.kind === "gherkin-step"), true);
+});
+
 // ---------------------------------------------------------------------------
 // LineMap option (ADR-016 Decision 6)
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #514 — partial/incorrect token highlighting for Gherkin, modal keywords, and `$` entity refs in VS Code.

## Root Cause

In `extractEntry`, the `bodyStartLine` and `bodyIndent` computation was gated behind `hasLineMap`. The LSP calls `parseFile` without a lineMap, triggering the legacy path that set:
- `bodyStartLine = entry.line + 1` (wrong — CommonMark loose lists have a blank line, so body starts at `entry.line + 2`)
- `bodyIndent = 0` (wrong — body text is indented 2 spaces in the file but stripped in the body string)

Every `bodyToken.location` was off by ~1 line and ~2 columns, causing semantic tokens to highlight wrong character ranges.

## Fix

Remove the `hasLineMap` conditional — always use the mdast-derived `item.children[1]?.position?.start.line` for bodyStartLine and compute the proper column offset.

## Verification

- All 2174 package tests pass (0 changes to test assertions needed)
- Manually verified: 92 body tokens in `docs/examples/entry-rendering.md` now align perfectly (was 100% mismatch before)