### PR TITLE
fix(vscode): status bar spinner never stops after initial indexing

### DIFF
--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -153,7 +153,7 @@ export function activate(context: ExtensionContext): void {
 
   client.start();
 
-  createStatusBar(context, client);
+  const statusBar = createStatusBar(context, client);
 
   const decorations = new DecorationManager(client);
   context.subscriptions.push(decorations);
@@ -172,11 +172,19 @@ export function activate(context: ExtensionContext): void {
     workspace.onDidChangeTextDocument((ev) => debouncedRefresh(ev.document)),
   );
 
-  // Refresh after the server finishes initial indexing.
-  client.onNotification("markspec/indexed", () => {
-    const ed = window.activeTextEditor;
-    if (ed) void decorations.refresh(ed);
-  });
+  // Single handler for markspec/indexed — updates both the status bar and
+  // decorations. vscode-languageclient@9 only keeps one handler per method
+  // (Map keyed by method name), so a second onNotification call for the same
+  // method would silently replace the first. Consolidating here ensures both
+  // consumers are notified.
+  client.onNotification(
+    "markspec/indexed",
+    (params: { files: number; entries: number } | undefined) => {
+      statusBar.notifyIndexed(params ?? { files: 0, entries: 0 });
+      const ed = window.activeTextEditor;
+      if (ed) void decorations.refresh(ed);
+    },
+  );
 
   // Initial paint for whatever is open at activation.
   if (window.activeTextEditor) {

--- a/editors/vscode/src/statusBar.ts
+++ b/editors/vscode/src/statusBar.ts
@@ -9,6 +9,13 @@
  *   ✗  failed / stopped unexpectedly
  *
  * Click action opens the MarkSpec output channel.
+ *
+ * NOTE: `createStatusBar` intentionally does NOT register a
+ * `client.onNotification("markspec/indexed", ...)` handler.
+ * `vscode-languageclient@9` uses a `Map` keyed by method name, so calling
+ * `onNotification` twice for the same method silently replaces the first
+ * handler. The caller (extension.ts) owns the single `markspec/indexed`
+ * handler and must call `notifyIndexed()` from it.
  */
 
 import {
@@ -23,10 +30,20 @@ import { type LanguageClient, State } from "vscode-languageclient/node";
 
 const COMMAND_SHOW_OUTPUT = "markspec.showOutput";
 
+/** Returned by `createStatusBar` so the caller can forward notifications. */
+export interface StatusBarController {
+  readonly item: StatusBarItem;
+  /**
+   * Call this when the `markspec/indexed` notification arrives.
+   * Transitions the status bar from "starting" to "ready".
+   */
+  notifyIndexed(params: { files: number; entries: number }): void;
+}
+
 export function createStatusBar(
   context: ExtensionContext,
   client: LanguageClient,
-): StatusBarItem {
+): StatusBarController {
   const item = window.createStatusBarItem(StatusBarAlignment.Right, 100);
   item.command = COMMAND_SHOW_OUTPUT;
 
@@ -37,15 +54,7 @@ export function createStatusBar(
     if (event.newState === State.Starting) setStarting(item);
     else if (event.newState === State.Stopped) setFailed(item);
     // State.Running alone doesn't mean indexing complete — wait for
-    // markspec/indexed notification.
-  });
-
-  client.onNotification("markspec/indexed", (params) => {
-    setReady(
-      item,
-      (params as { files: number; entries: number } | undefined) ??
-        { files: 0, entries: 0 },
-    );
+    // the markspec/indexed notification forwarded via notifyIndexed().
   });
 
   context.subscriptions.push(
@@ -55,7 +64,10 @@ export function createStatusBar(
     },
   );
 
-  return item;
+  return {
+    item,
+    notifyIndexed: (params) => setReady(item, params),
+  };
 }
 
 function setStarting(item: StatusBarItem): void {


### PR DESCRIPTION
## Problem

The `$(sync~spin) MarkSpec` status bar icon kept spinning indefinitely — it never transitioned to `$(check) MarkSpec` once indexing finished.

## Root Cause

`vscode-languageclient@9` stores notification handlers in a `Map` keyed by method name (`_pendingNotificationHandlers.set(method, handler)`). Calling `onNotification()` twice for the same method **silently replaces** the first handler — standard `Map.set` semantics.

Two `onNotification("markspec/indexed")` calls were registered during `activate()` (both before the server connected, so both went through `_pendingNotificationHandlers`):

1. `createStatusBar` → registers `setReady` handler
2. `extension.ts` line 176 → registers `decorations.refresh` handler ← **replaced #1**

When the server connected and flushed `_pendingNotificationHandlers` onto the live connection, only the decoration handler survived. `setReady()` was never called.

## Fix

- **`statusBar.ts`**: Removed the `onNotification` registration from `createStatusBar`. Returns a `StatusBarController` with a `notifyIndexed()` method instead.
- **`extension.ts`**: Owns the single `"markspec/indexed"` handler; calls both `statusBar.notifyIndexed(params)` and `decorations.refresh(ed)` from it. Comment explains the constraint so it doesn't regress.

## Testing

Compile passes clean (`tsc` exits 0). Manual verification: open a MarkSpec project in VS Code — the spinner should stop and show `✓ MarkSpec` once the server finishes indexing.