### PR TITLE
feat(lint): corpus-scan $Identifier resolver hook for Q500

### DIFF
--- a/packages/markspec/core/lint/rules/xref.ts
+++ b/packages/markspec/core/lint/rules/xref.ts
@@ -13,12 +13,57 @@ import type { GlossaryIndex } from "../glossary.ts";
 import { deriveTermSlug } from "../../parser/glossary.ts";
 import { offsetToRange } from "../range_util.ts";
 
-/** Hook signature for the deferred $Identifier registry leg. Returns
- * true when the token is a resolvable $Identifier (i.e. should be
- * skipped by Q500). Today, always returns false; ADR-016's marker
- * pass replaces this with a real registry lookup. See ADR-021
- * Decision 1. */
+/** Hook signature for the $Identifier registry leg. Returns true when
+ * the token is a resolvable $Identifier (i.e. should be skipped by
+ * Q500). See ADR-021 Decision 1 for the integration seam, and
+ * {@linkcode buildIdentifierIndex} + {@linkcode buildIsIdentifierHook}
+ * for the corpus-scan implementation that backs it today. */
 export type IsIdentifierHook = (token: string) => boolean;
+
+/**
+ * Build a corpus-wide `$Identifier` index from every entry's `bodyTokens`.
+ *
+ * Aggregates the bare name (text with leading `$` stripped) of every
+ * `entity-ref` token across `entries` into a `Set<string>`. The set is
+ * the data backing the {@linkcode IsIdentifierHook} closure produced by
+ * {@linkcode buildIsIdentifierHook}.
+ *
+ * Behavioural contract (ADR-021 Decision 1, additive-enrichment invariant):
+ *   - Every name in the index is observed in the corpus as `$Name`.
+ *   - The index is purely additive: more entries → more silenced phrases,
+ *     never more diagnostics.
+ *
+ * Scope note: this is the pragmatic minimal resolver leg per issue #502.
+ * The formal `MSL-M050`/`MSL-M051` entity-resolution model (definition
+ * vs. use, typed identifiers, profile Aliases) is deferred to a
+ * follow-up story — the closure body changes but the hook signature
+ * stays the same.
+ */
+export function buildIdentifierIndex(
+  entries: readonly Entry[],
+): ReadonlySet<string> {
+  const out = new Set<string>();
+  for (const entry of entries) {
+    for (const token of entry.bodyTokens) {
+      if (token.kind !== "entity-ref") continue;
+      // `token.text` is the full `$Identifier` form; strip the leading `$`.
+      out.add(token.text.slice(1));
+    }
+  }
+  return out;
+}
+
+/**
+ * Build the {@linkcode IsIdentifierHook} closure from a precomputed
+ * index. Separated from {@linkcode buildIdentifierIndex} so the index
+ * can be computed once per `runLint` invocation and reused across
+ * every in-scope entry.
+ */
+export function buildIsIdentifierHook(
+  index: ReadonlySet<string>,
+): IsIdentifierHook {
+  return (phrase) => index.has(phrase);
+}
 
 /** RFC 2119 modal verbs + EARS leading-clause keywords that must never
  * trigger Q500 mid-sentence. Sentence-initial exclusion is handled

--- a/packages/markspec/core/lint/rules/xref_test.ts
+++ b/packages/markspec/core/lint/rules/xref_test.ts
@@ -6,10 +6,10 @@
 
 import { assertEquals } from "@std/assert";
 import type { BodyBlock } from "../../ast/nodes.ts";
-import type { Entry } from "../../model/mod.ts";
+import type { BodyToken, Entry } from "../../model/mod.ts";
 import { makeDisplayId } from "../../model/mod.ts";
 import { loadLexicon } from "../../lexicons/mod.ts";
-import { runXrefRules } from "./xref.ts";
+import { buildIdentifierIndex, runXrefRules } from "./xref.ts";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -31,6 +31,7 @@ function makeParagraph(text: string, line = 1, column = 1): BodyBlock {
 interface MakeEntryOpts {
   location?: { file: string; line: number; column: number };
   bodyStartLine?: number;
+  bodyTokens?: readonly BodyToken[];
 }
 
 function makeEntry(
@@ -61,7 +62,23 @@ function makeEntry(
       ? { bodyStartLine: opts.bodyStartLine }
       : {}),
     source: { kind: "markdown" },
-    bodyTokens: [],
+    bodyTokens: opts.bodyTokens ?? [],
+  };
+}
+
+function entityRef(text: string, line = 1, column = 1): BodyToken {
+  const bare = text.startsWith("$") ? text.slice(1) : text;
+  const convention =
+    /^[A-Z][A-Z0-9_]*[A-Z0-9]$/.test(bare) && /[_0-9]/.test(bare)
+      ? "constant"
+      : /^[A-Z]/.test(bare)
+      ? "type"
+      : "instance";
+  return {
+    kind: "entity-ref",
+    text: text.startsWith("$") ? text : `$${text}`,
+    convention,
+    location: { file: "test.md", line, column },
   };
 }
 
@@ -249,4 +266,58 @@ Deno.test("Q500: 'Brake of the Vehicle System' is one phrase (ADR-021 Decision 2
   const q500 = diags.filter((d) => d.code === "MSL-Q500");
   assertEquals(q500.length, 1);
   assertEquals(q500[0].message.includes("Brake of the Vehicle System"), true);
+});
+
+// ---------------------------------------------------------------------------
+// buildIdentifierIndex — corpus-scan $Identifier resolver leg (issue #502)
+// ---------------------------------------------------------------------------
+
+Deno.test("buildIdentifierIndex: aggregates entity-ref bare names across entries", () => {
+  const e1 = makeEntry("ignored prose", "REQ_0001", {
+    bodyTokens: [entityRef("$BrakePedalPressed")],
+  });
+  const e2 = makeEntry("ignored prose", "REQ_0002", {
+    bodyTokens: [entityRef("$sensorStatus"), entityRef("$ASIL_D")],
+  });
+  const index = buildIdentifierIndex([e1, e2]);
+  // Bare names with leading `$` stripped.
+  assertEquals(index.has("BrakePedalPressed"), true);
+  assertEquals(index.has("sensorStatus"), true);
+  assertEquals(index.has("ASIL_D"), true);
+  // Words appearing in prose but never as $Identifier MUST NOT enter the index.
+  assertEquals(index.has("ignored"), false);
+  assertEquals(index.has("prose"), false);
+  // Set size matches the number of distinct identifiers observed.
+  assertEquals(index.size, 3);
+});
+
+Deno.test("buildIdentifierIndex: empty input yields empty index", () => {
+  const index = buildIdentifierIndex([]);
+  assertEquals(index.size, 0);
+});
+
+Deno.test("buildIdentifierIndex: ignores non-entity-ref body tokens", () => {
+  // Modal + EARS-trigger tokens must not pollute the identifier index.
+  const e = makeEntry("ignored prose", "REQ_0001", {
+    bodyTokens: [
+      {
+        kind: "modal",
+        text: "shall",
+        case: "lower",
+        location: { file: "test.md", line: 1, column: 1 },
+      },
+      {
+        kind: "ears-trigger",
+        text: "When",
+        trigger: "When",
+        location: { file: "test.md", line: 1, column: 1 },
+      },
+      entityRef("$RealIdentifier"),
+    ],
+  });
+  const index = buildIdentifierIndex([e]);
+  assertEquals(index.size, 1);
+  assertEquals(index.has("RealIdentifier"), true);
+  assertEquals(index.has("shall"), false);
+  assertEquals(index.has("When"), false);
 });

--- a/packages/markspec/core/lint/runner.ts
+++ b/packages/markspec/core/lint/runner.ts
@@ -21,8 +21,11 @@ import {
 } from "./rules/suppression.ts";
 import { buildGlossaryIndex } from "./glossary.ts";
 import type { FileReader, GlossaryIndex } from "./glossary.ts";
-import { runXrefRules } from "./rules/xref.ts";
-import type { IsIdentifierHook } from "./rules/xref.ts";
+import {
+  buildIdentifierIndex,
+  buildIsIdentifierHook,
+  runXrefRules,
+} from "./rules/xref.ts";
 import { runEarsRules } from "./rules/ears.ts";
 import { runModalSentenceRules } from "./rules/modal_sentence.ts";
 import { runIncoseSentenceRules } from "./rules/incose_sentence.ts";
@@ -128,7 +131,11 @@ export async function runLint(options: LintOptions): Promise<LintResult> {
     options.readFile ?? (() => Promise.resolve(undefined)),
     options.glossaryFilePaths ?? [],
   );
-  const isIdHook: IsIdentifierHook = () => false;
+  // Corpus-scan resolver leg (issue #502, ADR-021 Decision 1). Built once
+  // per invocation; reused across every in-scope entry. Honors the
+  // additive-enrichment invariant — Q500 fires *less* as the resolver
+  // grows, never *more*.
+  const isIdHook = buildIsIdentifierHook(buildIdentifierIndex(entries));
 
   // Steps 1–9: collect diagnostics keyed by entry
   const inScopeDiags = new Map<Entry, LintDiagnostic[]>();

--- a/packages/markspec/core/lint/runner_test.ts
+++ b/packages/markspec/core/lint/runner_test.ts
@@ -518,3 +518,83 @@ Deno.test("runLint: MSL-Q902 does NOT fire for unknown codes (Q901's territory)"
     false,
   );
 });
+
+// ---------------------------------------------------------------------------
+// Q500 $Identifier corpus-scan hook (issue #502)
+// ---------------------------------------------------------------------------
+
+Deno.test("runLint: corpus-scan hook silences Q500 on cross-entry $Identifier", async () => {
+  // Entry A: prose-irrelevant; carries one `entity-ref` body token for
+  // `$BrakePedalPressed`. In production the parser would emit this token
+  // when encountering `$BrakePedalPressed` somewhere in the body; here
+  // we synthesise it directly.
+  const a = makeEntry({
+    displayId: "REQ-001",
+    body: "Some unrelated prose.",
+    bodyAst: [
+      {
+        kind: "paragraph",
+        content: { text: "Some unrelated prose." },
+        range: {
+          start: { line: 1, column: 1 },
+          end: { line: 1, column: 22 },
+        },
+      },
+    ],
+    bodyTokens: [
+      {
+        kind: "entity-ref",
+        text: "$BrakePedalPressed",
+        convention: "type",
+        location: { file: "test.md", line: 1, column: 1 },
+      },
+    ],
+  });
+  // Entry B: prose mentions `BrakePedalPressed` capitalized but without
+  // the leading `$`, mid-sentence — Q500 would normally fire on it.
+  const text = "When triggered, the BrakePedalPressed signal shall propagate.";
+  const b = makeEntry({
+    displayId: "REQ-002",
+    body: text,
+    bodyAst: [
+      {
+        kind: "paragraph",
+        content: { text },
+        range: {
+          start: { line: 1, column: 1 },
+          end: { line: 1, column: text.length },
+        },
+      },
+    ],
+    location: { file: "test.md", line: 5, column: 1 },
+  });
+  const result = await runLint({ entries: [a, b] });
+  const q500 = result.diagnostics.filter((d) => d.code === "MSL-Q500");
+  // The corpus-scan hook resolves `BrakePedalPressed` via A's entity-ref
+  // token, so Q500 must not fire on B's prose occurrence.
+  assertEquals(q500.length, 0);
+});
+
+Deno.test("runLint: corpus-scan hook leaves Q500 firing on truly unknown phrases", async () => {
+  // No entity-ref tokens exist for `UnknownTerm` anywhere in the corpus
+  // → Q500 must still fire on it.
+  const text = "When triggered, the UnknownTerm signal shall propagate.";
+  const entry = makeEntry({
+    displayId: "REQ-001",
+    body: text,
+    bodyAst: [
+      {
+        kind: "paragraph",
+        content: { text },
+        range: {
+          start: { line: 1, column: 1 },
+          end: { line: 1, column: text.length },
+        },
+      },
+    ],
+  });
+  const result = await runLint({ entries: [entry] });
+  const q500 = result.diagnostics.filter((d) => d.code === "MSL-Q500");
+  assertEquals(q500.length, 1);
+  assertEquals(q500[0].message.includes("UnknownTerm"), true);
+});


### PR DESCRIPTION
## Summary

- Replaces Q500's no-op `IsIdentifierHook` with a corpus-scan closure built from every entry's `entity-ref` body tokens (ADR-021 Decision 1's pragmatic minimal version).
- Adds `buildIdentifierIndex` + `buildIsIdentifierHook` exports in [`core/lint/rules/xref.ts`](packages/markspec/core/lint/rules/xref.ts) so the seam is discoverable for the follow-up story.
- Closes #502. Formal MSL-M050/M051 entity-resolution semantics remain deferred — tracked in #518.

## Behavioural contract

ADR-021 Decision 1's additive-enrichment invariant: **Q500 fires *less* as the resolver grows, never *more*.** The corpus-scan closure honors this — it only adds members to the silenced set, never removes them. Reviewers should sanity-check this on the diff.

## Test plan

- [x] `deno test packages/markspec/core/lint/rules/xref_test.ts` — 3 new unit tests for `buildIdentifierIndex` (aggregation, empty input, non-entity-ref token filtering)
- [x] `deno test packages/markspec/core/lint/runner_test.ts` — 2 new integration tests (corpus-scan silences cross-entry $Identifier; unknown phrases still fire)
- [x] `just build` — all 2657 tests pass, lint + type-check + compile clean
- [x] `deno fmt --check && dprint check` — format gates clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
