### PR TITLE
feat(mcp): trigger language baseline + project soft-gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -415,6 +415,9 @@ docs/
 - `adr-022-lockfile-and-external-sync.md` — `markspec.lock` format for upstream
   version pinning + sync state tracking (`markspec lock`,
   `markspec sync status|log|show`)
+- `adr-023-mcp-trigger-language.md` — MCP server's agent-facing trigger language
+  (TRIGGER / PREFER over / SKIP grammar) + project-detection soft gate so tools
+  self-describe "no MarkSpec project found" outside MarkSpec workspaces
 - `overview.md` — narrative architecture tour
 
 See [docs/architecture/overview.md](docs/architecture/overview.md) for a reading

--- a/docs/architecture/adr-023-mcp-trigger-language.md
+++ b/docs/architecture/adr-023-mcp-trigger-language.md
@@ -1,0 +1,338 @@
+# ADR-023 — MCP trigger language and project-detection soft gate
+
+Status: Proposed (2026-05-27)\
+Supersedes: none\
+Related: none — first ADR scoping the MCP layer's agent-facing surface.
+
+## Context
+
+The MCP server in [packages/markspec/mcp/](../../packages/markspec/mcp/) exposes
+the project's traceability graph as five tools (`entry_search`, `entry_context`,
+`validate`, `markspec_refresh`, `profile_describe`) and three resources
+(`markspec://entries`, `markspec://profile`, `markspec://entry/{id}`). Agents
+are observed to **never invoke** these tools when run inside GitHub Copilot,
+even on questions about requirements, traceability, or display IDs that are
+clearly in scope. They default to `grep` / `Read` / `Glob` on Markdown files
+instead.
+
+Root cause is in the trigger surface, not the tools themselves:
+
+1. `SERVER_INSTRUCTIONS` in
+   [packages/markspec/mcp/server.ts](../../packages/markspec/mcp/server.ts)
+   opens with a definition ("MarkSpec exposes a project's…") rather than a
+   directive ("Use this for X").
+2. Tool descriptions are descriptive ("Find entries by keyword…") instead of
+   trigger-oriented ("Use when the user asks to …").
+3. No tool description tells the agent to **prefer** the MCP over built-in file
+   tools.
+4. No project-detection signal — the server starts and registers tools even in
+   workspaces without `.markspec.yaml` or `project.yaml`, so agents in
+   misconfigured Copilot setups can get tools that have nothing to operate on.
+
+Client support for the MCP `Implementation.instructions` field is uneven (Claude
+Code and Cursor surface it; Copilot does not reliably). Top-level guidance alone
+cannot fix the Copilot failure mode — the trigger signal must live in every tool
+description as well.
+
+## Decisions
+
+### 1. Defense in depth — same trigger vocabulary in both layers
+
+Both `SERVER_INSTRUCTIONS` and every individual tool description carry the same
+trigger language. Copilot misses `SERVER_INSTRUCTIONS`; without per-tool
+triggers it has no signal at all. Other clients get reinforcement when the same
+vocabulary appears in two places. Duplication is the redundancy, by design.
+
+### 2. Shared trigger grammar
+
+Every TRIGGER block follows three labelled sections in this order:
+
+```text
+TRIGGER when: <user-phrasing patterns, comma-separated>
+PREFER over: <built-in tools this replaces>
+SKIP when: <anti-triggers>
+```
+
+This mirrors the imperative pattern that works for Anthropic skills ("Use when
+X") and for high-trigger MCP servers like context7. `PREFER over:` is the
+anti-fallback directive currently missing — it's what explicitly outranks `grep`
+/ `Read` / `Glob`. `SKIP when:` prevents over-triggering on adjacent intents.
+
+### 3. Locked trigger vocabulary
+
+User-facing nouns to match in trigger blocks. The internal noun "entries" is
+**excluded** from trigger phrasings (users say "requirement" or "spec";
+"entries" is MarkSpec-internal vocabulary) and appears only in mechanical
+return-type descriptions where unavoidable (`markspec://entry/{id}`).
+
+| Category                 | Terms                                                                                                                                                               |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Generic                  | requirement(s), specification(s), spec(s)                                                                                                                           |
+| Level-specific           | stakeholder requirement, system requirement, software requirement                                                                                                   |
+| Architecture / Interface | architecture description, interface control document, ICD                                                                                                           |
+| Trace                    | traceability, satisfies-chain                                                                                                                                       |
+| Process verbs            | verification, validation                                                                                                                                            |
+| Safety                   | safety, ASIL-A/B/C/D                                                                                                                                                |
+| Patterns                 | EARS, acceptance criteria                                                                                                                                           |
+| **Anchor regex**         | `[A-Z]{2,}_[A-Z0-9_]+` — catches any uppercase-prefixed display ID like `STK_AEB_0001`, `SAD_BRK_0042`, `ICD_…`, or any profile-specific prefix without enumerating |
+
+**Deliberately dropped** (over-trigger risk): test, test case, design, module,
+component, AC, Gherkin scenario, ASPICE, ISO 26262. The display-ID regex anchor
+catches the `TST_` / `SWT_` / `SIT_` prefixes for test-shaped entries; ASPICE
+and ISO 26262 are workflow standards rather than entry-level vocabulary.
+
+### 4. Rewritten `SERVER_INSTRUCTIONS`
+
+Replace the current `SERVER_INSTRUCTIONS` constant in
+[packages/markspec/mcp/server.ts](../../packages/markspec/mcp/server.ts) with
+the following text:
+
+```text
+MarkSpec is this project's traceability graph — requirements, specifications,
+and tests with their cross-references. Use this server for ALL questions
+about requirements, specs, IDs, and traceability in this project.
+
+TRIGGER when the user:
+  - mentions a display ID matching [A-Z]{2,}_[A-Z0-9_]+ (e.g. STK_0001,
+    SAD_AEB_0042, ICD_BRK_0010, or any uppercase-prefixed underscored token)
+  - asks about requirements, specifications, specs, interface control
+    documents (ICDs), architecture descriptions, verification, validation,
+    safety requirements, ASIL levels, EARS requirements, acceptance
+    criteria, or traceability in this project
+  - asks what a requirement satisfies, what depends on it, what it traces
+    to, or what implements it
+  - asks whether a file or the project is valid, has broken refs, or has
+    duplicate IDs
+
+PREFER over: grep, Read, Glob, or file-system search whenever the question
+is about requirements or traceability. Built-in tools see Markdown text;
+this server sees the compiled traceability graph.
+
+Pick the right surface per intent:
+  - Find requirements by keyword      → entry_search
+  - Show one requirement by ID        → resources/read markspec://entry/{id}
+  - Walk satisfies-chain upward       → entry_context
+  - See what depends on a requirement → "Incoming links" in markspec://entry/{id}
+  - Check project health              → validate
+  - Refresh after external file edits → markspec_refresh
+
+SKIP when:
+  - any MarkSpec tool returns "No MarkSpec project found" — this workspace
+    doesn't use MarkSpec (no .markspec.yaml or project.yaml in scope);
+    stop calling MarkSpec tools for the rest of this session
+  - the user asks about source-code symbols, language features, framework
+    APIs, or library documentation — use context7 / language servers /
+    Read instead
+  - the user wants to edit a file directly ("change line 42 to X", "fix
+    this typo") — MarkSpec MCP is read-only; use Edit
+  - the user wants to create or insert a new requirement — writes are
+    CLI-only (markspec format, markspec insert)
+  - the user wants a rendered preview of a Markdown file — use markspec
+    doc build / markspec book build via Bash, not the MCP
+
+Do NOT use this server to edit entries. Writes are CLI-only:
+  markspec format, markspec insert.
+
+All resource bodies are Markdown with markspec:// URIs you can follow with
+resources/read.
+```
+
+### 5. Rewritten tool descriptions
+
+#### 5.1 `entry_search` — [packages/markspec/mcp/tools/search.ts](../../packages/markspec/mcp/tools/search.ts)
+
+Replace the `description` field of `ENTRY_SEARCH_DESCRIPTOR`:
+
+```text
+TRIGGER when: user asks to find/list/show/search requirements,
+specifications, ICDs, architecture descriptions, or tests about X; mentions
+a display ID like STK_0001, SAD_AEB_0042, or ICD_BRK_0010; or asks "what
+requirements cover X", "where is Y specified", "list stakeholder
+requirements", "show ASIL-B safety requirements". PREFER over: grep, Read,
+Glob on Markdown files — this returns ranked matches from the compiled
+traceability graph in one call instead of N file reads.
+
+Returns up to 100 ranked matches as Markdown links to markspec://entry/{id}
+resources, searching across display IDs and titles. Limit: 5–20 for broad
+exploration, 50+ only when listing every match in a domain.
+
+SKIP when: returns "No MarkSpec project found" — this workspace doesn't use
+MarkSpec; stop calling MarkSpec tools.
+```
+
+#### 5.2 `entry_context` — [packages/markspec/mcp/tools/context.ts](../../packages/markspec/mcp/tools/context.ts)
+
+Replace the `description` field of `ENTRY_CONTEXT_DESCRIPTOR`:
+
+```text
+TRIGGER when: user asks "what does this requirement satisfy", "why does
+this spec exist", "what does this trace up to", "what does X implement",
+"what higher-level requirement covers Y", or wants the upward chain from
+any display ID to its parents. PREFER over: grep'ing Satisfies: lines
+across files — this walks the compiled graph deterministically.
+
+For the opposite direction (what depends on this requirement), read
+markspec://entry/{id} and inspect its "Incoming links" section.
+
+Returns a nested Markdown list with markspec://entry/{id} links. Depth
+defaults to 10; lower to 2–3 for quick orientation, raise only for full
+transitive context.
+```
+
+#### 5.3 `validate` — [packages/markspec/mcp/tools/validate.ts](../../packages/markspec/mcp/tools/validate.ts)
+
+Replace the `description` field of `VALIDATE_DESCRIPTOR`:
+
+```text
+TRIGGER when: user asks "is this file valid", "are there broken refs",
+"check the project for errors", "run validate", or after entry-bearing
+files were edited and traceability needs confirming. PREFER over:
+re-reading every file to spot dangling Satisfies: targets — the validator
+runs the full diagnostic pipeline (broken refs, missing or duplicate IDs,
+malformed entries, profile rule violations) in one call.
+
+Returns a Markdown report grouped by severity. Optional 'files' restricts
+diagnostics to a subset of paths (relative to project root); empty 'files'
+list means all files.
+
+SKIP when: returns "No MarkSpec project found" — this workspace doesn't use
+MarkSpec.
+```
+
+#### 5.4 `markspec_refresh` — [packages/markspec/mcp/tools/refresh.ts](../../packages/markspec/mcp/tools/refresh.ts)
+
+Replace the `description` field of `REFRESH_DESCRIPTOR`:
+
+```text
+TRIGGER when: files were modified outside this MCP session (CLI commands,
+editor saves, git checkout, branch switch) and subsequent reads need to
+see fresh state. PREFER over: re-running validate or entry_search hoping
+to see fresh data — this guarantees the cache picks up disk changes.
+
+Do NOT call between back-to-back reads — the cache is already coherent
+within a session. Unnecessary calls slow down subsequent tool calls.
+
+Returns a one-line confirmation with entry and link counts.
+```
+
+#### 5.5 `profile_describe` — [packages/markspec/mcp/tools/profile_describe.ts](../../packages/markspec/mcp/tools/profile_describe.ts)
+
+Replace the `description` field of `PROFILE_DESCRIBE_DESCRIPTOR`:
+
+```text
+TRIGGER when: user asks "what does <Type> mean in this project", "what
+attribute is X", "is Y a valid label", "what relations does this profile
+define", "what's the EARS convention here", or any question about the
+project's profile-declared vocabulary. PREFER over: reading profile YAML
+files directly — this returns resolved element details from the compiled
+profile chain.
+
+Supply `name` (required) and optionally `kind`
+(type/attribute/relation/label/convention) to narrow the search. Fuzzy
+matching when no exact match; response lists candidates if multiple match.
+```
+
+### 6. Server-side soft gate — D2 (soft) over D1 (hard)
+
+Today the MCP server starts and registers tools regardless of whether the
+workspace is a MarkSpec project. Add a soft gate so tools self-describe "not
+applicable" instead of returning empty or confusing results.
+
+**D2 (soft) chosen over D1 (hard, refuse to start without config):** D2 is
+friendlier to client retry logic — the server appears healthy and registers
+normally; only the per-call behavior changes. Some clients log launch failures
+or back off when the server exits 0 without tools.
+
+#### 6.1 Detection signal
+
+A workspace is a MarkSpec project when, walking up from the server's cwd:
+
+1. **`project.yaml`** exists (canonical config — strongest signal), OR
+2. **`.markspec.yaml`** exists (profile activation chain).
+
+The detection reuses `discoverProjectRoot()` from
+[packages/markspec/core/config/mod.ts](../../packages/markspec/core/config/mod.ts).
+Markdown files containing `[TYPE_NNNN]` entry blocks would be a weaker third
+signal for ad-hoc adoption, but searching is too costly at startup and is left
+out of the baseline.
+
+#### 6.2 Code changes
+
+| File                                                                                   | Change                                                                                                                                                                                                                                                                                                                                                                                  |
+| -------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [packages/markspec/mcp/project.ts](../../packages/markspec/mcp/project.ts)             | Add `markspecDetected: boolean` to the `Project` interface. Set during `createProject()` by checking for `.markspec.yaml` OR `project.yaml` via `discoverProjectRoot()`.                                                                                                                                                                                                                |
+| [packages/markspec/mcp/tools/mod.ts](../../packages/markspec/mcp/tools/mod.ts)         | At the top of every handler in the `HANDLERS` map, if `!project.markspecDetected` return the uniform message below **as normal content** (`{ content: [{ type: "text", text: SOFT_GATE_MESSAGE }] }`), **not** with `isError: true`. The SKIP rule depends on the agent seeing the message text in the response body — `isError: true` causes some clients to suppress message content. |
+| [packages/markspec/mcp/resources/mod.ts](../../packages/markspec/mcp/resources/mod.ts) | Same early-return guard in `resources/read` handlers, returning the same string as a normal `text/plain` resource content (not an error).                                                                                                                                                                                                                                               |
+
+#### 6.3 Uniform error string (load-bearing)
+
+The SKIP rule keys on the **exact phrase** "No MarkSpec project found". Do not
+paraphrase across handlers. Canonical text:
+
+```text
+No MarkSpec project found in this workspace (looked for .markspec.yaml and
+project.yaml from cwd upward). This MCP server has no work to do here —
+stop calling MarkSpec tools.
+```
+
+#### 6.4 What stays the same
+
+- Server still starts in any cwd, opens stdio transport, registers all
+  tools/resources, and responds to `tools/list` / `resources/list`.
+- Tool descriptions (per decision 5) are identical regardless of detection
+  result — the SKIP rule teaches the agent to stop calling; the server just
+  enforces the response.
+- No structural change to project loading, resource subscription, or cache
+  invalidation.
+
+## Consequences
+
+### Token budget
+
+One-shot cost per MCP session (sent during `initialize` + `tools/list`, not per
+turn):
+
+| Surface                        | Today        | Proposed      | Delta    |
+| ------------------------------ | ------------ | ------------- | -------- |
+| `SERVER_INSTRUCTIONS`          | ~150 tok     | ~280 tok      | +130     |
+| `entry_search` description     | ~95 tok      | ~190 tok      | +95      |
+| `entry_context` description    | ~95 tok      | ~165 tok      | +70      |
+| `validate` description         | ~85 tok      | ~155 tok      | +70      |
+| `markspec_refresh` description | ~70 tok      | ~110 tok      | +40      |
+| `profile_describe` description | ~55 tok      | ~135 tok      | +80      |
+| **Total**                      | **~550 tok** | **~1035 tok** | **+485** |
+
+Acceptable. Worth it given the current Copilot zero-fire failure mode.
+
+### Verification plan
+
+Failure mode is anecdotal (Copilot ignores the MCP); success is also anecdotal
+in v1. Smoke tests after implementation:
+
+1. **Copilot in a MarkSpec project** — open a workspace with `project.yaml` and
+   ask "find requirements about braking". Confirm Copilot calls `entry_search`
+   instead of grep.
+2. **Copilot in a non-MarkSpec project** — open a workspace with no
+   `.markspec.yaml` / `project.yaml`, register the MCP server, ask "find
+   requirements about X". Confirm the soft-gate message appears and Copilot does
+   not retry.
+3. **Claude Code in a MarkSpec project** — same first test, confirm
+   reinforcement from both `SERVER_INSTRUCTIONS` and tool descriptions does not
+   produce double-firing or self-contradictory plans.
+4. **Display-ID trigger** — ask "what does STK_0001 satisfy" in any client;
+   confirm `entry_context` fires (the regex anchor working).
+
+No automated regression suite for prompt copy — these descriptors are not
+unit-testable for trigger behavior, only for content shape.
+
+### Out of scope
+
+- **No new markspec skill.** Refinement of the markspec-core skills bundle with
+  a dedicated MCP-trigger skill is a separate, Phase-2 effort. Phase 2 builds on
+  top of this baseline once impact is observed.
+- **No client-config documentation.** GitHub Copilot / Cursor / Claude Desktop
+  registration instructions are an ops concern, not changed here.
+- **No telemetry.** No instrumentation of "did the trigger fire?". Success is
+  measured by anecdotal user reports.
+- **No hard server-side gate (D1).** Server still starts in non-MarkSpec
+  workspaces; only response content changes.

--- a/packages/markspec/mcp/project.ts
+++ b/packages/markspec/mcp/project.ts
@@ -23,6 +23,42 @@ import {
   type ReadFile,
 } from "../core/mod.ts";
 
+/**
+ * Canonical soft-gate message returned when no MarkSpec project is detected
+ * in the workspace. Load-bearing: the trigger language in tool descriptions
+ * (ADR-023) keys on the phrase "No MarkSpec project found" verbatim. Do not
+ * paraphrase across handlers.
+ */
+export const SOFT_GATE_MESSAGE =
+  "No MarkSpec project found in this workspace (looked for .markspec.yaml and project.yaml from cwd upward). This MCP server has no work to do here — stop calling MarkSpec tools.";
+
+/**
+ * Detect whether the workspace at `cwd` is a MarkSpec project.
+ *
+ * Walks up from `cwd` checking for either `project.yaml` (canonical config)
+ * or `.markspec.yaml` (profile activation chain). Returns `true` as soon as
+ * either is found, `false` only when neither is found anywhere up to the
+ * filesystem root.
+ *
+ * Per ADR-023 §6.1.
+ */
+export async function detectMarkspecProject(
+  cwd: string,
+  readFile: ReadFile,
+): Promise<boolean> {
+  let dir = cwd;
+  while (true) {
+    if (await readFile(join(dir, "project.yaml")) !== undefined) return true;
+    if (await readFile(join(dir, ".markspec.yaml")) !== undefined) return true;
+    const parent = join(dir, "..");
+    // join("/", "..") → "/" on POSIX (idempotent at root). Detect with
+    // equality rather than parent.length, which doesn't catch the case.
+    const resolvedParent = parent === dir ? null : parent;
+    if (resolvedParent === null) return false;
+    dir = resolvedParent;
+  }
+}
+
 /** Files MarkSpec parses: Markdown plus supported source extensions. */
 const TRACKED_EXTENSIONS = new Set([
   ".md",
@@ -112,6 +148,13 @@ export type InvalidationHandler = (
 export interface Project {
   /** Discovered project root, or undefined when no `project.yaml` was found. */
   readonly projectRoot: string | undefined;
+  /**
+   * `true` when the workspace contains either `project.yaml` or
+   * `.markspec.yaml` anywhere up the directory tree from cwd. Tools and
+   * resources should short-circuit with `SOFT_GATE_MESSAGE` when this is
+   * `false`. Per ADR-023 §6.
+   */
+  readonly markspecDetected: boolean;
   /** Loaded project config, or undefined when no `project.yaml` was found. */
   readonly config: ProjectConfig | undefined;
   /** Active profile chain, or null when no profile is configured. */
@@ -179,6 +222,7 @@ async function* walkFs(dir: string): AsyncGenerator<string> {
  */
 export async function createProject(env: ProjectEnv): Promise<Project> {
   const cwd = env.cwd();
+  const markspecDetected = await detectMarkspecProject(cwd, env.readFile);
   const projectRoot = await discoverProjectRoot(cwd, env.readFile);
 
   let config: ProjectConfig | undefined;
@@ -327,6 +371,7 @@ export async function createProject(env: ProjectEnv): Promise<Project> {
 
   return {
     projectRoot,
+    markspecDetected,
     config,
     profileChain,
     profile: profileChain?.effective,

--- a/packages/markspec/mcp/project_test.ts
+++ b/packages/markspec/mcp/project_test.ts
@@ -300,37 +300,49 @@ Deno.test("getCompiled: same content, mtime bumped → NOT stale (SHA256 gate)",
 // detectMarkspecProject tests
 // ---------------------------------------------------------------------------
 
+// detectMarkspecProject fixtures use `join()` to build Map keys because the
+// helper itself constructs lookup paths via `join(dir, "project.yaml")` —
+// on Windows this returns backslash paths (`\proj\project.yaml`), so a
+// hard-coded POSIX literal like `/proj/project.yaml` would miss the map
+// lookup. Pre-computing the constants with `join()` keeps the tests
+// cross-platform.
+const FIXTURE_ROOT = join("/", "proj");
+const FIXTURE_PROJECT_YAML = join(FIXTURE_ROOT, "project.yaml");
+const FIXTURE_MARKSPEC_YAML = join(FIXTURE_ROOT, ".markspec.yaml");
+const FIXTURE_NESTED_CWD = join(FIXTURE_ROOT, "sub", "nested");
+const FIXTURE_UNRELATED_CWD = join("/", "some", "other", "cwd");
+
 Deno.test("detectMarkspecProject: returns true when project.yaml exists", async () => {
   const files = new Map<string, string>([
-    ["/proj/project.yaml", "name: x\n"],
+    [FIXTURE_PROJECT_YAML, "name: x\n"],
   ]);
   const readFile = (path: string) => Promise.resolve(files.get(path));
-  const detected = await detectMarkspecProject("/proj", readFile);
+  const detected = await detectMarkspecProject(FIXTURE_ROOT, readFile);
   assertEquals(detected, true);
 });
 
 Deno.test("detectMarkspecProject: returns true when .markspec.yaml exists", async () => {
   const files = new Map<string, string>([
-    ["/proj/.markspec.yaml", "extends: default\n"],
+    [FIXTURE_MARKSPEC_YAML, "extends: default\n"],
   ]);
   const readFile = (path: string) => Promise.resolve(files.get(path));
-  const detected = await detectMarkspecProject("/proj", readFile);
+  const detected = await detectMarkspecProject(FIXTURE_ROOT, readFile);
   assertEquals(detected, true);
 });
 
 Deno.test("detectMarkspecProject: walks up parent directories", async () => {
   const files = new Map<string, string>([
-    ["/proj/project.yaml", "name: x\n"],
+    [FIXTURE_PROJECT_YAML, "name: x\n"],
   ]);
   const readFile = (path: string) => Promise.resolve(files.get(path));
-  const detected = await detectMarkspecProject("/proj/sub/nested", readFile);
+  const detected = await detectMarkspecProject(FIXTURE_NESTED_CWD, readFile);
   assertEquals(detected, true);
 });
 
 Deno.test("detectMarkspecProject: returns false when neither file exists", async () => {
   const files = new Map<string, string>();
   const readFile = (path: string) => Promise.resolve(files.get(path));
-  const detected = await detectMarkspecProject("/some/other/cwd", readFile);
+  const detected = await detectMarkspecProject(FIXTURE_UNRELATED_CWD, readFile);
   assertEquals(detected, false);
 });
 

--- a/packages/markspec/mcp/project_test.ts
+++ b/packages/markspec/mcp/project_test.ts
@@ -11,7 +11,9 @@ import { join, resolve } from "@std/path";
 import {
   checkFileStaleness,
   createProject,
+  detectMarkspecProject,
   type ProjectEnv,
+  SOFT_GATE_MESSAGE,
 } from "./project.ts";
 
 /** Platform-native project root used by `makeEnv`'s cwd. */
@@ -292,4 +294,51 @@ Deno.test("getCompiled: same content, mtime bumped → NOT stale (SHA256 gate)",
   const r2 = await proj.getCompiled();
   assertEquals(r2.entries.size, 1);
   assertEquals(r2, r1, "cached result returned — no recompile triggered");
+});
+
+// ---------------------------------------------------------------------------
+// detectMarkspecProject tests
+// ---------------------------------------------------------------------------
+
+Deno.test("detectMarkspecProject: returns true when project.yaml exists", async () => {
+  const files = new Map<string, string>([
+    ["/proj/project.yaml", "name: x\n"],
+  ]);
+  const readFile = (path: string) => Promise.resolve(files.get(path));
+  const detected = await detectMarkspecProject("/proj", readFile);
+  assertEquals(detected, true);
+});
+
+Deno.test("detectMarkspecProject: returns true when .markspec.yaml exists", async () => {
+  const files = new Map<string, string>([
+    ["/proj/.markspec.yaml", "extends: default\n"],
+  ]);
+  const readFile = (path: string) => Promise.resolve(files.get(path));
+  const detected = await detectMarkspecProject("/proj", readFile);
+  assertEquals(detected, true);
+});
+
+Deno.test("detectMarkspecProject: walks up parent directories", async () => {
+  const files = new Map<string, string>([
+    ["/proj/project.yaml", "name: x\n"],
+  ]);
+  const readFile = (path: string) => Promise.resolve(files.get(path));
+  const detected = await detectMarkspecProject("/proj/sub/nested", readFile);
+  assertEquals(detected, true);
+});
+
+Deno.test("detectMarkspecProject: returns false when neither file exists", async () => {
+  const files = new Map<string, string>();
+  const readFile = (path: string) => Promise.resolve(files.get(path));
+  const detected = await detectMarkspecProject("/some/other/cwd", readFile);
+  assertEquals(detected, false);
+});
+
+Deno.test("SOFT_GATE_MESSAGE: contains the exact load-bearing phrase", () => {
+  // The trigger language in tool descriptions keys on this phrase verbatim.
+  // Do not paraphrase across handlers.
+  assertEquals(
+    SOFT_GATE_MESSAGE.startsWith("No MarkSpec project found"),
+    true,
+  );
 });

--- a/packages/markspec/mcp/resources/mod.ts
+++ b/packages/markspec/mcp/resources/mod.ts
@@ -17,7 +17,7 @@ import {
   type ReadResourceRequest,
   ReadResourceRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
-import type { Project } from "../project.ts";
+import { type Project, SOFT_GATE_MESSAGE } from "../project.ts";
 import {
   ENTRIES_URI,
   entryUri,
@@ -49,6 +49,7 @@ export interface ResourceDescriptor {
 export async function listResourceDescriptors(
   project: Project,
 ): Promise<ResourceDescriptor[]> {
+  if (!project.markspecDetected) return [];
   const result = await project.getCompiled();
   const out: ResourceDescriptor[] = [
     {
@@ -103,6 +104,13 @@ export async function readResource(
   uri: string,
   project: Project,
 ): Promise<ReadResourceResult> {
+  if (!project.markspecDetected) {
+    return {
+      uri,
+      mimeType: "text/plain",
+      text: SOFT_GATE_MESSAGE,
+    };
+  }
   if (uri === PROFILE_URI) {
     const intro = buildProfileView(project.profileChain);
     return {

--- a/packages/markspec/mcp/resources/mod_test.ts
+++ b/packages/markspec/mcp/resources/mod_test.ts
@@ -16,6 +16,7 @@ import type {
 } from "../../core/mod.ts";
 import { makeDisplayId } from "../../core/mod.ts";
 import type { Project } from "../project.ts";
+import { SOFT_GATE_MESSAGE } from "../project.ts";
 import { listResourceDescriptors, readResource } from "./mod.ts";
 
 function mkProject(entries: Entry[]): Project {
@@ -101,4 +102,38 @@ Deno.test("readResource: rejects missing entry", async () => {
     Error,
     "entry not found",
   );
+});
+
+function gatedProject(): Project {
+  return {
+    projectRoot: undefined,
+    markspecDetected: false,
+    config: undefined,
+    profileChain: null,
+    profile: undefined,
+    getCompiled: () =>
+      Promise.reject(new Error("getCompiled must not be called when gated")),
+    forceRefresh: () =>
+      Promise.reject(new Error("forceRefresh must not be called when gated")),
+    subscribeInvalidation: () => () => {},
+  };
+}
+
+Deno.test("readResource: returns soft-gate text when markspecDetected=false", async () => {
+  const project = gatedProject();
+  const result = await readResource("markspec://entries", project);
+  assertEquals(result.mimeType, "text/plain");
+  assertEquals(result.text, SOFT_GATE_MESSAGE);
+});
+
+Deno.test("readResource: soft-gate fires for any URI when gated", async () => {
+  const project = gatedProject();
+  const result = await readResource("markspec://entry/STK_0001", project);
+  assertEquals(result.text, SOFT_GATE_MESSAGE);
+});
+
+Deno.test("listResourceDescriptors: returns empty list when gated", async () => {
+  const project = gatedProject();
+  const list = await listResourceDescriptors(project);
+  assertEquals(list, []);
 });

--- a/packages/markspec/mcp/resources/mod_test.ts
+++ b/packages/markspec/mcp/resources/mod_test.ts
@@ -33,6 +33,7 @@ function mkProject(entries: Entry[]): Project {
   const chain: ProfileChain | null = null;
   return {
     projectRoot: "/proj",
+    markspecDetected: true,
     config: undefined,
     profileChain: chain,
     profile: undefined,

--- a/packages/markspec/mcp/server.ts
+++ b/packages/markspec/mcp/server.ts
@@ -20,27 +20,61 @@ import { ENTRIES_URI, entryUri, PROFILE_URI } from "./uri.ts";
 
 /**
  * Top-level guidance shown to MCP clients on `initialize`. Teaches the agent
- * what this server is for, which surface to use for which intent, and what to
- * avoid. Clients typically inject this into the system prompt once per
- * session — keep it dense and stable.
+ * when to fire the MarkSpec MCP, which surface to use for which intent, and
+ * when to stop. Defense-in-depth: the same vocabulary appears in every tool
+ * description so coverage holds even in clients that do not surface the
+ * `Implementation.instructions` field (notably Copilot).
+ *
+ * Per ADR-023 §4.
  */
-const SERVER_INSTRUCTIONS =
-  `MarkSpec exposes a project's requirements, specifications, and tests as a typed traceability graph. Use it to answer questions about entries, their relationships, and validation status.
+export const SERVER_INSTRUCTIONS =
+  `MarkSpec is this project's traceability graph — requirements, specifications,
+and tests with their cross-references. Use this server for ALL questions
+about requirements, specs, IDs, and traceability in this project.
+
+TRIGGER when the user:
+  - mentions a display ID matching [A-Z]{2,}_[A-Z0-9_]+ (e.g. STK_0001,
+    SAD_AEB_0042, ICD_BRK_0010, or any uppercase-prefixed underscored token)
+  - asks about requirements, specifications, specs, interface control
+    documents (ICDs), architecture descriptions, verification, validation,
+    safety requirements, ASIL levels, EARS requirements, acceptance
+    criteria, or traceability in this project
+  - asks what a requirement satisfies, what depends on it, what it traces
+    to, or what implements it
+  - asks whether a file or the project is valid, has broken refs, or has
+    duplicate IDs
+
+PREFER over: grep, Read, Glob, or file-system search whenever the question
+is about requirements or traceability. Built-in tools see Markdown text;
+this server sees the compiled traceability graph.
 
 Pick the right surface per intent:
-- Find entries by keyword → entry_search tool (scales to thousands of entries; preferred discovery path)
-- Show one entry by display ID → resources/read markspec://entry/{displayId}
-- Walk upward from an entry to see what it satisfies → entry_context tool
-- See what depends on an entry → the "Incoming links" section in markspec://entry/{id}
-- Check project health (broken refs, duplicates, rule violations) → validate tool
-- Refresh after CLI/file edits → markspec_refresh tool
+  - Find requirements by keyword      → entry_search
+  - Show one requirement by ID        → resources/read markspec://entry/{id}
+  - Walk satisfies-chain upward       → entry_context
+  - See what depends on a requirement → "Incoming links" in markspec://entry/{id}
+  - Check project health              → validate
+  - Refresh after external file edits → markspec_refresh
 
-Avoid:
-- Reading markspec://entries on projects with more than ~50 entries; use entry_search instead.
-- Calling markspec_refresh between back-to-back reads — MCP reads are cache-coherent within a session.
-- Using this server to edit entries. Writes are CLI-only (markspec format, markspec insert).
+SKIP when:
+  - any MarkSpec tool returns "No MarkSpec project found" — this workspace
+    doesn't use MarkSpec (no .markspec.yaml or project.yaml in scope);
+    stop calling MarkSpec tools for the rest of this session
+  - the user asks about source-code symbols, language features, framework
+    APIs, or library documentation — use context7 / language servers /
+    Read instead
+  - the user wants to edit a file directly ("change line 42 to X", "fix
+    this typo") — MarkSpec MCP is read-only; use Edit
+  - the user wants to create or insert a new requirement — writes are
+    CLI-only (markspec format, markspec insert)
+  - the user wants a rendered preview of a Markdown file — use markspec
+    doc build / markspec book build via Bash, not the MCP
 
-All resource bodies are Markdown with cross-references as markspec:// URIs you can follow with resources/read.`;
+Do NOT use this server to edit entries. Writes are CLI-only:
+  markspec format, markspec insert.
+
+All resource bodies are Markdown with markspec:// URIs you can follow with
+resources/read.`;
 
 /**
  * Start the MarkSpec MCP server.

--- a/packages/markspec/mcp/server_test.ts
+++ b/packages/markspec/mcp/server_test.ts
@@ -1,0 +1,58 @@
+/**
+ * @module mcp/server_test
+ *
+ * Structural assertions on SERVER_INSTRUCTIONS per ADR-023 §4. The text
+ * itself is not testable for LLM-behavioural effect — these tests catch
+ * accidental regressions to the trigger grammar (TRIGGER / PREFER / SKIP)
+ * and the locked vocabulary anchors.
+ */
+
+import { assertStringIncludes } from "@std/assert";
+import { SERVER_INSTRUCTIONS } from "./server.ts";
+
+Deno.test("SERVER_INSTRUCTIONS: contains TRIGGER block", () => {
+  assertStringIncludes(SERVER_INSTRUCTIONS, "TRIGGER when");
+});
+
+Deno.test("SERVER_INSTRUCTIONS: contains PREFER over block", () => {
+  assertStringIncludes(SERVER_INSTRUCTIONS, "PREFER over");
+});
+
+Deno.test("SERVER_INSTRUCTIONS: contains SKIP when block", () => {
+  assertStringIncludes(SERVER_INSTRUCTIONS, "SKIP when");
+});
+
+Deno.test("SERVER_INSTRUCTIONS: lists the display-ID regex anchor", () => {
+  assertStringIncludes(SERVER_INSTRUCTIONS, "[A-Z]{2,}_[A-Z0-9_]+");
+});
+
+Deno.test("SERVER_INSTRUCTIONS: names grep/Read/Glob in PREFER over", () => {
+  assertStringIncludes(SERVER_INSTRUCTIONS, "grep");
+  assertStringIncludes(SERVER_INSTRUCTIONS, "Read");
+  assertStringIncludes(SERVER_INSTRUCTIONS, "Glob");
+});
+
+Deno.test("SERVER_INSTRUCTIONS: references the soft-gate phrase verbatim", () => {
+  // SKIP rule keys on this exact phrase — see ADR-023 §6.3.
+  assertStringIncludes(SERVER_INSTRUCTIONS, "No MarkSpec project found");
+});
+
+Deno.test("SERVER_INSTRUCTIONS: lists locked vocabulary nouns", () => {
+  // Spot-check that the noun list survives — the full vocabulary is
+  // documented in ADR-023 §3.
+  for (
+    const noun of [
+      "requirements",
+      "specifications",
+      "ICD",
+      "architecture",
+      "verification",
+      "validation",
+      "ASIL",
+      "EARS",
+      "traceability",
+    ]
+  ) {
+    assertStringIncludes(SERVER_INSTRUCTIONS, noun);
+  }
+});

--- a/packages/markspec/mcp/tools/context.ts
+++ b/packages/markspec/mcp/tools/context.ts
@@ -106,10 +106,7 @@ export const ENTRY_CONTEXT_INPUT_SCHEMA = {
 export const ENTRY_CONTEXT_DESCRIPTOR = {
   name: "entry_context",
   description:
-    "Walk the satisfies-chain upward from one entry to discover what higher-level requirements it implements. Returns a nested Markdown list with markspec://entry/{id} links. " +
-    "Use to answer 'why does this entry exist' or 'what does this trace up to'. " +
-    "For the opposite direction (what depends on this entry), read markspec://entry/{id} and inspect its Incoming Links section. " +
-    "Depth defaults to 10; lower it (2–3) for quick orientation, raise it only when full transitive context is needed.",
+    `TRIGGER when: user asks "what does this requirement satisfy", "why does this spec exist", "what does this trace up to", "what does X implement", "what higher-level requirement covers Y", or wants the upward chain from any display ID to its parents. PREFER over: grep'ing Satisfies: lines across files — this walks the compiled graph deterministically.\n\nFor the opposite direction (what depends on this requirement), read markspec://entry/{id} and inspect its "Incoming links" section.\n\nReturns a nested Markdown list with markspec://entry/{id} links. Depth defaults to 10; lower to 2–3 for quick orientation, raise only for full transitive context.`,
   inputSchema: ENTRY_CONTEXT_INPUT_SCHEMA,
   annotations: {
     title: "Trace satisfies chain",

--- a/packages/markspec/mcp/tools/context_test.ts
+++ b/packages/markspec/mcp/tools/context_test.ts
@@ -7,7 +7,7 @@
 import { assertEquals, assertStringIncludes } from "@std/assert";
 import type { CompileResult, DisplayId, Entry, Link } from "../../core/mod.ts";
 import { makeDisplayId } from "../../core/mod.ts";
-import { renderContext, walkContext } from "./context.ts";
+import { ENTRY_CONTEXT_DESCRIPTOR, renderContext, walkContext } from "./context.ts";
 
 function mk(displayId: string, title: string): Entry {
   return {
@@ -133,5 +133,25 @@ Deno.test("renderContext: nested list with indentation", () => {
   assertStringIncludes(
     md,
     "    - satisfies → [C_0001](markspec://entry/C_0001) — C",
+  );
+});
+
+Deno.test("ENTRY_CONTEXT_DESCRIPTOR.description: has TRIGGER and PREFER blocks", () => {
+  const desc = ENTRY_CONTEXT_DESCRIPTOR.description;
+  assertStringIncludes(desc, "TRIGGER when:");
+  assertStringIncludes(desc, "PREFER over:");
+});
+
+Deno.test("ENTRY_CONTEXT_DESCRIPTOR.description: names satisfies-chain intent verbs", () => {
+  const desc = ENTRY_CONTEXT_DESCRIPTOR.description;
+  assertStringIncludes(desc, "satisfy");
+  assertStringIncludes(desc, "trace");
+  assertStringIncludes(desc, "implement");
+});
+
+Deno.test("ENTRY_CONTEXT_DESCRIPTOR.description: points at Incoming links for opposite direction", () => {
+  assertStringIncludes(
+    ENTRY_CONTEXT_DESCRIPTOR.description,
+    "Incoming links",
   );
 });

--- a/packages/markspec/mcp/tools/context_test.ts
+++ b/packages/markspec/mcp/tools/context_test.ts
@@ -7,7 +7,11 @@
 import { assertEquals, assertStringIncludes } from "@std/assert";
 import type { CompileResult, DisplayId, Entry, Link } from "../../core/mod.ts";
 import { makeDisplayId } from "../../core/mod.ts";
-import { ENTRY_CONTEXT_DESCRIPTOR, renderContext, walkContext } from "./context.ts";
+import {
+  ENTRY_CONTEXT_DESCRIPTOR,
+  renderContext,
+  walkContext,
+} from "./context.ts";
 
 function mk(displayId: string, title: string): Entry {
   return {

--- a/packages/markspec/mcp/tools/mod.ts
+++ b/packages/markspec/mcp/tools/mod.ts
@@ -12,7 +12,7 @@ import {
   CallToolRequestSchema,
   ListToolsRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
-import type { Project } from "../project.ts";
+import { type Project, SOFT_GATE_MESSAGE } from "../project.ts";
 import {
   ENTRY_SEARCH_DESCRIPTOR,
   renderSearchResults,
@@ -109,6 +109,35 @@ const HANDLERS: Record<string, ToolHandler> = {
   },
 };
 
+/**
+ * Dispatch a tool call by name. Soft-gates per ADR-023 §6 — when the
+ * workspace is not a MarkSpec project, every tool returns the canonical
+ * soft-gate message as normal content (not isError) so the agent's SKIP
+ * rule fires.
+ *
+ * Throws on unknown tool names so callers (the MCP request handler) can
+ * map that to an isError response.
+ */
+export async function dispatchTool(
+  name: string,
+  // deno-lint-ignore no-explicit-any
+  args: any,
+  project: Project,
+): Promise<string> {
+  // Soft gate first — every known tool short-circuits.
+  if (!project.markspecDetected) {
+    if (!HANDLERS[name]) {
+      throw new Error(`unknown tool: ${name}`);
+    }
+    return SOFT_GATE_MESSAGE;
+  }
+  const handler = HANDLERS[name];
+  if (!handler) {
+    throw new Error(`unknown tool: ${name}`);
+  }
+  return await handler(args ?? {}, project);
+}
+
 /** Attach `tools/list` and `tools/call` handlers to a Server instance. */
 export function registerTools(server: Server, project: Project): void {
   server.setRequestHandler(ListToolsRequestSchema, () =>
@@ -119,16 +148,12 @@ export function registerTools(server: Server, project: Project): void {
   server.setRequestHandler(
     CallToolRequestSchema,
     async (req: CallToolRequest) => {
-      const name = req.params.name;
-      const handler = HANDLERS[name];
-      if (!handler) {
-        return {
-          isError: true,
-          content: [{ type: "text", text: `unknown tool: ${name}` }],
-        };
-      }
       try {
-        const text = await handler(req.params.arguments ?? {}, project);
+        const text = await dispatchTool(
+          req.params.name,
+          req.params.arguments,
+          project,
+        );
         return { content: [{ type: "text", text }] };
       } catch (err) {
         return {

--- a/packages/markspec/mcp/tools/mod_test.ts
+++ b/packages/markspec/mcp/tools/mod_test.ts
@@ -32,7 +32,11 @@ Deno.test("dispatchTool: returns soft-gate message when markspecDetected=false",
 
 Deno.test("dispatchTool: gates every tool name (entry_context)", async () => {
   const project = mockProject(false);
-  const result = await dispatchTool("entry_context", { id: "STK_0001" }, project);
+  const result = await dispatchTool(
+    "entry_context",
+    { id: "STK_0001" },
+    project,
+  );
   assertStringIncludes(result, "No MarkSpec project found");
 });
 
@@ -50,7 +54,11 @@ Deno.test("dispatchTool: gates markspec_refresh", async () => {
 
 Deno.test("dispatchTool: gates profile_describe", async () => {
   const project = mockProject(false);
-  const result = await dispatchTool("profile_describe", { name: "Stk" }, project);
+  const result = await dispatchTool(
+    "profile_describe",
+    { name: "Stk" },
+    project,
+  );
   assertStringIncludes(result, "No MarkSpec project found");
 });
 

--- a/packages/markspec/mcp/tools/mod_test.ts
+++ b/packages/markspec/mcp/tools/mod_test.ts
@@ -1,0 +1,66 @@
+/**
+ * @module mcp/tools/mod_test
+ *
+ * Soft-gate dispatch behaviour per ADR-023 §6.
+ */
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { dispatchTool } from "./mod.ts";
+import type { Project } from "../project.ts";
+import { SOFT_GATE_MESSAGE } from "../project.ts";
+
+function mockProject(detected: boolean): Project {
+  return {
+    projectRoot: detected ? "/proj" : undefined,
+    markspecDetected: detected,
+    config: undefined,
+    profileChain: null,
+    profile: undefined,
+    getCompiled: () =>
+      Promise.reject(new Error("getCompiled must not be called when gated")),
+    forceRefresh: () =>
+      Promise.reject(new Error("forceRefresh must not be called when gated")),
+    subscribeInvalidation: () => () => {},
+  };
+}
+
+Deno.test("dispatchTool: returns soft-gate message when markspecDetected=false", async () => {
+  const project = mockProject(false);
+  const result = await dispatchTool("entry_search", { query: "x" }, project);
+  assertEquals(result, SOFT_GATE_MESSAGE);
+});
+
+Deno.test("dispatchTool: gates every tool name (entry_context)", async () => {
+  const project = mockProject(false);
+  const result = await dispatchTool("entry_context", { id: "STK_0001" }, project);
+  assertStringIncludes(result, "No MarkSpec project found");
+});
+
+Deno.test("dispatchTool: gates validate", async () => {
+  const project = mockProject(false);
+  const result = await dispatchTool("validate", {}, project);
+  assertStringIncludes(result, "No MarkSpec project found");
+});
+
+Deno.test("dispatchTool: gates markspec_refresh", async () => {
+  const project = mockProject(false);
+  const result = await dispatchTool("markspec_refresh", {}, project);
+  assertStringIncludes(result, "No MarkSpec project found");
+});
+
+Deno.test("dispatchTool: gates profile_describe", async () => {
+  const project = mockProject(false);
+  const result = await dispatchTool("profile_describe", { name: "Stk" }, project);
+  assertStringIncludes(result, "No MarkSpec project found");
+});
+
+Deno.test("dispatchTool: unknown tool returns error message regardless of gate", async () => {
+  const project = mockProject(false);
+  let caught: Error | null = null;
+  try {
+    await dispatchTool("nonexistent", {}, project);
+  } catch (err) {
+    caught = err as Error;
+  }
+  assertEquals(caught?.message.includes("unknown tool"), true);
+});

--- a/packages/markspec/mcp/tools/profile_describe.ts
+++ b/packages/markspec/mcp/tools/profile_describe.ts
@@ -23,9 +23,7 @@ const URI_KIND_TO_ELEMENT_KIND: Record<string, ProfileElementKind> = {
 export const PROFILE_DESCRIBE_DESCRIPTOR = {
   name: "profile_describe",
   description:
-    "Fetch the full description of a profile element (type, attribute, relation, label concern, or convention). " +
-    "Supply a `name` and optionally a `kind` to narrow the search. " +
-    "Fuzzy matching is used when no exact match is found — the response lists candidates if more than one matches.",
+    `TRIGGER when: user asks "what does <Type> mean in this project", "what attribute is X", "is Y a valid label", "what relations does this profile define", "what's the EARS convention here", or any question about the project's profile-declared vocabulary. PREFER over: reading profile YAML files directly — this returns resolved element details from the compiled profile chain.\n\nSupply 'name' (required) and optionally 'kind' (type/attribute/relation/label/convention) to narrow the search. Fuzzy matching when no exact match; response lists candidates if multiple match.`,
   inputSchema: {
     type: "object",
     properties: {

--- a/packages/markspec/mcp/tools/profile_describe_test.ts
+++ b/packages/markspec/mcp/tools/profile_describe_test.ts
@@ -115,3 +115,23 @@ Deno.test(
     );
   },
 );
+
+import { PROFILE_DESCRIBE_DESCRIPTOR } from "./profile_describe.ts";
+
+Deno.test(
+  "PROFILE_DESCRIBE_DESCRIPTOR.description: has TRIGGER and PREFER blocks",
+  () => {
+    const desc = PROFILE_DESCRIBE_DESCRIPTOR.description;
+    assertStringIncludes(desc, "TRIGGER when:");
+    assertStringIncludes(desc, "PREFER over:");
+  },
+);
+
+Deno.test(
+  "PROFILE_DESCRIBE_DESCRIPTOR.description: names profile-vocabulary intent phrases",
+  () => {
+    const desc = PROFILE_DESCRIBE_DESCRIPTOR.description;
+    assertStringIncludes(desc, "what does");
+    assertStringIncludes(desc, "EARS convention");
+  },
+);

--- a/packages/markspec/mcp/tools/refresh.ts
+++ b/packages/markspec/mcp/tools/refresh.ts
@@ -23,10 +23,7 @@ export const REFRESH_INPUT_SCHEMA = {
 export const REFRESH_DESCRIPTOR = {
   name: "markspec_refresh",
   description:
-    "Force-invalidate the MarkSpec compile cache so subsequent reads see fresh state. " +
-    "Use only after files were modified outside this MCP session (CLI commands, editor saves, git operations). " +
-    "Do NOT call between back-to-back reads — the cache is already coherent within a session. " +
-    "Returns a one-line confirmation with entry and link counts.",
+    `TRIGGER when: files were modified outside this MCP session (CLI commands, editor saves, git checkout, branch switch) and subsequent reads need to see fresh state. PREFER over: re-running validate or entry_search hoping to see fresh data — this guarantees the cache picks up disk changes.\n\nDo NOT call between back-to-back reads — the cache is already coherent within a session. Unnecessary calls slow down subsequent tool calls.\n\nReturns a one-line confirmation with entry and link counts.`,
   inputSchema: REFRESH_INPUT_SCHEMA,
   annotations: {
     title: "Refresh compile cache",

--- a/packages/markspec/mcp/tools/refresh_test.ts
+++ b/packages/markspec/mcp/tools/refresh_test.ts
@@ -33,5 +33,8 @@ Deno.test("REFRESH_DESCRIPTOR.description: names external-edit causes", () => {
 });
 
 Deno.test("REFRESH_DESCRIPTOR.description: warns against unnecessary calls", () => {
-  assertStringIncludes(REFRESH_DESCRIPTOR.description, "Do NOT call between back-to-back reads");
+  assertStringIncludes(
+    REFRESH_DESCRIPTOR.description,
+    "Do NOT call between back-to-back reads",
+  );
 });

--- a/packages/markspec/mcp/tools/refresh_test.ts
+++ b/packages/markspec/mcp/tools/refresh_test.ts
@@ -17,3 +17,21 @@ Deno.test("renderRefresh: zero counts", () => {
   assertStringIncludes(md, "Refreshed.");
   assertEquals(md.includes("0 entries"), true);
 });
+
+import { REFRESH_DESCRIPTOR } from "./refresh.ts";
+
+Deno.test("REFRESH_DESCRIPTOR.description: has TRIGGER and PREFER blocks", () => {
+  const desc = REFRESH_DESCRIPTOR.description;
+  assertStringIncludes(desc, "TRIGGER when:");
+  assertStringIncludes(desc, "PREFER over:");
+});
+
+Deno.test("REFRESH_DESCRIPTOR.description: names external-edit causes", () => {
+  const desc = REFRESH_DESCRIPTOR.description;
+  assertStringIncludes(desc, "CLI commands");
+  assertStringIncludes(desc, "git checkout");
+});
+
+Deno.test("REFRESH_DESCRIPTOR.description: warns against unnecessary calls", () => {
+  assertStringIncludes(REFRESH_DESCRIPTOR.description, "Do NOT call between back-to-back reads");
+});

--- a/packages/markspec/mcp/tools/search.ts
+++ b/packages/markspec/mcp/tools/search.ts
@@ -119,10 +119,7 @@ export const ENTRY_SEARCH_INPUT_SCHEMA = {
 export const ENTRY_SEARCH_DESCRIPTOR = {
   name: "entry_search",
   description:
-    "Find entries by keyword across display IDs and titles. Returns up to 100 ranked matches as Markdown links to markspec://entry/{id} resources. " +
-    "Use this for any 'find/search/list entries about X' query. " +
-    "Prefer over reading markspec://entries — search scales to thousands of entries; the full index does not. " +
-    "Limit: keep at 5–20 for broad exploratory queries, 50+ only when listing every match in a domain.",
+    `TRIGGER when: user asks to find/list/show/search requirements, specifications, ICDs, architecture descriptions, or tests about X; mentions a display ID like STK_0001, SAD_AEB_0042, or ICD_BRK_0010; or asks "what requirements cover X", "where is Y specified", "list stakeholder requirements", "show ASIL-B safety requirements". PREFER over: grep, Read, Glob on Markdown files — this returns ranked matches from the compiled traceability graph in one call instead of N file reads.\n\nReturns up to 100 ranked matches as Markdown links to markspec://entry/{id} resources, searching across display IDs and titles. Limit: 5–20 for broad exploration, 50+ only when listing every match in a domain.\n\nSKIP when: returns "No MarkSpec project found" — this workspace doesn't use MarkSpec; stop calling MarkSpec tools.`,
   inputSchema: ENTRY_SEARCH_INPUT_SCHEMA,
   annotations: {
     title: "Search entries",

--- a/packages/markspec/mcp/tools/search_test.ts
+++ b/packages/markspec/mcp/tools/search_test.ts
@@ -7,7 +7,7 @@
 import { assertEquals, assertStringIncludes } from "@std/assert";
 import type { Entry } from "../../core/mod.ts";
 import { makeDisplayId } from "../../core/mod.ts";
-import { renderSearchResults, scoreEntries } from "./search.ts";
+import { renderSearchResults, scoreEntries, ENTRY_SEARCH_DESCRIPTOR } from "./search.ts";
 
 function mk(displayId: string, title: string): Entry {
   return {
@@ -90,4 +90,27 @@ Deno.test("renderSearchResults: links each hit", () => {
     "[STK_AEB_0001](markspec://entry/STK_AEB_0001) — Stop on collision",
   );
   assertStringIncludes(md, "score 11");
+});
+
+Deno.test("ENTRY_SEARCH_DESCRIPTOR.description: has TRIGGER/PREFER/SKIP blocks", () => {
+  const desc = ENTRY_SEARCH_DESCRIPTOR.description;
+  assertStringIncludes(desc, "TRIGGER when:");
+  assertStringIncludes(desc, "PREFER over:");
+  assertStringIncludes(desc, "SKIP when:");
+});
+
+Deno.test("ENTRY_SEARCH_DESCRIPTOR.description: names user-facing nouns", () => {
+  const desc = ENTRY_SEARCH_DESCRIPTOR.description;
+  assertStringIncludes(desc, "requirements");
+  assertStringIncludes(desc, "specifications");
+  assertStringIncludes(desc, "ICD");
+});
+
+Deno.test("ENTRY_SEARCH_DESCRIPTOR.description: names anti-fallback tools", () => {
+  const desc = ENTRY_SEARCH_DESCRIPTOR.description;
+  assertStringIncludes(desc, "grep");
+});
+
+Deno.test("ENTRY_SEARCH_DESCRIPTOR.description: keys on canonical soft-gate phrase", () => {
+  assertStringIncludes(ENTRY_SEARCH_DESCRIPTOR.description, "No MarkSpec project found");
 });

--- a/packages/markspec/mcp/tools/search_test.ts
+++ b/packages/markspec/mcp/tools/search_test.ts
@@ -7,7 +7,11 @@
 import { assertEquals, assertStringIncludes } from "@std/assert";
 import type { Entry } from "../../core/mod.ts";
 import { makeDisplayId } from "../../core/mod.ts";
-import { renderSearchResults, scoreEntries, ENTRY_SEARCH_DESCRIPTOR } from "./search.ts";
+import {
+  ENTRY_SEARCH_DESCRIPTOR,
+  renderSearchResults,
+  scoreEntries,
+} from "./search.ts";
 
 function mk(displayId: string, title: string): Entry {
   return {
@@ -112,5 +116,8 @@ Deno.test("ENTRY_SEARCH_DESCRIPTOR.description: names anti-fallback tools", () =
 });
 
 Deno.test("ENTRY_SEARCH_DESCRIPTOR.description: keys on canonical soft-gate phrase", () => {
-  assertStringIncludes(ENTRY_SEARCH_DESCRIPTOR.description, "No MarkSpec project found");
+  assertStringIncludes(
+    ENTRY_SEARCH_DESCRIPTOR.description,
+    "No MarkSpec project found",
+  );
 });

--- a/packages/markspec/mcp/tools/validate.ts
+++ b/packages/markspec/mcp/tools/validate.ts
@@ -106,10 +106,7 @@ export const VALIDATE_INPUT_SCHEMA = {
 export const VALIDATE_DESCRIPTOR = {
   name: "validate",
   description:
-    "Run the project's validation pipeline: broken cross-references, missing or duplicate IDs, malformed entries, and profile rule violations. Returns a Markdown report grouped by severity. " +
-    "Use after edits, before committing, or when an entry's relationships look wrong. " +
-    "Optional 'files' restricts diagnostics to a subset of paths (relative to the project root). " +
-    "An empty 'files' list means all files.",
+    `TRIGGER when: user asks "is this file valid", "are there broken refs", "check the project for errors", "run validate", or after entry-bearing files were edited and traceability needs confirming. PREFER over: re-reading every file to spot dangling Satisfies: targets — the validator runs the full diagnostic pipeline (broken refs, missing or duplicate IDs, malformed entries, profile rule violations) in one call.\n\nReturns a Markdown report grouped by severity. Optional 'files' restricts diagnostics to a subset of paths (relative to project root); empty 'files' list means all files.\n\nSKIP when: returns "No MarkSpec project found" — this workspace doesn't use MarkSpec.`,
   inputSchema: VALIDATE_INPUT_SCHEMA,
   annotations: {
     title: "Validate project",

--- a/packages/markspec/mcp/tools/validate_test.ts
+++ b/packages/markspec/mcp/tools/validate_test.ts
@@ -247,5 +247,8 @@ Deno.test("VALIDATE_DESCRIPTOR.description: names validation intent phrases", ()
 });
 
 Deno.test("VALIDATE_DESCRIPTOR.description: keys on canonical soft-gate phrase", () => {
-  assertStringIncludes(VALIDATE_DESCRIPTOR.description, "No MarkSpec project found");
+  assertStringIncludes(
+    VALIDATE_DESCRIPTOR.description,
+    "No MarkSpec project found",
+  );
 });

--- a/packages/markspec/mcp/tools/validate_test.ts
+++ b/packages/markspec/mcp/tools/validate_test.ts
@@ -185,6 +185,7 @@ function emptyCompileResult(): CompileResult {
 function stubProject(profileChain: ProfileChain): Project {
   return {
     projectRoot: "/proj",
+    markspecDetected: true,
     config: undefined,
     profileChain,
     profile: profileChain.effective,

--- a/packages/markspec/mcp/tools/validate_test.ts
+++ b/packages/markspec/mcp/tools/validate_test.ts
@@ -230,3 +230,22 @@ Deno.test(
     assertEquals(report.includes("@markspec/profile-default"), false);
   },
 );
+
+import { VALIDATE_DESCRIPTOR } from "./validate.ts";
+
+Deno.test("VALIDATE_DESCRIPTOR.description: has TRIGGER/PREFER/SKIP blocks", () => {
+  const desc = VALIDATE_DESCRIPTOR.description;
+  assertStringIncludes(desc, "TRIGGER when:");
+  assertStringIncludes(desc, "PREFER over:");
+  assertStringIncludes(desc, "SKIP when:");
+});
+
+Deno.test("VALIDATE_DESCRIPTOR.description: names validation intent phrases", () => {
+  const desc = VALIDATE_DESCRIPTOR.description;
+  assertStringIncludes(desc, "broken refs");
+  assertStringIncludes(desc, "duplicate IDs");
+});
+
+Deno.test("VALIDATE_DESCRIPTOR.description: keys on canonical soft-gate phrase", () => {
+  assertStringIncludes(VALIDATE_DESCRIPTOR.description, "No MarkSpec project found");
+});

--- a/tests/e2e/mcp_test.ts
+++ b/tests/e2e/mcp_test.ts
@@ -384,3 +384,86 @@ Deno.test("mcp: touching a file without changing content does not break results"
     await Deno.remove(cwd, { recursive: true });
   }
 });
+
+/** Create a non-MarkSpec workspace (no project.yaml, no .markspec.yaml). */
+async function setupGated(): Promise<
+  { proc: McpProcess; cwd: string; initResponse: RpcResponse }
+> {
+  const dir = await Deno.makeTempDir();
+  // Deliberately do NOT create project.yaml or .markspec.yaml.
+  const proc = new McpProcess(dir);
+  const initResponse = await proc.request("initialize", {
+    protocolVersion: "2024-11-05",
+    capabilities: {},
+    clientInfo: { name: "test", version: "0.0.1" },
+  });
+  await proc.notify("notifications/initialized", {});
+  return { proc, cwd: dir, initResponse };
+}
+
+Deno.test("mcp soft-gate: tools/call returns canonical message in non-MarkSpec workspace", async () => {
+  const { proc, cwd } = await setupGated();
+  try {
+    const resp = await proc.request("tools/call", {
+      name: "entry_search",
+      arguments: { query: "anything" },
+    });
+    // deno-lint-ignore no-explicit-any
+    const result = resp.result as any;
+    // Per ADR-023 §6.2: returned as normal content, NOT isError: true.
+    assertEquals(result.isError, undefined);
+    assertEquals(result.content[0].type, "text");
+    assertStringIncludes(result.content[0].text, "No MarkSpec project found");
+  } finally {
+    await proc.close();
+    await Deno.remove(cwd, { recursive: true });
+  }
+});
+
+Deno.test("mcp soft-gate: resources/read returns text/plain soft-gate content in non-MarkSpec workspace", async () => {
+  const { proc, cwd } = await setupGated();
+  try {
+    const resp = await proc.request("resources/read", {
+      uri: "markspec://entries",
+    });
+    // deno-lint-ignore no-explicit-any
+    const contents = (resp.result as any).contents as Array<
+      { text: string; mimeType: string }
+    >;
+    assertEquals(contents[0].mimeType, "text/plain");
+    assertStringIncludes(contents[0].text, "No MarkSpec project found");
+  } finally {
+    await proc.close();
+    await Deno.remove(cwd, { recursive: true });
+  }
+});
+
+Deno.test("mcp soft-gate: resources/list returns empty in non-MarkSpec workspace", async () => {
+  const { proc, cwd } = await setupGated();
+  try {
+    const resp = await proc.request("resources/list", {});
+    // deno-lint-ignore no-explicit-any
+    const resources = (resp.result as any).resources as Array<{ uri: string }>;
+    assertEquals(resources, []);
+  } finally {
+    await proc.close();
+    await Deno.remove(cwd, { recursive: true });
+  }
+});
+
+Deno.test("mcp soft-gate: initialize still succeeds in non-MarkSpec workspace (D2 soft, not D1 hard)", async () => {
+  const { proc, cwd, initResponse } = await setupGated();
+  try {
+    // Server must still start, advertise capabilities, and return instructions
+    // per ADR-023 decision to choose D2 (soft) over D1 (hard refuse-to-start).
+    // deno-lint-ignore no-explicit-any
+    const caps = (initResponse.result as any).capabilities;
+    assertEquals(typeof caps.tools, "object");
+    // deno-lint-ignore no-explicit-any
+    const instructions = (initResponse.result as any).instructions as string;
+    assertStringIncludes(instructions, "TRIGGER when");
+  } finally {
+    await proc.close();
+    await Deno.remove(cwd, { recursive: true });
+  }
+});


### PR DESCRIPTION
## Summary

- Rewrite `SERVER_INSTRUCTIONS` and all 5 MCP tool descriptions with a shared `TRIGGER when:` / `PREFER over:` / `SKIP when:` grammar so agents (Copilot in particular) reliably reach for the MarkSpec MCP instead of grep/Read on Markdown files. Defense in depth: same trigger vocabulary lives in both layers, so clients that don't surface the `Implementation.instructions` field still get the signal via tool descriptions.
- Add a project-detection soft gate (D2 in ADR-023): `Project.markspecDetected` is set at startup by walking up for `project.yaml` OR `.markspec.yaml`. Tool calls and `resources/read` return the canonical phrase **"No MarkSpec project found"** as normal content (not `isError: true`) so the SKIP rule fires and the agent stops calling MCP tools in non-MarkSpec workspaces. `resources/list` returns empty.
- Drive the whole thing end-to-end: 4 new e2e tests in `tests/e2e/mcp_test.ts` that drive the real `markspec mcp` binary via JSON-RPC verify tools/call, resources/read, resources/list, and initialize all behave correctly without a MarkSpec project.

See [ADR-023](docs/architecture/adr-023-mcp-trigger-language.md) for the full design.

## Test Plan

- [x] `just test` — 2691 passed, 0 failed
- [x] `just lint` (deno lint + dprint check) — clean
- [x] `deno fmt --check` — clean (run separately per project policy)
- [x] `just build` — passes, binary at `dist/markspec` (158 MB)
- [x] 4 new e2e soft-gate tests pass through real JSON-RPC protocol
- [ ] **Manual smoke test (post-merge):** Copilot in a non-MarkSpec workspace asks "find requirements about X" → confirm soft-gate message appears and Copilot does not retry MarkSpec tools
- [ ] **Manual smoke test (post-merge):** Copilot in the markspec repo asks "find requirements about the MCP server" → confirm `entry_search` fires instead of grep
- [ ] **Manual smoke test (post-merge):** Display-ID trigger — ask "what does STK_0001 satisfy" in any MCP client; confirm `entry_context` fires
- [ ] **Manual smoke test (post-merge):** Claude Code in markspec repo — confirm reinforcement from both SERVER_INSTRUCTIONS and tool descriptions does not produce double-firing

## Out of scope (deferred to Phase 2)

- New markspec skill in the markspec-core skills bundle that triggers earlier in Claude Code's decision loop
- Telemetry on trigger firing
- Hard server-side gate (D1 — refuse to start in non-MarkSpec workspaces)
- Loosening `getCompiled()` to fully support `.markspec.yaml`-only projects (currently a known edge case noted in ADR-023)

🤖 Generated with [Claude Code](https://claude.com/claude-code)