### PR TITLE
feat(lsp): add MARKSPEC_LSP_TIMING_LOG instrumentation

### DIFF
--- a/packages/markspec/lsp/server.ts
+++ b/packages/markspec/lsp/server.ts
@@ -102,6 +102,7 @@ import {
   uriToPath,
 } from "./util.ts";
 import { debugLog } from "./debug_log.ts";
+import { time, timeAsync } from "./timing.ts";
 import {
   buildDollarNameCompletions,
   dollarNameAtPosition,
@@ -200,7 +201,10 @@ function publishFileDiagnostics(
 
 /** Run cross-file validation and publish diagnostics for all files. */
 function publishAllDiagnostics(): void {
-  const allDiags = index.validateAll(profile ?? null);
+  const allDiags = time(
+    `validateAll/${index.getAllEntries().length}`,
+    () => index.validateAll(profile ?? null),
+  );
   lastDiagnostics = allDiags;
   const grouped = groupDiagnosticsByFile(allDiags);
 
@@ -454,14 +458,19 @@ connection.onInitialized(async () => {
     }
 
     // Parse all files
-    for (const filePath of files) {
-      try {
-        const content = await readFileRequired(filePath);
-        await index.parseAndUpdateFile(filePath, content);
-      } catch {
-        connection.console.warn(`Failed to parse: ${filePath}`);
+    await timeAsync("onInitialized/parseAll", async () => {
+      for (const filePath of files) {
+        try {
+          const content = await readFileRequired(filePath);
+          await timeAsync(
+            "onInitialized/parseFile",
+            () => index.parseAndUpdateFile(filePath, content),
+          );
+        } catch {
+          connection.console.warn(`Failed to parse: ${filePath}`);
+        }
       }
-    }
+    });
 
     connection.console.log(
       `Indexed ${files.length} files, ${index.getAllEntries().length} entries`,
@@ -608,74 +617,84 @@ connection.onCompletion((params): CompletionItem[] => {
 
   // Trigger 1: Block scaffold
   if (isBlockScaffoldTrigger(line)) {
-    const types = getEntryTypes();
-    const items = buildBlockScaffoldItems(types, ulid);
-    return items.map((item, i) => {
-      const type = types[i];
-      return {
-        label: item.label,
-        detail: item.detail,
-        insertText: item.insertText,
-        insertTextFormat: item.isSnippet
-          ? InsertTextFormat.Snippet
-          : InsertTextFormat.PlainText,
-        kind: item.isSnippet
-          ? CompletionItemKind.Snippet
-          : CompletionItemKind.Reference,
-        data: type
-          ? {
-            kind: SCAFFOLD_COMPLETION_KIND,
-            typeName: type.name,
-            prefix: type.prefix,
-          } satisfies ScaffoldCompletionData
-          : undefined,
-      };
+    return time("onCompletion/scaffold", () => {
+      const types = getEntryTypes();
+      const items = buildBlockScaffoldItems(types, ulid);
+      return items.map((item, i) => {
+        const type = types[i];
+        return {
+          label: item.label,
+          detail: item.detail,
+          insertText: item.insertText,
+          insertTextFormat: item.isSnippet
+            ? InsertTextFormat.Snippet
+            : InsertTextFormat.PlainText,
+          kind: item.isSnippet
+            ? CompletionItemKind.Snippet
+            : CompletionItemKind.Reference,
+          data: type
+            ? {
+              kind: SCAFFOLD_COMPLETION_KIND,
+              typeName: type.name,
+              prefix: type.prefix,
+            } satisfies ScaffoldCompletionData
+            : undefined,
+        };
+      });
     });
   }
 
   // Trigger 2: Trailer attribute key — indented blank or partial key.
   if (isTrailerKeyContext(line)) {
-    const items = buildTrailerKeyItems();
-    return items.map((item) => ({
-      label: item.label,
-      detail: item.detail,
-      insertText: item.insertText,
-      kind: CompletionItemKind.Property,
-    }));
+    return time("onCompletion/trailerKey", () => {
+      const items = buildTrailerKeyItems();
+      return items.map((item) => ({
+        label: item.label,
+        detail: item.detail,
+        insertText: item.insertText,
+        kind: CompletionItemKind.Property,
+      }));
+    });
   }
 
   // Trigger 3: ID reference
   if (isTraceAttributeTrigger(line)) {
-    const displayIds = index.getAllDisplayIds();
-    const items = buildIdReferenceItems(displayIds);
-    return items.map((item) => ({
-      label: item.label,
-      detail: item.detail,
-      kind: CompletionItemKind.Reference,
-    }));
+    return time("onCompletion/idRef", () => {
+      const displayIds = index.getAllDisplayIds();
+      const items = buildIdReferenceItems(displayIds);
+      return items.map((item) => ({
+        label: item.label,
+        detail: item.detail,
+        kind: CompletionItemKind.Reference,
+      }));
+    });
   }
 
   // Trigger 4: Type: attribute value — core types + profile types.
   if (isTypeAttributeTrigger(line)) {
-    const profileTypeNames = profile ? [...profile.types.keys()] : [];
-    const items = buildTypeAttributeItems(profileTypeNames);
-    return items.map((item) => ({
-      label: item.label,
-      detail: item.detail,
-      kind: CompletionItemKind.Reference,
-    }));
+    return time("onCompletion/typeAttr", () => {
+      const profileTypeNames = profile ? [...profile.types.keys()] : [];
+      const items = buildTypeAttributeItems(profileTypeNames);
+      return items.map((item) => ({
+        label: item.label,
+        detail: item.detail,
+        kind: CompletionItemKind.Reference,
+      }));
+    });
   }
 
   // Trigger 5: $Name identifier — typl binding names from the corpus registry.
   if (isDollarNameTrigger(line)) {
-    const registry = index.getTypeRegistry();
-    const items = buildDollarNameCompletions(registry);
-    return items.map((item) => ({
-      label: item.label,
-      detail: item.detail,
-      documentation: item.documentation,
-      kind: CompletionItemKind.Variable,
-    }));
+    return time("onCompletion/dollarName", () => {
+      const registry = index.getTypeRegistry();
+      const items = buildDollarNameCompletions(registry);
+      return items.map((item) => ({
+        label: item.label,
+        detail: item.detail,
+        documentation: item.documentation,
+        kind: CompletionItemKind.Variable,
+      }));
+    });
   }
 
   return [];

--- a/packages/markspec/lsp/timing.ts
+++ b/packages/markspec/lsp/timing.ts
@@ -1,0 +1,70 @@
+/**
+ * @module lsp/timing
+ *
+ * Performance timing for LSP hot paths. Activated by the
+ * MARKSPEC_LSP_TIMING_LOG environment variable, which doubles as the
+ * destination path. When unset, every helper is a near-zero no-op.
+ *
+ * Output format: one line per measurement, append-only, e.g.
+ *   [2026-05-27T14:32:11.123Z] timing: onCompletion/scaffold 0.42ms
+ *
+ * Kept separate from MARKSPEC_LSP_DEBUG_LOG so timing noise doesn't
+ * drown out lifecycle/crash events when both are enabled.
+ */
+
+let logPath: string | undefined;
+let initialized = false;
+
+function lazyInit(): void {
+  if (initialized) return;
+  initialized = true;
+  const value = Deno.env.get("MARKSPEC_LSP_TIMING_LOG");
+  if (value && value.length > 0) logPath = value;
+}
+
+function write(label: string, ms: number): void {
+  if (!logPath) return;
+  try {
+    Deno.writeTextFileSync(
+      logPath,
+      `[${new Date().toISOString()}] timing: ${label} ${ms.toFixed(2)}ms\n`,
+      { append: true },
+    );
+  } catch {
+    // Drop silently — stderr is captured by the LSP framework, and a
+    // failed log write must not crash the server.
+  }
+}
+
+/** Time a synchronous function. Returns its result. */
+export function time<T>(label: string, fn: () => T): T {
+  lazyInit();
+  if (!logPath) return fn();
+  const start = performance.now();
+  try {
+    return fn();
+  } finally {
+    write(label, performance.now() - start);
+  }
+}
+
+/** Time an async function. Returns its result. */
+export async function timeAsync<T>(
+  label: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  lazyInit();
+  if (!logPath) return await fn();
+  const start = performance.now();
+  try {
+    return await fn();
+  } finally {
+    write(label, performance.now() - start);
+  }
+}
+
+/** Test-only reset. */
+export function _resetTiming(): void {
+  initialized = false;
+  logPath = undefined;
+}

--- a/packages/markspec/lsp/timing_test.ts
+++ b/packages/markspec/lsp/timing_test.ts
@@ -1,0 +1,87 @@
+/**
+ * @module lsp/timing_test
+ */
+
+import { assert, assertEquals, assertStringIncludes } from "@std/assert";
+import { _resetTiming, time, timeAsync } from "./timing.ts";
+
+async function withTempLog<T>(
+  fn: (path: string) => T | Promise<T>,
+): Promise<T> {
+  _resetTiming();
+  const path = await Deno.makeTempFile({ prefix: "markspec-timing-" });
+  Deno.env.set("MARKSPEC_LSP_TIMING_LOG", path);
+  try {
+    return await fn(path);
+  } finally {
+    Deno.env.delete("MARKSPEC_LSP_TIMING_LOG");
+    _resetTiming();
+    try {
+      await Deno.remove(path);
+    } catch {
+      /* already gone */
+    }
+  }
+}
+
+Deno.test("timing: no-op when env var unset", () => {
+  _resetTiming();
+  Deno.env.delete("MARKSPEC_LSP_TIMING_LOG");
+  const result = time("noop", () => 42);
+  assertEquals(result, 42);
+});
+
+Deno.test("timing: time() returns result and writes log line", async () => {
+  await withTempLog(async (path) => {
+    const result = time("sync-test", () => "hello");
+    assertEquals(result, "hello");
+    const contents = await Deno.readTextFile(path);
+    assertStringIncludes(contents, "timing: sync-test");
+    assertStringIncludes(contents, "ms");
+  });
+});
+
+Deno.test("timing: timeAsync() returns result and writes log line", async () => {
+  await withTempLog(async (path) => {
+    const result = await timeAsync("async-test", async () => {
+      await Promise.resolve();
+      return 7;
+    });
+    assertEquals(result, 7);
+    const contents = await Deno.readTextFile(path);
+    assertStringIncludes(contents, "timing: async-test");
+  });
+});
+
+Deno.test("timing: time() still logs when wrapped fn throws", async () => {
+  await withTempLog(async (path) => {
+    let threw = false;
+    try {
+      time("throws", () => {
+        throw new Error("boom");
+      });
+    } catch {
+      threw = true;
+    }
+    assert(threw, "expected exception to propagate");
+    const contents = await Deno.readTextFile(path);
+    assertStringIncludes(contents, "timing: throws");
+  });
+});
+
+Deno.test("timing: timeAsync() still logs when wrapped fn rejects", async () => {
+  await withTempLog(async (path) => {
+    let threw = false;
+    try {
+      await timeAsync("rejects", async () => {
+        await Promise.resolve();
+        throw new Error("boom");
+      });
+    } catch {
+      threw = true;
+    }
+    assert(threw, "expected rejection to propagate");
+    const contents = await Deno.readTextFile(path);
+    assertStringIncludes(contents, "timing: rejects");
+  });
+});


### PR DESCRIPTION
## Summary

- Add `lsp/timing.ts` with `time()` / `timeAsync()` helpers gated on the `MARKSPEC_LSP_TIMING_LOG` env var. When unset, every helper is a near-zero no-op; when set, each measurement appends one line to the configured path.
- Instrument four LSP hot paths:
  - `validateAll/{N}` — cross-file validation cost, with current entry count in the label
  - `onCompletion/{scaffold,trailerKey,idRef,typeAttr,dollarName}` — per-trigger completion cost
  - `onInitialized/parseFile` — per-file parse cost (one line per file)
  - `onInitialized/parseAll` — cold-start parse total
- Kept separate from `MARKSPEC_LSP_DEBUG_LOG` so timing noise does not drown out lifecycle/crash events when both are enabled.

## Why

Editor responsiveness in large MarkSpec projects has been reported as not ideal. Before guessing at the bottleneck and refactoring `validate()`, the trace-attribute completion payload, or the startup parse loop, this PR ships the instrumentation to actually measure which path is slow under real workloads.

```bash
MARKSPEC_LSP_TIMING_LOG=/tmp/markspec-timing.log code /path/to/project
sort -t' ' -k4 -h /tmp/markspec-timing.log | tail -20
```

## Initial measurement on the markspec self-hosted workspace (581 files, 40 entries)

| Path | Result |
|---|---|
| `onInitialized/parseAll` | 2370 ms cold start (dominant) |
| `onInitialized/parseFile` | mean 3.5 ms · max 125 ms · 87% of parseAll |
| `validateAll/40` | 0.4–1.1 ms |
| `onCompletion/*` | sub-millisecond for all five triggers |

The data justified parallelizing the `onInitialized` parse loop — that work lives in a separate follow-up PR rather than this one. (Earlier revisions of this PR body claimed both changes shipped here; that was incorrect. Only the instrumentation merged via this PR.)

## Test plan

- [x] `deno fmt --check` — clean
- [x] `deno lint` — clean
- [x] `deno test` — 2719 passed, 0 failed
- [x] `timing_test.ts`: 5 tests cover no-op, sync, async, throw-propagation, reject-propagation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
