### PR TITLE
perf(lsp): parallelize onInitialized parse loop

### DIFF
--- a/packages/markspec/lsp/server.ts
+++ b/packages/markspec/lsp/server.ts
@@ -457,19 +457,34 @@ connection.onInitialized(async () => {
       }
     }
 
-    // Parse all files
+    // Parse all files with bounded concurrency. The serial loop spent
+    // most of its wall time waiting on file I/O while CPU was idle —
+    // overlapping reads + parses cuts cold-start dramatically. Side
+    // effect: when duplicate display IDs exist across files, the
+    // "first entry wins" tiebreak now resolves to whichever parse
+    // finishes first (previously: alphabetical file order). The
+    // validator still flags the duplicate in either case; the
+    // diagnostic location is the only thing that becomes
+    // nondeterministic.
     await timeAsync("onInitialized/parseAll", async () => {
-      for (const filePath of files) {
-        try {
-          const content = await readFileRequired(filePath);
-          await timeAsync(
-            "onInitialized/parseFile",
-            () => index.parseAndUpdateFile(filePath, content),
-          );
-        } catch {
-          connection.console.warn(`Failed to parse: ${filePath}`);
-        }
-      }
+      const CONCURRENCY = 8;
+      let cursor = 0;
+      await Promise.all(
+        Array.from({ length: CONCURRENCY }, async () => {
+          while (cursor < files.length) {
+            const filePath = files[cursor++];
+            try {
+              const content = await readFileRequired(filePath);
+              await timeAsync(
+                "onInitialized/parseFile",
+                () => index.parseAndUpdateFile(filePath, content),
+              );
+            } catch {
+              connection.console.warn(`Failed to parse: ${filePath}`);
+            }
+          }
+        }),
+      );
     });
 
     connection.console.log(


### PR DESCRIPTION
## Summary

Replace the serial `for (const filePath of files)` parse loop in `onInitialized` with an 8-worker pool that pulls from a shared cursor. Workers run concurrently; each worker reads + parses files sequentially within itself.

Follow-up to #523 (which shipped the timing instrumentation that motivated this change). The earlier #523 body briefly claimed both changes shipped together — that was a mistake; only the instrumentation merged. This PR ships the perf change cleanly off main.

## Measured impact

On the markspec self-hosted workspace (581 files, 40 entries), using the timing log from #523:

| Metric | Serial | 8-way concurrent | Change |
|---|---|---|---|
| `onInitialized/parseAll` (wall) | 2370 ms | **1736 ms** | **−27%** |
| `indexed` event (wall) | 2748 ms | **1914 ms** | **−30%** |
| `parseFile` mean (per-call) | 3.5 ms | 15.4 ms | (event-loop contention) |
| `parseFile` cumulative sum | 2056 ms | 8956 ms | (overlap — see note) |

Per-call `parseFile` numbers grow under concurrency because each parse contends for the event loop with up to seven others. The cumulative sum (8956 ms) exceeds wall time (1736 ms) by exactly the overlap we wanted. The right metric is the wall-clock `parseAll`.

A 27% gain rather than 4–8× tells us the parser is CPU-bound on the single-threaded event loop — moving the parser itself to a Worker would unlock more, but is a much bigger change.

## Behavior change

When duplicate display IDs exist across files, the "first entry wins" tiebreak in `WorkspaceIndex.updateFile` now resolves to whichever parse finishes first, rather than alphabetical iteration order. The validator still flags the duplicate (MSL-R002); only the diagnostic location becomes nondeterministic.

In Node.js single-threaded model, parallel `await parseFile()` calls execute their synchronous tails one-at-a-time on the event loop, so `byDisplayId` mutations remain atomic — no concurrent-write hazard, only ordering nondeterminism for duplicate keys.

## Test plan

- [x] `deno check packages/markspec/lsp/server.ts` — clean
- [x] `deno fmt --check` — clean
- [x] `deno lint` — clean
- [x] `deno test packages/markspec/lsp/` — 266 passed, 0 failed
- [x] Before/after wall-clock measurement against the markspec worktree using `MARKSPEC_LSP_TIMING_LOG`
- [ ] **Manual smoke test (post-merge):** drive against a real compliance project (hundreds-to-thousands of entries) to see whether the wall-clock win scales

## Out of scope

- Moving the Markdown parser to a Worker (would unlock more than 30% but is a much bigger change)
- Tuning the concurrency constant — 8 is a reasonable default; can revisit when scale data is available

🤖 Generated with [Claude Code](https://claude.com/claude-code)
