### PR TITLE
feat(cli): add claude-code and opencode MCP install adapters

### DIFF
--- a/docs/guide/ai-agents.md
+++ b/docs/guide/ai-agents.md
@@ -55,12 +55,44 @@ markspec mcp install --client claude-desktop \
   --binary-path /opt/markspec/bin/markspec
 ```
 
+### Claude Code
+
+`markspec mcp install --client claude-code` writes `.mcp.json` at the project
+root. The file uses the same `mcpServers.markspec` shape as Claude Desktop and
+is read automatically by Claude Code when it opens the directory.
+
+```sh
+markspec mcp install --client claude-code --scope workspace
+markspec mcp install --client claude-code --scope workspace \
+  --binary-path /opt/markspec/bin/markspec
+```
+
+The `--scope=user` flag is not supported for `claude-code` — the config is
+always project-scoped (`.mcp.json` at the repo root).
+
 ### Cursor
 
 ```sh
 markspec mcp install --client cursor
 markspec mcp install --client cursor --binary-path /opt/markspec/bin/markspec
 ```
+
+### opencode
+
+`markspec mcp install --client opencode` writes `opencode.json` at the project
+root. The file uses a flat `mcp.markspec` object with a `type: "local"` entry
+(no `mcpServers` nesting), which matches the opencode JSON schema verified
+against the [anomalyco/opencode](https://github.com/anomalyco/opencode)
+repository.
+
+```sh
+markspec mcp install --client opencode --scope workspace
+markspec mcp install --client opencode --scope workspace \
+  --binary-path /opt/markspec/bin/markspec
+```
+
+The `--scope=user` flag is not supported for `opencode` — the config is always
+project-scoped (`opencode.json` at the repo root).
 
 ### VS Code (Copilot / Claude)
 

--- a/packages/markspec/cli/commands/mcp_cmd.ts
+++ b/packages/markspec/cli/commands/mcp_cmd.ts
@@ -21,7 +21,7 @@ export const mcpCmd = new Command()
   .description("Install or print MCP server configuration for a client")
   .option(
     "--client <client:string>",
-    "Client ID (claude-desktop|cursor|vscode)",
+    "Client ID (claude-desktop|claude-code|cursor|opencode|vscode)",
     { required: true },
   )
   .option("--scope <scope:string>", "Config scope: user|workspace")

--- a/packages/markspec/cli/install/adapters.ts
+++ b/packages/markspec/cli/install/adapters.ts
@@ -14,7 +14,12 @@ export interface AdapterResult {
 }
 
 export type LspEditorId = "vscode" | "neovim" | "zed";
-export type McpClientId = "claude-desktop" | "cursor" | "vscode";
+export type McpClientId =
+  | "claude-desktop"
+  | "claude-code"
+  | "cursor"
+  | "opencode"
+  | "vscode";
 
 export const LSP_EDITOR_IDS: readonly LspEditorId[] = [
   "vscode",
@@ -23,7 +28,9 @@ export const LSP_EDITOR_IDS: readonly LspEditorId[] = [
 ];
 export const MCP_CLIENT_IDS: readonly McpClientId[] = [
   "claude-desktop",
+  "claude-code",
   "cursor",
+  "opencode",
   "vscode",
 ];
 
@@ -79,6 +86,30 @@ export interface LspAdapter {
   renderBlock(input: RenderBlockInput): string;
 }
 
+/** Result of an adapter's detection check. */
+export interface DetectResult {
+  /** True when at least one detection signal fired. */
+  readonly detected: boolean;
+  /** Human-readable signals that fired (for `--format json` and debug). */
+  readonly signals: readonly string[];
+}
+
+/**
+ * Test seam for detection — production wires real Deno APIs. Adapters'
+ * `detect()` consumes this env so unit tests inject fakes for zero
+ * filesystem / process I/O.
+ */
+export interface DetectEnv {
+  /** Resolve a command name to a path; undefined when not on PATH. */
+  readonly whichCommand: (name: string) => Promise<string | undefined>;
+  /** Test whether an absolute or repo-relative path exists. */
+  readonly pathExists: (path: string) => Promise<boolean>;
+  /** Absolute project root, for repo-relative checks. */
+  readonly projectRoot: string;
+  /** Home directory, for `~/.claude/` etc. */
+  readonly homeDir: string;
+}
+
 /**
  * Adapter descriptor consumed by the MCP install orchestrator. Each
  * adapter exposes pure functions (no I/O) for path resolution and block
@@ -90,6 +121,12 @@ export interface LspAdapter {
  */
 export interface McpAdapter {
   readonly id: McpClientId;
+  /**
+   * JSON path of the managed entry under the target config file's root.
+   * For claude-desktop / claude-code this is `["mcpServers", "markspec"]`.
+   * For opencode it differs — see `mcp_adapters_opencode.ts`.
+   */
+  readonly jsonPath: readonly (string | number)[];
   /**
    * Resolve the config file path for the given scope.
    * - `home` is `Deno.env.get("HOME")` (POSIX) or equivalent.
@@ -111,6 +148,12 @@ export interface McpAdapter {
   ): string;
   /** Render the JSON object for the `mcpServers.<name>` key. */
   renderBlock(input: RenderBlockInput): Record<string, unknown>;
+  /**
+   * Optional detection — returns whether the client is in use (machine
+   * CLI on PATH OR repo marker OR user-home marker). Consumed by
+   * `markspec init` in slice G1. Not surfaced via CLI in G0.
+   */
+  readonly detect?: (env: DetectEnv) => Promise<DetectResult>;
 }
 
 /** Iterative O(n·m) Levenshtein distance with a single row buffer. */

--- a/packages/markspec/cli/install/mcp_adapters.ts
+++ b/packages/markspec/cli/install/mcp_adapters.ts
@@ -44,6 +44,7 @@ const VSCODE_MARKETPLACE_URL =
  */
 export const claudeDesktopDescriptor: McpAdapter = {
   id: "claude-desktop",
+  jsonPath: ["mcpServers", "markspec"],
   resolveConfigPath(scope, _cwd, home, appData, _workspaceRoot) {
     if (scope === "workspace") {
       throw new Error(

--- a/packages/markspec/cli/install/mcp_adapters_claude_code.ts
+++ b/packages/markspec/cli/install/mcp_adapters_claude_code.ts
@@ -1,0 +1,52 @@
+/**
+ * @module cli/install/mcp_adapters_claude_code
+ *
+ * `claude-code` MCP install adapter — project-scoped. Writes the
+ * managed `markspec` entry to `<workspaceRoot>/.mcp.json`, which
+ * Claude Code reads on session start. See ADR-023 for the broader
+ * trigger-language context.
+ *
+ * Slice G0 of the install/upgrade devex epic. The detect() function is
+ * exposed for slice G1's `markspec init` to consume; no CLI surface
+ * uses it in G0.
+ */
+
+import { join } from "@std/path";
+import type {
+  DetectEnv,
+  DetectResult,
+  McpAdapter,
+  RenderBlockInput,
+} from "./adapters.ts";
+
+export const claudeCodeDescriptor: McpAdapter = {
+  id: "claude-code",
+  // Same JSON path as claude-desktop — the .mcp.json shape mirrors the
+  // user-scope Claude Desktop config but lives at the project root.
+  jsonPath: ["mcpServers", "markspec"],
+  resolveConfigPath(scope, cwd, _home, _appData, workspaceRoot) {
+    if (scope !== "workspace") {
+      throw new Error(
+        "claude-code does not support user scope (project-scoped only)",
+      );
+    }
+    const root = workspaceRoot ?? cwd;
+    return join(root, ".mcp.json");
+  },
+  renderBlock(input: RenderBlockInput): Record<string, unknown> {
+    return { command: input.binaryPath, args: ["mcp"] };
+  },
+  detect: async (env: DetectEnv): Promise<DetectResult> => {
+    const signals: string[] = [];
+    if (await env.whichCommand("claude") !== undefined) {
+      signals.push("claude-cli-on-path");
+    }
+    if (await env.pathExists(join(env.projectRoot, ".mcp.json"))) {
+      signals.push("project-mcp-json-present");
+    }
+    if (await env.pathExists(join(env.homeDir, ".claude"))) {
+      signals.push("user-claude-home-present");
+    }
+    return { detected: signals.length > 0, signals };
+  },
+};

--- a/packages/markspec/cli/install/mcp_adapters_claude_code_test.ts
+++ b/packages/markspec/cli/install/mcp_adapters_claude_code_test.ts
@@ -6,8 +6,21 @@
  */
 
 import { assertEquals, assertThrows } from "@std/assert";
+import { join } from "@std/path";
 import { claudeCodeDescriptor } from "./mcp_adapters_claude_code.ts";
 import type { DetectEnv } from "./adapters.ts";
+
+// Path fixtures use `join()` so the constants match the platform-aware
+// paths the adapter constructs at runtime — on Windows the std `join`
+// returns backslash paths (`\repo\.mcp.json`), so a POSIX literal
+// would miss the equality check.
+const REPO_ROOT = join("/", "repo");
+const HOME_DIR = join("/", "home", "u");
+const CWD_DIR = join("/", "some", "cwd");
+const CLAUDE_BIN = join("/", "usr", "local", "bin", "claude");
+const REPO_MCP_JSON = join(REPO_ROOT, ".mcp.json");
+const CWD_MCP_JSON = join(CWD_DIR, ".mcp.json");
+const HOME_CLAUDE = join(HOME_DIR, ".claude");
 
 // ---------------------------------------------------------------------------
 // jsonPath + id
@@ -25,21 +38,21 @@ Deno.test("claudeCodeDescriptor: id and jsonPath", () => {
 Deno.test("claudeCodeDescriptor: workspace scope → <workspaceRoot>/.mcp.json", () => {
   const path = claudeCodeDescriptor.resolveConfigPath(
     "workspace",
-    "/some/cwd",
-    "/home/u",
+    CWD_DIR,
+    HOME_DIR,
     undefined,
-    "/repo",
+    REPO_ROOT,
   );
-  assertEquals(path, "/repo/.mcp.json");
+  assertEquals(path, REPO_MCP_JSON);
 });
 
 Deno.test("claudeCodeDescriptor: workspace scope without workspaceRoot → falls back to cwd", () => {
   const path = claudeCodeDescriptor.resolveConfigPath(
     "workspace",
-    "/some/cwd",
-    "/home/u",
+    CWD_DIR,
+    HOME_DIR,
   );
-  assertEquals(path, "/some/cwd/.mcp.json");
+  assertEquals(path, CWD_MCP_JSON);
 });
 
 Deno.test("claudeCodeDescriptor: user scope throws", () => {
@@ -77,8 +90,8 @@ function makeEnv(overrides: Partial<DetectEnv> = {}): DetectEnv {
   return {
     whichCommand: () => Promise.resolve(undefined),
     pathExists: () => Promise.resolve(false),
-    projectRoot: "/repo",
-    homeDir: "/home/u",
+    projectRoot: REPO_ROOT,
+    homeDir: HOME_DIR,
     ...overrides,
   };
 }
@@ -93,9 +106,7 @@ Deno.test("claudeCodeDescriptor.detect: claude on PATH → claude-cli-on-path si
   const result = await claudeCodeDescriptor.detect!(
     makeEnv({
       whichCommand: (name) =>
-        Promise.resolve(
-          name === "claude" ? "/usr/local/bin/claude" : undefined,
-        ),
+        Promise.resolve(name === "claude" ? CLAUDE_BIN : undefined),
     }),
   );
   assertEquals(result.detected, true);
@@ -105,7 +116,7 @@ Deno.test("claudeCodeDescriptor.detect: claude on PATH → claude-cli-on-path si
 Deno.test("claudeCodeDescriptor.detect: project .mcp.json present → project-mcp-json-present signal", async () => {
   const result = await claudeCodeDescriptor.detect!(
     makeEnv({
-      pathExists: (path) => Promise.resolve(path === "/repo/.mcp.json"),
+      pathExists: (path) => Promise.resolve(path === REPO_MCP_JSON),
     }),
   );
   assertEquals(result.detected, true);
@@ -115,7 +126,7 @@ Deno.test("claudeCodeDescriptor.detect: project .mcp.json present → project-mc
 Deno.test("claudeCodeDescriptor.detect: ~/.claude/ present → user-claude-home-present signal", async () => {
   const result = await claudeCodeDescriptor.detect!(
     makeEnv({
-      pathExists: (path) => Promise.resolve(path === "/home/u/.claude"),
+      pathExists: (path) => Promise.resolve(path === HOME_CLAUDE),
     }),
   );
   assertEquals(result.detected, true);
@@ -126,13 +137,9 @@ Deno.test("claudeCodeDescriptor.detect: all signals fire → all listed", async 
   const result = await claudeCodeDescriptor.detect!(
     makeEnv({
       whichCommand: (name) =>
-        Promise.resolve(
-          name === "claude" ? "/usr/local/bin/claude" : undefined,
-        ),
+        Promise.resolve(name === "claude" ? CLAUDE_BIN : undefined),
       pathExists: (path) =>
-        Promise.resolve(
-          path === "/repo/.mcp.json" || path === "/home/u/.claude",
-        ),
+        Promise.resolve(path === REPO_MCP_JSON || path === HOME_CLAUDE),
     }),
   );
   assertEquals(result.detected, true);

--- a/packages/markspec/cli/install/mcp_adapters_claude_code_test.ts
+++ b/packages/markspec/cli/install/mcp_adapters_claude_code_test.ts
@@ -1,0 +1,148 @@
+/**
+ * @module cli/install/mcp_adapters_claude_code_test
+ *
+ * Tests for the claude-code adapter — slice G0 of the install/upgrade
+ * devex epic.
+ */
+
+import { assertEquals, assertThrows } from "@std/assert";
+import { claudeCodeDescriptor } from "./mcp_adapters_claude_code.ts";
+import type { DetectEnv } from "./adapters.ts";
+
+// ---------------------------------------------------------------------------
+// jsonPath + id
+// ---------------------------------------------------------------------------
+
+Deno.test("claudeCodeDescriptor: id and jsonPath", () => {
+  assertEquals(claudeCodeDescriptor.id, "claude-code");
+  assertEquals(claudeCodeDescriptor.jsonPath, ["mcpServers", "markspec"]);
+});
+
+// ---------------------------------------------------------------------------
+// resolveConfigPath
+// ---------------------------------------------------------------------------
+
+Deno.test("claudeCodeDescriptor: workspace scope → <workspaceRoot>/.mcp.json", () => {
+  const path = claudeCodeDescriptor.resolveConfigPath(
+    "workspace",
+    "/some/cwd",
+    "/home/u",
+    undefined,
+    "/repo",
+  );
+  assertEquals(path, "/repo/.mcp.json");
+});
+
+Deno.test("claudeCodeDescriptor: workspace scope without workspaceRoot → falls back to cwd", () => {
+  const path = claudeCodeDescriptor.resolveConfigPath(
+    "workspace",
+    "/some/cwd",
+    "/home/u",
+  );
+  assertEquals(path, "/some/cwd/.mcp.json");
+});
+
+Deno.test("claudeCodeDescriptor: user scope throws", () => {
+  assertThrows(
+    () => claudeCodeDescriptor.resolveConfigPath("user", "/cwd", "/home"),
+    Error,
+    "claude-code does not support user scope",
+  );
+});
+
+// ---------------------------------------------------------------------------
+// renderBlock
+// ---------------------------------------------------------------------------
+
+Deno.test("claudeCodeDescriptor: renderBlock returns command + args", () => {
+  const block = claudeCodeDescriptor.renderBlock({ binaryPath: "markspec" });
+  assertEquals(block, { command: "markspec", args: ["mcp"] });
+});
+
+Deno.test("claudeCodeDescriptor: renderBlock honors absolute binary path", () => {
+  const block = claudeCodeDescriptor.renderBlock({
+    binaryPath: "/opt/markspec/bin/markspec",
+  });
+  assertEquals(block, {
+    command: "/opt/markspec/bin/markspec",
+    args: ["mcp"],
+  });
+});
+
+// ---------------------------------------------------------------------------
+// detect()
+// ---------------------------------------------------------------------------
+
+function makeEnv(overrides: Partial<DetectEnv> = {}): DetectEnv {
+  return {
+    whichCommand: () => Promise.resolve(undefined),
+    pathExists: () => Promise.resolve(false),
+    projectRoot: "/repo",
+    homeDir: "/home/u",
+    ...overrides,
+  };
+}
+
+Deno.test("claudeCodeDescriptor.detect: all signals false → detected=false", async () => {
+  const result = await claudeCodeDescriptor.detect!(makeEnv());
+  assertEquals(result.detected, false);
+  assertEquals(result.signals, []);
+});
+
+Deno.test("claudeCodeDescriptor.detect: claude on PATH → claude-cli-on-path signal", async () => {
+  const result = await claudeCodeDescriptor.detect!(
+    makeEnv({
+      whichCommand: (name) =>
+        Promise.resolve(
+          name === "claude" ? "/usr/local/bin/claude" : undefined,
+        ),
+    }),
+  );
+  assertEquals(result.detected, true);
+  assertEquals(result.signals, ["claude-cli-on-path"]);
+});
+
+Deno.test("claudeCodeDescriptor.detect: project .mcp.json present → project-mcp-json-present signal", async () => {
+  const result = await claudeCodeDescriptor.detect!(
+    makeEnv({
+      pathExists: (path) => Promise.resolve(path === "/repo/.mcp.json"),
+    }),
+  );
+  assertEquals(result.detected, true);
+  assertEquals(result.signals, ["project-mcp-json-present"]);
+});
+
+Deno.test("claudeCodeDescriptor.detect: ~/.claude/ present → user-claude-home-present signal", async () => {
+  const result = await claudeCodeDescriptor.detect!(
+    makeEnv({
+      pathExists: (path) => Promise.resolve(path === "/home/u/.claude"),
+    }),
+  );
+  assertEquals(result.detected, true);
+  assertEquals(result.signals, ["user-claude-home-present"]);
+});
+
+Deno.test("claudeCodeDescriptor.detect: all signals fire → all listed", async () => {
+  const result = await claudeCodeDescriptor.detect!(
+    makeEnv({
+      whichCommand: (name) =>
+        Promise.resolve(
+          name === "claude" ? "/usr/local/bin/claude" : undefined,
+        ),
+      pathExists: (path) =>
+        Promise.resolve(
+          path === "/repo/.mcp.json" || path === "/home/u/.claude",
+        ),
+    }),
+  );
+  assertEquals(result.detected, true);
+  // Order is implementation-defined but stable; assert as a set.
+  assertEquals(
+    new Set(result.signals),
+    new Set([
+      "claude-cli-on-path",
+      "project-mcp-json-present",
+      "user-claude-home-present",
+    ]),
+  );
+});

--- a/packages/markspec/cli/install/mcp_adapters_opencode.ts
+++ b/packages/markspec/cli/install/mcp_adapters_opencode.ts
@@ -1,0 +1,67 @@
+/**
+ * @module cli/install/mcp_adapters_opencode
+ *
+ * `opencode` MCP install adapter — project-scoped. Writes the managed
+ * `markspec` entry to `<workspaceRoot>/opencode.json`, which opencode
+ * reads on session start. Slice G0 of the install/upgrade devex epic.
+ *
+ * The JSON shape was verified against the anomalyco/opencode repository
+ * during implementation (slice G0 spec acceptance criterion #7):
+ *   - Config file: `opencode.json` at the project root (NOT `.opencode/mcp.json`)
+ *   - JSON path: `["mcp", "markspec"]` (flat — no "servers" nesting)
+ *   - Local server shape: `{ type: "local", command: string[] }`
+ *   Source: packages/opencode/src/config/mcp.ts (Local schema struct)
+ *           packages/opencode/src/config/config.ts (project file resolution)
+ *
+ * If a future opencode release changes the shape, update both `jsonPath`
+ * and `renderBlock` together with the colocated tests.
+ */
+
+import { join } from "@std/path";
+import type {
+  DetectEnv,
+  DetectResult,
+  McpAdapter,
+  RenderBlockInput,
+} from "./adapters.ts";
+
+export const opencodeDescriptor: McpAdapter = {
+  id: "opencode",
+  // Verified: opencode uses a flat `mcp` object — no "servers" nesting.
+  // The entry sits directly at mcp.<name>, not mcp.servers.<name>.
+  jsonPath: ["mcp", "markspec"],
+  resolveConfigPath(scope, cwd, _home, _appData, workspaceRoot) {
+    if (scope !== "workspace") {
+      throw new Error(
+        "opencode does not support user scope (project-scoped only)",
+      );
+    }
+    const root = workspaceRoot ?? cwd;
+    // Verified: opencode reads `opencode.json` at the project root,
+    // not `.opencode/mcp.json` as originally inferred by the spec.
+    return join(root, "opencode.json");
+  },
+  renderBlock(input: RenderBlockInput): Record<string, unknown> {
+    // Verified: Local schema in anomalyco/opencode uses `type: "local"`
+    // and `command: string[]` — the same shape as the spec's inference.
+    return { type: "local", command: [input.binaryPath, "mcp"] };
+  },
+  detect: async (env: DetectEnv): Promise<DetectResult> => {
+    const signals: string[] = [];
+    if (await env.whichCommand("opencode") !== undefined) {
+      signals.push("opencode-cli-on-path");
+    }
+    // opencode reads `opencode.json` (or `opencode.jsonc`) at the
+    // project root. Verified against anomalyco/opencode.
+    if (
+      await env.pathExists(join(env.projectRoot, "opencode.json")) ||
+      await env.pathExists(join(env.projectRoot, "opencode.jsonc"))
+    ) {
+      signals.push("project-opencode-config-present");
+    }
+    if (await env.pathExists(join(env.homeDir, ".opencode"))) {
+      signals.push("user-opencode-home-present");
+    }
+    return { detected: signals.length > 0, signals };
+  },
+};

--- a/packages/markspec/cli/install/mcp_adapters_opencode_test.ts
+++ b/packages/markspec/cli/install/mcp_adapters_opencode_test.ts
@@ -1,0 +1,169 @@
+/**
+ * @module cli/install/mcp_adapters_opencode_test
+ *
+ * Tests for the opencode adapter — slice G0 of the install/upgrade
+ * devex epic. opencode's exact JSON shape was verified during
+ * implementation (see Task 5 Step 1); if a future opencode release
+ * changes the shape, update the adapter and these tests together.
+ *
+ * Verification source: anomalyco/opencode repo
+ *   packages/opencode/src/config/mcp.ts — Local schema struct
+ *   packages/opencode/src/config/config.ts — project file resolution
+ * The config file is `opencode.json` at the project root (NOT
+ * `.opencode/mcp.json` as the spec inferred). The JSON path is
+ * ["mcp", "markspec"] (no "servers" nesting).
+ */
+
+import { assertEquals, assertThrows } from "@std/assert";
+import { opencodeDescriptor } from "./mcp_adapters_opencode.ts";
+import type { DetectEnv } from "./adapters.ts";
+
+// ---------------------------------------------------------------------------
+// jsonPath + id
+// ---------------------------------------------------------------------------
+
+Deno.test("opencodeDescriptor: id and jsonPath", () => {
+  assertEquals(opencodeDescriptor.id, "opencode");
+  // Verified against anomalyco/opencode — flat mcp object, no "servers" nesting:
+  assertEquals(opencodeDescriptor.jsonPath, ["mcp", "markspec"]);
+});
+
+// ---------------------------------------------------------------------------
+// resolveConfigPath
+// ---------------------------------------------------------------------------
+
+Deno.test("opencodeDescriptor: workspace scope → <workspaceRoot>/opencode.json", () => {
+  const path = opencodeDescriptor.resolveConfigPath(
+    "workspace",
+    "/some/cwd",
+    "/home/u",
+    undefined,
+    "/repo",
+  );
+  // Verified: opencode reads opencode.json at the project root (not .opencode/mcp.json)
+  assertEquals(path, "/repo/opencode.json");
+});
+
+Deno.test("opencodeDescriptor: workspace scope without workspaceRoot → falls back to cwd", () => {
+  const path = opencodeDescriptor.resolveConfigPath(
+    "workspace",
+    "/some/cwd",
+    "/home/u",
+  );
+  assertEquals(path, "/some/cwd/opencode.json");
+});
+
+Deno.test("opencodeDescriptor: user scope throws", () => {
+  assertThrows(
+    () => opencodeDescriptor.resolveConfigPath("user", "/cwd", "/home"),
+    Error,
+    "opencode does not support user scope",
+  );
+});
+
+// ---------------------------------------------------------------------------
+// renderBlock
+// ---------------------------------------------------------------------------
+
+Deno.test("opencodeDescriptor: renderBlock returns the opencode JSON shape", () => {
+  const block = opencodeDescriptor.renderBlock({ binaryPath: "markspec" });
+  // Verified: Local schema in anomalyco/opencode has { type: "local", command: string[] }
+  assertEquals(block, { type: "local", command: ["markspec", "mcp"] });
+});
+
+Deno.test("opencodeDescriptor: renderBlock honors absolute binary path", () => {
+  const block = opencodeDescriptor.renderBlock({
+    binaryPath: "/opt/markspec/bin/markspec",
+  });
+  assertEquals(block, {
+    type: "local",
+    command: ["/opt/markspec/bin/markspec", "mcp"],
+  });
+});
+
+// ---------------------------------------------------------------------------
+// detect()
+// ---------------------------------------------------------------------------
+
+function makeEnv(overrides: Partial<DetectEnv> = {}): DetectEnv {
+  return {
+    whichCommand: () => Promise.resolve(undefined),
+    pathExists: () => Promise.resolve(false),
+    projectRoot: "/repo",
+    homeDir: "/home/u",
+    ...overrides,
+  };
+}
+
+Deno.test("opencodeDescriptor.detect: all signals false → detected=false", async () => {
+  const result = await opencodeDescriptor.detect!(makeEnv());
+  assertEquals(result.detected, false);
+  assertEquals(result.signals, []);
+});
+
+Deno.test("opencodeDescriptor.detect: opencode on PATH → opencode-cli-on-path signal", async () => {
+  const result = await opencodeDescriptor.detect!(
+    makeEnv({
+      whichCommand: (name) =>
+        Promise.resolve(
+          name === "opencode" ? "/usr/local/bin/opencode" : undefined,
+        ),
+    }),
+  );
+  assertEquals(result.detected, true);
+  assertEquals(result.signals, ["opencode-cli-on-path"]);
+});
+
+Deno.test("opencodeDescriptor.detect: project opencode.json present → project-opencode-config-present", async () => {
+  const result = await opencodeDescriptor.detect!(
+    makeEnv({
+      pathExists: (path) => Promise.resolve(path === "/repo/opencode.json"),
+    }),
+  );
+  assertEquals(result.detected, true);
+  assertEquals(result.signals, ["project-opencode-config-present"]);
+});
+
+Deno.test("opencodeDescriptor.detect: project opencode.jsonc present → project-opencode-config-present", async () => {
+  const result = await opencodeDescriptor.detect!(
+    makeEnv({
+      pathExists: (path) => Promise.resolve(path === "/repo/opencode.jsonc"),
+    }),
+  );
+  assertEquals(result.detected, true);
+  assertEquals(result.signals, ["project-opencode-config-present"]);
+});
+
+Deno.test("opencodeDescriptor.detect: ~/.opencode/ present → user-opencode-home-present", async () => {
+  const result = await opencodeDescriptor.detect!(
+    makeEnv({
+      pathExists: (path) => Promise.resolve(path === "/home/u/.opencode"),
+    }),
+  );
+  assertEquals(result.detected, true);
+  assertEquals(result.signals, ["user-opencode-home-present"]);
+});
+
+Deno.test("opencodeDescriptor.detect: all signals fire → all listed", async () => {
+  const result = await opencodeDescriptor.detect!(
+    makeEnv({
+      whichCommand: (name) =>
+        Promise.resolve(
+          name === "opencode" ? "/usr/local/bin/opencode" : undefined,
+        ),
+      pathExists: (path) =>
+        Promise.resolve(
+          path === "/repo/opencode.json" || path === "/home/u/.opencode",
+        ),
+    }),
+  );
+  assertEquals(result.detected, true);
+  assertEquals(
+    new Set(result.signals),
+    new Set([
+      "opencode-cli-on-path",
+      "project-opencode-config-present",
+      "user-opencode-home-present",
+    ]),
+  );
+});

--- a/packages/markspec/cli/install/mcp_adapters_opencode_test.ts
+++ b/packages/markspec/cli/install/mcp_adapters_opencode_test.ts
@@ -15,8 +15,22 @@
  */
 
 import { assertEquals, assertThrows } from "@std/assert";
+import { join } from "@std/path";
 import { opencodeDescriptor } from "./mcp_adapters_opencode.ts";
 import type { DetectEnv } from "./adapters.ts";
+
+// Path fixtures use `join()` so the constants match the platform-aware
+// paths the adapter constructs at runtime — on Windows the std `join`
+// returns backslash paths (`\repo\opencode.json`), so a POSIX literal
+// would miss the equality check.
+const REPO_ROOT = join("/", "repo");
+const HOME_DIR = join("/", "home", "u");
+const CWD_DIR = join("/", "some", "cwd");
+const OPENCODE_BIN = join("/", "usr", "local", "bin", "opencode");
+const REPO_OPENCODE_JSON = join(REPO_ROOT, "opencode.json");
+const REPO_OPENCODE_JSONC = join(REPO_ROOT, "opencode.jsonc");
+const CWD_OPENCODE_JSON = join(CWD_DIR, "opencode.json");
+const HOME_OPENCODE = join(HOME_DIR, ".opencode");
 
 // ---------------------------------------------------------------------------
 // jsonPath + id
@@ -35,22 +49,22 @@ Deno.test("opencodeDescriptor: id and jsonPath", () => {
 Deno.test("opencodeDescriptor: workspace scope → <workspaceRoot>/opencode.json", () => {
   const path = opencodeDescriptor.resolveConfigPath(
     "workspace",
-    "/some/cwd",
-    "/home/u",
+    CWD_DIR,
+    HOME_DIR,
     undefined,
-    "/repo",
+    REPO_ROOT,
   );
   // Verified: opencode reads opencode.json at the project root (not .opencode/mcp.json)
-  assertEquals(path, "/repo/opencode.json");
+  assertEquals(path, REPO_OPENCODE_JSON);
 });
 
 Deno.test("opencodeDescriptor: workspace scope without workspaceRoot → falls back to cwd", () => {
   const path = opencodeDescriptor.resolveConfigPath(
     "workspace",
-    "/some/cwd",
-    "/home/u",
+    CWD_DIR,
+    HOME_DIR,
   );
-  assertEquals(path, "/some/cwd/opencode.json");
+  assertEquals(path, CWD_OPENCODE_JSON);
 });
 
 Deno.test("opencodeDescriptor: user scope throws", () => {
@@ -89,8 +103,8 @@ function makeEnv(overrides: Partial<DetectEnv> = {}): DetectEnv {
   return {
     whichCommand: () => Promise.resolve(undefined),
     pathExists: () => Promise.resolve(false),
-    projectRoot: "/repo",
-    homeDir: "/home/u",
+    projectRoot: REPO_ROOT,
+    homeDir: HOME_DIR,
     ...overrides,
   };
 }
@@ -105,9 +119,7 @@ Deno.test("opencodeDescriptor.detect: opencode on PATH → opencode-cli-on-path 
   const result = await opencodeDescriptor.detect!(
     makeEnv({
       whichCommand: (name) =>
-        Promise.resolve(
-          name === "opencode" ? "/usr/local/bin/opencode" : undefined,
-        ),
+        Promise.resolve(name === "opencode" ? OPENCODE_BIN : undefined),
     }),
   );
   assertEquals(result.detected, true);
@@ -117,7 +129,7 @@ Deno.test("opencodeDescriptor.detect: opencode on PATH → opencode-cli-on-path 
 Deno.test("opencodeDescriptor.detect: project opencode.json present → project-opencode-config-present", async () => {
   const result = await opencodeDescriptor.detect!(
     makeEnv({
-      pathExists: (path) => Promise.resolve(path === "/repo/opencode.json"),
+      pathExists: (path) => Promise.resolve(path === REPO_OPENCODE_JSON),
     }),
   );
   assertEquals(result.detected, true);
@@ -127,7 +139,7 @@ Deno.test("opencodeDescriptor.detect: project opencode.json present → project-
 Deno.test("opencodeDescriptor.detect: project opencode.jsonc present → project-opencode-config-present", async () => {
   const result = await opencodeDescriptor.detect!(
     makeEnv({
-      pathExists: (path) => Promise.resolve(path === "/repo/opencode.jsonc"),
+      pathExists: (path) => Promise.resolve(path === REPO_OPENCODE_JSONC),
     }),
   );
   assertEquals(result.detected, true);
@@ -137,7 +149,7 @@ Deno.test("opencodeDescriptor.detect: project opencode.jsonc present → project
 Deno.test("opencodeDescriptor.detect: ~/.opencode/ present → user-opencode-home-present", async () => {
   const result = await opencodeDescriptor.detect!(
     makeEnv({
-      pathExists: (path) => Promise.resolve(path === "/home/u/.opencode"),
+      pathExists: (path) => Promise.resolve(path === HOME_OPENCODE),
     }),
   );
   assertEquals(result.detected, true);
@@ -148,13 +160,9 @@ Deno.test("opencodeDescriptor.detect: all signals fire → all listed", async ()
   const result = await opencodeDescriptor.detect!(
     makeEnv({
       whichCommand: (name) =>
-        Promise.resolve(
-          name === "opencode" ? "/usr/local/bin/opencode" : undefined,
-        ),
+        Promise.resolve(name === "opencode" ? OPENCODE_BIN : undefined),
       pathExists: (path) =>
-        Promise.resolve(
-          path === "/repo/opencode.json" || path === "/home/u/.opencode",
-        ),
+        Promise.resolve(path === REPO_OPENCODE_JSON || path === HOME_OPENCODE),
     }),
   );
   assertEquals(result.detected, true);

--- a/packages/markspec/cli/install/mcp_orchestrator.ts
+++ b/packages/markspec/cli/install/mcp_orchestrator.ts
@@ -16,18 +16,22 @@
  */
 
 import { dirname } from "@std/path";
-import { MCP_CLIENT_IDS, type McpClientId, suggestId } from "./adapters.ts";
+import {
+  MCP_CLIENT_IDS,
+  type McpAdapter,
+  type McpClientId,
+  suggestId,
+} from "./adapters.ts";
 import {
   claudeDesktopDescriptor,
   cursorAdapter,
   vscodeMcpAdapter,
 } from "./mcp_adapters.ts";
+import { claudeCodeDescriptor } from "./mcp_adapters_claude_code.ts";
+import { opencodeDescriptor } from "./mcp_adapters_opencode.ts";
 import { applyJsonBlock, removeJsonBlock } from "./managed_block.ts";
 import { writeBackup } from "./backup.ts";
 import { renderDiff } from "./preview.ts";
-
-/** JSON path of the managed entry under any MCP client config. */
-const MCP_JSON_PATH: readonly (string | number)[] = ["mcpServers", "markspec"];
 
 /** Options accepted by {@linkcode runMcpInstall}. */
 export interface McpInstallOptions {
@@ -101,10 +105,44 @@ export async function runMcpInstall(
     };
   }
 
-  // 4. claude-desktop — full managed-block flow.
-  //    Reject --scope=workspace before any other work: Claude Desktop
-  //    is per-user only.
-  if (options.scope === "workspace") {
+  // 4. Managed-block flow — claude-desktop, claude-code, or opencode.
+  if (
+    clientId === "claude-desktop" ||
+    clientId === "claude-code" ||
+    clientId === "opencode"
+  ) {
+    const adapter: McpAdapter = clientId === "claude-desktop"
+      ? claudeDesktopDescriptor
+      : clientId === "claude-code"
+      ? claudeCodeDescriptor
+      : opencodeDescriptor;
+    return await runManagedBlockFlow(adapter, options);
+  }
+
+  // Defensive: clientId is fully covered above, but TypeScript can't
+  // narrow `MCP_CLIENT_IDS.includes(...)` to the union.
+  return {
+    stdout: "",
+    stderr: `error: client '${clientId}' has no registered adapter\n`,
+    exitCode: 1,
+  };
+}
+
+/**
+ * Shared managed-block flow used by claude-desktop, claude-code, and opencode.
+ * Reads current content, computes next via `applyJsonBlock` /
+ * `removeJsonBlock`, handles --print / --force / atomic write /
+ * sidecar backup.
+ */
+async function runManagedBlockFlow(
+  adapter: McpAdapter,
+  options: McpInstallOptions,
+): Promise<OrchestratorResult> {
+  const isClaudeDesktop = adapter.id === "claude-desktop";
+  const isProjectScoped = adapter.id === "claude-code" ||
+    adapter.id === "opencode";
+
+  if (isClaudeDesktop && options.scope === "workspace") {
     return {
       stdout: "",
       stderr:
@@ -112,7 +150,19 @@ export async function runMcpInstall(
       exitCode: 1,
     };
   }
-  if (options.scope !== undefined && options.scope !== "user") {
+  if (isProjectScoped && options.scope === "user") {
+    return {
+      stdout: "",
+      stderr:
+        `error: --scope=user is not supported for --client=${adapter.id} (project-scoped only); use --scope=workspace or omit\n`,
+      exitCode: 1,
+    };
+  }
+  if (
+    options.scope !== undefined &&
+    options.scope !== "user" &&
+    options.scope !== "workspace"
+  ) {
     return {
       stdout: "",
       stderr:
@@ -142,12 +192,16 @@ export async function runMcpInstall(
   };
   const isTty = options.env?.isTty ?? Deno.stdin.isTerminal();
 
-  // claude-desktop is always user-scope; resolve the config path.
-  const configPath = claudeDesktopDescriptor.resolveConfigPath(
-    "user",
+  // Resolve the target config path. claude-desktop uses "user" (default
+  // when scope is omitted); claude-code and opencode use "workspace" with
+  // workspaceRoot=cwd.
+  const scope: "user" | "workspace" = isProjectScoped ? "workspace" : "user";
+  const configPath = adapter.resolveConfigPath(
+    scope,
     cwd,
     readHome(),
     readAppData(),
+    isProjectScoped ? cwd : undefined,
   );
 
   // 5. Read current content. Missing file → empty string.
@@ -170,11 +224,11 @@ export async function runMcpInstall(
 
   // 6. Compute next content.
   const next = options.remove
-    ? removeJsonBlock(current, MCP_JSON_PATH)
+    ? removeJsonBlock(current, adapter.jsonPath)
     : applyJsonBlock(
       current,
-      MCP_JSON_PATH,
-      claudeDesktopDescriptor.renderBlock({ binaryPath: options.binaryPath }),
+      adapter.jsonPath,
+      adapter.renderBlock({ binaryPath: options.binaryPath }),
     );
 
   // 7. Idempotence check.
@@ -185,7 +239,7 @@ export async function runMcpInstall(
     return { stdout: "", stderr: msg, exitCode: 0 };
   }
 
-  // 8. --print path: emit `next` to stdout, target path to stderr.
+  // 8. --print path.
   if (options.print) {
     return {
       stdout: next,
@@ -230,7 +284,6 @@ export async function runMcpInstall(
     }
   }
 
-  // Ensure parent directory exists.
   try {
     await Deno.mkdir(dirname(configPath), { recursive: true });
   } catch (err) {
@@ -246,7 +299,6 @@ export async function runMcpInstall(
     }
   }
 
-  // Atomic write: stage to .tmp, rename.
   const tmpPath = `${configPath}.tmp`;
   try {
     await Deno.writeTextFile(tmpPath, next);

--- a/packages/markspec/cli/install/mcp_orchestrator_test.ts
+++ b/packages/markspec/cli/install/mcp_orchestrator_test.ts
@@ -1,5 +1,14 @@
 import { assertEquals, assertStringIncludes } from "@std/assert";
+import { join } from "@std/path";
 import { runMcpInstall } from "./mcp_orchestrator.ts";
+
+// Expected stderr paths use `join()` so the assertion matches the
+// platform-aware path the adapter renders — on Windows `join` produces
+// backslash paths (`\tmp\some-repo\.mcp.json`), so a POSIX literal
+// would fail the substring check.
+const REPO_CWD = join("/", "tmp", "some-repo");
+const REPO_MCP_JSON = join(REPO_CWD, ".mcp.json");
+const REPO_OPENCODE_JSON = join(REPO_CWD, "opencode.json");
 
 Deno.test("runMcpInstall: unknown client → exit 1 with suggestion", async () => {
   const r = await runMcpInstall({
@@ -58,7 +67,7 @@ Deno.test("runMcpInstall: --client=claude-code routes through managed-block flow
     binaryPath: "markspec",
     print: true,
     env: {
-      cwd: "/tmp/some-repo",
+      cwd: REPO_CWD,
       home: "/home/u",
       isTty: true,
     },
@@ -68,7 +77,7 @@ Deno.test("runMcpInstall: --client=claude-code routes through managed-block flow
   assertStringIncludes(result.stdout, `"mcpServers"`);
   assertStringIncludes(result.stdout, `"markspec"`);
   // stderr shows the target path under cwd
-  assertStringIncludes(result.stderr, "/tmp/some-repo/.mcp.json");
+  assertStringIncludes(result.stderr, REPO_MCP_JSON);
 });
 
 Deno.test("runMcpInstall: --client=claude-code --scope=user is rejected", async () => {
@@ -93,7 +102,7 @@ Deno.test("runMcpInstall: --client=opencode routes through managed-block flow", 
     binaryPath: "markspec",
     print: true,
     env: {
-      cwd: "/tmp/some-repo",
+      cwd: REPO_CWD,
       home: "/home/u",
       isTty: true,
     },
@@ -103,7 +112,7 @@ Deno.test("runMcpInstall: --client=opencode routes through managed-block flow", 
   assertStringIncludes(result.stdout, `"mcp"`);
   assertStringIncludes(result.stdout, `"markspec"`);
   // Verified opencode path: `opencode.json` at project root.
-  assertStringIncludes(result.stderr, "/tmp/some-repo/opencode.json");
+  assertStringIncludes(result.stderr, REPO_OPENCODE_JSON);
 });
 
 Deno.test("runMcpInstall: --client=opencode --scope=user is rejected", async () => {

--- a/packages/markspec/cli/install/mcp_orchestrator_test.ts
+++ b/packages/markspec/cli/install/mcp_orchestrator_test.ts
@@ -49,3 +49,74 @@ Deno.test("runMcpInstall: cursor → delegates to legacy print-only adapter", as
   assertStringIncludes(r.stdout, "mcpServers");
   assertStringIncludes(r.stderr, "mcp.json");
 });
+
+Deno.test("runMcpInstall: --client=claude-code routes through managed-block flow", async () => {
+  // Use --print path so we don't write any file.
+  const result = await runMcpInstall({
+    client: "claude-code",
+    scope: "workspace",
+    binaryPath: "markspec",
+    print: true,
+    env: {
+      cwd: "/tmp/some-repo",
+      home: "/home/u",
+      isTty: true,
+    },
+  });
+  assertEquals(result.exitCode, 0);
+  // stdout has the rendered JSON
+  assertStringIncludes(result.stdout, `"mcpServers"`);
+  assertStringIncludes(result.stdout, `"markspec"`);
+  // stderr shows the target path under cwd
+  assertStringIncludes(result.stderr, "/tmp/some-repo/.mcp.json");
+});
+
+Deno.test("runMcpInstall: --client=claude-code --scope=user is rejected", async () => {
+  const result = await runMcpInstall({
+    client: "claude-code",
+    scope: "user",
+    binaryPath: "markspec",
+    print: true,
+    env: { cwd: "/tmp", home: "/home/u", isTty: true },
+  });
+  assertEquals(result.exitCode, 1);
+  assertStringIncludes(
+    result.stderr,
+    "--scope=user is not supported for --client=claude-code",
+  );
+});
+
+Deno.test("runMcpInstall: --client=opencode routes through managed-block flow", async () => {
+  const result = await runMcpInstall({
+    client: "opencode",
+    scope: "workspace",
+    binaryPath: "markspec",
+    print: true,
+    env: {
+      cwd: "/tmp/some-repo",
+      home: "/home/u",
+      isTty: true,
+    },
+  });
+  assertEquals(result.exitCode, 0);
+  // Verified opencode shape — flat `mcp.markspec`, no `mcpServers`.
+  assertStringIncludes(result.stdout, `"mcp"`);
+  assertStringIncludes(result.stdout, `"markspec"`);
+  // Verified opencode path: `opencode.json` at project root.
+  assertStringIncludes(result.stderr, "/tmp/some-repo/opencode.json");
+});
+
+Deno.test("runMcpInstall: --client=opencode --scope=user is rejected", async () => {
+  const result = await runMcpInstall({
+    client: "opencode",
+    scope: "user",
+    binaryPath: "markspec",
+    print: true,
+    env: { cwd: "/tmp", home: "/home/u", isTty: true },
+  });
+  assertEquals(result.exitCode, 1);
+  assertStringIncludes(
+    result.stderr,
+    "--scope=user is not supported for --client=opencode",
+  );
+});

--- a/tests/e2e/mcp_install_test.ts
+++ b/tests/e2e/mcp_install_test.ts
@@ -293,6 +293,100 @@ Deno.test(
 );
 
 // ---------------------------------------------------------------------------
+// Test: claude-code --print emits JSON for .mcp.json
+// ---------------------------------------------------------------------------
+
+Deno.test(
+  "mcp install claude-code: --print emits JSON for .mcp.json",
+  async () => {
+    const { code, stdout, stderr } = await markspec(
+      [
+        "mcp",
+        "install",
+        "--client=claude-code",
+        "--scope=workspace",
+        "--print",
+      ],
+      { permissions: ["--allow-env"] },
+    );
+    assertEquals(code, 0);
+    assertStringIncludes(stdout, '"mcpServers"');
+    assertStringIncludes(stdout, '"markspec"');
+    assertStringIncludes(stderr.replaceAll("\\", "/"), ".mcp.json");
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Test: claude-code --force writes .mcp.json
+// ---------------------------------------------------------------------------
+
+Deno.test(
+  "mcp install claude-code: --force writes .mcp.json",
+  async () => {
+    const { code, stderr } = await markspec(
+      [
+        "mcp",
+        "install",
+        "--client=claude-code",
+        "--scope=workspace",
+        "--force",
+      ],
+      { permissions: ["--allow-env"] },
+    );
+    assertEquals(code, 0);
+    assertStringIncludes(stderr.replaceAll("\\", "/"), ".mcp.json");
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Test: opencode --print emits JSON for opencode.json
+// ---------------------------------------------------------------------------
+
+Deno.test(
+  "mcp install opencode: --print emits JSON for opencode.json",
+  async () => {
+    const { code, stdout, stderr } = await markspec(
+      [
+        "mcp",
+        "install",
+        "--client=opencode",
+        "--scope=workspace",
+        "--print",
+      ],
+      { permissions: ["--allow-env"] },
+    );
+    assertEquals(code, 0);
+    // Verified opencode shape — flat `mcp.markspec`, no `mcpServers` nesting.
+    assertStringIncludes(stdout, '"mcp"');
+    assertStringIncludes(stdout, '"markspec"');
+    assertStringIncludes(stderr.replaceAll("\\", "/"), "opencode.json");
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Test: opencode --force writes opencode.json
+// ---------------------------------------------------------------------------
+
+Deno.test(
+  "mcp install opencode: --force writes opencode.json",
+  async () => {
+    const { code, stderr } = await markspec(
+      [
+        "mcp",
+        "install",
+        "--client=opencode",
+        "--scope=workspace",
+        "--force",
+      ],
+      { permissions: ["--allow-env"] },
+    );
+    assertEquals(code, 0);
+    // Verified opencode path: opencode.json at project root.
+    assertStringIncludes(stderr.replaceAll("\\", "/"), "opencode.json");
+  },
+);
+
+// ---------------------------------------------------------------------------
 // Test 8: --remove strips only the markspec entry; re-remove is no-op
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Add `claude-code` MCP install adapter (writes `.mcp.json` at repo root, project-scoped)
- Add `opencode` MCP install adapter (writes `opencode.json` at repo root, project-scoped)
- Extend `McpAdapter` contract with required `jsonPath` field + optional `detect?` function
- Extract orchestrator's managed-block flow into a reusable helper parameterized by adapter

This is slice **G0** of the install/upgrade devex epic — foundation for slice G1's `markspec init` command. Each new adapter is usable today via `markspec mcp install --client claude-code|opencode --scope workspace`.

## Test plan

- [x] `just build` passes (lint + test + typecheck + compile)
- [x] `deno fmt --check` passes
- [x] Unit tests cover each adapter's `resolveConfigPath`, `renderBlock`, `jsonPath`, and `detect()` (each signal individually + combined)
- [x] Orchestrator tests cover dispatch routing + scope rejection for each new client
- [x] E2E tests cover `markspec mcp install --client claude-code|opencode` end-to-end (4 new cases)
- [x] `claude-desktop` / `cursor` / `vscode` behavior unchanged

## opencode JSON shape verification

Per spec acceptance criterion #7, opencode's MCP config schema was verified against the **anomalyco/opencode** repository:
- `packages/opencode/src/config/mcp.ts` — defines the `Local` schema struct (`type: "local"`, `command: string[]`)
- `packages/opencode/src/config/config.ts` — shows project config resolves `opencode.json`/`opencode.jsonc` at the project root
- `packages/web/src/content/docs/mcp-servers.mdx` — confirms the `mcp.<name>` top-level structure

**Adjustments from the spec's initial inference:**
| | Spec inference | Verified reality |
|---|---|---|
| Config file | `.opencode/mcp.json` | `opencode.json` (project root) |
| JSON path | `["mcp", "servers", "markspec"]` | `["mcp", "markspec"]` (flat, no `servers`) |
| renderBlock | `{ type: "local", command: [...] }` | matches |

The adapter and its colocated tests reflect the verified shape. The header doc-comment in `mcp_adapters_opencode.ts` documents the sources.

## Spec

Local spec at `docs/superpowers/specs/2026-05-27-mcp-adapters-g0-design.md` (gitignored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
