### PR TITLE
feat: external requirement scoring (scoreText + markspec score)

### DIFF
--- a/packages/markspec/cli/commands/mod.ts
+++ b/packages/markspec/cli/commands/mod.ts
@@ -23,6 +23,7 @@ export { mcpCmd } from "./mcp_cmd.ts";
 export { nextIdCmd } from "./next_id.ts";
 export { profileCmd } from "./profile.ts";
 export { reportCmd } from "./report.ts";
+export { scoreCmd } from "./score.ts";
 export { showCmd } from "./show.ts";
 export { syncCmd } from "./sync.ts";
 export { validateCmd } from "./validate.ts";

--- a/packages/markspec/cli/commands/score.ts
+++ b/packages/markspec/cli/commands/score.ts
@@ -1,0 +1,34 @@
+/**
+ * @module cli/commands/score
+ *
+ * `markspec score` — score a single piece of requirement prose using
+ * the PA-3 lint pipeline. One-shot mode via `--text`, batch mode via
+ * JSONL on stdin.
+ */
+
+import { Command } from "@cliffy/command";
+import { scoreText } from "../../core/lint/mod.ts";
+
+export const scoreCmd = new Command()
+  .description(
+    "Score a single requirement prose against the PA-3 rule catalog",
+  )
+  .option("--text <text:string>", "Inline prose to score")
+  .option("--id <id:string>", "Identifier to echo in the result")
+  .option(
+    "--format <format:string>",
+    "Output format (json|text). Default: json when stdout is not a TTY, text otherwise.",
+  )
+  .action(
+    async (options: { text?: string; id?: string; format?: string }) => {
+      if (options.text === undefined) {
+        // Stdin/batch path lands in Task 4; for now require --text.
+        console.error(
+          "error: --text is required (stdin mode not yet implemented)",
+        );
+        Deno.exit(1);
+      }
+      const result = await scoreText(options.text, { id: options.id });
+      console.log(JSON.stringify(result, null, 2));
+    },
+  );

--- a/packages/markspec/cli/commands/score.ts
+++ b/packages/markspec/cli/commands/score.ts
@@ -28,7 +28,7 @@ export const scoreCmd = new Command()
   .option("--id <id:string>", "Identifier to echo in the result")
   .option(
     "--format <format:string>",
-    "Output format (json|text). Currently only json is wired; text rendering lands later.",
+    "Output format (json|text). Default: text when stdout is a TTY, json otherwise.",
   )
   .action(async (options: ScoreOptions) => {
     const format = pickFormat(options.format);
@@ -103,9 +103,15 @@ function printResult(
     );
     return;
   }
-  // Text-format path lands in Task 5; for now emit JSON so the wiring
-  // works end-to-end and pickFormat is exercised.
-  console.log(JSON.stringify(result));
+  const header =
+    `${result.id} — Score: ${result.score}, Warnings: ${result.warningCount}, Infos: ${result.infoCount}`;
+  console.log(header);
+  for (const d of result.diagnostics) {
+    const loc = d.location
+      ? `${d.location.file}:${d.location.line}:${d.location.column} `
+      : "";
+    console.log(`  ${loc}${d.severity} ${d.slug} [${d.code}]: ${d.message}`);
+  }
 }
 
 async function readAllStdin(): Promise<string> {

--- a/packages/markspec/cli/commands/score.ts
+++ b/packages/markspec/cli/commands/score.ts
@@ -48,6 +48,11 @@ export const scoreCmd = new Command()
     }
 
     const stdinText = await readAllStdin();
+    if (stdinText.trim().length === 0) {
+      // stdin is closed or empty — print help and exit 0.
+      await scoreCmd.showHelp();
+      Deno.exit(0);
+    }
     const lines = stdinText.split("\n");
     let scored = 0;
     let malformed = 0;

--- a/packages/markspec/cli/commands/score.ts
+++ b/packages/markspec/cli/commands/score.ts
@@ -76,7 +76,7 @@ export const scoreCmd = new Command()
       }
       const id = typeof parsed.id === "string" && parsed.id.length > 0
         ? parsed.id
-        : `EXT_${nonBlankIndex}`;
+        : `EXT_${String(nonBlankIndex).padStart(4, "0")}`;
       const result = await scoreText(parsed.text, { id });
       printResult(result, format, false);
       scored++;

--- a/packages/markspec/cli/commands/score.ts
+++ b/packages/markspec/cli/commands/score.ts
@@ -11,13 +11,13 @@ import { scoreText } from "../../core/lint/mod.ts";
 
 export const scoreCmd = new Command()
   .description(
-    "Score a single requirement prose against the PA-3 rule catalog",
+    "Score a single piece of requirement prose against the PA-3 rule catalog",
   )
   .option("--text <text:string>", "Inline prose to score")
   .option("--id <id:string>", "Identifier to echo in the result")
   .option(
     "--format <format:string>",
-    "Output format (json|text). Default: json when stdout is not a TTY, text otherwise.",
+    "Output format (json|text). Currently only json is wired; text rendering lands later.",
   )
   .action(
     async (options: { text?: string; id?: string; format?: string }) => {

--- a/packages/markspec/cli/commands/score.ts
+++ b/packages/markspec/cli/commands/score.ts
@@ -4,10 +4,21 @@
  * `markspec score` — score a single piece of requirement prose using
  * the PA-3 lint pipeline. One-shot mode via `--text`, batch mode via
  * JSONL on stdin.
+ *
+ * Exit codes (clig.dev mapping):
+ *   0 — at least one input was scored successfully and no malformed lines.
+ *   1 — no inputs were scored.
+ *   2 — partial: some inputs were malformed but at least one was scored.
  */
 
 import { Command } from "@cliffy/command";
-import { scoreText } from "../../core/lint/mod.ts";
+import { scoreText, type ScoreTextResult } from "../../core/lint/mod.ts";
+
+interface ScoreOptions {
+  text?: string;
+  id?: string;
+  format?: string;
+}
 
 export const scoreCmd = new Command()
   .description(
@@ -19,16 +30,98 @@ export const scoreCmd = new Command()
     "--format <format:string>",
     "Output format (json|text). Currently only json is wired; text rendering lands later.",
   )
-  .action(
-    async (options: { text?: string; id?: string; format?: string }) => {
-      if (options.text === undefined) {
-        // Stdin/batch path lands in Task 4; for now require --text.
-        console.error(
-          "error: --text is required (stdin mode not yet implemented)",
-        );
-        Deno.exit(1);
-      }
+  .action(async (options: ScoreOptions) => {
+    const format = pickFormat(options.format);
+
+    if (options.text !== undefined) {
+      // One-shot mode wins over stdin per the spec.
       const result = await scoreText(options.text, { id: options.id });
-      console.log(JSON.stringify(result, null, 2));
-    },
-  );
+      printResult(result, format, true);
+      Deno.exit(0);
+    }
+
+    // Batch mode reads JSONL from stdin.
+    if (Deno.stdin.isTerminal()) {
+      // No input requested at all — print help and exit 0.
+      await scoreCmd.showHelp();
+      Deno.exit(0);
+    }
+
+    const stdinText = await readAllStdin();
+    const lines = stdinText.split("\n");
+    let scored = 0;
+    let malformed = 0;
+    let nonBlankIndex = 0;
+    for (let i = 0; i < lines.length; i++) {
+      const raw = lines[i];
+      if (raw.trim().length === 0) continue;
+      nonBlankIndex++;
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(raw);
+      } catch {
+        console.error(`error: malformed JSON on line ${i + 1}`);
+        malformed++;
+        continue;
+      }
+      if (!isJsonlInput(parsed)) {
+        console.error(`error: missing 'text' field on line ${i + 1}`);
+        malformed++;
+        continue;
+      }
+      const id = typeof parsed.id === "string" && parsed.id.length > 0
+        ? parsed.id
+        : `EXT_${nonBlankIndex}`;
+      const result = await scoreText(parsed.text, { id });
+      printResult(result, format, false);
+      scored++;
+    }
+
+    if (scored === 0) Deno.exit(1);
+    if (malformed > 0) Deno.exit(2);
+    Deno.exit(0);
+  });
+
+function pickFormat(opt: string | undefined): "json" | "text" {
+  if (opt === "json" || opt === "text") return opt;
+  return Deno.stdout.isTerminal() ? "text" : "json";
+}
+
+function isJsonlInput(v: unknown): v is { text: string; id?: string } {
+  return typeof v === "object" && v !== null &&
+    typeof (v as { text?: unknown }).text === "string";
+}
+
+function printResult(
+  result: ScoreTextResult,
+  format: "json" | "text",
+  pretty: boolean,
+): void {
+  if (format === "json") {
+    console.log(
+      pretty ? JSON.stringify(result, null, 2) : JSON.stringify(result),
+    );
+    return;
+  }
+  // Text-format path lands in Task 5; for now emit JSON so the wiring
+  // works end-to-end and pickFormat is exercised.
+  console.log(JSON.stringify(result));
+}
+
+async function readAllStdin(): Promise<string> {
+  const chunks: Uint8Array[] = [];
+  const reader = Deno.stdin.readable.getReader();
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    chunks.push(value);
+  }
+  const total = chunks.reduce((n, c) => n + c.length, 0);
+  const buf = new Uint8Array(total);
+  let off = 0;
+  for (const c of chunks) {
+    buf.set(c, off);
+    off += c.length;
+  }
+  return new TextDecoder().decode(buf);
+}

--- a/packages/markspec/core/lint/mod.ts
+++ b/packages/markspec/core/lint/mod.ts
@@ -10,5 +10,7 @@ export { isProseScope, runLint } from "./runner.ts";
 export type { LintOptions, LintResult } from "./runner.ts";
 export { ANTI_PATTERN_NOTE, computeScoreRollup } from "./score.ts";
 export type { EntryScore, RuleContribution, ScoreRollup } from "./score.ts";
+export { scoreText } from "./score_text.ts";
+export type { ScoreTextOptions, ScoreTextResult } from "./score_text.ts";
 export { segmentSentences } from "./segmenter.ts";
 export type { Sentence } from "./segmenter.ts";

--- a/packages/markspec/core/lint/score_text.ts
+++ b/packages/markspec/core/lint/score_text.ts
@@ -18,9 +18,14 @@
  *
  * Corpus-dependent rules (Q500 xref-glossary, xref-undefined,
  * suppression hygiene) self-skip because there is nothing for them
- * to cross-reference on a one-entry corpus.
- *
- * See `docs/superpowers/specs/2026-05-27-external-requirement-scoring-design.md`.
+ * to cross-reference on a one-entry corpus. Note specifically:
+ * `bodyTokens` is left empty here, which means any `$Identifier`
+ * style entity references inside `text` are NOT extracted and so
+ * Q500 cannot fire on them in either direction. External requirement
+ * prose (DOORS / Word / PDF) does not use MarkSpec's `$Identifier`
+ * syntax, so this is the right trade for v1; a caller that does want
+ * `$Identifier` resolution should run the prose through `parseFile`
+ * to get a real entry and use the normal `runLint` path instead.
  */
 
 import type { Entry } from "../model/mod.ts";

--- a/packages/markspec/core/lint/score_text.ts
+++ b/packages/markspec/core/lint/score_text.ts
@@ -1,0 +1,105 @@
+/**
+ * @module core/lint/score_text
+ *
+ * Score a single piece of requirement prose using the PA-3 lint
+ * pipeline. Wraps the input text in a synthetic `Entry` (type
+ * `Requirement`, body = text, bodyAst = parsed) and runs `runLint`
+ * against a one-entry corpus.
+ *
+ * Two non-obvious wrapping choices:
+ *   - `bodyAst` is populated via `buildBodyAst(text)`. Most PA-3
+ *     rules (modal, EARS, INCOSE, passive, lexicon) walk `bodyAst`,
+ *     not the raw `body` string — without the AST, ~95% of the
+ *     rule catalog silently no-ops.
+ *   - `title` is set to the resolved id. Q400 (`struct-title-length`)
+ *     fires when title length is outside [3, 120]; reusing the id
+ *     (always ≥ 3 chars) keeps Q400 silent so the score reflects
+ *     prose quality, not the absence of an authored title.
+ *
+ * Corpus-dependent rules (Q500 xref-glossary, xref-undefined,
+ * suppression hygiene) self-skip because there is nothing for them
+ * to cross-reference on a one-entry corpus.
+ *
+ * See `docs/superpowers/specs/2026-05-27-external-requirement-scoring-design.md`.
+ */
+
+import type { Entry } from "../model/mod.ts";
+import { makeDisplayId } from "../model/mod.ts";
+import { buildBodyAst } from "../ast/build.ts";
+import { runLint } from "./runner.ts";
+import type { LintDiagnostic } from "./types.ts";
+import type { RuleContribution } from "./score.ts";
+
+const SYNTHETIC_FILE = "<scoreText>";
+const DEFAULT_ID = "EXT_0001";
+
+/** Options for {@linkcode scoreText}. */
+export interface ScoreTextOptions {
+  /**
+   * Caller-supplied identifier carried through to the result so a
+   * batch caller can correlate inputs and outputs. Defaults to
+   * `"EXT_0001"` when absent or empty.
+   */
+  readonly id?: string;
+}
+
+/** Result returned by {@linkcode scoreText}. */
+export interface ScoreTextResult {
+  readonly id: string;
+  /** Sum of `weight × occurrences` across all firings. */
+  readonly score: number;
+  /** Number of diagnostics with severity `"warning"`. */
+  readonly warningCount: number;
+  /** Number of diagnostics with severity `"info"`. */
+  readonly infoCount: number;
+  /** Sorted by weight DESC, code ASC. */
+  readonly contributions: readonly RuleContribution[];
+  /** Full lint diagnostics, in pipeline order. */
+  readonly diagnostics: readonly LintDiagnostic[];
+}
+
+/**
+ * Score a single piece of requirement prose against the PA-3 rule
+ * catalog. See module doc for the wrapping strategy.
+ */
+export async function scoreText(
+  text: string,
+  opts?: ScoreTextOptions,
+): Promise<ScoreTextResult> {
+  const id = typeof opts?.id === "string" && opts.id.length > 0
+    ? opts.id
+    : DEFAULT_ID;
+
+  const entry: Entry = {
+    displayId: makeDisplayId(id),
+    title: id,
+    body: text,
+    bodyAst: buildBodyAst(text),
+    rawAttributes: [],
+    typedAttributes: new Map(),
+    type: "Requirement",
+    shape: "Authored",
+    location: { file: SYNTHETIC_FILE, line: 1, column: 1 },
+    source: { kind: "markdown" },
+    bodyTokens: [],
+  };
+
+  const lintResult = await runLint({ entries: [entry] });
+
+  let warningCount = 0;
+  let infoCount = 0;
+  for (const d of lintResult.diagnostics) {
+    if (d.severity === "warning") warningCount++;
+    else if (d.severity === "info") infoCount++;
+  }
+
+  const entryScore = lintResult.score.perEntry[0];
+  return {
+    id,
+    score: entryScore?.score ?? 0,
+    warningCount,
+    infoCount,
+    contributions: entryScore?.contributions ?? [],
+    diagnostics: lintResult.diagnostics,
+  };
+}

--- a/packages/markspec/core/lint/score_text.ts
+++ b/packages/markspec/core/lint/score_text.ts
@@ -43,7 +43,14 @@ export interface ScoreTextOptions {
   readonly id?: string;
 }
 
-/** Result returned by {@linkcode scoreText}. */
+/**
+ * Result returned by {@linkcode scoreText}.
+ *
+ * `warningCount + infoCount === diagnostics.length` by convention:
+ * every PA-3 rule emits `warning` or `info` only. The `Severity` type
+ * permits `error`, but no current rule produces one; if that ever
+ * changes the partition will need a third counter.
+ */
 export interface ScoreTextResult {
   readonly id: string;
   /** Sum of `weight × occurrences` across all firings. */

--- a/packages/markspec/core/lint/score_text_test.ts
+++ b/packages/markspec/core/lint/score_text_test.ts
@@ -1,0 +1,65 @@
+/**
+ * @module core/lint/score_text_test
+ *
+ * Unit tests for the `scoreText` external-prose scoring primitive.
+ */
+
+import { assertEquals } from "@std/assert";
+import { scoreText } from "./score_text.ts";
+
+Deno.test("scoreText: empty text → only Q401 fires (short body)", async () => {
+  // Q400 (title-length) does NOT fire because we set title to the
+  // synthetic id (≥ 3 chars). Q401 (body-length) DOES fire because
+  // body word count is 0 (< 5). No other rules can fire on empty
+  // input. This is correct signal for an empty external requirement.
+  const r = await scoreText("");
+  assertEquals(r.diagnostics.length, 1);
+  assertEquals(r.diagnostics[0].code, "MSL-Q401");
+  assertEquals(r.score, 1);
+  assertEquals(r.infoCount, 1);
+  assertEquals(r.warningCount, 0);
+});
+
+Deno.test("scoreText: default id is EXT_0001", async () => {
+  const r = await scoreText("");
+  assertEquals(r.id, "EXT_0001");
+});
+
+Deno.test("scoreText: caller-supplied id is echoed", async () => {
+  const r = await scoreText("", { id: "DOORS-9912" });
+  assertEquals(r.id, "DOORS-9912");
+});
+
+Deno.test("scoreText: empty opts.id falls back to default", async () => {
+  const r = await scoreText("", { id: "" });
+  assertEquals(r.id, "EXT_0001");
+});
+
+Deno.test("scoreText: multi-modal sentence triggers Q200 warning", async () => {
+  // Q200 (`modal-multiple`, warning, weight 3) fires when ≥ 2
+  // normative modals appear in the same sentence — a compound
+  // requirement. Two `shall` in one sentence is the simplest trigger.
+  const r = await scoreText(
+    "The system shall stop within 200 ms and shall log the event.",
+  );
+  assertEquals(r.warningCount >= 1, true, "expected ≥ 1 warning from Q200");
+  assertEquals(r.score >= 3, true, "expected score ≥ 3 (warning weight)");
+  // At least one Q200 diagnostic in the set.
+  const codes = r.diagnostics.map((d) => d.code);
+  assertEquals(
+    codes.includes("MSL-Q200"),
+    true,
+    `expected MSL-Q200 in diagnostics; got: ${codes.join(", ")}`,
+  );
+});
+
+Deno.test("scoreText: warningCount and infoCount partition diagnostics", async () => {
+  const r = await scoreText(
+    "The system shall handle errors appropriately and shall log them.",
+  );
+  assertEquals(
+    r.warningCount + r.infoCount,
+    r.diagnostics.length,
+    "every diagnostic must be either warning or info",
+  );
+});

--- a/packages/markspec/main.ts
+++ b/packages/markspec/main.ts
@@ -31,6 +31,7 @@ import {
   nextIdCmd,
   profileCmd,
   reportCmd,
+  scoreCmd,
   showCmd,
   syncCmd,
   validateCmd,
@@ -55,6 +56,7 @@ const cli = new Command()
   .command("dependents", dependentsCmd)
   .command("report", reportCmd)
   .command("lint", lintCmd)
+  .command("score", scoreCmd)
   .command("lock", lockCmd)
   .command("sync", syncCmd)
   .command("hook", hookCmd)

--- a/tests/e2e/score_test.ts
+++ b/tests/e2e/score_test.ts
@@ -99,7 +99,7 @@ Deno.test("score: JSONL batch synthesises EXT_<n> when id absent", async () => {
   );
   assertEquals(code, 0);
   const ids = stdout.trim().split("\n").map((l) => JSON.parse(l).id);
-  assertEquals(ids, ["EXT_1", "EXT_2"]);
+  assertEquals(ids, ["EXT_0001", "EXT_0002"]);
 });
 
 Deno.test("score: malformed JSONL line → exit 2, stderr cites line", async () => {
@@ -182,6 +182,7 @@ Deno.test("score: no --text and no stdin → prints help, exit 0", async () => {
     stderr: "piped",
   });
   const out = await cmd.output();
+  assertEquals(out.code, 0);
   const combined = new TextDecoder().decode(out.stdout) +
     new TextDecoder().decode(out.stderr);
   assertStringIncludes(combined.toLowerCase(), "score");

--- a/tests/e2e/score_test.ts
+++ b/tests/e2e/score_test.ts
@@ -5,7 +5,7 @@
  * shared markspec() helper.
  */
 
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertStringIncludes } from "@std/assert";
 import { markspec } from "./helpers.ts";
 
 Deno.test("score --text --format json: prints structured result", async () => {
@@ -39,4 +39,10 @@ Deno.test("score --text: caller-supplied id is echoed", async () => {
   assertEquals(code, 0);
   const parsed = JSON.parse(stdout);
   assertEquals(parsed.id, "DOORS-001");
+});
+
+Deno.test("score: missing --text exits 1 with error message", async () => {
+  const { code, stderr } = await markspec(["score"]);
+  assertEquals(code, 1);
+  assertStringIncludes(stderr, "error: --text is required");
 });

--- a/tests/e2e/score_test.ts
+++ b/tests/e2e/score_test.ts
@@ -41,8 +41,103 @@ Deno.test("score --text: caller-supplied id is echoed", async () => {
   assertEquals(parsed.id, "DOORS-001");
 });
 
-Deno.test("score: missing --text exits 1 with error message", async () => {
-  const { code, stderr } = await markspec(["score"]);
+// Wrapper to pipe a stdin string into `markspec score`. The shared
+// helper does not expose stdin, so we use Deno.Command directly for
+// these tests with the same arg layout the helper would build.
+async function markspecStdin(
+  args: string[],
+  stdin: string,
+): Promise<{ code: number; stdout: string; stderr: string }> {
+  const CLI_ENTRY = new URL(
+    "../../packages/markspec/main.ts",
+    import.meta.url,
+  ).pathname;
+  const cmd = new Deno.Command("deno", {
+    args: ["run", "--allow-read", "--allow-write", CLI_ENTRY, ...args],
+    stdin: "piped",
+    stdout: "piped",
+    stderr: "piped",
+  });
+  const child = cmd.spawn();
+  const writer = child.stdin.getWriter();
+  await writer.write(new TextEncoder().encode(stdin));
+  await writer.close();
+  const out = await child.output();
+  return {
+    code: out.code,
+    stdout: new TextDecoder().decode(out.stdout),
+    stderr: new TextDecoder().decode(out.stderr),
+  };
+}
+
+Deno.test("score: JSONL batch mode emits one JSON per line in order", async () => {
+  const stdin = [
+    JSON.stringify({ id: "A", text: "The system shall stop." }),
+    JSON.stringify({ id: "B", text: "It should be fast." }),
+    JSON.stringify({ id: "C", text: "Errors handled appropriately." }),
+  ].join("\n") + "\n";
+
+  const { code, stdout } = await markspecStdin(
+    ["score", "--format", "json"],
+    stdin,
+  );
+  assertEquals(code, 0);
+  const lines = stdout.trim().split("\n");
+  assertEquals(lines.length, 3);
+  const ids = lines.map((l) => JSON.parse(l).id);
+  assertEquals(ids, ["A", "B", "C"]);
+});
+
+Deno.test("score: JSONL batch synthesises EXT_<n> when id absent", async () => {
+  const stdin = [
+    JSON.stringify({ text: "The system shall stop." }),
+    JSON.stringify({ text: "It should be fast." }),
+  ].join("\n") + "\n";
+  const { code, stdout } = await markspecStdin(
+    ["score", "--format", "json"],
+    stdin,
+  );
+  assertEquals(code, 0);
+  const ids = stdout.trim().split("\n").map((l) => JSON.parse(l).id);
+  assertEquals(ids, ["EXT_1", "EXT_2"]);
+});
+
+Deno.test("score: malformed JSONL line → exit 2, stderr cites line", async () => {
+  const stdin = [
+    JSON.stringify({ text: "First." }),
+    "{not json",
+    JSON.stringify({ text: "Third." }),
+  ].join("\n") + "\n";
+  const { code, stdout, stderr } = await markspecStdin(
+    ["score", "--format", "json"],
+    stdin,
+  );
+  assertEquals(code, 2);
+  const lines = stdout.trim().split("\n").filter((l) => l.length > 0);
+  assertEquals(lines.length, 2);
+  assertStringIncludes(stderr, "line 2");
+});
+
+Deno.test("score: all malformed → exit 1", async () => {
+  const stdin = "not json\n{also not\n";
+  const { code, stdout } = await markspecStdin(
+    ["score", "--format", "json"],
+    stdin,
+  );
   assertEquals(code, 1);
-  assertStringIncludes(stderr, "error: --text is required");
+  assertEquals(stdout.trim(), "");
+});
+
+Deno.test("score: missing 'text' field → skipped with stderr message", async () => {
+  const stdin = [
+    JSON.stringify({ text: "First." }),
+    JSON.stringify({ id: "noText" }),
+  ].join("\n") + "\n";
+  const { code, stdout, stderr } = await markspecStdin(
+    ["score", "--format", "json"],
+    stdin,
+  );
+  assertEquals(code, 2);
+  assertEquals(stdout.trim().split("\n").length, 1);
+  assertStringIncludes(stderr, "text");
 });

--- a/tests/e2e/score_test.ts
+++ b/tests/e2e/score_test.ts
@@ -1,0 +1,42 @@
+/**
+ * @module tests/e2e/score_test
+ *
+ * Blackbox E2E tests for `markspec score`. Invokes the CLI via the
+ * shared markspec() helper.
+ */
+
+import { assertEquals } from "@std/assert";
+import { markspec } from "./helpers.ts";
+
+Deno.test("score --text --format json: prints structured result", async () => {
+  const { code, stdout, stderr } = await markspec([
+    "score",
+    "--text",
+    "The system SHALL stop within 200 ms.",
+    "--format",
+    "json",
+  ]);
+  assertEquals(code, 0, `stderr: ${stderr}`);
+  const parsed = JSON.parse(stdout);
+  assertEquals(parsed.id, "EXT_0001");
+  assertEquals(typeof parsed.score, "number");
+  assertEquals(typeof parsed.warningCount, "number");
+  assertEquals(typeof parsed.infoCount, "number");
+  assertEquals(Array.isArray(parsed.contributions), true);
+  assertEquals(Array.isArray(parsed.diagnostics), true);
+});
+
+Deno.test("score --text: caller-supplied id is echoed", async () => {
+  const { code, stdout } = await markspec([
+    "score",
+    "--text",
+    "The system shall be fast.",
+    "--id",
+    "DOORS-001",
+    "--format",
+    "json",
+  ]);
+  assertEquals(code, 0);
+  const parsed = JSON.parse(stdout);
+  assertEquals(parsed.id, "DOORS-001");
+});

--- a/tests/e2e/score_test.ts
+++ b/tests/e2e/score_test.ts
@@ -169,3 +169,57 @@ Deno.test("score --text --format text: empty input prints Q401 banner", async ()
   assertStringIncludes(stdout, "Warnings: 0");
   assertStringIncludes(stdout, "Infos: 1");
 });
+
+Deno.test("score: no --text and no stdin → prints help, exit 0", async () => {
+  const CLI_ENTRY = new URL(
+    "../../packages/markspec/main.ts",
+    import.meta.url,
+  ).pathname;
+  const cmd = new Deno.Command("deno", {
+    args: ["run", "--allow-read", "--allow-write", CLI_ENTRY, "score"],
+    stdin: "null",
+    stdout: "piped",
+    stderr: "piped",
+  });
+  const out = await cmd.output();
+  const combined = new TextDecoder().decode(out.stdout) +
+    new TextDecoder().decode(out.stderr);
+  assertStringIncludes(combined.toLowerCase(), "score");
+});
+
+Deno.test("score: --text wins over stdin", async () => {
+  const CLI_ENTRY = new URL(
+    "../../packages/markspec/main.ts",
+    import.meta.url,
+  ).pathname;
+  const cmd = new Deno.Command("deno", {
+    args: [
+      "run",
+      "--allow-read",
+      "--allow-write",
+      CLI_ENTRY,
+      "score",
+      "--text",
+      "Inline wins.",
+      "--format",
+      "json",
+    ],
+    stdin: "piped",
+    stdout: "piped",
+    stderr: "piped",
+  });
+  const child = cmd.spawn();
+  const w = child.stdin.getWriter();
+  await w.write(
+    new TextEncoder().encode(
+      JSON.stringify({ id: "should-be-ignored", text: "from stdin" }) + "\n",
+    ),
+  );
+  await w.close();
+  const out = await child.output();
+  assertEquals(out.code, 0);
+  const stdoutText = new TextDecoder().decode(out.stdout).trim();
+  // One-shot mode pretty-prints JSON; parse the whole stdout as one object.
+  const parsed = JSON.parse(stdoutText);
+  assertEquals(parsed.id, "EXT_0001");
+});

--- a/tests/e2e/score_test.ts
+++ b/tests/e2e/score_test.ts
@@ -141,3 +141,31 @@ Deno.test("score: missing 'text' field → skipped with stderr message", async (
   assertEquals(stdout.trim().split("\n").length, 1);
   assertStringIncludes(stderr, "text");
 });
+
+Deno.test("score --text --format text: prints score + counts + diagnostics", async () => {
+  const { code, stdout, stderr } = await markspec([
+    "score",
+    "--text",
+    "The system SHALL handle errors appropriately.",
+    "--format",
+    "text",
+  ]);
+  assertEquals(code, 0, `stderr: ${stderr}`);
+  assertStringIncludes(stdout, "Score:");
+  assertStringIncludes(stdout, "Warnings:");
+  assertStringIncludes(stdout, "Infos:");
+});
+
+Deno.test("score --text --format text: empty input prints Q401 banner", async () => {
+  const { code, stdout } = await markspec([
+    "score",
+    "--text",
+    " ",
+    "--format",
+    "text",
+  ]);
+  assertEquals(code, 0);
+  assertStringIncludes(stdout, "Score: 1");
+  assertStringIncludes(stdout, "Warnings: 0");
+  assertStringIncludes(stdout, "Infos: 1");
+});


### PR DESCRIPTION
## Summary

- New `scoreText(text, opts?)` library primitive (in `core/lint/score_text.ts`, re-exported from `core/lint/mod.ts`) that scores a single piece of requirement prose against the PA-3 lint catalog. Returns `{ id, score, warningCount, infoCount, contributions, diagnostics }` so a caller can express both score-band gating and a "no warnings allowed" gate without conflating severity with score.
- New `markspec score` CLI subcommand: `--text` one-shot mode, JSONL stdin batch mode, `--format text|json` with TTY-aware defaults, exit codes 0/1/2 per clig.dev.
- Strategy: wrap input text in a synthetic Requirement-shaped Entry (bodyAst populated via `buildBodyAst(text)`, title = id so Q400 stays silent) and run the existing `runLint` pipeline against a one-entry corpus. No changes to the rule catalog.

## Why

Lets an agent skill or human author score inbound external requirements (DOORS, Word, PDF, free-form Markdown) before deciding to ingest, and gives a reusable primitive for pre/post-rewrite quality deltas. Format extraction stays in the agent skill; this PR is just the scoring engine + CLI surface.

## Non-goals (deferred)

- Format adapters (CSV / ReqIF / PDF / Word) — agents do extraction.
- `--before / --after` delta — skills call `markspec score` twice and diff themselves.
- Persistence, project-level rollup, traceability/consistency checks.

## Test plan

- [x] `deno test packages/markspec/core/lint/score_text_test.ts` — 6 unit tests pass
- [x] `deno test --allow-read --allow-write --allow-run --allow-env --allow-ffi tests/e2e/score_test.ts` — 11 e2e tests pass
- [x] `just build` (lint + test + typecheck + compile) — green (2737 tests pass, 0 fail)
- [x] `deno fmt --check && dprint check` — both clean
- [x] Smoke: `echo '{"text": "The system shall stop within 200 ms."}' | ./dist/markspec score --format json` returns a structured ScoreTextResult with a real MSL-Q312 diagnostic (INCOSE range-of-values)

Design spec: `docs/superpowers/specs/2026-05-27-external-requirement-scoring-design.md` (gitignored — local-only design doc).