### PR TITLE
feat(lsp): event log rotation (Job 6)

### DIFF
--- a/packages/markspec/lsp/event_log.ts
+++ b/packages/markspec/lsp/event_log.ts
@@ -47,6 +47,21 @@ export type EventFields = Record<
 const FLUSH_INTERVAL_MS = 250;
 const FLUSH_THRESHOLD_BYTES = 4096;
 
+/**
+ * Size cap (in bytes) at which the active log file is rotated. When the
+ * existing `lsp.log` is at or above this size on session open, it is
+ * rotated to `lsp.log.1` and a fresh `lsp.log` is created. Exported so
+ * tests can size pre-rotation fixtures against the production threshold.
+ */
+export const MAX_BYTES = 1024 * 1024;
+
+/**
+ * Number of rotated log files to retain on disk. The active file
+ * (`lsp.log`) plus `lsp.log.1` … `lsp.log.{KEEP}`. The oldest rotated
+ * file is evicted on each rotation.
+ */
+const KEEP = 3;
+
 let initialized = false;
 let disabled = false;
 let projectRoot: string | undefined;
@@ -81,16 +96,63 @@ function resolveLogPath(): string | undefined {
   return undefined;
 }
 
+/**
+ * Run an `fs` step that is expected to be a no-op when the target
+ * doesn't exist. Swallows `Deno.errors.NotFound` and rethrows
+ * everything else (permission denied, cross-device link, etc.) so the
+ * outer `openHandleIfNeeded` catch can disable the channel cleanly.
+ */
+function ignoreNotFound(fn: () => void): void {
+  try {
+    fn();
+  } catch (err) {
+    if (!(err instanceof Deno.errors.NotFound)) throw err;
+  }
+}
+
+/**
+ * Rotate the active log file when it has reached {@linkcode MAX_BYTES}.
+ * Performs the classic newsyslog-style shuffle:
+ *
+ *   lsp.log.3  ← evicted
+ *   lsp.log.2  → lsp.log.3
+ *   lsp.log.1  → lsp.log.2
+ *   lsp.log    → lsp.log.1
+ *
+ * A fresh `lsp.log` is then created by the open-for-append in
+ * {@linkcode openHandleIfNeeded}. The function is a no-op when the
+ * file does not yet exist or is below the cap. Rotation happens at
+ * most once per session because the buffered writer keeps the handle
+ * open after the first open.
+ */
+function rotateIfNeeded(path: string): void {
+  let stat: Deno.FileInfo;
+  try {
+    stat = Deno.statSync(path);
+  } catch (err) {
+    if (err instanceof Deno.errors.NotFound) return;
+    throw err;
+  }
+  if (stat.size < MAX_BYTES) return;
+  ignoreNotFound(() => Deno.removeSync(`${path}.${KEEP}`));
+  for (let i = KEEP - 1; i >= 1; i--) {
+    ignoreNotFound(() => Deno.renameSync(`${path}.${i}`, `${path}.${i + 1}`));
+  }
+  Deno.renameSync(path, `${path}.1`);
+}
+
 function openHandleIfNeeded(): void {
   if (handle || disabled) return;
   const path = resolveLogPath();
   if (!path) return;
   try {
     Deno.mkdirSync(dirname(path), { recursive: true });
+    rotateIfNeeded(path);
     handle = Deno.openSync(path, { create: true, append: true });
   } catch {
-    // Any failure opening the log makes the channel inert for the
-    // session — better than crashing the server. We do not retry.
+    // Any failure opening (or rotating) the log makes the channel
+    // inert for the session — better than crashing the server. We
+    // do not retry.
     disabled = true;
     handle = undefined;
   }

--- a/packages/markspec/lsp/event_log_test.ts
+++ b/packages/markspec/lsp/event_log_test.ts
@@ -9,6 +9,7 @@ import {
   flushSync,
   isEnabled,
   logEvent,
+  MAX_BYTES,
   setProjectRoot,
 } from "./event_log.ts";
 
@@ -149,5 +150,101 @@ Deno.test("event_log: undefined field values are skipped", async () => {
     const contents = await Deno.readTextFile(logPath);
     assertStringIncludes(contents, "real=yes");
     assertEquals(contents.includes("missing="), false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Rotation (Job 6)
+// ---------------------------------------------------------------------------
+
+/** Helper: returns true iff `path` exists. */
+async function fileExists(path: string): Promise<boolean> {
+  try {
+    await Deno.stat(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+Deno.test("event_log: rotation does NOT fire below cap", async () => {
+  await withTempRoot(async (root, logPath) => {
+    await Deno.mkdir(join(root, ".markspec"), { recursive: true });
+    // Pre-seed with content well under MAX_BYTES.
+    await Deno.writeTextFile(logPath, "pre-rotation small content\n");
+    setProjectRoot(root);
+    logEvent("info", "after-init");
+    flushSync();
+    assertEquals(
+      await fileExists(`${logPath}.1`),
+      false,
+      "lsp.log.1 must not exist when active log is below cap",
+    );
+    const contents = await Deno.readTextFile(logPath);
+    assertStringIncludes(contents, "pre-rotation small content");
+    assertStringIncludes(contents, "kind=after-init");
+  });
+});
+
+Deno.test("event_log: rotation fires at-or-above cap; preserves old content as .1", async () => {
+  await withTempRoot(async (root, logPath) => {
+    await Deno.mkdir(join(root, ".markspec"), { recursive: true });
+    // Pre-seed with content of size >= MAX_BYTES so rotation triggers.
+    const atCap = "x".repeat(MAX_BYTES);
+    await Deno.writeTextFile(logPath, atCap);
+    setProjectRoot(root);
+    logEvent("info", "after-rotate");
+    flushSync();
+    const rotated = await Deno.readTextFile(`${logPath}.1`);
+    assertEquals(rotated, atCap, "lsp.log.1 must hold the pre-rotation bytes");
+    const fresh = await Deno.readTextFile(logPath);
+    assert(
+      fresh.includes("kind=after-rotate"),
+      "fresh lsp.log must contain the post-rotation event",
+    );
+    assert(
+      !fresh.startsWith("x"),
+      "fresh lsp.log must not start with the pre-rotation 'x' bytes",
+    );
+  });
+});
+
+Deno.test("event_log: rotation cycles correctly (.2 -> .3, .1 -> .2, orig -> .1)", async () => {
+  await withTempRoot(async (root, logPath) => {
+    await Deno.mkdir(join(root, ".markspec"), { recursive: true });
+    const atCap = "x".repeat(MAX_BYTES);
+    await Deno.writeTextFile(logPath, atCap);
+    await Deno.writeTextFile(`${logPath}.1`, "one");
+    await Deno.writeTextFile(`${logPath}.2`, "two");
+    setProjectRoot(root);
+    logEvent("info", "after-rotate");
+    flushSync();
+    assertEquals(await Deno.readTextFile(`${logPath}.3`), "two");
+    assertEquals(await Deno.readTextFile(`${logPath}.2`), "one");
+    assertEquals(await Deno.readTextFile(`${logPath}.1`), atCap);
+    const fresh = await Deno.readTextFile(logPath);
+    assert(fresh.includes("kind=after-rotate"));
+    assert(!fresh.startsWith("x"));
+  });
+});
+
+Deno.test("event_log: rotation evicts .3", async () => {
+  await withTempRoot(async (root, logPath) => {
+    await Deno.mkdir(join(root, ".markspec"), { recursive: true });
+    const atCap = "x".repeat(MAX_BYTES);
+    await Deno.writeTextFile(logPath, atCap);
+    await Deno.writeTextFile(`${logPath}.1`, "one");
+    await Deno.writeTextFile(`${logPath}.2`, "two");
+    await Deno.writeTextFile(`${logPath}.3`, "old-three");
+    setProjectRoot(root);
+    logEvent("info", "after-rotate");
+    flushSync();
+    // The old `.3` content is gone; `.3` now holds what `.2` had.
+    const dotThree = await Deno.readTextFile(`${logPath}.3`);
+    assertEquals(dotThree, "two");
+    assert(
+      !dotThree.includes("old-three"),
+      "old-three must have been evicted by rotation",
+    );
   });
 });


### PR DESCRIPTION
## Summary

- Cap: **1 MB** (`1024 * 1024` bytes). When the active `lsp.log` is at or above the cap on session open, it is rotated before the open-for-append.
- Keep: **3** historical files (`lsp.log.1`, `lsp.log.2`, `lsp.log.3`); `lsp.log.3` is evicted on each rotation.
- When: inside `openHandleIfNeeded()`, just after `mkdirSync` and just before `Deno.openSync`. Rotation therefore happens at most once per LSP session (the handle is kept open across the session).
- Failure handling: `Deno.errors.NotFound` is swallowed per step (so a partial rotation history is fine); any other error propagates to the existing outer catch which sets `disabled = true` so the server never crashes on a logging fault.

## Why

The buffered event log (PR #527) is default-on. Without a size cap the
file grows unbounded on long-running editor sessions. Rotating at 1 MB
with 3 backups bounds worst-case disk usage to ~4 MB per workspace —
small enough to be invisible and large enough to retain useful history
across server restarts.

## Test plan

- [x] `deno check packages/markspec/lsp/event_log.ts`
- [x] `deno fmt --check packages/markspec/lsp/`
- [x] `deno lint packages/markspec/lsp/`
- [x] `deno test --allow-read --allow-write --allow-env --allow-run packages/markspec/lsp/event_log_test.ts` — 12 passed (8 prior + 4 new)
- [x] New rotation tests cover: no rotation below cap; rotation at-or-above cap with `.1` preservation; full cycle `.2 → .3`, `.1 → .2`, `lsp.log → .1`; `.3` eviction.

## Out of scope

Jobs 2, 3, 4, and 5 of the LSP event-log epic — this PR only adds rotation.

Follow-up to #527.
