### PR TITLE
feat(lsp): kind=diagnostics histogram per validateAll (Job 3)

### DIFF
--- a/packages/markspec/lsp/diagnostics_histogram.ts
+++ b/packages/markspec/lsp/diagnostics_histogram.ts
@@ -1,0 +1,61 @@
+/**
+ * @module lsp/diagnostics_histogram
+ *
+ * Build a bounded histogram of diagnostic codes for the
+ * `kind=diagnostics` event_log entry that `publishAllDiagnostics`
+ * emits after every cross-file validation.
+ *
+ * The cap matters: a single broken-reference cascade can fire the
+ * same MSL code thousands of times in a large project. Without a
+ * cap, the event log line would grow without bound and lose its
+ * `grep`-ability. We keep the top-N most frequent codes by name and
+ * lump the long tail into a synthetic `"other"` field so the line
+ * size stays bounded.
+ */
+
+import type { Diagnostic } from "../core/mod.ts";
+
+/**
+ * Build a code-frequency histogram from a flat diagnostic list,
+ * capped at the {@linkcode topN} most frequent codes. Excess codes
+ * are summed into a single `"other"` field.
+ *
+ * The returned object is sorted by descending count so the resulting
+ * event-log line reads top-down (most-fired code first), then by
+ * code name as a deterministic tiebreaker so a flapping
+ * least-frequent code does not produce flaky tests.
+ *
+ * @param diags - Flat list of core diagnostics from a single
+ *   `validateAll` run. Each diagnostic's `code` field is used as the
+ *   histogram key.
+ * @param topN - Maximum number of distinct codes to surface by
+ *   name. Codes beyond the cutoff contribute to the `"other"`
+ *   bucket.
+ */
+export function buildDiagnosticsHistogram(
+  diags: readonly Diagnostic[],
+  topN: number,
+): Record<string, number> {
+  const counts = new Map<string, number>();
+  for (const diag of diags) {
+    counts.set(diag.code, (counts.get(diag.code) ?? 0) + 1);
+  }
+  // Sort by count desc, then code asc — deterministic tiebreak so
+  // tests are not flaky when two codes share the cutoff count.
+  const sorted = [...counts.entries()].sort((a, b) => {
+    if (b[1] !== a[1]) return b[1] - a[1];
+    return a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0;
+  });
+  const out: Record<string, number> = {};
+  if (sorted.length <= topN) {
+    for (const [code, count] of sorted) out[code] = count;
+    return out;
+  }
+  const kept = sorted.slice(0, topN);
+  const rest = sorted.slice(topN);
+  for (const [code, count] of kept) out[code] = count;
+  let otherSum = 0;
+  for (const [, count] of rest) otherSum += count;
+  out["other"] = otherSum;
+  return out;
+}

--- a/packages/markspec/lsp/diagnostics_histogram_test.ts
+++ b/packages/markspec/lsp/diagnostics_histogram_test.ts
@@ -1,0 +1,109 @@
+/**
+ * @module lsp/diagnostics_histogram_test
+ *
+ * Unit tests for the per-validateAll diagnostic-code histogram
+ * surfaced through the `kind=diagnostics` event_log entry.
+ */
+
+import { assertEquals } from "@std/assert";
+import type { Diagnostic as CoreDiagnostic } from "../core/mod.ts";
+import { buildDiagnosticsHistogram } from "./diagnostics_histogram.ts";
+
+/** Build a minimal core Diagnostic with just the code field — the
+ * only field the histogram reads. */
+function diag(code: string): CoreDiagnostic {
+  return {
+    code,
+    severity: "warning",
+    message: code,
+    location: { file: "x.md", line: 1, column: 1 },
+  };
+}
+
+Deno.test("buildDiagnosticsHistogram: empty input → empty object", () => {
+  const hist = buildDiagnosticsHistogram([], 20);
+  assertEquals(hist, {});
+});
+
+Deno.test("buildDiagnosticsHistogram: groups by code with exact counts", () => {
+  const hist = buildDiagnosticsHistogram(
+    [
+      diag("MSL-R002"),
+      diag("MSL-R002"),
+      diag("MSL-Q401"),
+    ],
+    20,
+  );
+  assertEquals(hist, { "MSL-R002": 2, "MSL-Q401": 1 });
+});
+
+Deno.test("buildDiagnosticsHistogram: sorts by count desc", () => {
+  const hist = buildDiagnosticsHistogram(
+    [
+      diag("MSL-A001"),
+      diag("MSL-B002"),
+      diag("MSL-B002"),
+      diag("MSL-B002"),
+      diag("MSL-C003"),
+      diag("MSL-C003"),
+    ],
+    20,
+  );
+  // Object.keys preserves insertion order — verifying the sort.
+  assertEquals(Object.keys(hist), ["MSL-B002", "MSL-C003", "MSL-A001"]);
+  assertEquals(hist["MSL-B002"], 3);
+  assertEquals(hist["MSL-C003"], 2);
+  assertEquals(hist["MSL-A001"], 1);
+});
+
+Deno.test("buildDiagnosticsHistogram: caps at topN and adds 'other' bucket", () => {
+  // 25 distinct codes, each firing a unique number of times so the
+  // sort order is deterministic. Code "MSL-R000" fires 25×, R001 24×,
+  // …, R024 once. With topN=20 we keep R000..R019 and roll R020..R024
+  // (5+4+3+2+1 = 15 events) into "other".
+  const diags: CoreDiagnostic[] = [];
+  for (let i = 0; i < 25; i++) {
+    const code = `MSL-R${String(i).padStart(3, "0")}`;
+    const fireCount = 25 - i;
+    for (let n = 0; n < fireCount; n++) diags.push(diag(code));
+  }
+  const hist = buildDiagnosticsHistogram(diags, 20);
+  // 20 code keys + 1 "other" field
+  assertEquals(Object.keys(hist).length, 21);
+  // Top entries present
+  assertEquals(hist["MSL-R000"], 25);
+  assertEquals(hist["MSL-R019"], 25 - 19);
+  // Lumped tail correctness: 5+4+3+2+1 = 15
+  assertEquals(hist["other"], 15);
+  // Codes past the cap are not surfaced by name
+  assertEquals(hist["MSL-R020"], undefined);
+  assertEquals(hist["MSL-R024"], undefined);
+});
+
+Deno.test("buildDiagnosticsHistogram: ties at cutoff resolve by code name (deterministic)", () => {
+  // Three codes each fire twice; topN=2 forces one into 'other'.
+  // The deterministic tiebreak is alphabetical by code, so MSL-A001
+  // and MSL-B002 are kept and MSL-C003 is lumped.
+  const diags = [
+    diag("MSL-C003"),
+    diag("MSL-C003"),
+    diag("MSL-A001"),
+    diag("MSL-A001"),
+    diag("MSL-B002"),
+    diag("MSL-B002"),
+  ];
+  const hist = buildDiagnosticsHistogram(diags, 2);
+  assertEquals(hist["MSL-A001"], 2);
+  assertEquals(hist["MSL-B002"], 2);
+  assertEquals(hist["MSL-C003"], undefined);
+  assertEquals(hist["other"], 2);
+});
+
+Deno.test("buildDiagnosticsHistogram: topN exactly matches distinct count → no 'other'", () => {
+  const hist = buildDiagnosticsHistogram(
+    [diag("MSL-A"), diag("MSL-B"), diag("MSL-C")],
+    3,
+  );
+  assertEquals(Object.keys(hist).length, 3);
+  assertEquals(hist["other"], undefined);
+});

--- a/packages/markspec/lsp/server.ts
+++ b/packages/markspec/lsp/server.ts
@@ -54,6 +54,7 @@ import { buildCodeLenses } from "./code_lens.ts";
 import { buildDocumentLinks } from "./document_links.ts";
 import { buildFormattingEdits } from "./formatting.ts";
 import { groupDiagnosticsByFile, toLspDiagnostic } from "./diagnostics.ts";
+import { buildDiagnosticsHistogram } from "./diagnostics_histogram.ts";
 import { buildCodeActions } from "./code_actions.ts";
 import { entryToLspLocation } from "./definition.ts";
 import { displayIdAtPosition, formatHoverContent } from "./hover.ts";
@@ -206,13 +207,34 @@ function publishFileDiagnostics(
   connection.sendDiagnostics({ uri, diagnostics: lspDiags });
 }
 
+/**
+ * Cap on the number of distinct MSL codes the `kind=diagnostics`
+ * histogram surfaces by name. Anything past the cap is summed into a
+ * synthetic `other` field — see {@linkcode buildDiagnosticsHistogram}.
+ * 20 keeps the event-log line under a couple hundred bytes even when
+ * the project fires every catalogue rule.
+ */
+const DIAGNOSTICS_HISTOGRAM_TOP_N = 20;
+
 /** Run cross-file validation and publish diagnostics for all files. */
 function publishAllDiagnostics(): void {
+  const entryCount = index.getAllEntries().length;
   const allDiags = time(
-    `validateAll/${index.getAllEntries().length}`,
+    `validateAll/${entryCount}`,
     () => index.validateAll(profile ?? null),
   );
   lastDiagnostics = allDiags;
+
+  // Emit a per-validateAll histogram of MSL codes that fired. Always
+  // emitted (zero diagnostics is a valid analytics signal — "the
+  // project validated cleanly"); the zero case carries just the
+  // entry count.
+  const histogram = buildDiagnosticsHistogram(
+    allDiags,
+    DIAGNOSTICS_HISTOGRAM_TOP_N,
+  );
+  logEvent("info", "diagnostics", { entries: entryCount, ...histogram });
+
   const grouped = groupDiagnosticsByFile(allDiags);
 
   // Send diagnostics for files that have issues


### PR DESCRIPTION
## Summary

- After every `publishAllDiagnostics` run, emit one `kind=diagnostics` info event to the LSP event log with a histogram of MSL codes that fired.
- Always emitted — even when zero diagnostics fired. That zero case is a valid analytics signal ("the project validated cleanly") and carries just the entry count.
- **Cap detail:** the histogram is bounded to the top 20 most frequent codes. Anything past the cap is summed into a synthetic `other` field so a thousand-instance broken-reference cascade does not blow up the event-log line size or break `grep` workflows. Codes are sorted by count desc; ties resolve alphabetically so tests are not flaky.
- Histogram construction lives in a new `diagnostics_histogram.ts` helper for clean unit testability. `server.ts` only gains the import, a cap constant, and a four-line call site inside `publishAllDiagnostics`.

## Why

Default-on rule-fire visibility. With Job 1 (event log) and Job 2 (slow flags) merged, the next missing pillar is "what rules are actually firing in this project, right now?" — answerable from a single `grep "kind=diagnostics" lsp.log | tail -1`. No new flags, no opt-in. The 20-code cap keeps the cost per emit bounded regardless of project size.

## Test plan

- [x] `deno check packages/markspec/lsp/server.ts` — passes (also full main.ts/core/mcp check)
- [x] `deno fmt --check packages/markspec/lsp/` — passes
- [x] `deno lint packages/markspec/lsp/` — passes
- [x] `deno test … packages/markspec/lsp/` — 289 tests pass (6 new histogram tests added)
- [x] Unit cases: empty input, exact small-N grouping, top-N cap with `other` bucket, deterministic tie-handling at the cutoff, exact-fit no-`other` case.

## Out of scope

- Job 4 (in flight in parallel — do not anticipate)
- Job 5 (debug_log / timing migration to event_log)

Follow-up to #527 (event log MVP). Part of the LSP event-log epic.
