### PR TITLE
feat(lsp): per-method counters + kind=shutdown summary event (Job 4)

### DIFF
--- a/packages/markspec/lsp/method_counts.ts
+++ b/packages/markspec/lsp/method_counts.ts
@@ -1,0 +1,33 @@
+/**
+ * @module lsp/method_counts
+ *
+ * Per-method LSP request/notification counter. The server calls
+ * {@linkcode tally} at the top of each handler; at session shutdown
+ * {@linkcode snapshot} feeds the rolled-up counts into the `kind=shutdown`
+ * event log entry. Kept in its own module so the counter state is unit-
+ * testable without spinning up the LSP transport.
+ *
+ * State is module-scoped — there is exactly one LSP session per server
+ * process, so a singleton is the right shape.
+ */
+
+const counts = new Map<string, number>();
+
+/** Record one invocation of the named LSP method. O(1). */
+export function tally(method: string): void {
+  counts.set(method, (counts.get(method) ?? 0) + 1);
+}
+
+/**
+ * Read-only view of the current counts. Returned `Map` is the live
+ * instance (not a copy) so iteration is allocation-free, but it is
+ * typed as `ReadonlyMap` to discourage mutation by callers.
+ */
+export function snapshot(): ReadonlyMap<string, number> {
+  return counts;
+}
+
+/** Reset counters. Test-only — there is no production use case. */
+export function _reset(): void {
+  counts.clear();
+}

--- a/packages/markspec/lsp/method_counts_test.ts
+++ b/packages/markspec/lsp/method_counts_test.ts
@@ -1,0 +1,40 @@
+import { assertEquals } from "@std/assert";
+import { _reset, snapshot, tally } from "./method_counts.ts";
+
+Deno.test("method_counts: tally increments distinct methods", () => {
+  _reset();
+  tally("completion");
+  tally("hover");
+  tally("definition");
+  const s = snapshot();
+  assertEquals(s.get("completion"), 1);
+  assertEquals(s.get("hover"), 1);
+  assertEquals(s.get("definition"), 1);
+  assertEquals(s.size, 3);
+});
+
+Deno.test("method_counts: tally accumulates same method", () => {
+  _reset();
+  tally("completion");
+  tally("completion");
+  tally("completion");
+  const s = snapshot();
+  assertEquals(s.get("completion"), 3);
+  assertEquals(s.size, 1);
+});
+
+Deno.test("method_counts: _reset clears state", () => {
+  _reset();
+  tally("hover");
+  tally("hover");
+  _reset();
+  const s = snapshot();
+  assertEquals(s.size, 0);
+  assertEquals(s.get("hover"), undefined);
+});
+
+Deno.test("method_counts: unseen method reads undefined", () => {
+  _reset();
+  const s = snapshot();
+  assertEquals(s.get("never-called"), undefined);
+});

--- a/packages/markspec/lsp/server.ts
+++ b/packages/markspec/lsp/server.ts
@@ -107,6 +107,7 @@ import {
   logEvent,
   setProjectRoot as setEventLogProjectRoot,
 } from "./event_log.ts";
+import { snapshot as methodCountsSnapshot, tally } from "./method_counts.ts";
 import { time, timeAsync } from "./timing.ts";
 import {
   buildDollarNameCompletions,
@@ -152,6 +153,12 @@ globalThis.addEventListener("error", (e) => {
 // ---------------------------------------------------------------------------
 // Server state
 // ---------------------------------------------------------------------------
+
+/** Monotonic clock reading captured at module load. Subtracted from the
+ * `onShutdown` reading to compute the `durMs` field on the shutdown
+ * event — close enough to "session lifetime" for analytics; the wall
+ * clock is unsuitable here because it can jump backwards. */
+const sessionStartedAt = performance.now();
 
 let projectRoot: string | undefined;
 let _config: ProjectConfig = DEFAULT_PROJECT_CONFIG;
@@ -628,6 +635,7 @@ documents.onDidOpen(async (event) => {
 // ---------------------------------------------------------------------------
 
 connection.onCompletion((params): CompletionItem[] => {
+  tally("completion");
   const document = documents.get(params.textDocument.uri);
   if (!document) return [];
 
@@ -764,6 +772,7 @@ connection.onCompletionResolve((item): CompletionItem => {
 // ---------------------------------------------------------------------------
 
 connection.onHover((params) => {
+  tally("hover");
   const document = documents.get(params.textDocument.uri);
   if (!document) return null;
 
@@ -807,6 +816,7 @@ connection.onHover((params) => {
 // ---------------------------------------------------------------------------
 
 connection.onDefinition((params) => {
+  tally("definition");
   const document = documents.get(params.textDocument.uri);
   if (!document) return null;
 
@@ -838,6 +848,7 @@ connection.onDefinition((params) => {
 // ---------------------------------------------------------------------------
 
 connection.onReferences((params) => {
+  tally("references");
   const document = documents.get(params.textDocument.uri);
   if (!document) return null;
 
@@ -874,6 +885,7 @@ connection.onReferences((params) => {
 // ---------------------------------------------------------------------------
 
 connection.onDocumentSymbol((params) => {
+  tally("documentSymbol");
   const filePath = uriToPath(params.textDocument.uri);
   if (!isMarkspecFile(filePath)) return null;
   const entries = index.getEntriesForFile(filePath);
@@ -889,6 +901,7 @@ connection.onDocumentSymbol((params) => {
 // ---------------------------------------------------------------------------
 
 connection.onWorkspaceSymbol((params) => {
+  tally("workspaceSymbol");
   // The result conforms to LSP `SymbolInformation[]`; cast to satisfy
   // the typed `SymbolKind` enum the d.ts expects.
   // deno-lint-ignore no-explicit-any
@@ -900,6 +913,7 @@ connection.onWorkspaceSymbol((params) => {
 // ---------------------------------------------------------------------------
 
 connection.onPrepareRename((params) => {
+  tally("prepareRename");
   const document = documents.get(params.textDocument.uri);
   if (!document) return null;
 
@@ -923,6 +937,7 @@ connection.onPrepareRename((params) => {
 });
 
 connection.onRenameRequest(async (params) => {
+  tally("rename");
   const document = documents.get(params.textDocument.uri);
   if (!document) return null;
 
@@ -970,6 +985,7 @@ connection.onRenameRequest(async (params) => {
 // ---------------------------------------------------------------------------
 
 connection.onCodeAction((params) => {
+  tally("codeAction");
   const filePath = uriToPath(params.textDocument.uri);
   if (!isMarkspecFile(filePath)) return null;
   const document = documents.get(params.textDocument.uri);
@@ -990,6 +1006,7 @@ connection.onCodeAction((params) => {
 // ---------------------------------------------------------------------------
 
 connection.onDocumentLinks((params) => {
+  tally("documentLink");
   const document = documents.get(params.textDocument.uri);
   if (!document) return [];
   const filePath = uriToPath(params.textDocument.uri);
@@ -1016,6 +1033,7 @@ connection.onDocumentLinks((params) => {
 // ---------------------------------------------------------------------------
 
 connection.onDocumentFormatting((params) => {
+  tally("documentFormatting");
   const document = documents.get(params.textDocument.uri);
   if (!document) return null;
 
@@ -1041,6 +1059,7 @@ connection.onDocumentFormatting((params) => {
 // ---------------------------------------------------------------------------
 
 connection.onCodeLens((params) => {
+  tally("codeLens");
   const filePath = uriToPath(params.textDocument.uri);
   if (!isMarkspecFile(filePath)) return [];
   const entries = index.getEntriesForFile(filePath);
@@ -1054,6 +1073,7 @@ connection.onCodeLens((params) => {
 // ---------------------------------------------------------------------------
 
 connection.languages.inlayHint.on((params) => {
+  tally("inlayHint");
   const filePath = uriToPath(params.textDocument.uri);
   if (!isMarkspecFile(filePath)) return [];
   const document = documents.get(params.textDocument.uri);
@@ -1071,6 +1091,7 @@ connection.languages.inlayHint.on((params) => {
 // ---------------------------------------------------------------------------
 
 connection.onDocumentHighlight((params) => {
+  tally("documentHighlight");
   const document = documents.get(params.textDocument.uri);
   if (!document) return null;
 
@@ -1097,6 +1118,7 @@ connection.onDocumentHighlight((params) => {
 // ---------------------------------------------------------------------------
 
 connection.onFoldingRanges((params) => {
+  tally("foldingRanges");
   const document = documents.get(params.textDocument.uri);
   if (!document) return null;
   const filePath = uriToPath(params.textDocument.uri);
@@ -1112,6 +1134,7 @@ connection.onFoldingRanges((params) => {
 // ---------------------------------------------------------------------------
 
 connection.languages.semanticTokens.on((params) => {
+  tally("semanticTokens");
   const document = documents.get(params.textDocument.uri);
   if (!document) return { data: [] };
   const filePath = uriToPath(params.textDocument.uri);
@@ -1129,6 +1152,7 @@ connection.languages.semanticTokens.on((params) => {
 connection.onRequest(
   "markspec/profile",
   (_params: { uri?: string }): MarkspecProfileResponse => {
+    tally("markspecProfile");
     // `_params.uri` is accepted for forward compatibility but ignored in v1;
     // the server uses its rootUri. See design doc §3.1.
     return cachedProfileResponse;
@@ -1142,6 +1166,7 @@ connection.onRequest(
 connection.onRequest(
   "markspec/entryRanges",
   (params: { uri: string }): EntryRangesResponse => {
+    tally("markspecEntryRanges");
     const document = documents.get(params.uri);
     if (!document) return { entries: [] };
     const filePath = uriToPath(params.uri);
@@ -1165,6 +1190,16 @@ connection.onShutdown(() => {
   debugLog("onShutdown");
   debouncedValidateAll.cancel();
   debouncedReloadProfile.cancel();
+  // Roll up per-method counters + session duration into one final
+  // `kind=shutdown` event. Emitted from `onShutdown` (orderly exit)
+  // rather than `onExit` (hard close) so the summary still lands in
+  // the log when the client skips the exit notification.
+  const durMs = Math.round(performance.now() - sessionStartedAt);
+  const fields: Record<string, number> = { durMs };
+  for (const [method, n] of methodCountsSnapshot()) {
+    fields[`requests.${method}`] = n;
+  }
+  logEvent("info", "shutdown", fields);
   flushEventLog();
 });
 


### PR DESCRIPTION
## Summary

Job 4 of the LSP event-log epic — analytics on what the LSP actually gets asked to do, and how long the session ran.

What ships:

- New `packages/markspec/lsp/method_counts.ts` module — `tally(method)` + `snapshot()` + `_reset()`. Singleton `Map<string, number>` keyed by the LSP method name; O(1) increment per request.
- `tally(...)` call prepended at the top of every LSP request/notification handler in `server.ts`. Tracked methods:
  - `completion`, `hover`, `definition`, `references`
  - `documentSymbol`, `workspaceSymbol`
  - `prepareRename`, `rename` (counted separately)
  - `codeAction`, `documentLink`, `documentFormatting`
  - `codeLens`, `inlayHint`, `documentHighlight`, `foldingRanges`, `semanticTokens`
  - `markspecProfile`, `markspecEntryRanges` (custom requests)
- Module-scope `sessionStartedAt = performance.now()` captured at module load.
- `connection.onShutdown` now emits one `kind=shutdown` event before the existing `flushEventLog()` call, with fields:
  - `durMs` — session duration via `performance.now() - sessionStartedAt`
  - `requests.<method>` — one numeric field per tracked method with a non-zero count

Out of scope:

- Job 3 (publishAllDiagnostics structured event) — separate worktree
- Job 5 (timing/debug channel migration) — separate worktree
- e2e log-assertion test — counters are exercised via the unit test on the extracted module; the LSP-driven path adds no new logic the unit test doesn't already cover.

## Why

Default-on event log (PR #527) is the substrate. The shutdown summary is the cheapest possible "what did this session do" probe: one event per session, structured fields, no per-request overhead beyond a single `Map.set`. Pairs naturally with the slow-flag warnings (PR #530) — that channel says "something was slow", this channel says "and the user used these features N times".

`onShutdown` rather than `onExit` because shutdown runs first and is the orderly path; the existing `onExit` `flushEventLog()` already covers the hard-close case. The flush is preserved unchanged.

## Test plan

- [x] `deno check packages/markspec/lsp/server.ts` passes
- [x] `deno fmt --check packages/markspec/lsp/` passes
- [x] `deno lint packages/markspec/lsp/` passes
- [x] `deno test --allow-read --allow-write --allow-env --allow-run packages/markspec/lsp/` — 287 passed, 0 failed (4 new tests in `method_counts_test.ts`)

## Refs

- Follow-up to #527 (event-log MVP)
- Part of the LSP event-log epic alongside #530 (slow flags) and #527 + the rotation work in 92fa4b2 (Job 6)
