### PR TITLE
fix(cli): address PR #528 code-review findings (5 commits)

### DIFF
--- a/packages/markspec/cli/commands/init.ts
+++ b/packages/markspec/cli/commands/init.ts
@@ -9,6 +9,7 @@
 import { Command, EnumType } from "@cliffy/command";
 import { resolve } from "@std/path";
 import { VERSION } from "../../core/mod.ts";
+import { parseProfileSpec } from "../init/mod.ts";
 import { parseWhichOutput } from "../init/which_command.ts";
 
 const clientType = new EnumType(["claude-code", "opencode"]);
@@ -185,12 +186,11 @@ function resolveProfileFromFlags(
     // TTY interactive picker is wired in a follow-up; v1 uses bundled default.
     return { kind: "bundled" };
   }
-  const s = options.profile.trim();
-  if (s === "bundled") return { kind: "bundled" };
-  if (s === "false") return { kind: "none" };
-  if (/^git\+(https?|ssh):\/\/.+$/.test(s)) return { kind: "git", spec: s };
-  if (/^\.{0,2}\/.+|^\/.+$/.test(s)) return { kind: "local", spec: s };
-  console.error(`error: unrecognized --profile spec '${s}'`);
+  const parsed = parseProfileSpec(options.profile);
+  if (parsed) return parsed;
+  console.error(
+    `error: unrecognized --profile spec '${options.profile.trim()}'`,
+  );
   console.error(
     "       accepted: bundled | false | git+https://... | ./path | /abs/path",
   );

--- a/packages/markspec/cli/commands/init.ts
+++ b/packages/markspec/cli/commands/init.ts
@@ -9,6 +9,7 @@
 import { Command, EnumType } from "@cliffy/command";
 import { resolve } from "@std/path";
 import { VERSION } from "../../core/mod.ts";
+import { parseWhichOutput } from "../init/which_command.ts";
 
 const clientType = new EnumType(["claude-code", "opencode"]);
 const formatType = new EnumType(["text", "json"]);
@@ -90,8 +91,7 @@ export const initCmd = new Command()
           stderr: "null",
         });
         const out = await p.output();
-        if (out.code !== 0) return undefined;
-        return new TextDecoder().decode(out.stdout).split(/\r?\n/)[0].trim();
+        return parseWhichOutput(out.code, out.stdout);
       } catch {
         return undefined;
       }

--- a/packages/markspec/cli/init/client_resolver.ts
+++ b/packages/markspec/cli/init/client_resolver.ts
@@ -30,8 +30,7 @@ export async function resolveClientSet(
   const write = new Set<InitClientId>();
 
   if (options.allClients) {
-    write.add("claude-code");
-    write.add("opencode");
+    for (const c of INIT_CLIENT_IDS) write.add(c);
   } else {
     if ((await claudeCodeDescriptor.detect!(options.env)).detected) {
       write.add("claude-code");

--- a/packages/markspec/cli/init/mod.ts
+++ b/packages/markspec/cli/init/mod.ts
@@ -21,3 +21,4 @@ export type {
 } from "./types.ts";
 export { renderJsonSummary, renderTextSummary } from "./summary.ts";
 export { createDenoFs, createMemFs } from "./fake_fs.ts";
+export { parseProfileSpec } from "./profile_picker.ts";

--- a/packages/markspec/cli/init/orchestrator.ts
+++ b/packages/markspec/cli/init/orchestrator.ts
@@ -134,8 +134,12 @@ export async function runInit(options: RunInitOptions): Promise<InitResult> {
     const dirName = basename(options.targetDir);
     const minVersion = toolchainMinVersion(options.version);
 
-    // Steps 4–7: execute file writes per plan.
+    // Steps 4–7: execute file writes per plan. Each branch reports
+    // whether the action actually completed; only successes land in
+    // executedActions so the InitResult does not advertise writes
+    // that an MCP failure silently rolled back.
     for (const a of plan.actions) {
+      let ok = true;
       switch (a.file) {
         case "project.yaml":
           if (a.kind === "create" || a.kind === "overwrite") {
@@ -191,11 +195,12 @@ export async function runInit(options: RunInitOptions): Promise<InitResult> {
               message:
                 `runMcpInstall(${client}) exit=${r.exitCode}: ${r.stderr}`,
             });
+            ok = false;
           }
           break;
         }
       }
-      executedActions.push(a);
+      if (ok) executedActions.push(a);
     }
 
     // Step 8: install skills bundle via upskill.

--- a/packages/markspec/cli/init/orchestrator_test.ts
+++ b/packages/markspec/cli/init/orchestrator_test.ts
@@ -258,4 +258,8 @@ Deno.test("runInit: mcpRunner failure → MCP_INSTALL_FAILED warning + exit 2", 
   const warn = result.warnings.find((w) => w.code === "MCP_INSTALL_FAILED");
   assertEquals(warn !== undefined, true);
   assertEquals(warn!.message.includes("claude-code"), true);
+  // The failed write must not appear in actions — otherwise the
+  // summary advertises a config that was never written.
+  const mcpAction = result.actions.find((a) => a.file === ".mcp.json");
+  assertEquals(mcpAction, undefined);
 });

--- a/packages/markspec/cli/init/which_command.ts
+++ b/packages/markspec/cli/init/which_command.ts
@@ -1,0 +1,30 @@
+/**
+ * @module cli/init/which_command
+ *
+ * Pure parser for `which`/`where` output. Used by the inline
+ * `whichCommand` callback in `cli/commands/init.ts`. Lives in its
+ * own module so the empty-stdout edge case is testable without
+ * spawning a real subprocess.
+ *
+ * Sandboxed CIs and PATH wrappers occasionally produce exit code 0
+ * with empty stdout for unresolved names. Treating that as a hit
+ * pushes a bogus `'<tool>-on-path'` signal into adapter detection;
+ * see PR #528 review finding #1.
+ */
+
+/**
+ * Project the output of a `which name` / `where name` invocation to
+ * either the resolved absolute path or `undefined`.
+ *
+ *   - Non-zero exit code → `undefined`.
+ *   - Empty or whitespace-only first line → `undefined`.
+ *   - Otherwise the trimmed first line of stdout.
+ */
+export function parseWhichOutput(
+  exitCode: number,
+  stdout: Uint8Array,
+): string | undefined {
+  if (exitCode !== 0) return undefined;
+  const firstLine = new TextDecoder().decode(stdout).split(/\r?\n/)[0].trim();
+  return firstLine.length > 0 ? firstLine : undefined;
+}

--- a/packages/markspec/cli/init/which_command_test.ts
+++ b/packages/markspec/cli/init/which_command_test.ts
@@ -1,0 +1,38 @@
+import { assertEquals } from "@std/assert";
+import { parseWhichOutput } from "./which_command.ts";
+
+Deno.test("parseWhichOutput: empty stdout with exit 0 → undefined", () => {
+  assertEquals(parseWhichOutput(0, new Uint8Array(0)), undefined);
+});
+
+Deno.test("parseWhichOutput: whitespace-only stdout → undefined", () => {
+  const stdout = new TextEncoder().encode("   \n");
+  assertEquals(parseWhichOutput(0, stdout), undefined);
+});
+
+Deno.test("parseWhichOutput: blank first line, content later → undefined", () => {
+  // Defensive: callers only look at line 1; blank line 1 still means no match.
+  const stdout = new TextEncoder().encode("\n/usr/bin/markspec\n");
+  assertEquals(parseWhichOutput(0, stdout), undefined);
+});
+
+Deno.test("parseWhichOutput: non-zero exit code → undefined", () => {
+  const stdout = new TextEncoder().encode("/usr/bin/markspec\n");
+  assertEquals(parseWhichOutput(1, stdout), undefined);
+});
+
+Deno.test("parseWhichOutput: posix path on first line → trimmed", () => {
+  const stdout = new TextEncoder().encode("/usr/bin/markspec\n");
+  assertEquals(parseWhichOutput(0, stdout), "/usr/bin/markspec");
+});
+
+Deno.test("parseWhichOutput: multi-line output → first line only", () => {
+  // `where` on Windows can emit multiple matches; we use the first.
+  const stdout = new TextEncoder().encode(
+    "C:\\Program Files\\markspec\\markspec.exe\r\nC:\\other\\markspec.exe\r\n",
+  );
+  assertEquals(
+    parseWhichOutput(0, stdout),
+    "C:\\Program Files\\markspec\\markspec.exe",
+  );
+});

--- a/packages/markspec/cli/install/mcp_adapters_claude_code.ts
+++ b/packages/markspec/cli/install/mcp_adapters_claude_code.ts
@@ -38,10 +38,16 @@ export const claudeCodeDescriptor: McpAdapter = {
   },
   detect: async (env: DetectEnv): Promise<DetectResult> => {
     const signals: string[] = [];
-    const fake = Deno.env.get("MARKSPEC_FAKE_CLIENT_DETECT");
-    if (fake !== undefined && fake.split(",").includes("claude-code")) {
-      signals.push("env-fake");
-      return { detected: true, signals };
+    // The fake-detect hook is gated behind MARKSPEC_TEST_MODE so a stray
+    // MARKSPEC_FAKE_CLIENT_DETECT in a user's parent shell / .env / CI env
+    // cannot trick a production run into writing unwanted MCP configs.
+    // Both vars must be set together; the test harness owns both.
+    if (Deno.env.get("MARKSPEC_TEST_MODE") === "1") {
+      const fake = Deno.env.get("MARKSPEC_FAKE_CLIENT_DETECT");
+      if (fake !== undefined && fake.split(",").includes("claude-code")) {
+        signals.push("env-fake");
+        return { detected: true, signals };
+      }
     }
     if (await env.whichCommand("claude") !== undefined) {
       signals.push("claude-cli-on-path");

--- a/packages/markspec/cli/install/mcp_adapters_claude_code_test.ts
+++ b/packages/markspec/cli/install/mcp_adapters_claude_code_test.ts
@@ -154,27 +154,54 @@ Deno.test("claudeCodeDescriptor.detect: all signals fire → all listed", async 
   );
 });
 
-Deno.test("detect: MARKSPEC_FAKE_CLIENT_DETECT=claude-code forces detected=true", async () => {
-  const original = Deno.env.get("MARKSPEC_FAKE_CLIENT_DETECT");
-  Deno.env.set("MARKSPEC_FAKE_CLIENT_DETECT", "claude-code");
+/**
+ * Run `body` with MARKSPEC_TEST_MODE + MARKSPEC_FAKE_CLIENT_DETECT
+ * set to the given values, restoring the previous values afterward.
+ * Both vars are required because the adapter's fake-detect hook is
+ * gated behind MARKSPEC_TEST_MODE=1.
+ */
+async function withFakeEnv(
+  testMode: string | undefined,
+  fake: string | undefined,
+  body: () => Promise<void>,
+): Promise<void> {
+  const origMode = Deno.env.get("MARKSPEC_TEST_MODE");
+  const origFake = Deno.env.get("MARKSPEC_FAKE_CLIENT_DETECT");
+  if (testMode === undefined) Deno.env.delete("MARKSPEC_TEST_MODE");
+  else Deno.env.set("MARKSPEC_TEST_MODE", testMode);
+  if (fake === undefined) Deno.env.delete("MARKSPEC_FAKE_CLIENT_DETECT");
+  else Deno.env.set("MARKSPEC_FAKE_CLIENT_DETECT", fake);
   try {
+    await body();
+  } finally {
+    if (origMode === undefined) Deno.env.delete("MARKSPEC_TEST_MODE");
+    else Deno.env.set("MARKSPEC_TEST_MODE", origMode);
+    if (origFake === undefined) Deno.env.delete("MARKSPEC_FAKE_CLIENT_DETECT");
+    else Deno.env.set("MARKSPEC_FAKE_CLIENT_DETECT", origFake);
+  }
+}
+
+Deno.test("detect: MARKSPEC_FAKE_CLIENT_DETECT=claude-code forces detected=true (with TEST_MODE)", async () => {
+  await withFakeEnv("1", "claude-code", async () => {
     const r = await claudeCodeDescriptor.detect!(makeEnv());
     assertEquals(r.detected, true);
     assertEquals(r.signals.includes("env-fake"), true);
-  } finally {
-    if (original === undefined) Deno.env.delete("MARKSPEC_FAKE_CLIENT_DETECT");
-    else Deno.env.set("MARKSPEC_FAKE_CLIENT_DETECT", original);
-  }
+  });
 });
 
-Deno.test("detect: MARKSPEC_FAKE_CLIENT_DETECT=opencode does NOT force claude-code", async () => {
-  const original = Deno.env.get("MARKSPEC_FAKE_CLIENT_DETECT");
-  Deno.env.set("MARKSPEC_FAKE_CLIENT_DETECT", "opencode");
-  try {
+Deno.test("detect: MARKSPEC_FAKE_CLIENT_DETECT=opencode does NOT force claude-code (with TEST_MODE)", async () => {
+  await withFakeEnv("1", "opencode", async () => {
     const r = await claudeCodeDescriptor.detect!(makeEnv());
     assertEquals(r.detected, false);
-  } finally {
-    if (original === undefined) Deno.env.delete("MARKSPEC_FAKE_CLIENT_DETECT");
-    else Deno.env.set("MARKSPEC_FAKE_CLIENT_DETECT", original);
-  }
+  });
+});
+
+Deno.test("detect: MARKSPEC_FAKE_CLIENT_DETECT without MARKSPEC_TEST_MODE is ignored", async () => {
+  // Env-bleed guard: a stray MARKSPEC_FAKE_CLIENT_DETECT in a parent
+  // shell / .env / CI environment must not trick a production run.
+  await withFakeEnv(undefined, "claude-code", async () => {
+    const r = await claudeCodeDescriptor.detect!(makeEnv());
+    assertEquals(r.detected, false);
+    assertEquals(r.signals.includes("env-fake"), false);
+  });
 });

--- a/packages/markspec/cli/install/mcp_adapters_opencode.ts
+++ b/packages/markspec/cli/install/mcp_adapters_opencode.ts
@@ -48,10 +48,16 @@ export const opencodeDescriptor: McpAdapter = {
   },
   detect: async (env: DetectEnv): Promise<DetectResult> => {
     const signals: string[] = [];
-    const fake = Deno.env.get("MARKSPEC_FAKE_CLIENT_DETECT");
-    if (fake !== undefined && fake.split(",").includes("opencode")) {
-      signals.push("env-fake");
-      return { detected: true, signals };
+    // The fake-detect hook is gated behind MARKSPEC_TEST_MODE so a stray
+    // MARKSPEC_FAKE_CLIENT_DETECT in a user's parent shell / .env / CI env
+    // cannot trick a production run into writing unwanted MCP configs.
+    // Both vars must be set together; the test harness owns both.
+    if (Deno.env.get("MARKSPEC_TEST_MODE") === "1") {
+      const fake = Deno.env.get("MARKSPEC_FAKE_CLIENT_DETECT");
+      if (fake !== undefined && fake.split(",").includes("opencode")) {
+        signals.push("env-fake");
+        return { detected: true, signals };
+      }
     }
     if (await env.whichCommand("opencode") !== undefined) {
       signals.push("opencode-cli-on-path");

--- a/packages/markspec/cli/install/mcp_adapters_opencode_test.ts
+++ b/packages/markspec/cli/install/mcp_adapters_opencode_test.ts
@@ -176,27 +176,54 @@ Deno.test("opencodeDescriptor.detect: all signals fire → all listed", async ()
   );
 });
 
-Deno.test("detect: MARKSPEC_FAKE_CLIENT_DETECT=opencode forces detected=true", async () => {
-  const original = Deno.env.get("MARKSPEC_FAKE_CLIENT_DETECT");
-  Deno.env.set("MARKSPEC_FAKE_CLIENT_DETECT", "opencode");
+/**
+ * Run `body` with MARKSPEC_TEST_MODE + MARKSPEC_FAKE_CLIENT_DETECT
+ * set to the given values, restoring the previous values afterward.
+ * Both vars are required because the adapter's fake-detect hook is
+ * gated behind MARKSPEC_TEST_MODE=1.
+ */
+async function withFakeEnv(
+  testMode: string | undefined,
+  fake: string | undefined,
+  body: () => Promise<void>,
+): Promise<void> {
+  const origMode = Deno.env.get("MARKSPEC_TEST_MODE");
+  const origFake = Deno.env.get("MARKSPEC_FAKE_CLIENT_DETECT");
+  if (testMode === undefined) Deno.env.delete("MARKSPEC_TEST_MODE");
+  else Deno.env.set("MARKSPEC_TEST_MODE", testMode);
+  if (fake === undefined) Deno.env.delete("MARKSPEC_FAKE_CLIENT_DETECT");
+  else Deno.env.set("MARKSPEC_FAKE_CLIENT_DETECT", fake);
   try {
+    await body();
+  } finally {
+    if (origMode === undefined) Deno.env.delete("MARKSPEC_TEST_MODE");
+    else Deno.env.set("MARKSPEC_TEST_MODE", origMode);
+    if (origFake === undefined) Deno.env.delete("MARKSPEC_FAKE_CLIENT_DETECT");
+    else Deno.env.set("MARKSPEC_FAKE_CLIENT_DETECT", origFake);
+  }
+}
+
+Deno.test("detect: MARKSPEC_FAKE_CLIENT_DETECT=opencode forces detected=true (with TEST_MODE)", async () => {
+  await withFakeEnv("1", "opencode", async () => {
     const r = await opencodeDescriptor.detect!(makeEnv());
     assertEquals(r.detected, true);
     assertEquals(r.signals.includes("env-fake"), true);
-  } finally {
-    if (original === undefined) Deno.env.delete("MARKSPEC_FAKE_CLIENT_DETECT");
-    else Deno.env.set("MARKSPEC_FAKE_CLIENT_DETECT", original);
-  }
+  });
 });
 
-Deno.test("detect: MARKSPEC_FAKE_CLIENT_DETECT=claude-code does NOT force opencode", async () => {
-  const original = Deno.env.get("MARKSPEC_FAKE_CLIENT_DETECT");
-  Deno.env.set("MARKSPEC_FAKE_CLIENT_DETECT", "claude-code");
-  try {
+Deno.test("detect: MARKSPEC_FAKE_CLIENT_DETECT=claude-code does NOT force opencode (with TEST_MODE)", async () => {
+  await withFakeEnv("1", "claude-code", async () => {
     const r = await opencodeDescriptor.detect!(makeEnv());
     assertEquals(r.detected, false);
-  } finally {
-    if (original === undefined) Deno.env.delete("MARKSPEC_FAKE_CLIENT_DETECT");
-    else Deno.env.set("MARKSPEC_FAKE_CLIENT_DETECT", original);
-  }
+  });
+});
+
+Deno.test("detect: MARKSPEC_FAKE_CLIENT_DETECT without MARKSPEC_TEST_MODE is ignored", async () => {
+  // Env-bleed guard: a stray MARKSPEC_FAKE_CLIENT_DETECT in a parent
+  // shell / .env / CI environment must not trick a production run.
+  await withFakeEnv(undefined, "opencode", async () => {
+    const r = await opencodeDescriptor.detect!(makeEnv());
+    assertEquals(r.detected, false);
+    assertEquals(r.signals.includes("env-fake"), false);
+  });
 });

--- a/tests/e2e/init_test.ts
+++ b/tests/e2e/init_test.ts
@@ -76,7 +76,10 @@ Deno.test(
           "opencode",
         ],
         PERMS,
-        { MARKSPEC_FAKE_CLIENT_DETECT: "claude-code,opencode" },
+        {
+          MARKSPEC_TEST_MODE: "1",
+          MARKSPEC_FAKE_CLIENT_DETECT: "claude-code,opencode",
+        },
       );
       assertEquals(
         [0, 2].includes(code),


### PR DESCRIPTION
## Summary

Addresses 5 of 14 findings from the [code review](https://github.com/driftsys/markspec/pull/528#issuecomment-4562732929) on PR #528 (slice G1, `markspec init`). The fixes were prepared before the original PR merged, so they ship as a separate review-fix PR against `main`.

The 3 critical findings plus 2 small cleanup wins, in 5 small commits:

| # | Commit | Finding |
|---|---|---|
| 1 | `c75b5e1` | `whichCommand` returns `undefined` when `which`/`where` exits 0 with empty stdout (sandboxed CIs and PATH wrappers occasionally do this — would otherwise push a phantom `*-on-path` signal into adapter detection). Extracted `parseWhichOutput` to a pure helper + 6 unit tests. |
| 2 | `4cc3a1c` | Failed `mcpRunner` calls no longer push the action onto `executedActions` — the InitResult cannot advertise a write that the warning just said did not happen. Extended the existing failure-path test. |
| 3 | `937f8fc` | `MARKSPEC_FAKE_CLIENT_DETECT` is now gated behind `MARKSPEC_TEST_MODE=1`. Adapter unit tests add an env-bleed guard asserting the fake var alone is ignored. E2E + adapter tests updated to set both vars. (Option B from the review handoff; Option A — detector injection — left as a follow-up.) |
| 10 | `376ffcb` | `--all-clients` iterates `INIT_CLIENT_IDS` instead of hardcoding the pair. |
| 11 | `6626a0e` | Re-exported `parseProfileSpec` from `cli/init/mod.ts` and called it from `resolveProfileFromFlags`; the two regex/keyword copies are now one. |

## Deferred to follow-up

Findings 4–9 + 12–14 not addressed here:

- **#4** `MemFs.mkdir` not walking parents — test-only `fake_fs`, low blast radius
- **#5** Missing `a.kind` guard on the MCP executor branch — latent risk
- **#6** `TARGET_WHITELIST` hardcodes init's own outputs — DX papercut on re-runs after adding a scaffolder
- **#7** `runProfilePicker` maps Ctrl-D to bundled — picker is not wired to the CLI yet (see #14), so live blast radius is zero, but worth fixing before the picker ships
- **#8** Windows cmd.exe 9009 / "not recognized" misses `UPSKILL_NOT_FOUND`
- **#9** Planner hardcodes client→filename mapping
- **#13** Three `scaffold*Forced` helpers worth a `forceWrite()` collapse

Happy to file these as follow-up issues or roll some into a second PR if you prefer.

## Test plan

- [x] `just build` — green
- [x] `deno fmt --check` + `dprint check` — clean
- [x] All 8 orchestrator + 29 adapter + 15 init-e2e tests pass locally
- [x] 6 new unit tests for `parseWhichOutput` + 2 new env-bleed guard tests (one per adapter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)