### PR TITLE
fix(cli): walk parent dirs in MemFs.mkdir before adding leaf

### DIFF
--- a/packages/markspec/cli/init/fake_fs.ts
+++ b/packages/markspec/cli/init/fake_fs.ts
@@ -68,8 +68,8 @@ export function createMemFs(options: MemFsOptions = {}): MemFs {
     },
     mkdir: (path) => {
       const key = normalize(path);
+      ensureParents(key);
       dirs.add(key);
-      ensureParents(key + "/.");
       return Promise.resolve();
     },
     remove: (path) => {

--- a/packages/markspec/cli/init/fake_fs_test.ts
+++ b/packages/markspec/cli/init/fake_fs_test.ts
@@ -21,6 +21,14 @@ Deno.test("MemFs: mkdir is idempotent", async () => {
   assertEquals(await fs.exists("/a/b/c"), true);
 });
 
+Deno.test("MemFs: mkdir adds intermediate parent dirs", async () => {
+  const fs = createMemFs();
+  await fs.mkdir("/a/b/c");
+  assertEquals(await fs.exists("/a"), true);
+  assertEquals(await fs.exists("/a/b"), true);
+  assertEquals(await fs.exists("/a/b/c"), true);
+});
+
 Deno.test("MemFs: remove deletes the file", async () => {
   const fs = createMemFs();
   await fs.write("/x", "y");


### PR DESCRIPTION
## Summary

- Closes finding #4 from the [PR #528 review](https://github.com/driftsys/markspec/pull/528#issuecomment-4562732929).
- `MemFs.mkdir` (the in-memory test FS) was adding the leaf to `dirs` *before* walking parents, so `ensureParents(key + "/.")` short-circuited (its `dirname` equals `key`, which had just been added). `mkdir("/a/b/c")` left `/a` and `/a/b` missing — any `exists()` or `listEntries()` check on intermediates returned false.
- Fix: walk parents first, then add the leaf.

## Test plan

- [x] New unit test `MemFs: mkdir adds intermediate parent dirs` (fails before fix, passes after)
- [x] All 8 `fake_fs_test.ts` tests pass
- [x] All 97 init + e2e tests pass
- [x] `just build` (lint + test + typecheck + compile) green
- [x] `deno fmt --check` + `dprint check` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)