### PR TITLE
fix(cli): guard MCP executor branch on action kind

### DIFF
--- a/packages/markspec/cli/init/orchestrator.ts
+++ b/packages/markspec/cli/init/orchestrator.ts
@@ -179,6 +179,15 @@ export async function runInit(options: RunInitOptions): Promise<InitResult> {
           break;
         case ".mcp.json":
         case "opencode.json": {
+          // Defensive guard. The planner only emits `create` or `merge`
+          // for MCP files today, so this gate is a no-op against the
+          // current planner. It exists so a future planner change that
+          // emits `skip`/`no-op` for MCP files cannot silently invoke
+          // the runner — matching the gates on the other file branches.
+          if (
+            a.kind !== "create" && a.kind !== "merge" &&
+            a.kind !== "overwrite"
+          ) break;
           const client: string = a.file === "opencode.json"
             ? "opencode"
             : "claude-code";


### PR DESCRIPTION
Closes #538.

## Summary

- Closes finding #5 from the [PR #528 review](https://github.com/driftsys/markspec/pull/528#issuecomment-4562732929).
- The `.mcp.json` / `opencode.json` branch in the orchestrator's executor switch had no `a.kind` gate, unlike the other file branches that gate on `create` / `merge` / `overwrite`.
- Defensive only: the current planner emits only `create` or `merge` for MCP files, so this gate has no observable effect against today's planner. It exists so a future planner change that adds `skip` / `no-op` for MCP files cannot silently invoke the runner.

## TDD deviation note

No new test added — the handoff explicitly tagged this as "no new test needed (current behaviour preserved)". Strict TDD would require either engineering a planner state that emits `skip`/`no-op` for MCP files (the planner does not have a code path for that today) or refactoring the executor so its plan can be injected. Both are larger than the 3-line guard. All 97 existing init + e2e tests still pass.

## Test plan

- [x] All 97 init + e2e tests pass
- [x] `just build` (lint + test + typecheck + compile) green
- [x] `deno fmt --check` + `dprint check` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
