### PR TITLE
refactor(cli): init cleanup — forceWrite helper + picker TODO (#543, #544)

### DIFF
--- a/packages/markspec/cli/commands/init.ts
+++ b/packages/markspec/cli/commands/init.ts
@@ -183,7 +183,10 @@ function resolveProfileFromFlags(
   }
   if (options.profile === undefined) {
     // No --profile, no --no-profile → default bundled (non-interactive).
-    // TTY interactive picker is wired in a follow-up; v1 uses bundled default.
+    // TODO(#544): TTY interactive picker (`runProfilePicker`) is implemented
+    // in `cli/init/profile_picker.ts` but not wired here. A future slice
+    // detects `Deno.stdin.isTerminal()` and calls the picker; v1 falls
+    // back to bundled so non-TTY (CI, piped) runs do not block.
     return { kind: "bundled" };
   }
   const parsed = parseProfileSpec(options.profile);

--- a/packages/markspec/cli/init/orchestrator.ts
+++ b/packages/markspec/cli/init/orchestrator.ts
@@ -143,32 +143,40 @@ export async function runInit(options: RunInitOptions): Promise<InitResult> {
       switch (a.file) {
         case "project.yaml":
           if (a.kind === "create" || a.kind === "overwrite") {
-            await scaffoldProjectYamlForced(
+            await forceWrite(
               options.fs,
-              options.targetDir,
-              dirName,
+              join(options.targetDir, "project.yaml"),
               a.kind === "overwrite",
+              () => scaffoldProjectYaml(options.fs, options.targetDir, dirName),
             );
           }
           break;
         case ".markspec.yaml":
           if (a.kind === "create" || a.kind === "overwrite") {
-            await scaffoldMarkspecYamlForced(
+            await forceWrite(
               options.fs,
-              options.targetDir,
-              options.profileChoice,
+              join(options.targetDir, ".markspec.yaml"),
               a.kind === "overwrite",
+              () =>
+                scaffoldMarkspecYaml(
+                  options.fs,
+                  options.targetDir,
+                  options.profileChoice,
+                ),
             );
           }
           break;
         case "markspec.lock":
           if (a.kind === "create" || a.kind === "overwrite") {
-            await scaffoldMarkspecLockForced(
+            await forceWrite(
               options.fs,
-              options.targetDir,
-              minVersion,
-              options.now(),
+              join(options.targetDir, "markspec.lock"),
               a.kind === "overwrite",
+              () =>
+                scaffoldMarkspecLock(options.fs, options.targetDir, {
+                  toolchainMinVersion: minVersion,
+                  lockedAt: options.now(),
+                }),
             );
           }
           break;
@@ -290,36 +298,18 @@ function toolchainMinVersion(version: string): string {
   return m ? `${m[1]}.${m[2]}` : version;
 }
 
-async function scaffoldProjectYamlForced(
+/**
+ * Remove `path` if `overwrite` is true, then invoke the supplied
+ * scaffolder. Lets the executor handle every per-file write with one
+ * call shape — `create` (overwrite=false) goes straight to the
+ * scaffolder; `overwrite` clears the existing file first.
+ */
+async function forceWrite(
   fs: MemFs,
-  targetDir: string,
-  dirName: string,
+  path: string,
   overwrite: boolean,
+  scaffold: () => Promise<unknown>,
 ): Promise<void> {
-  if (overwrite) await fs.remove(join(targetDir, "project.yaml"));
-  await scaffoldProjectYaml(fs, targetDir, dirName);
-}
-
-async function scaffoldMarkspecYamlForced(
-  fs: MemFs,
-  targetDir: string,
-  choice: ProfileChoice,
-  overwrite: boolean,
-): Promise<void> {
-  if (overwrite) await fs.remove(join(targetDir, ".markspec.yaml"));
-  await scaffoldMarkspecYaml(fs, targetDir, choice);
-}
-
-async function scaffoldMarkspecLockForced(
-  fs: MemFs,
-  targetDir: string,
-  minVersion: string,
-  lockedAt: string,
-  overwrite: boolean,
-): Promise<void> {
-  if (overwrite) await fs.remove(join(targetDir, "markspec.lock"));
-  await scaffoldMarkspecLock(fs, targetDir, {
-    toolchainMinVersion: minVersion,
-    lockedAt,
-  });
+  if (overwrite) await fs.remove(path);
+  await scaffold();
 }

--- a/packages/markspec/cli/init/profile_picker.ts
+++ b/packages/markspec/cli/init/profile_picker.ts
@@ -7,6 +7,11 @@
  *     `--profile <spec>` flag.
  *   - {@linkcode runProfilePicker}: drives the TTY numbered menu via a
  *     {@linkcode Prompter} test seam (no direct console I/O).
+ *
+ * Note: `runProfilePicker` is implemented and unit-tested but is not
+ * yet invoked by `cli/commands/init.ts` — `resolveProfileFromFlags`
+ * falls back to the bundled default when neither `--profile` nor
+ * `--no-profile` is supplied. See issue #544 for the wiring task.
  */
 
 import type { ProfileChoice } from "./types.ts";


### PR DESCRIPTION
## Summary

Two small init cleanup wins from the PR #528 review backlog. Both are isolated to `cli/init/` with no behavioural change.

| Issue | Commit | Change |
|---|---|---|
| #543 | `f200cdb` | Collapse `scaffoldProjectYamlForced`, `scaffoldMarkspecYamlForced`, `scaffoldMarkspecLockForced` into one `forceWrite(fs, path, overwrite, scaffold)` helper. Each call site now passes a scaffold thunk; the duplicated `if (overwrite) await fs.remove(path)` shape lives in one place. |
| #544 | `40bdca0` | Upgrade the inline comment in `resolveProfileFromFlags` to a `TODO(#544)` and mirror the note in the `profile_picker.ts` module docstring so anyone reading either file sees the same paper trail. Keeps `runProfilePicker` in tree (it is tested in isolation; a future TTY slice will wire it). |

## Test plan

- [x] `just build` — green
- [x] `deno fmt --check` + `dprint check` — clean
- [x] All 8 orchestrator tests pass locally (no behavioural change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)