### PR TITLE
fix(lsp): share display-id-pattern parsing between CLI and LSP

### DIFF
--- a/packages/markspec/cli/commands/id_helpers.ts
+++ b/packages/markspec/cli/commands/id_helpers.ts
@@ -5,7 +5,12 @@
  * Extracts the copy-pasted `nextDisplayId` computation into one place.
  */
 
-import type { ProfileChain } from "../../core/mod.ts";
+import {
+  formatDisplayId,
+  highestDisplayIdNumber,
+  parseDisplayIdPattern,
+  type ProfileChain,
+} from "../../core/mod.ts";
 
 /**
  * Compute the next display ID for a given pattern and existing entries.
@@ -21,28 +26,14 @@ export function nextDisplayId(
   pattern: string,
   entries: Iterable<{ displayId: string }>,
 ): string {
-  const placeholderMatch = /\{n:(\d+)d\}/.exec(pattern);
-  if (!placeholderMatch) {
+  const shape = parseDisplayIdPattern(pattern);
+  if (!shape) {
     console.error(
       `error: display-id-pattern '${pattern}' does not contain a recognised number placeholder ('{n:Nd}')`,
     );
     Deno.exit(1);
   }
-  const width = parseInt(placeholderMatch[1], 10);
-  const prefix = pattern.slice(0, placeholderMatch.index);
-  const suffix = pattern.slice(
-    placeholderMatch.index + placeholderMatch[0].length,
-  );
-  let max = 0;
-  for (const entry of entries) {
-    const id = entry.displayId;
-    if (!id.startsWith(prefix)) continue;
-    if (suffix && !id.endsWith(suffix)) continue;
-    const numberPart = id.slice(prefix.length, id.length - suffix.length);
-    const n = parseInt(numberPart, 10);
-    if (!isNaN(n) && n > max) max = n;
-  }
-  return `${prefix}${String(max + 1).padStart(width, "0")}${suffix}`;
+  return formatDisplayId(shape, highestDisplayIdNumber(shape, entries) + 1);
 }
 
 /**

--- a/packages/markspec/core/mod.ts
+++ b/packages/markspec/core/mod.ts
@@ -144,6 +144,14 @@ export type {
 export { buildEffectiveDisciplineRegistry } from "./profile/mod.ts";
 export { inferDisciplineMode, resolveDisciplineMode } from "./profile/mod.ts";
 // DisciplineMode type already re-exported via Task 2.
+export {
+  formatDisplayId,
+  highestDisplayIdNumber,
+  padDisplayIdNumber,
+  parseDisplayIdPattern,
+} from "./profile/mod.ts";
+export type { DisplayIdPatternShape } from "./profile/mod.ts";
+
 export { buildProfileIntrospection } from "./profile/mod.ts";
 export type {
   AttributeDetail,

--- a/packages/markspec/core/profile/display_id.ts
+++ b/packages/markspec/core/profile/display_id.ts
@@ -1,0 +1,101 @@
+/**
+ * @module core/profile/display_id
+ *
+ * Shared parser for the `display-id-pattern` template used by profile
+ * type declarations. Patterns look like:
+ *
+ *   STK_{n:4d}
+ *   STK_AEB_{n:04d}
+ *   REQ-{n:03d}-draft
+ *
+ * The `{n:Nd}` placeholder (with optional leading zero in the Nd
+ * form) names the sequential number slot. The text before the
+ * placeholder becomes the literal prefix; the text after becomes the
+ * literal suffix.
+ *
+ * Note: the `{scope}` placeholder documented in the profile schema
+ * is NOT substituted here — callers handle that separately. For
+ * patterns containing `{scope}`, the literal text `{scope}` ends up
+ * in `prefix` (or `suffix`) and must be replaced upstream before the
+ * pattern is fed to scaffolding.
+ */
+
+/** Width-and-position decomposition of a display-id-pattern. */
+export interface DisplayIdPatternShape {
+  /** Literal text before the `{n:Nd}` placeholder. */
+  readonly prefix: string;
+  /** Width of the zero-padded numeric segment. */
+  readonly width: number;
+  /** Literal text after the `{n:Nd}` placeholder (often empty). */
+  readonly suffix: string;
+}
+
+/** Regex capturing the `{n:Nd}` placeholder; `0` and the digit count are both captured. */
+const PLACEHOLDER_RE = /\{n:(\d+)d\}/;
+
+/**
+ * Parse a `display-id-pattern` template. Returns `undefined` when
+ * the pattern does not contain a recognised `{n:Nd}` placeholder so
+ * callers can decide how to surface the error (CLI exits, LSP
+ * silently skips the type).
+ */
+export function parseDisplayIdPattern(
+  pattern: string,
+): DisplayIdPatternShape | undefined {
+  const match = PLACEHOLDER_RE.exec(pattern);
+  if (!match) return undefined;
+  const width = parseInt(match[1], 10);
+  if (!Number.isFinite(width) || width < 1) return undefined;
+  return {
+    prefix: pattern.slice(0, match.index),
+    width,
+    suffix: pattern.slice(match.index + match[0].length),
+  };
+}
+
+/**
+ * Pad a positive integer with leading zeros to at least `width`
+ * characters. Numbers longer than `width` are left unchanged — the
+ * pattern's width is a minimum, not a maximum, mirroring printf
+ * `%0Nd` semantics.
+ */
+export function padDisplayIdNumber(n: number, width: number): string {
+  return n.toString().padStart(width, "0");
+}
+
+/**
+ * Format a display ID from a parsed pattern and a numeric value.
+ * Inverse of the per-entry scan that {@linkcode highestDisplayIdNumber}
+ * performs.
+ */
+export function formatDisplayId(
+  shape: DisplayIdPatternShape,
+  n: number,
+): string {
+  return `${shape.prefix}${padDisplayIdNumber(n, shape.width)}${shape.suffix}`;
+}
+
+/**
+ * Scan `entries` for the highest numeric value used by any display
+ * ID that matches the given shape (same prefix AND same suffix; the
+ * numeric segment is parsed as a base-10 integer). Returns 0 when no
+ * matching ID exists, so `+ 1` yields the next sequential number.
+ */
+export function highestDisplayIdNumber(
+  shape: DisplayIdPatternShape,
+  entries: Iterable<{ displayId: string }>,
+): number {
+  let max = 0;
+  for (const entry of entries) {
+    const id = entry.displayId;
+    if (!id.startsWith(shape.prefix)) continue;
+    if (shape.suffix && !id.endsWith(shape.suffix)) continue;
+    const numberPart = id.slice(
+      shape.prefix.length,
+      id.length - shape.suffix.length,
+    );
+    const n = parseInt(numberPart, 10);
+    if (!isNaN(n) && n > max) max = n;
+  }
+  return max;
+}

--- a/packages/markspec/core/profile/display_id_test.ts
+++ b/packages/markspec/core/profile/display_id_test.ts
@@ -1,0 +1,102 @@
+/**
+ * @module core/profile/display_id_test
+ */
+
+import { assertEquals } from "@std/assert";
+import {
+  formatDisplayId,
+  highestDisplayIdNumber,
+  padDisplayIdNumber,
+  parseDisplayIdPattern,
+} from "./display_id.ts";
+
+Deno.test("parseDisplayIdPattern: simple 4-digit prefix", () => {
+  const shape = parseDisplayIdPattern("STK_{n:4d}");
+  assertEquals(shape, { prefix: "STK_", width: 4, suffix: "" });
+});
+
+Deno.test("parseDisplayIdPattern: leading-zero form is equivalent", () => {
+  const shape = parseDisplayIdPattern("STK_{n:04d}");
+  assertEquals(shape, { prefix: "STK_", width: 4, suffix: "" });
+});
+
+Deno.test("parseDisplayIdPattern: 6-digit width", () => {
+  const shape = parseDisplayIdPattern("STK_AEB_{n:6d}");
+  assertEquals(shape, { prefix: "STK_AEB_", width: 6, suffix: "" });
+});
+
+Deno.test("parseDisplayIdPattern: suffix after placeholder", () => {
+  const shape = parseDisplayIdPattern("REQ-{n:03d}-draft");
+  assertEquals(shape, { prefix: "REQ-", width: 3, suffix: "-draft" });
+});
+
+Deno.test("parseDisplayIdPattern: empty prefix", () => {
+  const shape = parseDisplayIdPattern("{n:4d}_TAIL");
+  assertEquals(shape, { prefix: "", width: 4, suffix: "_TAIL" });
+});
+
+Deno.test("parseDisplayIdPattern: malformed returns undefined", () => {
+  assertEquals(parseDisplayIdPattern("STK_NOPATTERN"), undefined);
+  assertEquals(parseDisplayIdPattern("STK_{NNNN}"), undefined);
+  assertEquals(parseDisplayIdPattern("STK_{n:0d}"), undefined); // zero width
+  assertEquals(parseDisplayIdPattern(""), undefined);
+});
+
+Deno.test("parseDisplayIdPattern: scope placeholder stays literal", () => {
+  // Schema documents {scope} but it is callers' job to substitute.
+  // The parser sees it as part of the prefix.
+  const shape = parseDisplayIdPattern("SRS_{scope}_{n:04d}");
+  assertEquals(shape, {
+    prefix: "SRS_{scope}_",
+    width: 4,
+    suffix: "",
+  });
+});
+
+Deno.test("padDisplayIdNumber: pads to minimum width", () => {
+  assertEquals(padDisplayIdNumber(1, 4), "0001");
+  assertEquals(padDisplayIdNumber(123, 4), "0123");
+  assertEquals(padDisplayIdNumber(1234, 4), "1234");
+  // Wider than the pattern: respects printf %0Nd "minimum width" semantics.
+  assertEquals(padDisplayIdNumber(12345, 4), "12345");
+});
+
+Deno.test("formatDisplayId: composes prefix + padded number + suffix", () => {
+  const shape = { prefix: "STK_", width: 4, suffix: "" };
+  assertEquals(formatDisplayId(shape, 7), "STK_0007");
+  const wide = { prefix: "STK_AEB_", width: 6, suffix: "" };
+  assertEquals(formatDisplayId(wide, 7), "STK_AEB_000007");
+  const withSuffix = { prefix: "REQ-", width: 3, suffix: "-draft" };
+  assertEquals(formatDisplayId(withSuffix, 12), "REQ-012-draft");
+});
+
+Deno.test("highestDisplayIdNumber: finds max within prefix+suffix match", () => {
+  const shape = { prefix: "STK_AEB_", width: 4, suffix: "" };
+  const entries = [
+    { displayId: "STK_AEB_0001" },
+    { displayId: "STK_AEB_0042" },
+    { displayId: "STK_AEB_0007" },
+    { displayId: "SYS_NOMATCH_0099" }, // different prefix
+    { displayId: "STK_AEB_0099_extra" }, // wrong suffix shape — but our suffix is empty, so it matches
+  ];
+  // "STK_AEB_0099_extra" → starts with STK_AEB_, suffix "" matches anything,
+  // numberPart = "0099_extra" → parseInt → 99. So 99 is the max.
+  // (The trailing junk doesn't fail parseInt; this matches CLI behavior.)
+  assertEquals(highestDisplayIdNumber(shape, entries), 99);
+});
+
+Deno.test("highestDisplayIdNumber: requires suffix match when shape has one", () => {
+  const shape = { prefix: "REQ-", width: 3, suffix: "-draft" };
+  const entries = [
+    { displayId: "REQ-001-draft" },
+    { displayId: "REQ-042-draft" },
+    { displayId: "REQ-099" }, // missing suffix
+  ];
+  assertEquals(highestDisplayIdNumber(shape, entries), 42);
+});
+
+Deno.test("highestDisplayIdNumber: returns 0 when no matching IDs", () => {
+  const shape = { prefix: "STK_", width: 4, suffix: "" };
+  const entries = [{ displayId: "SYS_0001" }];
+  assertEquals(highestDisplayIdNumber(shape, entries), 0);
+});

--- a/packages/markspec/core/profile/mod.ts
+++ b/packages/markspec/core/profile/mod.ts
@@ -49,6 +49,14 @@ export {
   resolveDisciplineMode,
 } from "./discipline_mode.ts";
 
+export {
+  formatDisplayId,
+  highestDisplayIdNumber,
+  padDisplayIdNumber,
+  parseDisplayIdPattern,
+} from "./display_id.ts";
+export type { DisplayIdPatternShape } from "./display_id.ts";
+
 export { buildProfileIntrospection } from "./introspect.ts";
 export type {
   AttributeDetail,

--- a/packages/markspec/lsp/completions.ts
+++ b/packages/markspec/lsp/completions.ts
@@ -17,6 +17,7 @@
  */
 
 import { CORE_ABSTRACT_TYPES, CORE_CONCRETE_TYPES } from "../core/model/mod.ts";
+import { formatDisplayId } from "../core/mod.ts";
 import type { DisplayIdEntry } from "./workspace.ts";
 
 /** Block scaffold trigger pattern: `- [` at the start of a list item. */
@@ -128,6 +129,15 @@ const KIND_PROPERTY = 10;
 export interface EntryTypeInfo {
   readonly name: string;
   readonly prefix: string;
+  /**
+   * Width of the zero-padded numeric segment from the profile's
+   * `display-id-pattern`. Patterns declared as `{n:6d}` produce
+   * 6-character IDs (`STK_000007`); a hardcoded 4-digit pad would
+   * silently violate the pattern and fail validation.
+   */
+  readonly width: number;
+  /** Literal text after the `{n:Nd}` placeholder (often empty). */
+  readonly suffix: string;
   readonly nextNumber: number;
   /**
    * `true` when this type is the recommended scaffold for the active
@@ -136,11 +146,6 @@ export interface EntryTypeInfo {
    * `detail` field. `undefined` or `false` → no special treatment.
    */
   readonly modeRecommended?: boolean;
-}
-
-/** Pad a number with leading zeros to at least 4 digits. */
-function padNumber(n: number): string {
-  return n.toString().padStart(4, "0");
 }
 
 /**
@@ -218,6 +223,8 @@ export function buildTrailerKeyItems(): CompletionItemData[] {
 export interface ScaffoldSnippetInput {
   readonly typeName: string;
   readonly prefix: string;
+  readonly width: number;
+  readonly suffix: string;
   readonly nextNumber: number;
   readonly ulid: string;
 }
@@ -242,6 +249,8 @@ export interface ScaffoldCompletionData {
   readonly kind: typeof SCAFFOLD_COMPLETION_KIND;
   readonly typeName: string;
   readonly prefix: string;
+  readonly width: number;
+  readonly suffix: string;
 }
 
 /**
@@ -267,9 +276,17 @@ function escapeSnippet(s: string): string {
 export function renderScaffoldSnippet(
   input: ScaffoldSnippetInput,
 ): { label: string; insertText: string } {
-  const safePrefix = escapeSnippet(input.prefix);
   const safeTypeName = escapeSnippet(input.typeName);
-  const displayId = `${safePrefix}${padNumber(input.nextNumber)}`;
+  // Format the display ID via the shared `formatDisplayId` so width
+  // + suffix come straight from the profile's pattern, then escape
+  // the result for snippet syntax. Escaping AFTER formatting is
+  // safe because formatDisplayId only concatenates the pieces.
+  const displayId = escapeSnippet(
+    formatDisplayId(
+      { prefix: input.prefix, width: input.width, suffix: input.suffix },
+      input.nextNumber,
+    ),
+  );
   return {
     label: `New ${safeTypeName} (${displayId})`,
     insertText:
@@ -336,6 +353,8 @@ export function buildBlockScaffoldItems(
     const rendered = renderScaffoldSnippet({
       typeName: type.name,
       prefix: type.prefix,
+      width: type.width,
+      suffix: type.suffix,
       nextNumber: type.nextNumber,
       ulid: ulidProvider(),
     });

--- a/packages/markspec/lsp/completions_test.ts
+++ b/packages/markspec/lsp/completions_test.ts
@@ -93,8 +93,20 @@ Deno.test("buildBlockScaffoldItems: returns generic item when no types", () => {
 
 Deno.test("buildBlockScaffoldItems: returns one item per type", () => {
   const types = [
-    { name: "stakeholder-requirement", prefix: "STK_AEB_", nextNumber: 4 },
-    { name: "architecture", prefix: "SAD_AEB_", nextNumber: 2 },
+    {
+      name: "stakeholder-requirement",
+      prefix: "STK_AEB_",
+      width: 4,
+      suffix: "",
+      nextNumber: 4,
+    },
+    {
+      name: "architecture",
+      prefix: "SAD_AEB_",
+      width: 4,
+      suffix: "",
+      nextNumber: 2,
+    },
   ];
   const items = buildBlockScaffoldItems(
     types,
@@ -107,7 +119,13 @@ Deno.test("buildBlockScaffoldItems: returns one item per type", () => {
 
 Deno.test("buildBlockScaffoldItems: bakes provided ULID into snippet", () => {
   const items = buildBlockScaffoldItems(
-    [{ name: "stakeholder-requirement", prefix: "STK_AEB_", nextNumber: 1 }],
+    [{
+      name: "stakeholder-requirement",
+      prefix: "STK_AEB_",
+      width: 4,
+      suffix: "",
+      nextNumber: 1,
+    }],
     () => "01HGW2Q8MNP3RSTVWXYZABCDEF",
   );
   assertEquals(items.length, 1);
@@ -122,8 +140,20 @@ Deno.test("buildBlockScaffoldItems: calls provider once per item", () => {
   const provider = () =>
     `01HGW2Q8MNP3RSTVWXYZ${(counter++).toString().padStart(6, "0")}`;
   const types = [
-    { name: "stakeholder-requirement", prefix: "STK_", nextNumber: 1 },
-    { name: "architecture", prefix: "SAD_", nextNumber: 1 },
+    {
+      name: "stakeholder-requirement",
+      prefix: "STK_",
+      width: 4,
+      suffix: "",
+      nextNumber: 1,
+    },
+    {
+      name: "architecture",
+      prefix: "SAD_",
+      width: 4,
+      suffix: "",
+      nextNumber: 1,
+    },
   ];
   const items = buildBlockScaffoldItems(types, provider);
   assertEquals(items.length, 2);
@@ -187,6 +217,8 @@ Deno.test("renderScaffoldSnippet: formats display ID and ULID", () => {
   const snippet = renderScaffoldSnippet({
     typeName: "stakeholder-requirement",
     prefix: "STK_AEB_",
+    width: 4,
+    suffix: "",
     nextNumber: 42,
     ulid: "01HGW2Q8MNP3RSTVWXYZABCDEF",
   });
@@ -208,6 +240,8 @@ Deno.test("renderScaffoldSnippet: escapes $ in profile-provided prefix and typeN
   const snippet = renderScaffoldSnippet({
     typeName: "type-with-$",
     prefix: "STK_$_",
+    width: 4,
+    suffix: "",
     nextNumber: 1,
     ulid: "01HGW2Q8MNP3RSTVWXYZABCDEF",
   });
@@ -215,6 +249,37 @@ Deno.test("renderScaffoldSnippet: escapes $ in profile-provided prefix and typeN
   // does not interpret them as tab stops.
   assertEquals(snippet.insertText.includes("STK_\\$_0001"), true);
   assertEquals(snippet.label.includes("type-with-\\$"), true);
+});
+
+Deno.test("renderScaffoldSnippet: 6-digit profile pattern produces 6-digit ID", () => {
+  // Regression test: profiles declared with `{n:6d}` previously
+  // produced 4-digit IDs from the LSP scaffold completion because
+  // the LSP hardcoded `padStart(4, "0")`. The resulting ID failed
+  // validation against the pattern. Plumbing width through the
+  // shared formatDisplayId fixes this.
+  const snippet = renderScaffoldSnippet({
+    typeName: "stakeholder-requirement",
+    prefix: "STK_",
+    width: 6,
+    suffix: "",
+    nextNumber: 7,
+    ulid: "01HGW2Q8MNP3RSTVWXYZABCDEF",
+  });
+  assertEquals(snippet.label, "New stakeholder-requirement (STK_000007)");
+  assertEquals(snippet.insertText.startsWith("STK_000007]"), true);
+});
+
+Deno.test("renderScaffoldSnippet: pattern suffix is preserved in the ID", () => {
+  const snippet = renderScaffoldSnippet({
+    typeName: "draft-requirement",
+    prefix: "REQ-",
+    width: 3,
+    suffix: "-draft",
+    nextNumber: 12,
+    ulid: "01HGW2Q8MNP3RSTVWXYZABCDEF",
+  });
+  assertEquals(snippet.label, "New draft-requirement (REQ-012-draft)");
+  assertEquals(snippet.insertText.startsWith("REQ-012-draft]"), true);
 });
 
 // --- Trailer key trigger ---
@@ -286,10 +351,38 @@ Deno.test("buildTrailerKeyItems: each label matches a TRAILER_KEYS entry", () =>
 
 Deno.test("Slice 5 LSP: buildBlockScaffoldItems sorts modeRecommended items first", () => {
   const types = [
-    { name: "Aaa", prefix: "AAA_", nextNumber: 1, modeRecommended: false },
-    { name: "Bbb", prefix: "BBB_", nextNumber: 1, modeRecommended: true },
-    { name: "Ccc", prefix: "CCC_", nextNumber: 1, modeRecommended: true },
-    { name: "Ddd", prefix: "DDD_", nextNumber: 1, modeRecommended: false },
+    {
+      name: "Aaa",
+      prefix: "AAA_",
+      width: 4,
+      suffix: "",
+      nextNumber: 1,
+      modeRecommended: false,
+    },
+    {
+      name: "Bbb",
+      prefix: "BBB_",
+      width: 4,
+      suffix: "",
+      nextNumber: 1,
+      modeRecommended: true,
+    },
+    {
+      name: "Ccc",
+      prefix: "CCC_",
+      width: 4,
+      suffix: "",
+      nextNumber: 1,
+      modeRecommended: true,
+    },
+    {
+      name: "Ddd",
+      prefix: "DDD_",
+      width: 4,
+      suffix: "",
+      nextNumber: 1,
+      modeRecommended: false,
+    },
   ];
   const items = buildBlockScaffoldItems(
     types,
@@ -304,8 +397,8 @@ Deno.test("Slice 5 LSP: buildBlockScaffoldItems sorts modeRecommended items firs
 
 Deno.test("Slice 5 LSP: buildBlockScaffoldItems leaves order unchanged when modeRecommended is absent", () => {
   const types = [
-    { name: "Aaa", prefix: "AAA_", nextNumber: 1 },
-    { name: "Bbb", prefix: "BBB_", nextNumber: 1 },
+    { name: "Aaa", prefix: "AAA_", width: 4, suffix: "", nextNumber: 1 },
+    { name: "Bbb", prefix: "BBB_", width: 4, suffix: "", nextNumber: 1 },
   ];
   const items = buildBlockScaffoldItems(
     types,
@@ -318,8 +411,22 @@ Deno.test("Slice 5 LSP: buildBlockScaffoldItems leaves order unchanged when mode
 
 Deno.test("Slice 5 LSP: '(recommended)' suffix appears only on modeRecommended items", () => {
   const types = [
-    { name: "Yes", prefix: "YES_", nextNumber: 1, modeRecommended: true },
-    { name: "No", prefix: "NO_", nextNumber: 1, modeRecommended: false },
+    {
+      name: "Yes",
+      prefix: "YES_",
+      width: 4,
+      suffix: "",
+      nextNumber: 1,
+      modeRecommended: true,
+    },
+    {
+      name: "No",
+      prefix: "NO_",
+      width: 4,
+      suffix: "",
+      nextNumber: 1,
+      modeRecommended: false,
+    },
   ];
   const items = buildBlockScaffoldItems(
     types,

--- a/packages/markspec/lsp/server.ts
+++ b/packages/markspec/lsp/server.ts
@@ -44,6 +44,7 @@ import {
   loadProfileForCommand,
   type Lockfile,
   makeDisplayId,
+  parseDisplayIdPattern,
   parseLockfile,
   type ProjectConfig,
   VERSION,
@@ -284,12 +285,13 @@ function getEntryTypes(): EntryTypeInfo[] {
   for (const [name, typeDef] of profile.types) {
     const pattern = typeDef.value.displayIdPattern.value;
     if (!pattern) continue;
-    // Extract the fixed prefix before the numeric placeholder.
-    // Patterns look like "STK_AEB_{NNNN}" or "STK_{NNNN}".
-    const placeholderIndex = pattern.indexOf("{");
-    if (placeholderIndex < 0) continue;
-    const prefix = pattern.slice(0, placeholderIndex);
-    const nextNumber = index.getNextDisplayIdNumber(prefix);
+    // Parse the `{n:Nd}` placeholder. Width and suffix flow through
+    // the snippet so profiles using non-4-digit IDs (`{n:6d}`) or
+    // a trailing literal don't produce mis-formatted scaffolds.
+    const shape = parseDisplayIdPattern(pattern);
+    if (!shape) continue;
+    const { prefix, width, suffix } = shape;
+    const nextNumber = index.getNextDisplayIdNumber(prefix, suffix);
 
     // ADR-017 Slice 5: mark mode-relevant types as recommended.
     const isRequirementShaped = extendsTransitively(
@@ -302,7 +304,7 @@ function getEntryTypes(): EntryTypeInfo[] {
       (mode === "flat" && isRequirementShaped && !hasDiscipline) ||
       (mode === "none" && isRequirementShaped);
 
-    types.push({ name, prefix, nextNumber, modeRecommended });
+    types.push({ name, prefix, width, suffix, nextNumber, modeRecommended });
   }
   return types;
 }
@@ -706,6 +708,8 @@ connection.onCompletion((params): CompletionItem[] => {
               kind: SCAFFOLD_COMPLETION_KIND,
               typeName: type.name,
               prefix: type.prefix,
+              width: type.width,
+              suffix: type.suffix,
             } satisfies ScaffoldCompletionData
             : undefined,
         };
@@ -779,14 +783,19 @@ connection.onCompletionResolve((item): CompletionItem => {
   // buggy LSP client. The typed cast above does not validate at runtime.
   if (
     typeof data.prefix !== "string" || data.prefix.length > 64 ||
-    typeof data.typeName !== "string" || data.typeName.length > 128
+    typeof data.typeName !== "string" || data.typeName.length > 128 ||
+    typeof data.suffix !== "string" || data.suffix.length > 64 ||
+    typeof data.width !== "number" || !Number.isInteger(data.width) ||
+    data.width < 1 || data.width > 32
   ) {
     return item;
   }
-  const nextNumber = index.getNextDisplayIdNumber(data.prefix);
+  const nextNumber = index.getNextDisplayIdNumber(data.prefix, data.suffix);
   const rendered = renderScaffoldSnippet({
     typeName: data.typeName,
     prefix: data.prefix,
+    width: data.width,
+    suffix: data.suffix,
     nextNumber,
     ulid: ulid(),
   });

--- a/packages/markspec/lsp/workspace.ts
+++ b/packages/markspec/lsp/workspace.ts
@@ -162,25 +162,25 @@ export class WorkspaceIndex {
   }
 
   /**
-   * Compute the next sequential number for a display-ID prefix.
+   * Compute the next sequential number for a display-ID pattern,
+   * filtering by `prefix` and (when present) `suffix`. Scans all
+   * display IDs matching both, extracts the numeric segment between
+   * them, and returns max + 1. Returns 1 when no matching ID exists.
    *
-   * Scans all display IDs that start with `prefix`, extracts the trailing
-   * numeric segment, and returns max + 1. Returns 1 if no matching IDs
-   * exist.
-   *
-   * @param prefix - The prefix including the trailing separator,
+   * @param prefix - Literal text before the numeric placeholder,
    *   e.g., `"STK_AEB_"` for IDs like `STK_AEB_0001`.
+   * @param suffix - Optional literal text after the numeric
+   *   placeholder, e.g., `"-draft"` for IDs like `REQ-012-draft`.
+   *   Defaults to empty.
    */
-  getNextDisplayIdNumber(prefix: string): number {
+  getNextDisplayIdNumber(prefix: string, suffix = ""): number {
     let max = 0;
     for (const id of this.byDisplayId.keys()) {
-      if (id.startsWith(prefix)) {
-        const suffix = id.slice(prefix.length);
-        const num = parseInt(suffix, 10);
-        if (!isNaN(num) && num > max) {
-          max = num;
-        }
-      }
+      if (!id.startsWith(prefix)) continue;
+      if (suffix && !id.endsWith(suffix)) continue;
+      const numberPart = id.slice(prefix.length, id.length - suffix.length);
+      const num = parseInt(numberPart, 10);
+      if (!isNaN(num) && num > max) max = num;
     }
     return max + 1;
   }


### PR DESCRIPTION
## Summary

First of the editing-experience devex fixes (#1 of the 5-item list from the post-event-log review). The LSP scaffold completion silently produced wrong-width display IDs for any profile that didn't use the default 4-digit pattern.

## Bug

The LSP at `server.ts:289` extracted everything before the first `{` as the prefix and ignored the rest of the pattern. `completions.ts:142` then hardcoded `padStart(4, "0")`. Consequences:

- A profile with `{n:6d}` produced IDs like `STK_0007` instead of `STK_000007` → fails MSL validation against the declared pattern.
- A pattern with a suffix like `REQ-{n:03d}-draft` lost the `-draft` suffix entirely → produces `REQ-012` instead of `REQ-012-draft`.

The CLI's `nextDisplayId` in `cli/commands/id_helpers.ts` already handled both correctly, so `markspec next-id` and `markspec insert` produced valid IDs while the editor produced invalid ones.

## Fix

Extract a shared pattern parser to `core/profile/display_id.ts`:

```ts
parseDisplayIdPattern(pattern): { prefix, width, suffix } | undefined
formatDisplayId(shape, n): string
highestDisplayIdNumber(shape, entries): number
padDisplayIdNumber(n, width): string
```

The CLI's `nextDisplayId` now delegates to these. Behavior unchanged for the CLI.

The LSP plumbs `width` and `suffix` through:

- `EntryTypeInfo` gains `width` + `suffix` fields
- `ScaffoldSnippetInput` and `ScaffoldCompletionData` carry them so the resolve-time path re-renders with the freshest values
- `renderScaffoldSnippet` uses `formatDisplayId` — the LSP and CLI now produce identical IDs from the same pattern
- `workspace.getNextDisplayIdNumber(prefix, suffix?)` filters by both
- The resolve handler validates the new payload fields (width is an integer in `[1, 32]`, suffix is a bounded string) before honoring them

## Test plan

- [x] `deno fmt --check` — clean
- [x] `deno lint` — clean
- [x] `deno test` — 2911 passed, 0 failed
- [x] 12 new unit tests in `display_id_test.ts` cover parser, padder, formatter, scanner
- [x] 2 new regression tests in `completions_test.ts`:
  - `6-digit profile pattern produces 6-digit ID` (the bug fix)
  - `pattern suffix is preserved in the ID`
- [x] 15 existing `EntryTypeInfo` fixtures updated to include `width: 4, suffix: ""`

## Devex backlog (for follow-up PRs)

This is the **correctness** fix from the 5-item editing-experience list. Remaining items, in recommended order:

2. Type-aware filtering on trace-attribute completion — when authoring SRS, suggest only relation-target IDs, not all 5000 workspace IDs (biggest UX win)
3. Server-side prefix filter on `Satisfies: SYS_…` — server-side narrowing reduces JSON-RPC payload at scale (perf, only matters at scale)
4. Auto-complete next sequential number for mid-typed `[STK_AEB_…`
5. Race window: two rapid completion accepts within the 50 ms debounce produce duplicate display IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
