### PR TITLE
refactor(cli): derive init's TARGET_NOT_EMPTY whitelist from plan outputs

### DIFF
--- a/packages/markspec/cli/init/orchestrator.ts
+++ b/packages/markspec/cli/init/orchestrator.ts
@@ -72,32 +72,6 @@ const SKILLS_BUNDLE_SOURCE =
   "driftsys/markspec:skills/markspec-core.bundle.yaml";
 
 export async function runInit(options: RunInitOptions): Promise<InitResult> {
-  // Spec §3 step 1: refuse non-empty target without --force.
-  if (!options.force) {
-    const entries = await options.fs.listEntries(options.targetDir);
-    const unexpected = entries.filter((name) => !isWhitelistedEntry(name));
-    if (unexpected.length > 0) {
-      return {
-        ok: false,
-        exitCode: 1,
-        target: options.targetDir,
-        profile: options.profileChoice,
-        clientsWritten: [],
-        actions: [],
-        warnings: [],
-        skills: { installed: false, attempted: false },
-        error: {
-          code: "TARGET_NOT_EMPTY",
-          message:
-            `target directory not empty: ${options.targetDir} (unexpected: ${
-              unexpected.join(", ")
-            })`,
-          details: { unexpectedEntries: unexpected },
-        },
-      };
-    }
-  }
-
   // Step 1+2: resolve client set and binary ref in parallel.
   const [clientSet, binaryRef] = await Promise.all([
     resolveClientSet({
@@ -120,6 +94,42 @@ export async function runInit(options: RunInitOptions): Promise<InitResult> {
     clientSet,
     force: options.force,
   });
+
+  // Spec §3 step 1: refuse non-empty target without --force.
+  // Whitelist = pre-existing project files (static) ∪ top-level
+  // entries the planner intends to write this run (dynamic).
+  // Deriving the dynamic half from `plan.actions` means a future
+  // scaffolder output is recognised automatically — no manual
+  // sync of the static set required.
+  if (!options.force) {
+    const planOutputs = new Set(
+      plan.actions.map((a) => a.file.split("/")[0]),
+    );
+    const entries = await options.fs.listEntries(options.targetDir);
+    const unexpected = entries.filter(
+      (name) => !isWhitelistedEntry(name, planOutputs),
+    );
+    if (unexpected.length > 0) {
+      return {
+        ok: false,
+        exitCode: 1,
+        target: options.targetDir,
+        profile: options.profileChoice,
+        clientsWritten: [],
+        actions: [],
+        warnings: [],
+        skills: { installed: false, attempted: false },
+        error: {
+          code: "TARGET_NOT_EMPTY",
+          message:
+            `target directory not empty: ${options.targetDir} (unexpected: ${
+              unexpected.join(", ")
+            })`,
+          details: { unexpectedEntries: unexpected },
+        },
+      };
+    }
+  }
 
   const warnings: Warning[] = [];
   if (binaryRef.warning) {
@@ -257,29 +267,27 @@ export async function runInit(options: RunInitOptions): Promise<InitResult> {
 }
 
 /**
- * Entries that init tolerates in an otherwise-empty target directory.
- * The seed list comes from spec §3 step 1. Conservative — add to it
- * if e2e fixtures uncover common cases that should not block init.
+ * Common pre-existing project files that should not block init.
+ *
+ * Init's own scaffolder outputs are NOT listed here — they are derived
+ * per-run from the planner's actions in `runInit`, so adding a new
+ * scaffolder requires no manual sync with this set.
  */
 const TARGET_WHITELIST = new Set([
-  // Common pre-existing project files that should not block init.
   ".git",
   ".gitignore",
   "README.md",
   "LICENSE",
   ".editorconfig",
   ".vscode",
-  // Init's own scaffolder outputs — allow re-runs without --force
-  // to fall through to per-file skip/merge logic.
-  "project.yaml",
-  ".markspec.yaml",
-  "markspec.lock",
-  ".mcp.json",
-  "opencode.json",
 ]);
 
-function isWhitelistedEntry(name: string): boolean {
+function isWhitelistedEntry(
+  name: string,
+  planOutputs: ReadonlySet<string>,
+): boolean {
   if (TARGET_WHITELIST.has(name)) return true;
+  if (planOutputs.has(name)) return true;
   if (name.startsWith("LICENSE.")) return true;
   return false;
 }

--- a/packages/markspec/cli/init/orchestrator_test.ts
+++ b/packages/markspec/cli/init/orchestrator_test.ts
@@ -206,6 +206,37 @@ Deno.test("runInit: non-whitelisted content (src/) → TARGET_NOT_EMPTY error + 
   assertEquals(result.error?.code, "TARGET_NOT_EMPTY");
 });
 
+Deno.test("runInit: plan outputs are dynamically whitelisted for TARGET_NOT_EMPTY", async () => {
+  // The static TARGET_WHITELIST covers only pre-existing project
+  // files. Multiple init outputs in the target should still pass
+  // the empty-check via the per-run plan-derived whitelist —
+  // regression test for finding #6.
+  const fs = createMemFs();
+  await fs.write("/repo/project.yaml", "user content");
+  await fs.write("/repo/markspec.lock", "older lock");
+  await fs.write("/repo/.markspec.yaml", "older profile config");
+  const result = await runInit({
+    targetDir: "/repo",
+    profileChoice: { kind: "bundled" },
+    forcedClients: [],
+    allClients: false,
+    noMcp: false,
+    noSkills: true,
+    binaryPathFlag: undefined,
+    force: false,
+    dryRun: false,
+    fs,
+    detectEnv: noClientEnv,
+    binaryEnv: noClientEnv,
+    mcpRunner: okMcpRunner,
+    execRunner: okExec,
+    now: fakeNow,
+    version: "0.6.0",
+  });
+  assertEquals(result.ok, true);
+  assertEquals(result.error, undefined);
+});
+
 Deno.test("runInit: existing project.yaml only → skip + exit 2 (whitelisted output)", async () => {
   const fs = createMemFs();
   await fs.write("/repo/project.yaml", "user content");


### PR DESCRIPTION
Closes #539.

## Summary

- Closes finding #6 from the [PR #528 review](https://github.com/driftsys/markspec/pull/528#issuecomment-4562732929).
- Previously, the static `TARGET_WHITELIST` hardcoded init's own scaffolder outputs (`project.yaml`, `.markspec.yaml`, `markspec.lock`, `.mcp.json`, `opencode.json`) alongside pre-existing project files. Adding a new scaffolder output would silently break `init` re-runs with `TARGET_NOT_EMPTY` until someone remembered to update the set.
- Refactored to compute the plan **before** the empty-check, derive a per-run whitelist from `plan.actions` (top-level entries, so `.vscode/extensions.json` collapses to `.vscode`), and combine it with the static set in `isWhitelistedEntry`. The static set now only carries pre-existing project files.

## Test plan

- [x] New unit test `runInit: plan outputs are dynamically whitelisted for TARGET_NOT_EMPTY` covers the dynamic contract with multiple init outputs pre-seeded in the target
- [x] All 98 init + e2e tests pass (97 prior + 1 new)
- [x] `just build` (lint + test + typecheck + compile) green
- [x] `deno fmt --check` + `dprint check` green

## Behaviour notes

The new check happens **after** plan computation rather than before, so `runInit` does a little more work before refusing a non-empty target without `--force`. The extra work is two small pure resolutions (`resolveClientSet`, `resolveBinaryRef`) plus the planner's existence probes — all cheap and side-effect-free.

One subtle semantic change: if a previous run wrote a client-specific file (e.g. `opencode.json`) and a later non-`--force` run resolves a different client set that does not include that client, the plan no longer emits an action for that file and the static set no longer covers it — so `TARGET_NOT_EMPTY` will fire on the stale file. This is the intended behaviour per the review handoff (the user is expected to either pass `--force` or clean up the stale output).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
