### PR TITLE
fix(lsp): register openDefinition and openReferences in VS Code extension

### DIFF
--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "markspec-ide",
-  "version": "0.5.2",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "markspec-ide",
-      "version": "0.5.2",
+      "version": "0.6.1",
       "license": "Apache-2.0",
       "dependencies": {
         "vscode-languageclient": "^9.0.1"

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -284,7 +284,7 @@
     "bundle": "deno run --config ../../deno.json --allow-read --allow-write scripts/bundleBinary.ts",
     "package": "npm run bundle && vsce package",
     "lint": "eslint src",
-    "test": "tsc -p tsconfig.json && node --require ./out/test-setup.js --test out/serverOptions.test.js out/mcpDefinition.test.js out/inlineCompletions.test.js"
+    "test": "tsc -p tsconfig.json && node --require ./out/test-setup.js --test out/serverOptions.test.js out/mcpDefinition.test.js out/inlineCompletions.test.js out/codeLensCommands.test.js"
   },
   "dependencies": {
     "vscode-languageclient": "^9.0.1"

--- a/editors/vscode/src/codeLensCommands.test.ts
+++ b/editors/vscode/src/codeLensCommands.test.ts
@@ -1,0 +1,91 @@
+import { test } from "node:test";
+import { strict as assert } from "node:assert";
+import { parseCodeLensTarget } from "./codeLensCommands";
+
+test("parseCodeLensTarget: well-formed [uri, position] → open", () => {
+  const result = parseCodeLensTarget([
+    "file:///foo/bar.md",
+    { line: 12, character: 0 },
+  ]);
+  assert.deepEqual(result, {
+    kind: "open",
+    uri: "file:///foo/bar.md",
+    line: 12,
+    character: 0,
+  });
+});
+
+test("parseCodeLensTarget: empty args → missing (unresolved Satisfies case)", () => {
+  // The LSP emits `arguments: []` for `↓ Satisfies: <ID>` lenses whose
+  // target isn't in the indexed workspace — see
+  // `packages/markspec/lsp/code_lens.ts:114`.
+  assert.deepEqual(parseCodeLensTarget([]), { kind: "missing" });
+});
+
+test("parseCodeLensTarget: missing position → missing", () => {
+  assert.deepEqual(
+    parseCodeLensTarget(["file:///foo/bar.md"]),
+    { kind: "missing" },
+  );
+});
+
+test("parseCodeLensTarget: non-string uri → missing", () => {
+  assert.deepEqual(
+    parseCodeLensTarget([42, { line: 0, character: 0 }]),
+    { kind: "missing" },
+  );
+});
+
+test("parseCodeLensTarget: empty-string uri → missing", () => {
+  assert.deepEqual(
+    parseCodeLensTarget(["", { line: 0, character: 0 }]),
+    { kind: "missing" },
+  );
+});
+
+test("parseCodeLensTarget: null position → missing", () => {
+  assert.deepEqual(
+    parseCodeLensTarget(["file:///foo/bar.md", null]),
+    { kind: "missing" },
+  );
+});
+
+test("parseCodeLensTarget: missing line field → missing", () => {
+  assert.deepEqual(
+    parseCodeLensTarget(["file:///foo/bar.md", { character: 0 }]),
+    { kind: "missing" },
+  );
+});
+
+test("parseCodeLensTarget: negative line → missing", () => {
+  assert.deepEqual(
+    parseCodeLensTarget(["file:///foo/bar.md", { line: -1, character: 0 }]),
+    { kind: "missing" },
+  );
+});
+
+test("parseCodeLensTarget: NaN character → missing", () => {
+  assert.deepEqual(
+    parseCodeLensTarget([
+      "file:///foo/bar.md",
+      { line: 0, character: Number.NaN },
+    ]),
+    { kind: "missing" },
+  );
+});
+
+test("parseCodeLensTarget: extra trailing args are tolerated", () => {
+  // VS Code may dispatch with additional positional arguments in
+  // future protocol revisions; the parser only cares about [0] + [1].
+  const result = parseCodeLensTarget([
+    "file:///foo/bar.md",
+    { line: 5, character: 2 },
+    "ignored",
+  ]);
+  assert.deepEqual(result, {
+    kind: "open",
+    uri: "file:///foo/bar.md",
+    line: 5,
+    character: 2,
+  });
+});

--- a/editors/vscode/src/codeLensCommands.ts
+++ b/editors/vscode/src/codeLensCommands.ts
@@ -1,0 +1,57 @@
+/**
+ * @module codeLensCommands
+ *
+ * Pure helpers for the two CodeLens commands the MarkSpec LSP emits
+ * in `packages/markspec/lsp/code_lens.ts`:
+ *
+ *   - `markspec.openDefinition` — clicking the "↓ Satisfies: ID — Title"
+ *     lens. Arguments are `[uri, { line, character }]` when the target
+ *     resolves, or `[]` when it doesn't (the LSP still emits the lens so
+ *     the author can see the unresolved reference).
+ *   - `markspec.openReferences` — clicking the "↑ N dependents" lens.
+ *     Arguments are always `[uri, { line, character }]`.
+ *
+ * The parser below validates the rehydrated payload (VS Code reconstitutes
+ * `arguments` as plain objects across the LSP boundary, not as `Position`
+ * instances) and returns a discriminated union the extension dispatches on.
+ * Defended against malformed payloads from a buggy / hostile LSP build —
+ * the handler should surface an info message rather than throw.
+ */
+
+/** Discriminated result of {@linkcode parseCodeLensTarget}. */
+export type CodeLensTarget =
+  | {
+    readonly kind: "open";
+    readonly uri: string;
+    readonly line: number;
+    readonly character: number;
+  }
+  | { readonly kind: "missing" };
+
+/**
+ * Parse a CodeLens command's `arguments` payload.
+ *
+ * Returns `{ kind: "missing" }` for the unresolved-Satisfies case
+ * (empty argument list) and for any malformed shape (wrong arity,
+ * non-string URI, non-numeric position fields, NaN, …). Returns
+ * `{ kind: "open", … }` only when both the URI and the position
+ * pass shape validation.
+ */
+export function parseCodeLensTarget(args: readonly unknown[]): CodeLensTarget {
+  if (args.length === 0) return { kind: "missing" };
+  if (args.length < 2) return { kind: "missing" };
+  const uri = args[0];
+  const pos = args[1];
+  if (typeof uri !== "string" || uri.length === 0) return { kind: "missing" };
+  if (pos === null || typeof pos !== "object") return { kind: "missing" };
+  const line = (pos as { line?: unknown }).line;
+  const character = (pos as { character?: unknown }).character;
+  if (
+    typeof line !== "number" || !Number.isFinite(line) || line < 0 ||
+    typeof character !== "number" || !Number.isFinite(character) ||
+    character < 0
+  ) {
+    return { kind: "missing" };
+  }
+  return { kind: "open", uri, line, character };
+}

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -19,11 +19,15 @@ import {
   lm,
   McpStdioServerDefinition,
   type OutputChannel,
+  Position,
+  Range,
+  Selection,
   type TextDocument,
   Uri,
   window,
   workspace,
 } from "vscode";
+import { parseCodeLensTarget } from "./codeLensCommands";
 import process from "node:process";
 import {
   LanguageClient,
@@ -149,6 +153,43 @@ export function activate(context: ExtensionContext): void {
     commands.registerCommand("markspec.showOutput", () => {
       outputChannel?.show();
     }),
+    // CodeLens command handlers — the LSP emits these from
+    // `packages/markspec/lsp/code_lens.ts`. The "↓ Satisfies: ID — Title"
+    // lens dispatches `markspec.openDefinition`; the "↑ N dependents"
+    // lens dispatches `markspec.openReferences`. VS Code rehydrates the
+    // LSP `Position` payload as a plain `{ line, character }` object,
+    // so we validate the shape via `parseCodeLensTarget` before
+    // calling into the editor API.
+    commands.registerCommand(
+      "markspec.openDefinition",
+      async (...args: unknown[]) => {
+        const target = parseCodeLensTarget(args);
+        if (target.kind === "missing") {
+          window.showInformationMessage(
+            "MarkSpec: Satisfies target not found in workspace",
+          );
+          return;
+        }
+        const doc = await workspace.openTextDocument(Uri.parse(target.uri));
+        const pos = new Position(target.line, target.character);
+        await window.showTextDocument(doc, {
+          selection: new Selection(pos, pos),
+        });
+      },
+    ),
+    commands.registerCommand(
+      "markspec.openReferences",
+      async (...args: unknown[]) => {
+        const target = parseCodeLensTarget(args);
+        if (target.kind === "missing") return;
+        await commands.executeCommand(
+          "editor.action.showReferences",
+          Uri.parse(target.uri),
+          new Position(target.line, target.character),
+          [],
+        );
+      },
+    ),
   );
 
   client.start();


### PR DESCRIPTION
Closes #547.

## Summary

- Register `markspec.openDefinition` and `markspec.openReferences` command handlers in the VS Code extension so the LSP-emitted CodeLenses (`↓ Satisfies: ID — Title` and `↑ N dependents`) become clickable. Previously surfaced a "command not found" toast.
- `openDefinition` opens the target file and moves the selection to the entry's title position. The unresolved-Satisfies case (LSP emits `arguments: []`) surfaces an informational message instead of opening nothing.
- `openReferences` dispatches `editor.action.showReferences` at the entry's position so the references peek lists every entry that traces back to it.
- A new pure `parseCodeLensTarget` helper validates the rehydrated argument shape before either handler touches the editor API — defends against malformed payloads from a buggy LSP build.

## Test plan

- [x] `npm test` in `editors/vscode/` — 49 / 49 pass (10 new `parseCodeLensTarget` cases covering well-formed, empty-args, missing position, non-string URI, null position, missing line, negative line, NaN, and trailing-arg shapes).
- [x] `just build` — green (lint + test + type-check + compile).
- [x] `deno fmt --check` + `dprint check` — clean.
- [ ] Manual smoke in VS Code: open a workspace with two entries linked by `Satisfies:`, click the `↓ Satisfies:` lens, confirm the editor opens the target file at the entry's title; click `↑ N dependents`, confirm the references peek lists every dependent.

## Notes

- The commands are intentionally **not** declared in `contributes.commands` in `package.json` — they're only useful from a CodeLens with `[uri, position]` arguments, so surfacing them in the command palette (where they'd always report "target not found") would be confusing.
- `package-lock.json` picked up a `version` field bump (0.5.2 → 0.6.1) from `npm install` — the lock file was out of sync with `package.json`.
