### PR TITLE
feat(lsp): vscode status bar shows CLI version and workspace floor skew

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -284,7 +284,7 @@
     "bundle": "deno run --config ../../deno.json --allow-read --allow-write scripts/bundleBinary.ts",
     "package": "npm run bundle && vsce package",
     "lint": "eslint src",
-    "test": "tsc -p tsconfig.json && node --require ./out/test-setup.js --test out/serverOptions.test.js out/mcpDefinition.test.js out/inlineCompletions.test.js out/codeLensCommands.test.js"
+    "test": "tsc -p tsconfig.json && node --require ./out/test-setup.js --test out/serverOptions.test.js out/mcpDefinition.test.js out/inlineCompletions.test.js out/codeLensCommands.test.js out/statusBar.test.js"
   },
   "dependencies": {
     "vscode-languageclient": "^9.0.1"

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -227,6 +227,25 @@ export function activate(context: ExtensionContext): void {
     },
   );
 
+  // Single handler for markspec/version — forwards CLI release + workspace
+  // toolchain floor + skew verdict to the status bar. Same one-handler-per-
+  // method constraint as markspec/indexed.
+  client.onNotification(
+    "markspec/version",
+    (
+      params:
+        | {
+          release: string;
+          coreSchemaVersion: number;
+          minVersion: string | null;
+          isBelow: boolean;
+        }
+        | undefined,
+    ) => {
+      if (params) statusBar.notifyVersion(params);
+    },
+  );
+
   // Initial paint for whatever is open at activation.
   if (window.activeTextEditor) {
     void decorations.refresh(window.activeTextEditor);

--- a/editors/vscode/src/statusBar.test.ts
+++ b/editors/vscode/src/statusBar.test.ts
@@ -1,0 +1,99 @@
+import { test } from "node:test";
+import { strict as assert } from "node:assert";
+import {
+  type IndexedInfo,
+  renderState,
+  type VersionInfo,
+} from "./statusBar";
+
+const VERSION_NO_FLOOR: VersionInfo = {
+  release: "0.6.1",
+  coreSchemaVersion: 1,
+  minVersion: null,
+  isBelow: false,
+};
+
+const VERSION_FLOOR_MET: VersionInfo = {
+  release: "0.6.1",
+  coreSchemaVersion: 1,
+  minVersion: "0.6",
+  isBelow: false,
+};
+
+const VERSION_BELOW_FLOOR: VersionInfo = {
+  release: "0.5.99",
+  coreSchemaVersion: 1,
+  minVersion: "0.6",
+  isBelow: true,
+};
+
+const INDEXED: IndexedInfo = { files: 12, entries: 187 };
+
+test("renderState: starting", () => {
+  const r = renderState("starting", undefined, undefined);
+  assert.equal(r.text, "$(sync~spin) MarkSpec");
+  assert.equal(r.tooltip, "MarkSpec LSP starting…");
+  assert.equal(r.background, undefined);
+});
+
+test("renderState: failed", () => {
+  const r = renderState("failed", undefined, undefined);
+  assert.equal(r.text, "$(error) MarkSpec");
+  assert.equal(r.tooltip, "MarkSpec LSP not running. Click to view output.");
+  assert.equal(r.background, "error");
+});
+
+test("renderState: ready + indexed only (no version yet)", () => {
+  const r = renderState("ready", INDEXED, undefined);
+  assert.equal(r.text, "$(check) MarkSpec");
+  assert.ok(r.tooltip.includes("**MarkSpec LSP** ready"));
+  assert.ok(r.tooltip.includes("Indexed 12 files, 187 entries."));
+  assert.ok(!r.tooltip.includes("Version:"));
+  assert.equal(r.background, undefined);
+});
+
+test("renderState: ready + version only, no floor", () => {
+  const r = renderState("ready", undefined, VERSION_NO_FLOOR);
+  assert.equal(r.text, "$(check) MarkSpec");
+  assert.ok(r.tooltip.includes("Version: 0.6.1"));
+  assert.ok(r.tooltip.includes("No workspace floor declared"));
+  assert.ok(!r.tooltip.includes("Indexed"));
+  assert.equal(r.background, undefined);
+});
+
+test("renderState: ready + version only, floor met", () => {
+  const r = renderState("ready", undefined, VERSION_FLOOR_MET);
+  assert.equal(r.text, "$(check) MarkSpec");
+  assert.ok(r.tooltip.includes("Version: 0.6.1"));
+  assert.ok(r.tooltip.includes("Workspace floor: 0.6 ✓"));
+  assert.equal(r.background, undefined);
+});
+
+test("renderState: ready + version only, below floor", () => {
+  const r = renderState("ready", undefined, VERSION_BELOW_FLOOR);
+  assert.equal(r.text, "$(warning) MarkSpec");
+  assert.ok(r.tooltip.includes("**MarkSpec LSP** below workspace floor"));
+  assert.ok(
+    r.tooltip.includes("Running 0.5.99; project requires 0.6+."),
+  );
+  assert.ok(r.tooltip.includes("Reload window"));
+  assert.equal(r.background, "warning");
+});
+
+test("renderState: ready + both, floor met", () => {
+  const r = renderState("ready", INDEXED, VERSION_FLOOR_MET);
+  assert.equal(r.text, "$(check) MarkSpec");
+  assert.ok(r.tooltip.includes("Indexed 12 files, 187 entries."));
+  assert.ok(r.tooltip.includes("Workspace floor: 0.6 ✓"));
+  assert.equal(r.background, undefined);
+});
+
+test("renderState: ready + both, below floor", () => {
+  const r = renderState("ready", INDEXED, VERSION_BELOW_FLOOR);
+  assert.equal(r.text, "$(warning) MarkSpec");
+  assert.ok(r.tooltip.includes("Indexed 12 files, 187 entries."));
+  assert.ok(
+    r.tooltip.includes("Running 0.5.99; project requires 0.6+."),
+  );
+  assert.equal(r.background, "warning");
+});

--- a/editors/vscode/src/statusBar.test.ts
+++ b/editors/vscode/src/statusBar.test.ts
@@ -1,10 +1,6 @@
 import { test } from "node:test";
 import { strict as assert } from "node:assert";
-import {
-  type IndexedInfo,
-  renderState,
-  type VersionInfo,
-} from "./statusBar";
+import { type IndexedInfo, renderState, type VersionInfo } from "./statusBar";
 
 const VERSION_NO_FLOOR: VersionInfo = {
   release: "0.6.1",

--- a/editors/vscode/src/statusBar.ts
+++ b/editors/vscode/src/statusBar.ts
@@ -1,21 +1,30 @@
 /**
  * @module statusBar
  *
- * Status bar item showing the LSP health. Driven by LanguageClient state
- * transitions plus the server's custom `markspec/indexed` notification.
+ * Status bar item showing the LSP health, the running CLI release, and
+ * any skew between that release and the workspace's declared toolchain
+ * floor (`meta.toolchain.minVersion`).
  *
  *   ⟳  starting / restarting / indexing
  *   ✓  ready (initial indexing complete)
+ *   ⚠  ready, but the CLI is below the workspace floor
  *   ✗  failed / stopped unexpectedly
+ *
+ * The tooltip composes whatever state the controller has on hand:
+ * indexed counts (from `markspec/indexed`) and CLI version + floor
+ * (from `markspec/version`). The two notifications can arrive in
+ * either order; the controller re-renders on each update.
  *
  * Click action opens the MarkSpec output channel.
  *
- * NOTE: `createStatusBar` intentionally does NOT register a
- * `client.onNotification("markspec/indexed", ...)` handler.
- * `vscode-languageclient@9` uses a `Map` keyed by method name, so calling
- * `onNotification` twice for the same method silently replaces the first
- * handler. The caller (extension.ts) owns the single `markspec/indexed`
- * handler and must call `notifyIndexed()` from it.
+ * NOTE: `createStatusBar` intentionally does NOT register
+ * `client.onNotification("markspec/indexed", …)` or
+ * `client.onNotification("markspec/version", …)` handlers.
+ * `vscode-languageclient@9` uses a `Map` keyed by method name, so
+ * calling `onNotification` twice for the same method silently replaces
+ * the first handler. The caller (extension.ts) owns the single
+ * handler per method and must forward via `notifyIndexed()` /
+ * `notifyVersion()`.
  */
 
 import {
@@ -30,14 +39,120 @@ import { type LanguageClient, State } from "vscode-languageclient/node";
 
 const COMMAND_SHOW_OUTPUT = "markspec.showOutput";
 
+/** Payload from `markspec/indexed`. */
+export interface IndexedInfo {
+  readonly files: number;
+  readonly entries: number;
+}
+
+/** Payload from `markspec/version`. */
+export interface VersionInfo {
+  readonly release: string;
+  readonly coreSchemaVersion: number;
+  readonly minVersion: string | null;
+  readonly isBelow: boolean;
+}
+
+/** LSP lifecycle states the renderer cares about. */
+export type LspState = "starting" | "ready" | "failed";
+
+/** Pure render output — plain data, no vscode objects. */
+export interface RenderedState {
+  readonly text: string;
+  /** Composed Markdown tooltip body. Empty string for transitional states. */
+  readonly tooltip: string;
+  /** `"warning"` selects `statusBarItem.warningBackground`; `"error"` selects `statusBarItem.errorBackground`; `undefined` = no tint. */
+  readonly background: "warning" | "error" | undefined;
+}
+
 /** Returned by `createStatusBar` so the caller can forward notifications. */
 export interface StatusBarController {
   readonly item: StatusBarItem;
   /**
    * Call this when the `markspec/indexed` notification arrives.
-   * Transitions the status bar from "starting" to "ready".
+   * Updates the cached IndexedInfo and re-renders.
    */
-  notifyIndexed(params: { files: number; entries: number }): void;
+  notifyIndexed(params: IndexedInfo): void;
+  /**
+   * Call this when the `markspec/version` notification arrives.
+   * Updates the cached VersionInfo and re-renders.
+   */
+  notifyVersion(params: VersionInfo): void;
+}
+
+/**
+ * Pure render function. Returns the desired `(text, tooltip, background)`
+ * for the given LSP state and accumulated notification info. Exported for
+ * unit testing without a real VS Code runtime.
+ */
+export function renderState(
+  lspState: LspState,
+  indexed: IndexedInfo | undefined,
+  version: VersionInfo | undefined,
+): RenderedState {
+  if (lspState === "starting") {
+    return {
+      text: "$(sync~spin) MarkSpec",
+      tooltip: "MarkSpec LSP starting…",
+      background: undefined,
+    };
+  }
+  if (lspState === "failed") {
+    return {
+      text: "$(error) MarkSpec",
+      tooltip: "MarkSpec LSP not running. Click to view output.",
+      background: "error",
+    };
+  }
+  // ready
+  const belowFloor = version?.isBelow === true;
+  const text = belowFloor ? "$(warning) MarkSpec" : "$(check) MarkSpec";
+  const tooltip = belowFloor
+    ? composeReadyBelowFloorTooltip(indexed, version!)
+    : composeReadyOkTooltip(indexed, version);
+  return {
+    text,
+    tooltip,
+    background: belowFloor ? "warning" : undefined,
+  };
+}
+
+function composeReadyOkTooltip(
+  indexed: IndexedInfo | undefined,
+  version: VersionInfo | undefined,
+): string {
+  const sections: string[] = ["**MarkSpec LSP** ready"];
+  if (indexed) {
+    sections.push(`Indexed ${indexed.files} files, ${indexed.entries} entries.`);
+  }
+  if (version) {
+    sections.push(`Version: ${version.release}`);
+    sections.push(
+      version.minVersion === null
+        ? "No workspace floor declared"
+        : `Workspace floor: ${version.minVersion} ✓`,
+    );
+  }
+  return sections.join("\n\n");
+}
+
+function composeReadyBelowFloorTooltip(
+  indexed: IndexedInfo | undefined,
+  version: VersionInfo,
+): string {
+  const sections: string[] = ["**MarkSpec LSP** below workspace floor"];
+  if (indexed) {
+    sections.push(`Indexed ${indexed.files} files, ${indexed.entries} entries.`);
+  }
+  // `version.minVersion` is guaranteed non-null when `isBelow` is true —
+  // see `isBelowFloor`: it returns false for `undefined` floor.
+  sections.push(
+    `Running ${version.release}; project requires ${version.minVersion}+.`,
+  );
+  sections.push(
+    "Reload window after upgrading the CLI to refresh this check.",
+  );
+  return sections.join("\n\n");
 }
 
 export function createStatusBar(
@@ -47,14 +162,36 @@ export function createStatusBar(
   const item = window.createStatusBarItem(StatusBarAlignment.Right, 100);
   item.command = COMMAND_SHOW_OUTPUT;
 
-  setStarting(item);
+  let lspState: LspState = "starting";
+  let indexed: IndexedInfo | undefined;
+  let version: VersionInfo | undefined;
+
+  function repaint(): void {
+    const rendered = renderState(lspState, indexed, version);
+    item.text = rendered.text;
+    if (rendered.tooltip === "") {
+      item.tooltip = undefined;
+    } else {
+      const md = new MarkdownString();
+      md.appendMarkdown(rendered.tooltip);
+      item.tooltip = md;
+    }
+    item.backgroundColor = rendered.background === "warning"
+      ? new ThemeColor("statusBarItem.warningBackground")
+      : rendered.background === "error"
+      ? new ThemeColor("statusBarItem.errorBackground")
+      : undefined;
+  }
+
+  repaint();
   item.show();
 
   client.onDidChangeState((event) => {
-    if (event.newState === State.Starting) setStarting(item);
-    else if (event.newState === State.Stopped) setFailed(item);
+    if (event.newState === State.Starting) lspState = "starting";
+    else if (event.newState === State.Stopped) lspState = "failed";
     // State.Running alone doesn't mean indexing complete — wait for
     // the markspec/indexed notification forwarded via notifyIndexed().
+    repaint();
   });
 
   context.subscriptions.push(
@@ -66,32 +203,14 @@ export function createStatusBar(
 
   return {
     item,
-    notifyIndexed: (params) => setReady(item, params),
+    notifyIndexed: (params) => {
+      lspState = "ready";
+      indexed = params;
+      repaint();
+    },
+    notifyVersion: (params) => {
+      version = params;
+      repaint();
+    },
   };
-}
-
-function setStarting(item: StatusBarItem): void {
-  item.text = "$(sync~spin) MarkSpec";
-  item.tooltip = "MarkSpec LSP starting…";
-  item.backgroundColor = undefined;
-}
-
-function setReady(
-  item: StatusBarItem,
-  params: { files: number; entries: number },
-): void {
-  item.text = "$(check) MarkSpec";
-  const tooltip = new MarkdownString();
-  tooltip.appendMarkdown("**MarkSpec LSP** ready\n\n");
-  tooltip.appendMarkdown(
-    `Indexed ${params.files} files, ${params.entries} entries.`,
-  );
-  item.tooltip = tooltip;
-  item.backgroundColor = undefined;
-}
-
-function setFailed(item: StatusBarItem): void {
-  item.text = "$(error) MarkSpec";
-  item.tooltip = "MarkSpec LSP not running. Click to view output.";
-  item.backgroundColor = new ThemeColor("statusBarItem.errorBackground");
 }

--- a/editors/vscode/src/statusBar.ts
+++ b/editors/vscode/src/statusBar.ts
@@ -123,7 +123,9 @@ function composeReadyOkTooltip(
 ): string {
   const sections: string[] = ["**MarkSpec LSP** ready"];
   if (indexed) {
-    sections.push(`Indexed ${indexed.files} files, ${indexed.entries} entries.`);
+    sections.push(
+      `Indexed ${indexed.files} files, ${indexed.entries} entries.`,
+    );
   }
   if (version) {
     sections.push(`Version: ${version.release}`);
@@ -142,7 +144,9 @@ function composeReadyBelowFloorTooltip(
 ): string {
   const sections: string[] = ["**MarkSpec LSP** below workspace floor"];
   if (indexed) {
-    sections.push(`Indexed ${indexed.files} files, ${indexed.entries} entries.`);
+    sections.push(
+      `Indexed ${indexed.files} files, ${indexed.entries} entries.`,
+    );
   }
   // `version.minVersion` is guaranteed non-null when `isBelow` is true —
   // see `isBelowFloor`: it returns false for `undefined` floor.

--- a/packages/markspec/lsp/server.ts
+++ b/packages/markspec/lsp/server.ts
@@ -174,10 +174,11 @@ const index = new WorkspaceIndex();
 let lastDiagnostics: readonly CoreDiagnostic[] = [];
 
 /**
- * Module-scoped reader for the loaded lockfile. Currently no LSP handler
- * consumes the lockfile, but the loader is wired in so future features
- * (federated-registry pinning, stale-pin hover hint) can opt in without
- * a second init pass.
+ * Module-scoped reader for the loaded lockfile. The send-site for
+ * `markspec/version` reads the module-scoped `lockfile` directly via
+ * `buildVersionNotification`; this accessor is kept as a stable entry
+ * point for future LSP handlers (federated-registry pinning, stale-pin
+ * hover hint) so they don't need a second init pass.
  */
 function _getLockfile(): Lockfile | undefined {
   return lockfile;

--- a/packages/markspec/lsp/server.ts
+++ b/packages/markspec/lsp/server.ts
@@ -116,6 +116,7 @@ import {
   formatTyplHoverContent,
   isDollarNameTrigger,
 } from "./typl.ts";
+import { buildVersionNotification } from "./version_notification.ts";
 
 // ---------------------------------------------------------------------------
 // Connection and document manager
@@ -552,10 +553,10 @@ connection.onInitialized(async () => {
       parseAllMs,
     });
 
-    connection.sendNotification("markspec/version", {
-      release: VERSION,
-      coreSchemaVersion: CORE_SCHEMA_VERSION,
-    });
+    connection.sendNotification(
+      "markspec/version",
+      buildVersionNotification(VERSION, CORE_SCHEMA_VERSION, lockfile),
+    );
 
     // Register the profile-file watcher. We do this even when no profile
     // is currently loaded so a later `.markspec.yaml` creation triggers

--- a/packages/markspec/lsp/version_notification.ts
+++ b/packages/markspec/lsp/version_notification.ts
@@ -1,0 +1,43 @@
+/**
+ * @module lsp/version_notification
+ *
+ * Pure builder for the `markspec/version` LSP notification payload.
+ * Composes the running binary's release + core schema with the
+ * workspace lockfile's toolchain floor and the {@linkcode isBelowFloor}
+ * verdict, so the server send-site is a one-liner and the four
+ * lockfile-state cases are unit-testable without an LSP fixture.
+ *
+ * The four cases the consumer (VS Code status bar) cares about are:
+ *   - no lockfile loaded                       → minVersion null, isBelow false
+ *   - lockfile present, no [meta.toolchain]    → minVersion null, isBelow false
+ *   - floor declared and met                   → minVersion echoed, isBelow false
+ *   - floor declared and unmet                 → minVersion echoed, isBelow true
+ */
+
+import { isBelowFloor, type Lockfile } from "../core/mod.ts";
+
+/** Wire shape of the `markspec/version` notification. */
+export interface VersionNotificationPayload {
+  readonly release: string;
+  readonly coreSchemaVersion: number;
+  readonly minVersion: string | null;
+  readonly isBelow: boolean;
+}
+
+/**
+ * Build the `markspec/version` payload from the running binary's
+ * version constants and the optionally-loaded lockfile.
+ */
+export function buildVersionNotification(
+  release: string,
+  coreSchemaVersion: number,
+  lockfile: Lockfile | undefined,
+): VersionNotificationPayload {
+  const floor = lockfile?.meta.toolchain?.minVersion;
+  return {
+    release,
+    coreSchemaVersion,
+    minVersion: floor ?? null,
+    isBelow: isBelowFloor(release, floor),
+  };
+}

--- a/packages/markspec/lsp/version_notification_test.ts
+++ b/packages/markspec/lsp/version_notification_test.ts
@@ -1,0 +1,69 @@
+/**
+ * @module lsp/version_notification_test
+ *
+ * Unit tests for the markspec/version notification payload builder.
+ * Covers the four lockfile cases (none / no toolchain / floor met /
+ * floor unmet).
+ */
+
+import { assertEquals } from "@std/assert";
+import type { Lockfile } from "../core/mod.ts";
+import { buildVersionNotification } from "./version_notification.ts";
+
+const EMPTY_CACHE = { edgesHash: "sha256:0", edgesCount: 0 };
+
+function lockfileWith(toolchainMinVersion: string | undefined): Lockfile {
+  return {
+    schema: 1,
+    meta: {
+      markspecSchema: 1,
+      lockedAt: "2026-05-28T00:00:00Z",
+      toolchain: toolchainMinVersion === undefined
+        ? undefined
+        : { minVersion: toolchainMinVersion },
+    },
+    upstreams: [],
+    boundEntries: [],
+    generatedCache: EMPTY_CACHE,
+  };
+}
+
+Deno.test("buildVersionNotification: no lockfile → minVersion null, isBelow false", () => {
+  const payload = buildVersionNotification("0.6.1", 1, undefined);
+  assertEquals(payload, {
+    release: "0.6.1",
+    coreSchemaVersion: 1,
+    minVersion: null,
+    isBelow: false,
+  });
+});
+
+Deno.test("buildVersionNotification: lockfile without [meta.toolchain] → minVersion null, isBelow false", () => {
+  const payload = buildVersionNotification("0.6.1", 1, lockfileWith(undefined));
+  assertEquals(payload, {
+    release: "0.6.1",
+    coreSchemaVersion: 1,
+    minVersion: null,
+    isBelow: false,
+  });
+});
+
+Deno.test("buildVersionNotification: floor met → minVersion echoed, isBelow false", () => {
+  const payload = buildVersionNotification("0.6.1", 1, lockfileWith("0.6"));
+  assertEquals(payload, {
+    release: "0.6.1",
+    coreSchemaVersion: 1,
+    minVersion: "0.6",
+    isBelow: false,
+  });
+});
+
+Deno.test("buildVersionNotification: floor unmet → minVersion echoed, isBelow true", () => {
+  const payload = buildVersionNotification("0.6.1", 1, lockfileWith("999.0"));
+  assertEquals(payload, {
+    release: "0.6.1",
+    coreSchemaVersion: 1,
+    minVersion: "999.0",
+    isBelow: true,
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `minVersion` + `isBelow` fields to the `markspec/version` LSP notification via a new pure `buildVersionNotification` helper (server side), reusing slice B's `isBelowFloor` SSOT from `core/lock/compare.ts`.
- Extracts a pure `renderState` from `editors/vscode/src/statusBar.ts` and extends the tooltip to show the running CLI release + the workspace's `meta.toolchain.minVersion` floor. Below-floor flips to `$(warning) MarkSpec` with `statusBarItem.warningBackground`. Failed-state error background preserved.
- Registers a `markspec/version` notification handler in the extension to forward into the status-bar controller.
- 12 new tests (4 helper + 8 renderer). All existing tests unchanged: 2902 Deno + 47 extension passing.

Implements slice C of the install/upgrade devex epic. Depends on slice B (PR #522, shipped 2026-05-27). No lockfile file-watching — reload window after `markspec lock` to refresh the floor.

**Subtle by design:** status-bar-only signaling, no toast/modal. A teammate running an out-of-date CLI sees the warning when they look at the bar.

## Test plan

- [x] `just build` green (2902 Deno tests)
- [x] `cd editors/vscode && npm test` green (47 extension tests)
- [x] `deno fmt --check` on changed Deno files green
- [x] `dprint check` green
- [ ] Manually: workspace with no `markspec.lock`, hover the status bar — tooltip says "No workspace floor declared"
- [ ] Manually: workspace with `[meta.toolchain] min-version = "0.6"` and running CLI 0.6.x — tooltip says `Workspace floor: 0.6 ✓`
- [ ] Manually: bump lockfile floor to "999.0", reload window — bar shows `$(warning) MarkSpec` with warning background, tooltip explains skew

## Spec / plan

Local-only design + plan docs (gitignored per repo convention):
- `docs/superpowers/specs/2026-05-28-extension-toolchain-skew-c-design.md`
- `docs/superpowers/plans/2026-05-28-extension-toolchain-skew-c.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
