### PR TITLE
fix(cli): treat Prompter EOF as abort, not bundled-default confirmation

### DIFF
--- a/packages/markspec/cli/init/mod.ts
+++ b/packages/markspec/cli/init/mod.ts
@@ -21,4 +21,9 @@ export type {
 } from "./types.ts";
 export { renderJsonSummary, renderTextSummary } from "./summary.ts";
 export { createDenoFs, createMemFs } from "./fake_fs.ts";
-export { parseProfileSpec } from "./profile_picker.ts";
+export {
+  parseProfileSpec,
+  ProfilePickerAbortedError,
+  runProfilePicker,
+} from "./profile_picker.ts";
+export type { Prompter } from "./profile_picker.ts";

--- a/packages/markspec/cli/init/profile_picker.ts
+++ b/packages/markspec/cli/init/profile_picker.ts
@@ -16,9 +16,38 @@
 
 import type { ProfileChoice } from "./types.ts";
 
-/** Test seam — production wires `prompt()` from `@std/cli/prompt`. */
+/**
+ * Test seam — production wires `prompt()` from `@std/cli/prompt`.
+ *
+ * Returning `null` signals end-of-input (Ctrl-D on POSIX, Ctrl-Z on
+ * Windows) and is propagated as an abort by the picker. The empty
+ * string keeps its existing meaning of "user pressed Enter on a
+ * defaulted prompt", so the bundled-default branch still fires on
+ * a bare Enter.
+ */
 export interface Prompter {
-  question(message: string): Promise<string>;
+  question(message: string): Promise<string | null>;
+}
+
+/** Error raised by {@linkcode runProfilePicker} when the user aborts. */
+export class ProfilePickerAbortedError extends Error {
+  constructor() {
+    super("profile picker: aborted by user");
+    this.name = "ProfilePickerAbortedError";
+  }
+}
+
+/**
+ * Wrap a single `prompter.question` call: throw on EOF (null), return
+ * the trimmed string otherwise.
+ */
+async function askOrAbort(
+  prompter: Prompter,
+  message: string,
+): Promise<string> {
+  const raw = await prompter.question(message);
+  if (raw === null) throw new ProfilePickerAbortedError();
+  return raw.trim();
 }
 
 const GIT_RE = /^git\+(https?|ssh):\/\/.+$/;
@@ -49,29 +78,31 @@ export async function runProfilePicker(
   prompter: Prompter,
 ): Promise<ProfileChoice> {
   for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
-    const raw = (await prompter.question(MENU)).trim();
+    const raw = await askOrAbort(prompter, MENU);
     const choice = raw === "" ? "1" : raw;
     switch (choice) {
       case "1":
         return { kind: "bundled" };
       case "2": {
-        const url = (await prompter.question("Git URL: ")).trim();
+        const url = await askOrAbort(prompter, "Git URL: ");
         const parsed = parseProfileSpec(url);
         if (parsed?.kind === "git") return parsed;
         break;
       }
       case "3": {
-        const path =
-          (await prompter.question("Local path (relative to project): "))
-            .trim();
+        const path = await askOrAbort(
+          prompter,
+          "Local path (relative to project): ",
+        );
         const parsed = parseProfileSpec(path);
         if (parsed?.kind === "local") return parsed;
         break;
       }
       case "4": {
-        const yn = (await prompter.question(
+        const yn = (await askOrAbort(
+          prompter,
           "Core-only mode disables the default profile's type vocabulary. Continue? [y/N]: ",
-        )).trim().toLowerCase();
+        )).toLowerCase();
         if (yn === "y" || yn === "yes") return { kind: "none" };
         break;
       }

--- a/packages/markspec/cli/init/profile_picker_test.ts
+++ b/packages/markspec/cli/init/profile_picker_test.ts
@@ -91,3 +91,32 @@ Deno.test("runProfilePicker: gives up after 3 invalid inputs", async () => {
   };
   await assertRejects(() => runProfilePicker(prompter), Error, "max attempts");
 });
+
+Deno.test("runProfilePicker: null from prompter (EOF / Ctrl-D) aborts", async () => {
+  // Pressing Ctrl-D before answering must not silently scaffold the
+  // bundled default — it has to surface as an abort the CLI can
+  // exit non-zero on. Empty string `""` (plain Enter) keeps its
+  // existing meaning of "use bundled default".
+  const prompter: Prompter = {
+    question: () => Promise.resolve(null),
+  };
+  await assertRejects(
+    () => runProfilePicker(prompter),
+    Error,
+    "aborted by user",
+  );
+});
+
+Deno.test("runProfilePicker: null on sub-prompt (e.g. mid Git URL) aborts", async () => {
+  // EOF mid-flow on a follow-up prompt must abort, not loop back.
+  const answers: Array<string | null> = ["2", null];
+  let i = 0;
+  const prompter: Prompter = {
+    question: () => Promise.resolve(answers[i++]),
+  };
+  await assertRejects(
+    () => runProfilePicker(prompter),
+    Error,
+    "aborted by user",
+  );
+});


### PR DESCRIPTION
Closes #540.

## Summary

- Closes finding #7 from the [PR #528 review](https://github.com/driftsys/markspec/pull/528#issuecomment-4562732929).
- `Prompter.question` used to return `Promise<string>`, so EOF (Ctrl-D on POSIX, Ctrl-Z on Windows) had to be flattened to `""` by the production wrapper around `@std/cli/prompt`. The picker then mapped that empty string to choice `"1"` (bundled), silently scaffolding the bundled default instead of aborting.
- Changed `Prompter.question` to return `Promise<string | null>`. `null` is the EOF signal; the new helper `askOrAbort` propagates it as a typed `ProfilePickerAbortedError`. Empty string keeps its existing meaning of "user pressed Enter on a defaulted prompt", so the bundled-default branch still fires on a bare Enter.

## Test plan

- [x] New unit test `runProfilePicker: null from prompter (EOF / Ctrl-D) aborts` — verifies the top-level abort
- [x] New unit test `runProfilePicker: null on sub-prompt (e.g. mid Git URL) aborts` — verifies EOF mid-flow also aborts (not loop-back)
- [x] All 100 init + e2e tests pass (98 prior + 2 new)
- [x] `just build` (lint + test + typecheck + compile) green
- [x] `deno fmt --check` + `dprint check` green

## Notes

- `runProfilePicker` is not yet wired to `cli/commands/init.ts` (tracked in #544), so the production CLI does not yet hit this path — but the contract is now correct for when it is wired.
- The new `ProfilePickerAbortedError` class and `Prompter` type are re-exported from `cli/init/mod.ts` so the future wiring (#544) can catch the typed error and exit non-zero with a clear message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
