### PR TITLE
feat(lsp): narrow trace-attribute completions by profile target type

### DIFF
--- a/packages/markspec/core/mod.ts
+++ b/packages/markspec/core/mod.ts
@@ -152,6 +152,12 @@ export {
 } from "./profile/mod.ts";
 export type { DisplayIdPatternShape } from "./profile/mod.ts";
 
+export {
+  entryMatchesTargets,
+  filterEntriesByTraceTargets,
+  targetsForRelation,
+} from "./profile/mod.ts";
+
 export { buildProfileIntrospection } from "./profile/mod.ts";
 export type {
   AttributeDetail,

--- a/packages/markspec/core/profile/mod.ts
+++ b/packages/markspec/core/profile/mod.ts
@@ -57,6 +57,12 @@ export {
 } from "./display_id.ts";
 export type { DisplayIdPatternShape } from "./display_id.ts";
 
+export {
+  entryMatchesTargets,
+  filterEntriesByTraceTargets,
+  targetsForRelation,
+} from "./trace_targets.ts";
+
 export { buildProfileIntrospection } from "./introspect.ts";
 export type {
   AttributeDetail,

--- a/packages/markspec/core/profile/trace_targets.ts
+++ b/packages/markspec/core/profile/trace_targets.ts
@@ -1,0 +1,83 @@
+/**
+ * @module core/profile/trace_targets
+ *
+ * Pure helpers for resolving the legal target types of a trace
+ * attribute (e.g. `Satisfies:`, `Derived-from:`) given the source
+ * entry's type and the active profile chain.
+ *
+ * A profile declares per-type `traceability:` rules — each relation
+ * maps to a `TraceRule.target` list of {@linkcode TargetMatcher}s.
+ * A matcher is either a type name (string) or a shape selector
+ * (`{ shape: "Authored" | "Reference" }`). An entry matches when its
+ * `type` equals or extends a string matcher, or its `shape` equals a
+ * shape matcher.
+ *
+ * The LSP uses these helpers to narrow trace-attribute completion
+ * suggestions to the IDs the profile actually allows in that slot.
+ * Callers fall back to the unfiltered workspace listing when no
+ * rule applies (no source type known, relation undeclared, profile
+ * absent).
+ */
+
+import type { Entry } from "../model/mod.ts";
+import type { EffectiveProfile, TargetMatcher } from "../model/profile.ts";
+import { extendsTransitively } from "./discipline_mode.ts";
+
+/**
+ * Return the `TargetMatcher[]` for a given source-entry type and
+ * relation name, or `undefined` when no rule constrains it. Callers
+ * MUST treat `undefined` as "do not filter" rather than "no targets
+ * allowed" — the latter would silently hide every suggestion.
+ */
+export function targetsForRelation(
+  profile: EffectiveProfile,
+  sourceType: string | undefined,
+  relationName: string,
+): readonly TargetMatcher[] | undefined {
+  if (!sourceType) return undefined;
+  const typeDef = profile.types.get(sourceType);
+  if (!typeDef) return undefined;
+  const rule = typeDef.value.traceability.get(relationName);
+  if (!rule) return undefined;
+  return rule.value.target;
+}
+
+/**
+ * Whether `entry` satisfies any matcher in `targets`. A string
+ * matcher matches when the entry's `type` equals or transitively
+ * extends the named type. A shape matcher matches when the entry's
+ * `shape` equals the matcher's shape. An entry with no resolved
+ * `type` only matches shape selectors.
+ */
+export function entryMatchesTargets(
+  entry: Entry,
+  targets: readonly TargetMatcher[],
+  profile: EffectiveProfile,
+): boolean {
+  for (const target of targets) {
+    if (typeof target === "string") {
+      if (!entry.type) continue;
+      if (entry.type === target) return true;
+      if (extendsTransitively(entry.type, target, profile)) return true;
+    } else {
+      if (entry.shape === target.shape) return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Filter `entries` to those that satisfy at least one of `targets`.
+ * Order is preserved.
+ */
+export function filterEntriesByTraceTargets(
+  entries: Iterable<Entry>,
+  targets: readonly TargetMatcher[],
+  profile: EffectiveProfile,
+): Entry[] {
+  const out: Entry[] = [];
+  for (const entry of entries) {
+    if (entryMatchesTargets(entry, targets, profile)) out.push(entry);
+  }
+  return out;
+}

--- a/packages/markspec/core/profile/trace_targets_test.ts
+++ b/packages/markspec/core/profile/trace_targets_test.ts
@@ -1,0 +1,259 @@
+/**
+ * @module core/profile/trace_targets_test
+ */
+
+import { assertEquals } from "@std/assert";
+import {
+  entryMatchesTargets,
+  filterEntriesByTraceTargets,
+  targetsForRelation,
+} from "./trace_targets.ts";
+import type {
+  EffectiveProfile,
+  EffectiveTypeDef,
+  Entry,
+  ProvenancedMapEntry,
+  TargetMatcher,
+  TraceRule,
+} from "../model/mod.ts";
+import { makeDisplayId } from "../model/mod.ts";
+
+const ORIGIN = "@test/p";
+
+function makeTypeDef(
+  name: string,
+  extendsType: string,
+  rules: Record<string, TargetMatcher[]> = {},
+): ProvenancedMapEntry<EffectiveTypeDef> {
+  const traceability = new Map<string, ProvenancedMapEntry<TraceRule>>();
+  for (const [relation, target] of Object.entries(rules)) {
+    traceability.set(relation, {
+      value: { target, required: false },
+      origin: ORIGIN,
+    });
+  }
+  return {
+    value: {
+      name,
+      extends: extendsType,
+      displayIdPattern: { value: undefined, origin: ORIGIN },
+      displayIdPatternEnforcement: { value: "off", origin: ORIGIN },
+      color: { value: undefined, origin: ORIGIN },
+      required: { value: [], origin: ORIGIN },
+      attributes: new Map(),
+      traceability,
+      description: { value: undefined, origin: ORIGIN },
+      attrDescriptions: new Map(),
+      relationDescriptions: new Map(),
+      discipline: { value: undefined, origin: ORIGIN },
+    },
+    origin: ORIGIN,
+  };
+}
+
+function makeProfile(
+  types: Record<string, ProvenancedMapEntry<EffectiveTypeDef>>,
+): EffectiveProfile {
+  return {
+    attributes: new Map(),
+    labels: new Map(),
+    conventions: new Map(),
+    colors: new Map(),
+    types: new Map(Object.entries(types)),
+    documents: { types: new Map(), frontMatter: new Map() },
+    kinds: new Map(),
+    prose: {
+      lexicons: {
+        "capitalized-allow": { value: [], origin: "" },
+        "sentence-abbrev": { value: [], origin: "" },
+      },
+    },
+    disciplineMode: { value: "none", origin: "inferred" },
+  };
+}
+
+function makeEntry(opts: {
+  id?: string;
+  type?: string;
+  shape?: "Authored" | "Reference";
+}): Entry {
+  return {
+    displayId: makeDisplayId(opts.id ?? "TEST-001"),
+    title: "Test entry",
+    body: "Body.",
+    rawAttributes: [],
+    typedAttributes: new Map(),
+    type: opts.type,
+    shape: opts.shape ?? "Authored",
+    location: { file: "test.md", line: 1, column: 1 },
+    source: { kind: "markdown" },
+    bodyTokens: [],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// targetsForRelation
+// ---------------------------------------------------------------------------
+
+Deno.test("targetsForRelation: undefined when sourceType is undefined", () => {
+  const profile = makeProfile({});
+  assertEquals(targetsForRelation(profile, undefined, "Satisfies"), undefined);
+});
+
+Deno.test("targetsForRelation: undefined when type not in profile", () => {
+  const profile = makeProfile({});
+  assertEquals(
+    targetsForRelation(profile, "software-requirement", "Satisfies"),
+    undefined,
+  );
+});
+
+Deno.test("targetsForRelation: undefined when type has no rule for that relation", () => {
+  const profile = makeProfile({
+    "software-requirement": makeTypeDef("software-requirement", "Requirement"),
+  });
+  assertEquals(
+    targetsForRelation(profile, "software-requirement", "Satisfies"),
+    undefined,
+  );
+});
+
+Deno.test("targetsForRelation: returns the target list when rule exists", () => {
+  const profile = makeProfile({
+    "software-requirement": makeTypeDef(
+      "software-requirement",
+      "Requirement",
+      { "Satisfies": ["system-requirement"] },
+    ),
+  });
+  assertEquals(
+    targetsForRelation(profile, "software-requirement", "Satisfies"),
+    ["system-requirement"],
+  );
+});
+
+// ---------------------------------------------------------------------------
+// entryMatchesTargets
+// ---------------------------------------------------------------------------
+
+Deno.test("entryMatchesTargets: exact type match", () => {
+  const profile = makeProfile({
+    "system-requirement": makeTypeDef("system-requirement", "Requirement"),
+  });
+  const entry = makeEntry({ type: "system-requirement" });
+  assertEquals(
+    entryMatchesTargets(entry, ["system-requirement"], profile),
+    true,
+  );
+});
+
+Deno.test("entryMatchesTargets: matches via extends chain", () => {
+  // A "safety-system-requirement" that extends "system-requirement" should
+  // match a target of "system-requirement" via the extends transitively.
+  const profile = makeProfile({
+    "system-requirement": makeTypeDef("system-requirement", "Requirement"),
+    "safety-system-requirement": makeTypeDef(
+      "safety-system-requirement",
+      "system-requirement",
+    ),
+  });
+  const entry = makeEntry({ type: "safety-system-requirement" });
+  assertEquals(
+    entryMatchesTargets(entry, ["system-requirement"], profile),
+    true,
+  );
+});
+
+Deno.test("entryMatchesTargets: shape matcher (Authored) hits Authored entry", () => {
+  const profile = makeProfile({});
+  const entry = makeEntry({ shape: "Authored" });
+  assertEquals(
+    entryMatchesTargets(entry, [{ shape: "Authored" }], profile),
+    true,
+  );
+});
+
+Deno.test("entryMatchesTargets: shape matcher (Reference) misses Authored entry", () => {
+  const profile = makeProfile({});
+  const entry = makeEntry({ shape: "Authored" });
+  assertEquals(
+    entryMatchesTargets(entry, [{ shape: "Reference" }], profile),
+    false,
+  );
+});
+
+Deno.test("entryMatchesTargets: untyped entry never matches a string target", () => {
+  const profile = makeProfile({
+    "system-requirement": makeTypeDef("system-requirement", "Requirement"),
+  });
+  const entry = makeEntry({ type: undefined });
+  assertEquals(
+    entryMatchesTargets(entry, ["system-requirement"], profile),
+    false,
+  );
+});
+
+Deno.test("entryMatchesTargets: untyped entry still matches a shape target", () => {
+  const profile = makeProfile({});
+  const entry = makeEntry({ type: undefined, shape: "Reference" });
+  assertEquals(
+    entryMatchesTargets(entry, [{ shape: "Reference" }], profile),
+    true,
+  );
+});
+
+Deno.test("entryMatchesTargets: union of targets — matches any one", () => {
+  const profile = makeProfile({
+    "system-requirement": makeTypeDef("system-requirement", "Requirement"),
+    "stakeholder-requirement": makeTypeDef(
+      "stakeholder-requirement",
+      "Requirement",
+    ),
+  });
+  const entry = makeEntry({ type: "stakeholder-requirement" });
+  assertEquals(
+    entryMatchesTargets(
+      entry,
+      ["system-requirement", "stakeholder-requirement"],
+      profile,
+    ),
+    true,
+  );
+});
+
+Deno.test("entryMatchesTargets: no matcher matches", () => {
+  const profile = makeProfile({
+    "system-requirement": makeTypeDef("system-requirement", "Requirement"),
+    "test": makeTypeDef("test", "Test"),
+  });
+  const entry = makeEntry({ type: "test" });
+  assertEquals(
+    entryMatchesTargets(entry, ["system-requirement"], profile),
+    false,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// filterEntriesByTraceTargets
+// ---------------------------------------------------------------------------
+
+Deno.test("filterEntriesByTraceTargets: preserves order, keeps only matches", () => {
+  const profile = makeProfile({
+    "system-requirement": makeTypeDef("system-requirement", "Requirement"),
+    "test": makeTypeDef("test", "Test"),
+  });
+  const entries = [
+    makeEntry({ id: "SYS-001", type: "system-requirement" }),
+    makeEntry({ id: "TST-001", type: "test" }),
+    makeEntry({ id: "SYS-002", type: "system-requirement" }),
+    makeEntry({ id: "FREE-001", type: undefined }),
+  ];
+  const filtered = filterEntriesByTraceTargets(
+    entries,
+    ["system-requirement"],
+    profile,
+  );
+  assertEquals(filtered.length, 2);
+  assertEquals(filtered[0].displayId, "SYS-001");
+  assertEquals(filtered[1].displayId, "SYS-002");
+});

--- a/packages/markspec/lsp/find_entry.ts
+++ b/packages/markspec/lsp/find_entry.ts
@@ -1,0 +1,47 @@
+/**
+ * @module lsp/find_entry
+ *
+ * Cursor-to-entry mapping. Given the cursor's 1-based file line and
+ * the parsed entries in that file, return the entry that "contains"
+ * the cursor — defined as the entry whose start line is the greatest
+ * one less than or equal to the cursor line.
+ *
+ * This matches the LSP's needs: when the author is typing on a
+ * trailer line several lines below the entry's title, that line is
+ * still part of the enclosing entry's block.
+ */
+
+import type { Entry } from "../core/mod.ts";
+
+/**
+ * Return the entry whose declared block contains `cursorLine`, or
+ * `undefined` when no entry has started yet (cursor is above the
+ * first entry's title line, or the file has no entries).
+ *
+ * The block of entry `i` is treated as `[entry[i].line, entry[i+1].line)`
+ * — i.e. an entry "owns" lines from its title down to the line
+ * before the next entry's title (or to end-of-file). This is the
+ * same heuristic the folding-range helper uses.
+ *
+ * @param entries Parsed entries from a single file. Order is not
+ *   required.
+ * @param cursorLine 1-based file line, matching
+ *   {@linkcode Entry.location.line}'s convention.
+ */
+export function findEnclosingEntry(
+  entries: readonly Entry[],
+  cursorLine: number,
+): Entry | undefined {
+  if (entries.length === 0) return undefined;
+  // Walk in sorted-by-start-line order without mutating the caller's
+  // array — typical entry counts per file are small, sort is cheap.
+  const sorted = [...entries].sort(
+    (a, b) => a.location.line - b.location.line,
+  );
+  let chosen: Entry | undefined;
+  for (const entry of sorted) {
+    if (entry.location.line > cursorLine) break;
+    chosen = entry;
+  }
+  return chosen;
+}

--- a/packages/markspec/lsp/find_entry_test.ts
+++ b/packages/markspec/lsp/find_entry_test.ts
@@ -1,0 +1,55 @@
+/**
+ * @module lsp/find_entry_test
+ */
+
+import { assertEquals } from "@std/assert";
+import { findEnclosingEntry } from "./find_entry.ts";
+import type { Entry } from "../core/mod.ts";
+import { makeDisplayId } from "../core/mod.ts";
+
+function makeEntry(id: string, line: number): Entry {
+  return {
+    displayId: makeDisplayId(id),
+    title: id,
+    body: "",
+    rawAttributes: [],
+    typedAttributes: new Map(),
+    shape: "Authored",
+    location: { file: "f.md", line, column: 1 },
+    source: { kind: "markdown" },
+    bodyTokens: [],
+  };
+}
+
+Deno.test("findEnclosingEntry: empty list returns undefined", () => {
+  assertEquals(findEnclosingEntry([], 5), undefined);
+});
+
+Deno.test("findEnclosingEntry: cursor above first entry returns undefined", () => {
+  const entries = [makeEntry("A", 10), makeEntry("B", 20)];
+  assertEquals(findEnclosingEntry(entries, 5), undefined);
+});
+
+Deno.test("findEnclosingEntry: cursor on title line picks that entry", () => {
+  const entries = [makeEntry("A", 10), makeEntry("B", 20)];
+  assertEquals(findEnclosingEntry(entries, 10)?.displayId, "A");
+  assertEquals(findEnclosingEntry(entries, 20)?.displayId, "B");
+});
+
+Deno.test("findEnclosingEntry: cursor inside an entry block picks that entry", () => {
+  const entries = [makeEntry("A", 10), makeEntry("B", 20)];
+  assertEquals(findEnclosingEntry(entries, 15)?.displayId, "A");
+  assertEquals(findEnclosingEntry(entries, 19)?.displayId, "A");
+});
+
+Deno.test("findEnclosingEntry: cursor below the last entry sticks to it", () => {
+  const entries = [makeEntry("A", 10), makeEntry("B", 20)];
+  assertEquals(findEnclosingEntry(entries, 100)?.displayId, "B");
+});
+
+Deno.test("findEnclosingEntry: out-of-order input is sorted internally", () => {
+  const entries = [makeEntry("B", 20), makeEntry("A", 10), makeEntry("C", 30)];
+  assertEquals(findEnclosingEntry(entries, 15)?.displayId, "A");
+  assertEquals(findEnclosingEntry(entries, 25)?.displayId, "B");
+  assertEquals(findEnclosingEntry(entries, 35)?.displayId, "C");
+});

--- a/packages/markspec/lsp/server.ts
+++ b/packages/markspec/lsp/server.ts
@@ -39,6 +39,7 @@ import {
   type Diagnostic as CoreDiagnostic,
   discoverProjectRoot,
   type EffectiveProfile,
+  filterEntriesByTraceTargets,
   format,
   loadConfig,
   loadProfileForCommand,
@@ -47,6 +48,7 @@ import {
   parseDisplayIdPattern,
   parseLockfile,
   type ProjectConfig,
+  targetsForRelation,
   VERSION,
 } from "../core/mod.ts";
 import { extendsTransitively } from "../core/profile/discipline_mode.ts";
@@ -84,6 +86,7 @@ import {
   buildTrailerKeyItems,
   buildTypeAttributeItems,
   type EntryTypeInfo,
+  extractRelationName,
   isBlockScaffoldTrigger,
   isTraceAttributeTrigger,
   isTrailerKeyContext,
@@ -92,6 +95,7 @@ import {
   SCAFFOLD_COMPLETION_KIND,
   type ScaffoldCompletionData,
 } from "./completions.ts";
+import { findEnclosingEntry } from "./find_entry.ts";
 import {
   isDocCommentContext,
   isMarkspecFile,
@@ -733,7 +737,30 @@ connection.onCompletion((params): CompletionItem[] => {
   // Trigger 3: ID reference
   if (isTraceAttributeTrigger(line)) {
     return time("onCompletion/idRef", () => {
-      const displayIds = index.getAllDisplayIds();
+      // Narrow the suggestion list to entries the profile's trace
+      // rule actually allows in this slot (e.g. `Satisfies:` on a
+      // software-requirement should only suggest system-requirement
+      // IDs). The narrowing fires only when we can resolve: the
+      // enclosing entry's type, the relation name, and a TraceRule
+      // for that pair. Any missing piece falls back to the full
+      // workspace listing — better to over-suggest than to hide.
+      const enclosing = profile
+        ? findEnclosingEntry(
+          index.getEntriesForFile(filePath),
+          params.position.line + 1, // LSP is 0-based; Entry is 1-based.
+        )
+        : undefined;
+      const relationName = profile ? extractRelationName(line) : undefined;
+      const targets = profile && relationName
+        ? targetsForRelation(profile, enclosing?.type, relationName)
+        : undefined;
+      const displayIds = profile && targets
+        ? filterEntriesByTraceTargets(
+          index.getAllEntries(),
+          targets,
+          profile,
+        ).map((e) => ({ displayId: e.displayId, title: e.title }))
+        : index.getAllDisplayIds();
       const items = buildIdReferenceItems(displayIds);
       return items.map((item) => ({
         label: item.label,


### PR DESCRIPTION
## Summary

Devex item #2 of the editing-experience backlog. When the author types a trace attribute inside an entry whose type declares a `traceability:` rule for that relation, the completion list narrows to display IDs of entries whose type satisfies the rule's target matchers.

Authoring a `software-requirement` and typing `Satisfies: ` previously surfaced **every** workspace display ID. With this change the list narrows to the targets the profile actually allows (e.g. `system-requirement` IDs only).

When any prerequisite is absent — profile not loaded, enclosing entry's type unresolved, relation has no declared rule — the trigger falls back to the full unfiltered listing. Better to over-suggest than to hide valid IDs.

## Files

| File | What |
|---|---|
| `core/profile/trace_targets.ts` (new) | Pure helpers: `targetsForRelation`, `entryMatchesTargets`, `filterEntriesByTraceTargets`. String matchers walk the `extends` chain via `extendsTransitively`; shape matchers compare `entry.shape` |
| `lsp/find_entry.ts` (new) | `findEnclosingEntry(entries, line)` cursor-to-entry lookup. Matches the folding-range heuristic — an entry owns lines from its title down to the line before the next entry's title |
| `lsp/server.ts` | Rewires the trace-attribute trigger to compose the new helpers; falls back to `index.getAllDisplayIds()` when filtering can't apply |
| `core/profile/mod.ts`, `core/mod.ts` | Barrel + boundary re-exports |

## Test plan

- [x] `deno fmt --check` — clean
- [x] `deno lint` — clean
- [x] `deno test` — 2931 passed, 0 failed (+19 new)
- [x] 13 new tests in `trace_targets_test.ts` — `targetsForRelation` (undefined when source/type/rule missing; returns target list when present), `entryMatchesTargets` (exact match, extends chain, shape matchers, untyped entries, target unions), `filterEntriesByTraceTargets` (order preservation)
- [x] 6 new tests in `find_entry_test.ts` — empty list, above-first, on-title, mid-block, below-last, out-of-order inputs
- [ ] **Manual smoke test (post-merge):** open a project with declared trace rules (e.g. `demo-aeb-*`), type `Satisfies:` inside a software-requirement, confirm only `system-requirement` IDs appear

## Behaviour for projects without trace rules

Unchanged. The markspec workspace itself has no `Satisfies`-style declared rules in its profile, so its own LSP session behaves identically to before this PR. The narrowing only kicks in for projects with ASPICE/ISO-style profiles that declare `traceability:` blocks per type.

## Backlog status (LSP editing devex)

- [x] #1 display-ID pattern share — shipped (#549)
- [x] **#2 relation-target filtering — this PR**
- [ ] #3 server-side prefix filter on trace-attribute completion
- [ ] #4 mid-typed `[STK_AEB_…` auto-complete next sequential number
- [ ] #5 debounce-window race producing duplicate display IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
