### PR TITLE
fix(cli): recognise Windows cmd.exe 9009 as upskill-not-found

### DIFF
--- a/packages/markspec/cli/init/orchestrator.ts
+++ b/packages/markspec/cli/init/orchestrator.ts
@@ -238,7 +238,14 @@ export async function runInit(options: RunInitOptions): Promise<InitResult> {
         ["add", SKILLS_BUNDLE_SOURCE],
         { cwd: options.targetDir },
       );
-      if (r.code === 127 || r.stderr.includes("not found")) {
+      // POSIX shells emit code 127 + "not found". cmd.exe emits
+      // code 9009 + "is not recognized as an internal or external
+      // command". Match both so Windows users see UPSKILL_NOT_FOUND
+      // instead of the less-helpful UPSKILL_FAILED.
+      const notFound = r.code === 127 || r.code === 9009 ||
+        r.stderr.includes("not found") ||
+        r.stderr.includes("not recognized");
+      if (notFound) {
         warnings.push({
           code: "UPSKILL_NOT_FOUND",
           message:

--- a/packages/markspec/cli/init/orchestrator_test.ts
+++ b/packages/markspec/cli/init/orchestrator_test.ts
@@ -180,6 +180,48 @@ Deno.test("runInit: upskill missing → warning + exit 2", async () => {
   assertEquals(upskillWarn !== undefined, true);
 });
 
+Deno.test("runInit: upskill missing on Windows (exit 9009 / not recognized) → UPSKILL_NOT_FOUND", async () => {
+  // cmd.exe returns exit code 9009 with stderr containing 'is not
+  // recognized as an internal or external command' when the binary
+  // is not on PATH. Neither matches the POSIX `code === 127` /
+  // `'not found'` checks, so without this branch Windows users
+  // would see the less-helpful UPSKILL_FAILED warning.
+  const fs = createMemFs();
+  const windowsMissingExec: ExecRunner = () =>
+    Promise.resolve({
+      code: 9009,
+      stdout: "",
+      stderr:
+        "'upskill' is not recognized as an internal or external command, operable program or batch file.",
+    });
+  const result = await runInit({
+    targetDir: "/repo",
+    profileChoice: { kind: "bundled" },
+    forcedClients: [],
+    allClients: false,
+    noMcp: false,
+    noSkills: false,
+    binaryPathFlag: undefined,
+    force: false,
+    dryRun: false,
+    fs,
+    detectEnv: noClientEnv,
+    binaryEnv: noClientEnv,
+    mcpRunner: okMcpRunner,
+    execRunner: windowsMissingExec,
+    now: fakeNow,
+    version: "0.6.0",
+  });
+  const upskillNotFound = result.warnings.find((w) =>
+    w.code === "UPSKILL_NOT_FOUND"
+  );
+  const upskillFailed = result.warnings.find((w) =>
+    w.code === "UPSKILL_FAILED"
+  );
+  assertEquals(upskillNotFound !== undefined, true);
+  assertEquals(upskillFailed, undefined);
+});
+
 Deno.test("runInit: non-whitelisted content (src/) → TARGET_NOT_EMPTY error + exit 1", async () => {
   const fs = createMemFs();
   await fs.write("/repo/src/x.txt", "user code");


### PR DESCRIPTION
Closes #541.

## Summary

- Closes finding #8 from the [PR #528 review](https://github.com/driftsys/markspec/pull/528#issuecomment-4562732929).
- The upskill not-found check used `r.code === 127 || r.stderr.includes("not found")`. POSIX shells emit that signature when the binary is absent; Windows `cmd.exe` instead emits exit code `9009` with stderr `"'upskill' is not recognized as an internal or external command..."`. Neither condition matched, so Windows users saw the less-helpful `UPSKILL_FAILED` warning instead of `UPSKILL_NOT_FOUND` with its install hint.
- Extended the check to also match `code === 9009` and `stderr.includes("not recognized")`.

## Test plan

- [x] New unit test `runInit: upskill missing on Windows (exit 9009 / not recognized) → UPSKILL_NOT_FOUND` (fails before fix, passes after)
- [x] All 99 init + e2e tests pass (98 prior + 1 new)
- [x] `just build` (lint + test + typecheck + compile) green
- [x] `deno fmt --check` + `dprint check` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
