### PR TITLE
feat(lsp): server-side prefix filter on trace-attribute completion

### DIFF
--- a/packages/markspec/lsp/completions.ts
+++ b/packages/markspec/lsp/completions.ts
@@ -107,6 +107,30 @@ export function extractRelationName(textBefore: string): string | undefined {
   return match?.[1];
 }
 
+/**
+ * Extract the partial display-ID the user is currently typing on a
+ * trace-attribute line, for server-side prefix filtering.
+ *
+ * Handles both the canonical single-value form (`Satisfies: SY`) and
+ * the legacy CSV form (`Satisfies: STK_001, SY`). In the CSV case the
+ * partial is the text after the last comma — earlier complete values
+ * must not narrow the suggestion list.
+ *
+ * Returns an empty string when nothing has been typed after the
+ * colon yet. Callers MUST treat the empty result as "no prefix
+ * filter" rather than "no matches"; a `startsWith("")` would still
+ * match every ID, but the handler typically skips the filter step
+ * entirely to set the `isIncomplete` flag correctly.
+ */
+export function extractTracePartial(textBefore: string): string {
+  const colonIdx = textBefore.indexOf(":");
+  if (colonIdx < 0) return "";
+  const afterColon = textBefore.slice(colonIdx + 1);
+  const lastComma = afterColon.lastIndexOf(",");
+  const last = lastComma < 0 ? afterColon : afterColon.slice(lastComma + 1);
+  return last.trim();
+}
+
 /** A completion item — protocol-independent for testability. */
 export interface CompletionItemData {
   readonly label: string;

--- a/packages/markspec/lsp/completions_test.ts
+++ b/packages/markspec/lsp/completions_test.ts
@@ -11,6 +11,7 @@ import {
   buildTrailerKeyItems,
   buildTypeAttributeItems,
   extractRelationName,
+  extractTracePartial,
   isBlockScaffoldTrigger,
   isTraceAttributeTrigger,
   isTrailerKeyContext,
@@ -69,6 +70,42 @@ Deno.test("extractRelationName: extracts 'Satisfies' from line", () => {
 
 Deno.test("extractRelationName: extracts 'Derived-from'", () => {
   assertEquals(extractRelationName("  Derived-from: "), "Derived-from");
+});
+
+// --- extractTracePartial ---
+
+Deno.test("extractTracePartial: empty after colon returns empty string", () => {
+  assertEquals(extractTracePartial("  Satisfies:"), "");
+  assertEquals(extractTracePartial("  Satisfies: "), "");
+  assertEquals(extractTracePartial("  Satisfies:   "), "");
+});
+
+Deno.test("extractTracePartial: returns partial after colon", () => {
+  assertEquals(extractTracePartial("  Satisfies: SY"), "SY");
+  assertEquals(extractTracePartial("  Satisfies: SYS_AEB"), "SYS_AEB");
+});
+
+Deno.test("extractTracePartial: trims surrounding whitespace", () => {
+  assertEquals(extractTracePartial("  Satisfies:   SY  "), "SY");
+});
+
+Deno.test("extractTracePartial: CSV form takes text after last comma", () => {
+  assertEquals(
+    extractTracePartial("  Satisfies: STK_001, SY"),
+    "SY",
+  );
+  assertEquals(
+    extractTracePartial("  Satisfies: STK_001, STK_002, SY"),
+    "SY",
+  );
+});
+
+Deno.test("extractTracePartial: empty partial after trailing comma", () => {
+  assertEquals(extractTracePartial("  Satisfies: STK_001, "), "");
+});
+
+Deno.test("extractTracePartial: returns empty when no colon present", () => {
+  assertEquals(extractTracePartial("  Satisfies SY"), "");
 });
 
 // --- Completion item building ---

--- a/packages/markspec/lsp/server.ts
+++ b/packages/markspec/lsp/server.ts
@@ -14,6 +14,7 @@
 import {
   type CompletionItem,
   CompletionItemKind,
+  type CompletionList,
   createConnection,
   type Diagnostic as LspDiagnosticType,
   DidChangeWatchedFilesNotification,
@@ -87,6 +88,7 @@ import {
   buildTypeAttributeItems,
   type EntryTypeInfo,
   extractRelationName,
+  extractTracePartial,
   isBlockScaffoldTrigger,
   isTraceAttributeTrigger,
   isTrailerKeyContext,
@@ -672,7 +674,7 @@ documents.onDidOpen(async (event) => {
 // Completions
 // ---------------------------------------------------------------------------
 
-connection.onCompletion((params): CompletionItem[] => {
+connection.onCompletion((params): CompletionItem[] | CompletionList => {
   tally("completion");
   const document = documents.get(params.textDocument.uri);
   if (!document) return [];
@@ -756,19 +758,33 @@ connection.onCompletion((params): CompletionItem[] => {
       const targets = profile && relationName
         ? targetsForRelation(profile, enclosing?.type, relationName)
         : undefined;
-      const displayIds = profile && targets
+      let displayIds = profile && targets
         ? filterEntriesByTraceTargets(
           index.getAllEntries(),
           targets,
           profile,
         ).map((e) => ({ displayId: e.displayId, title: e.title }))
         : index.getAllDisplayIds();
-      const items = buildIdReferenceItems(displayIds);
-      return items.map((item) => ({
+      // Server-side prefix filter on the partial the user has typed
+      // after the colon. Case-insensitive to match VS Code's
+      // client-side filter UX. The CompletionList is marked
+      // `isIncomplete` so the client re-queries as the prefix grows
+      // — otherwise the client would narrow its cached set further,
+      // hiding IDs that match a different prefix path (e.g. after a
+      // backspace + retype).
+      const partial = extractTracePartial(line);
+      if (partial) {
+        const needle = partial.toLowerCase();
+        displayIds = displayIds.filter((e) =>
+          e.displayId.toLowerCase().startsWith(needle)
+        );
+      }
+      const items = buildIdReferenceItems(displayIds).map((item) => ({
         label: item.label,
         detail: item.detail,
         kind: CompletionItemKind.Reference,
       }));
+      return { isIncomplete: partial.length > 0, items };
     });
   }
 

--- a/tests/e2e/lsp_completions_test.ts
+++ b/tests/e2e/lsp_completions_test.ts
@@ -84,19 +84,102 @@ Deno.test("lsp completions: ID reference on 'Satisfies:'", async () => {
     // Give server time to parse and index
     await new Promise((r) => setTimeout(r, 500));
 
-    // Request completion after "Satisfies:" (line 11, char 16)
+    // Request completion after "Satisfies:" (line 11, char 16).
+    // Trace-attribute completion returns a CompletionList so the
+    // server can set isIncomplete when a partial prefix narrows
+    // the suggestion set (server-side prefix filter).
     const result = await client.request("textDocument/completion", {
       textDocument: { uri: fileUri },
       position: { line: 11, character: 16 },
-    }) as Array<{ label: string }>;
+    }) as { isIncomplete: boolean; items: Array<{ label: string }> };
 
     assertExists(result);
-    assert(result.length > 0, "Expected at least one completion item");
+    assertExists(result.items);
+    assert(result.items.length > 0, "Expected at least one completion item");
     assert(
-      result.some((item) => item.label === "STK_AEB_0001"),
+      result.items.some((item) => item.label === "STK_AEB_0001"),
       `Expected STK_AEB_0001 in completions, got: ${
-        JSON.stringify(result.map((i) => i.label))
+        JSON.stringify(result.items.map((i) => i.label))
       }`,
+    );
+    // No partial after the colon → list is not incomplete.
+    assert(
+      !result.isIncomplete,
+      "Empty partial should produce a complete list",
+    );
+  } finally {
+    await client.shutdown();
+  }
+});
+
+Deno.test("lsp completions: server-side prefix filter on 'Satisfies: STK_'", async () => {
+  const md = `- [STK_AEB_0001] Stakeholder requirement
+
+  Body text.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+
+- [SAD_AEB_0001] Architecture item
+
+  Body text.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEG
+
+- [SAD_AEB_0002] Another architecture item
+
+  Body text.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEH
+      Satisfies: STK_
+`;
+  const client = await LspTestClient.create({
+    "project.yaml": "name: test-project\n",
+    "reqs.md": md,
+  });
+  try {
+    await client.initialize();
+
+    const fileUri = toFileUrl(join(client.workDir, "reqs.md")).href;
+    await client.notify("textDocument/didOpen", {
+      textDocument: {
+        uri: fileUri,
+        languageId: "markdown",
+        version: 1,
+        text: md,
+      },
+    });
+
+    await new Promise((r) => setTimeout(r, 500));
+
+    // Cursor sits at the end of `      Satisfies: STK_` on line 17
+    // (0-based). character = 6 indent + "Satisfies: STK_".length = 21.
+    const result = await client.request("textDocument/completion", {
+      textDocument: { uri: fileUri },
+      position: { line: 17, character: 21 },
+    }) as { isIncomplete: boolean; items: Array<{ label: string }> };
+
+    assertExists(result);
+    assertExists(result.items);
+    const labels = result.items.map((i) => i.label);
+    // Only STK_-prefixed IDs survive the server-side filter.
+    assert(
+      labels.every((label) => label.startsWith("STK_")),
+      `Expected only STK_-prefixed labels, got: ${JSON.stringify(labels)}`,
+    );
+    assert(
+      labels.includes("STK_AEB_0001"),
+      `Expected STK_AEB_0001 in results, got: ${JSON.stringify(labels)}`,
+    );
+    // SAD_ items are excluded.
+    assert(
+      !labels.includes("SAD_AEB_0001") && !labels.includes("SAD_AEB_0002"),
+      `Expected SAD_AEB_* to be filtered out, got: ${JSON.stringify(labels)}`,
+    );
+    // Partial typed → list is marked incomplete so the client re-queries
+    // as the prefix grows or shrinks.
+    assert(
+      result.isIncomplete,
+      "Non-empty partial should produce an incomplete list",
     );
   } finally {
     await client.shutdown();


### PR DESCRIPTION
## Summary

Devex item #3 of the editing-experience backlog. Server-side prefix filter on trace-attribute completion. When the author has typed a partial display ID after the colon (`Satisfies: STK_`), narrow the suggestion list to IDs whose display ID starts with that partial (case-insensitive). Composes cleanly on top of #2's relation-target narrowing: type-narrow first, then prefix-narrow.

The `CompletionList` is marked `isIncomplete: true` whenever a partial is present so the LSP client re-queries as the prefix grows or shrinks. Without that flag the client would narrow its cached set further client-side, hiding IDs that match a different prefix path (e.g. after a backspace + retype).

## Files

| File | What |
|---|---|
| `lsp/completions.ts` | New pure helper `extractTracePartial(textBefore)` — finds the colon, walks past the last comma (CSV form), trims |
| `lsp/server.ts` | Trace-attribute branch returns `CompletionList { isIncomplete, items }`; filters by case-insensitive `startsWith(partial)` when partial is non-empty. Handler signature widened to `CompletionItem[] \| CompletionList`; other triggers continue to return bare arrays |
| `lsp/completions_test.ts` | 6 new unit tests for `extractTracePartial` |
| `tests/e2e/lsp_completions_test.ts` | Existing `Satisfies:` test updated to the CompletionList shape + new e2e test `server-side prefix filter on 'Satisfies: STK_'` exercises the real LSP end-to-end |

## Test plan

- [x] `deno fmt --check` — clean
- [x] `deno lint` — clean
- [x] `deno test` — 2945 passed, 0 failed (+7 new)
- [x] 6 new unit tests cover empty-after-colon, trimmed whitespace, simple partial, CSV form (text after last comma), empty after trailing comma, no-colon edge case
- [x] New e2e test confirms: only STK_-prefixed IDs returned, SAD_ IDs excluded, `isIncomplete: true`
- [x] Existing e2e test updated to consume `.items` and assert `isIncomplete: false` on empty partial
- [ ] **Manual smoke test (post-merge):** in a large workspace, type `Satisfies: ` then `SY` then `S_` and confirm responsiveness improves and the suggestion list narrows correctly

## Behaviour for empty-partial completions

Unchanged from #554. The new layer only kicks in once the author has typed at least one character after the colon — exactly the moment the all-IDs payload starts to feel large. With no partial, the client receives the relation-target-narrowed list (or the full list, if no rule applies) with `isIncomplete: false`, and its local fuzzy filter takes over.

## Backlog status

- [x] #1 display-ID pattern share — shipped (#549)
- [x] #2 relation-target filtering — shipped (#554)
- [x] **#3 server-side prefix filter — this PR**
- [ ] #4 mid-typed `[STK_AEB_…` auto-complete next sequential number
- [ ] #5 debounce-window race producing duplicate display IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
