### PR TITLE
refactor(cli): derive init MCP filenames from adapter.resolveConfigPath (#542)

### DIFF
--- a/packages/markspec/cli/commands/init.ts
+++ b/packages/markspec/cli/commands/init.ts
@@ -120,6 +120,17 @@ export const initCmd = new Command()
       execPath: () => Deno.execPath(),
     };
 
+    const { claudeCodeDescriptor } = await import(
+      "../install/mcp_adapters_claude_code.ts"
+    );
+    const { opencodeDescriptor } = await import(
+      "../install/mcp_adapters_opencode.ts"
+    );
+    const mcpAdapters = new Map([
+      ["claude-code" as const, claudeCodeDescriptor],
+      ["opencode" as const, opencodeDescriptor],
+    ]);
+
     const result = await runInit({
       targetDir,
       profileChoice,
@@ -133,6 +144,7 @@ export const initCmd = new Command()
       fs,
       detectEnv,
       binaryEnv,
+      mcpAdapters,
       mcpRunner: async (opts) => {
         const { runMcpInstall } = await import(
           "../install/mcp_orchestrator.ts"

--- a/packages/markspec/cli/init/orchestrator.ts
+++ b/packages/markspec/cli/init/orchestrator.ts
@@ -7,7 +7,8 @@
  * {@linkcode InitResult}; the CLI action surfaces stdout/stderr/exit.
  */
 
-import { basename, join } from "@std/path";
+import { basename, join, relative } from "@std/path";
+import type { McpAdapter } from "../install/adapters.ts";
 import type {
   McpInstallOptions,
   OrchestratorResult,
@@ -64,6 +65,14 @@ export interface RunInitOptions {
   };
   readonly mcpRunner: McpRunner;
   readonly execRunner: ExecRunner;
+  /**
+   * Per-client MCP adapter descriptors. Threaded through to the
+   * planner (for `adapter.resolveConfigPath` lookups) and used here
+   * to map the planner's emitted file paths back to client IDs at
+   * execute time. Production wires `claudeCodeDescriptor` +
+   * `opencodeDescriptor`; tests inject stubs.
+   */
+  readonly mcpAdapters: ReadonlyMap<InitClientId, McpAdapter>;
   readonly now: () => string;
   readonly version: string;
 }
@@ -93,7 +102,23 @@ export async function runInit(options: RunInitOptions): Promise<InitResult> {
     profileChoice: options.profileChoice,
     clientSet,
     force: options.force,
+    mcpAdapters: options.mcpAdapters,
   });
+
+  // Reverse-lookup for the executor: relative config path → client ID.
+  // Built once from the same adapters the planner used so the executor
+  // and planner agree on filenames without duplicating any literal.
+  const mcpFileToClient = new Map<string, InitClientId>();
+  for (const [clientId, adapter] of options.mcpAdapters) {
+    const abs = adapter.resolveConfigPath(
+      "workspace",
+      options.targetDir,
+      "",
+      undefined,
+      options.targetDir,
+    );
+    mcpFileToClient.set(relative(options.targetDir, abs), clientId);
+  }
 
   // Spec §3 step 1: refuse non-empty target without --force.
   // Whitelist = pre-existing project files (static) ∪ top-level
@@ -195,20 +220,24 @@ export async function runInit(options: RunInitOptions): Promise<InitResult> {
             await scaffoldVscodeExtensions(options.fs, options.targetDir);
           }
           break;
-        case ".mcp.json":
-        case "opencode.json": {
-          // Defensive guard. The planner only emits `create` or `merge`
-          // for MCP files today, so this gate is a no-op against the
-          // current planner. It exists so a future planner change that
-          // emits `skip`/`no-op` for MCP files cannot silently invoke
-          // the runner — matching the gates on the other file branches.
+        default: {
+          // Adapter-driven MCP branch. The planner emitted this file
+          // path via `adapter.resolveConfigPath`; the reverse lookup
+          // tells us which client it belongs to. Non-MCP files that
+          // don't match the static cases above are skipped silently —
+          // the planner does not emit any today.
+          const client = mcpFileToClient.get(a.file);
+          if (client === undefined) break;
+          // Defensive guard. The planner only emits `create` or
+          // `merge` for MCP files today, so this gate is a no-op
+          // against the current planner. It exists so a future
+          // planner change that emits `skip`/`no-op` for MCP files
+          // cannot silently invoke the runner — matching the gates
+          // on the other file branches.
           if (
             a.kind !== "create" && a.kind !== "merge" &&
             a.kind !== "overwrite"
           ) break;
-          const client: string = a.file === "opencode.json"
-            ? "opencode"
-            : "claude-code";
           const r = await options.mcpRunner({
             client,
             scope: "workspace",

--- a/packages/markspec/cli/init/orchestrator_test.ts
+++ b/packages/markspec/cli/init/orchestrator_test.ts
@@ -3,6 +3,13 @@
 import { assertEquals } from "@std/assert";
 import { createMemFs } from "./fake_fs.ts";
 import { type ExecRunner, type McpRunner, runInit } from "./orchestrator.ts";
+import { claudeCodeDescriptor } from "../install/mcp_adapters_claude_code.ts";
+import { opencodeDescriptor } from "../install/mcp_adapters_opencode.ts";
+
+const adapters = new Map([
+  ["claude-code" as const, claudeCodeDescriptor],
+  ["opencode" as const, opencodeDescriptor],
+]);
 
 const FROZEN_TIME = "2026-05-28T12:00:00Z";
 
@@ -60,6 +67,7 @@ Deno.test("runInit: empty target, no clients, ok path", async () => {
     execRunner: okExec,
     now: fakeNow,
     version: "0.6.0",
+    mcpAdapters: adapters,
   });
   assertEquals(result.ok, true);
   assertEquals(result.exitCode, 0);
@@ -91,6 +99,7 @@ Deno.test("runInit: --dry-run writes no files", async () => {
     execRunner: okExec,
     now: fakeNow,
     version: "0.6.0",
+    mcpAdapters: adapters,
   });
   assertEquals(result.ok, true);
   assertEquals(await fs.read("/repo/project.yaml"), undefined);
@@ -121,6 +130,7 @@ Deno.test("runInit: clients detected → mcpRunner invoked per client", async ()
     execRunner: okExec,
     now: fakeNow,
     version: "0.6.0",
+    mcpAdapters: adapters,
   });
   assertEquals(calls.sort(), ["claude-code", "opencode"]);
 });
@@ -149,6 +159,7 @@ Deno.test("runInit: --no-skills skips upskill", async () => {
     execRunner: exec,
     now: fakeNow,
     version: "0.6.0",
+    mcpAdapters: adapters,
   });
   assertEquals(calls.includes("upskill"), false);
 });
@@ -172,6 +183,7 @@ Deno.test("runInit: upskill missing → warning + exit 2", async () => {
     execRunner: missingExec,
     now: fakeNow,
     version: "0.6.0",
+    mcpAdapters: adapters,
   });
   assertEquals(result.exitCode, 2);
   const upskillWarn = result.warnings.find((w) =>
@@ -211,6 +223,7 @@ Deno.test("runInit: upskill missing on Windows (exit 9009 / not recognized) → 
     execRunner: windowsMissingExec,
     now: fakeNow,
     version: "0.6.0",
+    mcpAdapters: adapters,
   });
   const upskillNotFound = result.warnings.find((w) =>
     w.code === "UPSKILL_NOT_FOUND"
@@ -242,6 +255,7 @@ Deno.test("runInit: non-whitelisted content (src/) → TARGET_NOT_EMPTY error + 
     execRunner: okExec,
     now: fakeNow,
     version: "0.6.0",
+    mcpAdapters: adapters,
   });
   assertEquals(result.ok, false);
   assertEquals(result.exitCode, 1);
@@ -274,6 +288,7 @@ Deno.test("runInit: plan outputs are dynamically whitelisted for TARGET_NOT_EMPT
     execRunner: okExec,
     now: fakeNow,
     version: "0.6.0",
+    mcpAdapters: adapters,
   });
   assertEquals(result.ok, true);
   assertEquals(result.error, undefined);
@@ -299,6 +314,7 @@ Deno.test("runInit: existing project.yaml only → skip + exit 2 (whitelisted ou
     execRunner: okExec,
     now: fakeNow,
     version: "0.6.0",
+    mcpAdapters: adapters,
   });
   assertEquals(result.exitCode, 2);
   const skip = result.actions.find((a) => a.file === "project.yaml");
@@ -326,6 +342,7 @@ Deno.test("runInit: mcpRunner failure → MCP_INSTALL_FAILED warning + exit 2", 
     execRunner: okExec,
     now: fakeNow,
     version: "0.6.0",
+    mcpAdapters: adapters,
   });
   assertEquals(result.exitCode, 2);
   const warn = result.warnings.find((w) => w.code === "MCP_INSTALL_FAILED");

--- a/packages/markspec/cli/init/planner.ts
+++ b/packages/markspec/cli/init/planner.ts
@@ -7,13 +7,20 @@
  * spec §4 idempotency table becomes code.
  */
 
-import { join } from "@std/path";
+import { join, relative } from "@std/path";
 import type { MemFs } from "./fake_fs.ts";
+import type { McpAdapter } from "../install/adapters.ts";
 import {
   EXTENSION_ID,
   mergeVscodeExtensions,
 } from "./scaffolders/vscode_extensions.ts";
-import type { Action, ClientSet, ProfileChoice, WritePlan } from "./types.ts";
+import type {
+  Action,
+  ClientSet,
+  InitClientId,
+  ProfileChoice,
+  WritePlan,
+} from "./types.ts";
 
 export interface PlanInputs {
   readonly targetDir: string;
@@ -21,6 +28,14 @@ export interface PlanInputs {
   readonly profileChoice: ProfileChoice;
   readonly clientSet: ClientSet;
   readonly force: boolean;
+  /**
+   * Per-client adapter descriptors. The planner calls
+   * `adapter.resolveConfigPath("workspace", ...)` for each client in
+   * `clientSet.write` to discover where the client expects its config,
+   * so the planner does not hardcode client → filename mappings.
+   * Keyed by {@linkcode InitClientId}.
+   */
+  readonly mcpAdapters: ReadonlyMap<InitClientId, McpAdapter>;
 }
 
 const SKIP_HINT = "rerun with --force to overwrite";
@@ -33,8 +48,22 @@ export async function computeWritePlan(inputs: PlanInputs): Promise<WritePlan> {
   }
 
   for (const client of inputs.clientSet.write) {
-    const file = client === "opencode" ? "opencode.json" : ".mcp.json";
-    const exists = await inputs.fs.exists(join(inputs.targetDir, file));
+    const adapter = inputs.mcpAdapters.get(client);
+    if (!adapter) {
+      // Defensive: clientSet.write should only contain IDs the
+      // orchestrator has an adapter for. Skip rather than throw so a
+      // misconfigured wiring surfaces as a missing action, not a crash.
+      continue;
+    }
+    const absPath = adapter.resolveConfigPath(
+      "workspace",
+      inputs.targetDir,
+      "",
+      undefined,
+      inputs.targetDir,
+    );
+    const file = relative(inputs.targetDir, absPath);
+    const exists = await inputs.fs.exists(absPath);
     actions.push(
       exists ? { kind: "merge", file } : { kind: "create", file },
     );

--- a/packages/markspec/cli/init/planner_test.ts
+++ b/packages/markspec/cli/init/planner_test.ts
@@ -1,6 +1,13 @@
 import { assertEquals } from "@std/assert";
 import { createMemFs } from "./fake_fs.ts";
 import { computeWritePlan, type PlanInputs } from "./planner.ts";
+import { claudeCodeDescriptor } from "../install/mcp_adapters_claude_code.ts";
+import { opencodeDescriptor } from "../install/mcp_adapters_opencode.ts";
+
+const adapters = new Map([
+  ["claude-code" as const, claudeCodeDescriptor],
+  ["opencode" as const, opencodeDescriptor],
+]);
 
 const baseInputs = (overrides: Partial<PlanInputs> = {}): PlanInputs => ({
   targetDir: "/r",
@@ -8,6 +15,7 @@ const baseInputs = (overrides: Partial<PlanInputs> = {}): PlanInputs => ({
   profileChoice: { kind: "bundled" },
   clientSet: { write: new Set() },
   force: false,
+  mcpAdapters: adapters,
   ...overrides,
 });
 
@@ -65,4 +73,23 @@ Deno.test("planner: existing .vscode/extensions.json without our id → merge", 
   const plan = await computeWritePlan(baseInputs({ fs }));
   const action = plan.actions.find((a) => a.file === ".vscode/extensions.json");
   assertEquals(action?.kind, "merge");
+});
+
+Deno.test("planner: MCP filename comes from adapter.resolveConfigPath (no hardcoded mapping)", async () => {
+  // Wire a stub adapter that uses a non-default filename. The planner
+  // must surface it verbatim; if it ever reverts to a hardcoded
+  // client → filename map this test fails.
+  const stubAdapter = {
+    id: "claude-code" as const,
+    jsonPath: ["mcpServers", "markspec"] as const,
+    resolveConfigPath: () => "/r/.stub-mcp.json",
+    renderBlock: () => ({}),
+  };
+  const stubAdapters = new Map([["claude-code" as const, stubAdapter]]);
+  const plan = await computeWritePlan(baseInputs({
+    clientSet: { write: new Set(["claude-code"]) },
+    mcpAdapters: stubAdapters,
+  }));
+  const stubAction = plan.actions.find((a) => a.file === ".stub-mcp.json");
+  assertEquals(stubAction?.kind, "create");
 });


### PR DESCRIPTION
## Summary

Closes #542. Replaces the planner's hardcoded client → filename map (`claude-code → .mcp.json`, `opencode → opencode.json`) with `adapter.resolveConfigPath(...)` calls — the single source of truth each MCP adapter already exposes.

### Changes

- `cli/init/planner.ts`: `PlanInputs` gains `mcpAdapters: ReadonlyMap<InitClientId, McpAdapter>`. The MCP-client loop calls `adapter.resolveConfigPath("workspace", targetDir, …)` and stores the result (relative to `targetDir`) on `Action.file`.
- `cli/init/orchestrator.ts`: `RunInitOptions` gains the same `mcpAdapters` map. The executor builds a reverse `filename → InitClientId` lookup from the adapters and swaps the literal `case ".mcp.json": case "opencode.json":` branches for a `default:` lookup. Adding a third adapter now lights up automatically.
- `cli/commands/init.ts`: builds the production adapters map from `claudeCodeDescriptor` + `opencodeDescriptor` and threads it into `runInit`.
- `cli/init/planner_test.ts`: new test wires a **stub adapter with a non-default filename** and asserts the planner surfaces it verbatim. If the planner ever reverts to a hardcoded map this test fails.
- `cli/init/orchestrator_test.ts`: adds the production adapters map to every `runInit` call site (8 sites).

### Behaviour

For the production adapters the resolved relative paths are the same `.mcp.json` and `opencode.json` strings as before, so no visible behaviour changes for users. All existing orchestrator tests pass unchanged.

### Test plan

- [x] `just build` — green
- [x] `deno fmt --check` + `dprint check` — clean
- [x] 7/7 planner tests pass (including the new drift guard)
- [x] 9/9 orchestrator tests pass