### PR TITLE
feat(lsp): mid-typed display-ID auto-complete in block scaffold

### DIFF
--- a/packages/markspec/lsp/completions.ts
+++ b/packages/markspec/lsp/completions.ts
@@ -23,6 +23,16 @@ import type { DisplayIdEntry } from "./workspace.ts";
 /** Block scaffold trigger pattern: `- [` at the start of a list item. */
 const BLOCK_SCAFFOLD_RE = /^\s*-\s*\[$/;
 
+/**
+ * Mid-typed scaffold trigger pattern: `- [` followed by at least one
+ * display-ID prefix character (letters, digits, underscore, hyphen),
+ * with the cursor at the end. Fires once the author has started typing
+ * a prefix by hand (e.g. `- [STK_`), where the bare-bracket
+ * {@linkcode BLOCK_SCAFFOLD_RE} no longer matches. The captured group
+ * is the typed partial.
+ */
+const MID_TYPED_SCAFFOLD_RE = /^\s*-\s*\[([A-Za-z0-9_-]+)$/;
+
 /** Pattern matching a trace attribute keyword at line start. */
 const TRACE_ATTR_RE =
   /^\s*(Satisfies|Derived-from|Verified-by|References|Tests|Depends-on|Part-of|Allocated-to|Realizes|Generated-from|Supersedes)\s*:/;
@@ -79,6 +89,26 @@ export function isTrailerKeyContext(textBefore: string): boolean {
  */
 export function isBlockScaffoldTrigger(textBefore: string): boolean {
   return BLOCK_SCAFFOLD_RE.test(textBefore);
+}
+
+/**
+ * Check if the text before the cursor triggers a mid-typed scaffold
+ * completion — `- [` followed by ≥1 prefix character, cursor at end.
+ * This is more specific than {@linkcode isBlockScaffoldTrigger} (which
+ * matches only the bare `- [`); the server tries this trigger first.
+ */
+export function isMidTypedScaffoldTrigger(textBefore: string): boolean {
+  return MID_TYPED_SCAFFOLD_RE.test(textBefore);
+}
+
+/**
+ * Extract the partially-typed display-ID prefix from a mid-typed
+ * scaffold line. Returns the captured partial (e.g. `"STK_"` from
+ * `"- [STK_"`), or the empty string when the line is not a mid-typed
+ * scaffold trigger.
+ */
+export function extractMidTypedPartial(textBefore: string): string {
+  return MID_TYPED_SCAFFOLD_RE.exec(textBefore)?.[1] ?? "";
 }
 
 /**
@@ -275,6 +305,16 @@ export interface ScaffoldCompletionData {
   readonly prefix: string;
   readonly width: number;
   readonly suffix: string;
+  /**
+   * Present only for mid-typed scaffold items (see
+   * {@linkcode buildMidTypedScaffoldItems}): the exact range the
+   * accepted edit must replace — the typed partial. When set, the
+   * resolve handler rebuilds a `textEdit` (range + freshly rendered
+   * snippet) instead of plain `insertText`, so the editor replaces the
+   * partial rather than inserting after it. Absent for bare `- [`
+   * block-scaffold items, which keep the plain-insertText resolve path.
+   */
+  readonly replacementRange?: ReplacementRange;
 }
 
 /**
@@ -391,6 +431,107 @@ export function buildBlockScaffoldItems(
       insertText: rendered.insertText,
       isSnippet: true,
       kind: KIND_SNIPPET,
+    };
+  });
+}
+
+/**
+ * A zero-based LSP range (start/end line + character) — the span a
+ * mid-typed scaffold completion replaces. Matches the shape of the LSP
+ * `Range` type so callers can hand it straight to a `TextEdit`.
+ */
+export interface ReplacementRange {
+  readonly start: { readonly line: number; readonly character: number };
+  readonly end: { readonly line: number; readonly character: number };
+}
+
+/**
+ * One mid-typed scaffold completion item. Unlike
+ * {@linkcode CompletionItemData}, it always carries a `textEdit` so the
+ * editor replaces exactly the typed partial (not whatever its
+ * word-boundary heuristic would pick). `typeName`, `prefix`, `width`,
+ * and `suffix` are surfaced so the server can attach the resolve-time
+ * {@linkcode ScaffoldCompletionData} payload.
+ */
+export interface MidTypedScaffoldItem {
+  readonly label: string;
+  readonly detail: string;
+  readonly typeName: string;
+  readonly prefix: string;
+  readonly width: number;
+  readonly suffix: string;
+  readonly textEdit: {
+    readonly range: ReplacementRange;
+    readonly newText: string;
+  };
+}
+
+/**
+ * Build mid-typed scaffold completion items for a partially-typed
+ * display-ID prefix.
+ *
+ * A profile type matches the `partial` when its `prefix` is a (non-
+ * strict) prefix of the partial, or the partial is a (non-strict)
+ * prefix of its `prefix` — i.e. `prefix.startsWith(partial) ||
+ * partial.startsWith(prefix)`. This covers both directions: the author
+ * has typed a strict prefix of a declared prefix (`STK_` → `STK_AEB_`),
+ * or the author has already typed the full prefix and possibly more
+ * (`STK_AEB_0001`). Matching is case-sensitive — display IDs are.
+ *
+ * Each matched type's snippet is rendered via
+ * {@linkcode renderScaffoldSnippet} (filling the missing prefix suffix,
+ * the next sequential number, a freshly provided ULID and the trailer
+ * skeleton) and wrapped in a `textEdit` whose range is the supplied
+ * `replacementRange` (the span covering the typed partial). Items whose
+ * `prefix` exactly equals the partial sort first; remaining matches keep
+ * the caller's order.
+ *
+ * Returns an empty array when no profile type matches (including when
+ * `types` is empty), so the server falls back to no completion — the
+ * pre-existing behaviour for a mid-typed bracket.
+ *
+ * @param ulidProvider - Called once per matched item; the returned ULID
+ *   is baked into the snippet so no follow-up `markspec format` is
+ *   needed. The resolve handler re-renders with a fresh ULID on accept.
+ */
+export function buildMidTypedScaffoldItems(
+  types: readonly EntryTypeInfo[],
+  partial: string,
+  ulidProvider: () => string,
+  replacementRange: ReplacementRange,
+): MidTypedScaffoldItem[] {
+  const matched = types.filter((t) =>
+    t.prefix.startsWith(partial) || partial.startsWith(t.prefix)
+  );
+
+  // Exact prefix match first; otherwise preserve the caller's order.
+  const sorted = matched
+    .map((t, i) => ({ t, i }))
+    .sort((a, b) => {
+      const aExact = a.t.prefix === partial ? 1 : 0;
+      const bExact = b.t.prefix === partial ? 1 : 0;
+      if (aExact !== bExact) return bExact - aExact;
+      return a.i - b.i;
+    })
+    .map(({ t }) => t);
+
+  return sorted.map((type) => {
+    const rendered = renderScaffoldSnippet({
+      typeName: type.name,
+      prefix: type.prefix,
+      width: type.width,
+      suffix: type.suffix,
+      nextNumber: type.nextNumber,
+      ulid: ulidProvider(),
+    });
+    return {
+      label: rendered.label,
+      detail: type.name,
+      typeName: type.name,
+      prefix: type.prefix,
+      width: type.width,
+      suffix: type.suffix,
+      textEdit: { range: replacementRange, newText: rendered.insertText },
     };
   });
 }

--- a/packages/markspec/lsp/completions_test.ts
+++ b/packages/markspec/lsp/completions_test.ts
@@ -8,15 +8,19 @@ import { assertEquals, assertNotEquals } from "@std/assert";
 import {
   buildBlockScaffoldItems,
   buildIdReferenceItems,
+  buildMidTypedScaffoldItems,
   buildTrailerKeyItems,
   buildTypeAttributeItems,
+  extractMidTypedPartial,
   extractRelationName,
   extractTracePartial,
   isBlockScaffoldTrigger,
+  isMidTypedScaffoldTrigger,
   isTraceAttributeTrigger,
   isTrailerKeyContext,
   isTypeAttributeTrigger,
   renderScaffoldSnippet,
+  type ReplacementRange,
   TRAILER_KEYS,
 } from "./completions.ts";
 import type { DisplayIdEntry } from "./workspace.ts";
@@ -473,4 +477,187 @@ Deno.test("Slice 5 LSP: '(recommended)' suffix appears only on modeRecommended i
   const no = items.find((i) => i.detail?.startsWith("No"));
   assertEquals(yes?.detail, "Yes (recommended)");
   assertEquals(no?.detail, "No");
+});
+
+// --- Item #4: mid-typed display-ID scaffold trigger ---
+
+Deno.test("isMidTypedScaffoldTrigger: matches '- [S' (single char)", () => {
+  assertEquals(isMidTypedScaffoldTrigger("- [S"), true);
+});
+
+Deno.test("isMidTypedScaffoldTrigger: matches '- [STK_' (full prefix, underscore)", () => {
+  assertEquals(isMidTypedScaffoldTrigger("- [STK_"), true);
+});
+
+Deno.test("isMidTypedScaffoldTrigger: matches '- [STK_AEB_0' (with digit)", () => {
+  assertEquals(isMidTypedScaffoldTrigger("- [STK_AEB_0"), true);
+});
+
+Deno.test("isMidTypedScaffoldTrigger: matches '- [REQ-' (with hyphen)", () => {
+  assertEquals(isMidTypedScaffoldTrigger("- [REQ-"), true);
+});
+
+Deno.test("isMidTypedScaffoldTrigger: matches indented '  - [STK'", () => {
+  assertEquals(isMidTypedScaffoldTrigger("  - [STK"), true);
+});
+
+Deno.test("isMidTypedScaffoldTrigger: rejects bare '- [' (no partial)", () => {
+  assertEquals(isMidTypedScaffoldTrigger("- ["), false);
+});
+
+Deno.test("isMidTypedScaffoldTrigger: rejects closed bracket '- [STK]'", () => {
+  assertEquals(isMidTypedScaffoldTrigger("- [STK]"), false);
+});
+
+Deno.test("isMidTypedScaffoldTrigger: rejects mid-line text 'foo - [STK'", () => {
+  assertEquals(isMidTypedScaffoldTrigger("foo - [STK"), false);
+});
+
+Deno.test("extractMidTypedPartial: extracts 'STK_' from '- [STK_'", () => {
+  assertEquals(extractMidTypedPartial("- [STK_"), "STK_");
+});
+
+Deno.test("extractMidTypedPartial: extracts single char 'S' from '- [S'", () => {
+  assertEquals(extractMidTypedPartial("- [S"), "S");
+});
+
+Deno.test("extractMidTypedPartial: extracts 'REQ-0' from indented '  - [REQ-0'", () => {
+  assertEquals(extractMidTypedPartial("  - [REQ-0"), "REQ-0");
+});
+
+Deno.test("extractMidTypedPartial: returns '' for bare '- ['", () => {
+  assertEquals(extractMidTypedPartial("- ["), "");
+});
+
+Deno.test("extractMidTypedPartial: returns '' for non-matching line", () => {
+  assertEquals(extractMidTypedPartial("random text"), "");
+});
+
+// --- Item #4: buildMidTypedScaffoldItems ---
+
+const MID_RANGE: ReplacementRange = {
+  start: { line: 2, character: 3 },
+  end: { line: 2, character: 7 },
+};
+
+Deno.test("buildMidTypedScaffoldItems: subset matches by prefix-extends", () => {
+  const types = [
+    {
+      name: "stakeholder-requirement",
+      prefix: "STK_AEB_",
+      width: 4,
+      suffix: "",
+      nextNumber: 4,
+    },
+    {
+      name: "architecture",
+      prefix: "SAD_AEB_",
+      width: 4,
+      suffix: "",
+      nextNumber: 2,
+    },
+  ];
+  const items = buildMidTypedScaffoldItems(
+    types,
+    "STK_",
+    () => "01HGW2Q8MNP3RSTVWXYZABCDEF",
+    MID_RANGE,
+  );
+  // Only STK_AEB_ has a prefix that starts with the partial "STK_".
+  assertEquals(items.length, 1);
+  assertEquals(items[0].prefix, "STK_AEB_");
+  assertEquals(items[0].label, "New stakeholder-requirement (STK_AEB_0004)");
+});
+
+Deno.test("buildMidTypedScaffoldItems: matches when partial extends a declared prefix", () => {
+  const types = [
+    {
+      name: "stakeholder-requirement",
+      prefix: "STK_AEB_",
+      width: 4,
+      suffix: "",
+      nextNumber: 1,
+    },
+  ];
+  const items = buildMidTypedScaffoldItems(
+    types,
+    "STK_AEB_0001",
+    () => "01HGW2Q8MNP3RSTVWXYZABCDEF",
+    MID_RANGE,
+  );
+  // The partial already extends the declared prefix → still a match.
+  assertEquals(items.length, 1);
+  assertEquals(items[0].prefix, "STK_AEB_");
+});
+
+Deno.test("buildMidTypedScaffoldItems: exact-prefix match comes first", () => {
+  const types = [
+    { name: "scoped", prefix: "STK_AEB_", width: 4, suffix: "", nextNumber: 1 },
+    { name: "bare", prefix: "STK_", width: 4, suffix: "", nextNumber: 1 },
+  ];
+  const items = buildMidTypedScaffoldItems(
+    types,
+    "STK_",
+    () => "01HGW2Q8MNP3RSTVWXYZABCDEF",
+    MID_RANGE,
+  );
+  // Both match the partial "STK_"; the exact prefix match (STK_) is first.
+  assertEquals(items.length, 2);
+  assertEquals(items[0].prefix, "STK_");
+  assertEquals(items[1].prefix, "STK_AEB_");
+});
+
+Deno.test("buildMidTypedScaffoldItems: no matches → empty array", () => {
+  const types = [
+    {
+      name: "stakeholder-requirement",
+      prefix: "STK_AEB_",
+      width: 4,
+      suffix: "",
+      nextNumber: 1,
+    },
+  ];
+  const items = buildMidTypedScaffoldItems(
+    types,
+    "XYZ",
+    () => "01HGW2Q8MNP3RSTVWXYZABCDEF",
+    MID_RANGE,
+  );
+  assertEquals(items.length, 0);
+});
+
+Deno.test("buildMidTypedScaffoldItems: attaches the replacement range to each textEdit", () => {
+  const types = [
+    {
+      name: "stakeholder-requirement",
+      prefix: "STK_AEB_",
+      width: 4,
+      suffix: "",
+      nextNumber: 4,
+    },
+  ];
+  const items = buildMidTypedScaffoldItems(
+    types,
+    "STK_",
+    () => "01HGW2Q8MNP3RSTVWXYZABCDEF",
+    MID_RANGE,
+  );
+  assertEquals(items[0].textEdit.range, MID_RANGE);
+  // The replacement text is the full display ID + skeleton — replacing
+  // the typed partial with the rest of the entry.
+  assertEquals(items[0].textEdit.newText.startsWith("STK_AEB_0004]"), true);
+  assertEquals(
+    items[0].textEdit.newText.includes("Id: 01HGW2Q8MNP3RSTVWXYZABCDEF"),
+    true,
+  );
+});
+
+Deno.test("buildMidTypedScaffoldItems: empty types → empty array", () => {
+  const items = buildMidTypedScaffoldItems(
+    [],
+    "STK_",
+    () => "01HGW2Q8MNP3RSTVWXYZABCDEF",
+    MID_RANGE,
+  );
+  assertEquals(items.length, 0);
 });

--- a/packages/markspec/lsp/server.ts
+++ b/packages/markspec/lsp/server.ts
@@ -84,16 +84,20 @@ import {
 import {
   buildBlockScaffoldItems,
   buildIdReferenceItems,
+  buildMidTypedScaffoldItems,
   buildTrailerKeyItems,
   buildTypeAttributeItems,
   type EntryTypeInfo,
+  extractMidTypedPartial,
   extractRelationName,
   extractTracePartial,
   isBlockScaffoldTrigger,
+  isMidTypedScaffoldTrigger,
   isTraceAttributeTrigger,
   isTrailerKeyContext,
   isTypeAttributeTrigger,
   renderScaffoldSnippet,
+  type ReplacementRange,
   SCAFFOLD_COMPLETION_KIND,
   type ScaffoldCompletionData,
 } from "./completions.ts";
@@ -694,6 +698,50 @@ connection.onCompletion((params): CompletionItem[] | CompletionList => {
     end: params.position,
   });
 
+  // Trigger 0: Mid-typed display-ID scaffold — `- [<partial>`. More
+  // specific than the bare-bracket block scaffold below, so it is tried
+  // first. Each item carries an explicit textEdit replacing exactly the
+  // typed partial (VS Code's word-boundary heuristic treats `_` and
+  // digits as word chars and would otherwise pick the wrong span).
+  if (isMidTypedScaffoldTrigger(line)) {
+    return time("onCompletion/midTypedScaffold", () => {
+      const partial = extractMidTypedPartial(line);
+      const bracketIndex = line.lastIndexOf("[");
+      const replacementRange: ReplacementRange = {
+        start: { line: params.position.line, character: bracketIndex + 1 },
+        end: {
+          line: params.position.line,
+          character: params.position.character,
+        },
+      };
+      const items = buildMidTypedScaffoldItems(
+        getEntryTypes(),
+        partial,
+        ulid,
+        replacementRange,
+      );
+      // No matching profile type → return nothing (no profile loaded or
+      // the partial matches no declared prefix), matching prior behaviour
+      // for a mid-typed bracket.
+      return items.map((item) => ({
+        label: item.label,
+        detail: item.detail,
+        insertText: item.textEdit.newText,
+        insertTextFormat: InsertTextFormat.Snippet,
+        kind: CompletionItemKind.Snippet,
+        textEdit: item.textEdit,
+        data: {
+          kind: SCAFFOLD_COMPLETION_KIND,
+          typeName: item.typeName,
+          prefix: item.prefix,
+          width: item.width,
+          suffix: item.suffix,
+          replacementRange: item.textEdit.range,
+        } satisfies ScaffoldCompletionData,
+      }));
+    });
+  }
+
   // Trigger 1: Block scaffold
   if (isBlockScaffoldTrigger(line)) {
     return time("onCompletion/scaffold", () => {
@@ -844,6 +892,22 @@ connection.onCompletionResolve((item): CompletionItem => {
     nextNumber,
     ulid: ulid(),
   });
+  // Mid-typed scaffold items carry the replacement range: rebuild the
+  // textEdit with the freshly rendered snippet (a stale textEdit.newText
+  // would otherwise win over insertText). Range is unchanged — the cursor
+  // hasn't moved between completion and resolve. Bare block-scaffold items
+  // have no range and keep the plain-insertText path.
+  if (isValidReplacementRange(data.replacementRange)) {
+    return {
+      ...item,
+      label: rendered.label,
+      textEdit: {
+        range: data.replacementRange,
+        newText: rendered.insertText,
+      },
+      insertTextFormat: InsertTextFormat.Snippet,
+    };
+  }
   return {
     ...item,
     label: rendered.label,
@@ -851,6 +915,20 @@ connection.onCompletionResolve((item): CompletionItem => {
     insertTextFormat: InsertTextFormat.Snippet,
   };
 });
+
+/** Narrow + validate a resolve-payload replacement range. Defends against
+ * tampered or malformed `data` from a hostile or buggy LSP client — the
+ * typed cast at the resolve handler's top does not validate at runtime. */
+function isValidReplacementRange(
+  range: ReplacementRange | undefined,
+): range is ReplacementRange {
+  if (!range) return false;
+  const { start, end } = range;
+  return typeof start?.line === "number" &&
+    typeof start?.character === "number" &&
+    typeof end?.line === "number" &&
+    typeof end?.character === "number";
+}
 
 // ---------------------------------------------------------------------------
 // Hover

--- a/tests/e2e/lsp_completions_test.ts
+++ b/tests/e2e/lsp_completions_test.ts
@@ -4,7 +4,7 @@
  * E2E test: trigger completion at `- [` and `Satisfies:` positions.
  */
 
-import { assert, assertExists } from "@std/assert";
+import { assert, assertEquals, assertExists } from "@std/assert";
 import { join, toFileUrl } from "@std/path";
 import { LspTestClient } from "./lsp_helpers.ts";
 
@@ -180,6 +180,83 @@ Deno.test("lsp completions: server-side prefix filter on 'Satisfies: STK_'", asy
     assert(
       result.isIncomplete,
       "Non-empty partial should produce an incomplete list",
+    );
+  } finally {
+    await client.shutdown();
+  }
+});
+
+Deno.test("lsp completions: mid-typed prefix '- [STK_' scaffolds with textEdit", async () => {
+  // Profile declaring a stakeholder-requirement type with the
+  // STK_AEB_{n:04d} display-ID pattern → prefix "STK_AEB_".
+  const profileYaml = `id: "@acme/midtyped"
+version: 0.1.0
+profile:
+  types:
+    stakeholder-requirement:
+      extends: Requirement
+      display-id-pattern: "STK_AEB_{n:04d}"
+`;
+  const md = `# Requirements
+
+- [STK_
+`;
+  const client = await LspTestClient.create({
+    "project.yaml": "name: test-project\nversion: 0.1.0\n",
+    ".markspec.yaml": "profiles:\n  - ./profiles/midtyped\n",
+    "profiles/midtyped/markspec.yaml": profileYaml,
+    "reqs.md": md,
+  });
+  try {
+    await client.initialize();
+
+    const fileUri = toFileUrl(join(client.workDir, "reqs.md")).href;
+    await client.notify("textDocument/didOpen", {
+      textDocument: {
+        uri: fileUri,
+        languageId: "markdown",
+        version: 1,
+        text: md,
+      },
+    });
+
+    // Give the server time to load the profile and parse.
+    await new Promise((r) => setTimeout(r, 500));
+
+    // Cursor at the end of "- [STK_" on line 2 (0-based): char 7.
+    // "- [STK_" → `-`=0 ` `=1 `[`=2 `STK_`=3..6, cursor at 7.
+    const result = await client.request("textDocument/completion", {
+      textDocument: { uri: fileUri },
+      position: { line: 2, character: 7 },
+    }) as Array<{
+      label: string;
+      textEdit?: {
+        range: {
+          start: { line: number; character: number };
+          end: { line: number; character: number };
+        };
+        newText: string;
+      };
+    }>;
+
+    assertExists(result);
+    const item = result.find((i) =>
+      i.label === "New stakeholder-requirement (STK_AEB_0001)"
+    );
+    assertExists(
+      item,
+      `Expected mid-typed scaffold for STK_AEB_0001, got: ${
+        JSON.stringify(result.map((i) => i.label))
+      }`,
+    );
+    // The textEdit replaces exactly the typed partial "STK_" (chars 3..7)
+    // with the full display ID + entry skeleton.
+    assertExists(item.textEdit, "Expected a textEdit on the scaffold item");
+    assertEquals(item.textEdit.range.start, { line: 2, character: 3 });
+    assertEquals(item.textEdit.range.end, { line: 2, character: 7 });
+    assert(
+      item.textEdit.newText.startsWith("STK_AEB_0001]"),
+      `Expected newText to start with the full display ID, got: ${item.textEdit.newText}`,
     );
   } finally {
     await client.shutdown();


### PR DESCRIPTION
## Summary

The block-scaffold completion (`- [`) only fired when the cursor sat
immediately after the bare bracket. Once an author hand-typed part of a
prefix — `- [STK_` — completion went silent, and the existing items'
insert text would have duplicated the typed prefix on accept.

This adds a **more-specific trigger** that fires on `- [<partial>`:

- Lists every profile-declared type whose prefix is a (non-strict) prefix
  of the typed partial, **or** whose prefix the partial extends — covering
  both `STK_` → `STK_AEB_` and `STK_AEB_0001`. Exact-prefix matches sort first.
- Returns an explicit `textEdit` whose range covers exactly the typed
  partial (from `[`+1 to the cursor), replacing it with the full display
  ID, next sequential number, ULID stamp, and trailer skeleton — reusing
  `renderScaffoldSnippet`. The explicit range avoids VS Code's
  word-boundary heuristic, which treats `_` and digits as word characters
  and would otherwise pick the wrong span.
- `completionItem/resolve` re-renders with a fresh ULID + next number and
  **rebuilds the `textEdit`** (carrying the replacement range through the
  `data` payload) so its `newText` can't go stale.
- Falls back to no completion when no profile is loaded or no prefix
  matches — the prior behaviour for a mid-typed bracket.

The pre-existing bare-`- [` block-scaffold trigger and branch are
untouched; the new trigger fires only where the old one doesn't.

## Test plan

- **Unit** (`completions_test.ts`): `isMidTypedScaffoldTrigger` and
  `extractMidTypedPartial` (single char, full prefix, digits, hyphen,
  indented, no-match, closed-bracket, mid-line); `buildMidTypedScaffoldItems`
  (prefix-extends subset, partial-extends-prefix, exact-match-first ordering,
  no-match → empty, empty-types → empty, textEdit range/newText).
- **E2E** (`lsp_completions_test.ts`): drives the real LSP with a profile
  declaring `STK_AEB_{n:04d}`, opens `- [STK_`, requests completion, and
  asserts the `STK_AEB_0001` scaffold appears with a `textEdit` replacing
  exactly chars 3–7 (`STK_`).
- `deno fmt --check`, `deno lint`, full `deno test` suite (2909 passed),
  and `deno check` on all entry points all green.

## Backlog status

LSP editing-experience backlog. Items #1 (display-ID pattern share, #549),
#2 (relation-target filtering, #554), and #3 (server-side prefix filter,
#556) shipped previously. **This is item #4.** Item #5 (debounce race)
remains and is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)