### PR TITLE
fix(lsp): prevent duplicate display IDs across rapid scaffold accepts

### DIFF
--- a/packages/markspec/lsp/id_reservations.ts
+++ b/packages/markspec/lsp/id_reservations.ts
@@ -1,0 +1,151 @@
+/**
+ * @module lsp/id_reservations
+ *
+ * Short-lived, in-memory reservation set for display-ID numbers handed
+ * out by the scaffold-completion resolve handler but not yet observed in
+ * the parsed workspace index.
+ *
+ * ## Why this exists
+ *
+ * The per-file parse that feeds {@linkcode WorkspaceIndex} is debounced
+ * (50 ms) and asynchronous, so the index lags the document. When an
+ * author accepts a scaffold completion, the inserted entry does not reach
+ * `byDisplayId` until the next parse fires. If a second scaffold accept
+ * lands inside that window, both `completionItem/resolve` calls invoke
+ * `getNextDisplayIdNumber`, both observe the same indexed maximum, and
+ * both mint the *same* display ID — a duplicate the validator flags on
+ * the following debounce.
+ *
+ * This is a *staleness* race, not an event-loop concurrency race: the
+ * resolve handler is synchronous, so two resolves serialize, but neither
+ * sees the other's freshly-inserted entry because the parse has not yet
+ * run. {@linkcode reserve} records a number the instant resolve hands it
+ * out so the next resolve skips it; {@linkcode release} is called once a
+ * parse observes the entry in the index.
+ *
+ * Reservations live for the LSP process lifetime only — on restart the
+ * parsed index is authoritative again. A {@linkcode RESERVATION_TTL_MS}
+ * timeout drops reservations for completions abandoned mid-accept so a
+ * number is never blocked forever.
+ */
+
+/** Reservations older than this are evicted lazily on read. */
+const RESERVATION_TTL_MS = 60_000;
+
+/**
+ * Bucket key for a `(prefix, suffix)` pair. The NUL separator can never
+ * appear in a display-ID prefix or suffix, so it unambiguously joins the
+ * two halves without collisions (e.g. `("A_", "B")` vs `("A", "_B")`).
+ */
+function keyOf(prefix: string, suffix: string): string {
+  return `${prefix}\0${suffix}`;
+}
+
+/** key → (reserved number → reservation timestamp in ms). */
+const reservations = new Map<string, Map<number, number>>();
+
+/** Shared empty result for the no-bucket case — never mutated. */
+const EMPTY: ReadonlySet<number> = new Set<number>();
+
+/** Wall-clock source; overridable in tests via {@linkcode _setNow}. */
+let nowFn: () => number = () => Date.now();
+
+/**
+ * Drop entries in `bucket` whose reservation is at least
+ * {@linkcode RESERVATION_TTL_MS} old. Mutates the bucket in place.
+ */
+function evictStale(bucket: Map<number, number>, now: number): void {
+  for (const [n, ts] of bucket) {
+    if (now - ts >= RESERVATION_TTL_MS) bucket.delete(n);
+  }
+}
+
+/**
+ * Record that display-ID `n` (for the given `prefix`/`suffix` pattern)
+ * has been handed out. Overwrites the timestamp if `n` was already
+ * reserved, refreshing its TTL.
+ */
+export function reserve(prefix: string, suffix: string, n: number): void {
+  const key = keyOf(prefix, suffix);
+  let bucket = reservations.get(key);
+  if (!bucket) {
+    bucket = new Map();
+    reservations.set(key, bucket);
+  }
+  bucket.set(n, nowFn());
+}
+
+/**
+ * Return `true` when `n` is currently reserved for the given pattern.
+ * Evicts stale reservations first, so a number past its TTL reads as
+ * not reserved.
+ */
+export function isReserved(prefix: string, suffix: string, n: number): boolean {
+  const bucket = reservations.get(keyOf(prefix, suffix));
+  if (!bucket) return false;
+  evictStale(bucket, nowFn());
+  return bucket.has(n);
+}
+
+/**
+ * Drop the reservation for `n`. Called once a parse observes the entry
+ * in the index. A no-op when `n` was never reserved. Empties the bucket
+ * map entry when its last reservation is released so the map does not
+ * accumulate empty buckets.
+ */
+export function release(prefix: string, suffix: string, n: number): void {
+  const key = keyOf(prefix, suffix);
+  const bucket = reservations.get(key);
+  if (!bucket) return;
+  bucket.delete(n);
+  if (bucket.size === 0) reservations.delete(key);
+}
+
+/**
+ * Return the set of numbers currently reserved for the given pattern.
+ * Evicts stale reservations first. The returned set is a fresh copy —
+ * callers may not mutate the internal state through it.
+ */
+export function reservedNumbersFor(
+  prefix: string,
+  suffix: string,
+): ReadonlySet<number> {
+  const bucket = reservations.get(keyOf(prefix, suffix));
+  if (!bucket) return EMPTY;
+  evictStale(bucket, nowFn());
+  if (bucket.size === 0) return EMPTY;
+  return new Set(bucket.keys());
+}
+
+/**
+ * Atomically mint and reserve the next display-ID number for a scaffold
+ * resolve. Reads the current reservation set, asks `nextFree` for the
+ * next number above both the indexed maximum and the reserved set, then
+ * reserves it so an immediately-following mint skips it.
+ *
+ * The index lookup is injected as a callback rather than imported so this
+ * module stays decoupled from {@linkcode WorkspaceIndex}. `server.ts`'s
+ * `onCompletionResolve` wraps `index.getNextDisplayIdNumber`; tests can
+ * supply a stub that mimics a stale index whose maximum never moves.
+ */
+export function mintReservedNumber(
+  prefix: string,
+  suffix: string,
+  nextFree: (reserved: ReadonlySet<number>) => number,
+): number {
+  const reserved = reservedNumbersFor(prefix, suffix);
+  const n = nextFree(reserved);
+  reserve(prefix, suffix, n);
+  return n;
+}
+
+/** Test-only: clear every reservation and restore the real wall clock. */
+export function _reset(): void {
+  reservations.clear();
+  nowFn = () => Date.now();
+}
+
+/** Test-only: override the clock so TTL eviction can be exercised. */
+export function _setNow(fn: () => number): void {
+  nowFn = fn;
+}

--- a/packages/markspec/lsp/id_reservations_test.ts
+++ b/packages/markspec/lsp/id_reservations_test.ts
@@ -1,0 +1,184 @@
+/**
+ * @module lsp/id_reservations_test
+ *
+ * Unit tests for the short-lived display-ID reservation set used to
+ * close the rapid-scaffold-accept duplicate-ID race.
+ */
+
+import { assertEquals, assertNotEquals } from "@std/assert";
+import {
+  _reset,
+  _setNow,
+  isReserved,
+  mintReservedNumber,
+  release,
+  reserve,
+  reservedNumbersFor,
+} from "./id_reservations.ts";
+import { WorkspaceIndex } from "./workspace.ts";
+import { renderScaffoldSnippet } from "./completions.ts";
+import { makeDisplayId } from "../core/mod.ts";
+import type { Entry, SourceLocation } from "../core/mod.ts";
+
+function teardown() {
+  _reset();
+}
+
+Deno.test("id_reservations: reserve then isReserved returns true", () => {
+  teardown();
+  reserve("STK_", "", 5);
+  assertEquals(isReserved("STK_", "", 5), true);
+  assertEquals(isReserved("STK_", "", 6), false);
+});
+
+Deno.test("id_reservations: unreserved number is not reserved", () => {
+  teardown();
+  assertEquals(isReserved("STK_", "", 1), false);
+});
+
+Deno.test("id_reservations: reservations are keyed by (prefix, suffix)", () => {
+  teardown();
+  reserve("STK_", "", 5);
+  // Same number under a different prefix is independent.
+  assertEquals(isReserved("SYS_", "", 5), false);
+  // Same prefix but different suffix is independent.
+  assertEquals(isReserved("STK_", "-draft", 5), false);
+  reserve("STK_", "-draft", 5);
+  assertEquals(isReserved("STK_", "-draft", 5), true);
+  // Releasing one keying does not touch the other.
+  release("STK_", "", 5);
+  assertEquals(isReserved("STK_", "", 5), false);
+  assertEquals(isReserved("STK_", "-draft", 5), true);
+});
+
+Deno.test("id_reservations: release removes a reservation", () => {
+  teardown();
+  reserve("STK_", "", 5);
+  release("STK_", "", 5);
+  assertEquals(isReserved("STK_", "", 5), false);
+});
+
+Deno.test("id_reservations: release of an unknown number is a no-op", () => {
+  teardown();
+  reserve("STK_", "", 5);
+  release("STK_", "", 99); // never reserved
+  assertEquals(isReserved("STK_", "", 5), true);
+});
+
+Deno.test("id_reservations: reservedNumbersFor returns the reserved set", () => {
+  teardown();
+  reserve("STK_", "", 5);
+  reserve("STK_", "", 6);
+  const set = reservedNumbersFor("STK_", "");
+  assertEquals([...set].sort((a, b) => a - b), [5, 6]);
+});
+
+Deno.test("id_reservations: reservedNumbersFor is empty for unknown key", () => {
+  teardown();
+  assertEquals([...reservedNumbersFor("NOPE_", "")], []);
+});
+
+Deno.test("id_reservations: reservations older than the TTL are evicted", () => {
+  teardown();
+  let clock = 0;
+  _setNow(() => clock);
+  reserve("STK_", "", 5); // reserved at t=0
+  clock = 59_999; // just under the 60s TTL
+  assertEquals(isReserved("STK_", "", 5), true);
+  clock = 60_000; // at the TTL boundary → evicted
+  assertEquals(isReserved("STK_", "", 5), false);
+  assertEquals([...reservedNumbersFor("STK_", "")], []);
+});
+
+Deno.test("id_reservations: _reset clears all reservations and the clock", () => {
+  teardown();
+  const clock = 1_000;
+  _setNow(() => clock);
+  reserve("STK_", "", 5);
+  _reset();
+  assertEquals(isReserved("STK_", "", 5), false);
+  // After reset the injected clock is gone, so a fresh reservation
+  // is live under the real wall clock.
+  reserve("STK_", "", 7);
+  assertEquals(isReserved("STK_", "", 7), true);
+});
+
+Deno.test(
+  "id_reservations: two back-to-back mints on the same key yield distinct numbers",
+  () => {
+    teardown();
+    // Simulate the index reporting the same next-free number on both
+    // calls (the staleness window: parse hasn't run yet, so the index
+    // max never moves). The reservation set must still force the second
+    // mint to a different number.
+    const nextFree = (reserved: ReadonlySet<number>): number => {
+      // Index max is 4 (so bare next-free is 5); reservations bump it.
+      let max = 4;
+      for (const n of reserved) if (n > max) max = n;
+      return max + 1;
+    };
+
+    const first = mintReservedNumber("STK_", "", nextFree);
+    const second = mintReservedNumber("STK_", "", nextFree);
+    assertEquals(first, 5);
+    assertEquals(second, 6);
+    assertEquals(first === second, false);
+  },
+);
+
+/** Minimal identified entry for the integration test below. */
+function entry(displayId: string): Entry {
+  const location: SourceLocation = { file: "reqs.md", line: 1, column: 1 };
+  return {
+    displayId: makeDisplayId(displayId),
+    title: displayId,
+    body: "",
+    rawAttributes: [],
+    id: undefined,
+    shape: "Authored",
+    location,
+    source: { kind: "markdown" },
+    typedAttributes: new Map(),
+    bodyTokens: [],
+  };
+}
+
+Deno.test(
+  "id_reservations: two back-to-back resolves against a stale index render distinct display IDs",
+  () => {
+    teardown();
+    // Reproduce the real race: the index holds STK_0001/0002 and does NOT
+    // change between the two resolves (the parse that would add the first
+    // accept's entry is still debounced). This mirrors exactly what
+    // server.ts's onCompletionResolve composes: mintReservedNumber wrapping
+    // index.getNextDisplayIdNumber, then renderScaffoldSnippet.
+    const index = new WorkspaceIndex();
+    index.updateFile("reqs.md", [entry("STK_0001"), entry("STK_0002")]);
+
+    const resolveOnce = (): string => {
+      const n = mintReservedNumber(
+        "STK_",
+        "",
+        (reserved) => index.getNextDisplayIdNumber("STK_", "", reserved),
+      );
+      return renderScaffoldSnippet({
+        typeName: "StakeholderRequirement",
+        prefix: "STK_",
+        width: 4,
+        suffix: "",
+        nextNumber: n,
+        ulid: "01ARZ3NDEKTSV4RRFFQ69G5FAV",
+      }).insertText;
+    };
+
+    const firstInsert = resolveOnce();
+    const secondInsert = resolveOnce();
+
+    // Each insertText starts with the display ID followed by `]`.
+    const firstId = firstInsert.split("]")[0];
+    const secondId = secondInsert.split("]")[0];
+    assertEquals(firstId, "STK_0003");
+    assertEquals(secondId, "STK_0004");
+    assertNotEquals(firstId, secondId);
+  },
+);

--- a/packages/markspec/lsp/server.ts
+++ b/packages/markspec/lsp/server.ts
@@ -98,6 +98,7 @@ import {
   type ScaffoldCompletionData,
 } from "./completions.ts";
 import { findEnclosingEntry } from "./find_entry.ts";
+import { mintReservedNumber, release } from "./id_reservations.ts";
 import {
   isDocCommentContext,
   isMarkspecFile,
@@ -315,6 +316,52 @@ function getEntryTypes(): EntryTypeInfo[] {
     types.push({ name, prefix, width, suffix, nextNumber, modeRecommended });
   }
   return types;
+}
+
+/**
+ * Lean `(prefix, suffix)` pairs for every profile type with a parseable
+ * `display-id-pattern`. Unlike {@linkcode getEntryTypes} this skips the
+ * per-type `getNextDisplayIdNumber` scan — {@linkcode releaseObservedReservations}
+ * only needs the literal affixes to decompose a display ID, and it runs on
+ * every debounced parse.
+ */
+function getScaffoldPatterns(): Array<{ prefix: string; suffix: string }> {
+  if (!profile) return [];
+  const out: Array<{ prefix: string; suffix: string }> = [];
+  for (const [, typeDef] of profile.types) {
+    const pattern = typeDef.value.displayIdPattern.value;
+    if (!pattern) continue;
+    const shape = parseDisplayIdPattern(pattern);
+    if (!shape) continue;
+    out.push({ prefix: shape.prefix, suffix: shape.suffix });
+  }
+  return out;
+}
+
+/**
+ * Release any display-ID reservation now satisfied by a freshly-parsed
+ * file. The resolve handler reserves a number the instant it hands one
+ * out; once the inserted entry reaches the index (after the debounced
+ * parse) the reservation is redundant and must be dropped so the number
+ * is not blocked. Each entry's display ID is decomposed against the
+ * active profile's type affixes to recover the `(prefix, suffix, number)`
+ * triple. A no-op when no profile is loaded or nothing matches — cheap
+ * because reservation buckets are typically empty.
+ */
+function releaseObservedReservations(filePath: string): void {
+  const patterns = getScaffoldPatterns();
+  if (patterns.length === 0) return;
+  for (const entry of index.getEntriesForFile(filePath)) {
+    const id = entry.displayId as string;
+    for (const { prefix, suffix } of patterns) {
+      if (!id.startsWith(prefix)) continue;
+      if (suffix && !id.endsWith(suffix)) continue;
+      const numberPart = id.slice(prefix.length, id.length - suffix.length);
+      if (!/^\d+$/.test(numberPart)) continue;
+      release(prefix, suffix, parseInt(numberPart, 10));
+      break; // one pattern matched this entry; move on
+    }
+  }
 }
 
 /**
@@ -630,6 +677,9 @@ documents.onDidChangeContent((change) => {
       const content = pendingContent.get(filePath);
       if (content === undefined) return;
       const parseDiags = await index.parseAndUpdateFile(filePath, content);
+      // The just-parsed entries now carry any display ID a scaffold accept
+      // reserved — drop those reservations so the numbers aren't blocked.
+      releaseObservedReservations(filePath);
       publishFileDiagnostics(filePath, parseDiags);
       debouncedValidateAll();
     }, 50);
@@ -666,6 +716,7 @@ documents.onDidOpen(async (event) => {
     filePath,
     event.document.getText(),
   );
+  releaseObservedReservations(filePath);
   publishFileDiagnostics(filePath, parseDiags);
   debouncedValidateAll();
 });
@@ -835,7 +886,16 @@ connection.onCompletionResolve((item): CompletionItem => {
   ) {
     return item;
   }
-  const nextNumber = index.getNextDisplayIdNumber(data.prefix, data.suffix);
+  // Mint and reserve the number atomically. Reserving before the snippet
+  // is built means a second resolve firing inside the parse-debounce
+  // window — before this entry reaches the index — sees the number as
+  // taken and picks the next one, closing the duplicate-ID race.
+  const { prefix, suffix } = data;
+  const nextNumber = mintReservedNumber(
+    prefix,
+    suffix,
+    (reserved) => index.getNextDisplayIdNumber(prefix, suffix, reserved),
+  );
   const rendered = renderScaffoldSnippet({
     typeName: data.typeName,
     prefix: data.prefix,

--- a/packages/markspec/lsp/workspace.ts
+++ b/packages/markspec/lsp/workspace.ts
@@ -21,6 +21,10 @@ export interface DisplayIdEntry {
   readonly title: string;
 }
 
+/** Shared empty reserved-number set — the default for callers that do
+ * not participate in display-ID reservation. Never mutated. */
+const NO_RESERVATIONS: ReadonlySet<number> = new Set<number>();
+
 /**
  * In-memory index of all parsed entries, keyed by file path.
  *
@@ -172,8 +176,19 @@ export class WorkspaceIndex {
    * @param suffix - Optional literal text after the numeric
    *   placeholder, e.g., `"-draft"` for IDs like `REQ-012-draft`.
    *   Defaults to empty.
+   * @param reserved - Numbers handed out by the scaffold-completion
+   *   resolve handler but not yet observed in the index. Folded into the
+   *   maximum so two rapid accepts inside the parse-debounce window do not
+   *   both mint the same ID. Defaults to empty for callers that don't
+   *   participate in reservation (e.g. the build-time scaffold path). The
+   *   caller is responsible for passing a set scoped to this
+   *   `(prefix, suffix)`; entries are not re-filtered here.
    */
-  getNextDisplayIdNumber(prefix: string, suffix = ""): number {
+  getNextDisplayIdNumber(
+    prefix: string,
+    suffix = "",
+    reserved: ReadonlySet<number> = NO_RESERVATIONS,
+  ): number {
     let max = 0;
     for (const id of this.byDisplayId.keys()) {
       if (!id.startsWith(prefix)) continue;
@@ -181,6 +196,9 @@ export class WorkspaceIndex {
       const numberPart = id.slice(prefix.length, id.length - suffix.length);
       const num = parseInt(numberPart, 10);
       if (!isNaN(num) && num > max) max = num;
+    }
+    for (const n of reserved) {
+      if (n > max) max = n;
     }
     return max + 1;
   }

--- a/packages/markspec/lsp/workspace_test.ts
+++ b/packages/markspec/lsp/workspace_test.ts
@@ -142,6 +142,43 @@ Deno.test("WorkspaceIndex: getNextDisplayIdNumber returns 1 for empty prefix", (
   assertEquals(index.getNextDisplayIdNumber("STK_AEB_"), 1);
 });
 
+Deno.test("WorkspaceIndex: getNextDisplayIdNumber skips reserved numbers", () => {
+  const index = new WorkspaceIndex();
+  index.updateFile("reqs.md", [
+    entry("STK_AEB_0001", { file: "reqs.md" }),
+    entry("STK_AEB_0002", { file: "reqs.md" }),
+  ]);
+
+  // Without reservations the next number is 3.
+  assertEquals(index.getNextDisplayIdNumber("STK_AEB_"), 3);
+
+  // Reserving 3 bumps the next free number past it, even though 3 is
+  // not yet present in the parsed index.
+  assertEquals(
+    index.getNextDisplayIdNumber("STK_AEB_", "", new Set([3])),
+    4,
+  );
+
+  // The reserved max dominates when it exceeds the indexed max.
+  assertEquals(
+    index.getNextDisplayIdNumber("STK_AEB_", "", new Set([3, 7])),
+    8,
+  );
+});
+
+Deno.test("WorkspaceIndex: getNextDisplayIdNumber ignores reservations under a different prefix", () => {
+  const index = new WorkspaceIndex();
+  index.updateFile("reqs.md", [entry("STK_AEB_0001", { file: "reqs.md" })]);
+
+  // The reserved set is the caller's responsibility — getNextDisplayIdNumber
+  // simply folds it into the max. The server only ever passes the set that
+  // matches (prefix, suffix), so an empty set leaves the result unchanged.
+  assertEquals(
+    index.getNextDisplayIdNumber("STK_AEB_", "", new Set()),
+    2,
+  );
+});
+
 Deno.test("WorkspaceIndex: updateFile promotes survivor when owner loses a display ID", () => {
   const index = new WorkspaceIndex();
 


### PR DESCRIPTION
## Summary

Devex item **#5** of the editing-experience backlog: the debounce-window race that produces duplicate display IDs.

The per-file parse that feeds `WorkspaceIndex` is debounced (50ms) and async, so the index lags the document. When an author accepts a scaffold completion, the inserted entry does not reach `byDisplayId` until the next parse fires. If a second scaffold accept lands inside that window, both `completionItem/resolve` calls invoke `getNextDisplayIdNumber`, both observe the same indexed maximum, and both mint the **same** display ID — a duplicate the validator flags on the following debounce.

### Is the race real? (it is — and it's not what "race" usually means)

I confirmed the mechanism is live, not dead code. `onCompletionResolve` is **synchronous**, so two resolves do serialize on the event loop and never interleave. The bug is therefore a **staleness** race, not a concurrency race: neither resolve sees the other's freshly-inserted entry because the debounced parse that would add it to the index has not run yet. The integration test reproduces exactly this — a static index whose maximum never moves between the two resolves — and shows both mint the same number without the fix, distinct numbers with it.

## Mechanism

| File | What |
|---|---|
| `lsp/id_reservations.ts` *(new)* | Short-lived in-memory reservation set keyed by `(prefix, suffix)`. `reserve` / `isReserved` / `release` / `reservedNumbersFor`, plus `mintReservedNumber` (atomic compute-and-reserve, index lookup injected as a callback to keep the module decoupled from `WorkspaceIndex`). 60s TTL evicts reservations from abandoned accepts. |
| `lsp/workspace.ts` | `getNextDisplayIdNumber` gains an optional `reserved: ReadonlySet<number>` param folded into the maximum. Backwards-compatible — existing callers pass nothing. |
| `lsp/server.ts` | `onCompletionResolve` mints + reserves atomically *before* rendering the snippet, so an immediately-following resolve sees the number as taken. After each edit-driven `parseAndUpdateFile` (`onDidChangeContent`, `onDidOpen`), `releaseObservedReservations` drops reservations now present in the index. |

### Deliberately unchanged
- **Build-time scaffold path** (`onCompletion` / `getEntryTypes`) does **not** reserve — it is best-effort; the resolve-time path is authoritative. Reserving at build time would over-reserve when authors merely browse the list.
- **Parse debounce** is untouched. The debounce exists for performance under heavy typing; the race is fixed by reservation, not by removing it.
- Reservations live for the LSP process lifetime only. On restart the parsed index is authoritative again.

## Test plan

- [x] `deno fmt --check` — clean
- [x] `deno lint` — clean
- [x] `deno test --allow-read --allow-write --allow-run --allow-env --allow-ffi` — **2958 passed, 0 failed, 3 ignored** (+12 new)
- [x] `deno check` (all entry points) — clean
- [x] Unit tests for `id_reservations.ts`: reserve, isReserved, release (incl. unknown no-op), `(prefix, suffix)` keying independence, `reservedNumbersFor`, TTL eviction, `_reset`
- [x] `workspace_test.ts`: `getNextDisplayIdNumber` skips a reserved number; reserved-max dominates; empty set is a no-op
- [x] Integration: two back-to-back mints against a **stale** real `WorkspaceIndex` render distinct display IDs (`STK_0003` then `STK_0004`) via the exact `mintReservedNumber` + `getNextDisplayIdNumber` + `renderScaffoldSnippet` composition `server.ts` uses

## Backlog status

- [x] #1 display-ID pattern share — shipped (#549)
- [x] #2 relation-target filtering — shipped (#554)
- [x] #3 server-side prefix filter — shipped (#556)
- [ ] #4 mid-typed `[STK_AEB_…` auto-complete next sequential number — **still open** (not yet started)
- [x] **#5 debounce-window duplicate-ID race — this PR**

> Note: my brief assumed #4 would land before #5, but #4 has not shipped. This PR closes #5 only; the backlog is **not** fully closed until #4 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
