### PR TITLE
docs: lead landing page with the User Guide

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -63,6 +63,10 @@
     </a>
     <h1>MarkSpec</h1>
     <p>Markdown flavor and toolchain for traceable industrial documentation.</p>
+    <a href="guide/">
+      User Guide
+      <span>Getting started, configuration, CLI reference, recipes</span>
+    </a>
     <a href="spec/">
       Language Specification
       <span>CommonMark + GFM/GLFM subset, entry format, attributes,
@@ -71,10 +75,6 @@
     <a href="model/">
       Model Reference
       <span>Type taxonomy, profiles, traceability graph, compile output</span>
-    </a>
-    <a href="guide/">
-      User Guide
-      <span>Getting started, configuration, CLI reference, recipes</span>
     </a>
     <a href="typography/">
       Typography


### PR DESCRIPTION
## What

Move the **User Guide** card to the top of the docs landing page ([docs/index.html](docs/index.html)), ahead of the Language Specification and Model Reference cards.

## Why

First-time visitors should land on usage material — getting started, configuration, CLI reference, recipes — before the deeper reference docs (grammar, type taxonomy, compile output).

## Order before → after

```
MarkSpec intro            MarkSpec intro
  Language Specification    User Guide          ← now first
  Model Reference     →     Language Specification
  User Guide                Model Reference
  Typography                Typography
```

Scope is limited to the single card reorder — no content changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)