### PR TITLE
test(cli): regenerate init --help snapshot for 0.6.2

### DIFF
--- a/tests/e2e/__snapshots__/init_help_test.ts.snap
+++ b/tests/e2e/__snapshots__/init_help_test.ts.snap
@@ -3,7 +3,7 @@ export const snapshot = {};
 snapshot[`init --help snapshot 1`] = `
 \`
 [1mUsage:[22m   [95mmarkspec init [33m[[95m[95mtarget-dir[95m[33m][95m[39m
-[1mVersion:[22m [33m0.6.1 (core-schema 1)[39m     
+[1mVersion:[22m [33m0.6.2 (core-schema 1)[39m     
 
 [1mDescription:[22m
 


### PR DESCRIPTION
## Problem

The `chore(release): 0.6.2` commit (`3b3820a`) bumped the version constant in `packages/markspec/deno.json` from `0.6.1` → `0.6.2` but did not regenerate the version-bearing `init --help` snapshot. The rendered help now shows `Version: 0.6.2` while the committed snapshot still pinned `0.6.1`, failing the `init --help snapshot` test on all three OS matrix jobs.

- Failing run: https://github.com/driftsys/markspec/actions/runs/26609633072 (1 failed / 3046 passed, ubuntu/macos/windows)

## Fix

Regenerate `tests/e2e/__snapshots__/init_help_test.ts.snap` to reflect `0.6.2`. One-line change:

```diff
-Version: 0.6.1 (core-schema 1)
+Version: 0.6.2 (core-schema 1)
```

`deno test tests/e2e/init_help_test.ts` passes locally. CI reported only this one stale snapshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)