### PR TITLE
feat(mcp): add entry_show, entry_list, entry_neighborhood read tools

### DIFF
--- a/docs/guide/ai-agents.md
+++ b/docs/guide/ai-agents.md
@@ -65,12 +65,16 @@ markspec mcp
 It speaks the Model Context Protocol over stdio JSON-RPC and exposes the
 following tools:
 
-| Tool               | Description                                      |
-| ------------------ | ------------------------------------------------ |
-| `entry_search`     | Fuzzy search entries by display ID or title      |
-| `entry_context`    | Walk the `Satisfies` chain upward from an entry  |
-| `markspec_refresh` | Re-index the workspace after file changes        |
-| `validate`         | Run validation and return structured diagnostics |
+| Tool                 | Description                                                     |
+| -------------------- | --------------------------------------------------------------- |
+| `entry_search`       | Fuzzy search entries by display ID or title                     |
+| `entry_show`         | Show one entry's full detail (body, outgoing + incoming links)  |
+| `entry_list`         | Spec overview (per-type counts) or paginated listing of entries |
+| `entry_context`      | Walk the `Satisfies` chain upward from an entry                 |
+| `entry_neighborhood` | Show an entry's parents (up) and children (down) as a subgraph  |
+| `validate`           | Run validation and return structured diagnostics                |
+| `markspec_refresh`   | Re-index the workspace after file changes                       |
+| `profile_describe`   | Describe the active profile's types, attributes, and relations  |
 
 ### Claude Desktop
 

--- a/packages/markspec/mcp/tools/context.ts
+++ b/packages/markspec/mcp/tools/context.ts
@@ -6,61 +6,23 @@
  */
 
 import type { CompileResult } from "../../core/mod.ts";
-import { makeDisplayId } from "../../core/mod.ts";
 import { entryUri } from "../uri.ts";
+import { walkLinks, type WalkNode } from "./walk.ts";
 
-/** One entry in the context chain. */
-export interface ContextNode {
-  readonly displayId: string;
-  readonly title: string;
-  /** Hops from the start entry — 0 means the start entry itself. */
-  readonly depth: number;
-}
+/** One entry in the context chain. Re-exported from the shared walk module. */
+export type ContextNode = WalkNode;
 
 /**
  * BFS walk of the `satisfies` edge upward from `startId`.
  * Stops at `maxDepth` hops or when no outgoing satisfies links remain.
- * Cycle-safe via visited set.
+ * Cycle-safe. Delegates to the shared {@linkcode walkLinks}.
  */
 export function walkContext(
   result: CompileResult,
   startId: string,
   maxDepth: number,
 ): ContextNode[] {
-  const brandedStart = makeDisplayId(startId);
-  const start = result.entries.get(brandedStart);
-  if (!start) return [];
-
-  const out: ContextNode[] = [
-    { displayId: startId, title: start.title, depth: 0 },
-  ];
-  const visited = new Set<string>([startId]);
-  let frontier = [brandedStart];
-  let depth = 0;
-
-  while (depth < maxDepth && frontier.length > 0) {
-    const next: typeof frontier = [];
-    for (const id of frontier) {
-      const links = result.forward.get(id) ?? [];
-      for (const link of links) {
-        if (link.kind !== "satisfies") continue;
-        if (visited.has(link.to)) continue;
-        visited.add(link.to);
-        const target = result.entries.get(link.to);
-        if (!target) continue;
-        out.push({
-          displayId: link.to,
-          title: target.title,
-          depth: depth + 1,
-        });
-        next.push(link.to);
-      }
-    }
-    frontier = next;
-    depth++;
-  }
-
-  return out;
+  return walkLinks(result, startId, maxDepth, "forward", "satisfies");
 }
 
 /** Render a context chain as nested Markdown. */
@@ -106,7 +68,7 @@ export const ENTRY_CONTEXT_INPUT_SCHEMA = {
 export const ENTRY_CONTEXT_DESCRIPTOR = {
   name: "entry_context",
   description:
-    `TRIGGER when: user asks "what does this requirement satisfy", "why does this spec exist", "what does this trace up to", "what does X implement", "what higher-level requirement covers Y", or wants the upward chain from any display ID to its parents. PREFER over: grep'ing Satisfies: lines across files — this walks the compiled graph deterministically.\n\nFor the opposite direction (what depends on this requirement), read markspec://entry/{id} and inspect its "Incoming links" section.\n\nReturns a nested Markdown list with markspec://entry/{id} links. Depth defaults to 10; lower to 2–3 for quick orientation, raise only for full transitive context.`,
+    `TRIGGER when: user asks "what does this requirement satisfy", "why does this spec exist", "what does this trace up to", "what does X implement", "what higher-level requirement covers Y", or wants the upward chain from any display ID to its parents. PREFER over: grep'ing Satisfies: lines across files — this walks the compiled graph deterministically.\n\nThis is the UPWARD satisfies chain only. For both directions (parents and children) use entry_neighborhood; for what depends on this entry use entry_neighborhood or entry_show's "Incoming links".\n\nReturns a nested Markdown list with markspec://entry/{id} links. Depth defaults to 10; lower to 2–3 for quick orientation, raise only for full transitive context.`,
   inputSchema: ENTRY_CONTEXT_INPUT_SCHEMA,
   annotations: {
     title: "Trace satisfies chain",

--- a/packages/markspec/mcp/tools/list.ts
+++ b/packages/markspec/mcp/tools/list.ts
@@ -1,0 +1,132 @@
+/**
+ * @module mcp/tools/list
+ *
+ * `entry_list` MCP tool. Two modes:
+ *   - `summary` (default): counts per type + total — "what's in this spec?".
+ *   - `full`: the grouped listing (reuses `renderEntriesIndex`), optionally
+ *     filtered by `type` / `label`, paginated to `PAGE_SIZE`.
+ *
+ * Promotes the `markspec://entries` resource to a tool and adds an orientation
+ * summary, so agents stop grep'ing Markdown or running `markspec compile`.
+ */
+
+import type { Entry } from "../../core/mod.ts";
+import { renderEntriesIndex } from "../resources/entries.ts";
+
+/** Page size for `mode: "full"`. Fixed, not caller-tunable. */
+export const PAGE_SIZE = 50;
+
+/** Whitespace/comma token splitter for the `Labels` attribute value. */
+const LABEL_SEPARATORS_RE = /[\s,]+/;
+
+/** Options for {@linkcode renderList}. */
+export interface ListOptions {
+  readonly mode: "summary" | "full";
+  readonly type?: string;
+  readonly label?: string;
+  readonly page?: number;
+}
+
+/** Return the entry's labels, parsed from its `Labels` raw attribute. */
+function labelsOf(entry: Entry): string[] {
+  const out: string[] = [];
+  for (const attr of entry.rawAttributes) {
+    if (attr.key !== "Labels") continue;
+    for (const tok of attr.value.split(LABEL_SEPARATORS_RE)) {
+      if (tok.length > 0) out.push(tok);
+    }
+  }
+  return out;
+}
+
+/** Render the summary view: total + per-type counts, sorted by type name. */
+function renderSummary(entries: readonly Entry[]): string {
+  const byType = new Map<string, number>();
+  for (const e of entries) {
+    const t = e.type ?? "untyped";
+    byType.set(t, (byType.get(t) ?? 0) + 1);
+  }
+  const lines: string[] = [
+    `# Specification overview (${entries.length} entries)`,
+    "",
+  ];
+  if (entries.length === 0) {
+    lines.push("No entries in this project.");
+    return lines.join("\n") + "\n";
+  }
+  lines.push("## Entry counts by type", "");
+  for (const t of [...byType.keys()].sort()) {
+    lines.push(`- ${t}: ${byType.get(t)}`);
+  }
+  lines.push(
+    "",
+    "Call entry_list with mode=full for the full listing (paginated), or filter by type or label.",
+  );
+  return lines.join("\n") + "\n";
+}
+
+/**
+ * Render the entry list / overview.
+ *
+ * `summary` ignores `type` / `label` / `page`. `full` filters first
+ * (`type` then `label`), then paginates the filtered set to {@linkcode PAGE_SIZE}.
+ */
+export function renderList(
+  entries: readonly Entry[],
+  options: ListOptions,
+): string {
+  if (options.mode === "summary") return renderSummary(entries);
+
+  let filtered = [...entries];
+  if (options.type) filtered = filtered.filter((e) => e.type === options.type);
+  if (options.label) {
+    filtered = filtered.filter((e) => labelsOf(e).includes(options.label!));
+  }
+
+  const total = filtered.length;
+  const page = Math.max(1, Math.floor(options.page ?? 1));
+  const startIdx = (page - 1) * PAGE_SIZE;
+  const slice = filtered.slice(startIdx, startIdx + PAGE_SIZE);
+
+  if (slice.length === 0) {
+    return `# Entries\n\nNo entries on page ${page} (${total} total match).\n`;
+  }
+
+  const body = renderEntriesIndex(slice);
+  const from = startIdx + 1;
+  const to = startIdx + slice.length;
+  const footerLines = [`Showing ${from}–${to} of ${total}.`];
+  if (to < total) {
+    footerLines.push(
+      `Call entry_list with mode=full, page=${page + 1} for more.`,
+    );
+  }
+  return `${body}\n${footerLines.join(" ")}\n`;
+}
+
+/** Tool input schema. */
+export const ENTRY_LIST_INPUT_SCHEMA = {
+  type: "object",
+  properties: {
+    mode: { type: "string", enum: ["summary", "full"] },
+    type: { type: "string" },
+    label: { type: "string" },
+    page: { type: "integer", minimum: 1 },
+  },
+  additionalProperties: false,
+} as const;
+
+/** Tool descriptor metadata. */
+export const ENTRY_LIST_DESCRIPTOR = {
+  name: "entry_list",
+  description:
+    `TRIGGER when: user asks "what's in this spec", "list all requirements", "give me an overview", "how many X are there", or wants to browse entries. Defaults to a summary (per-type counts); pass mode=full for the listing (paginated, 50/page), optionally filtered by type or label. PREFER over: grep across Markdown files or 'markspec compile' — this lists the compiled graph.\n\nFor one entry's detail use entry_show; for the graph around an entry use entry_neighborhood.`,
+  inputSchema: ENTRY_LIST_INPUT_SCHEMA,
+  annotations: {
+    title: "List / overview of entries",
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
+};

--- a/packages/markspec/mcp/tools/list_test.ts
+++ b/packages/markspec/mcp/tools/list_test.ts
@@ -1,0 +1,91 @@
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import type { Entry } from "../../core/mod.ts";
+import { makeDisplayId } from "../../core/mod.ts";
+import { PAGE_SIZE, renderList } from "./list.ts";
+
+function entry(
+  displayId: string,
+  title: string,
+  type?: string,
+  labels: string[] = [],
+): Entry {
+  const rawAttributes = labels.length > 0
+    ? [{ key: "Labels", value: labels.join(", ") }]
+    : [];
+  return {
+    displayId: makeDisplayId(displayId),
+    title,
+    type,
+    rawAttributes,
+  } as unknown as Entry;
+}
+
+Deno.test("renderList: summary mode reports counts per type", () => {
+  const entries = [
+    entry("SWE_0001", "a", "software-requirement"),
+    entry("SWE_0002", "b", "software-requirement"),
+    entry("SYS_0001", "c", "system-requirement"),
+  ];
+  const text = renderList(entries, { mode: "summary" });
+  assertStringIncludes(text, "3 entries");
+  assertStringIncludes(text, "software-requirement: 2");
+  assertStringIncludes(text, "system-requirement: 1");
+});
+
+Deno.test("renderList: full mode lists entries with links", () => {
+  const entries = [entry("SWE_0001", "Title A", "software-requirement")];
+  const text = renderList(entries, { mode: "full", page: 1 });
+  assertStringIncludes(text, "SWE_0001");
+  assertStringIncludes(text, "Title A");
+});
+
+Deno.test("renderList: full mode filters by type", () => {
+  const entries = [
+    entry("SWE_0001", "a", "software-requirement"),
+    entry("SYS_0001", "b", "system-requirement"),
+  ];
+  const text = renderList(entries, {
+    mode: "full",
+    page: 1,
+    type: "system-requirement",
+  });
+  assertStringIncludes(text, "SYS_0001");
+  assertEquals(text.includes("SWE_0001"), false);
+});
+
+Deno.test("renderList: full mode filters by label", () => {
+  const entries = [
+    entry("SWE_0001", "a", "software-requirement", ["ASIL-B"]),
+    entry("SWE_0002", "b", "software-requirement", ["QM"]),
+  ];
+  const text = renderList(entries, { mode: "full", page: 1, label: "ASIL-B" });
+  assertStringIncludes(text, "SWE_0001");
+  assertEquals(text.includes("SWE_0002"), false);
+});
+
+Deno.test("renderList: paginates and shows a next-page footer", () => {
+  const entries = Array.from(
+    { length: PAGE_SIZE + 5 },
+    (_, i) =>
+      entry(
+        `SWE_${String(i).padStart(4, "0")}`,
+        `t${i}`,
+        "software-requirement",
+      ),
+  );
+  const page1 = renderList(entries, { mode: "full", page: 1 });
+  assertStringIncludes(page1, `Showing 1–50 of ${PAGE_SIZE + 5}`);
+  assertStringIncludes(page1, "page=2");
+  const page2 = renderList(entries, { mode: "full", page: 2 });
+  assertStringIncludes(
+    page2,
+    `Showing ${PAGE_SIZE + 1}–${PAGE_SIZE + 5} of ${PAGE_SIZE + 5}`,
+  );
+  assertEquals(page2.includes("page=3"), false);
+});
+
+Deno.test("renderList: page past the end reports no entries on this page", () => {
+  const entries = [entry("SWE_0001", "a", "software-requirement")];
+  const text = renderList(entries, { mode: "full", page: 99 });
+  assertStringIncludes(text, "No entries on page 99");
+});

--- a/packages/markspec/mcp/tools/mod.ts
+++ b/packages/markspec/mcp/tools/mod.ts
@@ -18,6 +18,7 @@ import {
   renderSearchResults,
   scoreEntries,
 } from "./search.ts";
+import { ENTRY_SHOW_DESCRIPTOR, renderShow } from "./show.ts";
 import {
   ENTRY_CONTEXT_DESCRIPTOR,
   renderContext,
@@ -34,11 +35,19 @@ import {
   PROFILE_DESCRIBE_DESCRIPTOR,
 } from "./profile_describe.ts";
 import { buildProfileView } from "../resources/profile.ts";
+import { ENTRY_LIST_DESCRIPTOR, renderList } from "./list.ts";
+import {
+  ENTRY_NEIGHBORHOOD_DESCRIPTOR,
+  renderNeighborhood,
+} from "./neighborhood.ts";
 
 /** All tool descriptors, in `tools/list` order. */
 export const TOOL_DESCRIPTORS = [
   ENTRY_SEARCH_DESCRIPTOR,
+  ENTRY_SHOW_DESCRIPTOR,
+  ENTRY_LIST_DESCRIPTOR,
   ENTRY_CONTEXT_DESCRIPTOR,
+  ENTRY_NEIGHBORHOOD_DESCRIPTOR,
   VALIDATE_DESCRIPTOR,
   REFRESH_DESCRIPTOR,
   PROFILE_DESCRIBE_DESCRIPTOR,
@@ -65,12 +74,27 @@ const HANDLERS: Record<string, ToolHandler> = {
   },
 
   // deno-lint-ignore no-explicit-any
+  entry_show: async (args: any, project) => {
+    const id = String(args?.id ?? "");
+    const result = await project.getCompiled();
+    return renderShow(result, id, project.projectRoot);
+  },
+
+  // deno-lint-ignore no-explicit-any
   entry_context: async (args: any, project) => {
     const id = String(args?.id ?? "");
     const depth = Math.min(50, Math.max(0, Number(args?.depth ?? 10)));
     const result = await project.getCompiled();
     const chain = walkContext(result, id, depth);
     return renderContext(chain, id);
+  },
+
+  // deno-lint-ignore no-explicit-any
+  entry_neighborhood: async (args: any, project) => {
+    const id = String(args?.id ?? "");
+    const depth = Math.min(50, Math.max(0, Number(args?.depth ?? 3)));
+    const result = await project.getCompiled();
+    return renderNeighborhood(result, id, depth);
   },
 
   // deno-lint-ignore no-explicit-any
@@ -95,6 +119,18 @@ const HANDLERS: Record<string, ToolHandler> = {
       result.entries.size,
       project.projectRoot,
     );
+  },
+
+  // deno-lint-ignore no-explicit-any
+  entry_list: async (args: any, project) => {
+    const mode = args?.mode === "full" ? "full" : "summary";
+    const result = await project.getCompiled();
+    return renderList([...result.entries.values()], {
+      mode,
+      type: args?.type !== undefined ? String(args.type) : undefined,
+      label: args?.label !== undefined ? String(args.label) : undefined,
+      page: args?.page !== undefined ? Number(args.page) : undefined,
+    });
   },
 
   markspec_refresh: async (_args, project) => {

--- a/packages/markspec/mcp/tools/mod_test.ts
+++ b/packages/markspec/mcp/tools/mod_test.ts
@@ -24,6 +24,29 @@ function mockProject(detected: boolean): Project {
   };
 }
 
+/** A detected project with an empty compiled graph — for routing smoke tests. */
+function emptyDetectedProject(): Project {
+  return {
+    projectRoot: "/proj",
+    markspecDetected: true,
+    config: undefined,
+    profileChain: null,
+    profile: undefined,
+    getCompiled: () =>
+      Promise.resolve({
+        entries: new Map(),
+        links: [],
+        forward: new Map(),
+        reverse: new Map(),
+        diagnostics: [],
+        // deno-lint-ignore no-explicit-any
+      } as any),
+    forceRefresh: () =>
+      Promise.reject(new Error("forceRefresh must not be called")),
+    subscribeInvalidation: () => () => {},
+  };
+}
+
 Deno.test("dispatchTool: returns soft-gate message when markspecDetected=false", async () => {
   const project = mockProject(false);
   const result = await dispatchTool("entry_search", { query: "x" }, project);
@@ -62,6 +85,28 @@ Deno.test("dispatchTool: gates profile_describe", async () => {
   assertStringIncludes(result, "No MarkSpec project found");
 });
 
+Deno.test("dispatchTool: gates entry_show", async () => {
+  const project = mockProject(false);
+  const result = await dispatchTool("entry_show", { id: "X_0001" }, project);
+  assertStringIncludes(result, "No MarkSpec project found");
+});
+
+Deno.test("dispatchTool: gates entry_list", async () => {
+  const project = mockProject(false);
+  const result = await dispatchTool("entry_list", {}, project);
+  assertStringIncludes(result, "No MarkSpec project found");
+});
+
+Deno.test("dispatchTool: gates entry_neighborhood", async () => {
+  const project = mockProject(false);
+  const result = await dispatchTool(
+    "entry_neighborhood",
+    { id: "X_0001" },
+    project,
+  );
+  assertStringIncludes(result, "No MarkSpec project found");
+});
+
 Deno.test("dispatchTool: unknown tool returns error message regardless of gate", async () => {
   const project = mockProject(false);
   let caught: Error | null = null;
@@ -71,4 +116,24 @@ Deno.test("dispatchTool: unknown tool returns error message regardless of gate",
     caught = err as Error;
   }
   assertEquals(caught?.message.includes("unknown tool"), true);
+});
+
+Deno.test("dispatchTool: entry_show routes", async () => {
+  const project = emptyDetectedProject();
+  const result = await dispatchTool("entry_show", { id: "X_0001" }, project);
+  assertStringIncludes(result, "No entry with display ID X_0001");
+});
+
+Deno.test("dispatchTool: entry_list routes (summary default)", async () => {
+  const result = await dispatchTool("entry_list", {}, emptyDetectedProject());
+  assertStringIncludes(result, "Specification overview");
+});
+
+Deno.test("dispatchTool: entry_neighborhood routes", async () => {
+  const result = await dispatchTool(
+    "entry_neighborhood",
+    { id: "X_0001" },
+    emptyDetectedProject(),
+  );
+  assertStringIncludes(result, "No entry with display ID X_0001");
 });

--- a/packages/markspec/mcp/tools/neighborhood.ts
+++ b/packages/markspec/mcp/tools/neighborhood.ts
@@ -1,0 +1,107 @@
+/**
+ * @module mcp/tools/neighborhood
+ *
+ * `entry_neighborhood` MCP tool. Renders the bounded trace neighbourhood of an
+ * entry: its parents (forward `satisfies`, up the hierarchy) and children
+ * (reverse `satisfies`, down the hierarchy), each as a nested Markdown tree.
+ * Bounded by `depth` and a node cap so output stays within context budget.
+ */
+
+import type { CompileResult } from "../../core/mod.ts";
+import { makeDisplayId } from "../../core/mod.ts";
+import { entryUri } from "../uri.ts";
+import { walkLinks, type WalkNode } from "./walk.ts";
+
+/** Cap on neighbour nodes emitted per direction. Keeps tool output bounded. */
+export const MAX_NODES = 200;
+
+/**
+ * Render one direction's nodes as a nested Markdown list. Callers guard the
+ * empty case (with direction-specific wording), so `nodes` is always non-empty.
+ * `depth - 1` indents: depth-1 nodes (immediate neighbours) sit at the top level.
+ */
+function renderBranch(nodes: readonly WalkNode[], arrow: string): string[] {
+  const lines: string[] = [];
+  for (const node of nodes) {
+    const indent = "  ".repeat(node.depth - 1);
+    lines.push(
+      `${indent}- ${arrow} [${node.displayId}](${
+        entryUri(node.displayId)
+      }) — ${node.title}`,
+    );
+  }
+  return lines;
+}
+
+/**
+ * Render the parent + child neighbourhood of `id` to depth `maxDepth`.
+ * Returns a not-found message when `id` is absent from the graph.
+ */
+export function renderNeighborhood(
+  result: CompileResult,
+  id: string,
+  maxDepth: number,
+): string {
+  const start = result.entries.get(makeDisplayId(id));
+  if (!start) return `No entry with display ID ${id}.\n`;
+
+  const parents = walkLinks(result, id, maxDepth, "forward", "satisfies", {
+    includeStart: false,
+    maxNodes: MAX_NODES,
+  });
+  const children = walkLinks(result, id, maxDepth, "reverse", "satisfies", {
+    includeStart: false,
+    maxNodes: MAX_NODES,
+  });
+
+  const lines: string[] = [
+    `# Neighbourhood of [${id}](${entryUri(id)}) — ${start.title}`,
+    "",
+    "## Parents (up)",
+    "",
+    ...(parents.length === 0
+      ? ["_No parents._"]
+      : renderBranch(parents, "satisfies →")),
+    "",
+    "## Children (down)",
+    "",
+    ...(children.length === 0
+      ? ["_No children._"]
+      : renderBranch(children, "← satisfied by")),
+  ];
+
+  if (parents.length >= MAX_NODES || children.length >= MAX_NODES) {
+    lines.push(
+      "",
+      `_Note: neighbourhood truncated at ${MAX_NODES} nodes per direction; narrow with a lower depth._`,
+    );
+  }
+
+  return lines.join("\n") + "\n";
+}
+
+/** Tool input schema. */
+export const ENTRY_NEIGHBORHOOD_INPUT_SCHEMA = {
+  type: "object",
+  properties: {
+    id: { type: "string", minLength: 1 },
+    depth: { type: "integer", minimum: 0, maximum: 50 },
+  },
+  required: ["id"],
+  additionalProperties: false,
+} as const;
+
+/** Tool descriptor metadata. */
+export const ENTRY_NEIGHBORHOOD_DESCRIPTOR = {
+  name: "entry_neighborhood",
+  description:
+    `TRIGGER when: user asks "what depends on X", "what's around X", "show the parents and children of X", "the trace neighbourhood of X", or wants both directions of the satisfies hierarchy at once. PREFER over: 'markspec dependents' / 'markspec compile' — this walks the compiled graph deterministically.\n\nReturns two nested Markdown trees (Parents up / Children down) with markspec://entry/{id} links. Depth defaults to 3; raise for deeper transitive context. For the UPWARD chain only use entry_context; for one entry's detail use entry_show.`,
+  inputSchema: ENTRY_NEIGHBORHOOD_INPUT_SCHEMA,
+  annotations: {
+    title: "Entry trace neighbourhood",
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
+};

--- a/packages/markspec/mcp/tools/neighborhood_test.ts
+++ b/packages/markspec/mcp/tools/neighborhood_test.ts
@@ -1,0 +1,77 @@
+import { assertStringIncludes } from "@std/assert";
+import type { CompileResult, Entry, Link } from "../../core/mod.ts";
+import { makeDisplayId } from "../../core/mod.ts";
+import { MAX_NODES, renderNeighborhood } from "./neighborhood.ts";
+
+function entry(displayId: string, title: string): Entry {
+  return { displayId: makeDisplayId(displayId), title } as unknown as Entry;
+}
+
+function link(from: string, to: string, kind = "satisfies"): Link {
+  return {
+    from: makeDisplayId(from),
+    to: makeDisplayId(to),
+    kind,
+    location: { file: "x.md", line: 1, column: 1 },
+  } as unknown as Link;
+}
+
+function compiled(entries: Entry[], links: Link[]): CompileResult {
+  const entryMap = new Map(entries.map((e) => [e.displayId, e]));
+  const forward = new Map<string, Link[]>();
+  const reverse = new Map<string, Link[]>();
+  for (const l of links) {
+    (forward.get(l.from) ?? forward.set(l.from, []).get(l.from)!).push(l);
+    (reverse.get(l.to) ?? reverse.set(l.to, []).get(l.to)!).push(l);
+  }
+  return {
+    entries: entryMap,
+    links,
+    forward,
+    reverse,
+  } as unknown as CompileResult;
+}
+
+Deno.test("renderNeighborhood: shows parents (up) and children (down)", () => {
+  // SWE satisfies SYS (SYS is parent); TST satisfies SWE (TST is child)
+  const result = compiled(
+    [
+      entry("SWE_0001", "Mid"),
+      entry("SYS_0001", "Up"),
+      entry("TST_0001", "Down"),
+    ],
+    [link("SWE_0001", "SYS_0001"), link("TST_0001", "SWE_0001")],
+  );
+  const text = renderNeighborhood(result, "SWE_0001", 5);
+  assertStringIncludes(text, "Parents (up)");
+  assertStringIncludes(text, "SYS_0001");
+  assertStringIncludes(text, "Children (down)");
+  assertStringIncludes(text, "TST_0001");
+});
+
+Deno.test("renderNeighborhood: unknown id returns not-found", () => {
+  const result = compiled([entry("SWE_0001", "Mid")], []);
+  assertStringIncludes(
+    renderNeighborhood(result, "NOPE_9999", 5),
+    "No entry with display ID NOPE_9999",
+  );
+});
+
+Deno.test("renderNeighborhood: leaf entry reports no parents/children", () => {
+  const result = compiled([entry("SWE_0001", "Mid")], []);
+  const text = renderNeighborhood(result, "SWE_0001", 5);
+  assertStringIncludes(text, "No parents");
+  assertStringIncludes(text, "No children");
+});
+
+Deno.test("renderNeighborhood: appends truncation note when node cap is hit", () => {
+  const entries = [entry("SWE_0001", "Mid")];
+  const links: Link[] = [];
+  for (let i = 0; i < MAX_NODES + 5; i++) {
+    const id = `TST_${String(i).padStart(4, "0")}`;
+    entries.push(entry(id, `t${i}`));
+    links.push(link(id, "SWE_0001")); // each is a child
+  }
+  const text = renderNeighborhood(compiled(entries, links), "SWE_0001", 5);
+  assertStringIncludes(text, "truncated");
+});

--- a/packages/markspec/mcp/tools/show.ts
+++ b/packages/markspec/mcp/tools/show.ts
@@ -1,0 +1,60 @@
+/**
+ * @module mcp/tools/show
+ *
+ * `entry_show` MCP tool. Renders one entry's full detail (body, outgoing and
+ * incoming links) by display ID — the `markspec://entry/{id}` resource exposed
+ * as a tool, because tool-using agents reliably reach for tools over resources.
+ */
+
+import type { CompileResult } from "../../core/mod.ts";
+import { makeDisplayId } from "../../core/mod.ts";
+import { renderEntry } from "../resources/entry.ts";
+
+/**
+ * Render one entry's detail to Markdown. Returns a plain "not found" message
+ * (not a thrown error) when no entry matches, so the agent can retry with a
+ * corrected ID.
+ */
+export function renderShow(
+  result: CompileResult,
+  id: string,
+  projectRoot: string | undefined,
+): string {
+  const displayId = makeDisplayId(id);
+  const entry = result.entries.get(displayId);
+  if (!entry) return `No entry with display ID ${id}.\n`;
+  const titles = new Map<string, string>();
+  for (const [eid, e] of result.entries) titles.set(eid, e.title);
+  return renderEntry(
+    entry,
+    result.forward.get(displayId) ?? [],
+    result.reverse.get(displayId) ?? [],
+    titles,
+    projectRoot,
+  );
+}
+
+/** Tool input schema. */
+export const ENTRY_SHOW_INPUT_SCHEMA = {
+  type: "object",
+  properties: {
+    id: { type: "string", minLength: 1 },
+  },
+  required: ["id"],
+  additionalProperties: false,
+} as const;
+
+/** Tool descriptor metadata. */
+export const ENTRY_SHOW_DESCRIPTOR = {
+  name: "entry_show",
+  description:
+    `TRIGGER when: user asks to "show", "open", "display", or "give me the full text of" a display ID, or "what does X say", "what are the details of X". PREFER over: Read, grep, or 'markspec show' — this returns the compiled entry (body, outgoing links, and the "Incoming links" that depend on it) in one call.\n\nReturns Markdown with markspec://entry/{id} cross-links. For the trace neighbourhood around the entry use entry_neighborhood; for just the upward chain use entry_context.`,
+  inputSchema: ENTRY_SHOW_INPUT_SCHEMA,
+  annotations: {
+    title: "Show entry detail",
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
+};

--- a/packages/markspec/mcp/tools/show_test.ts
+++ b/packages/markspec/mcp/tools/show_test.ts
@@ -1,0 +1,72 @@
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import type { CompileResult, Entry, Link } from "../../core/mod.ts";
+import { makeDisplayId } from "../../core/mod.ts";
+import { renderShow } from "./show.ts";
+
+function entry(displayId: string, title: string, body = "Body."): Entry {
+  return {
+    displayId: makeDisplayId(displayId),
+    title,
+    body,
+    shape: "identified",
+    rawAttributes: [],
+    type: undefined,
+    location: { file: "x.md", line: 1, column: 1 },
+  } as unknown as Entry;
+}
+
+function link(from: string, to: string, kind = "satisfies"): Link {
+  return {
+    from: makeDisplayId(from),
+    to: makeDisplayId(to),
+    kind,
+    location: { file: "x.md", line: 1, column: 1 },
+  } as unknown as Link;
+}
+
+function compiled(entries: Entry[], links: Link[]): CompileResult {
+  const entryMap = new Map(entries.map((e) => [e.displayId, e]));
+  const forward = new Map<string, Link[]>();
+  const reverse = new Map<string, Link[]>();
+  for (const l of links) {
+    (forward.get(l.from) ?? forward.set(l.from, []).get(l.from)!).push(l);
+    (reverse.get(l.to) ?? reverse.set(l.to, []).get(l.to)!).push(l);
+  }
+  return {
+    entries: entryMap,
+    links,
+    forward,
+    reverse,
+  } as unknown as CompileResult;
+}
+
+Deno.test("renderShow: renders entry with outgoing + incoming links", () => {
+  const result = compiled(
+    [
+      entry("SWE_0001", "Child"),
+      entry("SYS_0001", "Parent"),
+      entry("TST_0001", "Test"),
+    ],
+    [link("SWE_0001", "SYS_0001"), link("TST_0001", "SWE_0001", "verifies")],
+  );
+  const text = renderShow(result, "SWE_0001", undefined);
+  assertStringIncludes(text, "SWE_0001 — Child");
+  assertStringIncludes(text, "Outgoing links");
+  assertStringIncludes(text, "SYS_0001");
+  assertStringIncludes(text, "Incoming links");
+  assertStringIncludes(text, "TST_0001");
+});
+
+Deno.test("renderShow: unknown id returns a not-found message, not a throw", () => {
+  const result = compiled([entry("SWE_0001", "Child")], []);
+  const text = renderShow(result, "NOPE_9999", undefined);
+  assertStringIncludes(text, "No entry with display ID NOPE_9999");
+});
+
+Deno.test("renderShow: empty graph", () => {
+  const result = compiled([], []);
+  assertEquals(
+    renderShow(result, "X_0001", undefined),
+    "No entry with display ID X_0001.\n",
+  );
+});

--- a/packages/markspec/mcp/tools/walk.ts
+++ b/packages/markspec/mcp/tools/walk.ts
@@ -1,0 +1,97 @@
+/**
+ * @module mcp/tools/walk
+ *
+ * Direction-parameterised breadth-first walk over the compiled traceability
+ * graph. Shared by `entry_context` (forward `satisfies`, the upward chain)
+ * and `entry_neighborhood` (both directions). Cycle-safe; bounded by depth
+ * and an optional node cap.
+ */
+
+import type {
+  CompileResult,
+  DisplayId,
+  Link,
+  LinkKind,
+} from "../../core/mod.ts";
+import { makeDisplayId } from "../../core/mod.ts";
+
+/** One visited node — display ID, title, and hops from the start (0 = start). */
+export interface WalkNode {
+  readonly displayId: string;
+  readonly title: string;
+  readonly depth: number;
+}
+
+/** Which adjacency map to traverse: outgoing (`forward`) or incoming (`reverse`). */
+export type WalkDirection = "forward" | "reverse";
+
+/** Options for {@linkcode walkLinks}. */
+export interface WalkOptions {
+  /** Include the start entry as a depth-0 node. Default `true`. */
+  readonly includeStart?: boolean;
+  /** Cap on neighbour nodes emitted (excludes the start node). Default unbounded. */
+  readonly maxNodes?: number;
+}
+
+/**
+ * BFS from `startId` following links of `kind` in `direction`, up to
+ * `maxDepth` hops. Returns nodes in BFS order. Cycle-safe via a visited set.
+ * Returns `[]` when `startId` is not in the graph.
+ */
+export function walkLinks(
+  result: CompileResult,
+  startId: string,
+  maxDepth: number,
+  direction: WalkDirection,
+  kind: LinkKind,
+  options: WalkOptions = {},
+): WalkNode[] {
+  const includeStart = options.includeStart ?? true;
+  const maxNodes = options.maxNodes ?? Infinity;
+
+  const brandedStart = makeDisplayId(startId);
+  const start = result.entries.get(brandedStart);
+  if (!start) return [];
+
+  const adjacency = direction === "forward" ? result.forward : result.reverse;
+  const neighbourOf = (link: Link): DisplayId =>
+    direction === "forward" ? link.to : link.from;
+
+  const out: WalkNode[] = [];
+  if (includeStart) {
+    out.push({ displayId: startId, title: start.title, depth: 0 });
+  }
+
+  const visited = new Set<DisplayId>([brandedStart]);
+  let frontier: DisplayId[] = [brandedStart];
+  let depth = 0;
+  let emitted = 0;
+
+  while (depth < maxDepth && frontier.length > 0 && emitted < maxNodes) {
+    const next: DisplayId[] = [];
+    for (const id of frontier) {
+      const links = adjacency.get(id) ?? [];
+      for (const link of links) {
+        if (link.kind !== kind) continue;
+        const neighbour = neighbourOf(link);
+        if (visited.has(neighbour)) continue;
+        visited.add(neighbour);
+        const target = result.entries.get(neighbour);
+        if (!target) continue;
+        out.push({
+          displayId: neighbour,
+          title: target.title,
+          depth: depth + 1,
+        });
+        next.push(neighbour);
+        emitted++;
+        if (emitted >= maxNodes) break;
+      }
+      if (emitted >= maxNodes) break;
+    }
+    frontier = next;
+    depth++;
+  }
+
+  return out;
+}

--- a/packages/markspec/mcp/tools/walk_test.ts
+++ b/packages/markspec/mcp/tools/walk_test.ts
@@ -1,0 +1,93 @@
+import { assertEquals } from "@std/assert";
+import type { CompileResult, Entry, Link } from "../../core/mod.ts";
+import { makeDisplayId } from "../../core/mod.ts";
+import { walkLinks } from "./walk.ts";
+
+/** Minimal Entry stub — only the fields walkLinks reads. */
+function entry(displayId: string, title: string): Entry {
+  return { displayId: makeDisplayId(displayId), title } as unknown as Entry;
+}
+
+function link(from: string, to: string, kind = "satisfies"): Link {
+  return {
+    from: makeDisplayId(from),
+    to: makeDisplayId(to),
+    kind,
+    location: { file: "x.md", line: 1, column: 1 },
+  } as unknown as Link;
+}
+
+/** Build a CompileResult from entries + links. */
+function compiled(entries: Entry[], links: Link[]): CompileResult {
+  const entryMap = new Map(entries.map((e) => [e.displayId, e]));
+  const forward = new Map<string, Link[]>();
+  const reverse = new Map<string, Link[]>();
+  for (const l of links) {
+    (forward.get(l.from) ?? forward.set(l.from, []).get(l.from)!).push(l);
+    (reverse.get(l.to) ?? reverse.set(l.to, []).get(l.to)!).push(l);
+  }
+  return {
+    entries: entryMap,
+    links,
+    forward,
+    reverse,
+  } as unknown as CompileResult;
+}
+
+Deno.test("walkLinks: forward satisfies includes start at depth 0", () => {
+  const result = compiled(
+    [entry("A_0001", "A"), entry("B_0001", "B")],
+    [link("A_0001", "B_0001")],
+  );
+  const nodes = walkLinks(result, "A_0001", 10, "forward", "satisfies");
+  assertEquals(nodes.map((n) => [n.displayId, n.depth]), [
+    ["A_0001", 0],
+    ["B_0001", 1],
+  ]);
+});
+
+Deno.test("walkLinks: reverse direction follows incoming links", () => {
+  const result = compiled(
+    [entry("A_0001", "A"), entry("B_0001", "B")],
+    [link("B_0001", "A_0001")], // B satisfies A
+  );
+  const nodes = walkLinks(result, "A_0001", 10, "reverse", "satisfies", {
+    includeStart: false,
+  });
+  assertEquals(nodes.map((n) => n.displayId), ["B_0001"]);
+});
+
+Deno.test("walkLinks: respects maxDepth", () => {
+  const result = compiled(
+    [entry("A_0001", "A"), entry("B_0001", "B"), entry("C_0001", "C")],
+    [link("A_0001", "B_0001"), link("B_0001", "C_0001")],
+  );
+  const nodes = walkLinks(result, "A_0001", 1, "forward", "satisfies");
+  assertEquals(nodes.map((n) => n.displayId), ["A_0001", "B_0001"]);
+});
+
+Deno.test("walkLinks: cycle-safe", () => {
+  const result = compiled(
+    [entry("A_0001", "A"), entry("B_0001", "B")],
+    [link("A_0001", "B_0001"), link("B_0001", "A_0001")],
+  );
+  const nodes = walkLinks(result, "A_0001", 10, "forward", "satisfies");
+  assertEquals(nodes.map((n) => n.displayId), ["A_0001", "B_0001"]);
+});
+
+Deno.test("walkLinks: maxNodes caps emitted neighbours", () => {
+  const result = compiled(
+    [entry("A_0001", "A"), entry("B_0001", "B"), entry("C_0001", "C")],
+    [link("B_0001", "A_0001"), link("C_0001", "A_0001")],
+  );
+  const nodes = walkLinks(result, "A_0001", 10, "reverse", "satisfies", {
+    includeStart: false,
+    maxNodes: 1,
+  });
+  assertEquals(nodes.length, 1);
+});
+
+Deno.test("walkLinks: unknown start id returns empty", () => {
+  const result = compiled([entry("A_0001", "A")], []);
+  assertEquals(walkLinks(result, "Z_9999", 10, "forward", "satisfies"), []);
+});

--- a/tests/e2e/__snapshots__/init_help_test.ts.snap
+++ b/tests/e2e/__snapshots__/init_help_test.ts.snap
@@ -3,7 +3,7 @@ export const snapshot = {};
 snapshot[`init --help snapshot 1`] = `
 \`
 [1mUsage:[22m   [95mmarkspec init [33m[[95m[95mtarget-dir[95m[33m][95m[39m
-[1mVersion:[22m [33m0.6.1 (core-schema 1)[39m     
+[1mVersion:[22m [33m0.6.2 (core-schema 1)[39m     
 
 [1mDescription:[22m
 

--- a/tests/e2e/mcp_test.ts
+++ b/tests/e2e/mcp_test.ts
@@ -214,7 +214,7 @@ Deno.test("mcp: every tool advertises read-only annotations", async () => {
   }
 });
 
-Deno.test("mcp: tools/list returns all five tools", async () => {
+Deno.test("mcp: tools/list returns all eight tools", async () => {
   const { proc, cwd } = await setup();
   try {
     const resp = await proc.request("tools/list", {});
@@ -223,7 +223,10 @@ Deno.test("mcp: tools/list returns all five tools", async () => {
     const names = tools.map((t) => t.name).sort();
     assertEquals(names, [
       "entry_context",
+      "entry_list",
+      "entry_neighborhood",
       "entry_search",
+      "entry_show",
       "markspec_refresh",
       "profile_describe",
       "validate",


### PR DESCRIPTION
Closes #565.

## Summary

Agents were shelling out to `markspec compile`/CLI because several graph views existed only behind MCP **resources**, which tool-using agents don't reliably reach for. This PR promotes them to first-class **read-only tools** (MCP tool count 5 → 8):

- **`entry_show(id)`** — one entry's full detail (body, outgoing + incoming links). Reuses the existing `renderEntry` renderer.
- **`entry_list(mode, type, label, page)`** — `summary` (per-type counts) by default, or a paginated `full` listing (50/page) filterable by `type`/`label`. Reuses `renderEntriesIndex`.
- **`entry_neighborhood(id, depth)`** — parents (forward `satisfies`) **and** children (reverse `satisfies`) as bounded Markdown trees (depth + 200-node cap).

Supporting changes:
- Extracted a shared direction-parameterised graph walk (`walkLinks`) from `entry_context`, which now delegates — behaviour-preserving (and incidentally fixes a latent `DisplayId`-branding mismatch in the old `walkContext` visited-set).
- Disambiguated the `entry_context` descriptor (up-chain only) vs `entry_neighborhood` (both directions).
- Documented the new tools in `docs/guide/ai-agents.md`, including the previously-undocumented `profile_describe` row.
- Unit tests per tool + soft-gate + dispatch tests; updated the e2e `tools/list` assertion.

Resources stay registered and share the same renderers, so tool/resource output stays in lockstep. MCP remains read-only by design (no write tools).

## Notes / deviations from #565

- #565's ACs asked for `prefix` and `file`-glob filters and a flat output carrying file path + shape; the brainstormed design here uses `type`/`label` filters and the grouped index output. The core ask (list entries without CLI fallback, paginated, label filter) is met — flag if the `prefix`/`file` filters are still wanted as a follow-up.
- #565 mentions reading from the ADR-020 background index; that index isn't built yet, so this reads the existing in-memory `CompileResult` cache (the design doc scopes the shared index out).
- Includes a small unrelated commit refreshing the stale `init --help` snapshot (0.6.1 → 0.6.2), which was failing on `main` and blocked the pre-push `just check`.

## Test Plan

- [x] `deno test` full suite green (3071 passed; the previously-failing `init_help` snapshot now refreshed)
- [x] `just build` (lint + test + type-check + compile) passes
- [x] `deno fmt --check` + `dprint check` pass
- [x] e2e `tools/list` returns all eight tools; per-tool soft-gate + dispatch tests pass
- [ ] Reviewer: confirm the `type`/`label` filter set is acceptable vs #565's `prefix`/`file`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
