### PR TITLE
feat(core): model interfaces as contracts, not components

### DIFF
--- a/docs/spec/internal/markspec-core-data-model.md
+++ b/docs/spec/internal/markspec-core-data-model.md
@@ -115,8 +115,8 @@ The information type is expressed by a single `Type:` attribute (ADR-004 §Part
   TitleCase. Always available regardless of profile.
 - **Core concrete types** — the 15 built-in subtypes (ADR-003 §Part 1):
   - Under `Specification`: `Requirement`, `Test`, `Contract`, `Record`, `Risk`
-  - Under `Component`: `SoftwareComponent`, `HardwareComponent`,
-    `SoftwareInterface`, `HardwareInterface`
+  - Under `Component`: `SoftwareComponent`, `HardwareComponent`
+  - Under `Contract`: `SoftwareInterface`, `HardwareInterface`
   - Under `Unit`: `SoftwareUnit`, `HardwareUnit`
   - Standalone under `Item`: `Definition`
 - **Profile-declared concrete types** — extend any core type by inheritance.
@@ -241,8 +241,8 @@ parser knows which attribute keys are core-defined vs profile-declared.
 | `Component`         | `Kind`, `Part-of`, `Realizes`, `Depends-on`, `Provides`, `Requires`   | §Part 2 “Component"         |
 | `SoftwareComponent` | `License`, `Build-manifest`, `Package-manager`                        | §Part 2 “SoftwareComponent" |
 | `HardwareComponent` | `Manufacturer`, `Part-number`, `Datasheet`                            | §Part 2 “HardwareComponent" |
-| `SoftwareInterface` | _(inherits Component; no additions in core)_                          | §Part 2 “SoftwareInterface" |
-| `HardwareInterface` | `Bus-protocol`, `Connector-type`, `Voltage-level`, `Signal-direction` | §Part 2 “HardwareInterface" |
+| `SoftwareInterface` | _(inherits Contract → Specification; no additions in core)_           | §Part 2 “SoftwareInterface” |
+| `HardwareInterface` | `Bus-protocol`, `Connector-type`, `Voltage-level`, `Signal-direction` | §Part 2 “HardwareInterface” |
 | `Unit`              | `Part-of`, `Realizes`, `Depends-on`                                   | §Part 2 “Unit"              |
 | `SoftwareUnit`      | `Source`, `Symbol`, `Language`                                        | §Part 2 “SoftwareUnit"      |
 | `HardwareUnit`      | `Manufacturer`, `Part-number`, `Datasheet`, `Footprint`, `Value`      | §Part 2 “HardwareUnit"      |

--- a/docs/spec/internal/markspec-listing-directives.md
+++ b/docs/spec/internal/markspec-listing-directives.md
@@ -64,10 +64,11 @@ separately and the spec does not unify the three.
 **Cross-references to the companion spec:**
 
 - The Component types a `markspec:components` listing admits
-  (`SoftwareComponent`, `HardwareComponent`, `SoftwareInterface`,
-  `HardwareInterface`, and profile subtypes such as `dependency`, `ecu`) are
-  core types per core-data-model §1.3; profile subtyping is
-  [markspec-profile-schema.md §3/§4](markspec-profile-schema.md).
+  (`SoftwareComponent`, `HardwareComponent`, and profile subtypes such as
+  `dependency`, `ecu`) are core types per core-data-model §1.3; profile
+  subtyping is [markspec-profile-schema.md §3/§4](markspec-profile-schema.md).
+  `SoftwareInterface` and `HardwareInterface` are Contract subtypes and are
+  therefore NOT admitted by a components listing.
 - The glossary produces core `Definition` items (core-data-model §1.3 / ADR-003
   §Part 2 "Definition"); the default profile's `term`→`Definition` binding is
   [markspec-profile-schema.md §7.1](markspec-profile-schema.md).
@@ -473,10 +474,12 @@ segment    = 1*( ALPHA / DIGIT / "-" / "." / "_" )
 ### 6.3 Components listing
 
 - Every item MUST resolve to a Component-family `Type:`
-  (`Component`/`SoftwareComponent`/`HardwareComponent`/`SoftwareInterface`/`HardwareInterface`
-  or a profile subtype of one — core-data-model §1.3;
+  (`Component`/`SoftwareComponent`/`HardwareComponent` or a profile subtype of
+  one — core-data-model §1.3;
   [markspec-profile-schema.md §3](markspec-profile-schema.md)). A non-Component
-  type in a components listing → `MSL-L043` (error).
+  type in a components listing → `MSL-L043` (error). `SoftwareInterface` and
+  `HardwareInterface` are Contract subtypes (not Component) and therefore
+  trigger `MSL-L043`.
 - A Reference-shape component's `Id:` MUST parse under some §5 scheme **or** be
   a valid RFC 3986 URI (the `MSL-L030` info fallback applies; not an error —
   ADR-006 §Component Id schemes allows "any scheme that satisfies RFC 3986").

--- a/docs/spec/model/annex-profile-schema.md
+++ b/docs/spec/model/annex-profile-schema.md
@@ -137,13 +137,14 @@ There are **16 core type names** — 4 abstract roots plus 12 concrete subtypes.
 Fifteen are instantiable (every name except the purely abstract `Item`).
 `extends:` on a profile type must name one of these:
 
-| Group                    | Names                                                                              |
-| ------------------------ | ---------------------------------------------------------------------------------- |
-| Abstract roots (4)       | `Item`, `Specification`, `Component`, `Unit`                                       |
-| `Specification` subtypes | `Requirement`, `Test`, `Contract`, `Record`, `Risk`                                |
-| `Component` subtypes     | `SoftwareComponent`, `HardwareComponent`, `SoftwareInterface`, `HardwareInterface` |
-| `Unit` subtypes          | `SoftwareUnit`, `HardwareUnit`                                                     |
-| `Item` subtype           | `Definition`                                                                       |
+| Group                    | Names                                               |
+| ------------------------ | --------------------------------------------------- |
+| Abstract roots (4)       | `Item`, `Specification`, `Component`, `Unit`        |
+| `Specification` subtypes | `Requirement`, `Test`, `Contract`, `Record`, `Risk` |
+| `Contract` subtypes      | `SoftwareInterface`, `HardwareInterface`            |
+| `Component` subtypes     | `SoftwareComponent`, `HardwareComponent`            |
+| `Unit` subtypes          | `SoftwareUnit`, `HardwareUnit`                      |
+| `Item` subtype           | `Definition`                                        |
 
 `Specification`, `Component`, and `Unit` are abstract roots that are also
 directly instantiable (usable as fallbacks when no concrete subtype fits);

--- a/docs/spec/model/attributes.md
+++ b/docs/spec/model/attributes.md
@@ -185,15 +185,15 @@ above are available in core-only mode.
 
 ### Specification types
 
-| Type                | Typical profile attributes               | Typical relation attributes                             |
-| ------------------- | ---------------------------------------- | ------------------------------------------------------- |
-| `Requirement`       | `ASIL`, `Priority`, `Safety-goal`        | `Satisfies`, `Derived-from`                             |
-| `Test`              | `Test-level`, `Test-type`, `Test-result` | `Verifies`, `Tests`                                     |
-| `Contract`          | (none typical)                           | `Satisfies`, `Realized-by` (generated)                  |
-| `SoftwareInterface` | (none typical)                           | `Provided-by`, `Required-by`, `Realized-by` (generated) |
-| `HardwareInterface` | `Bus-protocol`, `Voltage-level`          | `Provided-by`, `Required-by`, `Realized-by` (generated) |
-| `Record`            | (none typical)                           | (standalone)                                            |
-| `Risk`              | `ASIL`, `Severity`, `Probability`        | `Mitigated-by` (generated)                              |
+| Type                | Typical profile attributes                                            | Typical relation attributes                             |
+| ------------------- | --------------------------------------------------------------------- | ------------------------------------------------------- |
+| `Requirement`       | `ASIL`, `Priority`, `Safety-goal`                                     | `Satisfies`, `Derived-from`                             |
+| `Test`              | `Test-level`, `Test-type`, `Test-result`                              | `Verifies`, `Tests`                                     |
+| `Contract`          | (none typical)                                                        | `Satisfies`, `Realized-by` (generated)                  |
+| `SoftwareInterface` | (none typical)                                                        | `Provided-by`, `Required-by`, `Realized-by` (generated) |
+| `HardwareInterface` | `Bus-protocol`, `Voltage-level`, `Connector-type`, `Signal-direction` | `Provided-by`, `Required-by`, `Realized-by` (generated) |
+| `Record`            | (none typical)                                                        | (standalone)                                            |
+| `Risk`              | `ASIL`, `Severity`, `Probability`                                     | `Mitigated-by` (generated)                              |
 
 ### Component types
 

--- a/docs/spec/model/attributes.md
+++ b/docs/spec/model/attributes.md
@@ -185,22 +185,22 @@ above are available in core-only mode.
 
 ### Specification types
 
-| Type          | Typical profile attributes               | Typical relation attributes            |
-| ------------- | ---------------------------------------- | -------------------------------------- |
-| `Requirement` | `ASIL`, `Priority`, `Safety-goal`        | `Satisfies`, `Derived-from`            |
-| `Test`        | `Test-level`, `Test-type`, `Test-result` | `Verifies`, `Tests`                    |
-| `Contract`    | (none typical)                           | `Satisfies`, `Realized-by` (generated) |
-| `Record`      | (none typical)                           | (standalone)                           |
-| `Risk`        | `ASIL`, `Severity`, `Probability`        | `Mitigated-by` (generated)             |
+| Type                | Typical profile attributes               | Typical relation attributes                             |
+| ------------------- | ---------------------------------------- | ------------------------------------------------------- |
+| `Requirement`       | `ASIL`, `Priority`, `Safety-goal`        | `Satisfies`, `Derived-from`                             |
+| `Test`              | `Test-level`, `Test-type`, `Test-result` | `Verifies`, `Tests`                                     |
+| `Contract`          | (none typical)                           | `Satisfies`, `Realized-by` (generated)                  |
+| `SoftwareInterface` | (none typical)                           | `Provided-by`, `Required-by`, `Realized-by` (generated) |
+| `HardwareInterface` | `Bus-protocol`, `Voltage-level`          | `Provided-by`, `Required-by`, `Realized-by` (generated) |
+| `Record`            | (none typical)                           | (standalone)                                            |
+| `Risk`              | `ASIL`, `Severity`, `Probability`        | `Mitigated-by` (generated)                              |
 
 ### Component types
 
-| Type                | Typical profile attributes       | Typical relation attributes          |
-| ------------------- | -------------------------------- | ------------------------------------ |
-| `SoftwareComponent` | `Version`, `License`, `Supplier` | `Part-of`, `Depends-on`              |
-| `HardwareComponent` | `Version`, `Supplier`            | `Part-of`                            |
-| `SoftwareInterface` | (none typical)                   | `Part-of`, `Realized-by` (generated) |
-| `HardwareInterface` | (none typical)                   | `Part-of`                            |
+| Type                | Typical profile attributes       | Typical relation attributes |
+| ------------------- | -------------------------------- | --------------------------- |
+| `SoftwareComponent` | `Version`, `License`, `Supplier` | `Part-of`, `Depends-on`     |
+| `HardwareComponent` | `Version`, `Supplier`            | `Part-of`                   |
 
 ### Unit types
 

--- a/docs/spec/model/relations.md
+++ b/docs/spec/model/relations.md
@@ -55,18 +55,26 @@ The following relations are declared by the `@markspec/default` profile and are
 available in any project that uses it. In core-only mode (no profile
 configured), these relation keys are treated as unknown attributes (`MSL-A020`).
 
-| Relation         | Inverse        | Typical source type | Typical target type         |
-| ---------------- | -------------- | ------------------- | --------------------------- |
-| `Satisfies`      | `Satisfied-by` | `Requirement`       | `Requirement`, `Objective`  |
-| `Derived-from`   | `Derived-by`   | `Requirement`       | `Requirement`               |
-| `Verifies`       | `Verified-by`  | `Test`              | `Requirement`, `Contract`   |
-| `Tests`          | `Tested-by`    | `Test`              | `SoftwareUnit`, `Component` |
-| `Depends-on`     | `Required-by`  | `Component`, `Unit` | `Component`                 |
-| `Part-of`        | `Has-part`     | `Component`, `Unit` | `Component`                 |
-| `Allocated-to`   | `Allocates`    | `Requirement`       | `Component`                 |
-| `Realizes`       | `Realized-by`  | `Component`, `Unit` | `Contract`, `Requirement`   |
-| `Generated-from` | (none)         | any                 | any                         |
-| `Addresses`      | `Addressed-by` | `Requirement`       | `Change`                    |
+| Relation         | Inverse          | Typical source type | Typical target type         |
+| ---------------- | ---------------- | ------------------- | --------------------------- |
+| `Satisfies`      | `Satisfied-by`   | `Requirement`       | `Requirement`, `Objective`  |
+| `Derived-from`   | `Derived-by`     | `Requirement`       | `Requirement`               |
+| `Verifies`       | `Verified-by`    | `Test`              | `Requirement`, `Contract`   |
+| `Tests`          | `Tested-by`      | `Test`              | `SoftwareUnit`, `Component` |
+| `Depends-on`     | `Depended-on-by` | `Component`, `Unit` | `Component`                 |
+| `Part-of`        | `Has-part`       | `Component`, `Unit` | `Component`                 |
+| `Provides`       | `Provided-by`    | `Component`         | `Contract`                  |
+| `Requires`       | `Required-by`    | `Component`         | `Contract`                  |
+| `Allocated-to`   | `Allocates`      | `Requirement`       | `Component`                 |
+| `Realizes`       | `Realized-by`    | `Component`, `Unit` | `Contract`, `Requirement`   |
+| `Generated-from` | (none)           | any                 | any                         |
+| `Addresses`      | `Addressed-by`   | `Requirement`       | `Change`                    |
+
+`Provides` / `Requires` are the symmetric provider/consumer relations between a
+component and a `Contract` (including `SoftwareInterface` /
+`HardwareInterface`): a provider `Provides` the contract, a consumer `Requires`
+it. `Allocated-to` is **not** reused for provider-hosting — it keeps its single
+requirement-allocation meaning.
 
 Note: `Supersedes` / `Superseded-by` are **universal attributes** (not relation
 attributes) — they are part of core and are available without any profile. See

--- a/docs/spec/model/types.md
+++ b/docs/spec/model/types.md
@@ -13,13 +13,13 @@ Item  (abstract — root)
 │   ├── Requirement
 │   ├── Test
 │   ├── Contract
+│   │   ├── SoftwareInterface
+│   │   └── HardwareInterface
 │   ├── Record
 │   └── Risk
 ├── Component  (abstract)
 │   ├── SoftwareComponent
-│   ├── HardwareComponent
-│   ├── SoftwareInterface
-│   └── HardwareInterface
+│   └── HardwareComponent
 ├── Unit  (abstract)
 │   ├── SoftwareUnit
 │   └── HardwareUnit
@@ -35,12 +35,12 @@ Four abstract types structure the taxonomy. They **cannot** be used directly as
 `Type:` values — they exist as extension targets for the concrete types below
 them and for profile-declared subtypes.
 
-| Abstract type   | Purpose                                         | Extended by                                                                        |
-| --------------- | ----------------------------------------------- | ---------------------------------------------------------------------------------- |
-| `Item`          | Root; ultimate fallback for all type resolution | All 15 concrete types; any profile subtype                                         |
-| `Specification` | Normative statements; things that must or shall | `Requirement`, `Test`, `Contract`, `Record`, `Risk`                                |
-| `Component`     | System-level building blocks with identity      | `SoftwareComponent`, `HardwareComponent`, `SoftwareInterface`, `HardwareInterface` |
-| `Unit`          | Fine-grained implementation-level elements      | `SoftwareUnit`, `HardwareUnit`                                                     |
+| Abstract type   | Purpose                                         | Extended by                                         |
+| --------------- | ----------------------------------------------- | --------------------------------------------------- |
+| `Item`          | Root; ultimate fallback for all type resolution | All 15 concrete types; any profile subtype          |
+| `Specification` | Normative statements; things that must or shall | `Requirement`, `Test`, `Contract`, `Record`, `Risk` |
+| `Component`     | System-level building blocks with identity      | `SoftwareComponent`, `HardwareComponent`            |
+| `Unit`          | Fine-grained implementation-level elements      | `SoftwareUnit`, `HardwareUnit`                      |
 
 ## Concrete types — Specification subtypes
 
@@ -93,6 +93,23 @@ layers.
 - **Typical relations:** `Satisfies` (→ `Requirement`), `Realized-by` (generated
   inverse of `Realizes` from a `Component`).
 
+### SoftwareInterface
+
+A software interface specification — an API surface (`.proto`, OpenAPI, WSDL)
+defining the contract between two software components.
+
+- **Typical relations:** `Provided-by` / `Required-by` (generated inverses of a
+  component's `Provides` / `Requires`); `Realized-by` (generated inverse of
+  `Realizes`); `Verified-by` (generated inverse of `Verifies`).
+
+### HardwareInterface
+
+A hardware interface specification — a connector, bus, or pin-level boundary
+spec. Carries `Bus-protocol`, `Connector-type`, `Voltage-level`,
+`Signal-direction`.
+
+- **Typical relations:** `Provided-by` / `Required-by`; `Realized-by`.
+
 ### Record
 
 An immutable audit record, decision log, or meeting minute. Typically stands
@@ -137,20 +154,6 @@ An ECU, sensor, actuator, or other physical hardware element.
 - **Typical relations:** `Part-of` (→ `HardwareComponent`), `Realizes` (→
   `Contract`).
 - **Typical profile attributes:** `Supplier`, `Part-number`
-
-### SoftwareInterface
-
-An API, IPC channel, or protocol definition — the contract between two software
-components.
-
-- **Typical relations:** `Part-of` (→ `SoftwareComponent`), `Realized-by`
-  (generated inverse of `Realizes`).
-
-### HardwareInterface
-
-A connector, bus, pin definition, or other physical interface.
-
-- **Typical relations:** `Part-of` (→ `HardwareComponent`).
 
 ## Concrete types — Unit subtypes
 

--- a/packages/markspec/core/compiler/constants.ts
+++ b/packages/markspec/core/compiler/constants.ts
@@ -11,7 +11,7 @@ import type { LinkKind } from "../model/mod.ts";
  *
  * Spec attributes: Satisfies, Derived-from, References, Allocated-to.
  * Test attributes: Verifies, Tests.
- * Element attributes: Realizes, Depends-on, Part-of, Generated-from.
+ * Element attributes: Realizes, Depends-on, Part-of, Generated-from, Provides, Requires.
  * Universal: Supersedes (same-family).
  */
 export const ATTR_TO_LINK_KIND: Readonly<Record<string, LinkKind>> = {
@@ -26,4 +26,6 @@ export const ATTR_TO_LINK_KIND: Readonly<Record<string, LinkKind>> = {
   "Part-of": "part-of",
   "Generated-from": "generated-from",
   "Supersedes": "supersedes",
+  "Provides": "provides",
+  "Requires": "requires",
 };

--- a/packages/markspec/core/compiler/mod_test.ts
+++ b/packages/markspec/core/compiler/mod_test.ts
@@ -5,7 +5,7 @@
  * entry-graph construction, link extraction, and diagnostic propagation.
  */
 
-import { assertEquals, assertExists } from "@std/assert";
+import { assertArrayIncludes, assertEquals, assertExists } from "@std/assert";
 import { compile } from "./mod.ts";
 import { makeDisplayId } from "../model/mod.ts";
 import type { EffectiveProfile, EffectiveTypeDef } from "../model/mod.ts";
@@ -202,6 +202,39 @@ Deno.test("compile: multi-value Derived-from splits into one link per target", a
   assertEquals(df.map((l) => l.to).sort(), ["REQ-PARENT-A", "REQ-PARENT-B"]);
   // No target retains the comma separator.
   assertEquals(df.every((l) => !l.to.includes(",")), true);
+});
+
+Deno.test("compile: Provides/Requires produce provides/requires links", async () => {
+  const files = {
+    "components.md": `- [SWC_0001] Order service
+
+      Id: ${ULID_A}
+      Type: SoftwareComponent
+      Provides: API_0001
+
+- [SWC_0002] Cart service
+
+      Id: ${ULID_B}
+      Type: SoftwareComponent
+      Requires: API_0001
+
+- [API_0001] Order API
+
+      Id: ${ULID_C}
+      Type: SoftwareInterface
+`,
+  };
+  const result = await compile(["components.md"], { readFile: reader(files) });
+  const kinds = result.links.map((l) => l.kind);
+  assertArrayIncludes(kinds, ["provides", "requires"]);
+  const providesLinks = result.links.filter((l) => l.kind === "provides");
+  assertEquals(providesLinks.length, 1);
+  assertEquals(providesLinks[0].from, "SWC_0001");
+  assertEquals(providesLinks[0].to, "API_0001");
+  const requiresLinks = result.links.filter((l) => l.kind === "requires");
+  assertEquals(requiresLinks.length, 1);
+  assertEquals(requiresLinks[0].from, "SWC_0002");
+  assertEquals(requiresLinks[0].to, "API_0001");
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/markspec/core/lock/resolve.ts
+++ b/packages/markspec/core/lock/resolve.ts
@@ -219,6 +219,8 @@ export function extractEdgeQuads(entries: readonly Entry[]): EdgeQuad[] {
     "Part-of",
     "Allocated-to",
     "Realizes",
+    "Provides",
+    "Requires",
     "Generated-from",
     "Supersedes",
   ];

--- a/packages/markspec/core/lock/resolve_test.ts
+++ b/packages/markspec/core/lock/resolve_test.ts
@@ -448,3 +448,59 @@ Deno.test(
     );
   },
 );
+
+Deno.test(
+  "extractEdgeQuads: Provides attribute yields an edge quad with relation Provides",
+  async () => {
+    const { extractEdgeQuads } = await import("./resolve.ts");
+    const entry: Entry = {
+      displayId: makeDisplayId("SWC-1"),
+      title: "t",
+      body: "",
+      rawAttributes: [
+        { key: "Id", value: "01HGW2Q8MNP3RSTVWXYZABCDEF" },
+        { key: "Provides", value: "IFC-1" },
+      ],
+      typedAttributes: new Map() as never,
+      id: "01HGW2Q8MNP3RSTVWXYZABCDEF",
+      shape: "Authored",
+      location: { file: "x.md", line: 1, column: 1 },
+      source: { kind: "markdown" },
+      bodyTokens: [],
+    };
+    const edges = extractEdgeQuads([entry]);
+    assertEquals(edges.length, 1);
+    assertEquals(edges[0].source, "SWC-1");
+    assertEquals(edges[0].relation, "Provides");
+    assertEquals(edges[0].target, "IFC-1");
+    assertEquals(edges[0].provenance, "local");
+  },
+);
+
+Deno.test(
+  "extractEdgeQuads: Requires attribute yields an edge quad with relation Requires",
+  async () => {
+    const { extractEdgeQuads } = await import("./resolve.ts");
+    const entry: Entry = {
+      displayId: makeDisplayId("SWC-2"),
+      title: "t",
+      body: "",
+      rawAttributes: [
+        { key: "Id", value: "01HGW2Q8MNP3RSTVWXYZABCDEF" },
+        { key: "Requires", value: "IFC-2" },
+      ],
+      typedAttributes: new Map() as never,
+      id: "01HGW2Q8MNP3RSTVWXYZABCDEF",
+      shape: "Authored",
+      location: { file: "x.md", line: 1, column: 1 },
+      source: { kind: "markdown" },
+      bodyTokens: [],
+    };
+    const edges = extractEdgeQuads([entry]);
+    assertEquals(edges.length, 1);
+    assertEquals(edges[0].source, "SWC-2");
+    assertEquals(edges[0].relation, "Requires");
+    assertEquals(edges[0].target, "IFC-2");
+    assertEquals(edges[0].provenance, "local");
+  },
+);

--- a/packages/markspec/core/model/attributes.ts
+++ b/packages/markspec/core/model/attributes.ts
@@ -227,6 +227,13 @@ export const ATTRIBUTE_CATALOG: readonly AttributeSpec[] = [
     required: false,
   },
   {
+    key: "Depended-on-by",
+    type: "id-list",
+    origin: "generated",
+    shapes: BOTH_SHAPES,
+    required: false,
+  },
+  {
     key: "Used-by",
     type: "id-list",
     origin: "generated",

--- a/packages/markspec/core/model/mod.ts
+++ b/packages/markspec/core/model/mod.ts
@@ -781,6 +781,8 @@ export const KNOWN_LINK_KINDS: readonly string[] = [
   "part-of",
   "generated-from",
   "supersedes",
+  "provides",
+  "requires",
 ] as const;
 
 /** A directional link between two entries in the traceability graph. */

--- a/packages/markspec/core/model/type_hierarchy.ts
+++ b/packages/markspec/core/model/type_hierarchy.ts
@@ -47,6 +47,19 @@ export const CORE_TYPE_HIERARCHY: Readonly<Record<string, CoreTypeDef>> = {
     excludedAttrs: ["Allocated-to"],
   },
   Contract: { parent: "Specification", ownAttrs: ["Schema-language"] },
+  // Interface specifications — software/hardware boundary contracts.
+  // Re-parented from Component (an interface is a spec, not a building
+  // block); names kept (literature terms for an interface specification).
+  SoftwareInterface: { parent: "Contract", ownAttrs: [] },
+  HardwareInterface: {
+    parent: "Contract",
+    ownAttrs: [
+      "Bus-protocol",
+      "Connector-type",
+      "Voltage-level",
+      "Signal-direction",
+    ],
+  },
   Record: { parent: "Specification", ownAttrs: ["Caused-by", "Affects"] },
   Risk: { parent: "Specification", ownAttrs: ["Caused-by", "Mitigated-by"] },
 
@@ -69,16 +82,6 @@ export const CORE_TYPE_HIERARCHY: Readonly<Record<string, CoreTypeDef>> = {
   HardwareComponent: {
     parent: "Component",
     ownAttrs: ["Manufacturer", "Part-number", "Datasheet"],
-  },
-  SoftwareInterface: { parent: "Component", ownAttrs: [] },
-  HardwareInterface: {
-    parent: "Component",
-    ownAttrs: [
-      "Bus-protocol",
-      "Connector-type",
-      "Voltage-level",
-      "Signal-direction",
-    ],
   },
 
   // Unit family (ADR-003 §Part 2 — Unit)

--- a/packages/markspec/core/model/type_hierarchy_test.ts
+++ b/packages/markspec/core/model/type_hierarchy_test.ts
@@ -40,11 +40,29 @@ Deno.test("attributesForType: SoftwareComponent inherits Component attrs + own",
   assertEquals(attrs.has("Satisfies"), false);
 });
 
-Deno.test("attributesForType: HardwareInterface inherits Component + own bus protocol attrs", () => {
+Deno.test("attributesForType: HardwareInterface owns physical attrs, inherits Contract chain", () => {
   const attrs = attributesForType("HardwareInterface");
+  // Own physical attributes retained after re-parenting.
   assertEquals(attrs.has("Bus-protocol"), true);
   assertEquals(attrs.has("Connector-type"), true);
-  assertEquals(attrs.has("Provides"), true); // inherited
+  assertEquals(attrs.has("Voltage-level"), true);
+  assertEquals(attrs.has("Signal-direction"), true);
+  // Inherited from Contract → Specification.
+  assertEquals(attrs.has("Schema-language"), true);
+  assertEquals(attrs.has("Satisfies"), true);
+  assertEquals(attrs.has("Derived-from"), true);
+  // No longer inherited from Component.
+  assertEquals(attrs.has("Provides"), false);
+  assertEquals(attrs.has("Requires"), false);
+  assertEquals(attrs.has("Kind"), false);
+});
+
+Deno.test("attributesForType: SoftwareInterface inherits Contract chain, no Component attrs", () => {
+  const attrs = attributesForType("SoftwareInterface");
+  assertEquals(attrs.has("Schema-language"), true); // from Contract
+  assertEquals(attrs.has("Satisfies"), true); // from Specification
+  assertEquals(attrs.has("Provides"), false); // not from Component anymore
+  assertEquals(attrs.has("Kind"), false);
 });
 
 Deno.test("attributesForType: Item root → empty set", () => {

--- a/packages/markspec/core/validator/listing.ts
+++ b/packages/markspec/core/validator/listing.ts
@@ -49,13 +49,16 @@ export interface ListingFileContext {
 // Component-family and Unit-family sets
 // ---------------------------------------------------------------------------
 
-/** Core Component-family type names per ADR-003 §Part 2 / spec §6.3. */
+/** Core Component-family type names per ADR-003 §Part 2 / spec §6.3.
+ *
+ * SoftwareInterface and HardwareInterface are NOT included here: they
+ * were re-parented from Component to Contract (interface-as-contract
+ * design). A components listing accepts only true structural components.
+ */
 const COMPONENT_FAMILY: ReadonlySet<string> = new Set([
   "Component",
   "SoftwareComponent",
   "HardwareComponent",
-  "SoftwareInterface",
-  "HardwareInterface",
 ]);
 
 /** Core Unit-family type names per ADR-003 §Part 2. */
@@ -280,8 +283,7 @@ function validateComponentsEntry(
       severity: "error",
       message: `${file}:${entry.location.line}: entry '[${entry.displayId}]' ` +
         `has Type: ${typeVal} which is not in the Component family ` +
-        `(Component/SoftwareComponent/HardwareComponent/` +
-        `SoftwareInterface/HardwareInterface) — ` +
+        `(Component/SoftwareComponent/HardwareComponent) — ` +
         `only Component-family types are permitted in a components listing ` +
         `(spec §6.3)`,
       location: entry.location,

--- a/packages/markspec/core/validator/mod_test.ts
+++ b/packages/markspec/core/validator/mod_test.ts
@@ -9,7 +9,7 @@
 import { assertEquals } from "@std/assert";
 import type { Entry } from "../model/mod.ts";
 import { makeDisplayId } from "../model/mod.ts";
-import { validate } from "./mod.ts";
+import { runPipeline, validate } from "./mod.ts";
 import type { TyplBlock } from "../typl/mod.ts";
 
 function entry(
@@ -434,4 +434,45 @@ Deno.test("validate: CSV attribute without empty element does not emit MSL-A006"
   const result = validate([e]);
   const a006 = result.diagnostics.filter((d) => d.code === "MSL-A006");
   assertEquals(a006.length, 0);
+});
+
+// ---------------------------------------------------------------------------
+// MSL-T022 — SoftwareInterface re-parented from Component to Contract
+// (interface-as-contract design). Satisfies is inherited from Specification
+// (via Contract); Provides is a Component attribute and must no longer fire
+// on SoftwareInterface.
+// ---------------------------------------------------------------------------
+
+Deno.test("MSL-T022: Satisfies is valid on a SoftwareInterface", () => {
+  const e = entry({
+    displayId: "API_0001",
+    rawAttributes: [
+      { key: "Id", value: ULID_A },
+      { key: "Type", value: "SoftwareInterface" },
+      { key: "Satisfies", value: "SRS_0001" },
+    ],
+    id: ULID_A,
+  });
+  // runPipeline runs validatePerTypeAttributes (Stage 1.5) which emits MSL-T022.
+  // Plain validate() does not — it is Stage 1 only.
+  const result = runPipeline([e], null);
+  const t022 = result.diagnostics.filter((d) => d.code === "MSL-T022");
+  assertEquals(t022.length, 0);
+});
+
+Deno.test("MSL-T022: Provides authored on a SoftwareInterface is flagged", () => {
+  const e = entry({
+    displayId: "API_0001",
+    rawAttributes: [
+      { key: "Id", value: ULID_A },
+      { key: "Type", value: "SoftwareInterface" },
+      { key: "Provides", value: "SWC_0002" },
+    ],
+    id: ULID_A,
+  });
+  // runPipeline runs validatePerTypeAttributes (Stage 1.5) which emits MSL-T022.
+  // Plain validate() does not — it is Stage 1 only.
+  const result = runPipeline([e], null);
+  const t022 = result.diagnostics.filter((d) => d.code === "MSL-T022");
+  assertEquals(t022.length >= 1, true);
 });

--- a/packages/markspec/core/validator/trace_types.ts
+++ b/packages/markspec/core/validator/trace_types.ts
@@ -34,23 +34,21 @@ const TRACE_RULES: readonly TraceRule[] = [
   { attr: "Allocated-to", allowedTargetTypes: ["Component"] },
   // Test (extends Specification)
   { attr: "Verifies", allowedTargetTypes: ["Requirement", "Contract"] },
-  { attr: "Tests", allowedTargetTypes: ["Component", "Unit"] },
+  { attr: "Tests", allowedTargetTypes: ["Component", "Unit", "Contract"] },
   // Component / Unit
   { attr: "Realizes", allowedTargetTypes: ["Specification"] },
-  {
-    attr: "Provides",
-    allowedTargetTypes: ["SoftwareInterface", "HardwareInterface"],
-  },
-  {
-    attr: "Requires",
-    allowedTargetTypes: ["SoftwareInterface", "HardwareInterface"],
-  },
+  // Provides/Requires: interfaces are Contract subtypes (re-parented from
+  // Component in the interface-as-contract design). Using ["Contract"] here
+  // accepts Contract itself AND every subtype (SoftwareInterface,
+  // HardwareInterface, profile-declared API/ICD, …) via the hierarchy walk.
+  { attr: "Provides", allowedTargetTypes: ["Contract"] },
+  { attr: "Requires", allowedTargetTypes: ["Contract"] },
   { attr: "Depends-on", allowedTargetTypes: ["Component", "Unit"] },
   { attr: "Part-of", allowedTargetTypes: ["Component"] },
   // Risk
   { attr: "Mitigated-by", allowedTargetTypes: ["Specification"] },
   // Record
-  { attr: "Affects", allowedTargetTypes: ["Component", "Unit"] },
+  { attr: "Affects", allowedTargetTypes: ["Component", "Unit", "Contract"] },
   // `Caused-by` is polymorphic between Record (cause = Requirement/Risk/
   // Contract/Record) and Risk (cause = Component/Unit/Specification).
   // The simplest correct rule is the union — handled by the loop below.

--- a/packages/markspec/core/validator/trace_types_test.ts
+++ b/packages/markspec/core/validator/trace_types_test.ts
@@ -147,3 +147,111 @@ Deno.test("Caused-by on Requirement (neither Record nor Risk) → no MSL-R083 (s
   const r083 = result.filter((d) => d.code === "MSL-R083");
   assertEquals(r083.length, 0);
 });
+
+// ---------------------------------------------------------------------------
+// Interface-as-contract re-parent (Fix 1):
+//   Provides/Requires now accept Contract (and subtypes).
+//   Tests/Affects now also accept Contract (and subtypes).
+// ---------------------------------------------------------------------------
+
+const ULID_C = "01HGW2Q8MNP3RSTVWXYZABCDEH";
+
+Deno.test("Provides: SoftwareInterface target → no MSL-R083 (Contract subtype)", () => {
+  const result = validateTraceTargetTypes([
+    entry({
+      displayId: "SWC-001",
+      type: "SoftwareComponent",
+      rawAttributes: [
+        { key: "Id", value: ULID_A },
+        { key: "Type", value: "SoftwareComponent" },
+        { key: "Provides", value: ULID_B },
+      ],
+    }),
+    entry({
+      displayId: "IFC-001",
+      type: "SoftwareInterface",
+      id: ULID_B,
+      rawAttributes: [
+        { key: "Id", value: ULID_B },
+        { key: "Type", value: "SoftwareInterface" },
+      ],
+    }),
+  ]);
+  const r083 = result.filter((d) => d.code === "MSL-R083");
+  assertEquals(r083.length, 0);
+});
+
+Deno.test("Provides: plain Contract target → no MSL-R083", () => {
+  const result = validateTraceTargetTypes([
+    entry({
+      displayId: "SWC-001",
+      type: "SoftwareComponent",
+      rawAttributes: [
+        { key: "Id", value: ULID_A },
+        { key: "Type", value: "SoftwareComponent" },
+        { key: "Provides", value: ULID_B },
+      ],
+    }),
+    entry({
+      displayId: "CTR-001",
+      type: "Contract",
+      id: ULID_B,
+      rawAttributes: [
+        { key: "Id", value: ULID_B },
+        { key: "Type", value: "Contract" },
+      ],
+    }),
+  ]);
+  const r083 = result.filter((d) => d.code === "MSL-R083");
+  assertEquals(r083.length, 0);
+});
+
+Deno.test("Tests: SoftwareInterface target → no MSL-R083 (Contract subtype)", () => {
+  const result = validateTraceTargetTypes([
+    entry({
+      displayId: "TST-001",
+      type: "Test",
+      rawAttributes: [
+        { key: "Id", value: ULID_A },
+        { key: "Type", value: "Test" },
+        { key: "Tests", value: ULID_B },
+      ],
+    }),
+    entry({
+      displayId: "IFC-001",
+      type: "SoftwareInterface",
+      id: ULID_B,
+      rawAttributes: [
+        { key: "Id", value: ULID_B },
+        { key: "Type", value: "SoftwareInterface" },
+      ],
+    }),
+  ]);
+  const r083 = result.filter((d) => d.code === "MSL-R083");
+  assertEquals(r083.length, 0);
+});
+
+Deno.test("Requires: HardwareInterface target → no MSL-R083 (Contract subtype)", () => {
+  const result = validateTraceTargetTypes([
+    entry({
+      displayId: "HWC-001",
+      type: "HardwareComponent",
+      rawAttributes: [
+        { key: "Id", value: ULID_A },
+        { key: "Type", value: "HardwareComponent" },
+        { key: "Requires", value: ULID_C },
+      ],
+    }),
+    entry({
+      displayId: "HIFC-001",
+      type: "HardwareInterface",
+      id: ULID_C,
+      rawAttributes: [
+        { key: "Id", value: ULID_C },
+        { key: "Type", value: "HardwareInterface" },
+      ],
+    }),
+  ]);
+  const r083 = result.filter((d) => d.code === "MSL-R083");
+  assertEquals(r083.length, 0);
+});

--- a/packages/markspec/lsp/completions.ts
+++ b/packages/markspec/lsp/completions.ts
@@ -35,14 +35,14 @@ const MID_TYPED_SCAFFOLD_RE = /^\s*-\s*\[([A-Za-z0-9_-]+)$/;
 
 /** Pattern matching a trace attribute keyword at line start. */
 const TRACE_ATTR_RE =
-  /^\s*(Satisfies|Derived-from|Verified-by|References|Tests|Depends-on|Part-of|Allocated-to|Realizes|Generated-from|Supersedes)\s*:/;
+  /^\s*(Satisfies|Derived-from|Verified-by|References|Tests|Depends-on|Part-of|Allocated-to|Realizes|Provides|Requires|Generated-from|Supersedes)\s*:/;
 
 /** Pattern matching the `Type:` attribute keyword at line start. */
 const TYPE_ATTR_RE = /^\s*Type\s*:/;
 
 /**
  * Trailer attribute keys offered as completions inside an entry's
- * trailer region. Includes the eleven trace-link keys (whose pattern
+ * trailer region. Includes the thirteen trace-link keys (whose pattern
  * also appears in `TRACE_ATTR_RE` and in `TRACE_KEYWORDS_RE` in
  * `context.ts`), plus the cardinal `Labels:` and `Type:` keys. When
  * the trace-keyword set changes here, also update those two regexes.
@@ -60,6 +60,8 @@ export const TRAILER_KEYS: readonly string[] = [
   "Part-of",
   "Allocated-to",
   "Realizes",
+  "Provides",
+  "Requires",
   "Generated-from",
   "Supersedes",
   "Labels",

--- a/packages/markspec/lsp/completions_test.ts
+++ b/packages/markspec/lsp/completions_test.ts
@@ -52,6 +52,14 @@ Deno.test("isTraceAttributeTrigger: matches 'Derived-from:'", () => {
   assertEquals(isTraceAttributeTrigger("  Derived-from:"), true);
 });
 
+Deno.test("isTraceAttributeTrigger: matches 'Provides:'", () => {
+  assertEquals(isTraceAttributeTrigger("      Provides:"), true);
+});
+
+Deno.test("isTraceAttributeTrigger: matches 'Requires:'", () => {
+  assertEquals(isTraceAttributeTrigger("      Requires:"), true);
+});
+
 Deno.test("isTraceAttributeTrigger: matches 'Satisfies: ' with trailing space", () => {
   assertEquals(isTraceAttributeTrigger("  Satisfies: "), true);
 });
@@ -326,7 +334,7 @@ Deno.test("renderScaffoldSnippet: pattern suffix is preserved in the ID", () => 
 // --- Trailer key trigger ---
 
 Deno.test("TRAILER_KEYS: includes the documented trace + label + type keys", () => {
-  assertEquals(TRAILER_KEYS.length, 13);
+  assertEquals(TRAILER_KEYS.length, 15);
   // Trace attribute keys.
   assertEquals(TRAILER_KEYS.includes("Satisfies"), true);
   assertEquals(TRAILER_KEYS.includes("Derived-from"), true);
@@ -337,6 +345,8 @@ Deno.test("TRAILER_KEYS: includes the documented trace + label + type keys", () 
   assertEquals(TRAILER_KEYS.includes("Part-of"), true);
   assertEquals(TRAILER_KEYS.includes("Allocated-to"), true);
   assertEquals(TRAILER_KEYS.includes("Realizes"), true);
+  assertEquals(TRAILER_KEYS.includes("Provides"), true);
+  assertEquals(TRAILER_KEYS.includes("Requires"), true);
   assertEquals(TRAILER_KEYS.includes("Generated-from"), true);
   assertEquals(TRAILER_KEYS.includes("Supersedes"), true);
   // Non-trace keys we also suggest.

--- a/packages/markspec/lsp/context.ts
+++ b/packages/markspec/lsp/context.ts
@@ -35,7 +35,7 @@ const ENTRY_MARKER_RE = /\[[A-Z]{2,}_[A-Z0-9_]+\]/;
 
 /** Trace attribute keywords that indicate a MarkSpec context. */
 const TRACE_KEYWORDS_RE =
-  /\b(Id|Satisfies|Derived-from|Verified-by|References|Tests|Depends-on|Part-of|Allocated-to|Realizes|Generated-from|Supersedes|Labels|Discipline-frozen|Discipline)\s*:/;
+  /\b(Id|Satisfies|Derived-from|Verified-by|References|Tests|Depends-on|Part-of|Allocated-to|Realizes|Provides|Requires|Generated-from|Supersedes|Labels|Discipline-frozen|Discipline)\s*:/;
 
 /**
  * Check whether a file path has a MarkSpec-relevant extension.

--- a/packages/markspec/lsp/context_test.ts
+++ b/packages/markspec/lsp/context_test.ts
@@ -100,3 +100,13 @@ Deno.test("Slice 3 LSP context: Discipline-frozen: keyword triggers doc-comment 
   const lines = ["/// Some prose", "/// Discipline-frozen: software"];
   assertEquals(isDocCommentContext(lines, 1), true);
 });
+
+Deno.test("isDocCommentContext: Provides: keyword triggers doc-comment context", () => {
+  const lines = ["/// Some prose", "/// Provides: IFC_001"];
+  assertEquals(isDocCommentContext(lines, 1), true);
+});
+
+Deno.test("isDocCommentContext: Requires: keyword triggers doc-comment context", () => {
+  const lines = ["/// Some prose", "/// Requires: IFC_002"];
+  assertEquals(isDocCommentContext(lines, 1), true);
+});

--- a/tests/e2e/validate_listing_test.ts
+++ b/tests/e2e/validate_listing_test.ts
@@ -704,6 +704,27 @@ Deno.test("validate/listing: L043 error on non-Component-family type in componen
   assertStringIncludes(stderr, "Component");
 });
 
+Deno.test("validate/listing: L043 error on SoftwareInterface type in components.md", async () => {
+  // SoftwareInterface re-parented from Component to Contract; it is no longer
+  // a Component-family type and must not appear in a components listing.
+  const { code, stderr } = await markspec(["validate", "components.md"], {
+    files: {
+      "components.md": `# Components
+
+- [some-api] A software interface (wrong family)
+
+  Body.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      Type: SoftwareInterface
+`,
+    },
+  });
+  assertEquals(code, 1, `expected exit 1, got ${code}; stderr: ${stderr}`);
+  assertStringIncludes(stderr, "MSL-L043");
+  assertStringIncludes(stderr, "SoftwareInterface");
+});
+
 Deno.test("validate/listing: L050 info on empty references.md", async () => {
   const { code, stderr } = await markspec(["validate", "references.md"], {
     files: {


### PR DESCRIPTION
## Summary

Re-parents `SoftwareInterface` and `HardwareInterface` from `Component` to `Contract` (the `Specification` family). An interface is a **specification of a boundary**, not a building block — the prior `Component` parentage was a modeling error (interfaces reused only 1 of `Component`'s 6 attributes, and the provider relations pointed backwards). UML / SysML / AUTOSAR / ICD all treat an interface *definition* as a contract distinct from the component that provides or requires it.

- **type_hierarchy:** interfaces now extend `Contract`; `HardwareInterface` keeps its physical attrs (`Bus-protocol`, `Connector-type`, `Voltage-level`, `Signal-direction`). Names kept (literature terms).
- **compiler:** `Provides`/`Requires` wired as `provides`/`requires` traceability links (`ATTR_TO_LINK_KIND` + `KNOWN_LINK_KINDS`) — symmetric provider/consumer relations Component → Contract.
- **attributes:** add `Depended-on-by` generated inverse, freeing `Required-by` to be the inverse of `Requires`.
- **lsp:** register `Provides`/`Requires` in the trace-keyword lists (completions + context) so they complete and are recognised like other trace keys.
- **docs(spec):** interface types moved under `Contract`; relations + attributes tables updated (`Depends-on`'s inverse renamed to `Depended-on-by`).

`Allocated-to` is unchanged (not reused for provider-hosting); interface discipline stays type-driven. No migration tooling (pre-1.0). An `Element` abstract parent over `{Component, Unit}` (ASPICE-4.0 alignment) is intentionally deferred to a later phase.

## Test Plan

- [x] `just check` — 3096 passed, 0 failed (lint + test + type-check, `--allow-net`)
- [x] `just compile` — binary builds
- [x] `deno fmt --check` and `dprint check` — clean
- [x] New tests: type-hierarchy inheritance (interfaces inherit Contract chain, not Component), `provides`/`requires` link emission, MSL-T022 reflects the re-parent, LSP `Provides`/`Requires` keyword triggers
- [x] `markspec validate docs/product/*.md` — exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)