### PR TITLE
docs(repo): add ADR-024 interface-as-contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -417,6 +417,10 @@ docs/
 - `adr-023-mcp-trigger-language.md` — MCP server's agent-facing trigger language
   (TRIGGER / PREFER over / SKIP grammar) + project-detection soft gate so tools
   self-describe "no MarkSpec project found" outside MarkSpec workspaces
+- `adr-024-interface-as-contract.md` — re-parent `SoftwareInterface` /
+  `HardwareInterface` from `Component` to `Contract` (an interface is a
+  specification, not a building block); `Provides`/`Requires` provider/consumer
+  links; supersedes the type tree shown in ADR-017
 - `overview.md` — narrative architecture tour
 
 See [docs/architecture/overview.md](docs/architecture/overview.md) for a reading

--- a/docs/architecture/adr-024-interface-as-contract.md
+++ b/docs/architecture/adr-024-interface-as-contract.md
@@ -19,15 +19,15 @@ Component (abstract)
 └── HardwareInterface     ← subtype of Component
 ```
 
-That parentage is a category error. An interface is not a *building block*; it
-is the *specification of a boundary* — the agreement two components meet at.
+That parentage is a category error. An interface is not a _building block_; it
+is the _specification of a boundary_ — the agreement two components meet at.
 Three observations forced the question:
 
-- **Attribute audit.** `Component` declares six own-attributes
-  (`Kind`, `Part-of`, `Realizes`, `Depends-on`, `Provides`, `Requires`). The
-  interface subtypes genuinely used only **one** (`Part-of`). Worse, the most
+- **Attribute audit.** `Component` declares six own-attributes (`Kind`,
+  `Part-of`, `Realizes`, `Depends-on`, `Provides`, `Requires`). The interface
+  subtypes genuinely used only **one** (`Part-of`). Worse, the most
   Component-specific relations point the wrong way: `Provides`/`Requires` are
-  *ports* a component declares — the interface is their **target**, not their
+  _ports_ a component declares — the interface is their **target**, not their
   holder; an interface is `Realized-by` something, it does not author
   `Realizes`. `SoftwareInterface` declared **zero** own attributes.
 
@@ -36,16 +36,16 @@ Three observations forced the question:
      OpenAPI doc, a PACT, an ICD message set);
   2. the **architectural connection** — "component A talks to component B", an
      edge in the architecture;
-  3. the **service** a component offers and another consumes.
-  These are not one type. Concept 1 is a *specification*; concept 2 is a *link*;
-  concept 3 is *edges* (provider/consumer) between components and a contract.
+  3. the **service** a component offers and another consumes. These are not one
+     type. Concept 1 is a _specification_; concept 2 is a _link_; concept 3 is
+     _edges_ (provider/consumer) between components and a contract.
 
 - **Prior art.** UML (`Interface` is a `Classifier`, distinct from `Component`),
   SysML v1/v2 (`InterfaceBlock` / `InterfaceDefinition`, sibling to
   `Block`/`PartDefinition`), AUTOSAR (`PortInterface` distinct from
-  `SwComponentType`), and ICD / INCOSE practice (an Interface Control *Document*
-  is a specification artifact) all model an interface *definition* as a
-  contract distinct from the component that provides or requires it. The
+  `SwComponentType`), and ICD / INCOSE practice (an Interface Control _Document_
+  is a specification artifact) all model an interface _definition_ as a contract
+  distinct from the component that provides or requires it. The
   interface-as-component reading is the one without support.
 
 A note on naming explored during design: "HardwareContract" was rejected — it is
@@ -75,30 +75,31 @@ Component (abstract)
 `Contract` stays **concrete** and discipline-neutral (the system / ICD level).
 `HardwareInterface` keeps its physical own-attributes (`Bus-protocol`,
 `Connector-type`, `Voltage-level`, `Signal-direction`). A physical connector you
-can hold is a `HardwareComponent`; its interface *spec* is a `HardwareInterface`.
+can hold is a `HardwareComponent`; its interface _spec_ is a
+`HardwareInterface`.
 
 ### Relation model
 
 A contract participates in three distinct component roles. Provider and consumer
 are a symmetric pair; `Allocated-to` is **not** reused for them.
 
-| Role | Authored relation | Source → Target | Inverse |
-| --- | --- | --- | --- |
-| Implementation (who builds it) | `Realizes` | Component/Unit → Contract | `Realized-by` |
-| Provider (who offers it) | `Provides` | Component → Contract | `Provided-by` |
-| Consumer (who needs it) | `Requires` | Component → Contract | `Required-by` |
+| Role                           | Authored relation | Source → Target           | Inverse       |
+| ------------------------------ | ----------------- | ------------------------- | ------------- |
+| Implementation (who builds it) | `Realizes`        | Component/Unit → Contract | `Realized-by` |
+| Provider (who offers it)       | `Provides`        | Component → Contract      | `Provided-by` |
+| Consumer (who needs it)        | `Requires`        | Component → Contract      | `Required-by` |
 
 - `Provides`/`Requires` are wired as `provides`/`requires` traceability link
   kinds (they previously existed as `Component` attributes but produced no
-  edges). Their target rule is `[Contract]`, which — because target compatibility
-  walks the type hierarchy — accepts `Contract` and every subtype
+  edges). Their target rule is `[Contract]`, which — because target
+  compatibility walks the type hierarchy — accepts `Contract` and every subtype
   (`SoftwareInterface`, `HardwareInterface`, profile-declared `API`/`ICD`, …).
 - `Required-by` is now the inverse of `Requires`; `Depends-on`'s inverse is
   renamed `Depended-on-by` to free the name.
 - **Interface discipline is type-driven** (`SoftwareInterface`→software,
   `HardwareInterface`→hardware). The provider relation is not `Allocated-to`, so
-  the ADR-017 discipline walk does not run on interfaces and there is no
-  "type vs provider" precedence question.
+  the ADR-017 discipline walk does not run on interfaces and there is no "type
+  vs provider" precedence question.
 
 ### Profile domain names
 
@@ -114,23 +115,23 @@ types:
 ### Rejected / out of scope
 
 - **`HardwareContract`** — not a real term (see Context).
-- **A core `Service` type** — a SOA/gRPC "service" is a `SoftwareComponent`
-  that `Provides` a `Contract`; the proto `service {}` block / WSDL / OpenAPI doc
-  is the `Contract`. A `Service` subtype, if wanted, is a profile concern.
+- **A core `Service` type** — a SOA/gRPC "service" is a `SoftwareComponent` that
+  `Provides` a `Contract`; the proto `service {}` block / WSDL / OpenAPI doc is
+  the `Contract`. A `Service` subtype, if wanted, is a profile concern.
 - **An `Element` abstract parent over `{Component, Unit}`** (ASPICE-4.0
   "element" alignment + hoisting the `Part-of`/`Realizes`/`Depends-on` they
   share) — deferred to a separate phase. Note: ASPICE's element→component→unit
-  is a *containment* ladder, already modeled by the `Part-of` link, not a
+  is a _containment_ ladder, already modeled by the `Part-of` link, not a
   generalization; only the generalization reading would be a type-tree change.
 
 ## Consequences
 
 - **Validator.** `attributesForType` now resolves interfaces through the
-  `Specification`→`Contract` chain, so `Satisfies`/`Derived-from`/`Schema-language`
-  are valid on an interface and the `Component` relations are not (MSL-T022
-  reflects this). The `MSL-R083` target-type matrix was reconciled:
-  `Tests`/`Affects` gained `Contract` (interfaces stay valid targets);
-  `Provides`/`Requires` target `[Contract]`.
+  `Specification`→`Contract` chain, so
+  `Satisfies`/`Derived-from`/`Schema-language` are valid on an interface and the
+  `Component` relations are not (MSL-T022 reflects this). The `MSL-R083`
+  target-type matrix was reconciled: `Tests`/`Affects` gained `Contract`
+  (interfaces stay valid targets); `Provides`/`Requires` target `[Contract]`.
 - **Components listings.** `SoftwareInterface`/`HardwareInterface` were removed
   from the components-listing family (`MSL-L043`) — they are specs, not BOM
   components.
@@ -144,8 +145,9 @@ types:
   for interface parentage.
 - **Known hazard (follow-up).** Trace-relation / type-family metadata is
   duplicated across four files — `ATTR_TO_LINK_KIND` (compiler), `TRACE_RULES`
-  (validator), `TRACE_KEYS` (lock), and `COMPONENT_FAMILY` (listing). This change
-  had to update all four by hand; a half-update shipped in the first PR commit
-  and was caught only in review. A single-source-of-truth refactor for these
-  lists is recommended so a relation/type change cannot half-land.
-- **No migration.** Pre-1.0; `Type:` semantics changed without migration tooling.
+  (validator), `TRACE_KEYS` (lock), and `COMPONENT_FAMILY` (listing). This
+  change had to update all four by hand; a half-update shipped in the first PR
+  commit and was caught only in review. A single-source-of-truth refactor for
+  these lists is recommended so a relation/type change cannot half-land.
+- **No migration.** Pre-1.0; `Type:` semantics changed without migration
+  tooling.

--- a/docs/architecture/adr-024-interface-as-contract.md
+++ b/docs/architecture/adr-024-interface-as-contract.md
@@ -1,0 +1,151 @@
+# ADR-024: Interface as Contract
+
+## Status
+
+Accepted (2026-05-30). Shipped in PR #569.
+
+## Context
+
+The core type hierarchy (ADR-003 / `core/model/type_hierarchy.ts`) placed
+`SoftwareInterface` and `HardwareInterface` as subtypes of `Component`
+("system-level building blocks with identity"), alongside `SoftwareComponent`
+and `HardwareComponent`:
+
+```text
+Component (abstract)
+├── SoftwareComponent
+├── HardwareComponent
+├── SoftwareInterface     ← subtype of Component
+└── HardwareInterface     ← subtype of Component
+```
+
+That parentage is a category error. An interface is not a *building block*; it
+is the *specification of a boundary* — the agreement two components meet at.
+Three observations forced the question:
+
+- **Attribute audit.** `Component` declares six own-attributes
+  (`Kind`, `Part-of`, `Realizes`, `Depends-on`, `Provides`, `Requires`). The
+  interface subtypes genuinely used only **one** (`Part-of`). Worse, the most
+  Component-specific relations point the wrong way: `Provides`/`Requires` are
+  *ports* a component declares — the interface is their **target**, not their
+  holder; an interface is `Realized-by` something, it does not author
+  `Realizes`. `SoftwareInterface` declared **zero** own attributes.
+
+- **The word "interface" is overloaded.** It smears three distinct concepts:
+  1. the **contract** — the published agreement / API surface (a `.proto`, an
+     OpenAPI doc, a PACT, an ICD message set);
+  2. the **architectural connection** — "component A talks to component B", an
+     edge in the architecture;
+  3. the **service** a component offers and another consumes.
+  These are not one type. Concept 1 is a *specification*; concept 2 is a *link*;
+  concept 3 is *edges* (provider/consumer) between components and a contract.
+
+- **Prior art.** UML (`Interface` is a `Classifier`, distinct from `Component`),
+  SysML v1/v2 (`InterfaceBlock` / `InterfaceDefinition`, sibling to
+  `Block`/`PartDefinition`), AUTOSAR (`PortInterface` distinct from
+  `SwComponentType`), and ICD / INCOSE practice (an Interface Control *Document*
+  is a specification artifact) all model an interface *definition* as a
+  contract distinct from the component that provides or requires it. The
+  interface-as-component reading is the one without support.
+
+A note on naming explored during design: "HardwareContract" was rejected — it is
+not a term used in the field. `SoftwareInterface` / `HardwareInterface` are the
+established literature terms and are kept.
+
+## Decision
+
+**Re-parent `SoftwareInterface` and `HardwareInterface` from `Component` to
+`Contract`** (in the `Specification` family). Names are unchanged.
+
+```text
+Specification (abstract)
+├── Requirement
+├── Test
+├── Contract                  concrete; system-level interface agreement
+│   ├── SoftwareInterface     re-parented; software; .proto/.openapi/.wsdl
+│   └── HardwareInterface     re-parented; hardware; Bus-protocol, Voltage-level, …
+├── Record
+└── Risk
+
+Component (abstract)
+├── SoftwareComponent
+└── HardwareComponent         ← physical connector/bus/transceiver lives here
+```
+
+`Contract` stays **concrete** and discipline-neutral (the system / ICD level).
+`HardwareInterface` keeps its physical own-attributes (`Bus-protocol`,
+`Connector-type`, `Voltage-level`, `Signal-direction`). A physical connector you
+can hold is a `HardwareComponent`; its interface *spec* is a `HardwareInterface`.
+
+### Relation model
+
+A contract participates in three distinct component roles. Provider and consumer
+are a symmetric pair; `Allocated-to` is **not** reused for them.
+
+| Role | Authored relation | Source → Target | Inverse |
+| --- | --- | --- | --- |
+| Implementation (who builds it) | `Realizes` | Component/Unit → Contract | `Realized-by` |
+| Provider (who offers it) | `Provides` | Component → Contract | `Provided-by` |
+| Consumer (who needs it) | `Requires` | Component → Contract | `Required-by` |
+
+- `Provides`/`Requires` are wired as `provides`/`requires` traceability link
+  kinds (they previously existed as `Component` attributes but produced no
+  edges). Their target rule is `[Contract]`, which — because target compatibility
+  walks the type hierarchy — accepts `Contract` and every subtype
+  (`SoftwareInterface`, `HardwareInterface`, profile-declared `API`/`ICD`, …).
+- `Required-by` is now the inverse of `Requires`; `Depends-on`'s inverse is
+  renamed `Depended-on-by` to free the name.
+- **Interface discipline is type-driven** (`SoftwareInterface`→software,
+  `HardwareInterface`→hardware). The provider relation is not `Allocated-to`, so
+  the ADR-017 discipline walk does not run on interfaces and there is no
+  "type vs provider" precedence question.
+
+### Profile domain names
+
+Profiles supply domain vocabulary via the existing `extends:` mechanism — there
+is no type-alias feature and none is added:
+
+```yaml
+types:
+  API: { extends: SoftwareInterface }   # services profile
+  ICD: { extends: Contract }            # automotive / system profile
+```
+
+### Rejected / out of scope
+
+- **`HardwareContract`** — not a real term (see Context).
+- **A core `Service` type** — a SOA/gRPC "service" is a `SoftwareComponent`
+  that `Provides` a `Contract`; the proto `service {}` block / WSDL / OpenAPI doc
+  is the `Contract`. A `Service` subtype, if wanted, is a profile concern.
+- **An `Element` abstract parent over `{Component, Unit}`** (ASPICE-4.0
+  "element" alignment + hoisting the `Part-of`/`Realizes`/`Depends-on` they
+  share) — deferred to a separate phase. Note: ASPICE's element→component→unit
+  is a *containment* ladder, already modeled by the `Part-of` link, not a
+  generalization; only the generalization reading would be a type-tree change.
+
+## Consequences
+
+- **Validator.** `attributesForType` now resolves interfaces through the
+  `Specification`→`Contract` chain, so `Satisfies`/`Derived-from`/`Schema-language`
+  are valid on an interface and the `Component` relations are not (MSL-T022
+  reflects this). The `MSL-R083` target-type matrix was reconciled:
+  `Tests`/`Affects` gained `Contract` (interfaces stay valid targets);
+  `Provides`/`Requires` target `[Contract]`.
+- **Components listings.** `SoftwareInterface`/`HardwareInterface` were removed
+  from the components-listing family (`MSL-L043`) — they are specs, not BOM
+  components.
+- **Lockfile.** The lockfile edge extractor now records `Provides`/`Requires`
+  edges (its trace-key list was independent of the compiler's).
+- **LSP.** `Provides`/`Requires` are registered in the trace-keyword lists
+  (completion + doc-comment context), like every other trace key.
+- **Supersedes.** The type tree embedded in
+  [ADR-017](./adr-017-discipline-classification.md) still shows interfaces under
+  `Component`; that tree is historical — this ADR is the current source of truth
+  for interface parentage.
+- **Known hazard (follow-up).** Trace-relation / type-family metadata is
+  duplicated across four files — `ATTR_TO_LINK_KIND` (compiler), `TRACE_RULES`
+  (validator), `TRACE_KEYS` (lock), and `COMPONENT_FAMILY` (listing). This change
+  had to update all four by hand; a half-update shipped in the first PR commit
+  and was caught only in review. A single-source-of-truth refactor for these
+  lists is recommended so a relation/type change cannot half-land.
+- **No migration.** Pre-1.0; `Type:` semantics changed without migration tooling.


### PR DESCRIPTION
## Summary

Records the interface-as-contract decision (shipped in #569) as a permanent ADR, since the design rationale otherwise lived only in a gitignored local spec.

- New `docs/architecture/adr-024-interface-as-contract.md`: context (attribute audit, the overloaded term, UML/SysML/AUTOSAR/ICD prior art), decision (re-parent under `Contract`, the Provides/Requires/Realizes relation model, profile API/ICD via extends), and consequences (validator/lock/listing/LSP reconciliation, supersedes ADR-017 tree, the four-duplicated-lists hazard, deferred Element phase).
- Adds the ADR to the index in AGENTS.md.

## Test Plan

- [x] dprint check clean (pre-commit hook)
- [x] Docs-only; no code paths touched🤖 Generated with [Claude Code](https://claude.com/claude-code)