### PR TITLE
feat(cli): report toolchain floor skew in markspec doctor

### DIFF
--- a/packages/markspec/cli/commands/doctor.ts
+++ b/packages/markspec/cli/commands/doctor.ts
@@ -5,6 +5,7 @@
  */
 
 import { Command } from "@cliffy/command";
+import { isBelowFloor, parseLockfile, VERSION } from "../../core/mod.ts";
 import { compileProject, requireProjectConfig } from "../helpers.ts";
 
 export const doctorCmd = new Command()
@@ -26,9 +27,28 @@ export const doctorCmd = new Command()
     // are fast and idempotent.
     const { config, projectRoot } = await requireProjectConfig();
 
+    // Toolchain floor skew (slice F): compare the running CLI version against
+    // the workspace markspec.lock min-version floor using the slice-B SSOT.
+    // A missing lockfile or missing floor means "no floor declared" — not skew.
+    let floor: string | undefined;
+    try {
+      const lockRaw = await Deno.readTextFile(`${projectRoot}/markspec.lock`);
+      floor = parseLockfile(lockRaw).lockfile?.meta.toolchain?.minVersion;
+    } catch {
+      // No lockfile (or unreadable) → no floor. Lockfile validity is the
+      // concern of `markspec check`/`lock`, not doctor.
+    }
+    const belowFloor = isBelowFloor(VERSION, floor);
+
     const diagnostics: Array<
       { severity: string; code: string; message: string }
-    > = [];
+    > = belowFloor
+      ? [{
+        severity: "warning",
+        code: "toolchain-below-floor",
+        message: `CLI version ${VERSION} is below the workspace floor ${floor}`,
+      }]
+      : [];
 
     const leaf = chain ? chain.tiers[chain.tiers.length - 1] : null;
     const tierCount = chain ? chain.tiers.length : 0;
@@ -69,6 +89,11 @@ export const doctorCmd = new Command()
           }
           : null,
         diagnostics,
+        toolchain: {
+          cliVersion: VERSION,
+          floor: floor ?? null,
+          belowFloor,
+        },
         ...(modeInfo ? { disciplineCounts: counts } : {}),
       };
       console.log(JSON.stringify(output, null, 2));
@@ -82,6 +107,17 @@ export const doctorCmd = new Command()
       } else {
         console.error("Profile: no profile configured");
       }
+      if (floor === undefined) {
+        console.error(
+          `Toolchain: CLI ${VERSION} · no workspace floor declared`,
+        );
+      } else if (belowFloor) {
+        console.error(
+          `⚠ Toolchain: CLI ${VERSION} below workspace floor ${floor} — upgrade markspec`,
+        );
+      } else {
+        console.error(`Toolchain: CLI ${VERSION} · workspace floor ${floor} ✓`);
+      }
       if (modeInfo) {
         console.error(
           `Discipline mode: ${modeInfo.value} (${modeInfo.origin})`,
@@ -93,4 +129,8 @@ export const doctorCmd = new Command()
         console.error(`Entries by discipline: ${countsLine || "(none)"}`);
       }
     }
+
+    // clig.dev: below-floor is a warning → exit 2 so CI can gate on toolchain
+    // skew. Hard errors (no config/profile) throw earlier and yield 1.
+    if (belowFloor) Deno.exit(2);
   });

--- a/tests/e2e/doctor_toolchain_test.ts
+++ b/tests/e2e/doctor_toolchain_test.ts
@@ -1,0 +1,108 @@
+/**
+ * @module tests/e2e/doctor_toolchain_test
+ *
+ * E2E tests for `markspec doctor` toolchain version-skew (slice F).
+ */
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { markspec } from "./helpers.ts";
+
+const PROJECT_YAML = `name: test-project\nversion: 0.1.0\n`;
+const MARKSPEC_YAML = `profiles:\n  - ./profiles/test\n`;
+const MINIMAL_PROFILE = `id: "@acme/test"\nversion: 0.2.0\n`;
+
+/** A valid lockfile with the given toolchain floor (or no floor when undefined). */
+function lockfile(floor: string | undefined): string {
+  const toolchain = floor === undefined
+    ? ""
+    : `\n[meta.toolchain]\nmin-version = "${floor}"\n`;
+  return `schema = 1
+
+[meta]
+markspec-schema = 1
+locked-at = "2026-05-27T12:00:00Z"
+${toolchain}
+[generated-cache]
+edges-hash = "sha256:abc"
+edges-count = 0
+`;
+}
+
+const baseFiles = {
+  "project.yaml": PROJECT_YAML,
+  ".markspec.yaml": MARKSPEC_YAML,
+  "profiles/test/markspec.yaml": MINIMAL_PROFILE,
+};
+
+Deno.test("doctor: CLI below workspace floor exits 2 with warning", async () => {
+  const { code, stderr } = await markspec(["doctor"], {
+    files: { ...baseFiles, "markspec.lock": lockfile("99.0") },
+  });
+  assertEquals(code, 2);
+  assertStringIncludes(stderr, "below workspace floor");
+  assertStringIncludes(stderr, "99.0");
+});
+
+Deno.test("doctor: below floor JSON has belowFloor + diagnostic", async () => {
+  const { code, stdout } = await markspec(["doctor", "--format", "json"], {
+    files: { ...baseFiles, "markspec.lock": lockfile("99.0") },
+  });
+  assertEquals(code, 2);
+  const data = JSON.parse(stdout);
+  assertEquals(data.toolchain.belowFloor, true);
+  assertEquals(data.toolchain.floor, "99.0");
+  assertEquals(
+    data.diagnostics.some((d: { code: string }) =>
+      d.code === "toolchain-below-floor"
+    ),
+    true,
+  );
+});
+
+Deno.test("doctor: CLI at/above floor exits 0 with check", async () => {
+  const { code, stderr } = await markspec(["doctor"], {
+    files: { ...baseFiles, "markspec.lock": lockfile("0.1") },
+  });
+  assertEquals(code, 0);
+  assertStringIncludes(stderr, "workspace floor 0.1");
+});
+
+Deno.test("doctor: lockfile without floor reports no floor, exits 0", async () => {
+  const { code, stderr } = await markspec(["doctor"], {
+    files: { ...baseFiles, "markspec.lock": lockfile(undefined) },
+  });
+  assertEquals(code, 0);
+  assertStringIncludes(stderr, "no workspace floor declared");
+});
+
+Deno.test("doctor: no lockfile reports no floor, JSON floor null", async () => {
+  const { code, stdout } = await markspec(["doctor", "--format", "json"], {
+    files: { ...baseFiles },
+  });
+  assertEquals(code, 0);
+  const data = JSON.parse(stdout);
+  assertEquals(data.toolchain.floor, null);
+  assertEquals(data.toolchain.belowFloor, false);
+  assertEquals(data.toolchain.cliVersion.length > 0, true);
+});
+
+Deno.test("doctor: present-but-malformed lockfile floor → no floor, exits 0", async () => {
+  const malformed = `schema = 1
+
+[meta]
+markspec-schema = 1
+locked-at = "2026-05-27T12:00:00Z"
+
+[meta.toolchain]
+min-version = "garbage"
+
+[generated-cache]
+edges-hash = "sha256:abc"
+edges-count = 0
+`;
+  const { code, stderr } = await markspec(["doctor"], {
+    files: { ...baseFiles, "markspec.lock": malformed },
+  });
+  assertEquals(code, 0);
+  assertStringIncludes(stderr, "no workspace floor declared");
+});


### PR DESCRIPTION
Advances #563 (slice F).

`markspec doctor` now reports toolchain version skew: it compares the running
CLI version against the workspace `markspec.lock` `[meta.toolchain] min-version`
floor — reusing slice-B's `isBelowFloor` SSOT (the same one the slice-C status
bar uses) — and **exits 2** when the CLI is below the floor, so CI can gate on
"is my toolchain current enough for this workspace?".

### Behaviour
- **Text (stderr):** a `Toolchain:` line — `… workspace floor <floor> ✓`,
  `⚠ … below workspace floor <floor> — upgrade markspec`, or
  `… no workspace floor declared`.
- **JSON (`--format json`):** a `toolchain` object
  `{ cliVersion, floor: string|null, belowFloor }`, plus a
  `toolchain-below-floor` warning in `diagnostics` when below floor.
- **Exit codes:** healthy `0`, below floor `2`, hard errors (no config/profile)
  stay `1` (they throw before the skew check runs).

Lockfile validity stays the job of `markspec check`/`lock` — a missing or
unparseable lockfile is treated as "no floor declared" (covered by a test).

### Scope
Floor skew only. Extension-bundle skew and skills-bundle drift are deferred
(the CLI can't see the installed extension; skills drift needs an upskill API
that doesn't exist yet) — consistent with the epic's notes.

6 e2e tests; no `core/` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
