### PR TITLE
feat(repo): add 'Install CLI to PATH' command to vscode extension

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -52,6 +52,11 @@
         "command": "markspec.showOutput",
         "title": "MarkSpec: Show Output",
         "category": "MarkSpec"
+      },
+      {
+        "command": "markspec.installToPath",
+        "title": "Install CLI to PATH",
+        "category": "MarkSpec"
       }
     ],
     "mcpServerDefinitionProviders": [
@@ -301,7 +306,7 @@
     "bundle": "deno run --config ../../deno.json --allow-read --allow-write scripts/bundleBinary.ts",
     "package": "npm run bundle && vsce package",
     "lint": "eslint src",
-    "test": "tsc -p tsconfig.json && node --require ./out/test-setup.js --test out/serverOptions.test.js out/mcpDefinition.test.js out/inlineCompletions.test.js out/codeLensCommands.test.js out/statusBar.test.js"
+    "test": "tsc -p tsconfig.json && node --require ./out/test-setup.js --test out/serverOptions.test.js out/mcpDefinition.test.js out/inlineCompletions.test.js out/codeLensCommands.test.js out/statusBar.test.js out/installToPath.test.js"
   },
   "dependencies": {
     "vscode-languageclient": "^9.0.1"

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -11,6 +11,7 @@
 
 import {
   commands,
+  env,
   EventEmitter,
   type ExtensionContext,
   InlineCompletionItem,
@@ -29,6 +30,13 @@ import {
 } from "vscode";
 import { parseCodeLensTarget } from "./codeLensCommands";
 import process from "node:process";
+import * as nodePath from "node:path";
+import {
+  isDirOnPath,
+  pathHint,
+  performCopy,
+  planForHost,
+} from "./installToPath";
 import {
   LanguageClient,
   type LanguageClientOptions,
@@ -152,6 +160,36 @@ export function activate(context: ExtensionContext): void {
   context.subscriptions.push(
     commands.registerCommand("markspec.showOutput", () => {
       outputChannel?.show();
+    }),
+    commands.registerCommand("markspec.installToPath", async () => {
+      const plan = planForHost(context.extensionPath);
+      try {
+        await performCopy(plan);
+        const onPath = isDirOnPath(
+          plan.targetDir,
+          process.env.PATH ?? process.env.Path,
+          nodePath.delimiter,
+          process.platform,
+        );
+        if (onPath) {
+          window.showInformationMessage(
+            `MarkSpec CLI installed to ${plan.target}`,
+          );
+        } else {
+          const hint = pathHint(plan.targetDir, process.platform);
+          const pick = await window.showWarningMessage(
+            `MarkSpec CLI copied to ${plan.target}, but ${plan.targetDir} is not on your PATH.`,
+            "Copy PATH command",
+          );
+          if (pick === "Copy PATH command") {
+            await env.clipboard.writeText(hint);
+            window.showInformationMessage("PATH command copied to clipboard");
+          }
+        }
+      } catch (err) {
+        const reason = err instanceof Error ? err.message : String(err);
+        window.showErrorMessage(`MarkSpec: install failed — ${reason}`);
+      }
     }),
     // CodeLens command handlers — the LSP emits these from
     // `packages/markspec/lsp/code_lens.ts`. The "↓ Satisfies: ID — Title"

--- a/editors/vscode/src/installToPath.test.ts
+++ b/editors/vscode/src/installToPath.test.ts
@@ -1,0 +1,118 @@
+import { test } from "node:test";
+import { strict as assert } from "node:assert";
+import * as path from "node:path";
+import * as os from "node:os";
+import { promises as fs } from "node:fs";
+import {
+  type InstallPlan,
+  isDirOnPath,
+  pathHint,
+  performCopy,
+  planInstall,
+} from "./installToPath";
+
+const EXT_PATH = "/fake/extensions/driftsys.markspec-ide-0.0.1";
+const HOME = "/home/dev";
+
+test("planInstall: darwin → markspec, chmod true", () => {
+  const p = planInstall({
+    platform: "darwin",
+    homedir: HOME,
+    extensionPath: EXT_PATH,
+  });
+  assert.equal(p.binaryName, "markspec");
+  assert.equal(p.source, path.join(EXT_PATH, "bin", "markspec"));
+  assert.equal(p.targetDir, path.join(HOME, ".local", "bin"));
+  assert.equal(p.target, path.join(HOME, ".local", "bin", "markspec"));
+  assert.equal(p.chmod, true);
+});
+
+test("planInstall: linux → same shape as darwin", () => {
+  const p = planInstall({
+    platform: "linux",
+    homedir: HOME,
+    extensionPath: EXT_PATH,
+  });
+  assert.equal(p.binaryName, "markspec");
+  assert.equal(p.chmod, true);
+});
+
+test("planInstall: win32 → markspec.exe, chmod false", () => {
+  const p = planInstall({
+    platform: "win32",
+    homedir: HOME,
+    extensionPath: EXT_PATH,
+  });
+  assert.equal(p.binaryName, "markspec.exe");
+  assert.equal(p.target, path.join(HOME, ".local", "bin", "markspec.exe"));
+  assert.equal(p.chmod, false);
+});
+
+test("isDirOnPath: true when present, false when absent", () => {
+  const dir = "/home/dev/.local/bin";
+  const env = ["/usr/bin", dir, "/bin"].join(path.delimiter);
+  assert.equal(isDirOnPath(dir, env, path.delimiter, "linux"), true);
+  assert.equal(
+    isDirOnPath(dir, "/usr/bin:/bin", path.delimiter, "linux"),
+    false,
+  );
+  assert.equal(isDirOnPath(dir, undefined, path.delimiter, "linux"), false);
+});
+
+test("isDirOnPath: win32 case-insensitive", () => {
+  const dir = "C:\\Users\\Dev\\.local\\bin";
+  const env = "C:\\Windows;c:\\users\\dev\\.local\\bin";
+  assert.equal(isDirOnPath(dir, env, ";", "win32"), true);
+});
+
+test("pathHint: unix export, win32 setx", () => {
+  assert.equal(
+    pathHint("/home/dev/.local/bin", "linux"),
+    'export PATH="/home/dev/.local/bin:$PATH"',
+  );
+  assert.equal(
+    pathHint("C:\\Users\\Dev\\.local\\bin", "win32"),
+    'setx PATH "C:\\Users\\Dev\\.local\\bin;%PATH%"',
+  );
+});
+
+test("performCopy: copies file into a fresh dir and chmods on unix", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "msinstall-"));
+  const src = path.join(tmp, "src-markspec");
+  await fs.writeFile(src, "#!/bin/sh\necho hi\n");
+  const plan: InstallPlan = {
+    binaryName: "markspec",
+    source: src,
+    targetDir: path.join(tmp, "out", "bin"),
+    target: path.join(tmp, "out", "bin", "markspec"),
+    chmod: process.platform !== "win32",
+  };
+  await performCopy(plan);
+  const copied = await fs.readFile(plan.target, "utf8");
+  assert.equal(copied, "#!/bin/sh\necho hi\n");
+  if (plan.chmod) {
+    const st = await fs.stat(plan.target);
+    assert.equal((st.mode & 0o111) !== 0, true);
+  }
+  await fs.rm(tmp, { recursive: true, force: true });
+});
+
+test("performCopy: overwrites an existing target file", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "msinstall-ow-"));
+  const src = path.join(tmp, "src-new");
+  await fs.writeFile(src, "new-content\n");
+  const targetDir = path.join(tmp, "out", "bin");
+  await fs.mkdir(targetDir, { recursive: true });
+  const target = path.join(targetDir, "markspec");
+  await fs.writeFile(target, "stale-content\n");
+  const plan: InstallPlan = {
+    binaryName: "markspec",
+    source: src,
+    targetDir,
+    target,
+    chmod: process.platform !== "win32",
+  };
+  await performCopy(plan);
+  assert.equal(await fs.readFile(target, "utf8"), "new-content\n");
+  await fs.rm(tmp, { recursive: true, force: true });
+});

--- a/editors/vscode/src/installToPath.ts
+++ b/editors/vscode/src/installToPath.ts
@@ -1,0 +1,77 @@
+/**
+ * @module installToPath
+ *
+ * Pure planning + filesystem copy for the "Install CLI to PATH" command.
+ * Deliberately imports NO `vscode` — the command handler in extension.ts
+ * supplies the notifications. Pure functions are unit-tested directly.
+ */
+
+import { promises as fs } from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+/** A resolved copy plan: where the bundled binary is and where it goes. */
+export interface InstallPlan {
+  readonly source: string;
+  readonly targetDir: string;
+  readonly target: string;
+  readonly binaryName: string;
+  readonly chmod: boolean;
+}
+
+/** Resolve the copy plan for the current platform. Pure. */
+export function planInstall(input: {
+  platform: NodeJS.Platform;
+  homedir: string;
+  extensionPath: string;
+}): InstallPlan {
+  const binaryName = input.platform === "win32" ? "markspec.exe" : "markspec";
+  const targetDir = path.join(input.homedir, ".local", "bin");
+  return {
+    binaryName,
+    source: path.join(input.extensionPath, "bin", binaryName),
+    targetDir,
+    target: path.join(targetDir, binaryName),
+    chmod: input.platform !== "win32",
+  };
+}
+
+/** Whether `targetDir` is a member of the PATH-style `pathEnv`. Pure. */
+export function isDirOnPath(
+  targetDir: string,
+  pathEnv: string | undefined,
+  delimiter: string,
+  platform: NodeJS.Platform,
+): boolean {
+  if (!pathEnv) return false;
+  const norm = (s: string) =>
+    platform === "win32" ? s.trim().toLowerCase() : s.trim();
+  const needle = norm(targetDir);
+  return pathEnv.split(delimiter).map(norm).includes(needle);
+}
+
+/** The shell command that adds `targetDir` to PATH. Pure. */
+export function pathHint(
+  targetDir: string,
+  platform: NodeJS.Platform,
+): string {
+  return platform === "win32"
+    ? `setx PATH "${targetDir};%PATH%"`
+    : `export PATH="${targetDir}:$PATH"`;
+}
+
+/** mkdir -p, copy (overwrite), and chmod 0o755 on Unix. */
+export async function performCopy(plan: InstallPlan): Promise<void> {
+  await fs.mkdir(plan.targetDir, { recursive: true });
+  await fs.copyFile(plan.source, plan.target);
+  if (plan.chmod) await fs.chmod(plan.target, 0o755);
+}
+
+/** Convenience for the handler: build the plan for this process. */
+export function planForHost(extensionPath: string): InstallPlan {
+  return planInstall({
+    platform: process.platform,
+    homedir: os.homedir(),
+    extensionPath,
+  });
+}


### PR DESCRIPTION
Advances #563 (slice H).

Adds a VS Code command **"MarkSpec: Install CLI to PATH"** (`markspec.installToPath`)
that copies the extension's bundled `markspec` binary onto the user's PATH so the
terminal `markspec` matches the extension's bundled version.

### Behaviour
- Copies `<extension>/bin/markspec` → `~/.local/bin/markspec` (overwrite,
  idempotent); `chmod +x` on Unix; `%USERPROFILE%\.local\bin\markspec.exe` on
  Windows (the `install.ps1` convention).
- If that directory is **not** on PATH, shows a warning with a **Copy PATH
  command** button that puts the exact `export PATH=…` / `setx PATH …` line on
  the clipboard. **Never auto-edits PATH.**
- Errors surface via an error notification.

### Why copy (not symlink)
The extension directory is version-stamped and deleted on every update, so a
symlink would dangle. A copy is stable; staleness after an extension update is
surfaced by the slice-C status bar + slice-F doctor skew warnings, and
re-running the command refreshes it.

### Design
Pure logic (`planInstall` / `isDirOnPath` / `pathHint` / `performCopy`) lives in
`src/installToPath.ts` with **no `vscode` import**, unit-tested directly
(8 tests incl. a real-tmp-dir copy + overwrite). The `vscode` glue is the
command handler in `extension.ts`. Does not touch the `markspec.server.path`
setting. Full extension suite: 65/65.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
