### PR TITLE
docs(repo): remind agents to verify tree-sitter grammars in fresh worktrees

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -827,7 +827,16 @@ severity/effort/priority, and review flow.
 
 - **Always work in a worktree.** Create a git worktree for every task. Never
   commit directly to the main working tree unless the user explicitly says to
-  work in the tree.
+  work in the tree. After `git worktree add`, run `./bootstrap` **and verify the
+  tree-sitter grammars were fetched**: `ls grammars/*.wasm` must list 9 files. A
+  fresh worktree starts with none, and `bootstrap` runs under
+  `set -euo
+  pipefail`, so it can exit before its grammar-fetch step if an
+  earlier step fails — leaving the worktree grammar-less. Without the grammars
+  the pre-push hook's `just check` fails on the source-file parsing e2e tests
+  (`source_body_tokens_test.ts`, `source_jsfamily_test.ts`). Fetch them with
+  `deno task fetch-grammars`, or copy from the main checkout:
+  `cp <main-checkout>/grammars/*.wasm grammars/`.
 - **Start from the issue.** Read the acceptance criteria and
   `docs/spec/language/language.md`, propose an approach, and wait for approval
   before implementing.


### PR DESCRIPTION
Reminds agents to verify the tree-sitter grammars are present after creating a
worktree.

A fresh `git worktree add` has no `grammars/*.wasm` (they're gitignored,
fetched), and `./bootstrap` runs under `set -euo pipefail` — so if an earlier
bootstrap step fails (e.g. installing git-std), the script exits **before** its
`deno task fetch-grammars` step, leaving the worktree grammar-less. The pre-push
hook's `just check` then fails on the source-file parsing e2e tests
(`source_body_tokens_test.ts`, `source_jsfamily_test.ts`) — which looks like a
code failure but is purely a setup gap.

This adds an explicit "verify `ls grammars/*.wasm` lists 9 files; fetch or copy
from the main checkout if not" step to the agent worktree rule in AGENTS.md.

Found while shipping slices F/H of #563 — the first push of each branch failed
the hook for exactly this reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
