### PR TITLE
test(cli): de-brittle init --help snapshot against version bumps

### DIFF
--- a/tests/e2e/__snapshots__/init_help_test.ts.snap
+++ b/tests/e2e/__snapshots__/init_help_test.ts.snap
@@ -3,7 +3,7 @@ export const snapshot = {};
 snapshot[`init --help snapshot 1`] = `
 \`
 [1mUsage:[22m   [95mmarkspec init [33m[[95m[95mtarget-dir[95m[33m][95m[39m
-[1mVersion:[22m [33m0.7.0 (core-schema 1)[39m     
+[1mVersion:[22m [33m<version> (core-schema <n>)[39m     
 
 [1mDescription:[22m
 

--- a/tests/e2e/init_help_test.ts
+++ b/tests/e2e/init_help_test.ts
@@ -3,5 +3,14 @@ import { markspec } from "./helpers.ts";
 
 Deno.test("init --help snapshot", async (t) => {
   const { stdout } = await markspec(["init", "--help"]);
-  await assertSnapshot(t, stdout);
+  // Mask the volatile version string so a routine version bump does not
+  // break this snapshot. The Version line's presence and format are still
+  // asserted — only the semver + core-schema number are normalized. (This
+  // snapshot was version-chased three times — #564, 9166600, 2266df6 —
+  // before being de-brittled.)
+  const normalized = stdout.replace(
+    /\d+\.\d+\.\d+\S* \(core-schema \d+\)/,
+    "<version> (core-schema <n>)",
+  );
+  await assertSnapshot(t, normalized);
 });


### PR DESCRIPTION
## Problem

The `init --help` snapshot embedded the full `Version: X.Y.Z (core-schema N)` string, coupling a prose-formatting test to the release cadence. It broke on every version bump and was version-chased **three times in one week** — #564, `9166600`, and most recently `2266df6`, which scrambled to fix `main` after the `0.7.0` release commit `fed97bc` shipped without regenerating it (turning `main` red).

## Fix

Mask the volatile semver + core-schema number with a stable placeholder before `assertSnapshot`:

```ts
const normalized = stdout.replace(
  /\d+\.\d+\.\d+\S* \(core-schema \d+\)/,
  "<version> (core-schema <n>)",
);
```

The `Version:` line's presence and format are still asserted — only the changing value is normalized, so routine version bumps no longer require a snapshot refresh.

## Verification

- `deno test … init_help_test.ts` passes.
- **Proved de-brittle:** temporarily bumped `VERSION` to `9.9.9` and the test still passed (previously the exact failure mode).
- `deno fmt --check` + `deno lint` clean; pre-push `just check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
