### PR TITLE
fix(cli): pin self-upgrade release origin to github.com (#580)

### DIFF
--- a/packages/markspec/cli/commands/self_upgrade.ts
+++ b/packages/markspec/cli/commands/self_upgrade.ts
@@ -10,28 +10,36 @@
  *   --version <vX.Y.Z>   Pin a specific release (downgrade allowed).
  *   --format <text|json> Output format (default: text).
  *
- * Environment overrides (test seams + advanced users):
+ * Environment overrides — all test-only, gated behind MARKSPEC_TEST_MODE=1
+ * so a stray or hostile env var in a user's parent shell cannot redirect a
+ * production self-upgrade to an attacker-controlled origin or path (#580):
  *   MARKSPEC_RELEASES_API
- *     Base URL for the releases API endpoint. Default:
+ *     Base URL for the releases API endpoint. Ignored unless
+ *     MARKSPEC_TEST_MODE=1; production always uses the pinned default
  *     "https://api.github.com/repos/driftsys/markspec/releases".
  *   MARKSPEC_RELEASES_DOWNLOAD_BASE
- *     Base URL for tarball downloads. Default:
+ *     Base URL for tarball downloads. Ignored unless MARKSPEC_TEST_MODE=1;
+ *     production always uses the pinned default
  *     "https://github.com/driftsys/markspec/releases/download".
  *   MARKSPEC_SELF_UPGRADE_BIN_PATH
- *     Override the binary path that will be swapped. Test-only; gated
- *     behind MARKSPEC_TEST_MODE=1 so a stray env var in a user's parent
- *     shell cannot redirect a production self-upgrade to an arbitrary
- *     path. Both vars must be set together.
+ *     Override the binary path that will be swapped. Ignored unless
+ *     MARKSPEC_TEST_MODE=1.
+ *
+ * As defence-in-depth, every resolved endpoint is run through
+ * assertTrustedReleaseUrl before any fetch: production permits only https
+ * to the github.com hosts; loopback http is allowed solely under test mode.
  */
 
 import { Command } from "@cliffy/command";
 import { basename, dirname } from "@std/path";
 import {
+  assertTrustedReleaseUrl,
   classifyInstallPath,
   compareVersions,
   detectTarget,
   platformFromBuild,
   releaseAssets,
+  resolveReleaseEndpoints,
   VERSION,
 } from "../../core/mod.ts";
 import { extractSingleBinary } from "../self_upgrade/extract.ts";
@@ -53,10 +61,6 @@ import {
   isDirWritable,
   swapBinary,
 } from "../self_upgrade/swap.ts";
-
-const DEFAULT_API = "https://api.github.com/repos/driftsys/markspec/releases";
-const DEFAULT_DOWNLOAD_BASE =
-  "https://github.com/driftsys/markspec/releases/download";
 
 interface SelfUpgradeOptions {
   check?: boolean;
@@ -94,13 +98,26 @@ export const selfUpgradeCmd = new Command()
 async function runSelfUpgrade(
   opts: SelfUpgradeOptions,
 ): Promise<Outcome> {
-  const apiBase = Deno.env.get("MARKSPEC_RELEASES_API") ?? DEFAULT_API;
-  const downloadBase = Deno.env.get("MARKSPEC_RELEASES_DOWNLOAD_BASE") ??
-    DEFAULT_DOWNLOAD_BASE;
-  // MARKSPEC_SELF_UPGRADE_BIN_PATH is gated on MARKSPEC_TEST_MODE=1 (see
-  // module docstring); a stray bin-path in a user's parent shell cannot
-  // redirect a production self-upgrade.
-  const binPathOverride = Deno.env.get("MARKSPEC_TEST_MODE") === "1"
+  // Every override (release URLs + bin path) is gated on MARKSPEC_TEST_MODE=1
+  // (see module docstring); a stray or hostile env var in a user's parent
+  // shell cannot redirect a production self-upgrade. In production the pinned
+  // github.com endpoints are always used (#580).
+  const testMode = Deno.env.get("MARKSPEC_TEST_MODE") === "1";
+  const { apiBase, downloadBase } = resolveReleaseEndpoints({
+    testMode,
+    apiOverride: Deno.env.get("MARKSPEC_RELEASES_API"),
+    downloadOverride: Deno.env.get("MARKSPEC_RELEASES_DOWNLOAD_BASE"),
+  });
+  // Defence-in-depth: refuse to fetch from an insecure or non-github origin
+  // even if a future change loosens the gating above. Loopback http is
+  // permitted only under test mode.
+  try {
+    assertTrustedReleaseUrl(apiBase, { allowInsecure: testMode });
+    assertTrustedReleaseUrl(downloadBase, { allowInsecure: testMode });
+  } catch (err) {
+    return error("network", VERSION, null, "", (err as Error).message);
+  }
+  const binPathOverride = testMode
     ? Deno.env.get("MARKSPEC_SELF_UPGRADE_BIN_PATH")
     : undefined;
 

--- a/packages/markspec/core/mod.ts
+++ b/packages/markspec/core/mod.ts
@@ -355,10 +355,13 @@ export type {
 // ── Self-upgrade ─────────────────────────────────────────────────────────
 export {
   type Arch as SelfUpgradeArch,
+  assertTrustedReleaseUrl,
   classifyInstallPath,
   type ClassifyResult as SelfUpgradeClassifyResult,
   compareVersions,
   type Comparison,
+  DEFAULT_RELEASES_API,
+  DEFAULT_RELEASES_DOWNLOAD_BASE,
   detectTarget,
   type InstallSource,
   type Os as SelfUpgradeOs,
@@ -367,5 +370,8 @@ export {
   platformFromBuild,
   type ReleaseAssets,
   releaseAssets,
+  type ReleaseEndpoints,
+  type ResolveEndpointsInput,
+  resolveReleaseEndpoints,
   type Target as SelfUpgradeTarget,
 } from "./self_upgrade/mod.ts";

--- a/packages/markspec/core/self_upgrade/manifest.ts
+++ b/packages/markspec/core/self_upgrade/manifest.ts
@@ -2,13 +2,19 @@
  * @module core/self_upgrade/manifest
  *
  * Build the release tarball + SHA-256 URLs for a (version, target) pair,
- * and parse the single-line .sha256 files produced by sha256sum /
- * shasum -a 256 in the release workflow. Pure — no I/O.
+ * parse the single-line .sha256 files produced by sha256sum / shasum -a 256
+ * in the release workflow, and pin the release endpoints to the canonical
+ * GitHub origin. Pure — no I/O.
  *
  * The .sha256 line format is the standard one shared by GNU coreutils
  * sha256sum and BSD/macOS shasum: `<64-hex>  <basename>` with a two-space
  * separator. We accept a trailing newline and lowercase the digest so
  * callers can compare strings directly.
+ *
+ * Release-endpoint pinning ({@linkcode resolveReleaseEndpoints} +
+ * {@linkcode assertTrustedReleaseUrl}) ensures a self-upgrade can only fetch
+ * from the canonical github.com origin in production — the env overrides are
+ * test-mode-only (issue #580).
  */
 
 export interface ReleaseAssets {
@@ -16,7 +22,118 @@ export interface ReleaseAssets {
   readonly checksumUrl: string;
 }
 
+/** Pinned GitHub releases API endpoint for the canonical markspec repo. */
+export const DEFAULT_RELEASES_API =
+  "https://api.github.com/repos/driftsys/markspec/releases";
+
+/** Pinned GitHub release-asset download base for the canonical markspec repo. */
+export const DEFAULT_RELEASES_DOWNLOAD_BASE =
+  "https://github.com/driftsys/markspec/releases/download";
+
+/**
+ * Hosts the self-upgrade fetches are permitted to contact in production.
+ * `objects.githubusercontent.com` is GitHub's release-asset CDN — a
+ * `releases/download` URL 302-redirects there, and `fetch` follows the
+ * redirect, so it must be on the allowlist even though we never build a
+ * URL pointing at it directly.
+ */
+const TRUSTED_RELEASE_HOSTS: ReadonlySet<string> = new Set([
+  "github.com",
+  "api.github.com",
+  "objects.githubusercontent.com",
+]);
+
 const SHA256_LINE_RE = /^([0-9a-fA-F]{64})\s+(\S.*?)\s*$/;
+
+/** Inputs to {@linkcode resolveReleaseEndpoints}. */
+export interface ResolveEndpointsInput {
+  /**
+   * `true` only when `MARKSPEC_TEST_MODE=1`. Gates the env overrides —
+   * see {@linkcode resolveReleaseEndpoints}.
+   */
+  readonly testMode: boolean;
+  /** Value of `MARKSPEC_RELEASES_API`, if set. */
+  readonly apiOverride?: string;
+  /** Value of `MARKSPEC_RELEASES_DOWNLOAD_BASE`, if set. */
+  readonly downloadOverride?: string;
+}
+
+/** Resolved release endpoints. */
+export interface ReleaseEndpoints {
+  readonly apiBase: string;
+  readonly downloadBase: string;
+}
+
+/**
+ * Resolve the releases-API and download-base URLs, honouring the
+ * `MARKSPEC_RELEASES_API` / `MARKSPEC_RELEASES_DOWNLOAD_BASE` overrides
+ * **only** under `MARKSPEC_TEST_MODE=1` (`input.testMode`). In production
+ * the pinned `DEFAULT_RELEASES_*` constants are always returned, so a stray
+ * or hostile env var in the user's shell cannot redirect a self-upgrade to
+ * an attacker-controlled origin (issue #580) — the same gating the
+ * `MARKSPEC_SELF_UPGRADE_BIN_PATH` override already uses. A missing override
+ * under test mode falls back to the pinned default for that endpoint.
+ */
+export function resolveReleaseEndpoints(
+  input: ResolveEndpointsInput,
+): ReleaseEndpoints {
+  const apiBase = input.testMode && input.apiOverride
+    ? input.apiOverride
+    : DEFAULT_RELEASES_API;
+  const downloadBase = input.testMode && input.downloadOverride
+    ? input.downloadOverride
+    : DEFAULT_RELEASES_DOWNLOAD_BASE;
+  return { apiBase, downloadBase };
+}
+
+/**
+ * Assert that a release-endpoint URL is safe to fetch from, throwing
+ * otherwise. Defence-in-depth for {@linkcode resolveReleaseEndpoints}: even
+ * if a future change reintroduces an unconditional override, no fetch can
+ * reach an insecure or non-GitHub origin.
+ *
+ * In production (`allowInsecure: false`) the URL MUST use `https:` and a
+ * host in the GitHub allowlist (`github.com`, `api.github.com`,
+ * `objects.githubusercontent.com`). Under test mode (`allowInsecure: true`)
+ * an `http(s)` URL to `localhost` / `127.0.0.1` / `[::1]` is additionally
+ * permitted so the e2e suite can point at a local mock server; every other
+ * host still falls through to the production https-+-allowlist check.
+ *
+ * @throws Error when the URL is malformed, uses a non-https scheme, or
+ *   targets a host outside the allowlist.
+ */
+export function assertTrustedReleaseUrl(
+  rawUrl: string,
+  opts: { allowInsecure: boolean },
+): void {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    throw new Error(`invalid release URL: ${JSON.stringify(rawUrl)}`);
+  }
+  if (opts.allowInsecure) {
+    const isLoopback = url.hostname === "localhost" ||
+      url.hostname === "127.0.0.1" || url.hostname === "[::1]";
+    if (
+      isLoopback && (url.protocol === "http:" || url.protocol === "https:")
+    ) {
+      return;
+    }
+  }
+  if (url.protocol !== "https:") {
+    throw new Error(
+      `refusing to self-upgrade over insecure transport: ${url.protocol}//${url.host} (only https: is permitted)`,
+    );
+  }
+  if (!TRUSTED_RELEASE_HOSTS.has(url.hostname)) {
+    throw new Error(
+      `refusing to self-upgrade from untrusted host: ${url.host} (permitted: ${
+        [...TRUSTED_RELEASE_HOSTS].join(", ")
+      })`,
+    );
+  }
+}
 
 /** Build the tarball + checksum URLs for a (version, target). */
 export function releaseAssets(

--- a/packages/markspec/core/self_upgrade/manifest_test.ts
+++ b/packages/markspec/core/self_upgrade/manifest_test.ts
@@ -1,5 +1,12 @@
 import { assertEquals, assertThrows } from "@std/assert";
-import { parseSha256Line, releaseAssets } from "./manifest.ts";
+import {
+  assertTrustedReleaseUrl,
+  DEFAULT_RELEASES_API,
+  DEFAULT_RELEASES_DOWNLOAD_BASE,
+  parseSha256Line,
+  releaseAssets,
+  resolveReleaseEndpoints,
+} from "./manifest.ts";
 
 const BASE = "https://github.com/driftsys/markspec/releases/download";
 
@@ -83,5 +90,133 @@ Deno.test("parseSha256Line: rejects wrong-length digest", () => {
     () => parseSha256Line("abcd  file.tar.gz"),
     Error,
     "malformed sha256 line",
+  );
+});
+
+// ---------------------------------------------------------------------------
+// resolveReleaseEndpoints — URL overrides are test-mode-only (issue #580)
+// ---------------------------------------------------------------------------
+
+Deno.test("resolveReleaseEndpoints: production ignores env overrides", () => {
+  assertEquals(
+    resolveReleaseEndpoints({
+      testMode: false,
+      apiOverride: "https://github.com/attacker/evil/releases",
+      downloadOverride: "http://evil.invalid/download",
+    }),
+    {
+      apiBase: DEFAULT_RELEASES_API,
+      downloadBase: DEFAULT_RELEASES_DOWNLOAD_BASE,
+    },
+  );
+});
+
+Deno.test("resolveReleaseEndpoints: production with no overrides uses defaults", () => {
+  assertEquals(
+    resolveReleaseEndpoints({ testMode: false }),
+    {
+      apiBase: DEFAULT_RELEASES_API,
+      downloadBase: DEFAULT_RELEASES_DOWNLOAD_BASE,
+    },
+  );
+});
+
+Deno.test("resolveReleaseEndpoints: test mode honors overrides", () => {
+  assertEquals(
+    resolveReleaseEndpoints({
+      testMode: true,
+      apiOverride: "http://127.0.0.1:8080/releases",
+      downloadOverride: "http://127.0.0.1:8080/releases/download",
+    }),
+    {
+      apiBase: "http://127.0.0.1:8080/releases",
+      downloadBase: "http://127.0.0.1:8080/releases/download",
+    },
+  );
+});
+
+Deno.test("resolveReleaseEndpoints: test mode with a missing override falls back to default", () => {
+  assertEquals(
+    resolveReleaseEndpoints({
+      testMode: true,
+      downloadOverride: "http://127.0.0.1:8080/releases/download",
+    }),
+    {
+      apiBase: DEFAULT_RELEASES_API,
+      downloadBase: "http://127.0.0.1:8080/releases/download",
+    },
+  );
+});
+
+// ---------------------------------------------------------------------------
+// assertTrustedReleaseUrl — scheme + host pinning (issue #580)
+// ---------------------------------------------------------------------------
+
+Deno.test("assertTrustedReleaseUrl: accepts https github.com hosts", () => {
+  assertTrustedReleaseUrl(DEFAULT_RELEASES_API, { allowInsecure: false });
+  assertTrustedReleaseUrl(DEFAULT_RELEASES_DOWNLOAD_BASE, {
+    allowInsecure: false,
+  });
+  assertTrustedReleaseUrl(
+    "https://objects.githubusercontent.com/foo",
+    { allowInsecure: false },
+  );
+});
+
+Deno.test("assertTrustedReleaseUrl: rejects non-https scheme in production", () => {
+  assertThrows(
+    () =>
+      assertTrustedReleaseUrl("http://github.com/driftsys/markspec", {
+        allowInsecure: false,
+      }),
+    Error,
+    "insecure transport",
+  );
+});
+
+Deno.test("assertTrustedReleaseUrl: rejects untrusted host in production", () => {
+  assertThrows(
+    () =>
+      assertTrustedReleaseUrl("https://evil.invalid/driftsys/markspec", {
+        allowInsecure: false,
+      }),
+    Error,
+    "untrusted host",
+  );
+});
+
+Deno.test("assertTrustedReleaseUrl: rejects a non-github https host even under allowInsecure", () => {
+  assertThrows(
+    () =>
+      assertTrustedReleaseUrl("https://evil.invalid/x", {
+        allowInsecure: true,
+      }),
+    Error,
+    "untrusted host",
+  );
+});
+
+Deno.test("assertTrustedReleaseUrl: allows http localhost only under allowInsecure", () => {
+  assertTrustedReleaseUrl("http://127.0.0.1:8080/releases", {
+    allowInsecure: true,
+  });
+  assertTrustedReleaseUrl("http://localhost:8080/releases", {
+    allowInsecure: true,
+  });
+  assertThrows(
+    () =>
+      assertTrustedReleaseUrl("http://127.0.0.1:8080/releases", {
+        allowInsecure: false,
+      }),
+    Error,
+    "insecure transport",
+  );
+});
+
+Deno.test("assertTrustedReleaseUrl: rejects a malformed URL", () => {
+  assertThrows(
+    () => assertTrustedReleaseUrl("not a url", { allowInsecure: false }),
+    Error,
+    "invalid release URL",
   );
 });

--- a/packages/markspec/core/self_upgrade/mod.ts
+++ b/packages/markspec/core/self_upgrade/mod.ts
@@ -13,9 +13,15 @@ export {
   type InstallSource,
 } from "./pm_detect.ts";
 export {
+  assertTrustedReleaseUrl,
+  DEFAULT_RELEASES_API,
+  DEFAULT_RELEASES_DOWNLOAD_BASE,
   parseSha256Line,
   type ReleaseAssets,
   releaseAssets,
+  type ReleaseEndpoints,
+  type ResolveEndpointsInput,
+  resolveReleaseEndpoints,
 } from "./manifest.ts";
 export {
   type Arch,


### PR DESCRIPTION
Closes #580.

## Problem

`markspec self-upgrade` read `MARKSPEC_RELEASES_API` / `MARKSPEC_RELEASES_DOWNLOAD_BASE` **unconditionally**, so a stray or hostile env var in the user's shell could redirect a self-replacing binary to an attacker-controlled origin. The `.sha256` was fetched from the same base, so the checksum gave **no protection against substitution**. Host-only pinning (the issue's first suggestion) would still be bypassable via any other `github.com` repo.

## Fix

Mirror the precedent already set for `MARKSPEC_SELF_UPGRADE_BIN_PATH`: **gate the URL overrides behind `MARKSPEC_TEST_MODE=1`**. In production the full pinned github.com release paths are always used — env vars can't influence them at all.

- `resolveReleaseEndpoints({ testMode, apiOverride?, downloadOverride? })` — pure; returns the pinned `DEFAULT_RELEASES_*` constants unless `testMode`, in which case it honours overrides (missing override → default).
- `assertTrustedReleaseUrl(url, { allowInsecure })` — pure defence-in-depth, run on every resolved endpoint before any `fetch`. Production permits only `https:` to `{github.com, api.github.com, objects.githubusercontent.com}` (the CDN redirect target); loopback `http` is allowed **only** under test mode. A violation returns a clean `error` outcome (exit 2), never a fetch.

Both helpers live in `core/self_upgrade/manifest.ts` (pure, no I/O) and are exported through `core/mod.ts`. The command now computes `testMode` once and threads it into both.

## Why gating, not just host-validation

An attacker who can set the download-base env var could otherwise point at `https://github.com/attacker/evil/releases/download` — still `https:`, still `github.com`, but a repo they control, with a matching `.sha256`. Pinning the full path (by ignoring the override in production) closes that; the host allowlist is the secondary net.

## Tests

- **Unit (`manifest_test.ts`, +11 cases):** `resolveReleaseEndpoints` ignores overrides in production / honours them under test mode / falls back per-endpoint; `assertTrustedReleaseUrl` accepts https-github, rejects http and non-github hosts, allows loopback only under `allowInsecure`, rejects malformed URLs. These deterministically prove the security property without network.
- **e2e:** the existing `self_upgrade_test.ts` suite already sets `MARKSPEC_TEST_MODE=1` and passes unchanged (8/8).
- Module docstring updated: the env overrides are now documented as test-only.

`deno fmt --check`, `deno lint`, and `deno check` (all 4 entry points) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
