### PR TITLE
chore(auto): update tree-sitter grammar versions

### DIFF
--- a/grammars/grammars.lock
+++ b/grammars/grammars.lock
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-05-25T14:01:20.819Z",
+  "generated": "2026-06-01T11:50:16.626Z",
   "grammars": [
     {
       "file": "tree-sitter-rust.wasm",
@@ -54,15 +54,15 @@
       "file": "tree-sitter-javascript.wasm",
       "source": "npm",
       "package": "tree-sitter-javascript",
-      "version": "0.23.1",
-      "sha256": "4a378293fe7853cbee2836023be072dafa0e53b3b5edb245920838ca834ed121"
+      "version": "0.25.0",
+      "sha256": "5fb488d0cabb4775a594bab85682de5ad6ce83c0d6ac997a9f82dd084d571240"
     },
     {
       "file": "tree-sitter-c-sharp.wasm",
       "source": "npm",
       "package": "tree-sitter-c-sharp",
-      "version": "0.23.1",
-      "sha256": "d7fe0bf8e8b8d26b2b253f375e3c43386b332d23f7b7b3e15d49fff180fe46e3"
+      "version": "0.23.5",
+      "sha256": "6f69e1cae44e1c32c1eccc170dc5a9778fb94ff716f71113fe1f8c4299aa2f40"
     }
   ]
 }

--- a/scripts/fetch_grammars.ts
+++ b/scripts/fetch_grammars.ts
@@ -89,12 +89,12 @@ const GRAMMARS: Record<string, Grammar> = {
   "tree-sitter-javascript.wasm": {
     source: "npm",
     pkg: "tree-sitter-javascript",
-    version: "0.23.1",
+    version: "0.25.0",
   },
   "tree-sitter-c-sharp.wasm": {
     source: "npm",
     pkg: "tree-sitter-c-sharp",
-    version: "0.23.1",
+    version: "0.23.5",
     // Upstream package ships its WASM with an underscore
     // (tree-sitter-c_sharp.wasm); we save it with a hyphen to match
     // the naming of the other grammars. Pinned to 0.23.1 because the


### PR DESCRIPTION
Automated update of tree-sitter WASM grammar versions.

Review the changes to `scripts/fetch_grammars.ts` (pinned versions)
and `grammars/grammars.lock` (pinned hashes). The `.wasm` binaries
themselves are fetched at build time, not committed.