### PR TITLE
fix(repo): default vscode server.path to bundled binary (#588)

### DIFF
--- a/.github/workflows/vsix-verify.yaml
+++ b/.github/workflows/vsix-verify.yaml
@@ -27,6 +27,13 @@ jobs:
       - name: Compile extension
         run: cd editors/vscode && npm run compile
 
+      # Unit tests cover the pure spawn-resolution logic (serverOptions /
+      # mcpDefinition), including the #588 regression guard that an unset
+      # `markspec.server.path` resolves to the bundled binary rather than a
+      # bare `markspec` PATH command.
+      - name: Test extension
+        run: cd editors/vscode && npm test
+
       # `vsce package` validates the manifest, icon reference, and gallery
       # metadata with no marketplace credentials. A fresh checkout has no
       # bundled binary (bin/ is gitignored); the manifest does not reference

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -70,8 +70,8 @@
       "properties": {
         "markspec.server.path": {
           "type": "string",
-          "default": "markspec",
-          "description": "Path to the markspec binary. Defaults to 'markspec' on PATH. Used by both the LSP client and the MCP server registration."
+          "default": "",
+          "description": "Path to the markspec binary used by both the LSP client and the MCP server registration. Leave empty (the default) to use the version-matched binary bundled with the extension. Set to 'markspec' to use the CLI on your PATH, or an absolute path for a development build."
         },
         "markspec.server.args": {
           "type": "array",

--- a/editors/vscode/src/mcpDefinition.test.ts
+++ b/editors/vscode/src/mcpDefinition.test.ts
@@ -1,6 +1,7 @@
 import { test } from "node:test";
 import { strict as assert } from "node:assert";
 import * as path from "node:path";
+import * as fs from "node:fs";
 import { resolveMcpDefinition } from "./mcpDefinition";
 
 const EXT_PATH = "/fake/extensions/driftsys.markspec-ide-0.5.0";
@@ -121,4 +122,26 @@ test("resolveMcpDefinition: workspaceFolder undefined leaves variables untouched
   assert.ok(def);
   assert.equal(def!.cwd, undefined);
   assert.deepEqual(def!.args, ["run", "${workspaceFolder}/main.ts", "mcp"]);
+});
+
+// Regression guard for #588 (MCP side). The same `markspec.server.path`
+// default flows into resolveMcpDefinition via extension.ts, so the MCP
+// server hit the same `spawn markspec ENOENT`. Bundled-first: an UNSET
+// server.path must resolve the MCP command to the bundled binary.
+test("resolveMcpDefinition: shipped server.path default resolves to bundled binary (#588)", () => {
+  const pkg = JSON.parse(
+    fs.readFileSync(path.join(__dirname, "..", "package.json"), "utf8"),
+  );
+  const shippedDefault: unknown = pkg.contributes.configuration
+    .properties["markspec.server.path"].default;
+  // Mirror extension.ts: `config.get<string>("server.path") || undefined`.
+  const configuredServerPath = (shippedDefault as string) || undefined;
+  const def = resolveMcpDefinition({ ...base(), configuredServerPath });
+  assert.ok(def);
+  assert.equal(
+    def!.command,
+    path.join(EXT_PATH, "bin", "markspec"),
+    "unset server.path must spawn the bundled binary for MCP too",
+  );
+  assert.notEqual(def!.command, "markspec");
 });

--- a/editors/vscode/src/serverOptions.test.ts
+++ b/editors/vscode/src/serverOptions.test.ts
@@ -1,10 +1,49 @@
 import { test } from "node:test";
 import { strict as assert } from "node:assert";
 import * as path from "node:path";
+import * as fs from "node:fs";
 import { expandVariables, resolveServerOptions } from "./serverOptions";
 
 const EXT_PATH = "/fake/extensions/driftsys.markspec-ide-0.0.1";
 const WORKSPACE = "/fake/workspace/markspec";
+
+// Regression guard for #588 — the LSP failed to start on a fresh
+// marketplace install with `spawn markspec ENOENT`. Root cause: the
+// shipped `markspec.server.path` default was the bare command
+// "markspec", which `config.get("server.path") || undefined` in
+// extension.ts can never reduce to `undefined`, so the bundled-binary
+// fallback was dead code and a bare PATH command was always spawned.
+// The fix is the policy "bundled-first": an UNSET server.path must
+// resolve to the bundled binary, never PATH. These tests pin that
+// policy at the package.json boundary, which the pure-function tests
+// above do not cover.
+test("resolveServerOptions: shipped server.path default resolves to bundled binary (#588)", () => {
+  const pkg = JSON.parse(
+    fs.readFileSync(path.join(__dirname, "..", "package.json"), "utf8"),
+  );
+  const shippedDefault: unknown = pkg.contributes.configuration
+    .properties["markspec.server.path"].default;
+  // Mirror extension.ts: `config.get<string>("server.path") || undefined`.
+  const configuredServerPath = (shippedDefault as string) || undefined;
+  const opts = resolveServerOptions({
+    extensionPath: EXT_PATH,
+    workspaceFolder: WORKSPACE,
+    configuredServerPath,
+    configuredServerArgs: undefined,
+    logPath: undefined,
+    platform: "linux",
+  }) as { command: string; args: string[] };
+  assert.equal(
+    opts.command,
+    path.join(EXT_PATH, "bin", "markspec"),
+    "unset server.path must spawn the bundled binary, not a bare PATH command",
+  );
+  assert.notEqual(
+    opts.command,
+    "markspec",
+    "a bare `markspec` command is the #588 ENOENT regression",
+  );
+});
 
 test("resolveServerOptions: bundled binary by default (linux)", () => {
   const opts = resolveServerOptions({


### PR DESCRIPTION
Closes #588.

## Problem

The **markspec-ide** VSCode extension fails to start its LSP (and MCP)
server on a fresh marketplace install:

```
Launching server using command markspec failed. Error: spawn markspec ENOENT
```

## Root cause

A config-default bug, not a missing-binary bug. The VSIX ships a
version-matched, per-platform binary in `bin/` (per `release.yaml`'s
`package-vsix` matrix), and `serverOptions` / `mcpDefinition` already fall
back to it when no server path is configured — but that fallback was dead
code:

- `package.json` declared `markspec.server.path` default `"markspec"`.
- `extension.ts`: `config.get<string>("server.path") || undefined` returns
  the *declared default* `"markspec"` (truthy), so `|| undefined` never
  fires and the bundled-binary branch is never reached.
- The server is therefore always spawned as the bare command `markspec`
  from PATH → `ENOENT` when the CLI isn't installed.

The same default flows into the MCP definition, so MCP was affected
identically.

## Fix — bundled-first

Default `markspec.server.path` to `""` so an **unset** value resolves to
the bundled binary for both the LSP client and the MCP registration. Users
opt into a PATH/dev binary by setting the value explicitly (`"markspec"`
for PATH, or an absolute path).

Bundled-first (rather than a PATH-probe-then-fallback) is deliberate: the
extension and CLI share a protocol + core-schema contract, so binding to
whatever stale `markspec` happens to be on PATH would risk silent
version-skew breakage. The existing **"Install CLI to PATH"** command
covers users who want `markspec` in their terminal — a separate concern
from what the extension binds to internally.

No change to `extension.ts` was needed — the `|| undefined` idiom was
already correct; flipping the default activates it.

## Tests

- Regression guards in `serverOptions.test.ts` and `mcpDefinition.test.ts`
  read the **shipped** `package.json` default, push it through the same
  `|| undefined` normalization `extension.ts` uses, and assert it resolves
  to the bundled binary rather than a bare `markspec` command. Both fail
  on the old default, pass on the new one. Full suite: 67/67.
- Wire `npm test` into `vsix-verify.yaml` so the extension's unit tests
  (previously never run in CI) execute on every PR touching
  `editors/vscode/**`.

## Per-platform VSIX (the related question)

Already implemented and correct — `release.yaml` cross-compiles all four
targets and the `win32-x64` VSIX bundles `bin/markspec.exe`, which is what
`serverOptions` looks for on Windows. No work needed there; this fix is the
whole bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
