### PR TITLE
fix(lsp): self-ignore the .markspec event-log directory

### DIFF
--- a/docs/guide/editor-vscode.md
+++ b/docs/guide/editor-vscode.md
@@ -61,6 +61,16 @@ All settings live under the `markspec.` prefix in VS Code settings.
 }
 ```
 
+## Logs
+
+The language server writes a per-project event log to
+`<workspace>/.markspec/lsp.log` (rotated at 1 MB, three files kept). The first
+time it opens that file it drops a self-ignoring `.markspec/.gitignore` (`*`)
+alongside it, so the log never shows up in `git status` — you do not need to add
+anything to your repository's `.gitignore`. Override the location with the
+`markspec.trace.logPath` setting (or the `MARKSPEC_LSP_LOG` environment
+variable); set `MARKSPEC_LSP_LOG_OFF=1` to disable logging entirely.
+
 ## Schema validation
 
 MarkSpec publishes JSON Schemas for its config files at

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -96,7 +96,7 @@
         "markspec.trace.logPath": {
           "type": "string",
           "default": "",
-          "description": "Override path for the LSP event log. When empty, the server writes to `<workspace>/.markspec/lsp.log` by default. Equivalent to setting MARKSPEC_LSP_LOG when spawning the server manually."
+          "description": "Override path for the LSP event log. When empty, the server writes to `<workspace>/.markspec/lsp.log` by default and drops a self-ignoring `.markspec/.gitignore` so the log never appears in `git status`. Equivalent to setting MARKSPEC_LSP_LOG when spawning the server manually."
         },
         "markspec.mcp.enabled": {
           "type": "boolean",

--- a/packages/markspec/lsp/event_log.ts
+++ b/packages/markspec/lsp/event_log.ts
@@ -16,6 +16,12 @@
  *   3. else, after `setProjectRoot(root)` is called → `<root>/.markspec/lsp.log`
  *   4. else → events are dropped silently (no project root, no env var)
  *
+ * When the default per-project destination (case 3) is opened, a
+ * self-ignoring `.markspec/.gitignore` (`*`) is dropped alongside it so
+ * the runtime log never pollutes the user's `git status`, in every
+ * workspace, regardless of the repo's root `.gitignore`. See
+ * {@linkcode ensureMarkspecDirIgnored}.
+ *
  * Line format: `[<ISO timestamp>] <level> kind=<kind> [key=value ...]`
  * where values containing whitespace are double-quoted. One line per
  * event. Designed for `grep` / `awk`.
@@ -157,12 +163,53 @@ function rotateIfNeeded(path: string): void {
   Deno.renameSync(path, `${path}.1`);
 }
 
+/**
+ * Drop a self-ignoring `.gitignore` into the default `.markspec/`
+ * directory so the runtime log never appears in the user's `git
+ * status`, in every workspace the LSP opens, no matter the repo's root
+ * `.gitignore`. The single `*` pattern ignores everything in the
+ * directory — the log files, their rotations, and the `.gitignore`
+ * itself — which is the right policy because `.markspec/` holds only
+ * per-session runtime artefacts (the event log and the sync cache).
+ *
+ * An existing `.gitignore` is never overwritten: a project that
+ * deliberately tracks something under `.markspec/` keeps its own rules.
+ * Best-effort — a write failure must never break logging, so any error
+ * is swallowed.
+ */
+function ensureMarkspecDirIgnored(markspecDir: string): void {
+  const ignorePath = join(markspecDir, ".gitignore");
+  try {
+    Deno.statSync(ignorePath);
+    return; // already present — respect the user's file
+  } catch (err) {
+    if (!(err instanceof Deno.errors.NotFound)) return;
+  }
+  try {
+    Deno.writeTextFileSync(
+      ignorePath,
+      "# Created by MarkSpec. Runtime files (LSP event log, sync cache);\n" +
+        "# regenerated each session, not meant to be committed.\n" +
+        "*\n",
+    );
+  } catch {
+    // Best-effort: never let an ignore-file write break logging.
+  }
+}
+
 function openHandleIfNeeded(): void {
   if (handle || disabled) return;
   const path = resolveLogPath();
   if (!path) return;
   try {
-    Deno.mkdirSync(dirname(path), { recursive: true });
+    const dir = dirname(path);
+    Deno.mkdirSync(dir, { recursive: true });
+    // Only self-ignore when writing to the default `<root>/.markspec/`
+    // location. An explicit `MARKSPEC_LSP_LOG` path is the user's
+    // deliberate choice — we must not litter a `.gitignore` beside it.
+    if (!explicitPath && projectRoot) {
+      ensureMarkspecDirIgnored(dir);
+    }
     rotateIfNeeded(path);
     handle = Deno.openSync(path, { create: true, append: true });
   } catch {

--- a/packages/markspec/lsp/event_log_test.ts
+++ b/packages/markspec/lsp/event_log_test.ts
@@ -280,3 +280,62 @@ Deno.test("event_log: rotation evicts .3", async () => {
     );
   });
 });
+
+// ---------------------------------------------------------------------------
+// Self-ignoring .markspec/.gitignore
+// ---------------------------------------------------------------------------
+
+Deno.test("event_log: writes self-ignoring .markspec/.gitignore on open", async () => {
+  await withTempRoot(async (root) => {
+    setProjectRoot(root);
+    logEvent("info", "startup");
+    flushSync();
+    const ignorePath = join(root, ".markspec", ".gitignore");
+    const contents = await Deno.readTextFile(ignorePath);
+    // A `*` pattern ignores every file in `.markspec/` — including the
+    // log files and the `.gitignore` itself — so git status stays clean
+    // in every workspace the LSP opens, regardless of the user's root
+    // .gitignore.
+    assertStringIncludes(contents, "*");
+  });
+});
+
+Deno.test("event_log: does not clobber an existing .markspec/.gitignore", async () => {
+  await withTempRoot(async (root) => {
+    const ignorePath = join(root, ".markspec", ".gitignore");
+    await Deno.mkdir(join(root, ".markspec"), { recursive: true });
+    await Deno.writeTextFile(ignorePath, "# hand-authored\nlsp.log*\n");
+    setProjectRoot(root);
+    logEvent("info", "startup");
+    flushSync();
+    const contents = await Deno.readTextFile(ignorePath);
+    // The pre-existing file is left exactly as the user wrote it.
+    assertEquals(contents, "# hand-authored\nlsp.log*\n");
+  });
+});
+
+Deno.test("event_log: MARKSPEC_LSP_LOG path gets no sibling .gitignore", async () => {
+  _resetEventLog();
+  Deno.env.delete("MARKSPEC_LSP_LOG_OFF");
+  const dir = await Deno.makeTempDir({ prefix: "markspec-explicit-dir-" });
+  const explicit = join(dir, "custom.log");
+  Deno.env.set("MARKSPEC_LSP_LOG", explicit);
+  try {
+    logEvent("info", "startup");
+    flushSync();
+    // An explicit path is the user's deliberate choice — we must not
+    // litter a `.gitignore` next to it.
+    let exists = false;
+    try {
+      await Deno.stat(join(dir, ".gitignore"));
+      exists = true;
+    } catch { /* expected: no .gitignore created */ }
+    assert(!exists, "explicit log path must not get a sibling .gitignore");
+  } finally {
+    Deno.env.delete("MARKSPEC_LSP_LOG");
+    _resetEventLog();
+    try {
+      await Deno.remove(dir, { recursive: true });
+    } catch { /* */ }
+  }
+});


### PR DESCRIPTION
## Problem

The LSP writes its event log to `<workspace>/.markspec/lsp.log` (plus rotations) in **every** workspace the server opens — not just MarkSpec projects. Any repo that doesn't ignore that path shows the log as untracked, polluting `git status`. Observed in the wild in a sibling repo (`upskill`) that has no `.markspec/` ignore rule, and across worktree branches that predate this repo's own `.gitignore` line.

Fixing it per-repo (or via a global `~/.gitignore`) doesn't scale — the binary follows the user into every project, for every user.

## Fix

When the LSP first creates the default `.markspec/` log directory, it now drops a **self-ignoring `.markspec/.gitignore`** containing `*`. Git then ignores the whole directory — log, rotations, and the `.gitignore` itself — in any repo, any editor (the single `markspec lsp` binary backs VS Code, neovim, zed), regardless of the project's root `.gitignore`. No user action, no per-repo edits.

Guards:
- An **existing** `.markspec/.gitignore` is never overwritten — a project that deliberately tracks something under `.markspec/` keeps its own rules.
- An **explicit** `MARKSPEC_LSP_LOG` path is the user's deliberate choice and gets **no** sibling `.gitignore`.
- Best-effort: a write failure never breaks logging.

`.markspec/` holds only per-session runtime artefacts (the event log and the sync cache), so `*` is the right scope.

## Tests

Three new `event_log_test.ts` cases (RED→GREEN): writes the self-ignore on open; does not clobber an existing one; explicit-path destination gets no sibling. Full suite: **3131 passed**.

## Verified end-to-end

Booted the compiled `markspec lsp` against a fresh temp git repo (committed `project.yaml`, no `.markspec` ignore rule):

```
.markspec/.gitignore  ← "# Created by MarkSpec…\n*\n"
.markspec/lsp.log
git status --porcelain → (clean)
git check-ignore -v .markspec/lsp.log → .markspec/.gitignore:3:*
```

## Docs

- `docs/guide/editor-vscode.md` — new **Logs** section.
- VS Code `markspec.trace.logPath` setting description notes the auto-ignore.

## Out of scope (per discussion)

Not adding a `markspec init` → root `.gitignore` mutation: the self-ignore already covers every repo (including non-init'd ones and old branches) more robustly, so a second mechanism would be redundant and add write-back risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
