### PR TITLE
feat(core): classify named types via counter-less display-id-pattern

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -421,6 +421,10 @@ docs/
   `HardwareInterface` from `Component` to `Contract` (an interface is a
   specification, not a building block); `Provides`/`Requires` provider/consumer
   links; supersedes the type tree shown in ADR-017
+- `adr-025-counter-less-display-id-pattern.md` — counter-less ("named")
+  `display-id-pattern` so types whose IDs are named, not numbered (components
+  `SWC_LIGHT_CTRL`, `HWC_PIU`) classify by prefix without an explicit `Type:`;
+  refines ADR-009 §5; classification-only (not mintable)
 - `overview.md` — narrative architecture tour
 
 See [docs/architecture/overview.md](docs/architecture/overview.md) for a reading

--- a/docs/architecture/adr-025-counter-less-display-id-pattern.md
+++ b/docs/architecture/adr-025-counter-less-display-id-pattern.md
@@ -1,0 +1,88 @@
+# ADR-025: Counter-less (named) display-id-pattern
+
+## Status
+
+Accepted (2026-06-05). Refines [ADR-009 §5](adr-009-core-profile-boundary.md)
+"Minimum pattern grammar". Addresses issue #594.
+
+## Context
+
+A profile classifies an Authored entry's type two ways: an explicit `Type:`
+trailer, or a `display-id-pattern` match (`core/validator/types.ts`
+`classifyEntry`, step 2). ADR-009 §5 set the minimum pattern grammar as "literal
+prefix + one numeric placeholder `{n}`", and `compileDisplayIdPattern`
+(`core/validator/pattern.ts`) enforced it: a pattern with zero `{n}` counters
+threw `missing {n} placeholder`.
+
+That excludes a whole class of types whose IDs are **named, not numbered** —
+components such as `SWC_LIGHT_CTRL`, `HWC_PIU`. They cannot declare a pattern,
+so `classifyEntry`'s pattern loop never matches them and every such entry must
+hand-write `Type:`. Worse, a profile that _did_ declare a counter-less pattern
+(e.g. `SWC_{name}`) crashed `markspec check` with an uncaught exception the
+moment classification reached that type.
+
+Late-stage inference (`types.ts` steps 5/6/8) only resolves the abstract _core_
+type and emits an `MSL-T021` advisory telling the author to declare `Type:`
+anyway — it does not assign the profile type.
+
+## Decision
+
+**Allow a counter-less `display-id-pattern` for classification.** A pattern is
+now one of two kinds, selected by the presence of the `{n}` counter:
+
+- **Numbered** (contains `{n}`) — unchanged. Exactly one counter; single-
+  segment `{scope}`-style placeholders; mintable and classifying. Because every
+  pre-existing pattern contains `{n}`, this guarantees zero behaviour change to
+  any pattern in the wild.
+- **Named** (no `{n}`) — new. Requires a non-empty literal anchor plus at least
+  one named placeholder. The trailing named placeholder captures the **rest of
+  the display ID** (character class `[A-Za-z0-9._/-]`, underscores included), so
+  `SWC_{name}` classifies `SWC_LIGHT_CTRL`. Classification only — not mintable.
+
+A bare `{name}` (no literal anchor) is rejected: it would match every ID and
+collide with every type. An all-literal template (no placeholder of any kind)
+keeps the historical `missing {n} placeholder` rejection.
+
+```yaml
+profile:
+  types:
+    sw-component:
+      extends: SoftwareComponent
+      display-id-pattern: "SWC_{name}" # ^SWC_(?<name>[A-Za-z0-9._/-]+)$
+      display-id-pattern-enforcement: off
+    hw-component:
+      extends: HardwareComponent
+      display-id-pattern: "HWC_{name}"
+      display-id-pattern-enforcement: off
+```
+
+`classifyEntry`'s single-match / `MSL-T002` ambiguous logic consumes the relaxed
+recognizer unchanged — overlapping named prefixes still emit `MSL-T002`.
+
+## Consequences
+
+- Named component / element types classify by prefix with no explicit `Type:`,
+  preserving the named-entity model (no forced `SWC_HMI_0001` numbering).
+- Pair named patterns with `display-id-pattern-enforcement: off`: there is no
+  counter to enforce, and the pattern exists purely for classification.
+- The minting path is untouched and already decoupled: `parseDisplayIdPattern`
+  (`core/profile/display_id.ts`, keyed on `{n:Nd}`) returns `undefined` for
+  counter-less patterns, so `markspec next-id` / `create` / `insert` and the LSP
+  scaffold skip named types and fall back to author-typed IDs.
+- `markspec.lock` references and other consumers are unaffected — the change is
+  confined to `compileDisplayIdPattern`.
+
+## Alternatives considered
+
+- **Overload `{name}` semantics by position in every pattern** (terminal named
+  placeholder is always rest-of-ID). Rejected: it risks changing behaviour of
+  existing numbered patterns that happen to end in a named placeholder. Gating
+  the rest-of-ID broadening on "no `{n}` present" keeps numbered patterns
+  provably unchanged.
+- **Keep the single-segment `[A-Za-z0-9]+` class for named placeholders.**
+  Rejected: `SWC_LIGHT_CTRL` (the headline example) would not match, since the
+  underscore between `LIGHT` and `CTRL` breaks a single-segment capture.
+- **Validate patterns at profile-load time** and emit a `PROFILE-*` diagnostic
+  for a malformed pattern instead of throwing during classification. Deferred:
+  invalid patterns still throw, as they did before; moving validation to
+  load-time is a larger, separable change.

--- a/docs/spec/language/language.md
+++ b/docs/spec/language/language.md
@@ -639,7 +639,10 @@ display-ID prefix (`SRS_BRK_0107` → `type: software-requirement` under an ASPI
 profile that declares
 `software-requirement: display-id-pattern: "SRS_{scope}_{n:04d}"`). An explicit
 `type:` attribute in source overrides inference and is required when the display
-ID matches no declared pattern.
+ID matches no declared pattern. Types whose IDs are named, not numbered — e.g.
+components `SWC_LIGHT_CTRL`, `HWC_PIU` — declare a counter-less pattern
+(`sw-component: display-id-pattern: "SWC_{name}"`) so they are classified by
+prefix without an explicit `type:` (see annex §B.3.2).
 
 **Profile-declared attributes:** every attribute beyond the universal set (§2.1)
 is declared by the active profile. Examples — declared by an automotive ASPICE

--- a/docs/spec/model/annex-profile-schema.md
+++ b/docs/spec/model/annex-profile-schema.md
@@ -152,17 +152,29 @@ directly instantiable (usable as fallbacks when no concrete subtype fits);
 
 ### B.3.2 `display-id-pattern` syntax
 
-| Placeholder | Meaning                                   | Example pattern   | Example output |
-| ----------- | ----------------------------------------- | ----------------- | -------------- |
-| `{n:4d}`    | Auto-increment, minimum 4 digits, padded  | `SRS_{n:4d}`      | `SRS_0042`     |
-| `{n:3d}`    | Auto-increment, minimum 3 digits, padded  | `HAZ_{n:3d}`      | `HAZ_003`      |
-| `{n:04d}`   | Leading-zero form, equivalent to `{n:4d}` | `STK_AEB_{n:04d}` | `STK_AEB_0007` |
+| Placeholder | Meaning                                   | Example pattern   | Example output   |
+| ----------- | ----------------------------------------- | ----------------- | ---------------- |
+| `{n:4d}`    | Auto-increment, minimum 4 digits, padded  | `SRS_{n:4d}`      | `SRS_0042`       |
+| `{n:3d}`    | Auto-increment, minimum 3 digits, padded  | `HAZ_{n:3d}`      | `HAZ_003`        |
+| `{n:04d}`   | Leading-zero form, equivalent to `{n:4d}` | `STK_AEB_{n:04d}` | `STK_AEB_0007`   |
+| `{name}`    | Named segment (no counter) — see below    | `SWC_{name}`      | `SWC_LIGHT_CTRL` |
 
 The text before the placeholder is the literal prefix; the text after is the
 literal suffix (e.g. `REQ-{n:3d}-draft` → `REQ-012-draft`). Width is a minimum,
 not a maximum — numbers wider than the pad are left intact. `markspec fmt`
 assigns the next available number; `markspec next-id <type>` prints it without
 writing; `markspec create` / `insert` scaffold a full block.
+
+**Numbered vs named patterns (ADR-025).** A pattern is _numbered_ when it
+carries exactly one `{n}` counter (the mintable, auto-incremented forms above)
+or _named_ when it carries no counter. A named pattern classifies types whose
+IDs are named, not numbered — components such as `SWC_LIGHT_CTRL` or `HWC_PIU`.
+It requires a non-empty literal prefix plus a trailing named placeholder (e.g.
+`SWC_{name}`); the named placeholder captures the rest of the display ID,
+underscores included. A bare `{name}` with no literal prefix is rejected — it
+would match every ID. Named patterns are classification-only: there is no
+counter to mint, so pair them with `display-id-pattern-enforcement: off` and
+author the ID by hand (`markspec next-id` / `create` skip named types).
 
 `display-id-pattern-enforcement` controls whether an entry whose display ID does
 not match the pattern is ignored (`off`), warned (`warn`), or rejected

--- a/packages/markspec/core/validator/pattern.ts
+++ b/packages/markspec/core/validator/pattern.ts
@@ -3,71 +3,160 @@
  *
  * Display-ID pattern template → anchored RegExp.
  *
- * Grammar (per ADR-009 §5):
- *   pattern     := segment+ (exactly one counter)
- *   segment     := literal | counter | named
- *   counter     := "{n}" | "{n:" PADDING "d}"
- *   named       := "{" identifier "}"   (e.g. {scope}, {feature})
- *   PADDING     := "0" digits
+ * A pattern is one of two kinds, selected by whether it contains the `{n}`
+ * counter:
  *
- * The counter `{n}` is the numeric running index (exactly one required). A
- * named placeholder such as `{scope}` matches a free alphanumeric segment —
- * it validates the *shape* `PREFIX_<scope>_<NNNN>` without pinning the scope
- * to a fixed value, so one profile pattern serves every feature scope.
+ *   numbered := segment+ (exactly one counter)   — mintable + classifying
+ *   named    := segment+ (literal anchor, ≥1 named, no counter) — classifying
+ *
+ *   segment  := literal | counter | named
+ *   counter  := "{n}" | "{n:" PADDING "d}"
+ *   named    := "{" identifier "}"   (e.g. {scope}, {name})
+ *   PADDING  := "0" digits
+ *
+ * **Numbered patterns** carry exactly one `{n}` counter — the numeric running
+ * index used both for classification (a recognizer regex) and for minting the
+ * next ID. A medial named placeholder such as `{scope}` matches a single free
+ * alphanumeric segment, so one pattern serves every feature scope.
+ *
+ * **Named patterns** (ADR-025, issue #594) carry no counter — they classify
+ * types whose IDs are *named, not numbered* (e.g. components `SWC_LIGHT_CTRL`,
+ * `HWC_PIU`). They require a non-empty literal anchor plus at least one named
+ * placeholder; the trailing named placeholder captures the rest of the
+ * display ID (underscores, dots, slashes, hyphens included). A bare `{name}`
+ * with no literal anchor is rejected — it would match every ID and collide
+ * with every type. Named patterns are not mintable (no counter to increment);
+ * `parseDisplayIdPattern` skips them so the scaffold/next-id paths fall back
+ * to author-typed IDs.
  *
  * Examples:
  *   REQ-{n}              → ^REQ-(\d+)$
  *   REQ-{n:04d}          → ^REQ-(\d{4})$
  *   XREQ_{scope}_{n:04d} → ^XREQ_(?<scope>[A-Za-z0-9]+)_(\d{4})$
+ *   SWC_{name}           → ^SWC_(?<name>[A-Za-z0-9._/-]+)$
  */
 
 // One token: the {n} counter (optionally padded) OR a {named} segment.
 const TOKEN_RE = /\{n(?::(0\d+)d)?\}|\{([A-Za-z][A-Za-z0-9_]*)\}/g;
 
 /**
- * Compile a display-ID pattern template into an anchored RegExp.
- *
- * Throws if the template is missing the `{n}` counter, has more than one, or
- * has an invalid padding specifier.
+ * Character class for the trailing named placeholder of a *named* pattern —
+ * the established display-ID token set (letters, digits, underscore, dot,
+ * slash, hyphen). Wider than the medial-segment class so `SWC_{name}` matches
+ * underscore-bearing IDs like `SWC_LIGHT_CTRL`.
  */
-export function compileDisplayIdPattern(template: string): RegExp {
-  let regexSource = "^";
+const REST_OF_ID_CLASS = "[A-Za-z0-9._/-]+";
+
+/**
+ * Character class for a medial named placeholder (e.g. `{scope}` between two
+ * literal segments). A single free alphanumeric run that stops at the next
+ * literal — never swallows an adjacent counter or separator.
+ */
+const SEGMENT_CLASS = "[A-Za-z0-9]+";
+
+type PatternToken =
+  | { readonly kind: "literal"; readonly text: string }
+  | { readonly kind: "counter"; readonly padding?: string }
+  | { readonly kind: "named"; readonly name: string };
+
+/** Split a template into its literal / counter / named tokens. */
+function tokenizePattern(template: string): PatternToken[] {
+  const tokens: PatternToken[] = [];
   let lastIndex = 0;
-  let counters = 0;
   const re = new RegExp(TOKEN_RE);
   let match: RegExpExecArray | null;
   while ((match = re.exec(template)) !== null) {
-    regexSource += escapeRegex(template.slice(lastIndex, match.index));
+    if (match.index > lastIndex) {
+      tokens.push({
+        kind: "literal",
+        text: template.slice(lastIndex, match.index),
+      });
+    }
     const named = match[2];
     if (named === undefined) {
-      // {n} / {n:0Nd} counter
-      const padding = match[1];
-      regexSource += "(" + (padding ? `\\d{${Number(padding)}}` : `\\d+`) + ")";
-      counters++;
+      tokens.push({ kind: "counter", padding: match[1] });
     } else {
-      // {scope}-style named segment → free alphanumeric capture
-      regexSource += `(?<${named}>[A-Za-z0-9]+)`;
+      tokens.push({ kind: "named", name: named });
     }
     lastIndex = match.index + match[0].length;
   }
-  regexSource += escapeRegex(template.slice(lastIndex)) + "$";
+  if (lastIndex < template.length) {
+    tokens.push({ kind: "literal", text: template.slice(lastIndex) });
+  }
+  return tokens;
+}
+
+/**
+ * Compile a display-ID pattern template into an anchored RegExp.
+ *
+ * Throws if the template:
+ *   - has more than one `{n}` counter,
+ *   - has an invalid padding specifier (`{n:...}` not of the `{n:NNd}` form),
+ *   - has zero counters and no named placeholder (no variable part), or
+ *   - has zero counters and no literal anchor (a bare `{name}` would match
+ *     every display ID).
+ */
+export function compileDisplayIdPattern(template: string): RegExp {
+  const tokens = tokenizePattern(template);
+  const counters = tokens.filter((t) => t.kind === "counter").length;
+  const namedCount = tokens.filter((t) => t.kind === "named").length;
+  const hasLiteralAnchor = tokens.some(
+    (t) => t.kind === "literal" && t.text.length > 0,
+  );
+
+  if (counters > 1) {
+    throw new Error(
+      `display-id-pattern '${template}': multiple {n} counters (expected one)`,
+    );
+  }
 
   if (counters === 0) {
+    // A malformed counter (`{n:abc}`, `{n:4d}`) is not tokenized as a counter
+    // — it lands in literal text. Surface it as an invalid padding error
+    // before the missing-counter / named-pattern checks, preserving the
+    // historical message for `{n:...}` typos.
     if (/\{n:[^}]*\}/.test(template)) {
       throw new Error(
         `display-id-pattern '${template}': invalid padding specifier ` +
           `(expected {n} or {n:NNd})`,
       );
     }
-    throw new Error(
-      `display-id-pattern '${template}': missing {n} placeholder`,
-    );
+    if (namedCount === 0) {
+      throw new Error(
+        `display-id-pattern '${template}': missing {n} placeholder`,
+      );
+    }
+    if (!hasLiteralAnchor) {
+      throw new Error(
+        `display-id-pattern '${template}': named pattern needs a literal ` +
+          `prefix (a bare {name} would match every display ID)`,
+      );
+    }
   }
-  if (counters > 1) {
-    throw new Error(
-      `display-id-pattern '${template}': multiple {n} counters (expected one)`,
-    );
-  }
+
+  // In a named (counter-less) pattern the trailing named placeholder matches
+  // the rest of the display ID; every other named placeholder — and every
+  // named placeholder in a numbered pattern — stays a single segment.
+  const restOfIdNamedIndex = counters === 0
+    ? tokens.reduce((acc, t, i) => (t.kind === "named" ? i : acc), -1)
+    : -1;
+
+  let regexSource = "^";
+  tokens.forEach((t, i) => {
+    if (t.kind === "literal") {
+      regexSource += escapeRegex(t.text);
+    } else if (t.kind === "counter") {
+      regexSource += "(" +
+        (t.padding ? `\\d{${Number(t.padding)}}` : `\\d+`) + ")";
+    } else {
+      const charClass = i === restOfIdNamedIndex
+        ? REST_OF_ID_CLASS
+        : SEGMENT_CLASS;
+      regexSource += `(?<${t.name}>${charClass})`;
+    }
+  });
+  regexSource += "$";
+
   return new RegExp(regexSource);
 }
 

--- a/packages/markspec/core/validator/pattern_test.ts
+++ b/packages/markspec/core/validator/pattern_test.ts
@@ -81,9 +81,46 @@ Deno.test("compileDisplayIdPattern: named {scope} segment matches any token", ()
   assertEquals(r.test("XREQ_IMMER_FOO_0010"), false); // extra segment
 });
 
-Deno.test("compileDisplayIdPattern: named segment without {n} still requires a counter", () => {
+Deno.test("compileDisplayIdPattern: counter-less named pattern matches rest-of-ID", () => {
+  // Named (no {n}) pattern with a literal anchor — issue #594. The trailing
+  // {name} captures the rest of the display ID, underscores included, so
+  // named component IDs classify by prefix.
+  const r = compileDisplayIdPattern("SWC_{name}");
+  assertEquals(r.test("SWC_DSG"), true);
+  assertEquals(r.test("SWC_LIGHT_CTRL"), true); // underscore in the name
+  assertEquals(r.test("SWC_io.adc"), true); // dot
+  assertEquals(r.test("SWC_drv/pwm"), true); // slash
+  assertEquals(r.test("HWC_PIU"), false); // wrong prefix
+  assertEquals(r.test("SWC_"), false); // empty name
+  assertEquals(r.test("XSWC_DSG"), false); // anchored prefix
+});
+
+Deno.test("compileDisplayIdPattern: counter-less {scope} pattern is now valid (named)", () => {
+  // `XREQ_{scope}` was rejected before #594 (no counter); it is now a named
+  // pattern whose {scope} captures the rest of the ID.
+  const r = compileDisplayIdPattern("XREQ_{scope}");
+  assertEquals(r.test("XREQ_LIGHT"), true);
+  assertEquals(r.test("XREQ_LIGHT_CTRL"), true);
+  assertEquals(r.test("XREQ_"), false);
+});
+
+Deno.test("compileDisplayIdPattern: bare {name} with no literal anchor throws", () => {
   try {
-    compileDisplayIdPattern("XREQ_{scope}");
+    compileDisplayIdPattern("{name}");
+    throw new Error("expected compileDisplayIdPattern to throw");
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (!msg.toLowerCase().includes("literal")) {
+      throw new Error(`expected 'literal' in error message, got: ${msg}`);
+    }
+  }
+});
+
+Deno.test("compileDisplayIdPattern: all-literal pattern (no placeholder) still throws", () => {
+  // A literal-only template has no variable part — neither counter nor named —
+  // and is rejected with the historical missing-{n} message.
+  try {
+    compileDisplayIdPattern("REQ_FIXED");
     throw new Error("expected compileDisplayIdPattern to throw");
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);

--- a/packages/markspec/core/validator/types_test.ts
+++ b/packages/markspec/core/validator/types_test.ts
@@ -133,6 +133,43 @@ Deno.test("classifyEntry: ambiguous match emits MSL-T002", () => {
   assertEquals(result.diagnostics[0].code, "MSL-T002");
 });
 
+Deno.test("classifyEntry: counter-less named pattern classifies underscore-bearing ID", () => {
+  // Issue #594: a named (non-numbered) component type declares a counter-less
+  // display-id-pattern and is classified by prefix with no explicit Type:.
+  const profile = buildProfile([
+    buildType({
+      name: "sw-component",
+      displayIdPattern: "SWC_{name}",
+      enforcement: "off",
+    }),
+  ]);
+  const entry = buildEntry({ displayId: "SWC_LIGHT_CTRL", shape: "Authored" });
+  const result = classifyEntry(entry, profile);
+  assertEquals(result.type, "sw-component");
+  assertEquals(result.diagnostics, []);
+});
+
+Deno.test("classifyEntry: overlapping named prefixes emit MSL-T002", () => {
+  // Two counter-less patterns can both match an ID; the existing ambiguity
+  // path applies unchanged.
+  const profile = buildProfile([
+    buildType({
+      name: "sw-component",
+      displayIdPattern: "SWC_{name}",
+      enforcement: "off",
+    }),
+    buildType({
+      name: "sw-light-component",
+      displayIdPattern: "SWC_LIGHT_{name}",
+      enforcement: "off",
+    }),
+  ]);
+  const entry = buildEntry({ displayId: "SWC_LIGHT_CTRL", shape: "Authored" });
+  const result = classifyEntry(entry, profile);
+  assertEquals(result.type, undefined);
+  assertEquals(result.diagnostics[0].code, "MSL-T002");
+});
+
 Deno.test("classifyEntry: all types participate in pattern match regardless of extends", () => {
   // Tier 2: types no longer have a 'shape' field; all participate in pattern
   // matching. Only the entry's own shape guards classification (Authored only).

--- a/tests/e2e/named_pattern_classification_test.ts
+++ b/tests/e2e/named_pattern_classification_test.ts
@@ -1,0 +1,84 @@
+/**
+ * @module tests/e2e/named_pattern_classification_test
+ *
+ * E2E tests for counter-less ("named") `display-id-pattern` classification
+ * (issue #594). A type whose IDs are named, not numbered — e.g. components
+ * `SWC_LIGHT_CTRL`, `HWC_PIU` — declares a pattern with no `{n}` counter so
+ * it is classified by prefix without an explicit `Type:` trailer.
+ */
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { markspec } from "./helpers.ts";
+
+const PROJECT_YAML = `name: named-types-e2e\nversion: 0.1.0\n`;
+
+// `sw-component` / `hw-component` are deliberately named, not numbered:
+// the pattern carries a literal prefix and a trailing `{name}` placeholder
+// and no `{n}` counter. Enforcement is `off` — there is no counter to
+// enforce; the pattern exists purely for prefix-based classification.
+const PROFILE_YAML = `id: "@acme/named-types"
+version: 0.1.0
+profile:
+  types:
+    sw-component:
+      extends: SoftwareComponent
+      display-id-pattern: "SWC_{name}"
+      display-id-pattern-enforcement: off
+    hw-component:
+      extends: HardwareComponent
+      display-id-pattern: "HWC_{name}"
+      display-id-pattern-enforcement: off
+`;
+
+Deno.test("named pattern e2e: underscore-bearing named ID classifies, no MSL-T", async () => {
+  const { code, stderr } = await markspec(["check", "components.md"], {
+    files: {
+      "project.yaml": PROJECT_YAML,
+      ".markspec.yaml": `profiles:\n  - ./profiles/named\n`,
+      "profiles/named/markspec.yaml": PROFILE_YAML,
+      "components.md": `# Components
+
+- [SWC_LIGHT_CTRL] Light controller
+
+  The light controller shall drive the exterior lamps.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+
+- [SWC_DSG] Diagnostic supervisor
+
+  The diagnostic supervisor shall report faults.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEG
+
+- [HWC_PIU] Power interface unit
+
+  The power interface unit shall regulate the supply rail.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEH
+`,
+    },
+  });
+  assertEquals(code, 0);
+  const mslT = stderr.split("\n").filter((l) => l.includes("MSL-T"));
+  assertEquals(mslT, []);
+});
+
+Deno.test("named pattern e2e: ID not matching any named prefix still emits MSL-T003", async () => {
+  const { code, stderr } = await markspec(["check", "components.md"], {
+    files: {
+      "project.yaml": PROJECT_YAML,
+      ".markspec.yaml": `profiles:\n  - ./profiles/named\n`,
+      "profiles/named/markspec.yaml": PROFILE_YAML,
+      "components.md": `# Components
+
+- [FOO_BAR] An entry with no matching named prefix
+
+  Body text.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+`,
+    },
+  });
+  assertEquals(code, 1);
+  assertStringIncludes(stderr, "MSL-T003");
+});


### PR DESCRIPTION
Closes #594.

## Summary

Allow a `display-id-pattern` with **no `{n}` counter** so types whose IDs are
*named, not numbered* — components `SWC_LIGHT_CTRL`, `HWC_PIU` — classify by
prefix without an explicit `Type:` trailer.

A pattern is now one of two kinds, selected by the presence of `{n}`:

- **Numbered** (contains `{n}`) — **unchanged**. Exactly one counter; medial
  `{scope}`-style placeholders stay single-segment; mintable + classifying.
  Every pre-existing pattern contains `{n}`, so **no pattern in the wild
  changes behaviour**.
- **Named** (no `{n}`) — new. Requires a non-empty literal anchor plus a
  trailing named placeholder that captures the **rest of the display ID**
  (`[A-Za-z0-9._/-]`, underscores included), so `SWC_{name}` matches
  `SWC_LIGHT_CTRL`. A bare `{name}` (no anchor) is rejected. Classification
  only — not mintable.

Previously a counter-less pattern crashed `markspec check` with an uncaught
`missing {n} placeholder` the moment classification reached the type.

## Design notes

- The split is gated on the absence of `{n}` (rather than overloading
  placeholder semantics by position), which is why numbered patterns are
  provably unchanged.
- The trailing-name char class includes `_` deliberately — a single-segment
  `[A-Za-z0-9]+` would *not* match the issue's headline `SWC_LIGHT_CTRL`.
- The minting path is already decoupled: `parseDisplayIdPattern` (keyed on
  `{n:Nd}`) returns `undefined` for counter-less patterns, so `next-id` /
  `create` / `insert` and the LSP scaffold skip named types unchanged.
- `classifyEntry`'s single-match / `MSL-T002` ambiguity logic is untouched —
  overlapping named prefixes still emit `MSL-T002`.

## Changes

- `core/validator/pattern.ts` — relax `compileDisplayIdPattern` (numbered vs
  named kinds; rest-of-ID terminal `{name}`; reject bare `{name}` / all-literal).
- Tests — `pattern_test.ts`, `types_test.ts`, new e2e
  `named_pattern_classification_test.ts`.
- Docs — `pattern.ts` grammar header, `language.md §2.2`, annex `§B.3.2`,
  **ADR-025** (refines ADR-009 §5), ADR index in `AGENTS.md`.

## Verification

- `just build` (lint + full test suite + typecheck + compile) — pass
- `deno fmt --check` + `dprint check` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)