### PR TITLE
feat(core): accept display IDs in trace relations (validator)

### DIFF
--- a/docs/spec/language/language.md
+++ b/docs/spec/language/language.md
@@ -840,6 +840,10 @@ an accepted input but never a canonical output.
 CSV is **forbidden** for the `citation` type. `References` values may carry
 free-text locators like `§9.4, Table 7` that would be ambiguous in CSV.
 
+The `id` and `id-list` types accept a 26-char ULID, a scheme-qualified URI, or a
+display ID. A display ID is resolved to its target by existence; an unresolved
+display ID is reported by `MSL-L006`, not by the value-format gate.
+
 ---
 
 ## Part 3 — Directives
@@ -1349,7 +1353,7 @@ declare additional keys; projects may allowlist SSG-ecosystem keys in
 | **modified** | Git last merge commit timestamp | File system modification time |
 
 These are **never authored in front matter** — `title:`, `author:`, `date:`,
-`description:`, `toc:`, `cover:` in front matter are errors (see §8.5 MSL-D001).
+`description:`, `toc:`, `cover:` in front matter are errors (see §8.6 MSL-D001).
 The H1, first paragraph, git history, and filesystem are the authoritative
 sources.
 
@@ -1537,7 +1541,15 @@ The core defines no enum vocabularies of its own.
 Direction and level-crossing rules (e.g., "acceptance tests verify stakeholder
 requirements") are profile concerns, not core concerns.
 
-### 8.4 References (MSL-M)
+### 8.4 Link rules (MSL-L)
+
+Existence and cardinality rules for the targets of trace-relation links.
+
+| ID         | Severity | Rule                                                                                                                            |
+| ---------- | -------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `MSL-L006` | warning  | Profile trace-relation target does not resolve to any entry (resolved by display ID or ULID). Scheme-qualified URIs are exempt. |
+
+### 8.5 References (MSL-M)
 
 | ID         | Severity | Rule                                                            |
 | ---------- | -------- | --------------------------------------------------------------- |
@@ -1545,7 +1557,7 @@ requirements") are profile concerns, not core concerns.
 | `MSL-M002` | error    | Namespace: `spec`, `test`, `element`, `ref`, `fig`, `tbl`, `h`. |
 | `MSL-M003` | error    | No sections, inverted sections, or partials.                    |
 
-### 8.5 Document structure (MSL-D)
+### 8.6 Document structure (MSL-D)
 
 | ID         | Severity     | Rule                                                                                                                                                                                                                                                                    |
 | ---------- | ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -1558,7 +1570,7 @@ requirements") are profile concerns, not core concerns.
 | `MSL-D007` | warning      | Reference definitions at end of document, alphabetical within groups. Auto-fixed.                                                                                                                                                                                       |
 | `MSL-D008` | error        | Image paths must be relative and stay within the document folder. Absolute URLs (`https://...`), repo-root links (`/...`), and paths escaping via `../../` are not permitted (ADR-003).                                                                                 |
 
-### 8.6 Glossary (MSL-G)
+### 8.7 Glossary (MSL-G)
 
 | ID         | Severity | Rule                                                                                 |
 | ---------- | -------- | ------------------------------------------------------------------------------------ |
@@ -1567,7 +1579,7 @@ requirements") are profile concerns, not core concerns.
 | `MSL-G003` | warning  | Link references at end of file, alphabetical within groups (internal then external). |
 | `MSL-G004` | error    | Cross-links reference existing headings.                                             |
 
-### 8.7 Summary (MSL-S)
+### 8.8 Summary (MSL-S)
 
 | ID         | Severity | Rule                                                              |
 | ---------- | -------- | ----------------------------------------------------------------- |

--- a/packages/markspec/core/model/mod.ts
+++ b/packages/markspec/core/model/mod.ts
@@ -280,6 +280,23 @@ export const ULID_RE = /^[0-9A-HJKMNP-TV-Z]{26}$/;
 export const URI_SCHEME_RE = /^[A-Za-z][A-Za-z0-9+\-.]*:/;
 
 /**
+ * Regex matching a display-ID-shaped token (a "slug"): a letter, then any of
+ * letters / digits / `.` `_` `/` `-`, ending on a letter or digit. Mirrors the
+ * parser's slug grammar in `core/parser/markdown.ts` (`SLUG_RE`).
+ *
+ * Used by the `id` / `id-list` value-type gate to accept a display ID in a
+ * trace-relation value. This is a SHAPE check only — whether the display ID
+ * resolves to a real entry is checked downstream by the Stage-4 existence rule
+ * (MSL-L006), not here.
+ *
+ * Single- and two-character slugs match here (mirroring `SLUG_RE`) but are
+ * unresolvable in the LSP, whose token grammar requires ≥ 3 characters. Real
+ * profile display-ID patterns always produce longer IDs, so the asymmetry is
+ * benign.
+ */
+export const DISPLAY_ID_RE = /^[A-Za-z]([A-Za-z0-9._/-]*[A-Za-z0-9])?$/;
+
+/**
  * Decide the shape of an entry from its `Id:` value.
  *
  * Returns `undefined` for inputs that are neither a bare ULID nor a

--- a/packages/markspec/core/validator/pipeline.ts
+++ b/packages/markspec/core/validator/pipeline.ts
@@ -140,16 +140,23 @@ export function runPipeline(
     }
   }
 
-  // Stage 4 — traceability rules (only when a profile is loaded). Builds a
-  // graph index keyed by `entry.id` from the post-classification entries so
-  // trace-rule target matchers can look up the classified type/shape.
+  // Stage 4 — traceability rules (only when a profile is loaded). Builds two
+  // indexes: by `entry.id` (ULID) and by `entry.displayId`, so trace values
+  // resolve in either form (issue #593).
   if (profile !== null) {
     const graph = new Map<string, Entry>();
+    const byDisplayId = new Map<string, Entry>();
     for (const e of finalEntries) {
-      if (e.id) graph.set(e.id, e);
+      if (e.id && !graph.has(e.id)) graph.set(e.id, e);
+      if (!byDisplayId.has(e.displayId)) byDisplayId.set(e.displayId, e);
     }
     for (const entry of finalEntries) {
-      const stage4 = validateTraceabilityForEntry(entry, profile, graph);
+      const stage4 = validateTraceabilityForEntry(
+        entry,
+        profile,
+        graph,
+        byDisplayId,
+      );
       diagnostics.push(...stage4);
     }
   }

--- a/packages/markspec/core/validator/traceability.ts
+++ b/packages/markspec/core/validator/traceability.ts
@@ -9,18 +9,20 @@
  *   - Required (MSL-L001)
  *   - Cardinality bounds (MSL-L002 upper / MSL-L003 lower)
  *   - Target match against the rule's target matchers (MSL-L004)
+ *   - Target existence (MSL-L006, warning; scheme-qualified URIs exempt)
  *
  * Referenced entries are skipped entirely — the profile manifest parser
  * rejects `referenced.traceability` at load time, so referenced entries
  * never have declared outgoing links.
  */
 
-import type {
-  Diagnostic,
-  EffectiveProfile,
-  Entry,
-  TargetMatcher,
-  TraceRule,
+import {
+  type Diagnostic,
+  type EffectiveProfile,
+  type Entry,
+  type TargetMatcher,
+  type TraceRule,
+  URI_SCHEME_RE,
 } from "../model/mod.ts";
 
 /**
@@ -81,12 +83,15 @@ export function matchesAnyTarget(
  * @param entry - The entry to validate (after Stage 2 classification +
  *                Stage 2.5 normalization)
  * @param profile - The effective profile (null → never called)
- * @param graph - Index keyed by entry.id for target lookup
+ * @param graph - Index keyed by entry.id (ULID) for target lookup
+ * @param byDisplayId - Index keyed by entry.displayId for target lookup
+ *                      (issue #593 — display-ID targets). Defaults to empty.
  */
 export function validateTraceabilityForEntry(
   entry: Entry,
   profile: EffectiveProfile,
   graph: ReadonlyMap<string, Entry>,
+  byDisplayId: ReadonlyMap<string, Entry> = new Map(),
 ): Diagnostic[] {
   const diagnostics: Diagnostic[] = [];
   if (entry.shape !== "Authored") return diagnostics;
@@ -137,10 +142,25 @@ export function validateTraceabilityForEntry(
       });
     }
 
-    // MSL-L004: target match for each resolved value.
+    // MSL-L004 target match + MSL-L006 existence, for each resolved value.
+    // Resolve by ULID (graph) first, then by display ID (byDisplayId) — the
+    // dual-resolution spine (issue #593).
     for (const v of values!) {
-      const target = graph.get(v);
-      if (!target) continue;
+      const target = graph.get(v) ?? byDisplayId.get(v);
+      if (!target) {
+        // Scheme-qualified URIs are intentionally external — never local
+        // graph targets, so they are not "broken references".
+        if (URI_SCHEME_RE.test(v)) continue;
+        diagnostics.push({
+          code: "MSL-L006",
+          severity: "warning",
+          message:
+            `${entry.displayId}: link '${linkName}' target '${v}' does not ` +
+            `resolve to any entry`,
+          location: entry.location,
+        });
+        continue;
+      }
       if (!matchesAnyTarget(target, rule.target)) {
         diagnostics.push({
           code: "MSL-L004",

--- a/packages/markspec/core/validator/traceability_test.ts
+++ b/packages/markspec/core/validator/traceability_test.ts
@@ -517,7 +517,7 @@ Deno.test("validateTraceabilityForEntry: shape matcher accepts any identified ta
   assertEquals(diags.filter((d) => d.code === "MSL-L004"), []);
 });
 
-Deno.test("validateTraceabilityForEntry: target not in graph is silently skipped (Stage 1 owns)", () => {
+Deno.test("validateTraceabilityForEntry: target not in either index → MSL-L006 (no MSL-L004)", () => {
   const rule: TraceRule = {
     target: ["requirement"],
     cardinality: { lower: 0, upper: Infinity },
@@ -531,9 +531,9 @@ Deno.test("validateTraceabilityForEntry: target not in graph is silently skipped
     type: "test",
     attrs: { Verifies: ["01MISSING000000000000000000"] },
   });
-  const graph = graphOf([e]);
-  const diags = validateTraceabilityForEntry(e, p, graph);
+  const diags = validateTraceabilityForEntry(e, p, graphOf([e]));
   assertEquals(diags.filter((d) => d.code === "MSL-L004"), []);
+  assertEquals(diags.filter((d) => d.code === "MSL-L006").length, 1);
 });
 
 Deno.test("validateTraceabilityForEntry: one valid + one invalid target → single MSL-L004", () => {
@@ -603,4 +603,127 @@ Deno.test("validateTraceabilityForEntry: un-classified Authored entry gets no ru
   const graph = graphOf([e]);
   const diags = validateTraceabilityForEntry(e, p, graph);
   assertEquals(diags, []);
+});
+
+// ---------------------------------------------------------------------------
+// Display-ID resolution + MSL-L006 existence (issue #593)
+// ---------------------------------------------------------------------------
+
+function byDisplayIdOf(entries: readonly Entry[]): Map<string, Entry> {
+  const m = new Map<string, Entry>();
+  for (const e of entries) m.set(e.displayId, e);
+  return m;
+}
+
+Deno.test("validateTraceabilityForEntry: display-ID target resolves and type-checks clean", () => {
+  const rule: TraceRule = {
+    target: ["requirement"],
+    cardinality: { lower: 0, upper: Infinity },
+    required: false,
+  };
+  const p = profile({
+    types: [typeDef({ name: "test", traceability: { Verifies: rule } })],
+  });
+  const target = entryWithAttrs({
+    id: "01T1T1T1T1T1T1T1T1T1T1T1T1",
+    displayId: "REQ-0001",
+    shape: "Authored",
+    type: "requirement",
+  });
+  const e = entryWithAttrs({
+    shape: "Authored",
+    type: "test",
+    attrs: { Verifies: ["REQ-0001"] }, // display ID, not ULID
+  });
+  const diags = validateTraceabilityForEntry(
+    e,
+    p,
+    graphOf([e, target]),
+    byDisplayIdOf([e, target]),
+  );
+  assertEquals(diags, []);
+});
+
+Deno.test("validateTraceabilityForEntry: display-ID target type mismatch → MSL-L004", () => {
+  const rule: TraceRule = {
+    target: ["requirement"],
+    cardinality: { lower: 0, upper: Infinity },
+    required: false,
+  };
+  const p = profile({
+    types: [typeDef({ name: "test", traceability: { Verifies: rule } })],
+  });
+  const wrong = entryWithAttrs({
+    id: "01T1T1T1T1T1T1T1T1T1T1T1T1",
+    displayId: "NOTE-0001",
+    shape: "Authored",
+    type: "note",
+  });
+  const e = entryWithAttrs({
+    shape: "Authored",
+    type: "test",
+    attrs: { Verifies: ["NOTE-0001"] },
+  });
+  const diags = validateTraceabilityForEntry(
+    e,
+    p,
+    graphOf([e, wrong]),
+    byDisplayIdOf([e, wrong]),
+  );
+  if (!diags.find((d) => d.code === "MSL-L004")) {
+    throw new Error(`expected MSL-L004, got: ${diags.map((d) => d.code)}`);
+  }
+});
+
+Deno.test("validateTraceabilityForEntry: unresolved target → MSL-L006 warning", () => {
+  const rule: TraceRule = {
+    target: ["requirement"],
+    cardinality: { lower: 0, upper: Infinity },
+    required: false,
+  };
+  const p = profile({
+    types: [typeDef({ name: "test", traceability: { Verifies: rule } })],
+  });
+  const e = entryWithAttrs({
+    shape: "Authored",
+    type: "test",
+    attrs: { Verifies: ["REQ-9999"] }, // exists nowhere
+  });
+  const diags = validateTraceabilityForEntry(
+    e,
+    p,
+    graphOf([e]),
+    byDisplayIdOf([e]),
+  );
+  const l006 = diags.find((d) => d.code === "MSL-L006");
+  if (!l006) {
+    throw new Error(`expected MSL-L006, got: ${diags.map((d) => d.code)}`);
+  }
+  assertEquals(l006.severity, "warning");
+  if (!l006.message.includes("REQ-9999")) {
+    throw new Error(`expected target in message: ${l006.message}`);
+  }
+});
+
+Deno.test("validateTraceabilityForEntry: scheme-qualified URI target is not flagged", () => {
+  const rule: TraceRule = {
+    target: [{ shape: "Authored" }],
+    cardinality: { lower: 0, upper: Infinity },
+    required: false,
+  };
+  const p = profile({
+    types: [typeDef({ name: "test", traceability: { Verifies: rule } })],
+  });
+  const e = entryWithAttrs({
+    shape: "Authored",
+    type: "test",
+    attrs: { Verifies: ["urn:iso:std:iso:26262"] },
+  });
+  const diags = validateTraceabilityForEntry(
+    e,
+    p,
+    graphOf([e]),
+    byDisplayIdOf([e]),
+  );
+  assertEquals(diags.filter((d) => d.code === "MSL-L006"), []);
 });

--- a/packages/markspec/core/validator/value_types.ts
+++ b/packages/markspec/core/validator/value_types.ts
@@ -9,7 +9,7 @@
  */
 
 import type { AttrDecl, ValueType } from "../model/mod.ts";
-import { ULID_RE, URI_SCHEME_RE } from "../model/mod.ts";
+import { DISPLAY_ID_RE, ULID_RE, URI_SCHEME_RE } from "../model/mod.ts";
 
 /**
  * Validate one string value against an attribute's declared value type.
@@ -66,7 +66,8 @@ const validateEnum: ValueValidator = (value, decl) => {
 const validateId: ValueValidator = (value, _decl) => {
   if (ULID_RE.test(value)) return null;
   if (URI_SCHEME_RE.test(value)) return null;
-  return `not a valid id: '${value}' (expected 26-char ULID or scheme-qualified URI)`;
+  if (DISPLAY_ID_RE.test(value)) return null;
+  return `not a valid id: '${value}' (expected a display ID, 26-char ULID, or scheme-qualified URI)`;
 };
 
 /**

--- a/packages/markspec/core/validator/value_types_test.ts
+++ b/packages/markspec/core/validator/value_types_test.ts
@@ -124,9 +124,19 @@ Deno.test("validateValue: id accepts URI with scheme", () => {
   assertEquals(validateValue("pkg:cargo/serde@1.0.0", d), null);
 });
 
-Deno.test("validateValue: id rejects bare strings without ULID or URI shape", () => {
+Deno.test("validateValue: id accepts a display-ID-shaped token", () => {
   const d = decl("id");
-  const bad = ["", "not-an-id", "REQ-0001", "01HGW2Q8MN"];
+  assertEquals(validateValue("REQ-0001", d), null);
+  assertEquals(validateValue("XREQ_TEST_0001", d), null);
+  assertEquals(validateValue("SYS_BRK_0042", d), null);
+  assertEquals(validateValue("a/b.c", d), null);
+});
+
+Deno.test("validateValue: id rejects empty, digit-leading, and punctuation-leading tokens", () => {
+  const d = decl("id");
+  // "" empty; "01HGW2Q8MN" digit-leading and not a 26-char ULID;
+  // "-x"/"9x" do not start with a letter; "@x" has no URI scheme colon.
+  const bad = ["", "01HGW2Q8MN", "-leading", "9digit", "@x"];
   for (const v of bad) {
     if (validateValue(v, d) === null) {
       throw new Error(`expected '${v}' to be invalid id`);
@@ -139,8 +149,9 @@ Deno.test("validateValue: id-list applies per-element id validation", () => {
   const d = decl("id-list", { cardinality: { lower: 0, upper: Infinity } });
   assertEquals(validateValue("01HGW2Q8MNP3RSTVWXYZABCDEF", d), null);
   assertEquals(validateValue("doi:10.1/xyz", d), null);
-  const bad = validateValue("not-an-id", d);
-  if (bad === null) throw new Error("expected 'not-an-id' to be invalid");
+  assertEquals(validateValue("REQ-0001", d), null); // display ID now valid
+  const bad = validateValue("@nope", d);
+  if (bad === null) throw new Error("expected '@nope' to be invalid");
 });
 
 // uri

--- a/tests/e2e/display_id_trace_test.ts
+++ b/tests/e2e/display_id_trace_test.ts
@@ -1,0 +1,89 @@
+/**
+ * @module tests/e2e/display_id_trace_test
+ *
+ * E2E: profile trace relations accept a display ID (issue #593). A resolving
+ * display ID validates clean; an unresolved one warns MSL-L006 (exit 2).
+ */
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { markspec } from "./helpers.ts";
+
+const PROJECT_YAML = `name: disp-id-e2e\nversion: 0.1.0\n`;
+
+const PROFILE_YAML = `id: "@acme/disp-id"
+version: 0.1.0
+profile:
+  types:
+    requirement:
+      extends: Requirement
+      display-id-pattern: "REQ-{n:04d}"
+    system-requirement:
+      extends: Requirement
+      display-id-pattern: "SREQ-{n:04d}"
+      traceability:
+        Satisfies:
+          target: [requirement]
+          cardinality: 0..3
+          required: false
+`;
+
+const BASE_FILES = {
+  "project.yaml": PROJECT_YAML,
+  ".markspec.yaml": `profiles:\n  - ./profiles/disp\n`,
+  "profiles/disp/markspec.yaml": PROFILE_YAML,
+};
+
+Deno.test("check: Satisfies a display ID that exists → clean (exit 0)", async () => {
+  const { code, stderr } = await markspec(["check", "doc.md"], {
+    files: {
+      ...BASE_FILES,
+      "doc.md": `# Reqs
+
+- [REQ-0001] A requirement
+
+  Body text.
+
+      Id: 01REQ000000000000000000001
+      Type: requirement
+
+- [SREQ-0001] A system requirement
+
+  Body text.
+
+      Id: 01SREQ00000000000000000001
+      Type: system-requirement
+      Satisfies: REQ-0001
+`,
+    },
+  });
+  assertEquals(code, 0);
+  // The regression: the display-ID value must NOT be rejected by the format
+  // gate (MSL-A004), and the resolving target must not warn (MSL-L006).
+  assertEquals(
+    stderr.split("\n").filter((l) =>
+      l.includes("MSL-A004") || l.includes("MSL-L006")
+    ),
+    [],
+  );
+});
+
+Deno.test("check: Satisfies a display ID that does not exist → MSL-L006 (exit 2)", async () => {
+  const { code, stderr } = await markspec(["check", "doc.md"], {
+    files: {
+      ...BASE_FILES,
+      "doc.md": `# Reqs
+
+- [SREQ-0001] A system requirement
+
+  Body text.
+
+      Id: 01SREQ00000000000000000001
+      Type: system-requirement
+      Satisfies: REQ-9999
+`,
+    },
+  });
+  assertEquals(code, 2); // warning-only → exit 2
+  assertStringIncludes(stderr, "MSL-L006");
+  assertStringIncludes(stderr, "REQ-9999");
+});


### PR DESCRIPTION
## Summary

PR 1 of 4 for #593 — the **validator** slice. `markspec check` now accepts a human-readable **display ID** (e.g. `Satisfies: XREQ_HMI_0001`) in profile trace-relation values, not only a 26-char ULID or scheme-qualified URI.

- **Format gate relaxed** — new `DISPLAY_ID_RE` in `core/model`; `validateId` accepts a slug-shaped display ID alongside ULID/URI, so the value is no longer rejected with `MSL-A004`. Existence is the gate, not value-format.
- **Dual resolution** — validator Stage 4 now indexes entries by both `id` (ULID) **and** `displayId`, so trace targets resolve in either form and target-type checks (`MSL-L004`) fire for display-ID targets.
- **New `MSL-L006` warning** (non-blocking) when a profile trace-relation target resolves to no entry. Scheme-qualified URIs are exempt (intentionally external). `MSL-L006` was chosen as the next free slot (`L005` is taken by inverse-consistency; the §8.3 `MSL-T` per-relation existence family stays deferred under ADR-012).
- **Docs** — new §8.4 *Link rules (MSL-L)* catalogue row + an `id`/`id-list` value-type note in §2.

Display IDs are preserved **verbatim** in source here. Canonicalisation (`fmt`), the lock ULID ledger, and LSP/MCP display-ID guarantees are the remaining 3 PRs in the epic.

## Test plan

- `just build` — 3135 passed / 0 failed / 2 ignored; `deno fmt --check` + `dprint check` clean.
- Unit (`value_types_test`, `traceability_test`): display ID accepted at the gate, garbage still rejected; dual-resolution clean path; type-mismatch via display ID → `MSL-L004`; unresolved → `MSL-L006` warning; URI-scheme value exempt.
- E2E (`tests/e2e/display_id_trace_test.ts`): `check` on a resolving display-ID `Satisfies:` exits 0 with no `MSL-A004`; on a missing target warns `MSL-L006` and exits 2.

Refs #593.

🤖 Generated with [Claude Code](https://claude.com/claude-code)