### PR TITLE
fix(core): unify the two display-id-pattern parsers

### DIFF
--- a/docs/spec/internal/markspec-profile-schema.md
+++ b/docs/spec/internal/markspec-profile-schema.md
@@ -247,7 +247,7 @@ ADR-008's per-type key set — Annex B):
 | -------------------------------- | ---------------------------------------------------------------------------------------------------- |
 | `extends`                        | Parent type (§3). Required.                                                                          |
 | `description`                    | Human-readable summary. Optional.                                                                    |
-| `display-id-pattern`             | Template (ADR-009 §5 grammar): literal prefix + `{n}`/`{n:0Nd}` + optional `{scope}`. Optional.      |
+| `display-id-pattern`             | Template (ADR-009 §5 grammar): literal prefix + `{n}`/`{n:Nd}` + optional `{scope}`. Optional.       |
 | `display-id-pattern-enforcement` | `off` \| `warn` \| `error`. Default `warn`. ADR-008 §6; ADR-010 §5.                                  |
 | `required`                       | List of attribute names that must be present on entries of this type. §4.2.                          |
 | `attributes`                     | Per-type attribute declarations (extend the inherited set). §4.1.                                    |

--- a/packages/markspec/core/mod.ts
+++ b/packages/markspec/core/mod.ts
@@ -153,8 +153,12 @@ export {
   highestDisplayIdNumber,
   padDisplayIdNumber,
   parseDisplayIdPattern,
+  validateDisplayIdPattern,
 } from "./profile/mod.ts";
-export type { DisplayIdPatternShape } from "./profile/mod.ts";
+export type {
+  DisplayIdPatternShape,
+  DisplayIdPatternValidation,
+} from "./profile/mod.ts";
 
 export {
   entryMatchesTargets,

--- a/packages/markspec/core/profile/display_id.ts
+++ b/packages/markspec/core/profile/display_id.ts
@@ -1,55 +1,222 @@
 /**
  * @module core/profile/display_id
  *
- * Shared parser for the `display-id-pattern` template used by profile
- * type declarations. Patterns look like:
+ * Single source of truth for the `display-id-pattern` template grammar.
  *
- *   STK_{n:4d}
- *   STK_AEB_{n:04d}
- *   REQ-{n:03d}-draft
+ * One tokenizer ({@linkcode tokenizePattern}) and one well-formedness
+ * oracle ({@linkcode validateDisplayIdPattern}) back both consumers of the
+ * grammar: classification (`compileDisplayIdPattern` in `core/validator`,
+ * which builds the recognizer regex) and minting/scaffolding
+ * ({@linkcode parseDisplayIdPattern}, which decomposes the numeric slot).
+ * Keeping a single grammar here prevents the two from drifting — see #596.
  *
- * The `{n:Nd}` placeholder (with optional leading zero in the Nd
- * form) names the sequential number slot. The text before the
- * placeholder becomes the literal prefix; the text after becomes the
- * literal suffix.
+ * A pattern is one of two kinds, selected by whether it contains a counter:
  *
- * Note: the `{scope}` placeholder documented in the profile schema
- * is NOT substituted here — callers handle that separately. For
- * patterns containing `{scope}`, the literal text `{scope}` ends up
- * in `prefix` (or `suffix`) and must be replaced upstream before the
- * pattern is fed to scaffolding.
+ *   numbered := segment+ (exactly one `{n}` counter)  — mintable + classifying
+ *   named    := segment+ (literal anchor, ≥1 named, no counter) — classifying
+ *
+ *   counter  := "{n}" | "{n:" digits "d}"   (e.g. {n}, {n:4d}, {n:04d})
+ *   named    := "{" identifier "}"          (e.g. {scope}, {name})
+ *
+ * The padding digit count is a minimum width; `{n:4d}` and `{n:04d}` are
+ * equivalent. A bare `{n}` mints with no zero-padding (width 1).
+ *
+ * Patterns:
+ *
+ *   STK_{n:4d}            → numbered, width 4
+ *   STK_AEB_{n:04d}       → numbered, width 4
+ *   REQ-{n:03d}-draft     → numbered, width 3, suffix "-draft"
+ *   REQ-{n}               → numbered, width 1
+ *   SWC_{name}            → named (classifying only — not mintable)
+ *
+ * Note: the `{scope}` placeholder documented in the profile schema is NOT
+ * substituted here. For a numbered pattern like `XREQ_{scope}_{n:04d}`,
+ * the literal `{scope}` text ends up in `prefix` and must be replaced
+ * upstream before the pattern is fed to scaffolding.
  */
 
-/** Width-and-position decomposition of a display-id-pattern. */
+/** Width-and-position decomposition of a *numbered* display-id-pattern. */
 export interface DisplayIdPatternShape {
-  /** Literal text before the `{n:Nd}` placeholder. */
+  /** Literal text before the counter placeholder. */
   readonly prefix: string;
-  /** Width of the zero-padded numeric segment. */
+  /** Minimum width of the numeric segment (1 for a bare `{n}`). */
   readonly width: number;
-  /** Literal text after the `{n:Nd}` placeholder (often empty). */
+  /** Literal text after the counter placeholder (often empty). */
   readonly suffix: string;
 }
 
-/** Regex capturing the `{n:Nd}` placeholder; `0` and the digit count are both captured. */
-const PLACEHOLDER_RE = /\{n:(\d+)d\}/;
+/**
+ * One template token: the `{n}` counter (optionally padded) OR a `{named}`
+ * segment. The padding capture accepts any positive digit count — `{n:4d}`
+ * and `{n:04d}` both tokenize to a counter (`Number()` collapses the
+ * leading zero downstream).
+ */
+const TOKEN_RE = /\{n(?::(\d+)d)?\}|\{([A-Za-z][A-Za-z0-9_]*)\}/g;
+
+/** A tokenized fragment of a display-id-pattern template. */
+export type PatternToken =
+  | { readonly kind: "literal"; readonly text: string }
+  | { readonly kind: "counter"; readonly padding?: string }
+  | { readonly kind: "named"; readonly name: string };
+
+/** Split a template into its literal / counter / named tokens. */
+export function tokenizePattern(template: string): PatternToken[] {
+  const tokens: PatternToken[] = [];
+  let lastIndex = 0;
+  const re = new RegExp(TOKEN_RE);
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(template)) !== null) {
+    if (match.index > lastIndex) {
+      tokens.push({
+        kind: "literal",
+        text: template.slice(lastIndex, match.index),
+      });
+    }
+    const named = match[2];
+    if (named === undefined) {
+      tokens.push({ kind: "counter", padding: match[1] });
+    } else {
+      tokens.push({ kind: "named", name: named });
+    }
+    lastIndex = match.index + match[0].length;
+  }
+  if (lastIndex < template.length) {
+    tokens.push({ kind: "literal", text: template.slice(lastIndex) });
+  }
+  return tokens;
+}
+
+/** Re-emit the literal source a non-counter token contributes to a
+ * numbered pattern's prefix/suffix. A named placeholder is rendered in
+ * its `{name}` form (callers substitute it upstream). */
+function reconstructLiteral(token: PatternToken): string {
+  switch (token.kind) {
+    case "literal":
+      return token.text;
+    case "named":
+      return `{${token.name}}`;
+    case "counter":
+      return token.padding ? `{n:${token.padding}d}` : "{n}";
+  }
+}
+
+/** Outcome of {@linkcode validateDisplayIdPattern}. */
+export type DisplayIdPatternValidation =
+  | { readonly ok: true }
+  | { readonly ok: false; readonly message: string };
 
 /**
- * Parse a `display-id-pattern` template. Returns `undefined` when
- * the pattern does not contain a recognised `{n:Nd}` placeholder so
- * callers can decide how to surface the error (CLI exits, LSP
- * silently skips the type).
+ * Decide whether a `display-id-pattern` template is well-formed, returning
+ * a MarkSpec-authored reason when it is not. This is the single oracle
+ * shared by classification (which throws this message) and profile-load
+ * validation (which emits it as a diagnostic), so a malformed pattern is
+ * reported identically everywhere and never reaches `new RegExp`.
+ *
+ * Rejects: more than one counter; a malformed/zero-width padding
+ * specifier; an all-literal template (no variable part); a counter-less
+ * pattern with no literal anchor (a bare `{name}` matches every ID); and
+ * a duplicate named placeholder (which would build an invalid RegExp).
+ */
+export function validateDisplayIdPattern(
+  template: string,
+): DisplayIdPatternValidation {
+  const tokens = tokenizePattern(template);
+  const counters = tokens.filter((t) => t.kind === "counter");
+  const named = tokens.filter((t) => t.kind === "named");
+  const hasLiteralAnchor = tokens.some(
+    (t) => t.kind === "literal" && t.text.length > 0,
+  );
+
+  if (counters.length > 1) {
+    return {
+      ok: false,
+      message:
+        `display-id-pattern '${template}': multiple {n} counters (expected one)`,
+    };
+  }
+
+  if (counters.length === 1) {
+    const padding = (counters[0] as { padding?: string }).padding;
+    if (padding !== undefined && parseInt(padding, 10) < 1) {
+      return {
+        ok: false,
+        message:
+          `display-id-pattern '${template}': invalid padding specifier ` +
+          `(expected {n} or {n:NNd})`,
+      };
+    }
+  }
+
+  if (counters.length === 0) {
+    // A malformed counter (`{n:abc}`, `{n:4}`) is not tokenized as a
+    // counter — it lands in literal text. Surface it as an invalid padding
+    // error before the missing-counter / named-pattern checks.
+    if (/\{n:[^}]*\}/.test(template)) {
+      return {
+        ok: false,
+        message:
+          `display-id-pattern '${template}': invalid padding specifier ` +
+          `(expected {n} or {n:NNd})`,
+      };
+    }
+    if (named.length === 0) {
+      return {
+        ok: false,
+        message: `display-id-pattern '${template}': missing {n} placeholder`,
+      };
+    }
+    if (!hasLiteralAnchor) {
+      return {
+        ok: false,
+        message:
+          `display-id-pattern '${template}': named pattern needs a literal ` +
+          `prefix (a bare {name} would match every display ID)`,
+      };
+    }
+  }
+
+  const seen = new Set<string>();
+  for (const t of named) {
+    const name = (t as { name: string }).name;
+    if (seen.has(name)) {
+      return {
+        ok: false,
+        message:
+          `display-id-pattern '${template}': duplicate named placeholder '{${name}}'`,
+      };
+    }
+    seen.add(name);
+  }
+
+  return { ok: true };
+}
+
+/**
+ * Decompose a *numbered* `display-id-pattern` into its mint shape.
+ *
+ * Returns `undefined` for any template that is not mintable — a named
+ * (counter-less) pattern, an all-literal template, or a malformed one —
+ * so callers can decide how to surface it (the CLI distinguishes a valid
+ * named type from a malformed pattern via {@linkcode validateDisplayIdPattern};
+ * the LSP skips non-mintable types). Shares the {@linkcode tokenizePattern}
+ * grammar with `compileDisplayIdPattern`, so the two never disagree about
+ * which counter forms are valid (#596).
  */
 export function parseDisplayIdPattern(
   pattern: string,
 ): DisplayIdPatternShape | undefined {
-  const match = PLACEHOLDER_RE.exec(pattern);
-  if (!match) return undefined;
-  const width = parseInt(match[1], 10);
+  const tokens = tokenizePattern(pattern);
+  const counters = tokens.filter(
+    (t): t is { kind: "counter"; padding?: string } => t.kind === "counter",
+  );
+  if (counters.length !== 1) return undefined; // named/none, or multi-counter
+  const counterIndex = tokens.indexOf(counters[0]);
+  const width = counters[0].padding ? parseInt(counters[0].padding, 10) : 1;
   if (!Number.isFinite(width) || width < 1) return undefined;
   return {
-    prefix: pattern.slice(0, match.index),
+    prefix: tokens.slice(0, counterIndex).map(reconstructLiteral).join(""),
     width,
-    suffix: pattern.slice(match.index + match[0].length),
+    suffix: tokens.slice(counterIndex + 1).map(reconstructLiteral).join(""),
   };
 }
 

--- a/packages/markspec/core/profile/display_id_test.ts
+++ b/packages/markspec/core/profile/display_id_test.ts
@@ -8,6 +8,7 @@ import {
   highestDisplayIdNumber,
   padDisplayIdNumber,
   parseDisplayIdPattern,
+  validateDisplayIdPattern,
 } from "./display_id.ts";
 
 Deno.test("parseDisplayIdPattern: simple 4-digit prefix", () => {
@@ -51,6 +52,60 @@ Deno.test("parseDisplayIdPattern: scope placeholder stays literal", () => {
     width: 4,
     suffix: "",
   });
+});
+
+Deno.test("parseDisplayIdPattern: bare {n} is mintable with width 1 (#596)", () => {
+  // The mirror of the {n:4d} bug: a bare {n} compiles for classification
+  // (\d+) but previously returned undefined here, so it was silently
+  // non-mintable. Now it mints with no zero-padding (width 1).
+  const shape = parseDisplayIdPattern("REQ-{n}");
+  assertEquals(shape, { prefix: "REQ-", width: 1, suffix: "" });
+  assertEquals(formatDisplayId(shape!, 7), "REQ-7");
+  assertEquals(formatDisplayId(shape!, 42), "REQ-42");
+});
+
+Deno.test("parseDisplayIdPattern: named (counter-less) pattern is non-mintable (#598)", () => {
+  // A named pattern classifies (compileDisplayIdPattern) but has no
+  // counter to increment, so the mint path must report it as undefined.
+  assertEquals(parseDisplayIdPattern("SWC_{name}"), undefined);
+  assertEquals(parseDisplayIdPattern("XREQ_{scope}"), undefined);
+});
+
+Deno.test("validateDisplayIdPattern: accepts numbered and named forms (#596)", () => {
+  for (
+    const ok of [
+      "STK_{n:4d}", // non-leading-zero padding — the #596 case
+      "STK_{n:04d}",
+      "REQ-{n}", // bare counter
+      "XREQ_{scope}_{n:04d}", // medial named + counter
+      "SWC_{name}", // counter-less named
+      "XREQ_{scope}", // counter-less named
+    ]
+  ) {
+    assertEquals(validateDisplayIdPattern(ok).ok, true, ok);
+  }
+});
+
+Deno.test("validateDisplayIdPattern: rejects malformed forms with a reason (#596/#597)", () => {
+  const cases: Array<[string, string]> = [
+    ["{name}", "literal"], // bare named, no anchor
+    ["REQ_FIXED", "{n}"], // no variable part
+    ["REQ-{n:abc}", "invalid"], // malformed padding
+    ["STK_{n:0d}", "invalid"], // zero width
+    ["X_{n}_{n:04d}", "multiple"], // two counters
+    ["SWC_{x}_{x}", "duplicate"], // duplicate named placeholder
+  ];
+  for (const [pattern, needle] of cases) {
+    const result = validateDisplayIdPattern(pattern);
+    assertEquals(result.ok, false, pattern);
+    if (!result.ok) {
+      assertEquals(
+        result.message.toLowerCase().includes(needle),
+        true,
+        `expected '${needle}' in message for '${pattern}', got: ${result.message}`,
+      );
+    }
+  }
 });
 
 Deno.test("padDisplayIdNumber: pads to minimum width", () => {

--- a/packages/markspec/core/profile/mod.ts
+++ b/packages/markspec/core/profile/mod.ts
@@ -54,8 +54,12 @@ export {
   highestDisplayIdNumber,
   padDisplayIdNumber,
   parseDisplayIdPattern,
+  validateDisplayIdPattern,
 } from "./display_id.ts";
-export type { DisplayIdPatternShape } from "./display_id.ts";
+export type {
+  DisplayIdPatternShape,
+  DisplayIdPatternValidation,
+} from "./display_id.ts";
 
 export {
   entryMatchesTargets,

--- a/packages/markspec/core/validator/pattern.ts
+++ b/packages/markspec/core/validator/pattern.ts
@@ -1,20 +1,23 @@
 /**
  * @module core/validator/pattern
  *
- * Display-ID pattern template → anchored RegExp.
+ * Display-ID pattern template → anchored RegExp (the classification half of
+ * the grammar). The tokenizer and well-formedness oracle live in
+ * `core/profile/display_id.ts` — {@linkcode tokenizePattern} and
+ * {@linkcode validateDisplayIdPattern} — and are shared with the
+ * minting/scaffold parser so the two never disagree about which forms are
+ * valid (#596). This module only builds the recognizer regex.
  *
- * A pattern is one of two kinds, selected by whether it contains the `{n}`
- * counter:
+ * A pattern is one of two kinds, selected by whether it contains a counter:
  *
  *   numbered := segment+ (exactly one counter)   — mintable + classifying
  *   named    := segment+ (literal anchor, ≥1 named, no counter) — classifying
  *
  *   segment  := literal | counter | named
- *   counter  := "{n}" | "{n:" PADDING "d}"
- *   named    := "{" identifier "}"   (e.g. {scope}, {name})
- *   PADDING  := "0" digits
+ *   counter  := "{n}" | "{n:" digits "d}"   (e.g. {n}, {n:4d}, {n:04d})
+ *   named    := "{" identifier "}"           (e.g. {scope}, {name})
  *
- * **Numbered patterns** carry exactly one `{n}` counter — the numeric running
+ * **Numbered patterns** carry exactly one counter — the numeric running
  * index used both for classification (a recognizer regex) and for minting the
  * next ID. A medial named placeholder such as `{scope}` matches a single free
  * alphanumeric segment, so one pattern serves every feature scope.
@@ -32,12 +35,16 @@
  * Examples:
  *   REQ-{n}              → ^REQ-(\d+)$
  *   REQ-{n:04d}          → ^REQ-(\d{4})$
+ *   STK_{n:4d}           → ^STK_(\d{4})$
  *   XREQ_{scope}_{n:04d} → ^XREQ_(?<scope>[A-Za-z0-9]+)_(\d{4})$
  *   SWC_{name}           → ^SWC_(?<name>[A-Za-z0-9._/-]+)$
  */
 
-// One token: the {n} counter (optionally padded) OR a {named} segment.
-const TOKEN_RE = /\{n(?::(0\d+)d)?\}|\{([A-Za-z][A-Za-z0-9_]*)\}/g;
+import {
+  type PatternToken,
+  tokenizePattern,
+  validateDisplayIdPattern,
+} from "../profile/display_id.ts";
 
 /**
  * Character class for the trailing named placeholder of a *named* pattern —
@@ -54,85 +61,21 @@ const REST_OF_ID_CLASS = "[A-Za-z0-9._/-]+";
  */
 const SEGMENT_CLASS = "[A-Za-z0-9]+";
 
-type PatternToken =
-  | { readonly kind: "literal"; readonly text: string }
-  | { readonly kind: "counter"; readonly padding?: string }
-  | { readonly kind: "named"; readonly name: string };
-
-/** Split a template into its literal / counter / named tokens. */
-function tokenizePattern(template: string): PatternToken[] {
-  const tokens: PatternToken[] = [];
-  let lastIndex = 0;
-  const re = new RegExp(TOKEN_RE);
-  let match: RegExpExecArray | null;
-  while ((match = re.exec(template)) !== null) {
-    if (match.index > lastIndex) {
-      tokens.push({
-        kind: "literal",
-        text: template.slice(lastIndex, match.index),
-      });
-    }
-    const named = match[2];
-    if (named === undefined) {
-      tokens.push({ kind: "counter", padding: match[1] });
-    } else {
-      tokens.push({ kind: "named", name: named });
-    }
-    lastIndex = match.index + match[0].length;
-  }
-  if (lastIndex < template.length) {
-    tokens.push({ kind: "literal", text: template.slice(lastIndex) });
-  }
-  return tokens;
-}
-
 /**
  * Compile a display-ID pattern template into an anchored RegExp.
  *
- * Throws if the template:
- *   - has more than one `{n}` counter,
- *   - has an invalid padding specifier (`{n:...}` not of the `{n:NNd}` form),
- *   - has zero counters and no named placeholder (no variable part), or
- *   - has zero counters and no literal anchor (a bare `{name}` would match
- *     every display ID).
+ * Throws the {@linkcode validateDisplayIdPattern} reason when the template is
+ * malformed (more than one counter, a malformed/zero-width padding specifier,
+ * no variable part, a counter-less pattern without a literal anchor, or a
+ * duplicate named placeholder). Validating first guarantees `new RegExp`
+ * below never sees a duplicate capture name.
  */
 export function compileDisplayIdPattern(template: string): RegExp {
+  const validation = validateDisplayIdPattern(template);
+  if (!validation.ok) throw new Error(validation.message);
+
   const tokens = tokenizePattern(template);
   const counters = tokens.filter((t) => t.kind === "counter").length;
-  const namedCount = tokens.filter((t) => t.kind === "named").length;
-  const hasLiteralAnchor = tokens.some(
-    (t) => t.kind === "literal" && t.text.length > 0,
-  );
-
-  if (counters > 1) {
-    throw new Error(
-      `display-id-pattern '${template}': multiple {n} counters (expected one)`,
-    );
-  }
-
-  if (counters === 0) {
-    // A malformed counter (`{n:abc}`, `{n:4d}`) is not tokenized as a counter
-    // — it lands in literal text. Surface it as an invalid padding error
-    // before the missing-counter / named-pattern checks, preserving the
-    // historical message for `{n:...}` typos.
-    if (/\{n:[^}]*\}/.test(template)) {
-      throw new Error(
-        `display-id-pattern '${template}': invalid padding specifier ` +
-          `(expected {n} or {n:NNd})`,
-      );
-    }
-    if (namedCount === 0) {
-      throw new Error(
-        `display-id-pattern '${template}': missing {n} placeholder`,
-      );
-    }
-    if (!hasLiteralAnchor) {
-      throw new Error(
-        `display-id-pattern '${template}': named pattern needs a literal ` +
-          `prefix (a bare {name} would match every display ID)`,
-      );
-    }
-  }
 
   // In a named (counter-less) pattern the trailing named placeholder matches
   // the rest of the display ID; every other named placeholder — and every
@@ -142,7 +85,7 @@ export function compileDisplayIdPattern(template: string): RegExp {
     : -1;
 
   let regexSource = "^";
-  tokens.forEach((t, i) => {
+  tokens.forEach((t: PatternToken, i) => {
     if (t.kind === "literal") {
       regexSource += escapeRegex(t.text);
     } else if (t.kind === "counter") {

--- a/packages/markspec/core/validator/pattern_test.ts
+++ b/packages/markspec/core/validator/pattern_test.ts
@@ -26,6 +26,43 @@ Deno.test("compileDisplayIdPattern: {n:04d} requires exactly 4 digits", () => {
   assertEquals(r.test("REQ-12345"), false);
 });
 
+Deno.test("compileDisplayIdPattern: {n:4d} (no leading zero) now compiles (#596)", () => {
+  // The annex documents SRS_{n:4d} / HAZ_{n:3d} as valid, and the mint
+  // parser accepts them — classification must too, or `markspec check`
+  // crashes. {n:4d} is exactly N digits, same as {n:04d}.
+  const r = compileDisplayIdPattern("STK_{n:4d}");
+  assertEquals(r.test("STK_0001"), true);
+  assertEquals(r.test("STK_9999"), true);
+  assertEquals(r.test("STK_1"), false); // wrong width
+  assertEquals(r.test("STK_12345"), false);
+});
+
+Deno.test("compileDisplayIdPattern: {n:0d} (zero width) throws (#596)", () => {
+  try {
+    compileDisplayIdPattern("REQ-{n:0d}");
+    throw new Error("expected compileDisplayIdPattern to throw");
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (!msg.toLowerCase().includes("invalid")) {
+      throw new Error(`expected 'invalid' in error message, got: ${msg}`);
+    }
+  }
+});
+
+Deno.test("compileDisplayIdPattern: duplicate named placeholder throws clean message (#597)", () => {
+  // Previously surfaced as a raw 'Duplicate capture group name' from
+  // `new RegExp`. The validateDisplayIdPattern oracle now catches it first.
+  try {
+    compileDisplayIdPattern("SWC_{x}_{x}");
+    throw new Error("expected compileDisplayIdPattern to throw");
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (!msg.toLowerCase().includes("duplicate")) {
+      throw new Error(`expected 'duplicate' in error message, got: ${msg}`);
+    }
+  }
+});
+
 Deno.test("compileDisplayIdPattern: multi-segment prefix allowed", () => {
   const r = compileDisplayIdPattern("STAKE-REQ-{n:06d}");
   assertEquals(r.test("STAKE-REQ-000001"), true);

--- a/tests/e2e/display_id_pattern_unification_test.ts
+++ b/tests/e2e/display_id_pattern_unification_test.ts
@@ -1,0 +1,73 @@
+/**
+ * @module tests/e2e/display_id_pattern_unification_test
+ *
+ * E2E regression tests for #596 — the two `display-id-pattern` parsers
+ * (classification vs minting) no longer disagree. The annex documents
+ * `SRS_{n:4d}` (no leading zero) as valid; before the fix the mint parser
+ * accepted it but the classification parser threw "invalid padding
+ * specifier", crashing `markspec check`. A bare `{n}` was the mirror case:
+ * classifiable but silently non-mintable.
+ */
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { markspec } from "./helpers.ts";
+
+const PROJECT_YAML = `name: pattern-unification-e2e\nversion: 0.1.0\n`;
+
+// `software-requirement` uses the documented non-leading-zero form
+// `SRS_{n:4d}`; `note` uses a bare `{n}` (unpadded, mintable).
+const PROFILE_YAML = `id: "@acme/pattern-unification"
+version: 0.1.0
+profile:
+  types:
+    software-requirement:
+      extends: Requirement
+      display-id-pattern: "SRS_{n:4d}"
+      display-id-pattern-enforcement: error
+    note:
+      extends: Requirement
+      display-id-pattern: "NOTE-{n}"
+`;
+
+const MARKSPEC_YAML = `profiles:\n  - ./profiles/acme\n`;
+
+Deno.test("#596 e2e: SRS_{n:4d} pattern classifies without crashing check", async () => {
+  const { code, stderr } = await markspec(["check", "requirements.md"], {
+    files: {
+      "project.yaml": PROJECT_YAML,
+      ".markspec.yaml": MARKSPEC_YAML,
+      "profiles/acme/markspec.yaml": PROFILE_YAML,
+      "requirements.md": `# Requirements
+
+- [SRS_0001] Sensor debouncing
+
+  The sensor driver shall debounce raw inputs within 5 ms.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+`,
+    },
+  });
+  // Before #596: compileDisplayIdPattern("SRS_{n:4d}") threw, crashing check.
+  assertEquals(code, 0, stderr);
+  const mslT = stderr.split("\n").filter((l) => l.includes("MSL-T"));
+  assertEquals(mslT, []);
+});
+
+Deno.test("#596 e2e: bare {n} type is mintable via next-id", async () => {
+  const { code, stdout, stderr } = await markspec([
+    "next-id",
+    "note",
+    "notes.md",
+  ], {
+    files: {
+      "project.yaml": PROJECT_YAML,
+      ".markspec.yaml": MARKSPEC_YAML,
+      "profiles/acme/markspec.yaml": PROFILE_YAML,
+      "notes.md": `# Notes\n`,
+    },
+  });
+  // Before #596: parseDisplayIdPattern("NOTE-{n}") returned undefined and
+  // next-id exited 1 with "does not contain a recognised number placeholder".
+  assertEquals(code, 0, stderr);
+  assertStringIncludes(stdout, "NOTE-1");
+});


### PR DESCRIPTION
Closes #596.

## Problem

`display-id-pattern` was parsed by **two independent parsers that disagreed**:

- `core/validator/pattern.ts` `compileDisplayIdPattern` (classification) required leading-zero padding, so **`{n:4d}` was rejected** as "invalid padding specifier".
- `core/profile/display_id.ts` `parseDisplayIdPattern` (minting) **accepted `{n:4d}`**.

The annex (`docs/spec/model/annex-profile-schema.md` §B.3.2) documents `SRS_{n:4d}` / `HAZ_{n:3d}` as valid. A profile following the docs minted fine but **crashed `markspec check`** the moment `classifyEntry` compiled the pattern. Bare `{n}` was the mirror case: classifiable (`\d+`) but silently non-mintable.

## Fix (direction (a): accept `{n:4d}` everywhere)

Single source of grammar truth in `core/profile/display_id.ts`:

- `tokenizePattern` (moved here from the validator) + a new `validateDisplayIdPattern(pattern)` oracle returning `{ok}` / `{ok:false, message}`.
- `compileDisplayIdPattern` (classification, still builds the regex) and `parseDisplayIdPattern` (minting) both derive from this one grammar — they can no longer drift.
- `{n}` and `{n:Nd}` (N ≥ 1, leading zero optional) accepted everywhere; `{n:0d}`, multiple counters, and duplicate named placeholders (`{x}_{x}`) rejected with a clean message (the last previously surfaced as a raw `new RegExp` "Duplicate capture group name" — relevant to #597).
- Bare `{n}` now mints with width 1 (no zero-padding).

Named (counter-less) patterns still classify but stay non-mintable — making the CLI/LSP named-aware is #598.

## Tests

- Unit: `validateDisplayIdPattern` accept/reject table; `compileDisplayIdPattern` now compiles `{n:4d}`, rejects `{n:0d}`, gives a clean duplicate-name message; `parseDisplayIdPattern` mints bare `{n}` and returns undefined for named patterns.
- E2E (`tests/e2e/display_id_pattern_unification_test.ts`): `markspec check` classifies a `SRS_{n:4d}` profile without crashing; `markspec next-id` mints a bare-`{n}` type.
- Docs: corrected the internal schema's stale `{n:0Nd}` grammar one-liner to `{n:Nd}`.

`just check` green (3146 passed); `deno fmt --check` + `dprint check` green.

First of three stacked PRs (#596 → #597 → #598) for the ADR-025 follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
