### PR TITLE
fix(core): validate display-id-pattern at profile-load (PROFILE-TYPE-008)

### DIFF
--- a/docs/spec/internal/markspec-profile-schema.md
+++ b/docs/spec/internal/markspec-profile-schema.md
@@ -258,6 +258,13 @@ ADR-008's per-type key set — Annex B):
 Any other per-type key is `PROFILE-TYPE-005` (new, error). The ADR-008 per-type
 `shape:` key is **removed** (§1.3 / Annex B).
 
+A malformed `display-id-pattern` — more than one `{n}` counter, an invalid or
+zero-width padding specifier, a counter-less pattern with no literal anchor, or
+a duplicate named placeholder — is a `PROFILE-TYPE-008` profile-load error
+(new). It is compile-checked once when the profile loads, against the same
+grammar the classifier uses, so a typo is reported cleanly at load instead of
+throwing an uncaught exception during validation.
+
 ### 4.1 Attributes — inherited, optional, required
 
 A type's effective attribute set is the **union** of:

--- a/docs/spec/model/annex-profile-schema.md
+++ b/docs/spec/model/annex-profile-schema.md
@@ -176,6 +176,11 @@ would match every ID. Named patterns are classification-only: there is no
 counter to mint, so pair them with `display-id-pattern-enforcement: off` and
 author the ID by hand (`markspec next-id` / `create` skip named types).
 
+A malformed pattern — more than one counter, an invalid or zero-width padding
+specifier, a counter-less pattern with no literal prefix, or a duplicate named
+placeholder — is a `PROFILE-TYPE-008` error reported when the profile loads, not
+an uncaught failure during validation.
+
 `display-id-pattern-enforcement` controls whether an entry whose display ID does
 not match the pattern is ignored (`off`), warned (`warn`), or rejected
 (`error`).

--- a/packages/markspec/core/profile/manifest.ts
+++ b/packages/markspec/core/profile/manifest.ts
@@ -32,6 +32,7 @@ import {
   VALUE_TYPES,
   type ValueType,
 } from "../model/mod.ts";
+import { validateDisplayIdPattern } from "./display_id.ts";
 
 const VALUE_TYPE_SET: ReadonlySet<string> = new Set(VALUE_TYPES);
 
@@ -1115,6 +1116,24 @@ function parseTypeDef(
       return undefined;
     }
     displayIdPattern = r["display-id-pattern"];
+    // Compile-check the pattern here, at profile-load, against the same grammar
+    // oracle classification uses. A malformed pattern (duplicate named
+    // placeholder, bad padding, no anchor, …) is reported as a clean
+    // PROFILE-TYPE-006 diagnostic instead of throwing an uncaught exception
+    // later inside classifyEntry / checkEnforcement. Like the sibling field
+    // checks above, an error here drops the type so the bad pattern never
+    // reaches compileDisplayIdPattern (and, per parseManifest's all-or-nothing
+    // error contract, the manifest is rejected). (#597)
+    const patternValidation = validateDisplayIdPattern(displayIdPattern);
+    if (!patternValidation.ok) {
+      diagnostics.push({
+        code: "PROFILE-TYPE-008",
+        severity: "error",
+        message: `${ctx}: ${patternValidation.message}`,
+        location: { file: sourcePath, line: 1, column: 1 },
+      });
+      return undefined;
+    }
   }
 
   let enforcement: EnforcementMode = "off";

--- a/packages/markspec/core/profile/manifest_test.ts
+++ b/packages/markspec/core/profile/manifest_test.ts
@@ -4,7 +4,7 @@
  * Unit tests for markspec.yaml manifest parsing.
  */
 
-import { assertEquals, assertExists } from "@std/assert";
+import { assertEquals, assertExists, assertStringIncludes } from "@std/assert";
 import { fromFileUrl } from "@std/path";
 import { parseManifest } from "./manifest.ts";
 
@@ -127,6 +127,45 @@ profile:
 `);
   assertEquals(result.manifest, null);
   assertEquals(result.diagnostics[0].code, "PROFILE-LOAD-003");
+});
+
+Deno.test("parseManifest: invalid display-id-pattern emits PROFILE-TYPE-008 (#597)", () => {
+  const result = parseManifest(`
+id: "@acme/x"
+version: 1.0.0
+profile:
+  types:
+    sw-component:
+      extends: SoftwareComponent
+      display-id-pattern: "SWC_{x}_{x}"
+`);
+  // A malformed pattern is reported as a clean diagnostic, not thrown later.
+  // Per parseManifest's all-or-nothing error contract, the manifest is
+  // rejected (null) — the same as every other type-field error.
+  assertEquals(result.manifest, null);
+  const t006 = result.diagnostics.find((d) => d.code === "PROFILE-TYPE-008");
+  assertExists(t006);
+  assertStringIncludes(t006.message, "duplicate named placeholder");
+});
+
+Deno.test("parseManifest: valid display-id-pattern emits no PROFILE-TYPE-008 (#597)", () => {
+  const result = parseManifest(`
+id: "@acme/x"
+version: 1.0.0
+profile:
+  types:
+    software-requirement:
+      extends: Requirement
+      display-id-pattern: "SRS_{n:4d}"
+`);
+  assertExists(result.manifest);
+  assertEquals(
+    result.diagnostics.some((d) => d.code === "PROFILE-TYPE-008"),
+    false,
+  );
+  const srs = result.manifest.types.get("software-requirement");
+  assertExists(srs);
+  assertEquals(srs.displayIdPattern, "SRS_{n:4d}");
 });
 
 Deno.test("parseManifest: referenced.traceability is not a recognized key", () => {

--- a/tests/e2e/profile_pattern_validation_test.ts
+++ b/tests/e2e/profile_pattern_validation_test.ts
@@ -1,0 +1,53 @@
+/**
+ * @module tests/e2e/profile_pattern_validation_test
+ *
+ * E2E for #597 — a malformed `display-id-pattern` in a profile is reported as
+ * a clean `PROFILE-TYPE-008` diagnostic at profile-load instead of throwing an
+ * uncaught exception mid-validation (which crashed `markspec check`).
+ */
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { markspec } from "./helpers.ts";
+
+const PROJECT_YAML = `name: pattern-validation-e2e\nversion: 0.1.0\n`;
+const MARKSPEC_YAML = `profiles:\n  - ./profiles/acme\n`;
+
+// `SWC_{x}_{x}` repeats the named placeholder `{x}` — building the recognizer
+// regex would throw "Duplicate capture group name". Before #597 that surfaced
+// as an uncaught engine error during classifyEntry.
+const BAD_PROFILE_YAML = `id: "@acme/bad-pattern"
+markspec-schema: "1"
+version: 0.1.0
+profile:
+  types:
+    sw-component:
+      extends: SoftwareComponent
+      display-id-pattern: "SWC_{x}_{x}"
+      display-id-pattern-enforcement: off
+`;
+
+const COMPONENTS_MD = `# Components
+
+- [SWC_LIGHT_CTRL] Light controller
+
+  The light controller shall drive the exterior lamps.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+`;
+
+Deno.test("#597 e2e: malformed profile pattern → PROFILE-TYPE-008, not an uncaught crash", async () => {
+  const { code, stderr } = await markspec(["check", "components.md"], {
+    files: {
+      "project.yaml": PROJECT_YAML,
+      ".markspec.yaml": MARKSPEC_YAML,
+      "profiles/acme/markspec.yaml": BAD_PROFILE_YAML,
+      "components.md": COMPONENTS_MD,
+    },
+  });
+  assertEquals(code, 1, stderr);
+  assertStringIncludes(stderr, "PROFILE-TYPE-008");
+  assertStringIncludes(stderr, "duplicate named placeholder");
+  // The crux of #597: a clean MarkSpec diagnostic, never an engine-level
+  // uncaught throw / stack trace.
+  assertEquals(stderr.includes("Uncaught"), false, stderr);
+});


### PR DESCRIPTION
Closes #597.

> Stacked on #600 (#596). Base is `fix/596-unify-display-id-pattern-parsers`; review/merge after #600. The diff shown here is just the #597 change.

## Problem

A malformed `display-id-pattern` was only exercised **lazily** during `classifyEntry` / `checkEnforcement`. The profile loader (`manifest.ts`) merely type-checked that the pattern was a string, so a bad pattern threw an **uncaught exception mid-validation**, crashing `markspec check` (and the LSP `validateAll` path) with an engine-level stack trace instead of a MarkSpec diagnostic.

Reproduced (before): a profile with `display-id-pattern: "SWC_{x}_{x}"` →

```
error: Uncaught (in promise) Error: display-id-pattern 'SWC_{x}_{x}': duplicate named placeholder '{x}'
    at compileDisplayIdPattern (.../pattern.ts)
    at classifyEntry (.../types.ts:200)
```

## Fix

`parseTypeDef` now compile-checks each type's `display-id-pattern` once, at profile-load, through the shared `validateDisplayIdPattern` oracle (introduced in #596 — the same grammar the classifier uses). A malformed pattern is reported as a clean **`PROFILE-TYPE-008`** error and the type is dropped, exactly like the sibling `extends` / enum / `color` field validations. The bad pattern therefore never reaches `compileDisplayIdPattern`, and downstream validation never crashes.

`PROFILE-TYPE-006`/`007` were already reserved in the spec for the kind-graph; `PROFILE-TYPE-008` is the next free code in the per-type family.

**No defensive guard in the classifier.** Every pattern in an `EffectiveProfile` is built from a load-validated `TypeDef`, and `parseManifest` rejects the whole manifest on any error — so a malformed pattern can never reach `classifyEntry`. Guarding there would be dead code.

## Tests

- Unit (`manifest_test.ts`): a malformed pattern emits `PROFILE-TYPE-008` (manifest rejected); a valid pattern emits none and is preserved.
- E2E (`tests/e2e/profile_pattern_validation_test.ts`): `markspec check` on a `SWC_{x}_{x}` profile exits 1 with `PROFILE-TYPE-008` and **no** `Uncaught` stack trace.
- Docs: documented `PROFILE-TYPE-008` in the internal profile schema and the published annex §B.3.2.

`just check` green (3149 passed); `deno fmt --check` + `dprint check` green.

Second of three stacked PRs (#596 → #597 → #598) for the ADR-025 follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
