### PR TITLE
feat(core): persist a per-edge ULID identity ledger in markspec lock

### DIFF
--- a/docs/spec/internal/markspec-lockfile.md
+++ b/docs/spec/internal/markspec-lockfile.md
@@ -105,6 +105,12 @@ api = "https://…/api/"
 resolved-manifest-hash = "sha256:…"
 markspec-schema = 1
 
+[[edge]] # §3.1 — ULID identity ledger, one per local trace edge (issue #593)
+source-ulid = "01J…SRC" # stable ULID of the edge's source entry
+relation = "Satisfies"
+target-ulid = "01J…TGT" # stable ULID of the resolved target; omitted when unresolved
+authored-target = "SYS_BRK_0042" # the display ID (or ULID) as authored at lock time
+
 [generated-cache] # §3 — generated inverse-edge cache
 edges-hash = "sha256:…" # digest of edges.ndjson (compile-output §4.6) at lock time
 ```
@@ -126,6 +132,24 @@ time — not the edges themselves (that would duplicate the compile output,
 violating anti-unification). A reproduction step recompiles, hashes, and
 compares: identical hash ⇒ the trace graph is bit-for-bit the one the audit saw.
 The cache is _integrity metadata_, not a second copy of the graph.
+
+### 3.1 Edge identity ledger
+
+Each local trace edge is recorded as an `[[edge]]` row carrying the **stable
+ULID** of its source and (when resolved) its target, alongside the **authored
+target token** — the display ID exactly as written in source at lock time. This
+is the _identity ledger_ `markspec fmt` uses to heal a stale cross-reference: if
+a target's display ID is renamed, the source's `target-ulid` still resolves, and
+`fmt` rewrites the stale token to the target's current display ID.
+
+The ledger is **not** a second copy of the graph (cf. §3). The authored token is
+the one datum a recompile cannot reconstruct after a rename — it is identity
+provenance, not derivable state. The `generated-cache.edges-hash` remains the
+sole integrity digest ("did the graph change"); the ledger answers a different
+question ("what stable identity did this edge point at last time"). An
+unresolved target omits `target-ulid` and is also surfaced by `MSL-L006` at
+`markspec check`. `markspec lock` writes the ledger; `markspec fmt` reads it and
+is the only command that edits source.
 
 ## 4. Update mechanics
 

--- a/packages/markspec/cli/commands/lock.ts
+++ b/packages/markspec/cli/commands/lock.ts
@@ -142,6 +142,8 @@ async function runLock(options: LockOptions): Promise<void> {
       ...resolved.registries.map((r) => r.upstream),
     ],
     boundEntries: resolved.boundEntries.map((b) => b.boundEntry),
+    // TODO(#593 Task 3): populate edges from resolved trace relations
+    edges: [],
     generatedCache: {
       edgesHash: resolved.canonicalEdgeHash,
       edgesCount: resolved.canonicalEdgeCount,

--- a/packages/markspec/cli/commands/lock.ts
+++ b/packages/markspec/cli/commands/lock.ts
@@ -142,8 +142,7 @@ async function runLock(options: LockOptions): Promise<void> {
       ...resolved.registries.map((r) => r.upstream),
     ],
     boundEntries: resolved.boundEntries.map((b) => b.boundEntry),
-    // TODO(#593 Task 3): populate edges from resolved trace relations
-    edges: [],
+    edges: resolved.edges,
     generatedCache: {
       edgesHash: resolved.canonicalEdgeHash,
       edgesCount: resolved.canonicalEdgeCount,
@@ -166,6 +165,7 @@ async function runLock(options: LockOptions): Promise<void> {
           registries: { resolved: resolved.registries.length },
           "bound-entries": { resolved: resolved.boundEntries.length },
           "canonical-edges": { count: resolved.canonicalEdgeCount },
+          "ledger-edges": { count: resolved.edges.length },
         },
         diagnostics: resolved.diagnostics.map((d) => ({
           code: d.code,
@@ -176,7 +176,7 @@ async function runLock(options: LockOptions): Promise<void> {
     );
   } else {
     console.error(
-      `wrote markspec.lock (${resolved.references.length} references, ${resolved.profiles.length} profiles, ${resolved.registries.length} registries, ${resolved.boundEntries.length} bound entries, ${resolved.canonicalEdgeCount} edges)`,
+      `wrote markspec.lock (${resolved.references.length} references, ${resolved.profiles.length} profiles, ${resolved.registries.length} registries, ${resolved.boundEntries.length} bound entries, ${resolved.canonicalEdgeCount} edges, ${resolved.edges.length} ledger edges)`,
     );
   }
 

--- a/packages/markspec/cli/init/scaffolders/markspec_lock.ts
+++ b/packages/markspec/cli/init/scaffolders/markspec_lock.ts
@@ -41,6 +41,7 @@ export async function buildMarkspecLockStub(
     },
     upstreams: [],
     boundEntries: [],
+    edges: [],
     generatedCache: { edgesHash, edgesCount: 0 },
   };
   return serializeLockfile(stub);

--- a/packages/markspec/core/lock/check_test.ts
+++ b/packages/markspec/core/lock/check_test.ts
@@ -19,6 +19,7 @@ const EMPTY_RESOLVED: ResolvedUpstreams = {
   boundEntries: [],
   canonicalEdgeHash: "sha256:0",
   canonicalEdgeCount: 0,
+  edges: [],
   lockedAt: "2026-05-25T12:00:00Z",
   diagnostics: [],
 };

--- a/packages/markspec/core/lock/check_test.ts
+++ b/packages/markspec/core/lock/check_test.ts
@@ -8,6 +8,7 @@ const EMPTY_LOCKED: Lockfile = {
   meta: { markspecSchema: 1, lockedAt: "2026-05-25T12:00:00Z" },
   upstreams: [],
   boundEntries: [],
+  edges: [],
   generatedCache: { edgesHash: "sha256:0", edgesCount: 0 },
 };
 

--- a/packages/markspec/core/lock/hash_test.ts
+++ b/packages/markspec/core/lock/hash_test.ts
@@ -44,6 +44,7 @@ Deno.test("hash differs when meta.toolchain.minVersion differs", async () => {
     meta: { markspecSchema: 1, lockedAt: "2026-05-27T12:00:00Z" },
     upstreams: [],
     boundEntries: [],
+    edges: [],
     generatedCache: { edgesHash: "sha256:abc", edgesCount: 0 },
   };
   const withFloor06: Lockfile = {

--- a/packages/markspec/core/lock/mod.ts
+++ b/packages/markspec/core/lock/mod.ts
@@ -11,6 +11,7 @@ export type {
   BoundEntryBinding,
   GeneratedCache,
   LockedAttributes,
+  LockEdge,
   Lockfile,
   LockfileMeta,
   LockfileToolchain,

--- a/packages/markspec/core/lock/mod.ts
+++ b/packages/markspec/core/lock/mod.ts
@@ -36,6 +36,7 @@ export { canonicalEdgeJson, hashCanonicalEdges } from "./canonical_edges.ts";
 export type { EdgeQuad } from "./canonical_edges.ts";
 
 export {
+  extractEdgeLedger,
   extractEdgeQuads,
   resolveBoundEntries,
   resolveProfileChain,

--- a/packages/markspec/core/lock/model.ts
+++ b/packages/markspec/core/lock/model.ts
@@ -68,6 +68,30 @@ export interface BoundEntry {
   readonly bindings: readonly BoundEntryBinding[];
 }
 
+/**
+ * One resolved trace edge in the ULID identity ledger (issue #593, Slice 3).
+ *
+ * Records the stable ULID identity of an edge's source and target alongside the
+ * verbatim authored target token at lock time. The authored token is the datum
+ * a recompile cannot recover after a rename, so the ledger is identity
+ * provenance for `fmt` rename-healing — distinct from the integrity digest in
+ * {@linkcode GeneratedCache}. Distinct from `EdgeQuad` (the display-ID hash
+ * input in `canonical_edges.ts`).
+ */
+export interface LockEdge {
+  /** Stable ULID of the source entry. Always present (source is a local entry). */
+  readonly sourceUlid: string;
+  /** Trace relation attribute name, e.g. "Satisfies". */
+  readonly relation: string;
+  /**
+   * Stable ULID of the resolved target. Absent when the authored target
+   * resolves to no entry (a dangling reference, already warned by MSL-L006).
+   */
+  readonly targetUlid?: string;
+  /** Verbatim authored target token (display ID or ULID) at lock time. */
+  readonly authoredTarget: string;
+}
+
 /** Canonical-edge-graph integrity record. */
 export interface GeneratedCache {
   readonly edgesHash: string;
@@ -101,6 +125,8 @@ export interface Lockfile {
   readonly meta: LockfileMeta;
   readonly upstreams: readonly Upstream[];
   readonly boundEntries: readonly BoundEntry[];
+  /** Per-edge ULID identity ledger (issue #593, Slice 3). */
+  readonly edges: readonly LockEdge[];
   readonly generatedCache: GeneratedCache;
 }
 

--- a/packages/markspec/core/lock/model_test.ts
+++ b/packages/markspec/core/lock/model_test.ts
@@ -13,6 +13,7 @@ Deno.test("Lockfile: empty lockfile constructs", () => {
     meta: { markspecSchema: 1, lockedAt: "2026-05-25T12:00:00Z" },
     upstreams: [],
     boundEntries: [],
+    edges: [],
     generatedCache: { edgesHash: "sha256:e3b0c44...", edgesCount: 0 },
   };
   assertEquals(lf.schema, 1);

--- a/packages/markspec/core/lock/parser.ts
+++ b/packages/markspec/core/lock/parser.ts
@@ -18,6 +18,7 @@ import type { Diagnostic } from "../model/mod.ts";
 import {
   type BoundEntry,
   type BoundEntryBinding,
+  type LockEdge,
   type Lockfile,
   LOCKFILE_SCHEMA_VERSION,
   type LockfileToolchain,
@@ -247,6 +248,31 @@ export function parseLockfile(toml: string): ParseLockfileResult {
     });
   }
 
+  const edges: LockEdge[] = [];
+  const rawEdges = (raw.edge as readonly Record<string, unknown>[]) ?? [];
+  for (let i = 0; i < rawEdges.length; i++) {
+    const e = rawEdges[i];
+    const sourceUlid = requireString(e, "source-ulid");
+    const relation = requireString(e, "relation");
+    const authoredTarget = requireString(e, "authored-target");
+    if (
+      sourceUlid === undefined || relation === undefined ||
+      authoredTarget === undefined
+    ) {
+      return diag(
+        "MSL-L001",
+        `[[edge]] entry ${i}: missing required field 'source-ulid', 'relation', or 'authored-target'`,
+      );
+    }
+    const targetUlid = e["target-ulid"];
+    edges.push({
+      sourceUlid,
+      relation,
+      authoredTarget,
+      ...(typeof targetUlid === "string" ? { targetUlid } : {}),
+    });
+  }
+
   const cache = raw["generated-cache"] as Record<string, unknown> | undefined;
   if (!cache) {
     return diag("MSL-L001", "Missing [generated-cache] table");
@@ -267,6 +293,7 @@ export function parseLockfile(toml: string): ParseLockfileResult {
       : { markspecSchema, lockedAt },
     upstreams,
     boundEntries,
+    edges,
     generatedCache: { edgesHash, edgesCount },
   };
   return { lockfile, diagnostics: [] };

--- a/packages/markspec/core/lock/parser_test.ts
+++ b/packages/markspec/core/lock/parser_test.ts
@@ -1,6 +1,8 @@
 // packages/markspec/core/lock/parser_test.ts
 import { assertEquals, assertExists } from "@std/assert";
 import { parseLockfile } from "./parser.ts";
+import { serializeLockfile } from "./serializer.ts";
+import type { Lockfile } from "./model.ts";
 
 Deno.test("parseLockfile: round-trips empty lockfile", () => {
   const toml = `
@@ -264,4 +266,79 @@ edges-count = 0
   assertEquals(lockfile, undefined);
   assertEquals(diagnostics.length, 1);
   assertEquals(diagnostics[0].code, "MSL-L032");
+});
+
+// ---------------------------------------------------------------------------
+// [[edge]] ledger (issue #593, Slice 3)
+// ---------------------------------------------------------------------------
+
+Deno.test("parseLockfile: round-trips [[edge]] ledger; omitted target-ulid → undefined", () => {
+  const lf: Lockfile = {
+    schema: 1,
+    meta: { markspecSchema: 1, lockedAt: "2026-06-06T00:00:00Z" },
+    upstreams: [],
+    boundEntries: [],
+    edges: [
+      {
+        sourceUlid: "01J0000000000000000000SRC1",
+        relation: "Satisfies",
+        targetUlid: "01J0000000000000000000TGT1",
+        authoredTarget: "SYS_BRK_0042",
+      },
+      {
+        sourceUlid: "01J0000000000000000000SRC1",
+        relation: "Derived-from",
+        authoredTarget: "SYS_GONE_0001",
+      },
+    ],
+    generatedCache: { edgesHash: "sha256:0", edgesCount: 0 },
+  };
+  const toml = serializeLockfile(lf);
+  const parsed = parseLockfile(toml);
+  assertEquals(parsed.diagnostics, []);
+  assertEquals(parsed.lockfile?.edges.length, 2);
+  const satisfies = parsed.lockfile!.edges.find((e) =>
+    e.relation === "Satisfies"
+  );
+  assertEquals(satisfies?.targetUlid, "01J0000000000000000000TGT1");
+  assertEquals(satisfies?.authoredTarget, "SYS_BRK_0042");
+  const derived = parsed.lockfile!.edges.find((e) =>
+    e.relation === "Derived-from"
+  );
+  assertEquals(derived?.targetUlid, undefined);
+  assertEquals(derived?.authoredTarget, "SYS_GONE_0001");
+});
+
+Deno.test("parseLockfile: lockfile with no [[edge]] table yields edges: []", () => {
+  const toml = `schema = 1
+[meta]
+markspec-schema = 1
+locked-at = "2026-06-06T00:00:00Z"
+[generated-cache]
+edges-hash = "sha256:0"
+edges-count = 0
+`;
+  const parsed = parseLockfile(toml);
+  assertEquals(parsed.diagnostics, []);
+  assertEquals(parsed.lockfile?.edges, []);
+});
+
+Deno.test("parseLockfile: [[edge]] missing source-ulid → MSL-L001", () => {
+  const toml = `schema = 1
+[meta]
+markspec-schema = 1
+locked-at = "2026-06-06T00:00:00Z"
+
+[[edge]]
+relation = "Satisfies"
+authored-target = "SYS_BRK_0042"
+
+[generated-cache]
+edges-hash = "sha256:0"
+edges-count = 0
+`;
+  const parsed = parseLockfile(toml);
+  assertEquals(parsed.lockfile, undefined);
+  assertEquals(parsed.diagnostics.length, 1);
+  assertEquals(parsed.diagnostics[0].code, "MSL-L001");
 });

--- a/packages/markspec/core/lock/resolve.ts
+++ b/packages/markspec/core/lock/resolve.ts
@@ -17,12 +17,17 @@ import type {
   ProfileSpecifier,
   ProjectConfig,
 } from "../model/mod.ts";
-import { CORE_RELATIONS, LOCK_EXTRA_INVERSE_KEYS } from "../model/mod.ts";
+import {
+  CORE_RELATIONS,
+  LOCK_EXTRA_INVERSE_KEYS,
+  URI_SCHEME_RE,
+} from "../model/mod.ts";
 import type { Mapping } from "../sync/mod.ts";
 import { inferLockedAttributes } from "../sync/locked_attributes.ts";
 import type {
   BoundEntry,
   BoundEntryBinding,
+  LockEdge,
   UpstreamProfile,
   UpstreamReference,
   UpstreamRegistry,
@@ -228,6 +233,43 @@ export function extractEdgeQuads(entries: readonly Entry[]): EdgeQuad[] {
         });
       }
     }
+  }
+  return out;
+}
+
+/**
+ * Resolve every trace edge to a ULID identity-ledger record (issue #593,
+ * Slice 3). Reuses {@linkcode extractEdgeQuads} for the trace-key walk, then
+ * resolves the source (always a local entry → `entry.id`) and target through
+ * the dual index `byDisplayId ?? byId`. The verbatim authored target token is
+ * preserved so `fmt` rename-healing can match it later.
+ *
+ * Skips:
+ *   - edges whose source has no ULID (unstamped — not lockable);
+ *   - edges whose target is a scheme-qualified URI (intentionally external,
+ *     never a local entry — mirrors the MSL-L006 existence-check skip).
+ *
+ * An unresolved (but non-URI) target yields a record with `targetUlid`
+ * undefined — a dangling reference already surfaced by MSL-L006 at `check`.
+ */
+export function extractEdgeLedger(
+  entries: readonly Entry[],
+  byDisplayId: ReadonlyMap<string, Entry>,
+  byId: ReadonlyMap<string, Entry>,
+): LockEdge[] {
+  const out: LockEdge[] = [];
+  for (const quad of extractEdgeQuads(entries)) {
+    const sourceEntry = byDisplayId.get(quad.source) ?? byId.get(quad.source);
+    const sourceUlid = sourceEntry?.id;
+    if (sourceUlid === undefined) continue; // unstamped source — not lockable
+    if (URI_SCHEME_RE.test(quad.target)) continue; // external reference
+    const targetEntry = byDisplayId.get(quad.target) ?? byId.get(quad.target);
+    out.push({
+      sourceUlid,
+      relation: quad.relation,
+      authoredTarget: quad.target,
+      ...(targetEntry?.id !== undefined ? { targetUlid: targetEntry.id } : {}),
+    });
   }
   return out;
 }

--- a/packages/markspec/core/lock/resolve.ts
+++ b/packages/markspec/core/lock/resolve.ts
@@ -105,6 +105,8 @@ export interface ResolvedUpstreams {
   /** sha256:* of the canonical edge serialization. */
   readonly canonicalEdgeHash: string;
   readonly canonicalEdgeCount: number;
+  /** Per-edge ULID identity ledger (issue #593, Slice 3). */
+  readonly edges: readonly LockEdge[];
   /** Wall-clock timestamp the lockfile was resolved. */
   readonly lockedAt: string;
   /** Aggregate diagnostics — empty when every upstream resolved cleanly. */
@@ -303,6 +305,16 @@ export async function resolveUpstreams(
   const edges = extractEdgeQuads(opts.entries);
   const canonicalEdgeHash = await hashCanonicalEdges(edges);
 
+  // Dual index for the ULID ledger — first-entry-wins on duplicate keys,
+  // matching the validator/workspace convention.
+  const byDisplayId = new Map<string, Entry>();
+  const byId = new Map<string, Entry>();
+  for (const e of opts.entries) {
+    if (!byDisplayId.has(e.displayId)) byDisplayId.set(e.displayId, e);
+    if (e.id !== undefined && !byId.has(e.id)) byId.set(e.id, e);
+  }
+  const edgeLedger = extractEdgeLedger(opts.entries, byDisplayId, byId);
+
   const diagnostics: Diagnostic[] = [
     ...refResults.flatMap((r) => r.diagnostics),
     ...profResults.flatMap((r) => r.diagnostics),
@@ -317,6 +329,7 @@ export async function resolveUpstreams(
     boundEntries: boundResults,
     canonicalEdgeHash,
     canonicalEdgeCount: edges.length,
+    edges: edgeLedger,
     lockedAt,
     diagnostics,
   };

--- a/packages/markspec/core/lock/resolve_test.ts
+++ b/packages/markspec/core/lock/resolve_test.ts
@@ -504,3 +504,154 @@ Deno.test(
     assertEquals(edges[0].provenance, "local");
   },
 );
+
+// ---------------------------------------------------------------------------
+// extractEdgeLedger tests (Task 2 / issue #593)
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a minimal Authored entry for extractEdgeLedger tests.
+ * Matches the shape used by `mkBoundEntry` above.
+ */
+function makeEntry(
+  partial: {
+    displayId: string;
+    id: string | undefined;
+    rawAttributes: Array<{ key: string; value: string }>;
+  },
+): Entry {
+  return {
+    displayId: makeDisplayId(partial.displayId),
+    title: partial.displayId,
+    body: "",
+    rawAttributes: partial.rawAttributes,
+    typedAttributes: new Map() as never,
+    id: partial.id,
+    shape: "Authored",
+    location: { file: "x.md", line: 1, column: 1 },
+    source: { kind: "markdown" },
+    bodyTokens: [],
+  };
+}
+
+Deno.test(
+  "extractEdgeLedger: display-ID target resolves to its ULID; authored kept",
+  async () => {
+    const { extractEdgeLedger } = await import("./resolve.ts");
+    const source = makeEntry({
+      displayId: "SWE_0001",
+      id: "01J0000000000000000000SRC1",
+      rawAttributes: [{ key: "Satisfies", value: "SYS_0001" }],
+    });
+    const target = makeEntry({
+      displayId: "SYS_0001",
+      id: "01J0000000000000000000TGT1",
+      rawAttributes: [],
+    });
+    const byDisplayId = new Map([
+      ["SWE_0001", source],
+      ["SYS_0001", target],
+    ]);
+    const byId = new Map([
+      ["01J0000000000000000000SRC1", source],
+      ["01J0000000000000000000TGT1", target],
+    ]);
+    const ledger = extractEdgeLedger([source, target], byDisplayId, byId);
+    assertEquals(ledger.length, 1);
+    assertEquals(ledger[0].sourceUlid, "01J0000000000000000000SRC1");
+    assertEquals(ledger[0].relation, "Satisfies");
+    assertEquals(ledger[0].targetUlid, "01J0000000000000000000TGT1");
+    assertEquals(ledger[0].authoredTarget, "SYS_0001");
+  },
+);
+
+Deno.test(
+  "extractEdgeLedger: ULID target resolves; authoredTarget keeps the ULID verbatim",
+  async () => {
+    const { extractEdgeLedger } = await import("./resolve.ts");
+    const source = makeEntry({
+      displayId: "SWE_0002",
+      id: "01J0000000000000000000SRC2",
+      rawAttributes: [
+        { key: "Satisfies", value: "01J0000000000000000000TGT1" },
+      ],
+    });
+    const target = makeEntry({
+      displayId: "SYS_0001",
+      id: "01J0000000000000000000TGT1",
+      rawAttributes: [],
+    });
+    const byDisplayId = new Map([
+      ["SWE_0002", source],
+      ["SYS_0001", target],
+    ]);
+    const byId = new Map([
+      ["01J0000000000000000000SRC2", source],
+      ["01J0000000000000000000TGT1", target],
+    ]);
+    const ledger = extractEdgeLedger([source, target], byDisplayId, byId);
+    assertEquals(ledger.length, 1);
+    assertEquals(ledger[0].targetUlid, "01J0000000000000000000TGT1");
+    assertEquals(ledger[0].authoredTarget, "01J0000000000000000000TGT1");
+  },
+);
+
+Deno.test(
+  "extractEdgeLedger: unresolved target → targetUlid undefined, authored kept",
+  async () => {
+    const { extractEdgeLedger } = await import("./resolve.ts");
+    const source = makeEntry({
+      displayId: "SWE_0003",
+      id: "01J0000000000000000000SRC3",
+      rawAttributes: [{ key: "Satisfies", value: "SYS_GONE" }],
+    });
+    const byDisplayId = new Map([["SWE_0003", source]]);
+    const byId = new Map([["01J0000000000000000000SRC3", source]]);
+    const ledger = extractEdgeLedger([source], byDisplayId, byId);
+    assertEquals(ledger.length, 1);
+    assertEquals(ledger[0].targetUlid, undefined);
+    assertEquals(ledger[0].authoredTarget, "SYS_GONE");
+  },
+);
+
+Deno.test(
+  "extractEdgeLedger: URI-scheme target is skipped (external, not a local edge)",
+  async () => {
+    const { extractEdgeLedger } = await import("./resolve.ts");
+    // References has lockEdge:true so extractEdgeQuads will emit a quad for it.
+    // The URI_SCHEME_RE skip then filters it out — exercising the skip branch.
+    const source = makeEntry({
+      displayId: "SWE_0004",
+      id: "01J0000000000000000000SRC4",
+      rawAttributes: [{ key: "References", value: "urn:iso:std:iso:26262" }],
+    });
+    const byDisplayId = new Map([["SWE_0004", source]]);
+    const byId = new Map([["01J0000000000000000000SRC4", source]]);
+    const ledger = extractEdgeLedger([source], byDisplayId, byId);
+    assertEquals(ledger.length, 0);
+  },
+);
+
+Deno.test(
+  "extractEdgeLedger: source with no ULID is skipped (not lockable)",
+  async () => {
+    const { extractEdgeLedger } = await import("./resolve.ts");
+    const source = makeEntry({
+      displayId: "SWE_0005",
+      id: undefined,
+      rawAttributes: [{ key: "Satisfies", value: "SYS_0001" }],
+    });
+    const target = makeEntry({
+      displayId: "SYS_0001",
+      id: "01J0000000000000000000TGT1",
+      rawAttributes: [],
+    });
+    const byDisplayId = new Map([
+      ["SWE_0005", source],
+      ["SYS_0001", target],
+    ]);
+    const byId = new Map([["01J0000000000000000000TGT1", target]]);
+    const ledger = extractEdgeLedger([source, target], byDisplayId, byId);
+    assertEquals(ledger.length, 0);
+  },
+);

--- a/packages/markspec/core/lock/resolve_test.ts
+++ b/packages/markspec/core/lock/resolve_test.ts
@@ -41,6 +41,7 @@ Deno.test("ResolveUpstreamsOptions: type compiles with empty inputs", () => {
     boundEntries: [],
     canonicalEdgeHash: "sha256:0",
     canonicalEdgeCount: 0,
+    edges: [],
     lockedAt: "2026-05-25T12:00:00Z",
     diagnostics: [],
   };
@@ -629,6 +630,47 @@ Deno.test(
     const byId = new Map([["01J0000000000000000000SRC4", source]]);
     const ledger = extractEdgeLedger([source], byDisplayId, byId);
     assertEquals(ledger.length, 0);
+  },
+);
+
+// ---------------------------------------------------------------------------
+// resolveUpstreams: edge ledger population (Task 3 / issue #593)
+// ---------------------------------------------------------------------------
+
+Deno.test(
+  "resolveUpstreams: populates the edge ledger from entries",
+  async () => {
+    const source = makeEntry({
+      displayId: "SWE_0001",
+      id: "01J0000000000000000000SRC1",
+      rawAttributes: [{ key: "Satisfies", value: "SYS_0001" }],
+    });
+    const target = makeEntry({
+      displayId: "SYS_0001",
+      id: "01J0000000000000000000TGT1",
+      rawAttributes: [],
+    });
+    const resolved = await resolveUpstreams({
+      entries: [source, target],
+      profileChain: [],
+      config: {
+        name: "x",
+        version: "0.0.0",
+        labels: [],
+        parents: [],
+        parentFallback: "",
+        captionConventions: {},
+      },
+      mappings: [],
+      fetchUrl: () => Promise.resolve({ error: "no network in test" }),
+      readFile: () => Promise.resolve({ error: "no fs in test" }),
+      now: () => new Date("2026-06-06T00:00:00Z"),
+    });
+    assertEquals(resolved.edges.length, 1);
+    assertEquals(resolved.edges[0].sourceUlid, "01J0000000000000000000SRC1");
+    assertEquals(resolved.edges[0].targetUlid, "01J0000000000000000000TGT1");
+    assertEquals(resolved.edges[0].authoredTarget, "SYS_0001");
+    assertEquals(resolved.edges[0].relation, "Satisfies");
   },
 );
 

--- a/packages/markspec/core/lock/schema_test.ts
+++ b/packages/markspec/core/lock/schema_test.ts
@@ -61,6 +61,14 @@ function richLockfile(): Lockfile {
         ],
       },
     ],
+    edges: [
+      {
+        sourceUlid: "01J0000000000000000000SRC1",
+        relation: "Satisfies",
+        targetUlid: "01J0000000000000000000TGT1",
+        authoredTarget: "SYS_BRK_0042",
+      },
+    ],
     generatedCache: {
       edgesHash: "sha256:edges001",
       edgesCount: 5,

--- a/packages/markspec/core/lock/serializer.ts
+++ b/packages/markspec/core/lock/serializer.ts
@@ -10,6 +10,7 @@
  */
 
 import type {
+  LockEdge,
   Lockfile,
   UpstreamProfile,
   UpstreamReference,
@@ -109,11 +110,34 @@ export function serializeLockfile(lf: Lockfile): string {
     }
   }
 
+  const edges = lf.edges.slice().sort(compareLockEdges);
+  for (const e of edges) {
+    parts.push("\n[[edge]]\n");
+    parts.push(`source-ulid     = ${tomlString(e.sourceUlid)}\n`);
+    parts.push(`relation        = ${tomlString(e.relation)}\n`);
+    if (e.targetUlid !== undefined) {
+      parts.push(`target-ulid     = ${tomlString(e.targetUlid)}\n`);
+    }
+    parts.push(`authored-target = ${tomlString(e.authoredTarget)}\n`);
+  }
+
   parts.push("\n[generated-cache]\n");
   parts.push(`edges-hash = ${tomlString(lf.generatedCache.edgesHash)}\n`);
   parts.push(`edges-count = ${lf.generatedCache.edgesCount}\n`);
 
   return parts.join("");
+}
+
+/**
+ * Deterministic edge order: (sourceUlid, relation, authoredTarget). Input order
+ * never affects output, so identical project state → byte-identical lockfile.
+ */
+function compareLockEdges(a: LockEdge, b: LockEdge): number {
+  const s = a.sourceUlid.localeCompare(b.sourceUlid);
+  if (s !== 0) return s;
+  const r = a.relation.localeCompare(b.relation);
+  if (r !== 0) return r;
+  return a.authoredTarget.localeCompare(b.authoredTarget);
 }
 
 /**

--- a/packages/markspec/core/lock/serializer_test.ts
+++ b/packages/markspec/core/lock/serializer_test.ts
@@ -9,6 +9,7 @@ const EMPTY_LOCKFILE: Lockfile = {
   meta: { markspecSchema: 1, lockedAt: "2026-05-25T12:00:00Z" },
   upstreams: [],
   boundEntries: [],
+  edges: [],
   generatedCache: { edgesHash: "sha256:e3b0c44", edgesCount: 0 },
 };
 
@@ -118,6 +119,7 @@ Deno.test("serializeLockfile: emits [meta.toolchain] after [meta]", () => {
     },
     upstreams: [],
     boundEntries: [],
+    edges: [],
     generatedCache: { edgesHash: "sha256:abc", edgesCount: 0 },
   };
   const out = serializeLockfile(lf);
@@ -148,6 +150,7 @@ Deno.test("serializeLockfile: omits [meta.toolchain] when absent", () => {
     },
     upstreams: [],
     boundEntries: [],
+    edges: [],
     generatedCache: { edgesHash: "sha256:abc", edgesCount: 0 },
   };
   const out = serializeLockfile(lf);
@@ -165,6 +168,7 @@ Deno.test("lockfile round-trips with [meta.toolchain]", () => {
     },
     upstreams: [],
     boundEntries: [],
+    edges: [],
     generatedCache: { edgesHash: "sha256:abc", edgesCount: 0 },
   };
   const serialized = serializeLockfile(original);
@@ -182,6 +186,7 @@ Deno.test("lockfile round-trips without [meta.toolchain]", () => {
     },
     upstreams: [],
     boundEntries: [],
+    edges: [],
     generatedCache: { edgesHash: "sha256:abc", edgesCount: 0 },
   };
   const serialized = serializeLockfile(original);
@@ -197,4 +202,44 @@ Deno.test("serializer: first line is the #:schema directive", () => {
     firstLine,
     "#:schema https://driftsys.github.io/markspec/schemas/lock/v1.json",
   );
+});
+
+Deno.test("serializeLockfile: emits [[edge]] tables sorted by (source, relation, authored-target)", () => {
+  const lf: Lockfile = {
+    schema: 1,
+    meta: { markspecSchema: 1, lockedAt: "2026-06-06T00:00:00Z" },
+    upstreams: [],
+    boundEntries: [],
+    edges: [
+      {
+        sourceUlid: "01J0000000000000000000SRC2",
+        relation: "Satisfies",
+        targetUlid: "01J0000000000000000000TGT2",
+        authoredTarget: "SYS_BRK_0099",
+      },
+      {
+        sourceUlid: "01J0000000000000000000SRC1",
+        relation: "Satisfies",
+        targetUlid: "01J0000000000000000000TGT1",
+        authoredTarget: "SYS_BRK_0042",
+      },
+      {
+        sourceUlid: "01J0000000000000000000SRC1",
+        relation: "Derived-from",
+        authoredTarget: "SYS_GONE_0001",
+      },
+    ],
+    generatedCache: { edgesHash: "sha256:0", edgesCount: 0 },
+  };
+  const toml = serializeLockfile(lf);
+  const firstSrc1 = toml.indexOf("01J0000000000000000000SRC1");
+  const src2 = toml.indexOf("01J0000000000000000000SRC2");
+  assertEquals(firstSrc1 < src2, true);
+  assertStringIncludes(toml, "[[edge]]");
+  assertStringIncludes(toml, 'relation        = "Satisfies"');
+  assertStringIncludes(toml, 'authored-target = "SYS_BRK_0042"');
+  const goneIdx = toml.indexOf('authored-target = "SYS_GONE_0001"');
+  const goneBlock = toml.slice(goneIdx - 200, goneIdx);
+  assertEquals(goneBlock.includes("01J0000000000000000000SRC1"), true);
+  assertEquals(serializeLockfile(lf), toml); // determinism
 });

--- a/packages/markspec/core/mod.ts
+++ b/packages/markspec/core/mod.ts
@@ -294,6 +294,7 @@ export * as typl from "./typl/mod.ts";
 export {
   canonicalEdgeJson,
   checkDrift,
+  extractEdgeLedger,
   extractEdgeQuads,
   hashCanonicalEdges,
   isBelowFloor,

--- a/packages/markspec/core/mod.ts
+++ b/packages/markspec/core/mod.ts
@@ -315,6 +315,7 @@ export type {
   FetchUrl,
   GeneratedCache,
   LockedAttributes,
+  LockEdge,
   Lockfile,
   LockfileMeta,
   LockfileToolchain,

--- a/packages/markspec/lsp/version_notification_test.ts
+++ b/packages/markspec/lsp/version_notification_test.ts
@@ -24,6 +24,7 @@ function lockfileWith(toolchainMinVersion: string | undefined): Lockfile {
     },
     upstreams: [],
     boundEntries: [],
+    edges: [],
     generatedCache: EMPTY_CACHE,
   };
 }

--- a/schemas/lock/v1.json
+++ b/schemas/lock/v1.json
@@ -102,6 +102,20 @@
         }
       }
     },
+    "edge": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["source-ulid", "relation", "authored-target"],
+        "properties": {
+          "source-ulid": { "type": "string" },
+          "relation": { "type": "string" },
+          "target-ulid": { "type": "string" },
+          "authored-target": { "type": "string" }
+        }
+      }
+    },
     "generated-cache": {
       "type": "object",
       "additionalProperties": false,

--- a/tests/e2e/display_id_trace_lock_test.ts
+++ b/tests/e2e/display_id_trace_lock_test.ts
@@ -1,0 +1,104 @@
+/**
+ * @module tests/e2e/display_id_trace_lock_test
+ *
+ * E2E tests for the edge ULID ledger written by `markspec lock`.
+ * Verifies that trace relations between stamped entries are recorded
+ * as `[[edge]]` blocks in markspec.lock, with ULIDs resolved from
+ * the workspace index.
+ */
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { join } from "@std/path";
+import { markspecInDir, markspecPersist } from "./helpers.ts";
+
+const PROJECT_YAML = `name: lock-edge-e2e\nversion: 0.1.0\n`;
+
+// Each Id is a 26-char Crockford-base32 string. Source Satisfies target by DISPLAY ID.
+const SYS = `# System
+
+- [SYS_0001] Target requirement
+
+  Body text.
+
+      Id: 01SYS000000000000000000001
+`;
+const SWE = `# Software
+
+- [SWE_0001] Source requirement
+
+  Body text.
+
+      Id: 01SWE000000000000000000001
+      Satisfies: SYS_0001
+`;
+const FILES = { "project.yaml": PROJECT_YAML, "sys.md": SYS, "swe.md": SWE };
+
+Deno.test(
+  "lock: persists target ULID per edge; never edits source; --check round-trips",
+  async () => {
+    const run = await markspecPersist(["lock"], {
+      files: FILES,
+      permissions: ["--allow-env", "--allow-run"],
+    });
+    try {
+      assertEquals(run.code, 0, run.stderr);
+      const lock = await Deno.readTextFile(join(run.dir, "markspec.lock"));
+      assertStringIncludes(lock, "[[edge]]");
+      assertStringIncludes(
+        lock,
+        'source-ulid     = "01SWE000000000000000000001"',
+      );
+      assertStringIncludes(lock, 'relation        = "Satisfies"');
+      assertStringIncludes(
+        lock,
+        'target-ulid     = "01SYS000000000000000000001"',
+      );
+      assertStringIncludes(lock, 'authored-target = "SYS_0001"');
+      // lock never edits source files.
+      assertEquals(await Deno.readTextFile(join(run.dir, "swe.md")), SWE);
+      assertEquals(await Deno.readTextFile(join(run.dir, "sys.md")), SYS);
+      // --check immediately after lock → no drift (exit 0).
+      const check = await markspecInDir(
+        run.dir,
+        ["lock", "--check"],
+        ["--allow-env", "--allow-run"],
+      );
+      assertEquals(check.code, 0, check.stderr);
+    } finally {
+      await Deno.remove(run.dir, { recursive: true });
+    }
+  },
+);
+
+Deno.test(
+  "lock: unresolved trace target omits target-ulid in the ledger",
+  async () => {
+    const SWE_DANGLING = `# Software
+
+- [SWE_0002] Source with dangling ref
+
+  Body text.
+
+      Id: 01SWE000000000000000000002
+      Satisfies: SYS_GONE_0001
+`;
+    const run = await markspecPersist(["lock"], {
+      files: {
+        "project.yaml": PROJECT_YAML,
+        "swe.md": SWE_DANGLING,
+      },
+      permissions: ["--allow-env", "--allow-run"],
+    });
+    try {
+      assertEquals(run.code, 0, run.stderr);
+      const lock = await Deno.readTextFile(join(run.dir, "markspec.lock"));
+      assertStringIncludes(lock, 'authored-target = "SYS_GONE_0001"');
+      // target-ulid must NOT appear in the edge block for a dangling ref.
+      const idx = lock.indexOf('authored-target = "SYS_GONE_0001"');
+      const block = lock.slice(Math.max(0, idx - 200), idx);
+      assertEquals(block.includes("target-ulid"), false);
+    } finally {
+      await Deno.remove(run.dir, { recursive: true });
+    }
+  },
+);


### PR DESCRIPTION
## Summary

PR2 of the #593 epic (*display IDs in trace relations*). Slice 3: `markspec lock`
now resolves and persists a **per-edge ULID identity ledger** to `markspec.lock`,
so a renamed display ID is always recoverable. `lock` never edits source.

Builds on PR1 (#599, merged): the validator's dual-resolution spine
(`byDisplayId.get(v) ?? byId.get(v)`) and the relaxed `id`/`id-list` format gate.

## What changed

- **Model** — new `LockEdge` type: `{ sourceUlid, relation, targetUlid?, authoredTarget }`.
  `Lockfile` gains a required `edges: readonly LockEdge[]`.
- **Serialization** — new `[[edge]]` TOML array-of-tables, sorted deterministically
  by `(sourceUlid, relation, authoredTarget)`; `target-ulid` omitted when the
  target is unresolved. Parser round-trips it (edge-less lockfiles → `edges: []`).
  JSON schema `schemas/lock/v1.json` extended with the `edge` property.
- **Resolver** — new pure `extractEdgeLedger(entries, byDisplayId, byId)` reuses
  `extractEdgeQuads` for the trace-key walk, resolves source (`entry.id`) and
  target (dual index) to ULIDs, keeps the verbatim authored token. Skips
  URI-scheme targets and unstamped sources.
- **CLI** — `resolveUpstreams` builds the dual index and populates the ledger;
  `markspec lock` persists it and reports the ledger count (human + `--format json`).
- **Docs** — `docs/spec/internal/markspec-lockfile.md` §2.2 example + new §3.1
  "Edge identity ledger".

## Design decisions (resolved from the spec's §9 open items)

- **Lockfile TOML shape:** a new top-level `[[edge]]` array-of-tables, **not** an
  extension of `[generated-cache]`. The summary digest stays a summary; the ledger
  is an idiomatic array-of-tables matching `[[upstream.*]]` / `[[bound-entry]]`.
  `[generated-cache]` stays byte-stable — the integrity hash is unchanged.
- **Anti-unification:** the ledger is *not* a second copy of the graph. It records
  stable ULIDs + the **authored display-ID token at lock time** — the one datum a
  recompile cannot recover after a rename. `edges-hash` remains the sole integrity
  digest; the ledger answers "what identity did this edge point at last time" for
  `fmt` rename-healing (PR3).
- **`checkDrift` unchanged:** graph drift stays covered by MSL-L212 (display-ID
  hash). `lock --check` round-trips the ledger by re-deriving it deterministically.

## Tests

- Unit (colocated): `LockEdge` serialize/parse round-trip incl. omitted
  `target-ulid` + absent-`[[edge]]` back-compat + the MSL-L001 missing-field path;
  `extractEdgeLedger` (display-ID/ULID/unresolved/URI-skip/unstamped-source);
  `resolveUpstreams` populates the ledger; schema test validates a populated
  `[[edge]]` lockfile via Ajv.
- E2E (blackbox): `lock` persists `target-ulid` per edge against the authored
  display ID; **source `.md` is byte-unchanged**; `lock --check` round-trips
  (exit 0); an unresolved target omits `target-ulid`.

`just build` + `deno fmt --check` + `dprint check` all green.

Refs #593.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
