### PR TITLE
feat(cli): named-aware next-id/create/insert + LSP scaffold

### DIFF
--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -341,6 +341,16 @@ markspec next-id requirement "docs/**/*.md" --format json
 # → {"type":"requirement","displayId":"SRS_PRJ_0004"}
 ```
 
+For a **named (counter-less) type** — one whose `display-id-pattern` has no
+`{n}` counter, e.g. `sw-component: "SWC_{name}"` (ADR-025) — there is no number
+to mint. `next-id`, `create`, and `insert` instead emit a `<name>` placeholder
+template for you to fill in by hand:
+
+```sh
+markspec next-id sw-component "docs/**/*.md"
+# → SWC_<name>   (with a note on stderr: author the identifier yourself)
+```
+
 #### lint
 
 Run prose-quality analysis on entries (INCOSE lexicon, modal keywords,

--- a/docs/spec/model/annex-profile-schema.md
+++ b/docs/spec/model/annex-profile-schema.md
@@ -174,7 +174,10 @@ It requires a non-empty literal prefix plus a trailing named placeholder (e.g.
 underscores included. A bare `{name}` with no literal prefix is rejected — it
 would match every ID. Named patterns are classification-only: there is no
 counter to mint, so pair them with `display-id-pattern-enforcement: off` and
-author the ID by hand (`markspec next-id` / `create` skip named types).
+author the identifier by hand. `markspec next-id` / `create` / `insert` do not
+auto-number a named type — they emit a `<name>` placeholder template (e.g.
+`SWC_<name>`) to fill in, and the LSP offers a matching `${1:name}` scaffold
+completion.
 
 A malformed pattern — more than one counter, an invalid or zero-width padding
 specifier, a counter-less pattern with no literal prefix, or a duplicate named

--- a/packages/markspec/cli/commands/id_helpers.ts
+++ b/packages/markspec/cli/commands/id_helpers.ts
@@ -10,30 +10,59 @@ import {
   highestDisplayIdNumber,
   parseDisplayIdPattern,
   type ProfileChain,
+  validateDisplayIdPattern,
 } from "../../core/mod.ts";
+
+/** A named (counter-less) placeholder — `{name}`, `{scope}` — in a pattern. */
+const NAMED_PLACEHOLDER_RE = /\{([A-Za-z][A-Za-z0-9_]*)\}/g;
+
+/**
+ * Render a *named* (counter-less) `display-id-pattern` as a fill-in
+ * template: each `{name}` placeholder becomes `<name>` for the author to
+ * replace by hand. e.g. `SWC_{name}` → `SWC_<name>`, `X_{a}_{b}` →
+ * `X_<a>_<b>`. Literals are left untouched.
+ */
+export function namedIdTemplate(pattern: string): string {
+  return pattern.replace(NAMED_PLACEHOLDER_RE, "<$1>");
+}
 
 /**
  * Compute the next display ID for a given pattern and existing entries.
  *
- * Parses the `{n:Nd}` placeholder from `pattern`, scans `entries` for
- * the highest existing number with the same prefix/suffix, and returns
+ * For a *numbered* pattern, parses the `{n:Nd}` counter, scans `entries`
+ * for the highest existing number with the same prefix/suffix, and returns
  * `prefix + (max+1 zero-padded to N digits) + suffix`.
  *
- * Exits with an error message if `pattern` contains no valid `{n:Nd}`
- * placeholder.
+ * A *named* (counter-less) type — e.g. `sw-component: "SWC_{name}"` (ADR-025)
+ * — has no counter to mint. Rather than failing, this prints a "named type,
+ * author the identifier yourself" note to stderr and returns a placeholder
+ * template (`SWC_<name>`) so `create` / `insert` still scaffold a usable
+ * block and `next-id` prints the form to fill in.
+ *
+ * Exits only when `pattern` is genuinely malformed (which profile-load now
+ * rejects upstream via PROFILE-TYPE-008, so this is a defensive fallback).
  */
 export function nextDisplayId(
   pattern: string,
   entries: Iterable<{ displayId: string }>,
 ): string {
   const shape = parseDisplayIdPattern(pattern);
-  if (!shape) {
-    console.error(
-      `error: display-id-pattern '${pattern}' does not contain a recognised number placeholder ('{n:Nd}')`,
-    );
-    Deno.exit(1);
+  if (shape) {
+    return formatDisplayId(shape, highestDisplayIdNumber(shape, entries) + 1);
   }
-  return formatDisplayId(shape, highestDisplayIdNumber(shape, entries) + 1);
+  const validation = validateDisplayIdPattern(pattern);
+  if (validation.ok) {
+    const template = namedIdTemplate(pattern);
+    console.error(
+      `note: '${pattern}' is a named (counter-less) type — not auto-numbered; ` +
+        `author the identifier yourself by replacing the placeholder in '${template}'`,
+    );
+    return template;
+  }
+  console.error(
+    `error: display-id-pattern '${pattern}' is invalid: ${validation.message}`,
+  );
+  Deno.exit(1);
 }
 
 /**

--- a/packages/markspec/cli/commands/id_helpers_test.ts
+++ b/packages/markspec/cli/commands/id_helpers_test.ts
@@ -1,0 +1,17 @@
+/**
+ * @module cli/commands/id_helpers_test
+ */
+
+import { assertEquals } from "@std/assert";
+import { namedIdTemplate } from "./id_helpers.ts";
+
+Deno.test("namedIdTemplate: replaces each named placeholder with <name>", () => {
+  assertEquals(namedIdTemplate("SWC_{name}"), "SWC_<name>");
+  assertEquals(namedIdTemplate("HWC_{name}"), "HWC_<name>");
+  assertEquals(namedIdTemplate("XREQ_{scope}"), "XREQ_<scope>");
+});
+
+Deno.test("namedIdTemplate: handles multiple placeholders and keeps literals", () => {
+  assertEquals(namedIdTemplate("X_{a}_{b}"), "X_<a>_<b>");
+  assertEquals(namedIdTemplate("SWC_{name}-draft"), "SWC_<name>-draft");
+});

--- a/packages/markspec/lsp/completions.ts
+++ b/packages/markspec/lsp/completions.ts
@@ -202,6 +202,14 @@ export interface EntryTypeInfo {
    * `detail` field. `undefined` or `false` → no special treatment.
    */
   readonly modeRecommended?: boolean;
+  /**
+   * `true` for a named (counter-less) type (ADR-025) whose IDs are named,
+   * not numbered — e.g. `sw-component: "SWC_{name}"`. `prefix` carries the
+   * literal anchor (`SWC_`); `width` / `suffix` / `nextNumber` are unused.
+   * The scaffold inserts a `${1:NAME}` tab stop after the prefix instead of
+   * a minted number (#598).
+   */
+  readonly named?: boolean;
 }
 
 /**
@@ -283,6 +291,12 @@ export interface ScaffoldSnippetInput {
   readonly suffix: string;
   readonly nextNumber: number;
   readonly ulid: string;
+  /**
+   * `true` to render a named (counter-less) scaffold: a `${1:NAME}` tab stop
+   * after the literal `prefix` instead of a minted display ID. `width`,
+   * `suffix`, and `nextNumber` are ignored in this mode (#598).
+   */
+  readonly named?: boolean;
 }
 
 /**
@@ -307,6 +321,12 @@ export interface ScaffoldCompletionData {
   readonly prefix: string;
   readonly width: number;
   readonly suffix: string;
+  /**
+   * `true` for a named (counter-less) type (#598). The resolve handler skips
+   * the number-minting path and re-renders the `${1:NAME}` snippet with a
+   * fresh ULID; `width` / `suffix` are unused.
+   */
+  readonly named?: boolean;
   /**
    * Present only for mid-typed scaffold items (see
    * {@linkcode buildMidTypedScaffoldItems}): the exact range the
@@ -343,6 +363,17 @@ export function renderScaffoldSnippet(
   input: ScaffoldSnippetInput,
 ): { label: string; insertText: string } {
   const safeTypeName = escapeSnippet(input.typeName);
+  // Named (counter-less) type (#598): no number to mint. The author types
+  // the identifier into the first tab stop after the literal prefix, so the
+  // Title/Body/Satisfies stops shift one place to avoid colliding with it.
+  if (input.named) {
+    const safePrefix = escapeSnippet(input.prefix);
+    return {
+      label: `New ${safeTypeName} (${input.prefix}<name>)`,
+      insertText:
+        `${safePrefix}\${1:NAME}] \${2:Title}\n\n  \${3:Body.}\n\n      Id: ${input.ulid}\n      \${4:Satisfies: }`,
+    };
+  }
   // Format the display ID via the shared `formatDisplayId` so width
   // + suffix come straight from the profile's pattern, then escape
   // the result for snippet syntax. Escaping AFTER formatting is
@@ -423,6 +454,7 @@ export function buildBlockScaffoldItems(
       suffix: type.suffix,
       nextNumber: type.nextNumber,
       ulid: ulidProvider(),
+      named: type.named,
     });
     const detail = type.modeRecommended === true
       ? `${type.name} (recommended)`
@@ -462,6 +494,10 @@ export interface MidTypedScaffoldItem {
   readonly prefix: string;
   readonly width: number;
   readonly suffix: string;
+  /** `true` for a named (counter-less) type — the server passes this into
+   * the resolve-time {@linkcode ScaffoldCompletionData} so it skips minting
+   * a number (#598). */
+  readonly named?: boolean;
   readonly textEdit: {
     readonly range: ReplacementRange;
     readonly newText: string;
@@ -525,6 +561,7 @@ export function buildMidTypedScaffoldItems(
       suffix: type.suffix,
       nextNumber: type.nextNumber,
       ulid: ulidProvider(),
+      named: type.named,
     });
     return {
       label: rendered.label,
@@ -533,6 +570,7 @@ export function buildMidTypedScaffoldItems(
       prefix: type.prefix,
       width: type.width,
       suffix: type.suffix,
+      named: type.named,
       textEdit: { range: replacementRange, newText: rendered.insertText },
     };
   });

--- a/packages/markspec/lsp/completions_test.ts
+++ b/packages/markspec/lsp/completions_test.ts
@@ -671,3 +671,63 @@ Deno.test("buildMidTypedScaffoldItems: empty types → empty array", () => {
   );
   assertEquals(items.length, 0);
 });
+
+// --- #598: named (counter-less) type scaffolds ---
+
+const NAMED_ULID = "01HGW2Q8MNP3RSTVWXYZABCDEF";
+
+Deno.test("renderScaffoldSnippet: named type emits a ${1:NAME} placeholder snippet (#598)", () => {
+  const snippet = renderScaffoldSnippet({
+    typeName: "sw-component",
+    prefix: "SWC_",
+    width: 0,
+    suffix: "",
+    nextNumber: 0,
+    ulid: NAMED_ULID,
+    named: true,
+  });
+  assertEquals(snippet.label, "New sw-component (SWC_<name>)");
+  // The author types the identifier into the first tab stop after the prefix.
+  assertEquals(snippet.insertText.startsWith("SWC_${1:NAME}]"), true);
+  assertEquals(snippet.insertText.includes(`Id: ${NAMED_ULID}`), true);
+  // Trailer tab stops shift past the name placeholder.
+  assertEquals(snippet.insertText.includes("${2:Title}"), true);
+  assertEquals(snippet.insertText.includes("${3:Body.}"), true);
+  assertEquals(snippet.insertText.includes("${4:Satisfies: }"), true);
+});
+
+Deno.test("buildBlockScaffoldItems: includes named types with a name placeholder (#598)", () => {
+  const items = buildBlockScaffoldItems(
+    [{
+      name: "sw-component",
+      prefix: "SWC_",
+      width: 0,
+      suffix: "",
+      nextNumber: 0,
+      named: true,
+    }],
+    () => NAMED_ULID,
+  );
+  assertEquals(items.length, 1);
+  assertEquals(items[0].label, "New sw-component (SWC_<name>)");
+  assertEquals(items[0].insertText?.startsWith("SWC_${1:NAME}]"), true);
+});
+
+Deno.test("buildMidTypedScaffoldItems: matches a named type by its leading literal (#598)", () => {
+  const items = buildMidTypedScaffoldItems(
+    [{
+      name: "sw-component",
+      prefix: "SWC_",
+      width: 0,
+      suffix: "",
+      nextNumber: 0,
+      named: true,
+    }],
+    "SWC_",
+    () => NAMED_ULID,
+    MID_RANGE,
+  );
+  assertEquals(items.length, 1);
+  assertEquals(items[0].named, true);
+  assertEquals(items[0].textEdit.newText.startsWith("SWC_${1:NAME}]"), true);
+});

--- a/packages/markspec/lsp/server.ts
+++ b/packages/markspec/lsp/server.ts
@@ -50,6 +50,7 @@ import {
   parseLockfile,
   type ProjectConfig,
   targetsForRelation,
+  validateDisplayIdPattern,
   VERSION,
 } from "../core/mod.ts";
 import { extendsTransitively } from "../core/profile/discipline_mode.ts";
@@ -298,15 +299,9 @@ function getEntryTypes(): EntryTypeInfo[] {
   for (const [name, typeDef] of profile.types) {
     const pattern = typeDef.value.displayIdPattern.value;
     if (!pattern) continue;
-    // Parse the `{n:Nd}` placeholder. Width and suffix flow through
-    // the snippet so profiles using non-4-digit IDs (`{n:6d}`) or
-    // a trailing literal don't produce mis-formatted scaffolds.
-    const shape = parseDisplayIdPattern(pattern);
-    if (!shape) continue;
-    const { prefix, width, suffix } = shape;
-    const nextNumber = index.getNextDisplayIdNumber(prefix, suffix);
 
-    // ADR-017 Slice 5: mark mode-relevant types as recommended.
+    // ADR-017 Slice 5: mark mode-relevant types as recommended. Shared by
+    // both the numbered and named branches below.
     const isRequirementShaped = extendsTransitively(
       name,
       "Requirement",
@@ -317,7 +312,33 @@ function getEntryTypes(): EntryTypeInfo[] {
       (mode === "flat" && isRequirementShaped && !hasDiscipline) ||
       (mode === "none" && isRequirementShaped);
 
-    types.push({ name, prefix, width, suffix, nextNumber, modeRecommended });
+    // Numbered pattern: parse the `{n:Nd}` placeholder. Width and suffix flow
+    // through the snippet so profiles using non-4-digit IDs (`{n:6d}`) or a
+    // trailing literal don't produce mis-formatted scaffolds.
+    const shape = parseDisplayIdPattern(pattern);
+    if (shape) {
+      const { prefix, width, suffix } = shape;
+      const nextNumber = index.getNextDisplayIdNumber(prefix, suffix);
+      types.push({ name, prefix, width, suffix, nextNumber, modeRecommended });
+      continue;
+    }
+
+    // Named (counter-less) type (ADR-025, #598): not mintable, but still
+    // offer a `${1:NAME}` scaffold. The literal anchor is everything before
+    // the first placeholder. A malformed pattern is skipped — profile-load
+    // (#597) already rejects those via PROFILE-TYPE-008.
+    if (!validateDisplayIdPattern(pattern).ok) continue;
+    const firstBrace = pattern.indexOf("{");
+    const prefix = firstBrace >= 0 ? pattern.slice(0, firstBrace) : pattern;
+    types.push({
+      name,
+      prefix,
+      width: 0,
+      suffix: "",
+      nextNumber: 0,
+      named: true,
+      modeRecommended,
+    });
   }
   return types;
 }
@@ -787,6 +808,7 @@ connection.onCompletion((params): CompletionItem[] | CompletionList => {
           prefix: item.prefix,
           width: item.width,
           suffix: item.suffix,
+          named: item.named,
           replacementRange: item.textEdit.range,
         } satisfies ScaffoldCompletionData,
       }));
@@ -817,6 +839,7 @@ connection.onCompletion((params): CompletionItem[] | CompletionList => {
               prefix: type.prefix,
               width: type.width,
               suffix: type.suffix,
+              named: type.named,
             } satisfies ScaffoldCompletionData
             : undefined,
         };
@@ -925,33 +948,53 @@ connection.onCompletionResolve((item): CompletionItem => {
   }
   // Defend against tampered or malformed resolve payloads from a hostile or
   // buggy LSP client. The typed cast above does not validate at runtime.
+  // These checks apply to both numbered and named scaffolds.
   if (
     typeof data.prefix !== "string" || data.prefix.length > 64 ||
     typeof data.typeName !== "string" || data.typeName.length > 128 ||
-    typeof data.suffix !== "string" || data.suffix.length > 64 ||
-    typeof data.width !== "number" || !Number.isInteger(data.width) ||
-    data.width < 1 || data.width > 32
+    typeof data.suffix !== "string" || data.suffix.length > 64
   ) {
     return item;
   }
-  // Mint and reserve the number atomically. Reserving before the snippet
-  // is built means a second resolve firing inside the parse-debounce
-  // window — before this entry reaches the index — sees the number as
-  // taken and picks the next one, closing the duplicate-ID race.
-  const { prefix, suffix } = data;
-  const nextNumber = mintReservedNumber(
-    prefix,
-    suffix,
-    (reserved) => index.getNextDisplayIdNumber(prefix, suffix, reserved),
-  );
-  const rendered = renderScaffoldSnippet({
-    typeName: data.typeName,
-    prefix: data.prefix,
-    width: data.width,
-    suffix: data.suffix,
-    nextNumber,
-    ulid: ulid(),
-  });
+  let rendered: { label: string; insertText: string };
+  if (data.named === true) {
+    // Named (counter-less) type (#598): no number to mint. Re-render the
+    // `${1:NAME}` snippet with a fresh ULID; width / suffix are unused.
+    rendered = renderScaffoldSnippet({
+      typeName: data.typeName,
+      prefix: data.prefix,
+      width: 0,
+      suffix: "",
+      nextNumber: 0,
+      ulid: ulid(),
+      named: true,
+    });
+  } else {
+    if (
+      typeof data.width !== "number" || !Number.isInteger(data.width) ||
+      data.width < 1 || data.width > 32
+    ) {
+      return item;
+    }
+    // Mint and reserve the number atomically. Reserving before the snippet
+    // is built means a second resolve firing inside the parse-debounce
+    // window — before this entry reaches the index — sees the number as
+    // taken and picks the next one, closing the duplicate-ID race.
+    const { prefix, suffix } = data;
+    const nextNumber = mintReservedNumber(
+      prefix,
+      suffix,
+      (reserved) => index.getNextDisplayIdNumber(prefix, suffix, reserved),
+    );
+    rendered = renderScaffoldSnippet({
+      typeName: data.typeName,
+      prefix: data.prefix,
+      width: data.width,
+      suffix: data.suffix,
+      nextNumber,
+      ulid: ulid(),
+    });
+  }
   // Mid-typed scaffold items carry the replacement range: rebuild the
   // textEdit with the freshly rendered snippet (a stale textEdit.newText
   // would otherwise win over insertText). Range is unchanged — the cursor

--- a/tests/e2e/named_authoring_test.ts
+++ b/tests/e2e/named_authoring_test.ts
@@ -1,0 +1,53 @@
+/**
+ * @module tests/e2e/named_authoring_test
+ *
+ * E2E for #598 — the mint/scaffold CLI paths are named-aware. A named
+ * (counter-less) type like `sw-component: "SWC_{name}"` is not mintable, but
+ * `next-id` / `create` / `insert` must offer a placeholder-name scaffold and a
+ * clear "author the identifier yourself" note instead of the misleading
+ * "does not contain a recognised number placeholder" error.
+ */
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { markspec } from "./helpers.ts";
+
+const PROJECT_YAML = `name: named-authoring-e2e\nversion: 0.1.0\n`;
+const MARKSPEC_YAML = `profiles:\n  - ./profiles/acme\n`;
+const PROFILE_YAML = `id: "@acme/named"
+markspec-schema: "1"
+version: 0.1.0
+profile:
+  types:
+    sw-component:
+      extends: SoftwareComponent
+      display-id-pattern: "SWC_{name}"
+      display-id-pattern-enforcement: off
+`;
+
+const FILES = {
+  "project.yaml": PROJECT_YAML,
+  ".markspec.yaml": MARKSPEC_YAML,
+  "profiles/acme/markspec.yaml": PROFILE_YAML,
+  "components.md": `# Components\n`,
+};
+
+Deno.test("#598 e2e: next-id on a named type prints a placeholder template, not an error", async () => {
+  const { code, stdout, stderr } = await markspec(
+    ["next-id", "sw-component", "components.md"],
+    { files: FILES },
+  );
+  // Before #598: exit 1 with "does not contain a recognised number placeholder".
+  assertEquals(code, 0, stderr);
+  assertStringIncludes(stdout, "SWC_<name>");
+  assertStringIncludes(stderr.toLowerCase(), "named");
+});
+
+Deno.test("#598 e2e: create on a named type scaffolds a placeholder-name block", async () => {
+  const { code, stdout, stderr } = await markspec(
+    ["create", "sw-component", "components.md"],
+    { files: FILES },
+  );
+  assertEquals(code, 0, stderr);
+  assertStringIncludes(stdout, "[SWC_<name>]");
+  assertStringIncludes(stdout, "Type: sw-component");
+});


### PR DESCRIPTION
Closes #598.

> Stacked on #601 (#597) → #600 (#596). Base is `feat/597-validate-display-id-pattern-at-load`; review/merge after #600 and #601. The diff shown here is just the #598 change.

## Problem

Named (counter-less) types like `sw-component: "SWC_{name}"` (ADR-025) now **classify** by prefix, but the authoring affordances still assumed "has a pattern ⇒ mintable":

- `markspec next-id` / `create` / `insert` hit the `!shape` branch and exited 1 with `display-id-pattern 'SWC_{name}' does not contain a recognised number placeholder ('{n:Nd}')` — which reads like a *malformed* pattern, not "this type is named, author the ID yourself".
- The LSP (`getEntryTypes` / `getScaffoldPatterns`) `continue`d past named types, so they got **no** block-scaffold or mid-typed `- [SWC_` completion — the validator classified `SWC_*` entries while the editor offered zero authoring affordance.

## Fix — named-aware mint + scaffold

**CLI** (`cli/commands/id_helpers.ts`): `nextDisplayId` distinguishes a *valid named* pattern (via the `validateDisplayIdPattern` oracle from #596) from a genuinely *malformed* one. For a named type it prints a "named type — author the identifier yourself" note to stderr and returns a `<name>` placeholder template (`SWC_<name>`), so `create` / `insert` still scaffold a usable block and `next-id` prints the form to fill in. `create` / `insert` need no changes — they consume the returned ID. A malformed pattern still errors (though #597 now rejects those at profile-load).

**LSP** (`lsp/server.ts` + `lsp/completions.ts`): `getEntryTypes` now includes named types (`named: true`, `prefix` = the literal anchor). `renderScaffoldSnippet` renders a `${1:NAME}` tab stop after the prefix instead of a minted number (Title/Body/Satisfies stops shift one place). Block-scaffold and mid-typed `- [SWC_` completions both offer the named snippet; the resolve handler skips number-minting for named items and re-renders with a fresh ULID.

## Tests

- Unit: `namedIdTemplate` (`{ident}` → `<ident>`); `renderScaffoldSnippet` / `buildBlockScaffoldItems` / `buildMidTypedScaffoldItems` named cases (`SWC_${1:NAME}` snippet, `SWC_<name>` label).
- E2E (`tests/e2e/named_authoring_test.ts`): `markspec next-id sw-component` prints `SWC_<name>` (exit 0, "named" note); `markspec create sw-component` scaffolds `[SWC_<name>]` + `Type: sw-component`.
- Docs: annex §B.3.2 and the `next-id` CLI guide updated (the old "next-id / create skip named types" wording was stale).

`just check` green; `deno fmt --check` + `dprint check` green.

Third and last of three stacked PRs (#596 → #597 → #598) for the ADR-025 follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
