### PR TITLE
feat(cli): fmt canonicalises + heals trace references (project-aware)

### DIFF
--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -108,6 +108,24 @@ markspec fmt docs/*.md
 markspec fmt --check docs/*.md
 ```
 
+**Project-aware trace canonicalisation (requires `project.yaml`):**
+
+When `markspec fmt` runs inside a project, it also canonicalises and heals trace
+reference values:
+
+- **Canonicalise** — any ULID written directly in a trace attribute
+  (`Satisfies:`, `Derived-from:`, `Verified-by:`, etc.) is rewritten to the
+  target entry's current display ID.
+- **Heal** — if a target's display ID was renamed, the edge ledger in
+  `markspec.lock` records the stable `target-ulid`; `fmt` uses it to rewrite the
+  stale display ID to the target's new name.
+- **Unresolved references are left as-is** — `markspec check` reports them via
+  MSL-L006.
+
+Neither action is performed when no `project.yaml` is discoverable (file-local
+invocation). `fmt` reads the edge ledger but never writes `markspec.lock`; the
+ledger is owned by `markspec lock`.
+
 #### check
 
 Check broken refs, missing Ids, malformed entries, duplicates.

--- a/docs/spec/internal/markspec-lockfile.md
+++ b/docs/spec/internal/markspec-lockfile.md
@@ -153,13 +153,13 @@ is the only command that edits source.
 
 ## 4. Update mechanics
 
-| Command                         | Behavior                                                                                                                                                   |
-| ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `markspec lock`                 | Resolve every upstream, write/refresh `markspec.lock`. Idempotent: re-running with no upstream change is a zero diff.                                      |
-| `markspec lock --check`         | **CI mode.** Resolve, compare to the committed lockfile, **write nothing**; exit non-zero on any drift (new/changed/removed upstream, hash mismatch).      |
-| `markspec lock --update[=<id>]` | Re-resolve all (or one) upstreams to current latest within the specifier range; the explicit "I am intentionally moving the pin" verb.                     |
-| `markspec fmt`                  | **Reads** the lockfile (to surface a stale-pin warning) but **never writes** it. Locking is not a formatting concern (AGENTS.md formatters/linters split). |
-| `markspec compile` / `lsp`      | Read the lockfile to pin federated resolution (compile-output §5); never write it.                                                                         |
+| Command                         | Behavior                                                                                                                                                                                                                                                                     |
+| ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `markspec lock`                 | Resolve every upstream, write/refresh `markspec.lock`. Idempotent: re-running with no upstream change is a zero diff.                                                                                                                                                        |
+| `markspec lock --check`         | **CI mode.** Resolve, compare to the committed lockfile, **write nothing**; exit non-zero on any drift (new/changed/removed upstream, hash mismatch).                                                                                                                        |
+| `markspec lock --update[=<id>]` | Re-resolve all (or one) upstreams to current latest within the specifier range; the explicit "I am intentionally moving the pin" verb.                                                                                                                                       |
+| `markspec fmt`                  | **Reads** the lockfile edge ledger (§3.1) to **heal stale trace references** (target display ID renamed → rewrite to current name) and surfaces stale-pin warnings; **never writes** the lockfile. Locking is not a formatting concern (AGENTS.md formatters/linters split). |
+| `markspec compile` / `lsp`      | Read the lockfile to pin federated resolution (compile-output §5); never write it.                                                                                                                                                                                           |
 
 Only `markspec lock` (and `--update`) mutate the file. This mirrors the
 `Cargo.lock` discipline: the build reads it, one explicit command writes it.

--- a/packages/markspec/cli/commands/fmt.ts
+++ b/packages/markspec/cli/commands/fmt.ts
@@ -5,6 +5,7 @@
  */
 
 import { Command } from "@cliffy/command";
+import type { LockEdge, RefIndex } from "../../core/mod.ts";
 import { loadActiveProfile, readFile } from "../helpers.ts";
 
 export const fmtCmd = new Command()
@@ -29,6 +30,26 @@ export const fmtCmd = new Command()
 
     const { format } = await import("../../core/mod.ts");
 
+    // Project-aware reference canonicalisation/healing (issue #593, Slice 4).
+    // Built once and reused for every file. File-local fmt (no project root)
+    // leaves refIndex undefined and skips canonicalisation entirely.
+    let refIndex: RefIndex | undefined = undefined;
+    let ledger: readonly LockEdge[] = [];
+    if (projectRoot !== undefined) {
+      const { buildRefIndex, parseLockfile } = await import(
+        "../../core/mod.ts"
+      );
+      const { collectEntries } = await import("./lock.ts");
+      const { join } = await import("@std/path");
+      const projectEntries = await collectEntries(projectRoot);
+      refIndex = buildRefIndex(projectEntries);
+      const lockRaw = await readFile(join(projectRoot, "markspec.lock"));
+      if (lockRaw !== undefined) {
+        const parsed = parseLockfile(lockRaw);
+        if (parsed.lockfile) ledger = parsed.lockfile.edges;
+      }
+    }
+
     let totalFormatted = 0;
     let totalUnchanged = 0;
 
@@ -45,16 +66,35 @@ export const fmtCmd = new Command()
       }
 
       const result = format(content, { file: filePath });
+      let output = result.output;
+      let changed = result.changed;
+
+      if (refIndex !== undefined) {
+        const { parseFile, canonicalizeRefs } = await import(
+          "../../core/mod.ts"
+        );
+        const parsed = await parseFile(output, { file: filePath });
+        const refResult = canonicalizeRefs(
+          output,
+          parsed.entries,
+          refIndex,
+          ledger,
+        );
+        if (refResult.changed) {
+          output = refResult.output;
+          changed = true;
+        }
+      }
 
       for (const d of result.diagnostics) {
         const loc = d.location ? `${d.location.file}:${d.location.line}` : "";
         console.error(`${d.severity}: ${loc} ${d.message}`);
       }
 
-      if (result.changed) {
+      if (changed) {
         totalFormatted++;
         if (!options.check) {
-          await Deno.writeTextFile(filePath, result.output);
+          await Deno.writeTextFile(filePath, output);
         }
       } else {
         totalUnchanged++;

--- a/packages/markspec/core/mod.ts
+++ b/packages/markspec/core/mod.ts
@@ -334,6 +334,14 @@ export type {
   UpstreamRegistry,
 } from "./lock/mod.ts";
 
+// ── Trace-reference canonicalisation + heal (issue #593, Slice 4) ────────
+export {
+  buildRefIndex,
+  canonicalizeRefs,
+  TRACE_ATTRIBUTE_KEYS,
+} from "./refs/mod.ts";
+export type { RefIndex } from "./refs/mod.ts";
+
 // ── External sync model (ADR-022) ────────────────────────────────────────
 export {
   aggregateStatusByState,

--- a/packages/markspec/core/refs/mod.ts
+++ b/packages/markspec/core/refs/mod.ts
@@ -1,0 +1,157 @@
+/**
+ * @module core/refs
+ *
+ * Project-aware trace-reference canonicalisation + rename-healing (issue #593,
+ * Slice 4). Pure module: given a project-wide display-ID ↔ ULID index and the
+ * lockfile's edge ledger, rewrite a file's trace-attribute values losslessly —
+ * ULID → current display ID (canonicalise), and a stale display ID → the
+ * ledger's stable target ULID → the target's current display ID (heal).
+ *
+ * Architecture: composed AROUND the pure `core/formatter` by the `markspec fmt`
+ * CLI. It MUST NOT import `core/formatter`, and `core/formatter` MUST NOT import
+ * it (WASM-migration purity guard, AGENTS.md).
+ */
+
+import type { Entry } from "../model/mod.ts";
+import {
+  CORE_RELATIONS,
+  DISPLAY_ID_RE,
+  LOCK_EXTRA_INVERSE_KEYS,
+  ULID_RE,
+} from "../model/mod.ts";
+import type { LockEdge } from "../lock/mod.ts";
+
+/**
+ * Trace-attribute keys whose values are canonicalised/healed: the core
+ * relations plus `Verified-by`. Derived from {@linkcode CORE_RELATIONS} so new
+ * relations are covered automatically.
+ */
+export const TRACE_ATTRIBUTE_KEYS: ReadonlySet<string> = new Set([
+  ...CORE_RELATIONS.map((r) => r.attr),
+  ...LOCK_EXTRA_INVERSE_KEYS,
+]);
+
+/** Bidirectional display-ID ↔ ULID resolution index over a project's entries. */
+export interface RefIndex {
+  readonly displayIdToUlid: ReadonlyMap<string, string>;
+  readonly ulidToDisplayId: ReadonlyMap<string, string>;
+}
+
+/**
+ * Build a {@linkcode RefIndex} from a project's entries. First-entry-wins on
+ * duplicate keys (validator/workspace convention). Entries without a ULID are
+ * skipped.
+ */
+export function buildRefIndex(entries: readonly Entry[]): RefIndex {
+  const displayIdToUlid = new Map<string, string>();
+  const ulidToDisplayId = new Map<string, string>();
+  for (const e of entries) {
+    if (e.id === undefined) continue;
+    if (!displayIdToUlid.has(e.displayId)) {
+      displayIdToUlid.set(e.displayId, e.id);
+    }
+    if (!ulidToDisplayId.has(e.id)) {
+      ulidToDisplayId.set(e.id, e.displayId);
+    }
+  }
+  return { displayIdToUlid, ulidToDisplayId };
+}
+
+/** Trailer trace line: indent, key, `:` + spaces, value-rest. */
+const TRACE_TRAILER_RE = /^(\s{4,})([A-Z][A-Za-z-]*)(\s*:\s*)(.*)$/;
+
+/** Token splitter that preserves separators between value tokens. */
+const VALUE_TOKEN_RE = /[^\s,]+/g;
+
+/**
+ * Rewrite trace-attribute values in `content` per the canonicalise/heal rules.
+ * `entries` MUST be the parse of `content` (used to map each trailer line to its
+ * source entry's stable ULID). Returns the rewritten text and whether anything
+ * changed. Lossless: only resolvable value tokens are replaced.
+ */
+export function canonicalizeRefs(
+  content: string,
+  entries: readonly Entry[],
+  index: RefIndex,
+  ledger: readonly LockEdge[],
+): { output: string; changed: boolean } {
+  const ledgerByKey = new Map<string, string>();
+  for (const e of ledger) {
+    if (e.targetUlid === undefined) continue;
+    ledgerByKey.set(
+      `${e.sourceUlid} ${e.relation} ${e.authoredTarget}`,
+      e.targetUlid,
+    );
+  }
+
+  // Sort entries by start line so binary-search for source ULID is correct.
+  const sorted = [...entries].sort((a, b) => a.location.line - b.location.line);
+
+  /** Return the ULID of the entry whose block contains the given 1-based line. */
+  const sourceUlidForLine = (line1: number): string | undefined => {
+    let lo = 0;
+    let hi = sorted.length - 1;
+    let ans = -1;
+    while (lo <= hi) {
+      const mid = (lo + hi) >> 1;
+      if (sorted[mid].location.line <= line1) {
+        ans = mid;
+        lo = mid + 1;
+      } else {
+        hi = mid - 1;
+      }
+    }
+    return ans >= 0 ? sorted[ans].id : undefined;
+  };
+
+  const lines = content.split("\n");
+  let changed = false;
+  for (let i = 0; i < lines.length; i++) {
+    const m = TRACE_TRAILER_RE.exec(lines[i]);
+    if (!m) continue;
+    const [, indent, key, sep, rest] = m;
+    if (!TRACE_ATTRIBUTE_KEYS.has(key)) continue;
+    // Multi-line continuation — leave untouched (debt: full multi-line support).
+    if (rest.endsWith("\\")) continue;
+    const sourceUlid = sourceUlidForLine(i + 1);
+    const rewritten = rest.replace(
+      VALUE_TOKEN_RE,
+      (token) => rewriteToken(token, sourceUlid, key, index, ledgerByKey),
+    );
+    if (rewritten !== rest) {
+      lines[i] = `${indent}${key}${sep}${rewritten}`;
+      changed = true;
+    }
+  }
+  return { output: lines.join("\n"), changed };
+}
+
+function rewriteToken(
+  token: string,
+  sourceUlid: string | undefined,
+  relation: string,
+  index: RefIndex,
+  ledgerByKey: ReadonlyMap<string, string>,
+): string {
+  if (ULID_RE.test(token)) {
+    // Rule 1: ULID → current display ID (canonicalise).
+    return index.ulidToDisplayId.get(token) ?? token;
+  }
+  if (!DISPLAY_ID_RE.test(token)) return token;
+  if (index.displayIdToUlid.has(token)) {
+    // Rule 2: current display ID — leave unchanged.
+    return token;
+  }
+  if (sourceUlid !== undefined) {
+    // Rule 3: stale display ID — try to heal via ledger.
+    const targetUlid = ledgerByKey.get(
+      `${sourceUlid} ${relation} ${token}`,
+    );
+    if (targetUlid !== undefined) {
+      const healed = index.ulidToDisplayId.get(targetUlid);
+      if (healed !== undefined) return healed;
+    }
+  }
+  // Rule 4: leave untouched (URI/broken/unknown).
+  return token;
+}

--- a/packages/markspec/core/refs/mod_test.ts
+++ b/packages/markspec/core/refs/mod_test.ts
@@ -1,0 +1,447 @@
+import { assertEquals } from "@std/assert";
+import { makeDisplayId } from "../model/mod.ts";
+import type { Entry } from "../model/mod.ts";
+import type { LockEdge } from "../lock/mod.ts";
+import {
+  buildRefIndex,
+  canonicalizeRefs,
+  TRACE_ATTRIBUTE_KEYS,
+} from "./mod.ts";
+
+// ---------------------------------------------------------------------------
+// Test fixture constants
+// ---------------------------------------------------------------------------
+
+const SRC = "01J0000000000000000000SRC1";
+const TGT = "01J0000000000000000000TGT1";
+
+/**
+ * Build a minimal Entry for refs tests. Mirrors the `makeEntry` baseline from
+ * `core/lock/resolve_test.ts` exactly — same field set, same defaults.
+ */
+function entry(
+  partial: {
+    displayId: string;
+    id: string | undefined;
+    rawAttributes: Array<{ key: string; value: string }>;
+    location?: { file: string; line: number; column: number };
+  },
+): Entry {
+  return {
+    displayId: makeDisplayId(partial.displayId),
+    title: partial.displayId,
+    body: "",
+    rawAttributes: partial.rawAttributes,
+    typedAttributes: new Map() as never,
+    id: partial.id,
+    shape: "Authored",
+    location: partial.location ?? { file: "x.md", line: 1, column: 1 },
+    source: { kind: "markdown" },
+    bodyTokens: [],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// TRACE_ATTRIBUTE_KEYS membership
+// ---------------------------------------------------------------------------
+
+Deno.test("TRACE_ATTRIBUTE_KEYS: includes core trace relations", () => {
+  assertEquals(TRACE_ATTRIBUTE_KEYS.has("Satisfies"), true);
+  assertEquals(TRACE_ATTRIBUTE_KEYS.has("Derived-from"), true);
+  assertEquals(TRACE_ATTRIBUTE_KEYS.has("Verified-by"), true);
+  assertEquals(TRACE_ATTRIBUTE_KEYS.has("References"), true);
+  assertEquals(TRACE_ATTRIBUTE_KEYS.has("Tests"), true);
+  assertEquals(TRACE_ATTRIBUTE_KEYS.has("Depends-on"), true);
+  assertEquals(TRACE_ATTRIBUTE_KEYS.has("Part-of"), true);
+  assertEquals(TRACE_ATTRIBUTE_KEYS.has("Allocated-to"), true);
+  assertEquals(TRACE_ATTRIBUTE_KEYS.has("Realizes"), true);
+  assertEquals(TRACE_ATTRIBUTE_KEYS.has("Provides"), true);
+  assertEquals(TRACE_ATTRIBUTE_KEYS.has("Requires"), true);
+});
+
+Deno.test("TRACE_ATTRIBUTE_KEYS: does not include non-trace keys", () => {
+  assertEquals(TRACE_ATTRIBUTE_KEYS.has("Labels"), false);
+  assertEquals(TRACE_ATTRIBUTE_KEYS.has("Id"), false);
+  assertEquals(TRACE_ATTRIBUTE_KEYS.has("Type"), false);
+});
+
+// ---------------------------------------------------------------------------
+// buildRefIndex
+// ---------------------------------------------------------------------------
+
+Deno.test("buildRefIndex: builds both directions", () => {
+  const src = entry({
+    displayId: "SWE_0001",
+    id: SRC,
+    rawAttributes: [],
+  });
+  const tgt = entry({
+    displayId: "SYS_0001",
+    id: TGT,
+    rawAttributes: [],
+  });
+  const idx = buildRefIndex([src, tgt]);
+  assertEquals(idx.displayIdToUlid.get("SWE_0001"), SRC);
+  assertEquals(idx.displayIdToUlid.get("SYS_0001"), TGT);
+  assertEquals(idx.ulidToDisplayId.get(SRC), "SWE_0001");
+  assertEquals(idx.ulidToDisplayId.get(TGT), "SYS_0001");
+});
+
+Deno.test("buildRefIndex: first-entry-wins on duplicate display ID", () => {
+  const a = entry({ displayId: "REQ_0001", id: SRC, rawAttributes: [] });
+  const b = entry({
+    displayId: "REQ_0001",
+    id: "01J0000000000000000000TGT2",
+    rawAttributes: [],
+  });
+  const idx = buildRefIndex([a, b]);
+  assertEquals(idx.displayIdToUlid.get("REQ_0001"), SRC);
+});
+
+Deno.test("buildRefIndex: entries without id are skipped", () => {
+  const e = entry({ displayId: "UNS_0001", id: undefined, rawAttributes: [] });
+  const idx = buildRefIndex([e]);
+  assertEquals(idx.displayIdToUlid.has("UNS_0001"), false);
+});
+
+// ---------------------------------------------------------------------------
+// canonicalizeRefs — rule 1: ULID → current display ID
+// ---------------------------------------------------------------------------
+
+Deno.test("canonicalizeRefs: ULID token in trace attr replaced with current display ID", () => {
+  // Content has the source entry's title at line 1, Satisfies at line 6
+  const content = [
+    `- [SWE_0001] Title`,
+    ``,
+    `  Body.`,
+    ``,
+    `      Id: ${SRC}`,
+    `      Satisfies: ${TGT}`,
+  ].join("\n");
+
+  const src = entry({
+    displayId: "SWE_0001",
+    id: SRC,
+    rawAttributes: [
+      { key: "Id", value: SRC },
+      { key: "Satisfies", value: TGT },
+    ],
+    location: { file: "x.md", line: 1, column: 1 },
+  });
+  const tgt = entry({
+    displayId: "SYS_0001",
+    id: TGT,
+    rawAttributes: [{ key: "Id", value: TGT }],
+    location: { file: "x.md", line: 8, column: 1 },
+  });
+
+  const idx = buildRefIndex([src, tgt]);
+  const { output, changed } = canonicalizeRefs(content, [src, tgt], idx, []);
+
+  assertEquals(changed, true);
+  assertEquals(
+    output.split("\n").find((l: string) => l.includes("Satisfies"))!,
+    "      Satisfies: SYS_0001",
+  );
+});
+
+// ---------------------------------------------------------------------------
+// canonicalizeRefs — rule 2: current display ID → no-op
+// ---------------------------------------------------------------------------
+
+Deno.test("canonicalizeRefs: current display ID token is left unchanged", () => {
+  const content = [
+    `- [SWE_0001] Title`,
+    ``,
+    `  Body.`,
+    ``,
+    `      Id: ${SRC}`,
+    `      Satisfies: SYS_0001`,
+  ].join("\n");
+
+  const src = entry({
+    displayId: "SWE_0001",
+    id: SRC,
+    rawAttributes: [
+      { key: "Id", value: SRC },
+      { key: "Satisfies", value: "SYS_0001" },
+    ],
+    location: { file: "x.md", line: 1, column: 1 },
+  });
+  const tgt = entry({
+    displayId: "SYS_0001",
+    id: TGT,
+    rawAttributes: [{ key: "Id", value: TGT }],
+    location: { file: "x.md", line: 8, column: 1 },
+  });
+
+  const idx = buildRefIndex([src, tgt]);
+  const { output, changed } = canonicalizeRefs(content, [src, tgt], idx, []);
+
+  assertEquals(changed, false);
+  assertEquals(output, content);
+});
+
+// ---------------------------------------------------------------------------
+// canonicalizeRefs — rule 3: stale display ID → heal via ledger
+// ---------------------------------------------------------------------------
+
+Deno.test("canonicalizeRefs: stale display ID healed via ledger", () => {
+  // Target was renamed from OLD_SYS_001 to SYS_0001; ledger records the edge.
+  const content = [
+    `- [SWE_0001] Title`,
+    ``,
+    `  Body.`,
+    ``,
+    `      Id: ${SRC}`,
+    `      Satisfies: OLD_SYS_001`,
+  ].join("\n");
+
+  const src = entry({
+    displayId: "SWE_0001",
+    id: SRC,
+    rawAttributes: [
+      { key: "Id", value: SRC },
+      { key: "Satisfies", value: "OLD_SYS_001" },
+    ],
+    location: { file: "x.md", line: 1, column: 1 },
+  });
+  const tgt = entry({
+    displayId: "SYS_0001",
+    id: TGT,
+    rawAttributes: [{ key: "Id", value: TGT }],
+    location: { file: "x.md", line: 8, column: 1 },
+  });
+
+  const idx = buildRefIndex([src, tgt]);
+  const ledger: LockEdge[] = [
+    {
+      sourceUlid: SRC,
+      relation: "Satisfies",
+      targetUlid: TGT,
+      authoredTarget: "OLD_SYS_001",
+    },
+  ];
+  const { output, changed } = canonicalizeRefs(
+    content,
+    [src, tgt],
+    idx,
+    ledger,
+  );
+
+  assertEquals(changed, true);
+  assertEquals(
+    output.split("\n").find((l: string) => l.includes("Satisfies"))!,
+    "      Satisfies: SYS_0001",
+  );
+});
+
+// ---------------------------------------------------------------------------
+// canonicalizeRefs — rule 4: orphan → left untouched
+// ---------------------------------------------------------------------------
+
+Deno.test("canonicalizeRefs: orphan display ID left untouched", () => {
+  const content = [
+    `- [SWE_0001] Title`,
+    ``,
+    `  Body.`,
+    ``,
+    `      Id: ${SRC}`,
+    `      Satisfies: GONE_0001`,
+  ].join("\n");
+
+  const src = entry({
+    displayId: "SWE_0001",
+    id: SRC,
+    rawAttributes: [
+      { key: "Id", value: SRC },
+      { key: "Satisfies", value: "GONE_0001" },
+    ],
+    location: { file: "x.md", line: 1, column: 1 },
+  });
+
+  const idx = buildRefIndex([src]);
+  const { output, changed } = canonicalizeRefs(content, [src], idx, []);
+
+  assertEquals(changed, false);
+  assertEquals(output, content);
+});
+
+// ---------------------------------------------------------------------------
+// canonicalizeRefs — CSV multi-token rewrite
+// ---------------------------------------------------------------------------
+
+Deno.test("canonicalizeRefs: CSV line with ULID and display ID — only ULID replaced", () => {
+  const content = [
+    `- [SWE_0001] Title`,
+    ``,
+    `  Body.`,
+    ``,
+    `      Id: ${SRC}`,
+    `      Satisfies: ${TGT}, SYS_0002`,
+  ].join("\n");
+
+  const src = entry({
+    displayId: "SWE_0001",
+    id: SRC,
+    rawAttributes: [
+      { key: "Id", value: SRC },
+      { key: "Satisfies", value: `${TGT}, SYS_0002` },
+    ],
+    location: { file: "x.md", line: 1, column: 1 },
+  });
+  const tgt1 = entry({
+    displayId: "SYS_0001",
+    id: TGT,
+    rawAttributes: [{ key: "Id", value: TGT }],
+    location: { file: "x.md", line: 8, column: 1 },
+  });
+  const tgt2 = entry({
+    displayId: "SYS_0002",
+    id: "01J0000000000000000000TGT2",
+    rawAttributes: [{ key: "Id", value: "01J0000000000000000000TGT2" }],
+    location: { file: "x.md", line: 14, column: 1 },
+  });
+
+  const idx = buildRefIndex([src, tgt1, tgt2]);
+  const { output, changed } = canonicalizeRefs(
+    content,
+    [src, tgt1, tgt2],
+    idx,
+    [],
+  );
+
+  assertEquals(changed, true);
+  assertEquals(
+    output.split("\n").find((l: string) => l.includes("Satisfies"))!,
+    "      Satisfies: SYS_0001, SYS_0002",
+  );
+});
+
+// ---------------------------------------------------------------------------
+// canonicalizeRefs — ULID in body prose is NOT rewritten
+// ---------------------------------------------------------------------------
+
+Deno.test("canonicalizeRefs: ULID in body prose is not rewritten", () => {
+  // The ULID appears in the body, not a trace trailer.
+  const content = [
+    `- [SWE_0001] Title`,
+    ``,
+    `  Prose mentioning ${TGT} for context.`,
+    ``,
+    `      Id: ${SRC}`,
+  ].join("\n");
+
+  const src = entry({
+    displayId: "SWE_0001",
+    id: SRC,
+    rawAttributes: [{ key: "Id", value: SRC }],
+    location: { file: "x.md", line: 1, column: 1 },
+  });
+  const tgt = entry({
+    displayId: "SYS_0001",
+    id: TGT,
+    rawAttributes: [{ key: "Id", value: TGT }],
+    location: { file: "x.md", line: 8, column: 1 },
+  });
+
+  const idx = buildRefIndex([src, tgt]);
+  const { output, changed } = canonicalizeRefs(content, [src, tgt], idx, []);
+
+  assertEquals(changed, false);
+  assertEquals(output, content);
+});
+
+// ---------------------------------------------------------------------------
+// canonicalizeRefs — multi-line continuation left untouched
+// ---------------------------------------------------------------------------
+
+Deno.test("canonicalizeRefs: trailer line with trailing backslash is left untouched", () => {
+  const line = `      Satisfies: ${TGT} \\`;
+  const content = [
+    `- [SWE_0001] Title`,
+    ``,
+    `  Body.`,
+    ``,
+    `      Id: ${SRC}`,
+    line,
+    `      SYS_0002`,
+  ].join("\n");
+
+  const src = entry({
+    displayId: "SWE_0001",
+    id: SRC,
+    rawAttributes: [
+      { key: "Id", value: SRC },
+      { key: "Satisfies", value: `${TGT}` },
+    ],
+    location: { file: "x.md", line: 1, column: 1 },
+  });
+  const tgt = entry({
+    displayId: "SYS_0001",
+    id: TGT,
+    rawAttributes: [{ key: "Id", value: TGT }],
+    location: { file: "x.md", line: 8, column: 1 },
+  });
+
+  const idx = buildRefIndex([src, tgt]);
+  const { output, changed } = canonicalizeRefs(content, [src, tgt], idx, []);
+
+  // The continuation line is left byte-for-byte identical.
+  assertEquals(changed, false);
+  assertEquals(output, content);
+});
+
+// ---------------------------------------------------------------------------
+// Spec-invariant hardening (review follow-up)
+// ---------------------------------------------------------------------------
+
+Deno.test("canonicalizeRefs: Verified-by file-path value is left as-is", () => {
+  // A path like `tests/val_foo.rs` matches DISPLAY_ID_RE (the class includes
+  // `.` and `/`), but resolves to no entry and has no ledger edge, so Rule 4
+  // leaves it untouched. Pins the path-or-id invariant for Verified-by.
+  const content = [
+    "- [SWE_0001] S",
+    "",
+    `      Id: ${SRC}`,
+    "      Verified-by: tests/val_foo.rs",
+    "",
+  ].join("\n");
+  const src = entry({
+    displayId: "SWE_0001",
+    id: SRC,
+    rawAttributes: [{ key: "Id", value: SRC }, {
+      key: "Verified-by",
+      value: "tests/val_foo.rs",
+    }],
+  });
+  const idx = buildRefIndex([src]);
+  const { output, changed } = canonicalizeRefs(content, [src], idx, []);
+  assertEquals(changed, false);
+  assertEquals(output, content);
+});
+
+Deno.test("canonicalizeRefs: a non-resolving ULID trace value is left as-is", () => {
+  // A ULID that resolves to no entry must NOT be rewritten (guards the
+  // `?? token` fallback in Rule 1).
+  const unknown = "01J0000000000000000000XXXX";
+  const content = [
+    "- [SWE_0001] S",
+    "",
+    `      Id: ${SRC}`,
+    `      Satisfies: ${unknown}`,
+    "",
+  ].join("\n");
+  const src = entry({
+    displayId: "SWE_0001",
+    id: SRC,
+    rawAttributes: [{ key: "Id", value: SRC }, {
+      key: "Satisfies",
+      value: unknown,
+    }],
+  });
+  const idx = buildRefIndex([src]);
+  const { output, changed } = canonicalizeRefs(content, [src], idx, []);
+  assertEquals(changed, false);
+  assertEquals(output, content);
+});

--- a/tests/e2e/display_id_trace_fmt_test.ts
+++ b/tests/e2e/display_id_trace_fmt_test.ts
@@ -1,0 +1,182 @@
+/**
+ * @module tests/e2e/display_id_trace_fmt_test
+ *
+ * E2E tests for project-aware `markspec fmt`:
+ *   - canonicalises a ULID trace value → target's current display ID
+ *   - heals a stale display-ID reference via the markspec.lock edge ledger
+ *   - leaves orphan references untouched
+ *   - file-local fmt (no project.yaml) does NOT canonicalise
+ */
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { join } from "@std/path";
+import { markspec, markspecInDir, markspecPersist } from "./helpers.ts";
+
+const PROJECT_YAML = `name: fmt-canon-e2e\nversion: 0.1.0\n`;
+
+// Each Id is a 26-char Crockford-base32 string (Crockford charset:
+// 0-9 A-Z minus I, L, O, U). These fixture ULIDs are synthetic — the
+// parser checks the format but does not validate the timestamp prefix.
+const SYS = `# System
+
+- [SYS_0001] Target
+
+  Body.
+
+      Id: 01SYS000000000000000000001
+`;
+// SWE_ULID references the target by its ULID instead of its display ID.
+// The pure formatter must be a no-op on this file (indentation is already
+// canonical: 6-space trailer), so --check exit 0 in file-local mode proves
+// canonicalisation was skipped, not that the pure formatter found nothing.
+const SWE_ULID = `# Software
+
+- [SWE_0001] Source
+
+  Body.
+
+      Id: 01SWE000000000000000000001
+      Satisfies: 01SYS000000000000000000001
+`;
+
+Deno.test(
+  "fmt: canonicalises a ULID trace value to the target display ID",
+  async () => {
+    const run = await markspecPersist(["fmt", "swe.md", "sys.md"], {
+      files: {
+        "project.yaml": PROJECT_YAML,
+        "sys.md": SYS,
+        "swe.md": SWE_ULID,
+      },
+      permissions: ["--allow-env", "--allow-run"],
+    });
+    try {
+      assertEquals(run.code, 0, run.stderr);
+      const swe = await Deno.readTextFile(join(run.dir, "swe.md"));
+      assertStringIncludes(swe, "Satisfies: SYS_0001");
+      assertEquals(
+        swe.includes("Satisfies: 01SYS000000000000000000001"),
+        false,
+      );
+    } finally {
+      await Deno.remove(run.dir, { recursive: true });
+    }
+  },
+);
+
+Deno.test(
+  "fmt --check: exit 1 when a ULID trace value needs canonicalisation",
+  async () => {
+    const { code } = await markspec(
+      ["fmt", "--check", "swe.md", "sys.md"],
+      {
+        files: {
+          "project.yaml": PROJECT_YAML,
+          "sys.md": SYS,
+          "swe.md": SWE_ULID,
+        },
+        permissions: ["--allow-env", "--allow-run"],
+      },
+    );
+    assertEquals(code, 1);
+  },
+);
+
+Deno.test(
+  "fmt: heals a renamed-target reference via the lock ledger",
+  async () => {
+    const sysOld = `# System
+
+- [SYS_OLD] Target
+
+  Body.
+
+      Id: 01SYS000000000000000000001
+`;
+    const sweOld = `# Software
+
+- [SWE_0001] Source
+
+  Body.
+
+      Id: 01SWE000000000000000000001
+      Satisfies: SYS_OLD
+`;
+    // Step 1: lock with SYS_OLD present → ledger records the edge.
+    const run = await markspecPersist(["lock"], {
+      files: {
+        "project.yaml": PROJECT_YAML,
+        "sys.md": sysOld,
+        "swe.md": sweOld,
+      },
+      permissions: ["--allow-env", "--allow-run"],
+    });
+    try {
+      assertEquals(run.code, 0, run.stderr);
+      // Verify the ledger captured the edge before renaming.
+      const lock = await Deno.readTextFile(join(run.dir, "markspec.lock"));
+      assertStringIncludes(lock, 'authored-target = "SYS_OLD"');
+
+      // Step 2: rename the target display ID (ULID unchanged).
+      const sysNew = sysOld.replace("[SYS_OLD]", "[SYS_NEW]");
+      await Deno.writeTextFile(join(run.dir, "sys.md"), sysNew);
+
+      // Step 3: fmt heals the stale reference SYS_OLD → SYS_NEW.
+      const fmt = await markspecInDir(
+        run.dir,
+        ["fmt", "swe.md", "sys.md"],
+        ["--allow-env", "--allow-run"],
+      );
+      assertEquals(fmt.code, 0, fmt.stderr);
+      const healed = await Deno.readTextFile(join(run.dir, "swe.md"));
+      assertStringIncludes(healed, "Satisfies: SYS_NEW");
+      assertEquals(healed.includes("Satisfies: SYS_OLD"), false);
+    } finally {
+      await Deno.remove(run.dir, { recursive: true });
+    }
+  },
+);
+
+Deno.test(
+  "fmt: leaves an orphan reference untouched",
+  async () => {
+    const sweOrphan = `# Software
+
+- [SWE_0001] Source
+
+  Body.
+
+      Id: 01SWE000000000000000000001
+      Satisfies: SYS_GONE
+`;
+    const run = await markspecPersist(["fmt", "swe.md"], {
+      files: { "project.yaml": PROJECT_YAML, "swe.md": sweOrphan },
+      permissions: ["--allow-env", "--allow-run"],
+    });
+    try {
+      assertEquals(run.code, 0, run.stderr);
+      const out = await Deno.readTextFile(join(run.dir, "swe.md"));
+      assertStringIncludes(out, "Satisfies: SYS_GONE");
+    } finally {
+      await Deno.remove(run.dir, { recursive: true });
+    }
+  },
+);
+
+Deno.test(
+  "fmt: file-local (no project root) does NOT canonicalise a ULID trace value",
+  async () => {
+    // No project.yaml → file-local fmt. The ULID reference must be left as
+    // authored. SWE_ULID's trailer is already canonical (6-space indent,
+    // no missing ULID to stamp), so the pure formatter is a no-op and
+    // --check exits 0 — proving canonicalisation was skipped.
+    const { code } = await markspec(
+      ["fmt", "--check", "swe.md"],
+      {
+        files: { "swe.md": SWE_ULID },
+        permissions: ["--allow-env", "--allow-run"],
+      },
+    );
+    assertEquals(code, 0);
+  },
+);


### PR DESCRIPTION
## Summary

PR3 of the #593 epic (*display IDs in trace relations*). Slice 4: `markspec fmt`
becomes **project-aware** — it canonicalises trace-relation values to display IDs
and heals references whose target was renamed, using the PR2 lock ledger. The
pure `core/formatter` is untouched; the rewrite is a new `core/refs/` module the
`fmt` CLI composes around the formatter. File-local `fmt` (no `project.yaml`)
behaves exactly as before.

## What changed

- **`core/refs/` (new, pure)** — `buildRefIndex(entries)` (display↔ULID index) +
  `canonicalizeRefs(content, entries, index, ledger)`: a lossless single-token
  rewrite of trace-attribute values:
  - ULID resolving in the index → target's **current display ID** (canonicalise, D2);
  - current display ID → left as-is;
  - stale display ID + a ledger edge `(sourceUlid, relation, authoredTarget)`
    whose `targetUlid` resolves → target's current display ID (**heal**; keyed on
    the source's stable ULID so a renamed source still heals);
  - anything else (URI, orphan, path) → left as-is (`check` warns MSL-L006).
  Only resolvable trace value tokens change — indentation, keys, separators, and
  all non-trace content (body prose, `Labels:`, `Id:`) are byte-preserved.
- **`markspec fmt`** — when a project root is found, builds the index + loads the
  lockfile ledger once, then applies `canonicalizeRefs` after the pure formatter.
  A ref rewrite counts as a format change, so `fmt --check` exits 1 and converges
  sources to display IDs. File-local `fmt` skips it. `fmt` writes **source**, never
  the lockfile.
- **Docs** — `docs/guide/cli.md` (`fmt` canonicalisation/healing) +
  `docs/spec/internal/markspec-lockfile.md` §4 (fmt reads the ledger to heal).

## Design decisions (resolved from the spec's §9 open items)

- **`fmt` rewrite module home:** a new `core/refs/` (not `core/compiler/`). Small
  dependency surface (`model` + the `LockEdge` type); the **architecture guard**
  holds trivially — `core/refs` never imports `core/formatter` and vice versa; the
  CLI composes them (format → canonicalise). WASM-migration boundary preserved.
- **Single-token, line-scoped, lossless** rewrite. Trace id-lists are canonically
  one value per trailer line, so a per-line token rewrite covers the real cases;
  CSV on one line is handled (each token rewritten, separators kept). Multi-line
  (`\`-continued) trace values are skipped (deferred; filed as debt).

## Tests

- Unit (`core/refs/mod_test.ts`, 14): all four rules incl. heal-via-ledger and the
  renamed-source case; CSV separator preservation; body-prose ULID untouched;
  `Verified-by:` file-path left as-is; non-resolving ULID left as-is; index
  first-entry-wins.
- E2E (`tests/e2e/display_id_trace_fmt_test.ts`, 5): canonicalise ULID→displayId;
  `fmt --check` exit 1; **heal** (lock → rename → fmt → SYS_NEW); orphan untouched;
  **file-local skip** (exit 0, ULID left).

`just build` + `deno fmt --check` + `dprint check` all green.

Refs #593.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
