### PR TITLE
test(lsp,mcp): guarantee display IDs in completion + read tools

### DIFF
--- a/docs/spec/language/language.md
+++ b/docs/spec/language/language.md
@@ -847,6 +847,15 @@ The `id` and `id-list` types accept a 26-char ULID, a scheme-qualified URI, or a
 display ID. A display ID is resolved to its target by existence; an unresolved
 display ID is reported by `MSL-L006`, not by the value-format gate.
 
+Display IDs are the canonical form across the full toolchain surface.
+`markspec
+fmt` canonicalises a raw ULID trace value to the target's current
+display ID and heals a renamed reference via the `markspec.lock` ledger (see the
+`fmt` command reference for details). The LSP ID-reference completion inserts
+display IDs directly, and the MCP read tools (`entry_show`, `entry_list`,
+`entry_neighborhood`, `entry_context`) present all trace targets as display IDs
+— authors and agents never see raw ULIDs in cross-references.
+
 ---
 
 ## Part 3 — Directives

--- a/packages/markspec/lsp/completions_test.ts
+++ b/packages/markspec/lsp/completions_test.ts
@@ -671,3 +671,24 @@ Deno.test("buildMidTypedScaffoldItems: empty types → empty array", () => {
   );
   assertEquals(items.length, 0);
 });
+
+// --- Issue #593: ID-reference completion inserts display ID, never ULID ---
+
+Deno.test(
+  "buildIdReferenceItems: inserts the display ID, never a ULID (issue #593)",
+  () => {
+    const items = buildIdReferenceItems([
+      { displayId: makeDisplayId("SYS_0001"), title: "Target one" },
+      { displayId: makeDisplayId("SWE_0002"), title: "Target two" },
+    ]);
+    assertEquals(items.length, 2);
+    for (const item of items) {
+      // No insertText — the editor inserts the label (the display ID).
+      assertEquals(item.insertText, undefined);
+      // The label must not look like a ULID (26 Crockford base-32 chars after "01").
+      assertEquals(/^01[0-9A-HJKMNP-TV-Z]{24}$/.test(item.label), false);
+    }
+    assertEquals(items[0].label, "SYS_0001");
+    assertEquals(items[1].label, "SWE_0002");
+  },
+);

--- a/packages/markspec/mcp/tools/context_test.ts
+++ b/packages/markspec/mcp/tools/context_test.ts
@@ -13,7 +13,7 @@ import {
   walkContext,
 } from "./context.ts";
 
-function mk(displayId: string, title: string): Entry {
+function mk(displayId: string, title: string, id?: string): Entry {
   return {
     displayId: makeDisplayId(displayId),
     title,
@@ -24,6 +24,7 @@ function mk(displayId: string, title: string): Entry {
     location: { file: "/proj/x.md", line: 1, column: 1 },
     source: { kind: "markdown" },
     bodyTokens: [],
+    ...(id !== undefined ? { id } : {}),
   };
 }
 
@@ -159,3 +160,29 @@ Deno.test("ENTRY_CONTEXT_DESCRIPTOR.description: points at Incoming links for op
     "Incoming links",
   );
 });
+
+// --- Issue #593: trace targets render as display IDs, never ULIDs ---
+
+Deno.test(
+  "entry_context: resolves a display-ID-authored satisfies chain (issue #593)",
+  () => {
+    // The target carries a known ULID id. renderContext renders nodes by
+    // displayId only — the ULID must not appear in the output.
+    const TARGET_ULID = "01J0000000000000000000TGT1";
+    const result = buildResult(
+      [
+        mk("SWE_0001", "Source"),
+        mk("SYS_0001", "Target", TARGET_ULID),
+      ],
+      [{ from: "SWE_0001", to: "SYS_0001", kind: "satisfies" }],
+    );
+    const chain = walkContext(result, "SWE_0001", 10);
+    assertEquals(chain.map((n) => n.displayId), ["SWE_0001", "SYS_0001"]);
+    const md = renderContext(chain, "SWE_0001");
+    assertStringIncludes(md, "SYS_0001");
+    // The target's ULID must not appear — nodes are identified by display
+    // ID, never by the internal ULID. This assertion would fail if
+    // renderContext ever emitted the `id` field instead of `displayId`.
+    assertEquals(md.includes(TARGET_ULID), false);
+  },
+);

--- a/packages/markspec/mcp/tools/list_test.ts
+++ b/packages/markspec/mcp/tools/list_test.ts
@@ -89,3 +89,39 @@ Deno.test("renderList: page past the end reports no entries on this page", () =>
   const text = renderList(entries, { mode: "full", page: 99 });
   assertStringIncludes(text, "No entries on page 99");
 });
+
+// --- Issue #593: entries listed by display ID, no ULID leaks ---
+
+Deno.test(
+  "entry_list: lists entries by display ID, never exposes their ULIDs (issue #593)",
+  () => {
+    // Entries carry distinct ULID ids. renderList must list them by
+    // displayId only — it must not emit any entry's ULID.
+    const SRC_ULID = "01J0000000000000000000SRC1";
+    const TGT_ULID = "01J0000000000000000000TGT1";
+    const entries = [
+      {
+        ...entry("SWE_0001", "Source", "software-requirement"),
+        id: SRC_ULID,
+      },
+      {
+        ...entry("SYS_0001", "Target", "system-requirement"),
+        id: TGT_ULID,
+      },
+    ];
+    const md = renderList(
+      entries as unknown as Parameters<typeof renderList>[0],
+      {
+        mode: "full",
+        page: 1,
+      },
+    );
+    assertStringIncludes(md, "SWE_0001");
+    assertStringIncludes(md, "SYS_0001");
+    // Neither entry's ULID may appear — entries are listed by display ID.
+    // These assertions would fail if renderList ever switched to emitting
+    // the `id` field instead of `displayId`.
+    assertEquals(md.includes(SRC_ULID), false);
+    assertEquals(md.includes(TGT_ULID), false);
+  },
+);

--- a/packages/markspec/mcp/tools/neighborhood_test.ts
+++ b/packages/markspec/mcp/tools/neighborhood_test.ts
@@ -1,4 +1,4 @@
-import { assertStringIncludes } from "@std/assert";
+import { assertEquals, assertStringIncludes } from "@std/assert";
 import type { CompileResult, Entry, Link } from "../../core/mod.ts";
 import { makeDisplayId } from "../../core/mod.ts";
 import { MAX_NODES, renderNeighborhood } from "./neighborhood.ts";
@@ -75,3 +75,31 @@ Deno.test("renderNeighborhood: appends truncation note when node cap is hit", ()
   const text = renderNeighborhood(compiled(entries, links), "SWE_0001", 5);
   assertStringIncludes(text, "truncated");
 });
+
+// --- Issue #593: trace targets render as display IDs, never ULIDs ---
+
+Deno.test(
+  "entry_neighborhood: renders neighbors as display IDs, never ULIDs (issue #593)",
+  () => {
+    // Neighbors carry known ULID ids. renderNeighborhood must identify them
+    // by displayId in the output, never by these ULIDs.
+    const TARGET_ULID = "01J0000000000000000000TGT1";
+    const CHILD_ULID = "01J0000000000000000000CHD1";
+    const result = compiled(
+      [
+        entry("SWE_0001", "Mid"),
+        { ...entry("SYS_0001", "Up"), id: TARGET_ULID } as unknown as Entry,
+        { ...entry("TST_0001", "Down"), id: CHILD_ULID } as unknown as Entry,
+      ],
+      [link("SWE_0001", "SYS_0001"), link("TST_0001", "SWE_0001")],
+    );
+    const md = renderNeighborhood(result, "SWE_0001", 5);
+    assertStringIncludes(md, "SYS_0001");
+    assertStringIncludes(md, "TST_0001");
+    // Neither neighbor's ULID may appear — neighbors are identified by
+    // display ID only. These assertions would fail if renderNeighborhood
+    // ever emitted the `id` fields instead of `displayId`.
+    assertEquals(md.includes(TARGET_ULID), false);
+    assertEquals(md.includes(CHILD_ULID), false);
+  },
+);

--- a/packages/markspec/mcp/tools/show_test.ts
+++ b/packages/markspec/mcp/tools/show_test.ts
@@ -70,3 +70,31 @@ Deno.test("renderShow: empty graph", () => {
     "No entry with display ID X_0001.\n",
   );
 });
+
+// --- Issue #593: trace targets render as display IDs, never ULIDs ---
+
+Deno.test(
+  "entry_show: renders trace targets as display IDs, never ULIDs (issue #593)",
+  () => {
+    // The target carries a known ULID id. renderShow must reference the
+    // target by its displayId in the link list, not by this ULID.
+    const TARGET_ULID = "01J0000000000000000000TGT1";
+    const target = {
+      ...entry("SYS_0001", "Target"),
+      id: TARGET_ULID,
+    };
+    const result = compiled(
+      [
+        entry("SWE_0001", "Source"),
+        target as unknown as ReturnType<typeof entry>,
+      ],
+      [link("SWE_0001", "SYS_0001")],
+    );
+    const md = renderShow(result, "SWE_0001", undefined);
+    assertStringIncludes(md, "SYS_0001");
+    // The target's ULID must not appear in the output — link targets are
+    // always identified by display ID. This assertion would fail if
+    // renderShow ever emitted the target's `id` field instead of `displayId`.
+    assertEquals(md.includes(TARGET_ULID), false);
+  },
+);


### PR DESCRIPTION
## Summary

PR4 — the **final** PR of the #593 epic (*display IDs in trace relations*). Slice
5: regression tests pinning the editor/agent surface — the LSP ID-reference
completion inserts **display IDs** (never ULIDs), and the MCP read tools
(`entry_show`, `entry_list`, `entry_neighborhood`, `entry_context`) present trace
targets as **display IDs**, with `entry_context` resolving a display-ID-authored
`Satisfies:` chain.

This is a **test + docs** PR: no production code changed — the completion path
already emits `label: entry.displayId` (no `insertText`), and the MCP tools
render the display-ID-keyed compiler graph. The tests lock these guarantees so a
future refactor can't silently leak a ULID into a cross-reference.

## What changed

- **LSP** (`lsp/completions_test.ts`): `buildIdReferenceItems` inserts the display
  ID — `label` is the display ID, `insertText` is unset (so the editor inserts the
  label), and no label is a 26-char ULID.
- **MCP** (`mcp/tools/{context,show,neighborhood,list}_test.ts`): each test gives
  the **target** entry a real ULID `id` and asserts the rendered Markdown contains
  the target's **display ID** and **not** that target's ULID — a genuine
  ULID-leak detector. `entry_context` resolves a display-ID-authored satisfies
  chain (`SWE_0001 → SYS_0001`).
- **Docs** (`docs/spec/language/language.md`): a short note on the end-to-end
  display-ID surface (authored display IDs → `fmt` canonicalise/heal → LSP
  completion + MCP read tools present display IDs). Skills already use display-ID
  `Satisfies:` examples (no change needed).

## Epic recap (#593)

1. PR1 (#599): validator accepts display-ID trace values + dual-resolution + MSL-L006.
2. PR2 (#602): `markspec lock` persists a per-edge ULID identity ledger.
3. PR3 (#604): `markspec fmt` canonicalises ULID→display-ID and heals renamed refs.
4. PR4 (this): LSP/MCP display-ID guarantees.

`just build` + `deno fmt --check` + `dprint check` all green.

Closes #593.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
