### PR TITLE
fix(core): handle CRLF in trace-ref canonicalisation

### DIFF
--- a/packages/markspec/core/refs/mod.ts
+++ b/packages/markspec/core/refs/mod.ts
@@ -107,7 +107,12 @@ export function canonicalizeRefs(
   const lines = content.split("\n");
   let changed = false;
   for (let i = 0; i < lines.length; i++) {
-    const m = TRACE_TRAILER_RE.exec(lines[i]);
+    // Strip a trailing CR before matching so CRLF files are handled (the
+    // trailer regex ends in `$`, which `\r` would block) and re-append it on
+    // rewrite so line endings stay byte-for-byte lossless.
+    const cr = lines[i].endsWith("\r");
+    const bare = cr ? lines[i].slice(0, -1) : lines[i];
+    const m = TRACE_TRAILER_RE.exec(bare);
     if (!m) continue;
     const [, indent, key, sep, rest] = m;
     if (!TRACE_ATTRIBUTE_KEYS.has(key)) continue;
@@ -119,7 +124,7 @@ export function canonicalizeRefs(
       (token) => rewriteToken(token, sourceUlid, key, index, ledgerByKey),
     );
     if (rewritten !== rest) {
-      lines[i] = `${indent}${key}${sep}${rewritten}`;
+      lines[i] = `${indent}${key}${sep}${rewritten}${cr ? "\r" : ""}`;
       changed = true;
     }
   }

--- a/packages/markspec/core/refs/mod_test.ts
+++ b/packages/markspec/core/refs/mod_test.ts
@@ -393,6 +393,60 @@ Deno.test("canonicalizeRefs: trailer line with trailing backslash is left untouc
 });
 
 // ---------------------------------------------------------------------------
+// canonicalizeRefs — CRLF line endings (#610 regression)
+// ---------------------------------------------------------------------------
+
+Deno.test("canonicalizeRefs: CRLF file canonicalises a ULID and preserves the CR", () => {
+  // Same content as the rule-1 test but with CRLF line endings. The trailer
+  // regex must still match (the CR is stripped before matching) and the
+  // rewritten line must retain its trailing CR so line endings are lossless.
+  // The Satisfies line must NOT be the final line — only a non-final line
+  // carries a trailing CR after `split("\n")`, which is what exposes the bug.
+  const content = [
+    `- [SWE_0001] Title`,
+    ``,
+    `  Body.`,
+    ``,
+    `      Id: ${SRC}`,
+    `      Satisfies: ${TGT}`,
+    ``,
+  ].join("\r\n");
+
+  const src = entry({
+    displayId: "SWE_0001",
+    id: SRC,
+    rawAttributes: [
+      { key: "Id", value: SRC },
+      { key: "Satisfies", value: TGT },
+    ],
+    location: { file: "x.md", line: 1, column: 1 },
+  });
+  const tgt = entry({
+    displayId: "SYS_0001",
+    id: TGT,
+    rawAttributes: [{ key: "Id", value: TGT }],
+    location: { file: "x.md", line: 8, column: 1 },
+  });
+
+  const idx = buildRefIndex([src, tgt]);
+  const { output, changed } = canonicalizeRefs(content, [src, tgt], idx, []);
+
+  assertEquals(changed, true);
+  // Output is byte-for-byte the input with only the ULID token canonicalised
+  // and every CRLF preserved.
+  const expected = [
+    `- [SWE_0001] Title`,
+    ``,
+    `  Body.`,
+    ``,
+    `      Id: ${SRC}`,
+    `      Satisfies: SYS_0001`,
+    ``,
+  ].join("\r\n");
+  assertEquals(output, expected);
+});
+
+// ---------------------------------------------------------------------------
 // Spec-invariant hardening (review follow-up)
 // ---------------------------------------------------------------------------
 

--- a/tests/e2e/display_id_trace_fmt_test.ts
+++ b/tests/e2e/display_id_trace_fmt_test.ts
@@ -164,6 +164,52 @@ Deno.test(
 );
 
 Deno.test(
+  "fmt --check: CRLF file with a ULID trace value still needs canonicalisation (#610)",
+  async () => {
+    // Regression for #610: a CRLF file must not silently pass --check while
+    // its LF twin (the test above) exits 1.
+    const { code } = await markspec(
+      ["fmt", "--check", "swe.md", "sys.md"],
+      {
+        files: {
+          "project.yaml": PROJECT_YAML,
+          "sys.md": SYS.replace(/\n/g, "\r\n"),
+          "swe.md": SWE_ULID.replace(/\n/g, "\r\n"),
+        },
+        permissions: ["--allow-env", "--allow-run"],
+      },
+    );
+    assertEquals(code, 1);
+  },
+);
+
+Deno.test(
+  "fmt: CRLF file canonicalises a ULID trace value and preserves CRLF (#610)",
+  async () => {
+    const run = await markspecPersist(["fmt", "swe.md", "sys.md"], {
+      files: {
+        "project.yaml": PROJECT_YAML,
+        "sys.md": SYS.replace(/\n/g, "\r\n"),
+        "swe.md": SWE_ULID.replace(/\n/g, "\r\n"),
+      },
+      permissions: ["--allow-env", "--allow-run"],
+    });
+    try {
+      assertEquals(run.code, 0, run.stderr);
+      const swe = await Deno.readTextFile(join(run.dir, "swe.md"));
+      // Canonicalised, and the CRLF line ending on the rewritten line survives.
+      assertStringIncludes(swe, "Satisfies: SYS_0001\r\n");
+      assertEquals(
+        swe.includes("Satisfies: 01SYS000000000000000000001"),
+        false,
+      );
+    } finally {
+      await Deno.remove(run.dir, { recursive: true });
+    }
+  },
+);
+
+Deno.test(
   "fmt: file-local (no project root) does NOT canonicalise a ULID trace value",
   async () => {
     // No project.yaml → file-local fmt. The ULID reference must be left as


### PR DESCRIPTION
Closes #610.

`canonicalizeRefs` (`core/refs/mod.ts`) split content on `"\n"` and matched each line against a `$`-anchored trailer regex (`TRACE_TRAILER_RE`). On a **CRLF** file the trailing `\r` blocks `(.*)$`, so **no trace line matched** — ULID canonicalisation and rename-healing were silently skipped, and `markspec fmt --check` exited **0** (false pass) where the LF twin exits 1. The secondary multi-line guard `rest.endsWith("\\")` was likewise `\r`-blind.

## Fix
Strip a trailing `\r` before matching and re-append it on rewrite, so CRLF files are canonicalised/healed and line endings stay byte-for-byte lossless. Surgical: 9 lines in `core/refs/mod.ts`, no behavior change for LF files.

## Tests
- **Unit** (`core/refs/mod_test.ts`): a CRLF file canonicalises a ULID and preserves every CRLF. The trace line is deliberately **non-final** (only a non-final line carries a trailing CR after `split("\n")` — a final-line fixture would pass even with the bug).
- **E2E** (`tests/e2e/display_id_trace_fmt_test.ts`): `fmt --check` exits 1 on a CRLF file with a stale ULID; `fmt` rewrites it and preserves CRLF.

Both fail on `main` and pass with the fix. `just check` green (3192 tests).

Found in review of #604.