### PR TITLE
fix(core): guard classification against a malformed display-id-pattern

### DIFF
--- a/packages/markspec/core/validator/pattern.ts
+++ b/packages/markspec/core/validator/pattern.ts
@@ -103,6 +103,27 @@ export function compileDisplayIdPattern(template: string): RegExp {
   return new RegExp(regexSource);
 }
 
+/**
+ * Compile a display-ID pattern, returning `undefined` instead of throwing when
+ * the template is malformed.
+ *
+ * Defensive guard for the classification stage: the canonical fix rejects a
+ * malformed `display-id-pattern` at profile-load (`PROFILE-TYPE-008`, #597),
+ * but until that fix is on the same branch a bad pattern reaching
+ * classification must not crash `markspec check` with an uncaught throw
+ * (clig.dev: never surface a raw stack trace). A skipped type simply does not
+ * classify — the entry surfaces as `MSL-T003` rather than a crash.
+ */
+export function tryCompileDisplayIdPattern(
+  template: string,
+): RegExp | undefined {
+  try {
+    return compileDisplayIdPattern(template);
+  } catch {
+    return undefined;
+  }
+}
+
 function escapeRegex(s: string): string {
   return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }

--- a/packages/markspec/core/validator/types.ts
+++ b/packages/markspec/core/validator/types.ts
@@ -16,7 +16,7 @@ import type {
   ProvenancedMapEntry,
 } from "../model/mod.ts";
 import { CORE_TYPES } from "../model/mod.ts";
-import { compileDisplayIdPattern } from "./pattern.ts";
+import { tryCompileDisplayIdPattern } from "./pattern.ts";
 import {
   explicitType,
   resolvedCoreType,
@@ -197,7 +197,10 @@ export function classifyEntry(
   for (const [typeName, typeEntry] of profile.types) {
     const pattern = typeEntry.value.displayIdPattern.value;
     if (pattern === undefined) continue;
-    const regex = compileDisplayIdPattern(pattern);
+    // A malformed pattern must not crash classification — skip it (canonical
+    // fix: load-time PROFILE-TYPE-008, #597).
+    const regex = tryCompileDisplayIdPattern(pattern);
+    if (regex === undefined) continue;
     if (regex.test(entry.displayId)) {
       matches.push(typeName);
     }
@@ -290,8 +293,10 @@ function checkEnforcement(
   if (pattern === undefined) return undefined;
   const level = typeEntry.value.displayIdPatternEnforcement.value;
   if (level === "off") return undefined;
-  const regex = compileDisplayIdPattern(pattern);
-  if (regex.test(entry.displayId)) return undefined;
+  // A malformed pattern cannot enforce anything — skip rather than crash
+  // (canonical fix: load-time PROFILE-TYPE-008, #597).
+  const regex = tryCompileDisplayIdPattern(pattern);
+  if (regex === undefined || regex.test(entry.displayId)) return undefined;
   return {
     code: "MSL-T004",
     severity: level === "error" ? "error" : "warning",

--- a/packages/markspec/core/validator/types_test.ts
+++ b/packages/markspec/core/validator/types_test.ts
@@ -409,3 +409,40 @@ Deno.test("classifyEntry: Reference-shape entry is NOT classified by display-id-
   // Must not be classified via pattern for Reference entries.
   assertEquals(result.type, undefined);
 });
+
+// ─── Malformed display-id-pattern: classification must not crash (#597) ───────
+
+Deno.test("classifyEntriesStage: malformed pattern is skipped, not thrown (#597 hardening)", () => {
+  // `SWC_{a}_{a}` is rejected by validateDisplayIdPattern (duplicate named
+  // placeholder) and would throw from compileDisplayIdPattern inside the
+  // per-entry loop, crashing the whole pipeline. The stage must skip the
+  // malformed type instead. Canonical fix: load-time PROFILE-TYPE-008 (#601).
+  const profile = buildProfile([
+    buildType({ name: "component", displayIdPattern: "SWC_{a}_{a}" }),
+  ]);
+  const entry = buildEntry({ displayId: "SWC_LIGHT_CTRL", shape: "Authored" });
+  const result = classifyEntriesStage([entry], profile);
+  // Pass-through unclassified — no usable pattern matched.
+  assertEquals(result.entries[0].type, undefined);
+});
+
+Deno.test("classifyEntriesStage: malformed pattern with explicit Type does not crash enforcement (#597 hardening)", () => {
+  // Explicit `Type: component` classifies via the trailer (bypassing the
+  // pattern), then checkEnforcement compiles the same malformed pattern. That
+  // compile must not throw either.
+  const profile = buildProfile([
+    buildType({
+      name: "component",
+      displayIdPattern: "SWC_{a}_{a}",
+      enforcement: "error",
+    }),
+  ]);
+  const entry = buildEntry({
+    displayId: "SWC_LIGHT_CTRL",
+    shape: "Authored",
+    typeAttribute: "component",
+  });
+  const result = classifyEntriesStage([entry], profile);
+  // Still classified by the explicit Type:; enforcement silently skipped.
+  assertEquals(result.entries[0].type, "component");
+});


### PR DESCRIPTION
Refs #597. (Does not close it — the canonical load-time fix is #601, currently stranded on `feat/597`; this is the immediate crash guard on `main`.)

A malformed `display-id-pattern` that reaches classification throws an uncaught error from `compileDisplayIdPattern`, crashing `markspec check` with a raw stack trace instead of a diagnostic (clig.dev violation). On current `main`:

```
error: Uncaught (in promise) Error: display-id-pattern 'SWC_{a}_{a}': duplicate named placeholder '{a}'
    at compileDisplayIdPattern (core/validator/pattern.ts:75)
    at classifyEntry (core/validator/types.ts:200)
    at classifyEntriesStage ...
```

Both classification call sites throw: `classifyEntry` (pattern-match path) and `checkEnforcement` (reached via an explicit `Type:` trailer, which bypasses the pattern match but still compiles the pattern for enforcement).

## Fix
Add `tryCompileDisplayIdPattern(template): RegExp | undefined`, which catches the malformed-pattern throw and returns `undefined`. Both sites skip the offending type, so a bad profile degrades to `MSL-T003` ("un-classified entry") rather than an uncaught crash. No behavior change for well-formed patterns.

This is **defense-in-depth** at the classification layer. The canonical fix (#601) rejects malformed patterns at profile-load with `PROFILE-TYPE-008` before any entry is classified; when that cascades to `main` this guard becomes dormant (the type never reaches classification with a bad pattern). The two do not conflict — #601 touches `core/profile/manifest.ts`, this touches `core/validator/`.

## Tests
Two unit regressions in `core/validator/types_test.ts` (both fail on `main`): a malformed pattern is skipped (pattern-match path) and does not crash enforcement (explicit-`Type:` path). `just check` green (3191 tests).

Found in review of #595/#599 (the M1 finding).