### PR TITLE
feat(cli): named-aware authoring + validate-pattern-at-load (cascade #597/#598)

### DIFF
--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -359,6 +359,17 @@ markspec next-id requirement "docs/**/*.md" --format json
 # → {"type":"requirement","displayId":"SRS_PRJ_0004"}
 ```
 
+For a **named (counter-less) type** — one whose `display-id-pattern` has no
+`{n}` counter, e.g. `sw-component: "SWC_{name}"` (ADR-025) — there is no number
+to mint. `next-id`, `create`, and `insert` instead emit an upper-case `NAME`
+placeholder template for you to fill in by hand (slug-valid, so the scaffold
+still passes `markspec check`):
+
+```sh
+markspec next-id sw-component "docs/**/*.md"
+# → SWC_NAME   (with a note on stderr: author the identifier yourself)
+```
+
 #### lint
 
 Run prose-quality analysis on entries (INCOSE lexicon, modal keywords,

--- a/docs/spec/internal/markspec-profile-schema.md
+++ b/docs/spec/internal/markspec-profile-schema.md
@@ -258,6 +258,13 @@ ADR-008's per-type key set — Annex B):
 Any other per-type key is `PROFILE-TYPE-005` (new, error). The ADR-008 per-type
 `shape:` key is **removed** (§1.3 / Annex B).
 
+A malformed `display-id-pattern` — more than one `{n}` counter, an invalid or
+zero-width padding specifier, a counter-less pattern with no literal anchor, or
+a duplicate named placeholder — is a `PROFILE-TYPE-008` profile-load error
+(new). It is compile-checked once when the profile loads, against the same
+grammar the classifier uses, so a typo is reported cleanly at load instead of
+throwing an uncaught exception during validation.
+
 ### 4.1 Attributes — inherited, optional, required
 
 A type's effective attribute set is the **union** of:

--- a/docs/spec/model/annex-profile-schema.md
+++ b/docs/spec/model/annex-profile-schema.md
@@ -174,7 +174,15 @@ It requires a non-empty literal prefix plus a trailing named placeholder (e.g.
 underscores included. A bare `{name}` with no literal prefix is rejected — it
 would match every ID. Named patterns are classification-only: there is no
 counter to mint, so pair them with `display-id-pattern-enforcement: off` and
-author the ID by hand (`markspec next-id` / `create` skip named types).
+author the identifier by hand. `markspec next-id` / `create` / `insert` do not
+auto-number a named type — they emit an upper-case placeholder template (e.g.
+`SWC_NAME`, slug-valid so the scaffold still passes `markspec check`) to fill
+in, and the LSP offers a matching `${1:NAME}` scaffold completion.
+
+A malformed pattern — more than one counter, an invalid or zero-width padding
+specifier, a counter-less pattern with no literal prefix, or a duplicate named
+placeholder — is a `PROFILE-TYPE-008` error reported when the profile loads, not
+an uncaught failure during validation.
 
 `display-id-pattern-enforcement` controls whether an entry whose display ID does
 not match the pattern is ignored (`off`), warned (`warn`), or rejected

--- a/packages/markspec/cli/commands/id_helpers.ts
+++ b/packages/markspec/cli/commands/id_helpers.ts
@@ -10,30 +10,69 @@ import {
   highestDisplayIdNumber,
   parseDisplayIdPattern,
   type ProfileChain,
+  validateDisplayIdPattern,
 } from "../../core/mod.ts";
+
+/** A named (counter-less) placeholder — `{name}`, `{scope}` — in a pattern. */
+const NAMED_PLACEHOLDER_RE = /\{([A-Za-z][A-Za-z0-9_]*)\}/g;
+
+/**
+ * Render a *named* (counter-less) `display-id-pattern` as a fill-in
+ * template: each `{name}` placeholder becomes its upper-cased identifier
+ * for the author to replace by hand. e.g. `SWC_{name}` → `SWC_NAME`,
+ * `X_{a}_{b}` → `X_A_B`. Literals are left untouched.
+ *
+ * The placeholder MUST be a slug-valid token, not `<name>`: an angle-bracket
+ * placeholder is parsed as inline HTML, so a scaffold like `- [SWC_<name>]`
+ * yields zero entries and fails `markspec check` (MSL-P003). Upper-casing the
+ * identifier keeps the form slug-valid and matches the LSP snippet, whose
+ * `${1:NAME}` tab stop renders to `SWC_NAME`.
+ */
+export function namedIdTemplate(pattern: string): string {
+  return pattern.replace(
+    NAMED_PLACEHOLDER_RE,
+    (_, ident) => ident.toUpperCase(),
+  );
+}
 
 /**
  * Compute the next display ID for a given pattern and existing entries.
  *
- * Parses the `{n:Nd}` placeholder from `pattern`, scans `entries` for
- * the highest existing number with the same prefix/suffix, and returns
+ * For a *numbered* pattern, parses the `{n:Nd}` counter, scans `entries`
+ * for the highest existing number with the same prefix/suffix, and returns
  * `prefix + (max+1 zero-padded to N digits) + suffix`.
  *
- * Exits with an error message if `pattern` contains no valid `{n:Nd}`
- * placeholder.
+ * A *named* (counter-less) type — e.g. `sw-component: "SWC_{name}"` (ADR-025)
+ * — has no counter to mint. Rather than failing, this prints a "named type,
+ * author the identifier yourself" note to stderr and returns a slug-valid
+ * placeholder template (`SWC_NAME`) so `create` / `insert` scaffold a block
+ * that still passes `markspec check`, and `next-id` prints the form to fill in.
+ *
+ * Exits only when `pattern` is genuinely malformed (which profile-load now
+ * rejects upstream via PROFILE-TYPE-008, so this is a defensive fallback).
  */
 export function nextDisplayId(
   pattern: string,
   entries: Iterable<{ displayId: string }>,
 ): string {
   const shape = parseDisplayIdPattern(pattern);
-  if (!shape) {
-    console.error(
-      `error: display-id-pattern '${pattern}' does not contain a recognised number placeholder ('{n:Nd}')`,
-    );
-    Deno.exit(1);
+  if (shape) {
+    return formatDisplayId(shape, highestDisplayIdNumber(shape, entries) + 1);
   }
-  return formatDisplayId(shape, highestDisplayIdNumber(shape, entries) + 1);
+  const validation = validateDisplayIdPattern(pattern);
+  if (validation.ok) {
+    const template = namedIdTemplate(pattern);
+    console.error(
+      `note: '${pattern}' is a named (counter-less) type — not auto-numbered; ` +
+        `author the identifier yourself by replacing the upper-case ` +
+        `placeholder in '${template}'`,
+    );
+    return template;
+  }
+  console.error(
+    `error: display-id-pattern '${pattern}' is invalid: ${validation.message}`,
+  );
+  Deno.exit(1);
 }
 
 /**

--- a/packages/markspec/cli/commands/id_helpers_test.ts
+++ b/packages/markspec/cli/commands/id_helpers_test.ts
@@ -1,0 +1,18 @@
+/**
+ * @module cli/commands/id_helpers_test
+ */
+
+import { assertEquals } from "@std/assert";
+import { namedIdTemplate } from "./id_helpers.ts";
+
+Deno.test("namedIdTemplate: replaces each named placeholder with its upper-cased identifier", () => {
+  // Slug-valid (no angle brackets) so the scaffold survives `markspec check`.
+  assertEquals(namedIdTemplate("SWC_{name}"), "SWC_NAME");
+  assertEquals(namedIdTemplate("HWC_{name}"), "HWC_NAME");
+  assertEquals(namedIdTemplate("XREQ_{scope}"), "XREQ_SCOPE");
+});
+
+Deno.test("namedIdTemplate: handles multiple placeholders and keeps literals", () => {
+  assertEquals(namedIdTemplate("X_{a}_{b}"), "X_A_B");
+  assertEquals(namedIdTemplate("SWC_{name}-draft"), "SWC_NAME-draft");
+});

--- a/packages/markspec/cli/commands/next_id.ts
+++ b/packages/markspec/cli/commands/next_id.ts
@@ -5,6 +5,7 @@
  */
 
 import { Command } from "@cliffy/command";
+import { parseDisplayIdPattern } from "../../core/mod.ts";
 import { compileProject } from "../helpers.ts";
 import { nextDisplayId, resolveTypePattern } from "./id_helpers.ts";
 
@@ -26,12 +27,23 @@ export const nextIdCmd = new Command()
         Deno.exit(1);
       }
       const pattern = resolveTypePattern(typeName, chain, "next-id");
-      const displayId = nextDisplayId(pattern, result.entries.values());
+      const value = nextDisplayId(pattern, result.entries.values());
+      // A named (counter-less) type is not mintable: `value` is a fill-in
+      // template (e.g. `SWC_NAME`), not an allocated ID. parseDisplayIdPattern
+      // returns undefined only for named patterns here (malformed ones already
+      // exited inside nextDisplayId), so it is a reliable discriminator.
+      const named = parseDisplayIdPattern(pattern) === undefined;
 
       if (options.format === "json") {
-        console.log(JSON.stringify({ type: typeName, displayId }));
+        // Give structured consumers an explicit flag so an agent does not write
+        // the placeholder template as if it were an allocated display ID.
+        console.log(JSON.stringify(
+          named
+            ? { type: typeName, named: true, template: value }
+            : { type: typeName, displayId: value },
+        ));
       } else {
-        console.log(displayId);
+        console.log(value);
       }
     },
   );

--- a/packages/markspec/core/profile/manifest.ts
+++ b/packages/markspec/core/profile/manifest.ts
@@ -32,6 +32,7 @@ import {
   VALUE_TYPES,
   type ValueType,
 } from "../model/mod.ts";
+import { validateDisplayIdPattern } from "./display_id.ts";
 
 const VALUE_TYPE_SET: ReadonlySet<string> = new Set(VALUE_TYPES);
 
@@ -1115,6 +1116,24 @@ function parseTypeDef(
       return undefined;
     }
     displayIdPattern = r["display-id-pattern"];
+    // Compile-check the pattern here, at profile-load, against the same grammar
+    // oracle classification uses. A malformed pattern (duplicate named
+    // placeholder, bad padding, no anchor, …) is reported as a clean
+    // PROFILE-TYPE-008 diagnostic instead of throwing an uncaught exception
+    // later inside classifyEntry / checkEnforcement. Like the sibling field
+    // checks above, an error here drops the type so the bad pattern never
+    // reaches compileDisplayIdPattern (and, per parseManifest's all-or-nothing
+    // error contract, the manifest is rejected). (#597)
+    const patternValidation = validateDisplayIdPattern(displayIdPattern);
+    if (!patternValidation.ok) {
+      diagnostics.push({
+        code: "PROFILE-TYPE-008",
+        severity: "error",
+        message: `${ctx}: ${patternValidation.message}`,
+        location: { file: sourcePath, line: 1, column: 1 },
+      });
+      return undefined;
+    }
   }
 
   let enforcement: EnforcementMode = "off";

--- a/packages/markspec/core/profile/manifest_test.ts
+++ b/packages/markspec/core/profile/manifest_test.ts
@@ -4,7 +4,7 @@
  * Unit tests for markspec.yaml manifest parsing.
  */
 
-import { assertEquals, assertExists } from "@std/assert";
+import { assertEquals, assertExists, assertStringIncludes } from "@std/assert";
 import { fromFileUrl } from "@std/path";
 import { parseManifest } from "./manifest.ts";
 
@@ -127,6 +127,45 @@ profile:
 `);
   assertEquals(result.manifest, null);
   assertEquals(result.diagnostics[0].code, "PROFILE-LOAD-003");
+});
+
+Deno.test("parseManifest: invalid display-id-pattern emits PROFILE-TYPE-008 (#597)", () => {
+  const result = parseManifest(`
+id: "@acme/x"
+version: 1.0.0
+profile:
+  types:
+    sw-component:
+      extends: SoftwareComponent
+      display-id-pattern: "SWC_{x}_{x}"
+`);
+  // A malformed pattern is reported as a clean diagnostic, not thrown later.
+  // Per parseManifest's all-or-nothing error contract, the manifest is
+  // rejected (null) — the same as every other type-field error.
+  assertEquals(result.manifest, null);
+  const t008 = result.diagnostics.find((d) => d.code === "PROFILE-TYPE-008");
+  assertExists(t008);
+  assertStringIncludes(t008.message, "duplicate named placeholder");
+});
+
+Deno.test("parseManifest: valid display-id-pattern emits no PROFILE-TYPE-008 (#597)", () => {
+  const result = parseManifest(`
+id: "@acme/x"
+version: 1.0.0
+profile:
+  types:
+    software-requirement:
+      extends: Requirement
+      display-id-pattern: "SRS_{n:4d}"
+`);
+  assertExists(result.manifest);
+  assertEquals(
+    result.diagnostics.some((d) => d.code === "PROFILE-TYPE-008"),
+    false,
+  );
+  const srs = result.manifest.types.get("software-requirement");
+  assertExists(srs);
+  assertEquals(srs.displayIdPattern, "SRS_{n:4d}");
 });
 
 Deno.test("parseManifest: referenced.traceability is not a recognized key", () => {

--- a/packages/markspec/lsp/completions.ts
+++ b/packages/markspec/lsp/completions.ts
@@ -202,6 +202,14 @@ export interface EntryTypeInfo {
    * `detail` field. `undefined` or `false` → no special treatment.
    */
   readonly modeRecommended?: boolean;
+  /**
+   * `true` for a named (counter-less) type (ADR-025) whose IDs are named,
+   * not numbered — e.g. `sw-component: "SWC_{name}"`. `prefix` carries the
+   * literal anchor (`SWC_`); `width` / `suffix` / `nextNumber` are unused.
+   * The scaffold inserts a `${1:NAME}` tab stop after the prefix instead of
+   * a minted number (#598).
+   */
+  readonly named?: boolean;
 }
 
 /**
@@ -283,6 +291,12 @@ export interface ScaffoldSnippetInput {
   readonly suffix: string;
   readonly nextNumber: number;
   readonly ulid: string;
+  /**
+   * `true` to render a named (counter-less) scaffold: a `${1:NAME}` tab stop
+   * after the literal `prefix` instead of a minted display ID. `width`,
+   * `suffix`, and `nextNumber` are ignored in this mode (#598).
+   */
+  readonly named?: boolean;
 }
 
 /**
@@ -307,6 +321,12 @@ export interface ScaffoldCompletionData {
   readonly prefix: string;
   readonly width: number;
   readonly suffix: string;
+  /**
+   * `true` for a named (counter-less) type (#598). The resolve handler skips
+   * the number-minting path and re-renders the `${1:NAME}` snippet with a
+   * fresh ULID; `width` / `suffix` are unused.
+   */
+  readonly named?: boolean;
   /**
    * Present only for mid-typed scaffold items (see
    * {@linkcode buildMidTypedScaffoldItems}): the exact range the
@@ -343,6 +363,17 @@ export function renderScaffoldSnippet(
   input: ScaffoldSnippetInput,
 ): { label: string; insertText: string } {
   const safeTypeName = escapeSnippet(input.typeName);
+  // Named (counter-less) type (#598): no number to mint. The author types
+  // the identifier into the first tab stop after the literal prefix, so the
+  // Title/Body/Satisfies stops shift one place to avoid colliding with it.
+  if (input.named) {
+    const safePrefix = escapeSnippet(input.prefix);
+    return {
+      label: `New ${safeTypeName} (${input.prefix}<name>)`,
+      insertText:
+        `${safePrefix}\${1:NAME}] \${2:Title}\n\n  \${3:Body.}\n\n      Id: ${input.ulid}\n      \${4:Satisfies: }`,
+    };
+  }
   // Format the display ID via the shared `formatDisplayId` so width
   // + suffix come straight from the profile's pattern, then escape
   // the result for snippet syntax. Escaping AFTER formatting is
@@ -423,6 +454,7 @@ export function buildBlockScaffoldItems(
       suffix: type.suffix,
       nextNumber: type.nextNumber,
       ulid: ulidProvider(),
+      named: type.named,
     });
     const detail = type.modeRecommended === true
       ? `${type.name} (recommended)`
@@ -462,6 +494,10 @@ export interface MidTypedScaffoldItem {
   readonly prefix: string;
   readonly width: number;
   readonly suffix: string;
+  /** `true` for a named (counter-less) type — the server passes this into
+   * the resolve-time {@linkcode ScaffoldCompletionData} so it skips minting
+   * a number (#598). */
+  readonly named?: boolean;
   readonly textEdit: {
     readonly range: ReplacementRange;
     readonly newText: string;
@@ -525,6 +561,7 @@ export function buildMidTypedScaffoldItems(
       suffix: type.suffix,
       nextNumber: type.nextNumber,
       ulid: ulidProvider(),
+      named: type.named,
     });
     return {
       label: rendered.label,
@@ -533,6 +570,7 @@ export function buildMidTypedScaffoldItems(
       prefix: type.prefix,
       width: type.width,
       suffix: type.suffix,
+      named: type.named,
       textEdit: { range: replacementRange, newText: rendered.insertText },
     };
   });

--- a/packages/markspec/lsp/completions_test.ts
+++ b/packages/markspec/lsp/completions_test.ts
@@ -692,3 +692,63 @@ Deno.test(
     assertEquals(items[1].label, "SWE_0002");
   },
 );
+
+// --- #598: named (counter-less) type scaffolds ---
+
+const NAMED_ULID = "01HGW2Q8MNP3RSTVWXYZABCDEF";
+
+Deno.test("renderScaffoldSnippet: named type emits a ${1:NAME} placeholder snippet (#598)", () => {
+  const snippet = renderScaffoldSnippet({
+    typeName: "sw-component",
+    prefix: "SWC_",
+    width: 0,
+    suffix: "",
+    nextNumber: 0,
+    ulid: NAMED_ULID,
+    named: true,
+  });
+  assertEquals(snippet.label, "New sw-component (SWC_<name>)");
+  // The author types the identifier into the first tab stop after the prefix.
+  assertEquals(snippet.insertText.startsWith("SWC_${1:NAME}]"), true);
+  assertEquals(snippet.insertText.includes(`Id: ${NAMED_ULID}`), true);
+  // Trailer tab stops shift past the name placeholder.
+  assertEquals(snippet.insertText.includes("${2:Title}"), true);
+  assertEquals(snippet.insertText.includes("${3:Body.}"), true);
+  assertEquals(snippet.insertText.includes("${4:Satisfies: }"), true);
+});
+
+Deno.test("buildBlockScaffoldItems: includes named types with a name placeholder (#598)", () => {
+  const items = buildBlockScaffoldItems(
+    [{
+      name: "sw-component",
+      prefix: "SWC_",
+      width: 0,
+      suffix: "",
+      nextNumber: 0,
+      named: true,
+    }],
+    () => NAMED_ULID,
+  );
+  assertEquals(items.length, 1);
+  assertEquals(items[0].label, "New sw-component (SWC_<name>)");
+  assertEquals(items[0].insertText?.startsWith("SWC_${1:NAME}]"), true);
+});
+
+Deno.test("buildMidTypedScaffoldItems: matches a named type by its leading literal (#598)", () => {
+  const items = buildMidTypedScaffoldItems(
+    [{
+      name: "sw-component",
+      prefix: "SWC_",
+      width: 0,
+      suffix: "",
+      nextNumber: 0,
+      named: true,
+    }],
+    "SWC_",
+    () => NAMED_ULID,
+    MID_RANGE,
+  );
+  assertEquals(items.length, 1);
+  assertEquals(items[0].named, true);
+  assertEquals(items[0].textEdit.newText.startsWith("SWC_${1:NAME}]"), true);
+});

--- a/packages/markspec/lsp/server.ts
+++ b/packages/markspec/lsp/server.ts
@@ -50,6 +50,7 @@ import {
   parseLockfile,
   type ProjectConfig,
   targetsForRelation,
+  validateDisplayIdPattern,
   VERSION,
 } from "../core/mod.ts";
 import { extendsTransitively } from "../core/profile/discipline_mode.ts";
@@ -298,15 +299,9 @@ function getEntryTypes(): EntryTypeInfo[] {
   for (const [name, typeDef] of profile.types) {
     const pattern = typeDef.value.displayIdPattern.value;
     if (!pattern) continue;
-    // Parse the `{n:Nd}` placeholder. Width and suffix flow through
-    // the snippet so profiles using non-4-digit IDs (`{n:6d}`) or
-    // a trailing literal don't produce mis-formatted scaffolds.
-    const shape = parseDisplayIdPattern(pattern);
-    if (!shape) continue;
-    const { prefix, width, suffix } = shape;
-    const nextNumber = index.getNextDisplayIdNumber(prefix, suffix);
 
-    // ADR-017 Slice 5: mark mode-relevant types as recommended.
+    // ADR-017 Slice 5: mark mode-relevant types as recommended. Shared by
+    // both the numbered and named branches below.
     const isRequirementShaped = extendsTransitively(
       name,
       "Requirement",
@@ -317,7 +312,33 @@ function getEntryTypes(): EntryTypeInfo[] {
       (mode === "flat" && isRequirementShaped && !hasDiscipline) ||
       (mode === "none" && isRequirementShaped);
 
-    types.push({ name, prefix, width, suffix, nextNumber, modeRecommended });
+    // Numbered pattern: parse the `{n:Nd}` placeholder. Width and suffix flow
+    // through the snippet so profiles using non-4-digit IDs (`{n:6d}`) or a
+    // trailing literal don't produce mis-formatted scaffolds.
+    const shape = parseDisplayIdPattern(pattern);
+    if (shape) {
+      const { prefix, width, suffix } = shape;
+      const nextNumber = index.getNextDisplayIdNumber(prefix, suffix);
+      types.push({ name, prefix, width, suffix, nextNumber, modeRecommended });
+      continue;
+    }
+
+    // Named (counter-less) type (ADR-025, #598): not mintable, but still
+    // offer a `${1:NAME}` scaffold. The literal anchor is everything before
+    // the first placeholder. A malformed pattern is skipped — profile-load
+    // (#597) already rejects those via PROFILE-TYPE-008.
+    if (!validateDisplayIdPattern(pattern).ok) continue;
+    const firstBrace = pattern.indexOf("{");
+    const prefix = firstBrace >= 0 ? pattern.slice(0, firstBrace) : pattern;
+    types.push({
+      name,
+      prefix,
+      width: 0,
+      suffix: "",
+      nextNumber: 0,
+      named: true,
+      modeRecommended,
+    });
   }
   return types;
 }
@@ -787,6 +808,7 @@ connection.onCompletion((params): CompletionItem[] | CompletionList => {
           prefix: item.prefix,
           width: item.width,
           suffix: item.suffix,
+          named: item.named,
           replacementRange: item.textEdit.range,
         } satisfies ScaffoldCompletionData,
       }));
@@ -817,6 +839,7 @@ connection.onCompletion((params): CompletionItem[] | CompletionList => {
               prefix: type.prefix,
               width: type.width,
               suffix: type.suffix,
+              named: type.named,
             } satisfies ScaffoldCompletionData
             : undefined,
         };
@@ -925,33 +948,53 @@ connection.onCompletionResolve((item): CompletionItem => {
   }
   // Defend against tampered or malformed resolve payloads from a hostile or
   // buggy LSP client. The typed cast above does not validate at runtime.
+  // These checks apply to both numbered and named scaffolds.
   if (
     typeof data.prefix !== "string" || data.prefix.length > 64 ||
     typeof data.typeName !== "string" || data.typeName.length > 128 ||
-    typeof data.suffix !== "string" || data.suffix.length > 64 ||
-    typeof data.width !== "number" || !Number.isInteger(data.width) ||
-    data.width < 1 || data.width > 32
+    typeof data.suffix !== "string" || data.suffix.length > 64
   ) {
     return item;
   }
-  // Mint and reserve the number atomically. Reserving before the snippet
-  // is built means a second resolve firing inside the parse-debounce
-  // window — before this entry reaches the index — sees the number as
-  // taken and picks the next one, closing the duplicate-ID race.
-  const { prefix, suffix } = data;
-  const nextNumber = mintReservedNumber(
-    prefix,
-    suffix,
-    (reserved) => index.getNextDisplayIdNumber(prefix, suffix, reserved),
-  );
-  const rendered = renderScaffoldSnippet({
-    typeName: data.typeName,
-    prefix: data.prefix,
-    width: data.width,
-    suffix: data.suffix,
-    nextNumber,
-    ulid: ulid(),
-  });
+  let rendered: { label: string; insertText: string };
+  if (data.named === true) {
+    // Named (counter-less) type (#598): no number to mint. Re-render the
+    // `${1:NAME}` snippet with a fresh ULID; width / suffix are unused.
+    rendered = renderScaffoldSnippet({
+      typeName: data.typeName,
+      prefix: data.prefix,
+      width: 0,
+      suffix: "",
+      nextNumber: 0,
+      ulid: ulid(),
+      named: true,
+    });
+  } else {
+    if (
+      typeof data.width !== "number" || !Number.isInteger(data.width) ||
+      data.width < 1 || data.width > 32
+    ) {
+      return item;
+    }
+    // Mint and reserve the number atomically. Reserving before the snippet
+    // is built means a second resolve firing inside the parse-debounce
+    // window — before this entry reaches the index — sees the number as
+    // taken and picks the next one, closing the duplicate-ID race.
+    const { prefix, suffix } = data;
+    const nextNumber = mintReservedNumber(
+      prefix,
+      suffix,
+      (reserved) => index.getNextDisplayIdNumber(prefix, suffix, reserved),
+    );
+    rendered = renderScaffoldSnippet({
+      typeName: data.typeName,
+      prefix: data.prefix,
+      width: data.width,
+      suffix: data.suffix,
+      nextNumber,
+      ulid: ulid(),
+    });
+  }
   // Mid-typed scaffold items carry the replacement range: rebuild the
   // textEdit with the freshly rendered snippet (a stale textEdit.newText
   // would otherwise win over insertText). Range is unchanged — the cursor

--- a/tests/e2e/named_authoring_test.ts
+++ b/tests/e2e/named_authoring_test.ts
@@ -1,0 +1,108 @@
+/**
+ * @module tests/e2e/named_authoring_test
+ *
+ * E2E for #598 — the mint/scaffold CLI paths are named-aware. A named
+ * (counter-less) type like `sw-component: "SWC_{name}"` is not mintable, but
+ * `next-id` / `create` / `insert` must offer a placeholder-name scaffold and a
+ * clear "author the identifier yourself" note instead of the misleading
+ * "does not contain a recognised number placeholder" error.
+ *
+ * The scaffolded placeholder MUST be slug-valid (`SWC_NAME`, not `SWC_<name>`):
+ * an angle-bracket token is parsed as inline HTML, so the block yields zero
+ * entries and fails `markspec check` (#613). The `insert → fmt → check` test
+ * below pins that the canonical agent write loop survives.
+ */
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { join } from "@std/path";
+import { markspec, markspecInDir, markspecPersist } from "./helpers.ts";
+
+const PROJECT_YAML = `name: named-authoring-e2e\nversion: 0.1.0\n`;
+const MARKSPEC_YAML = `profiles:\n  - ./profiles/acme\n`;
+const PROFILE_YAML = `id: "@acme/named"
+markspec-schema: "1"
+version: 0.1.0
+profile:
+  types:
+    sw-component:
+      extends: SoftwareComponent
+      display-id-pattern: "SWC_{name}"
+      display-id-pattern-enforcement: off
+`;
+
+const FILES = {
+  "project.yaml": PROJECT_YAML,
+  ".markspec.yaml": MARKSPEC_YAML,
+  "profiles/acme/markspec.yaml": PROFILE_YAML,
+  "components.md": `# Components\n`,
+  // A non-listing filename for the write-loop test, so the §6.3
+  // component-listing rule (orthogonal to the scaffold) does not interfere.
+  "parts.md": `# Parts\n`,
+};
+
+Deno.test("#598 e2e: next-id on a named type prints a placeholder template, not an error", async () => {
+  const { code, stdout, stderr } = await markspec(
+    ["next-id", "sw-component", "components.md"],
+    { files: FILES },
+  );
+  // Before #598: exit 1 with "does not contain a recognised number placeholder".
+  assertEquals(code, 0, stderr);
+  assertStringIncludes(stdout, "SWC_NAME");
+  assertStringIncludes(stderr.toLowerCase(), "named");
+});
+
+Deno.test("#598 e2e: create on a named type scaffolds a placeholder-name block", async () => {
+  const { code, stdout, stderr } = await markspec(
+    ["create", "sw-component", "components.md"],
+    { files: FILES },
+  );
+  assertEquals(code, 0, stderr);
+  assertStringIncludes(stdout, "[SWC_NAME]");
+  assertEquals(stdout.includes("[SWC_<name>]"), false);
+  assertStringIncludes(stdout, "Type: sw-component");
+});
+
+Deno.test("#613 e2e: next-id --format json flags a named type with a template field", async () => {
+  const { code, stdout } = await markspec(
+    ["next-id", "sw-component", "components.md", "--format", "json"],
+    { files: FILES },
+  );
+  assertEquals(code, 0);
+  const parsed = JSON.parse(stdout) as Record<string, unknown>;
+  // Structured consumers get an explicit discriminator, not a placeholder in
+  // the `displayId` slot.
+  assertEquals(parsed.named, true);
+  assertEquals(parsed.template, "SWC_NAME");
+  assertEquals("displayId" in parsed, false);
+});
+
+Deno.test("#613 e2e: insert → fmt → check on a named type produces a checkable block", async () => {
+  const run = await markspecPersist(
+    ["insert", "sw-component", "parts.md"],
+    { files: FILES, permissions: ["--allow-env", "--allow-run"] },
+  );
+  try {
+    assertEquals(run.code, 0, run.stderr);
+    const inserted = await Deno.readTextFile(join(run.dir, "parts.md"));
+    assertStringIncludes(inserted, "[SWC_NAME]");
+    assertEquals(inserted.includes("[SWC_<name>]"), false);
+
+    const fmt = await markspecInDir(
+      run.dir,
+      ["fmt", "parts.md"],
+      ["--allow-env", "--allow-run"],
+    );
+    assertEquals(fmt.code, 0, fmt.stderr);
+
+    // The canonical write loop must end clean — angle-bracket scaffolds failed
+    // here with MSL-P003 (#613).
+    const check = await markspecInDir(
+      run.dir,
+      ["check", "parts.md"],
+      ["--allow-env", "--allow-run"],
+    );
+    assertEquals(check.code, 0, check.stderr);
+  } finally {
+    await Deno.remove(run.dir, { recursive: true });
+  }
+});

--- a/tests/e2e/profile_pattern_validation_test.ts
+++ b/tests/e2e/profile_pattern_validation_test.ts
@@ -1,0 +1,53 @@
+/**
+ * @module tests/e2e/profile_pattern_validation_test
+ *
+ * E2E for #597 — a malformed `display-id-pattern` in a profile is reported as
+ * a clean `PROFILE-TYPE-008` diagnostic at profile-load instead of throwing an
+ * uncaught exception mid-validation (which crashed `markspec check`).
+ */
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { markspec } from "./helpers.ts";
+
+const PROJECT_YAML = `name: pattern-validation-e2e\nversion: 0.1.0\n`;
+const MARKSPEC_YAML = `profiles:\n  - ./profiles/acme\n`;
+
+// `SWC_{x}_{x}` repeats the named placeholder `{x}` — building the recognizer
+// regex would throw "Duplicate capture group name". Before #597 that surfaced
+// as an uncaught engine error during classifyEntry.
+const BAD_PROFILE_YAML = `id: "@acme/bad-pattern"
+markspec-schema: "1"
+version: 0.1.0
+profile:
+  types:
+    sw-component:
+      extends: SoftwareComponent
+      display-id-pattern: "SWC_{x}_{x}"
+      display-id-pattern-enforcement: off
+`;
+
+const COMPONENTS_MD = `# Components
+
+- [SWC_LIGHT_CTRL] Light controller
+
+  The light controller shall drive the exterior lamps.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+`;
+
+Deno.test("#597 e2e: malformed profile pattern → PROFILE-TYPE-008, not an uncaught crash", async () => {
+  const { code, stderr } = await markspec(["check", "components.md"], {
+    files: {
+      "project.yaml": PROJECT_YAML,
+      ".markspec.yaml": MARKSPEC_YAML,
+      "profiles/acme/markspec.yaml": BAD_PROFILE_YAML,
+      "components.md": COMPONENTS_MD,
+    },
+  });
+  assertEquals(code, 1, stderr);
+  assertStringIncludes(stderr, "PROFILE-TYPE-008");
+  assertStringIncludes(stderr, "duplicate named placeholder");
+  // The crux of #597: a clean MarkSpec diagnostic, never an engine-level
+  // uncaught throw / stack trace.
+  assertEquals(stderr.includes("Uncaught"), false, stderr);
+});


### PR DESCRIPTION
Closes #597, #598, #613.

## Why this PR exists
The stacked branches for #597 and #598 were merged into each other, not onto `main`: #600 (`fix/596`) landed on `main`, but **#601 (`feat/597`) merged into `fix/596`** and **#603 (`feat/598`) merged into `feat/597`** — leaving #601 and #603 "merged" in GitHub yet **stranded with no path to `main`**. This PR cascades that stranded work onto `main`, with the BLOCKER below fixed first.

## What it brings
- **#601 — validate `display-id-pattern` at profile-load** (`PROFILE-TYPE-008`). A malformed pattern is now rejected at load with a clean diagnostic instead of throwing an uncaught exception later inside `classifyEntry` / `checkEnforcement`.
- **#603 — named-aware `next-id` / `create` / `insert` + LSP scaffold** for counter-less ("named") types (ADR-025).

## Blocker fixed before landing (#613)
The named scaffold emitted `SWC_<name>` — the angle brackets parse as inline HTML, so `- [SWC_<name>]` produced **zero entries** and failed `markspec check` (`MSL-P003`), breaking the `insert → fmt → check` loop for exactly the types #603 targets. Now it emits the slug-valid `SWC_NAME` (matching the LSP `${1:NAME}` snippet). Verified end-to-end: `insert → fmt → check` exits 0.

## Also (review follow-ups)
- `next-id --format json` for a named type returns `{type, named: true, template}` instead of putting the placeholder in the `displayId` slot — structured consumers get an explicit discriminator.
- Fixed a stale `PROFILE-TYPE-006` comment (the code emits `008`) and a misnamed test var (#601 review nits).
- **Strengthened the named-authoring e2e** to actually run `insert → fmt → check` (the test gap that let the `<name>` scaffold ship) and to assert the JSON discriminator.
- Updated the guide + annex docs to the `NAME` placeholder and `${1:NAME}`.

## Conflict resolution
One merge conflict in `lsp/completions_test.ts` — #605 (display-ID guarantee test) and #603 (named-scaffold tests) both appended at the same spot; resolved by keeping both blocks.

## Verification
`just check` green — 3201 tests, 0 failed; all four entry points type-check; `deno fmt --check` + `dprint check` clean.

Found in review of #595/#599/#602/#603/#604/#605.