### PR TITLE
fix(core): make compareLockEdges a total order

### DIFF
--- a/packages/markspec/core/lock/serializer.ts
+++ b/packages/markspec/core/lock/serializer.ts
@@ -129,9 +129,13 @@ export function serializeLockfile(lf: Lockfile): string {
 }
 
 /**
- * Deterministic edge order: (sourceUlid, relation, authoredTarget, targetUlid).
- * `targetUlid` (treated as "" when absent) is the final tiebreaker so the
- * comparator is total — input order never affects output.
+ * Deterministic edge order: (sourceUlid, relation, authoredTarget,
+ * targetUlid). The first three keys can collide when one authored target
+ * resolves to two different ULIDs (e.g. duplicate display IDs across files
+ * whose first-wins tiebreak flips per machine); targetUlid breaks that tie
+ * so the comparator is a total order and input order never affects output.
+ * A missing targetUlid (dangling reference) sorts as the empty string,
+ * before any real ULID.
  */
 function compareLockEdges(a: LockEdge, b: LockEdge): number {
   const s = a.sourceUlid.localeCompare(b.sourceUlid);

--- a/packages/markspec/core/lock/serializer_test.ts
+++ b/packages/markspec/core/lock/serializer_test.ts
@@ -272,3 +272,35 @@ Deno.test("serializeLockfile: emits [[edge]] tables sorted by (source, relation,
   assertEquals(goneBlock.includes("01J0000000000000000000SRC1"), true);
   assertEquals(serializeLockfile(lf), toml); // determinism
 });
+
+Deno.test("serializeLockfile: edge order is total — colliding edges sort by target-ulid", () => {
+  // Two edges that collide on (source-ulid, relation, authored-target) and
+  // differ only in target-ulid. This arises when the same authored display ID
+  // resolves to two different ULIDs (duplicate display IDs across files whose
+  // first-wins tiebreak flips per machine). Without target-ulid in the
+  // comparator, the stable sort preserves input order — which comes from an
+  // unsorted Deno.readDir walk — so the bytes become machine-dependent.
+  const edgeA: Lockfile["edges"][number] = {
+    sourceUlid: "01J0000000000000000000SRC1",
+    relation: "Satisfies",
+    targetUlid: "01J0000000000000000000TGTA",
+    authoredTarget: "SYS_DUP_0001",
+  };
+  const edgeB: Lockfile["edges"][number] = {
+    sourceUlid: "01J0000000000000000000SRC1",
+    relation: "Satisfies",
+    targetUlid: "01J0000000000000000000TGTB",
+    authoredTarget: "SYS_DUP_0001",
+  };
+  const base: Lockfile = {
+    schema: 1,
+    meta: { markspecSchema: 1, lockedAt: "2026-06-06T00:00:00Z" },
+    upstreams: [],
+    boundEntries: [],
+    edges: [],
+    generatedCache: { edgesHash: "sha256:0", edgesCount: 0 },
+  };
+  const forward = serializeLockfile({ ...base, edges: [edgeA, edgeB] });
+  const reversed = serializeLockfile({ ...base, edges: [edgeB, edgeA] });
+  assertEquals(forward, reversed); // permutation-independent → total order
+});


### PR DESCRIPTION
Closes #611.

## What
Append `targetUlid` (treating `undefined` as `""`) as the final tiebreaker in `compareLockEdges` (`core/lock/serializer.ts`), making the `[[edge]]` ledger comparator a **total order**.

## Why
The comparator sorted on `(sourceUlid, relation, authoredTarget)` and omitted `targetUlid`. When two edges collide on those three fields but differ in `targetUlid` — e.g. one authored display ID resolving to two ULIDs because a duplicate display ID's first-wins tiebreak flips per machine — the stable sort fell back to **input order**, which comes from an unsorted `Deno.readDir` walk. That made `markspec.lock` bytes machine-dependent, defeating the deterministic-artifact contract (AGENTS.md). A missing `targetUlid` (dangling reference) sorts as the empty string, before any real ULID.

## Tests
Added `serializeLockfile: edge order is total — colliding edges sort by target-ulid`: serializes two **input permutations** of a colliding edge set (same `sourceUlid`+`relation`+`authoredTarget`, different `targetUlid`) and asserts byte-equality. Confirmed RED before the fix, GREEN after. Full suite: 3207 passed, 0 failed.

Note: the secondary `localeCompare`-locale-dependency concern raised in #611 is explicitly left as separate scope.
