### PR TITLE
fix(core): make compareLockEdges a total order (targetUlid tiebreaker)

### DIFF
--- a/packages/markspec/core/lock/serializer.ts
+++ b/packages/markspec/core/lock/serializer.ts
@@ -129,15 +129,18 @@ export function serializeLockfile(lf: Lockfile): string {
 }
 
 /**
- * Deterministic edge order: (sourceUlid, relation, authoredTarget). Input order
- * never affects output, so identical project state → byte-identical lockfile.
+ * Deterministic edge order: (sourceUlid, relation, authoredTarget, targetUlid).
+ * `targetUlid` (treated as "" when absent) is the final tiebreaker so the
+ * comparator is total — input order never affects output.
  */
 function compareLockEdges(a: LockEdge, b: LockEdge): number {
   const s = a.sourceUlid.localeCompare(b.sourceUlid);
   if (s !== 0) return s;
   const r = a.relation.localeCompare(b.relation);
   if (r !== 0) return r;
-  return a.authoredTarget.localeCompare(b.authoredTarget);
+  const t = a.authoredTarget.localeCompare(b.authoredTarget);
+  if (t !== 0) return t;
+  return (a.targetUlid ?? "").localeCompare(b.targetUlid ?? "");
 }
 
 /**

--- a/packages/markspec/core/lock/serializer_test.ts
+++ b/packages/markspec/core/lock/serializer_test.ts
@@ -204,6 +204,35 @@ Deno.test("serializer: first line is the #:schema directive", () => {
   );
 });
 
+Deno.test("serializeLockfile: edge sort is total — colliding (source, relation, authored-target) differ only by targetUlid produce identical bytes regardless of input order", () => {
+  // Two edges share (sourceUlid, relation, authoredTarget) but have different
+  // targetUlids — a collision that the old comparator left as input-order-dependent.
+  const edgeA = {
+    sourceUlid: "01J0000000000000000000SRC1",
+    relation: "Satisfies",
+    authoredTarget: "SYS_DUP_0001",
+    targetUlid: "01J0000000000000000000TGA1",
+  };
+  const edgeB = {
+    sourceUlid: "01J0000000000000000000SRC1",
+    relation: "Satisfies",
+    authoredTarget: "SYS_DUP_0001",
+    targetUlid: "01J0000000000000000000TGB2",
+  };
+  const base: Lockfile = {
+    ...EMPTY_LOCKFILE,
+    edges: [],
+    generatedCache: { edgesHash: "sha256:x", edgesCount: 2 },
+  };
+  const toml1 = serializeLockfile({ ...base, edges: [edgeA, edgeB] });
+  const toml2 = serializeLockfile({ ...base, edges: [edgeB, edgeA] });
+  assertEquals(
+    toml1,
+    toml2,
+    "both input permutations must produce identical bytes",
+  );
+});
+
 Deno.test("serializeLockfile: emits [[edge]] tables sorted by (source, relation, authored-target)", () => {
   const lf: Lockfile = {
     schema: 1,


### PR DESCRIPTION
Closes #611.

## What
`compareLockEdges` in `core/lock/serializer.ts` sorted on `(sourceUlid, relation, authoredTarget)` and omitted `targetUlid`. When two edges shared those three fields but differed only in `targetUlid`, the sort was unstable and fell back to input order — which comes from a non-deterministic `Deno.readDir` walk, making `markspec.lock` byte-variable across machines.

## Why
`markspec.lock` is a deterministic artifact (AGENTS.md). A non-total comparator breaks that guarantee for any project with colliding edges (duplicate display IDs, duplicate-ULID sources).

## Fix
Append `targetUlid` (treated as `""` when absent) as the fourth sort key in `compareLockEdges`, making it a total order.

## Tests
Added `serializeLockfile: edge sort is total — colliding (source, relation, authored-target) differ only by targetUlid produce identical bytes regardless of input order` — serializes two input permutations of a colliding edge set and asserts byte-equality. Was RED before the fix, GREEN after.