### PR TITLE
fix(lsp): gate activation and event log on .markspec.yaml (#609)

### DIFF
--- a/.markspec.yaml
+++ b/.markspec.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://driftsys.github.io/markspec/schemas/markspec/v1.json
+$schema: https://driftsys.github.io/markspec/schemas/markspec/v1.json
+# MarkSpec project activator (ADR-008). Its presence marks this repository as a
+# MarkSpec project, so the editor tooling (LSP server / VS Code extension)
+# activates here. Empty `profiles` keeps the bundled default profile active —
+# behaviorally identical to having no file at all (ADR-010).
+profiles: []

--- a/docs/guide/editor-vscode.md
+++ b/docs/guide/editor-vscode.md
@@ -41,7 +41,12 @@ use on the command line.
 <https://open-vsx.org/extension/driftsys/markspec-ide> — or
 `codium --install-extension driftsys.markspec-ide`.
 
-The extension activates on any workspace that contains `.md` files.
+The extension activates only in a **MarkSpec project** — a workspace that
+contains a `.markspec.yaml` activator (per ADR-008). In a plain Markdown or
+source repository with no `.markspec.yaml` the extension stays dormant: it never
+spawns the language server, never indexes, and never writes a `.markspec/`
+directory. Run `markspec init` (or add a `.markspec.yaml`) to turn a workspace
+into a MarkSpec project.
 
 ## Configuration
 
@@ -63,13 +68,15 @@ All settings live under the `markspec.` prefix in VS Code settings.
 
 ## Logs
 
-The language server writes a per-project event log to
+In a MarkSpec project the language server writes a per-project event log to
 `<workspace>/.markspec/lsp.log` (rotated at 1 MB, three files kept). The first
 time it opens that file it drops a self-ignoring `.markspec/.gitignore` (`*`)
 alongside it, so the log never shows up in `git status` — you do not need to add
-anything to your repository's `.gitignore`. Override the location with the
+anything to your repository's `.gitignore`. A workspace with no `.markspec.yaml`
+gets no `.markspec/` directory at all. Override the location with the
 `markspec.trace.logPath` setting (or the `MARKSPEC_LSP_LOG` environment
-variable); set `MARKSPEC_LSP_LOG_OFF=1` to disable logging entirely.
+variable); an explicit path writes the log regardless of project membership. Set
+`MARKSPEC_LSP_LOG_OFF=1` to disable logging entirely.
 
 ## Schema validation
 
@@ -149,6 +156,11 @@ markspec lsp install --editor neovim --binary-path /opt/markspec/bin/markspec
 ```
 
 ## Troubleshooting
+
+**Extension never activates**
+
+- The extension activates only when the workspace contains a `.markspec.yaml`.
+  Add one (or run `markspec init`) to mark the folder as a MarkSpec project.
 
 **Extension activates but shows no diagnostics**
 

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -42,8 +42,7 @@
     "aspice"
   ],
   "activationEvents": [
-    "onLanguage:markdown",
-    "workspaceContains:**/*.md"
+    "workspaceContains:**/.markspec.yaml"
   ],
   "main": "./out/extension.js",
   "contributes": {
@@ -96,7 +95,7 @@
         "markspec.trace.logPath": {
           "type": "string",
           "default": "",
-          "description": "Override path for the LSP event log. When empty, the server writes to `<workspace>/.markspec/lsp.log` by default and drops a self-ignoring `.markspec/.gitignore` so the log never appears in `git status`. Equivalent to setting MARKSPEC_LSP_LOG when spawning the server manually."
+          "description": "Override path for the LSP event log. When empty, the server writes to `<workspace>/.markspec/lsp.log` by default — but only in a MarkSpec project (a workspace containing a `.markspec.yaml`); a plain Markdown or source repo gets no `.markspec/` directory at all. In a MarkSpec project the server also drops a self-ignoring `.markspec/.gitignore` so the log never appears in `git status`. Setting an explicit path writes the log regardless of project membership. Equivalent to setting MARKSPEC_LSP_LOG when spawning the server manually."
         },
         "markspec.mcp.enabled": {
           "type": "boolean",

--- a/packages/markspec/core/config/markspec.ts
+++ b/packages/markspec/core/config/markspec.ts
@@ -9,7 +9,7 @@
  */
 
 import { parse as parseYaml } from "@std/yaml";
-import { join } from "@std/path";
+import { dirname, join, resolve } from "@std/path";
 import type { Diagnostic, ProfileSpecifier } from "../model/mod.ts";
 import type { ReadFile } from "./mod.ts";
 
@@ -30,6 +30,37 @@ export async function readMarkspecYaml(
   const path = join(projectRoot, MARKSPEC_YAML_FILENAME);
   const content = await readFile(path);
   return content ?? null;
+}
+
+/**
+ * Walk up from `startDir` to the filesystem root looking for a
+ * `.markspec.yaml` activator (ADR-008). Returns the absolute path to the
+ * directory containing it, or `undefined` when none is found.
+ *
+ * This is the membership test for "is this a MarkSpec project?". Unlike
+ * {@linkcode discoverProjectRoot}, which keys on `project.yaml`, a project
+ * is considered MarkSpec-activated only by the presence of a
+ * `.markspec.yaml` (per ADR-008): the LSP server uses this to stay inert —
+ * no `.markspec/` runtime directory or event log — in a plain Markdown or
+ * source repo (issue #609).
+ *
+ * @param startDir - Directory to begin the upward walk from (typically the
+ *   workspace root the editor opened).
+ * @param readFile - File reader returning `undefined` for missing paths.
+ */
+export async function discoverMarkspecRoot(
+  startDir: string,
+  readFile: ReadFile,
+): Promise<string | undefined> {
+  let current = resolve(startDir);
+  for (;;) {
+    const candidate = join(current, MARKSPEC_YAML_FILENAME);
+    const content = await readFile(candidate);
+    if (content !== undefined) return current;
+    const parent = dirname(current);
+    if (parent === current) return undefined;
+    current = parent;
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/markspec/core/config/markspec_test.ts
+++ b/packages/markspec/core/config/markspec_test.ts
@@ -8,6 +8,7 @@ import { assertEquals, assertExists, assertStringIncludes } from "@std/assert";
 import { join, resolve } from "@std/path";
 import {
   addProfileSpecifier,
+  discoverMarkspecRoot,
   MARKSPEC_YAML_FILENAME,
   parseMarkspecYaml,
   readMarkspecYaml,
@@ -310,4 +311,39 @@ Deno.test("addProfileSpecifier: preserves an existing default-profile key", asyn
   );
   assertStringIncludes(store[yamlPath], "default-profile: false");
   assertStringIncludes(store[yamlPath], '- "./b"');
+});
+
+// ---------------------------------------------------------------------------
+// discoverMarkspecRoot — the "is this a MarkSpec project?" membership test (#609)
+// ---------------------------------------------------------------------------
+
+Deno.test("discoverMarkspecRoot: finds .markspec.yaml in current directory", async () => {
+  const a = resolve("/a");
+  const yamlPath = join(a, MARKSPEC_YAML_FILENAME);
+  const readFile = (path: string) =>
+    Promise.resolve(path === yamlPath ? "profiles: []\n" : undefined);
+  assertEquals(await discoverMarkspecRoot(a, readFile), a);
+});
+
+Deno.test("discoverMarkspecRoot: finds .markspec.yaml several levels up", async () => {
+  const a = resolve("/a");
+  const yamlPath = join(a, MARKSPEC_YAML_FILENAME);
+  const deep = join(a, "b", "c", "d");
+  const readFile = (path: string) =>
+    Promise.resolve(path === yamlPath ? "profiles: []\n" : undefined);
+  assertEquals(await discoverMarkspecRoot(deep, readFile), a);
+});
+
+Deno.test("discoverMarkspecRoot: returns undefined when no .markspec.yaml exists", async () => {
+  const readFile = () => Promise.resolve(undefined);
+  assertEquals(await discoverMarkspecRoot("/a/b/c", readFile), undefined);
+});
+
+Deno.test("discoverMarkspecRoot: ignores a sibling project.yaml (marker is .markspec.yaml only)", async () => {
+  const a = resolve("/a");
+  const readFile = (path: string) =>
+    Promise.resolve(
+      path === join(a, "project.yaml") ? "name: test\n" : undefined,
+    );
+  assertEquals(await discoverMarkspecRoot(a, readFile), undefined);
 });

--- a/packages/markspec/core/mod.ts
+++ b/packages/markspec/core/mod.ts
@@ -106,6 +106,7 @@ export type { LoadConfigResult, ReadFile } from "./config/mod.ts";
 
 export {
   addProfileSpecifier,
+  discoverMarkspecRoot,
   MARKSPEC_YAML_FILENAME,
   parseMarkspecYaml,
   readMarkspecYaml,

--- a/packages/markspec/lsp/server.ts
+++ b/packages/markspec/lsp/server.ts
@@ -38,6 +38,7 @@ import {
   CORE_SCHEMA_VERSION,
   DEFAULT_PROJECT_CONFIG,
   type Diagnostic as CoreDiagnostic,
+  discoverMarkspecRoot,
   discoverProjectRoot,
   type EffectiveProfile,
   filterEntriesByTraceTargets,
@@ -411,7 +412,19 @@ connection.onInitialize(
         ? uriToPath(rootUri)
         : rootUri;
       projectRoot = await discoverProjectRoot(rootPath, readFile) ?? rootPath;
-      setEventLogProjectRoot(projectRoot);
+
+      // Gate the event log on MarkSpec-project membership (#609). A project
+      // is MarkSpec-activated only when a `.markspec.yaml` is discoverable
+      // (ADR-008). In a plain Markdown or source repo with no activator the
+      // server stays inert on disk — it never creates the `.markspec/`
+      // runtime directory or its `lsp.log`, so a non-MarkSpec working tree is
+      // never dirtied. In-memory indexing still runs (it writes nothing to
+      // disk), and the broad `projectRoot` fallback above keeps config and
+      // profile loading working for projects that carry only `project.yaml`.
+      const markspecRoot = await discoverMarkspecRoot(rootPath, readFile);
+      if (markspecRoot !== undefined) {
+        setEventLogProjectRoot(markspecRoot);
+      }
 
       // Load config
       try {

--- a/tests/e2e/lsp_activation_test.ts
+++ b/tests/e2e/lsp_activation_test.ts
@@ -1,0 +1,57 @@
+/**
+ * @module tests/e2e/lsp_activation_test
+ *
+ * E2E test: the LSP server is inert in a workspace that is not a MarkSpec
+ * project. A MarkSpec project is marked by a `.markspec.yaml` activator
+ * (ADR-008). With no `.markspec.yaml` discoverable, the server must not
+ * write its `.markspec/` runtime directory (event log) — see issue #609.
+ */
+
+import { assert, assertEquals } from "@std/assert";
+import { join } from "@std/path";
+import { LspTestClient } from "./lsp_helpers.ts";
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await Deno.stat(path);
+    return true;
+  } catch (err) {
+    if (err instanceof Deno.errors.NotFound) return false;
+    throw err;
+  }
+}
+
+Deno.test("lsp activation: no .markspec.yaml → no .markspec/ artifacts written", async () => {
+  const client = await LspTestClient.create({ "README.md": "# Plain repo\n" });
+  try {
+    await client.initialize();
+    // Give the server time to index and attempt any default log write.
+    await new Promise((r) => setTimeout(r, 300));
+    const markspecDir = join(client.workDir, ".markspec");
+    assertEquals(
+      await exists(markspecDir),
+      false,
+      "server must not create .markspec/ in a workspace with no .markspec.yaml",
+    );
+  } finally {
+    await client.shutdown();
+  }
+});
+
+Deno.test("lsp activation: .markspec.yaml present → event log written under .markspec/", async () => {
+  const client = await LspTestClient.create({
+    ".markspec.yaml": "profiles: []\n",
+    "doc.md": "# Doc\n",
+  });
+  try {
+    await client.initialize();
+    await new Promise((r) => setTimeout(r, 300));
+    const logPath = join(client.workDir, ".markspec", "lsp.log");
+    assert(
+      await exists(logPath),
+      "server must write .markspec/lsp.log when .markspec.yaml is present",
+    );
+  } finally {
+    await client.shutdown();
+  }
+});


### PR DESCRIPTION
Closes #609.

## Problem

The VS Code extension activated on any workspace containing a `.md` file
(`onLanguage:markdown` / `workspaceContains:**/*.md`) and spawned the LSP server
unconditionally. The server then fell back to the workspace root when no project
marker was found and wrote `<root>/.markspec/lsp.log`, dirtying non-MarkSpec
repos in `git status` (the original report was scaffolding a plain Rust repo).

## Fix

Gate on **MarkSpec-project membership** — a discoverable `.markspec.yaml`
activator (ADR-008) — at two complementary layers:

- **Extension** — `activationEvents` narrowed to
  `workspaceContains:**/.markspec.yaml`. A plain Markdown/source repo never wakes
  the extension: no spawn, no indexing, no log.
- **Server** (defense-in-depth for neovim/zed/manual spawns) — new
  `discoverMarkspecRoot` walks up for `.markspec.yaml`; the event-log root is set
  **only** when it resolves. No marker → no `.markspec/` directory on disk.
  In-memory indexing still runs (writes nothing to disk) and `projectRoot` still
  falls back to the workspace root, so config/profile loading for projects that
  carry only `project.yaml` is unaffected — only the on-disk log is gated.
- **This repo** — adds a behavior-neutral `.markspec.yaml` (empty `profiles` →
  bundled default chain; `markspec profile show` is unchanged) so MarkSpec's own
  LSP dogfooding keeps working under the `.markspec.yaml`-only gate.

## Tests

- New `tests/e2e/lsp_activation_test.ts`: "no `.markspec.yaml` → no `.markspec/`"
  (failed before the fix, passes now) + a guard that the log **is** written when
  a `.markspec.yaml` is present.
- New unit tests for `discoverMarkspecRoot`, including "ignores a sibling
  `project.yaml`" (marker is `.markspec.yaml` only).
- Full LSP e2e + `event_log` suites pass with no regressions; `just build`,
  `deno fmt --check`, and `dprint check` all green.

## Notes

- **Secondary defect (missing `.markspec/.gitignore`)** is already fixed on
  `main` (`7a9b9ee`, after the v0.7.2 tag the reporter ran); no change needed.
- **Deliberate non-change:** the neovim/zed install docs keep
  `root_pattern("project.yaml")`. The server-side gate already prevents disk
  pollution for those clients, so the bug is fixed without changing their
  attach conditions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
