### PR TITLE
fix(core): suppress MSL-L006 under file-local check (projectWide flag)

### DIFF
--- a/packages/markspec/cli/commands/check.ts
+++ b/packages/markspec/cli/commands/check.ts
@@ -89,10 +89,15 @@ export const checkCmd = new Command()
         });
       }
 
+      // projectWide: false — check operates on a file-local subset so MSL-L006
+      // ("link target does not resolve") is suppressed: the subset cannot
+      // distinguish a typo from a valid cross-file target. Full existence checks
+      // are available via `markspec compile` or the LSP (which index all files).
       const result = runPipeline(
         allEntries,
         chain?.effective ?? null,
         captionConventions,
+        { projectWide: false },
       );
 
       const listingDiagnostics = validateListingDocuments(listingContexts);

--- a/packages/markspec/core/mod.ts
+++ b/packages/markspec/core/mod.ts
@@ -233,6 +233,7 @@ export type {
   EffectiveAttrScope,
   ListingFileContext,
   ListingKind,
+  PipelineOptions,
   PipelineResult,
   ValidateResult,
   ValueValidator,

--- a/packages/markspec/core/validator/mod.ts
+++ b/packages/markspec/core/validator/mod.ts
@@ -525,7 +525,7 @@ export function findAttr(
 }
 
 export { runPipeline, suppressDeclaredAttrR010 } from "./pipeline.ts";
-export type { PipelineResult } from "./pipeline.ts";
+export type { PipelineOptions, PipelineResult } from "./pipeline.ts";
 
 export { validateListingDocuments } from "./listing.ts";
 export type { ListingFileContext, ListingKind } from "./listing.ts";

--- a/packages/markspec/core/validator/pipeline.ts
+++ b/packages/markspec/core/validator/pipeline.ts
@@ -44,6 +44,19 @@ export interface PipelineResult {
   readonly valid: boolean;
 }
 
+/** Options for {@linkcode runPipeline}. */
+export interface PipelineOptions {
+  /**
+   * When `false`, suppress MSL-L006 ("link target does not resolve") from
+   * Stage 4 output. Use this when the validator is running against a subset
+   * of the project's files (e.g. `markspec check <file>`): file-local scope
+   * cannot distinguish a typo from a valid cross-file target. MSL-L006 is
+   * only meaningful when the full entry set is available (LSP, `compile`).
+   * Defaults to `true` (full-project scope — emit MSL-L006 normally).
+   */
+  readonly projectWide?: boolean;
+}
+
 /**
  * Run the validator pipeline.
  *
@@ -58,11 +71,14 @@ export interface PipelineResult {
  *   conventions (from `ProjectConfig.captionConventions`). When supplied
  *   and non-empty, MSL-C072 is checked for each entry. Defaults to no
  *   conventions (rule inactive).
+ * @param opts - Pipeline options. Pass `{ projectWide: false }` when
+ *   validating a file-local subset so MSL-L006 is suppressed.
  */
 export function runPipeline(
   entries: readonly Entry[],
   profile: EffectiveProfile | null,
   captionConventions: CaptionConventions = {},
+  opts: PipelineOptions = {},
 ): PipelineResult {
   const diagnostics: Diagnostic[] = [];
 
@@ -150,6 +166,7 @@ export function runPipeline(
       if (e.id && !graph.has(e.id)) graph.set(e.id, e);
       if (!byDisplayId.has(e.displayId)) byDisplayId.set(e.displayId, e);
     }
+    const projectWide = opts.projectWide !== false;
     for (const entry of finalEntries) {
       const stage4 = validateTraceabilityForEntry(
         entry,
@@ -157,7 +174,12 @@ export function runPipeline(
         graph,
         byDisplayId,
       );
-      diagnostics.push(...stage4);
+      // Suppress MSL-L006 ("link target does not resolve") when running
+      // file-locally: the checked subset cannot distinguish a typo from a
+      // valid cross-file target. Only emit when the full entry set is present.
+      diagnostics.push(
+        ...projectWide ? stage4 : stage4.filter((d) => d.code !== "MSL-L006"),
+      );
     }
   }
 

--- a/tests/e2e/display_id_trace_test.ts
+++ b/tests/e2e/display_id_trace_test.ts
@@ -5,7 +5,7 @@
  * display ID validates clean; an unresolved one warns MSL-L006 (exit 2).
  */
 
-import { assertEquals, assertStringIncludes } from "@std/assert";
+import { assertEquals } from "@std/assert";
 import { markspec } from "./helpers.ts";
 
 const PROJECT_YAML = `name: disp-id-e2e\nversion: 0.1.0\n`;
@@ -67,7 +67,47 @@ Deno.test("check: Satisfies a display ID that exists → clean (exit 0)", async 
   );
 });
 
-Deno.test("check: Satisfies a display ID that does not exist → MSL-L006 (exit 2)", async () => {
+Deno.test("check: Satisfies a display ID in another file (not passed) → no MSL-L006 (exit 0)", async () => {
+  // REQ-0001 lives in req.md; only sreq.md is passed to check. A file-local
+  // check cannot distinguish a typo from a valid cross-file target, so MSL-L006
+  // must not fire — the link is only flagged when the full project is available
+  // (compile / LSP).
+  const { code, stderr } = await markspec(["check", "sreq.md"], {
+    files: {
+      ...BASE_FILES,
+      "req.md": `# Requirements
+
+- [REQ-0001] A requirement
+
+  Body text.
+
+      Id: 01REQ000000000000000000001
+      Type: requirement
+`,
+      "sreq.md": `# System Requirements
+
+- [SREQ-0001] A system requirement
+
+  Body text.
+
+      Id: 01SREQ00000000000000000001
+      Type: system-requirement
+      Satisfies: REQ-0001
+`,
+    },
+  });
+  assertEquals(code, 0, `expected exit 0, got ${code}; stderr: ${stderr}`);
+  assertEquals(
+    stderr.split("\n").filter((l) => l.includes("MSL-L006")),
+    [],
+    "file-local check must not emit MSL-L006 for cross-file trace targets",
+  );
+});
+
+Deno.test("check: Satisfies a display ID that does not exist in checked files → no MSL-L006 (exit 0)", async () => {
+  // check cannot distinguish a typo (REQ-9999) from a valid cross-file target,
+  // so MSL-L006 is suppressed for file-local scope. Use `markspec compile` or
+  // the LSP to surface existence errors across the full project.
   const { code, stderr } = await markspec(["check", "doc.md"], {
     files: {
       ...BASE_FILES,
@@ -83,7 +123,10 @@ Deno.test("check: Satisfies a display ID that does not exist → MSL-L006 (exit 
 `,
     },
   });
-  assertEquals(code, 2); // warning-only → exit 2
-  assertStringIncludes(stderr, "MSL-L006");
-  assertStringIncludes(stderr, "REQ-9999");
+  assertEquals(code, 0, `expected exit 0, got ${code}; stderr: ${stderr}`);
+  assertEquals(
+    stderr.split("\n").filter((l) => l.includes("MSL-L006")),
+    [],
+    "file-local check must not emit MSL-L006",
+  );
 });


### PR DESCRIPTION
Closes #612.

## What
`markspec check <file>` emitted MSL-L006 ("link target does not resolve") for every trace reference whose target lives in another file. The file-local check indexed only the named files, so it could not distinguish a typo from a valid cross-file target.

## Why
File-local `check` is the canonical agent write-loop workflow (AGENTS.md). Real ASPICE/ISO projects split requirements across files, so every cross-file `Satisfies:` produced spurious warnings — noisy and exit-2 under `--strict`.

## How
Add `projectWide?: boolean` to `PipelineOptions` (default `true`). When `false`, Stage 4 of the pipeline strips MSL-L006 from output. The `check` command passes `{ projectWide: false }` so existence checks are suppressed for file-local scope.

The LSP`s `validateAll` calls `validate()` directly with the full workspace index and is unaffected — MSL-L006 still fires there correctly.

## Tests
- Added: `check: Satisfies a display ID in another file (not passed) → no MSL-L006 (exit 0)` — the cross-file regression case
- Updated: `check: Satisfies a display ID that does not exist in checked files → no MSL-L006 (exit 0)` — file-local check now exits clean for both typos and cross-file targets