### PR TITLE
fix(cli): warn when init writes a stub markspec.lock for non-default profiles

### DIFF
--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -193,6 +193,14 @@ In an empty (or existing) project root this writes:
 VS Code + Copilot needs no MCP file — the bundled extension handles that wiring
 once the `.vscode/extensions.json` recommendation is in place.
 
+> **Non-default profiles need `markspec lock`.** `init` writes `markspec.lock`
+> with **no upstreams** — it does not fetch or resolve the profile chain (init
+> performs no network I/O). With the bundled default profile that stub is the
+> final, correct lock. With a git or local profile (`--profile git+…` /
+> `--profile ./path`), `init` warns `LOCKFILE_STUB_NEEDS_PIN`; run
+> [`markspec lock`](cli.md#lock) once to resolve and pin the profile's
+> upstreams.
+
 > See [AI agents and skillset](ai-agents.md) for the full `markspec init` flag
 > reference (`--client`, `--profile`) and MCP server details.
 

--- a/packages/markspec/cli/init/orchestrator.ts
+++ b/packages/markspec/cli/init/orchestrator.ts
@@ -294,6 +294,27 @@ export async function runInit(options: RunInitOptions): Promise<InitResult> {
     executedActions.push(...plan.actions);
   }
 
+  // A non-bundled (git/local) profile may pin upstreams, but `init` writes a
+  // stub `markspec.lock` with zero upstreams — it does not resolve the profile
+  // chain (no network I/O at init time). Surface a warning pointing at
+  // `markspec lock` so the stub is intentional and visible rather than a
+  // silent inconsistency with the `.markspec.yaml` profile (#581). Gated on a
+  // fresh lock actually being written (create/overwrite) so a re-run that
+  // skips an existing lock stays quiet.
+  const writesLockStub = (options.profileChoice.kind === "git" ||
+    options.profileChoice.kind === "local") &&
+    plan.actions.some((a) =>
+      a.file === "markspec.lock" &&
+      (a.kind === "create" || a.kind === "overwrite")
+    );
+  if (writesLockStub) {
+    warnings.push({
+      code: "LOCKFILE_STUB_NEEDS_PIN",
+      message:
+        `markspec.lock was written with no upstreams. Run \`markspec lock\` to resolve and pin the ${options.profileChoice.kind} profile chain.`,
+    });
+  }
+
   const hasSkip = executedActions.some((a) => a.kind === "skip");
   const exitCode: 0 | 1 | 2 = warnings.length > 0 || hasSkip ? 2 : 0;
   const clientsWritten: InitClientId[] = [...clientSet.write];

--- a/packages/markspec/cli/init/orchestrator_test.ts
+++ b/packages/markspec/cli/init/orchestrator_test.ts
@@ -353,3 +353,101 @@ Deno.test("runInit: mcpRunner failure → MCP_INSTALL_FAILED warning + exit 2", 
   const mcpAction = result.actions.find((a) => a.file === ".mcp.json");
   assertEquals(mcpAction, undefined);
 });
+
+// ---------------------------------------------------------------------------
+// #581 — a non-bundled profile writes a stub markspec.lock with zero
+// upstreams. init does not resolve upstreams (no network at init time), so it
+// must surface a LOCKFILE_STUB_NEEDS_PIN warning telling the user to run
+// `markspec lock` to pin the profile chain. Without it the empty lock is
+// silently inconsistent with the `.markspec.yaml` profile.
+// ---------------------------------------------------------------------------
+
+Deno.test("runInit: git profile → LOCKFILE_STUB_NEEDS_PIN warning + exit 2", async () => {
+  const fs = createMemFs();
+  const result = await runInit({
+    targetDir: "/repo",
+    profileChoice: { kind: "git", spec: "git+https://example.com/p.git" },
+    forcedClients: [],
+    allClients: false,
+    noMcp: true,
+    noSkills: true,
+    binaryPathFlag: undefined,
+    force: false,
+    dryRun: false,
+    fs,
+    detectEnv: noClientEnv,
+    binaryEnv: noClientEnv,
+    mcpRunner: okMcpRunner,
+    execRunner: okExec,
+    now: fakeNow,
+    version: "0.6.0",
+    mcpAdapters: adapters,
+  });
+  const lockWarn = result.warnings.find((w) =>
+    w.code === "LOCKFILE_STUB_NEEDS_PIN"
+  );
+  assertEquals(lockWarn !== undefined, true);
+  assertEquals(lockWarn!.message.includes("markspec lock"), true);
+  // A stub-lock advisory is the only warning here, so the run exits 2
+  // (clig.dev: 2 = warnings only) rather than 0.
+  assertEquals(result.exitCode, 2);
+  // The stub lock was still written — the warning is advisory, not a refusal.
+  assertEquals((await fs.read("/repo/markspec.lock")) !== undefined, true);
+});
+
+Deno.test("runInit: local profile → LOCKFILE_STUB_NEEDS_PIN warning", async () => {
+  const fs = createMemFs();
+  const result = await runInit({
+    targetDir: "/repo",
+    profileChoice: { kind: "local", spec: "./profiles/house.yaml" },
+    forcedClients: [],
+    allClients: false,
+    noMcp: true,
+    noSkills: true,
+    binaryPathFlag: undefined,
+    force: false,
+    dryRun: false,
+    fs,
+    detectEnv: noClientEnv,
+    binaryEnv: noClientEnv,
+    mcpRunner: okMcpRunner,
+    execRunner: okExec,
+    now: fakeNow,
+    version: "0.6.0",
+    mcpAdapters: adapters,
+  });
+  const lockWarn = result.warnings.find((w) =>
+    w.code === "LOCKFILE_STUB_NEEDS_PIN"
+  );
+  assertEquals(lockWarn !== undefined, true);
+});
+
+Deno.test("runInit: bundled profile → no LOCKFILE_STUB_NEEDS_PIN warning, exit 0", async () => {
+  const fs = createMemFs();
+  const result = await runInit({
+    targetDir: "/repo",
+    profileChoice: { kind: "bundled" },
+    forcedClients: [],
+    allClients: false,
+    noMcp: true,
+    noSkills: true,
+    binaryPathFlag: undefined,
+    force: false,
+    dryRun: false,
+    fs,
+    detectEnv: noClientEnv,
+    binaryEnv: noClientEnv,
+    mcpRunner: okMcpRunner,
+    execRunner: okExec,
+    now: fakeNow,
+    version: "0.6.0",
+    mcpAdapters: adapters,
+  });
+  const lockWarn = result.warnings.find((w) =>
+    w.code === "LOCKFILE_STUB_NEEDS_PIN"
+  );
+  assertEquals(lockWarn, undefined);
+  // The bundled profile expects no upstreams — an empty lock is correct,
+  // so the clean run exits 0.
+  assertEquals(result.exitCode, 0);
+});

--- a/packages/markspec/cli/init/scaffolders/markspec_lock.ts
+++ b/packages/markspec/cli/init/scaffolders/markspec_lock.ts
@@ -1,10 +1,14 @@
 /**
  * @module cli/init/scaffolders/markspec_lock
  *
- * Stub-path scaffolder for `markspec.lock` in the no-upstream case
- * (a fresh init with the bundled default profile). When the user
- * selects a non-default profile, the orchestrator delegates to
- * `runLock` instead — see {@linkcode runInit} step 5.
+ * Stub-path scaffolder for `markspec.lock`. `init` always writes a
+ * minimal lock with zero upstreams — it does not resolve the profile
+ * chain (resolution needs network I/O, which `init` deliberately
+ * avoids). For the bundled default profile that stub is the final,
+ * correct lock. For a non-default (git/local) profile the stub is a
+ * starting point: the orchestrator emits a `LOCKFILE_STUB_NEEDS_PIN`
+ * warning telling the user to run `markspec lock` to resolve and pin
+ * the profile's upstreams (#581).
  */
 
 import { join } from "@std/path";

--- a/tests/e2e/init_test.ts
+++ b/tests/e2e/init_test.ts
@@ -200,14 +200,12 @@ Deno.test(
         ],
         PERMS,
       );
-      // Exit 2 expected because lockfile resolve may warn in CI without net.
-      // Either exit 0 or 2 is acceptable here — we only assert the file
-      // contents.
-      assertEquals(
-        [0, 2].includes(code),
-        true,
-        `exit ${code}, stderr: ${stderr}`,
-      );
+      // init writes a stub markspec.lock with zero upstreams (it does not
+      // resolve the git profile — no network at init time), so it always
+      // warns LOCKFILE_STUB_NEEDS_PIN → exit 2 (#581).
+      assertEquals(code, 2, `exit ${code}, stderr: ${stderr}`);
+      assertStringIncludes(stderr, "LOCKFILE_STUB_NEEDS_PIN");
+      assertStringIncludes(stderr, "markspec lock");
       const md = await Deno.readTextFile(join(dir, ".markspec.yaml"));
       assertStringIncludes(md, "git+https://github.com/example/profile.git");
     } finally {


### PR DESCRIPTION
Closes #581.

## Problem

`markspec init` always wrote `markspec.lock` with **zero upstreams**, regardless of the chosen profile. For a git/local profile (`--profile git+…`) whose chain pins upstreams, the lock was immediately inconsistent with the `.markspec.yaml` it scaffolded — a silent traceability-integrity issue. The lock scaffolder's docstring claimed the orchestrator delegates to `runLock` for non-default profiles ("`runInit` step 5"), but **no such delegation exists** (`orchestrator.ts` always calls the empty-upstream `scaffoldMarkspecLock`).

## Approach — honest stub + warning

`init` deliberately performs **no network I/O**, and the orchestrator is a pure boundary (MemFs + test seams). Resolving upstreams at init time would require threading real `fetch`/`readFile` and reworking that boundary — out of scope and a behavioral change. Instead, this PR makes the stub honest and visible:

- For a **git/local** profile that writes a fresh lock (create/overwrite), emit a `LOCKFILE_STUB_NEEDS_PIN` warning pointing at `markspec lock` → exit 2 (clig.dev: 2 = warnings only).
- For the **bundled** default profile, no upstreams are expected, so the stub is the final correct lock — no warning, exit 0.
- Correct the misleading scaffolder docstring (no phantom "step 5").

The user runs `markspec lock` once to resolve and pin the profile chain.

```
$ markspec init --profile git+https://github.com/example/profile.git
…
warning: [LOCKFILE_STUB_NEEDS_PIN] markspec.lock was written with no upstreams.
  Run `markspec lock` to resolve and pin the git profile chain.
```

## Changes

- `cli/init/orchestrator.ts` — emit `LOCKFILE_STUB_NEEDS_PIN` for git/local profiles writing a fresh lock.
- `cli/init/scaffolders/markspec_lock.ts` — correct the docstring (init always writes a stub; non-default profiles run `markspec lock`).
- `cli/init/orchestrator_test.ts` — unit tests: git warns + exit 2, local warns, bundled silent + exit 0.
- `tests/e2e/init_test.ts` — strengthen the git-profile e2e to assert the warning surfaces through the real binary.
- `docs/guide/installation.md` — document the stub behaviour and the `markspec lock` follow-up.

## Verification

- `just build` — green (lint + test + type-check + compile).
- New + affected tests: orchestrator unit + 15 init e2e, 28 passed / 0 failed.
- `deno fmt --check` + `dprint check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
