### PR TITLE
fix(cli): report only succeeded MCP clients and gate the binary-path warning

### DIFF
--- a/packages/markspec/cli/init/orchestrator.ts
+++ b/packages/markspec/cli/init/orchestrator.ts
@@ -157,7 +157,12 @@ export async function runInit(options: RunInitOptions): Promise<InitResult> {
   }
 
   const warnings: Warning[] = [];
-  if (binaryRef.warning) {
+  // The binary reference is only written into MCP `command:` fields, so a
+  // path warning is only meaningful when at least one MCP client will be
+  // written. Under `--no-mcp` (or when no client is detected) `clientSet.write`
+  // is empty and the warning is spurious — gating it here keeps init from
+  // flipping the exit code to 2 for an unused binary path (#575).
+  if (binaryRef.warning && clientSet.write.size > 0) {
     warnings.push({ code: "BINARY_PATH_WARNING", message: binaryRef.warning });
   }
 
@@ -296,7 +301,14 @@ export async function runInit(options: RunInitOptions): Promise<InitResult> {
 
   const hasSkip = executedActions.some((a) => a.kind === "skip");
   const exitCode: 0 | 1 | 2 = warnings.length > 0 || hasSkip ? 2 : 0;
-  const clientsWritten: InitClientId[] = [...clientSet.write];
+  // Report only the clients whose MCP config actually landed. Deriving this
+  // from `executedActions` (not the planned `clientSet.write`) means a client
+  // whose MCP install failed — and was therefore excluded from
+  // `executedActions` — is not advertised as written, matching the
+  // "only successes land in the result" design (#575).
+  const clientsWritten: InitClientId[] = executedActions
+    .map((a) => mcpFileToClient.get(a.file))
+    .filter((c): c is InitClientId => c !== undefined);
 
   return {
     ok: true,

--- a/packages/markspec/cli/init/orchestrator_test.ts
+++ b/packages/markspec/cli/init/orchestrator_test.ts
@@ -352,4 +352,95 @@ Deno.test("runInit: mcpRunner failure → MCP_INSTALL_FAILED warning + exit 2", 
   // summary advertises a config that was never written.
   const mcpAction = result.actions.find((a) => a.file === ".mcp.json");
   assertEquals(mcpAction, undefined);
+  // …and the failed client must not be advertised as written (#575).
+  assertEquals(result.clientsWritten.includes("claude-code"), false);
+});
+
+Deno.test("runInit: clientsWritten lists the client whose MCP config landed", async () => {
+  const fs = createMemFs();
+  const result = await runInit({
+    targetDir: "/repo",
+    profileChoice: { kind: "bundled" },
+    forcedClients: ["claude-code"],
+    allClients: false,
+    noMcp: false,
+    noSkills: true,
+    binaryPathFlag: undefined,
+    force: false,
+    dryRun: false,
+    fs,
+    detectEnv: noClientEnv,
+    binaryEnv: noClientEnv,
+    mcpRunner: okMcpRunner,
+    execRunner: okExec,
+    now: fakeNow,
+    version: "0.6.0",
+    mcpAdapters: adapters,
+  });
+  assertEquals(result.clientsWritten, ["claude-code"]);
+});
+
+// ---------------------------------------------------------------------------
+// #575 — BINARY_PATH_WARNING is only meaningful when an MCP client will
+// reference the binary. Under --no-mcp (empty clientSet.write) it must be
+// suppressed so init does not flip to exit 2 for an unused binary path.
+// ---------------------------------------------------------------------------
+
+const mismatchBinaryEnv = {
+  whichCommand: (n: string) =>
+    Promise.resolve(n === "markspec" ? "/usr/bin/markspec" : undefined),
+  execPath: () => "/opt/markspec",
+  pathExists: () => Promise.resolve(true),
+};
+
+Deno.test("runInit: --no-mcp suppresses spurious BINARY_PATH_WARNING → exit 0", async () => {
+  const fs = createMemFs();
+  const result = await runInit({
+    targetDir: "/repo",
+    profileChoice: { kind: "bundled" },
+    forcedClients: [],
+    allClients: false,
+    noMcp: true,
+    noSkills: true,
+    binaryPathFlag: undefined,
+    force: false,
+    dryRun: false,
+    fs,
+    detectEnv: noClientEnv,
+    binaryEnv: mismatchBinaryEnv,
+    mcpRunner: okMcpRunner,
+    execRunner: okExec,
+    now: fakeNow,
+    version: "0.6.0",
+    mcpAdapters: adapters,
+  });
+  const binWarn = result.warnings.find((w) => w.code === "BINARY_PATH_WARNING");
+  assertEquals(binWarn, undefined);
+  assertEquals(result.exitCode, 0);
+});
+
+Deno.test("runInit: BINARY_PATH_WARNING still fires when an MCP client is written", async () => {
+  const fs = createMemFs();
+  const result = await runInit({
+    targetDir: "/repo",
+    profileChoice: { kind: "bundled" },
+    forcedClients: ["claude-code"],
+    allClients: false,
+    noMcp: false,
+    noSkills: true,
+    binaryPathFlag: undefined,
+    force: false,
+    dryRun: false,
+    fs,
+    detectEnv: noClientEnv,
+    binaryEnv: mismatchBinaryEnv,
+    mcpRunner: okMcpRunner,
+    execRunner: okExec,
+    now: fakeNow,
+    version: "0.6.0",
+    mcpAdapters: adapters,
+  });
+  const binWarn = result.warnings.find((w) => w.code === "BINARY_PATH_WARNING");
+  assertEquals(binWarn !== undefined, true);
+  assertEquals(result.exitCode, 2);
 });

--- a/tests/e2e/init_test.ts
+++ b/tests/e2e/init_test.ts
@@ -358,16 +358,25 @@ Deno.test("e2e[13] init --force on modified project.yaml overwrites", async () =
 Deno.test("e2e[14] init --binary-path /nonexistent warns or exits 1", async () => {
   const dir = await tempDir();
   try {
+    // Force an MCP client so the binary path is actually referenced — the
+    // BINARY_PATH_WARNING is gated on a client being written (#575), so a
+    // bare invocation with no detected client would (correctly) stay silent.
     const { code, stderr } = await markspecInDir(
       dir,
       [
         "init",
         "--no-skills",
         "--force",
+        "--client",
+        "claude-code",
         "--binary-path",
         "/nonexistent/markspec",
       ],
       PERMS,
+      {
+        MARKSPEC_TEST_MODE: "1",
+        MARKSPEC_FAKE_CLIENT_DETECT: "claude-code",
+      },
     );
     // Spec §6 maps non-existent --binary-path to a warning (exit 2),
     // not a hard error. Accept either 1 or 2 here.
@@ -400,6 +409,35 @@ Deno.test("e2e[15] init non-TTY without --force/--no-profile/--profile", async (
       [0, 1, 2].includes(code),
       true,
       `exit ${code}, stderr: ${stderr}`,
+    );
+  } finally {
+    await cleanup(dir);
+  }
+});
+
+Deno.test("e2e[16] init --no-mcp --binary-path /nonexistent stays silent (no spurious warning)", async () => {
+  // With --no-mcp no client references the binary, so a bad --binary-path
+  // must NOT raise BINARY_PATH_WARNING (#575). The lockfile is the bundled
+  // stub (no upstreams), so the run is clean → exit 0.
+  const dir = await tempDir();
+  try {
+    const { code, stderr } = await markspecInDir(
+      dir,
+      [
+        "init",
+        "--no-skills",
+        "--no-mcp",
+        "--force",
+        "--binary-path",
+        "/nonexistent/markspec",
+      ],
+      PERMS,
+    );
+    assertEquals(code, 0, `exit ${code}, stderr: ${stderr}`);
+    assertEquals(
+      stderr.includes("BINARY_PATH_WARNING"),
+      false,
+      `unexpected binary warning: ${stderr}`,
     );
   } finally {
     await cleanup(dir);


### PR DESCRIPTION
Two post-merge review findings on `markspec init`, folded into the v1.0-readiness epic #575.

## Findings fixed

1. **`clientsWritten` advertised failed clients.** It was built from the *planned* `clientSet.write` even when an MCP install returned non-zero — contradicting the orchestrator's stated "only successes land in the result" design. Now derived from `executedActions` via the existing file→client map, so a client whose install failed is not reported as written.

2. **Spurious `BINARY_PATH_WARNING` under `--no-mcp`.** The warning fired unconditionally, flipping the exit code to 2 for a binary path nothing references. The binary ref is only written into MCP `command:` fields, so it's now gated on `clientSet.write` being non-empty.

Both are checkbox items under #575's "Post-merge review findings (2026-05-31)".

## Tests

- **Unit** (`orchestrator_test.ts`): failed client excluded from `clientsWritten`; succeeded client listed; `--no-mcp` suppresses the binary warning (exit 0); the warning still fires when a client is written (exit 2).
- **E2E** (`init_test.ts`): `e2e[14]` now forces a client so the binary path is actually referenced; new `e2e[16]` asserts `--no-mcp --binary-path /nonexistent` stays silent and exits 0.

## Verification

- Pre-push `just check` green (lint + test + type-check).
- init unit suite 13/13, init e2e 16/16.

Part of the obvious-debt sweep; no design decisions involved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
