### PR TITLE
fix(core): canonicalise/heal multi-line trace values in fmt (#606)

### DIFF
--- a/packages/markspec/core/refs/mod.ts
+++ b/packages/markspec/core/refs/mod.ts
@@ -60,6 +60,12 @@ export function buildRefIndex(entries: readonly Entry[]): RefIndex {
 /** Trailer trace line: indent, key, `:` + spaces, value-rest. */
 const TRACE_TRAILER_RE = /^(\s{4,})([A-Z][A-Za-z-]*)(\s*:\s*)(.*)$/;
 
+/**
+ * A `\`-continuation line of a multi-line trace value: leading indent then a
+ * non-empty value-rest (no `Key:` — that sat on the first physical line).
+ */
+const CONTINUATION_LINE_RE = /^(\s+)(\S.*)$/;
+
 /** Token splitter that preserves separators between value tokens. */
 const VALUE_TOKEN_RE = /[^\s,]+/g;
 
@@ -116,19 +122,78 @@ export function canonicalizeRefs(
     if (!m) continue;
     const [, indent, key, sep, rest] = m;
     if (!TRACE_ATTRIBUTE_KEYS.has(key)) continue;
-    // Multi-line continuation — leave untouched (debt: full multi-line support).
-    if (rest.endsWith("\\")) continue;
     const sourceUlid = sourceUlidForLine(i + 1);
-    const rewritten = rest.replace(
-      VALUE_TOKEN_RE,
-      (token) => rewriteToken(token, sourceUlid, key, index, ledgerByKey),
+
+    // Rewrite the key line's value, preserving any trailing `\` continuation
+    // marker (only resolvable tokens change — indentation, separators and the
+    // backslash stay byte-for-byte).
+    const newRest = rewriteValuePreservingContinuation(
+      rest,
+      sourceUlid,
+      key,
+      index,
+      ledgerByKey,
     );
-    if (rewritten !== rest) {
-      lines[i] = `${indent}${key}${sep}${rewritten}${cr ? "\r" : ""}`;
+    if (newRest !== rest) {
+      lines[i] = `${indent}${key}${sep}${newRest}${cr ? "\r" : ""}`;
       changed = true;
     }
+
+    // Multi-line value: a `\`-continued value splits across physical lines,
+    // each non-final line ending in `\`. Walk the continuation lines (indent +
+    // value, no key) and rewrite each the same way, stopping at the first line
+    // that does not end in `\`. `i` is advanced past the consumed lines so the
+    // outer loop does not re-scan them (#606).
+    let continues = rest.endsWith("\\");
+    let j = i;
+    while (continues && j + 1 < lines.length) {
+      j++;
+      const crj = lines[j].endsWith("\r");
+      const barej = crj ? lines[j].slice(0, -1) : lines[j];
+      const cm = CONTINUATION_LINE_RE.exec(barej);
+      if (!cm) {
+        j--; // not a continuation line — leave it for the outer loop
+        break;
+      }
+      const [, cIndent, cVal] = cm;
+      const newVal = rewriteValuePreservingContinuation(
+        cVal,
+        sourceUlid,
+        key,
+        index,
+        ledgerByKey,
+      );
+      if (newVal !== cVal) {
+        lines[j] = `${cIndent}${newVal}${crj ? "\r" : ""}`;
+        changed = true;
+      }
+      continues = cVal.endsWith("\\");
+    }
+    i = j;
   }
   return { output: lines.join("\n"), changed };
+}
+
+/**
+ * Rewrite the value tokens of one trace-value line, preserving a trailing `\`
+ * continuation marker verbatim. The backslash is split off before token
+ * rewriting (so it is never mistaken for a value token) and re-appended after,
+ * keeping the multi-line continuation lossless.
+ */
+function rewriteValuePreservingContinuation(
+  value: string,
+  sourceUlid: string | undefined,
+  relation: string,
+  index: RefIndex,
+  ledgerByKey: ReadonlyMap<string, string>,
+): string {
+  const hasBackslash = value.endsWith("\\");
+  const core = hasBackslash ? value.slice(0, -1) : value;
+  const rewritten = core.replace(
+    VALUE_TOKEN_RE,
+    (token) => rewriteToken(token, sourceUlid, relation, index, ledgerByKey),
+  );
+  return hasBackslash ? `${rewritten}\\` : rewritten;
 }
 
 function rewriteToken(

--- a/packages/markspec/core/refs/mod_test.ts
+++ b/packages/markspec/core/refs/mod_test.ts
@@ -353,10 +353,10 @@ Deno.test("canonicalizeRefs: ULID in body prose is not rewritten", () => {
 });
 
 // ---------------------------------------------------------------------------
-// canonicalizeRefs — multi-line continuation left untouched
+// canonicalizeRefs — trailing-backslash key line is canonicalised (#606)
 // ---------------------------------------------------------------------------
 
-Deno.test("canonicalizeRefs: trailer line with trailing backslash is left untouched", () => {
+Deno.test("canonicalizeRefs: trailing-backslash key line has its ULID canonicalised, continuation orphan untouched", () => {
   const line = `      Satisfies: ${TGT} \\`;
   const content = [
     `- [SWE_0001] Title`,
@@ -387,9 +387,12 @@ Deno.test("canonicalizeRefs: trailer line with trailing backslash is left untouc
   const idx = buildRefIndex([src, tgt]);
   const { output, changed } = canonicalizeRefs(content, [src, tgt], idx, []);
 
-  // The continuation line is left byte-for-byte identical.
-  assertEquals(changed, false);
-  assertEquals(output, content);
+  assertEquals(changed, true);
+  const lines = output.split("\n");
+  // The key-line ULID is canonicalised; the trailing backslash is preserved.
+  assertEquals(lines[5], "      Satisfies: SYS_0001 \\");
+  // The continuation orphan (SYS_0002 not in the index) is left untouched.
+  assertEquals(lines[6], "      SYS_0002");
 });
 
 // ---------------------------------------------------------------------------
@@ -498,4 +501,198 @@ Deno.test("canonicalizeRefs: a non-resolving ULID trace value is left as-is", ()
   const { output, changed } = canonicalizeRefs(content, [src], idx, []);
   assertEquals(changed, false);
   assertEquals(output, content);
+});
+
+// ---------------------------------------------------------------------------
+// canonicalizeRefs — multi-line (\-continued) trace values (#606)
+// ---------------------------------------------------------------------------
+
+const TGT2 = "01J0000000000000000000TGT2";
+
+Deno.test("canonicalizeRefs: multi-line value canonicalises ULIDs on every line", () => {
+  const content = [
+    `- [SWE_0001] Title`,
+    ``,
+    `  Body.`,
+    ``,
+    `      Id: ${SRC}`,
+    `      Satisfies: ${TGT}, \\`,
+    `        ${TGT2}`,
+  ].join("\n");
+
+  const src = entry({
+    displayId: "SWE_0001",
+    id: SRC,
+    rawAttributes: [{ key: "Id", value: SRC }],
+    location: { file: "x.md", line: 1, column: 1 },
+  });
+  const tgt = entry({
+    displayId: "SYS_0001",
+    id: TGT,
+    rawAttributes: [{ key: "Id", value: TGT }],
+    location: { file: "x.md", line: 9, column: 1 },
+  });
+  const tgt2 = entry({
+    displayId: "SYS_0002",
+    id: TGT2,
+    rawAttributes: [{ key: "Id", value: TGT2 }],
+    location: { file: "x.md", line: 12, column: 1 },
+  });
+
+  const idx = buildRefIndex([src, tgt, tgt2]);
+  const { output, changed } = canonicalizeRefs(
+    content,
+    [src, tgt, tgt2],
+    idx,
+    [],
+  );
+
+  assertEquals(changed, true);
+  const lines = output.split("\n");
+  // Both ULIDs canonicalised; indentation + trailing backslash preserved.
+  assertEquals(lines[5], "      Satisfies: SYS_0001, \\");
+  assertEquals(lines[6], "        SYS_0002");
+});
+
+Deno.test("canonicalizeRefs: multi-line value heals a stale display ID on a continuation line", () => {
+  const content = [
+    `- [SWE_0001] Title`,
+    ``,
+    `  Body.`,
+    ``,
+    `      Id: ${SRC}`,
+    `      Satisfies: SYS_0001, \\`,
+    `        OLD_SYS_002`,
+  ].join("\n");
+
+  const src = entry({
+    displayId: "SWE_0001",
+    id: SRC,
+    rawAttributes: [{ key: "Id", value: SRC }],
+    location: { file: "x.md", line: 1, column: 1 },
+  });
+  const tgt = entry({
+    displayId: "SYS_0001",
+    id: TGT,
+    rawAttributes: [{ key: "Id", value: TGT }],
+    location: { file: "x.md", line: 9, column: 1 },
+  });
+  const tgt2 = entry({
+    displayId: "SYS_0002",
+    id: TGT2,
+    rawAttributes: [{ key: "Id", value: TGT2 }],
+    location: { file: "x.md", line: 12, column: 1 },
+  });
+
+  const idx = buildRefIndex([src, tgt, tgt2]);
+  const ledger: LockEdge[] = [
+    {
+      sourceUlid: SRC,
+      relation: "Satisfies",
+      targetUlid: TGT2,
+      authoredTarget: "OLD_SYS_002",
+    },
+  ];
+  const { output, changed } = canonicalizeRefs(
+    content,
+    [src, tgt, tgt2],
+    idx,
+    ledger,
+  );
+
+  assertEquals(changed, true);
+  const lines = output.split("\n");
+  assertEquals(lines[5], "      Satisfies: SYS_0001, \\");
+  assertEquals(lines[6], "        SYS_0002");
+});
+
+Deno.test("canonicalizeRefs: fully-canonical multi-line value is a lossless no-op", () => {
+  const content = [
+    `- [SWE_0001] Title`,
+    ``,
+    `  Body.`,
+    ``,
+    `      Id: ${SRC}`,
+    `      Satisfies: SYS_0001, \\`,
+    `        SYS_0002`,
+    ``,
+  ].join("\n");
+
+  const src = entry({
+    displayId: "SWE_0001",
+    id: SRC,
+    rawAttributes: [{ key: "Id", value: SRC }],
+    location: { file: "x.md", line: 1, column: 1 },
+  });
+  const tgt = entry({
+    displayId: "SYS_0001",
+    id: TGT,
+    rawAttributes: [{ key: "Id", value: TGT }],
+    location: { file: "x.md", line: 9, column: 1 },
+  });
+  const tgt2 = entry({
+    displayId: "SYS_0002",
+    id: TGT2,
+    rawAttributes: [{ key: "Id", value: TGT2 }],
+    location: { file: "x.md", line: 12, column: 1 },
+  });
+
+  const idx = buildRefIndex([src, tgt, tgt2]);
+  const { output, changed } = canonicalizeRefs(
+    content,
+    [src, tgt, tgt2],
+    idx,
+    [],
+  );
+
+  assertEquals(changed, false);
+  assertEquals(output, content);
+});
+
+Deno.test("canonicalizeRefs: continuation-only change does not skip the following trace line", () => {
+  // The key line is already canonical; only the continuation carries a ULID.
+  // A following `Verified-by:` line must still be reached by the outer loop.
+  const content = [
+    `- [SWE_0001] Title`,
+    ``,
+    `  Body.`,
+    ``,
+    `      Id: ${SRC}`,
+    `      Satisfies: SYS_0001, \\`,
+    `        ${TGT2}`,
+    `      Verified-by: ${SRC}`,
+  ].join("\n");
+
+  const src = entry({
+    displayId: "SWE_0001",
+    id: SRC,
+    rawAttributes: [{ key: "Id", value: SRC }],
+    location: { file: "x.md", line: 1, column: 1 },
+  });
+  const tgt = entry({
+    displayId: "SYS_0001",
+    id: TGT,
+    rawAttributes: [{ key: "Id", value: TGT }],
+    location: { file: "x.md", line: 10, column: 1 },
+  });
+  const tgt2 = entry({
+    displayId: "SYS_0002",
+    id: TGT2,
+    rawAttributes: [{ key: "Id", value: TGT2 }],
+    location: { file: "x.md", line: 13, column: 1 },
+  });
+
+  const idx = buildRefIndex([src, tgt, tgt2]);
+  const { output, changed } = canonicalizeRefs(
+    content,
+    [src, tgt, tgt2],
+    idx,
+    [],
+  );
+
+  assertEquals(changed, true);
+  const lines = output.split("\n");
+  assertEquals(lines[6], "        SYS_0002");
+  // The Verified-by line after the continuation is still canonicalised.
+  assertEquals(lines[7], "      Verified-by: SWE_0001");
 });


### PR DESCRIPTION
Closes #606. Refs #593.

## Problem

PR3 of the #593 epic (#604) added trace-reference canonicalise/heal in `markspec fmt` via `core/refs/canonicalizeRefs`. To stay conservative it **skipped any trailer line whose value ends in `\`** (a multi-line continuation):

```ts
if (rest.endsWith("\\")) continue; // multi-line continuation — leave (debt)
```

So a `\`-continued multi-line trace value never had its ULIDs canonicalised or stale display IDs healed.

## Fix

Walk the continuation lines instead of bailing. A shared `rewriteValuePreservingContinuation` splits off a trailing `\` before token rewriting (so the backslash is never mistaken for a value token) and re-appends it — keeping indentation, separators, and the marker byte-for-byte lossless. The outer loop advances `i` past consumed continuation lines so the next trace line is still reached.

```
      Satisfies: 01J…TGT1, \        →   Satisfies: SYS_0001, \
        01J…TGT2                            SYS_0002
```

## Tests (`core/refs/mod_test.ts`)

- multi-line value canonicalises ULIDs on **every** line (backslash + indent preserved);
- multi-line value **heals** a stale display ID on a continuation line via the ledger;
- fully-canonical multi-line value is a **lossless no-op** (`output === input`, `changed === false`);
- continuation-only change does **not** skip the following `Verified-by:` trace line.

The prior "left untouched" debt test is rewritten to assert the new behaviour.

## Verification

- Pre-push `just check` green (lint + test + type-check).
- `core/refs` unit suite 19/19.

Obvious-debt sweep; behaviour was already specified by the issue — no design decisions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
