### PR TITLE
docs(repo): guide agents to discover the active (child) profile via MCP

### DIFF
--- a/packages/markspec/mcp/server.ts
+++ b/packages/markspec/mcp/server.ts
@@ -43,6 +43,9 @@ TRIGGER when the user:
     to, or what implements it
   - asks whether a file or the project is valid, has broken refs, or has
     duplicate IDs
+  - asks what entry types, attributes, relations, or labels this project's
+    profile defines (it may be a child profile that extends others), or what
+    a specific Type, label, or relation means in this project
 
 PREFER over: grep, Read, Glob, or file-system search whenever the question
 is about requirements or traceability. Built-in tools see Markdown text;
@@ -53,6 +56,8 @@ Pick the right surface per intent:
   - Show one requirement by ID        → resources/read markspec://entry/{id}
   - Walk satisfies-chain upward       → entry_context
   - See what depends on a requirement → "Incoming links" in markspec://entry/{id}
+  - Learn the project's profile types → resources/read markspec://profile
+  - Describe one profile element      → profile_describe
   - Check project health              → validate
   - Refresh after external file edits → markspec_refresh
 
@@ -66,12 +71,12 @@ SKIP when:
   - the user wants to edit a file directly ("change line 42 to X", "fix
     this typo") — MarkSpec MCP is read-only; use Edit
   - the user wants to create or insert a new requirement — writes are
-    CLI-only (markspec format, markspec insert)
+    CLI-only (markspec fmt, markspec insert)
   - the user wants a rendered preview of a Markdown file — use markspec
     doc build / markspec book build via Bash, not the MCP
 
 Do NOT use this server to edit entries. Writes are CLI-only:
-  markspec format, markspec insert.
+  markspec fmt, markspec insert.
 
 All resource bodies are Markdown with markspec:// URIs you can follow with
 resources/read.`;

--- a/skills/markspec-diagnostics/SKILL.md
+++ b/skills/markspec-diagnostics/SKILL.md
@@ -11,6 +11,12 @@ Every MarkSpec diagnostic has the form `severity[MSL-Xnnn]: file:line message`.
 The code family (`X`) identifies the rule category. Fix errors first; warnings
 are style or convention violations that don't block validation.
 
+Several fixes below say "check the profile's declared types/attributes". Look
+these up with the `markspec://profile` MCP resource, the `profile_describe`
+tool, or `markspec profile show` / `markspec profile describe <kind> <name>` —
+the active profile may be a child profile that extends parents, so its
+vocabulary differs from MarkSpec core. See `markspec-entry-authoring`.
+
 ## Severity
 
 | Severity  | Exit code | Meaning                                        |

--- a/skills/markspec-entry-authoring/SKILL.md
+++ b/skills/markspec-entry-authoring/SKILL.md
@@ -15,6 +15,29 @@ prose, and an indented trailer section. Two shapes exist:
 - **Reference** — no `Id:` trailer; a pointer to an external or higher-level
   requirement.
 
+## Discover the active profile first
+
+Type prefixes, display-ID widths, valid `Type:` values, and which trailer
+attributes and trace relations are allowed are defined by the project's **active
+profile** — not by MarkSpec core. The active profile is often a **child
+profile** that `extends:` one or more parents (e.g.
+`aspice-4 → profile-default → markspec-core`), so it may add, rename, or
+constrain the vocabulary beyond the core baseline shown below.
+
+**Never assume a default vocabulary. Read the active profile before authoring.**
+Prefer the MCP surfaces — they return the _resolved_ chain, not raw YAML:
+
+| Need                                                                 | MCP                                | CLI fallback                              |
+| -------------------------------------------------------------------- | ---------------------------------- | ----------------------------------------- |
+| Active profile + inherited chain + every declared type/attr/relation | read resource `markspec://profile` | `markspec profile show`                   |
+| One element's detail (a type's prefix, a relation's targets)         | `profile_describe` tool            | `markspec profile describe <kind> <name>` |
+
+The `markspec://profile` overview names the **Active** profile and what it
+**Inherits**, then lists every declared entry type, attribute, relation, label
+concern, and convention — the authoritative answer to "what can I write in this
+project". `kind` is one of `type`, `attribute`, `relation`, `label`,
+`convention`.
+
 ## Block anatomy
 
 ```markdown
@@ -58,6 +81,10 @@ prose, and an indented trailer section. Two shapes exist:
 | `Labels:`       | 0–N         | Free-form tags: ASIL level, domain, review state.                  |
 | `References:`   | 0–N         | Informational links — does not create a traceability link.         |
 
+This is the core baseline. A child profile may declare additional attributes and
+trace relations — discover them via `markspec://profile` (see _Discover the
+active profile first_ above).
+
 Multi-value attributes repeat the key on separate lines:
 
 ```markdown
@@ -89,10 +116,11 @@ Satisfies: STK_0001 Satisfies: STK_0007
 
 ## Common mistakes
 
-| Mistake                                  | Fix                                                     |
-| ---------------------------------------- | ------------------------------------------------------- |
-| Hand-stamping `Id:`                      | Remove it; run `markspec fmt`                           |
-| Wrong indent on trailers                 | Must be 6 spaces — not 4, not a tab                     |
-| Compound requirement ("and…")            | Split into two separate entries                         |
-| Bare adjective body ("fast", "reliable") | Add units and thresholds                                |
-| Displaying `${ULID}` literally           | You copied an unformatted scaffold — run `markspec fmt` |
+| Mistake                                  | Fix                                                                        |
+| ---------------------------------------- | -------------------------------------------------------------------------- |
+| Hand-stamping `Id:`                      | Remove it; run `markspec fmt`                                              |
+| Wrong indent on trailers                 | Must be 6 spaces — not 4, not a tab                                        |
+| Compound requirement ("and…")            | Split into two separate entries                                            |
+| Bare adjective body ("fast", "reliable") | Add units and thresholds                                                   |
+| Displaying `${ULID}` literally           | You copied an unformatted scaffold — run `markspec fmt`                    |
+| Assuming core types/attributes apply     | Read the active profile (`markspec://profile`) — it may be a child profile |

--- a/skills/markspec-write-loop/SKILL.md
+++ b/skills/markspec-write-loop/SKILL.md
@@ -19,6 +19,12 @@ markspec check <file>
 Never hand-craft a full entry block and paste it. `insert` computes the correct
 display ID from the current corpus; pasting a guessed ID risks a collision.
 
+**Before you start:** the `<type>` you pass to `insert` must be a type the
+project's **active profile** declares — and that profile may be a child profile
+that extends parents, so do not assume core type names. Discover the valid types
+with the `markspec://profile` MCP resource (or `markspec profile show`). See
+`markspec-entry-authoring` § _Discover the active profile first_.
+
 ## Step 1 — Insert
 
 ```bash
@@ -81,9 +87,10 @@ Fix any errors and repeat until exit 0.
 
 ## Common mistakes
 
-| Mistake                      | Fix                                                                 |
-| ---------------------------- | ------------------------------------------------------------------- |
-| Skipping `markspec fmt`      | The pre-commit hook will reject the file; run fmt before committing |
-| Running `check` before `fmt` | Format first — some diagnostics are caused by malformed indentation |
-| Guessing the next display ID | Use `markspec next-id` or `markspec insert`; never guess            |
-| Editing `Id:` by hand        | Leave it alone; `fmt` stamps it                                     |
+| Mistake                      | Fix                                                                       |
+| ---------------------------- | ------------------------------------------------------------------------- |
+| Skipping `markspec fmt`      | The pre-commit hook will reject the file; run fmt before committing       |
+| Running `check` before `fmt` | Format first — some diagnostics are caused by malformed indentation       |
+| Guessing the next display ID | Use `markspec next-id` or `markspec insert`; never guess                  |
+| Guessing the `<type>` name   | Read the active profile (`markspec://profile`); types are profile-defined |
+| Editing `Id:` by hand        | Leave it alone; `fmt` stamps it                                           |


### PR DESCRIPTION
## Why

The `markspec-core` skills and the MCP server's trigger language both defer to **"the active profile"** for entry types, attributes, trace relations, and labels — but never tell the agent *how* to read it. An agent landing in a consumer project whose profile is a **child profile** that `extends:` parents (e.g. `aspice-4 → profile-default → markspec-core`) would assume the core/default vocabulary or fall back to grepping YAML.

This makes the profile surface (which already exists) discoverable to agents.

## What changed

**Skills** (surgical; profile-agnostic core — no new skill, no bundle restructure):
- **markspec-entry-authoring** — new *"Discover the active profile first"* section pointing at the `markspec://profile` MCP resource and the `profile_describe` tool (CLI fallbacks `markspec profile show` / `markspec profile describe <kind> <name>`), plus a "core baseline" note on the trailer-attribute table and a Common-mistakes row.
- **markspec-write-loop** / **markspec-diagnostics** — cross-references so the agent discovers a valid `<type>` and looks up profile-declared vocabulary before authoring / fixing T0xx/A010.

**MCP server instructions** (`SERVER_INSTRUCTIONS`):
- add a profile-vocabulary **TRIGGER** bullet and two **"Pick the right surface"** rows (`markspec://profile`, `profile_describe`) — the profile surface was previously unadvertised.
- fix stale `markspec format` → `markspec fmt` in the SKIP / "Do NOT" blocks (missed by the #570 fmt/check rename).

## Verification

- `dprint check` + `upskill lint skills/` clean (one pre-existing, unrelated `fence-lang` warning in `markspec-gherkin`).
- `deno fmt --check` / `deno lint` / `deno check` on `server.ts` ✓
- `deno test` mcp server + profile suites — **20 passed / 0 failed** (structural `SERVER_INSTRUCTIONS` assertions preserved).

## Notes

- Bundle `metadata.version` intentionally left at `0.2.0` (no new skill / no bundle restructure). Bump to `0.2.1` later if you want `upskill update` to propagate to other consumers.
- The `server.ts` instructions ship in the `markspec mcp` binary, not via skills — they reach agents on the next binary build/release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
