### PR TITLE
fix(core): suggest declared spelling on a case-only enum mismatch (#215)

### DIFF
--- a/packages/markspec/core/validator/value_types.ts
+++ b/packages/markspec/core/validator/value_types.ts
@@ -56,7 +56,14 @@ const validateDate: ValueValidator = (value, _decl) => {
 const validateEnum: ValueValidator = (value, decl) => {
   const values = decl.values ?? [];
   if (values.includes(value)) return null;
-  return `value '${value}' is not in declared enum [${values.join(", ")}]`;
+  const base = `value '${value}' is not in declared enum [${
+    values.join(", ")
+  }]`;
+  // Case-only mismatch: the author most likely title/upper-cased a valid
+  // member (e.g. `Approved` → `approved`). Suggest the declared spelling
+  // (#215). A genuine unknown value falls through with no hint.
+  const match = values.find((v) => v.toLowerCase() === value.toLowerCase());
+  return match !== undefined ? `${base}; did you mean '${match}'?` : base;
 };
 
 // ---------------------------------------------------------------------------

--- a/packages/markspec/core/validator/value_types_test.ts
+++ b/packages/markspec/core/validator/value_types_test.ts
@@ -4,7 +4,7 @@
  * Unit tests for per-type value validators.
  */
 
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertStringIncludes } from "@std/assert";
 import { validateValue } from "./value_types.ts";
 import type { AttrDecl } from "../model/mod.ts";
 
@@ -108,6 +108,27 @@ Deno.test("validateValue: enum is case-sensitive", () => {
   assertEquals(validateValue("Draft", d), null);
   const r = validateValue("draft", d);
   if (r === null) throw new Error("expected lowercase 'draft' to be invalid");
+});
+
+Deno.test("validateValue: enum case-only mismatch suggests the declared spelling (#215)", () => {
+  const d = decl("enum", { values: ["draft", "approved", "deprecated"] });
+  const r = validateValue("Approved", d);
+  if (r === null) throw new Error("expected 'Approved' to be invalid enum");
+  assertStringIncludes(r, "did you mean 'approved'?");
+});
+
+Deno.test("validateValue: enum suggests the declared mixed-case spelling", () => {
+  const d = decl("enum", { values: ["InProgress"] });
+  const r = validateValue("inprogress", d);
+  if (r === null) throw new Error("expected 'inprogress' to be invalid enum");
+  assertStringIncludes(r, "did you mean 'InProgress'?");
+});
+
+Deno.test("validateValue: enum genuine unknown value gets no suggestion", () => {
+  const d = decl("enum", { values: ["draft", "approved"] });
+  const r = validateValue("pending", d);
+  if (r === null) throw new Error("expected 'pending' to be invalid enum");
+  assertEquals(r.includes("did you mean"), false);
 });
 
 // id


### PR DESCRIPTION
Addresses the "smarter MSL-R014 diagnostic" item from #215 (the `MSL-R014` code in that note is stale; enum-value conformance is reported on `main` as **MSL-A004** via the value-types registry).

## Change

When an enum-typed attribute value is rejected only because of letter case, the validator now suggests the declared spelling:

```
value 'Approved' is not in declared enum [draft, approved, deprecated]; did you mean 'approved'?
```

The match is case-insensitive against the declared values and suggests their exact spelling, so it also covers mixed-case enums (`inprogress` → `InProgress`). A genuine unknown value still gets the plain "not in declared enum" message with no hint.

This flows through `validateValue` → the **MSL-A004** message (`attributes.ts`) unchanged — the hint rides along in the detail string.

## Tests (`core/validator/value_types_test.ts`)

- case-only mismatch suggests the declared spelling (the #215 `Approved` → `approved` example);
- mixed-case enum suggests the declared spelling (`inprogress` → `InProgress`);
- a genuine unknown value gets **no** suggestion.

## Verification

- Pre-push `just check` green (lint + test + type-check); validator suite 330/330.

Obvious-debt sweep; behaviour specified by the #215 note — no design decisions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
