### PR TITLE
fix(core): refuse self-upgrade for cargo-managed installs (#575)

### DIFF
--- a/packages/markspec/cli/commands/self_upgrade.ts
+++ b/packages/markspec/cli/commands/self_upgrade.ts
@@ -267,6 +267,7 @@ async function runSelfUpgrade(
   if (
     classification.source === "homebrew" ||
     classification.source === "npm" ||
+    classification.source === "cargo" ||
     classification.source === "system"
   ) {
     const hint = pmHint(classification.source);
@@ -415,9 +416,12 @@ function stripV(v: string): string {
   return v.startsWith("v") ? v.slice(1) : v;
 }
 
-function humanSourceLabel(s: "homebrew" | "npm" | "system"): string {
+function humanSourceLabel(
+  s: "homebrew" | "npm" | "cargo" | "system",
+): string {
   if (s === "homebrew") return "Homebrew";
   if (s === "npm") return "npm";
+  if (s === "cargo") return "Cargo";
   return "a system package";
 }
 

--- a/packages/markspec/cli/self_upgrade/report.ts
+++ b/packages/markspec/cli/self_upgrade/report.ts
@@ -19,6 +19,7 @@ export type Action =
 export type Reason =
   | "homebrew"
   | "npm"
+  | "cargo"
   | "system"
   | "unwritable"
   | "network"
@@ -57,5 +58,6 @@ export function renderJson(out: Outcome): string {
 export function pmHint(source: InstallSource): string | undefined {
   if (source === "homebrew") return "brew upgrade markspec";
   if (source === "npm") return "npm update -g markspec";
+  if (source === "cargo") return "cargo install markspec --force";
   return undefined;
 }

--- a/packages/markspec/core/self_upgrade/pm_detect.ts
+++ b/packages/markspec/core/self_upgrade/pm_detect.ts
@@ -1,14 +1,14 @@
 /**
  * @module core/self_upgrade/pm_detect
  *
- * Classify the realpath of the running binary into one of four
+ * Classify the realpath of the running binary into one of five
  * install-source buckets so the self-upgrade orchestrator can refuse
  * with a per-manager hint instead of fighting the package manager.
  *
  * The check is heuristic and order-sensitive — Homebrew first (because
  * brew's bin paths live under /opt/homebrew or /usr/local), npm second,
- * system third, user-local fourth. Anything that falls through is
- * "unknown" and the orchestrator proceeds with a warning.
+ * cargo third, user-local fourth, system fifth. Anything that falls
+ * through is "unknown" and the orchestrator proceeds with a warning.
  *
  * Path matching is whole-segment (path separator on both sides) to
  * avoid matching e.g. `/foo/.localfish/markspec` against the user-local
@@ -23,6 +23,7 @@ export type InstallSource =
   | "user-local"
   | "homebrew"
   | "npm"
+  | "cargo"
   | "system"
   | "unknown";
 
@@ -58,12 +59,19 @@ export function classifyInstallPath(
     return { source: "npm", hintCommand: "npm update -g markspec" };
   }
 
-  // 3. user-local paths under $HOME.
+  // 3. Cargo (`~/.cargo/bin`). A package-manager location like Homebrew/npm,
+  //    so it is refused rather than overwritten — self-upgrade's rename-swap
+  //    would leave cargo's own metadata stale (#575). Checked before the
+  //    user-local rule, which would otherwise claim `.cargo/bin/`.
+  if (h && p.startsWith(`${h}/.cargo/bin/`)) {
+    return { source: "cargo", hintCommand: "cargo install markspec --force" };
+  }
+
+  // 4. user-local paths under $HOME.
   if (h && p.startsWith(`${h}/`)) {
     const tail = p.slice(h.length + 1);
     if (
       tail.startsWith(".local/") ||
-      tail.startsWith(".cargo/bin/") ||
       tail.startsWith("bin/") ||
       tail.startsWith("Library/")
     ) {
@@ -71,7 +79,7 @@ export function classifyInstallPath(
     }
   }
 
-  // 4. system bins.
+  // 5. system bins.
   if (
     p.startsWith("/usr/") ||
     p.startsWith("/opt/") ||

--- a/packages/markspec/core/self_upgrade/pm_detect_test.ts
+++ b/packages/markspec/core/self_upgrade/pm_detect_test.ts
@@ -9,11 +9,13 @@ Deno.test("classifyInstallPath: ~/.local/bin → user-local", () => {
   assertEquals(r.source, "user-local");
 });
 
-Deno.test("classifyInstallPath: ~/.cargo/bin → user-local", () => {
-  assertEquals(
-    classifyInstallPath("/Users/alice/.cargo/bin/markspec", HOME_POSIX).source,
-    "user-local",
+Deno.test("classifyInstallPath: ~/.cargo/bin → cargo (refused, #575)", () => {
+  const r = classifyInstallPath(
+    "/Users/alice/.cargo/bin/markspec",
+    HOME_POSIX,
   );
+  assertEquals(r.source, "cargo");
+  assertEquals(r.hintCommand, "cargo install markspec --force");
 });
 
 Deno.test("classifyInstallPath: ~/bin → user-local", () => {

--- a/tests/e2e/self_upgrade_test.ts
+++ b/tests/e2e/self_upgrade_test.ts
@@ -378,6 +378,52 @@ Deno.test({
   },
 });
 
+Deno.test({
+  name: "self-upgrade: PM-managed path (~/.cargo/bin) → refused (#575)",
+  ignore: Deno.build.os === "windows",
+  fn: async () => {
+    const next = nextPatch(VERSION);
+    const tarGz = await makeTarGz(new TextEncoder().encode("NEW"));
+    const sum = await sha256Hex(tarGz);
+    const mock = startMock(
+      `v${next}`,
+      tarGz,
+      `${sum}  markspec-${TARGET}.tar.gz\n`,
+    );
+    const dir = await Deno.makeTempDir();
+    try {
+      // Resolve the temp dir's realpath up front: the classifier compares the
+      // binary's realpath against HOME, and on macOS the temp dir is a
+      // symlink (/var → /private/var), so both sides must be realpaths.
+      const realDir = await Deno.realPath(dir);
+      const cargoBin = join(realDir, ".cargo", "bin");
+      await Deno.mkdir(cargoBin, { recursive: true });
+      const realBin = join(cargoBin, BIN_NAME);
+      await Deno.writeTextFile(realBin, "CARGO-BIN");
+      const { code, stderr } = await markspecInDir(
+        dir,
+        ["self-upgrade"],
+        ["--allow-net", "--allow-env", "--allow-run"],
+        {
+          MARKSPEC_RELEASES_API: `${mock.baseUrl}/releases`,
+          MARKSPEC_RELEASES_DOWNLOAD_BASE: `${mock.baseUrl}/releases/download`,
+          MARKSPEC_SELF_UPGRADE_BIN_PATH: realBin,
+          MARKSPEC_TEST_MODE: "1",
+          // The cargo rule matches `${HOME}/.cargo/bin/` — point HOME at the
+          // temp dir's realpath so the realpath classifies as cargo.
+          HOME: realDir,
+        },
+      );
+      assertEquals(code, 2);
+      assertStringIncludes(stderr, "Cargo");
+      assertStringIncludes(stderr, "cargo install markspec --force");
+    } finally {
+      await Deno.remove(dir, { recursive: true });
+      await mock.close();
+    }
+  },
+});
+
 Deno.test(
   "self-upgrade --format json: emits valid JSON outcome",
   async () => {


### PR DESCRIPTION
Resolves the "self-upgrade — cargo installs are not refused" item from #575.

## Problem

`pm_detect` classified `~/.cargo/bin/markspec` as `user-local` (self-upgradeable), so `markspec self-upgrade`'s atomic rename-swap would silently overwrite a cargo-managed binary and leave cargo's own metadata stale — while Homebrew and npm locations are already **refused** with a "use your package manager" hint.

## Fix (refuse cargo, consistent with brew/npm)

- New `cargo` install source in `pm_detect`, matched **before** the user-local rule (which would otherwise claim `.cargo/bin/`).
- Refuse it like brew/npm, surfacing `cargo install markspec --force`.
- Wired through the command's refusal condition, `pmHint`, and `humanSourceLabel`.

```
~/.cargo/bin/markspec self-upgrade ->
  refused (exit 2): "this markspec was installed via Cargo …
  run `cargo install markspec --force` instead"
```

Conservative + consistent: self-upgrade never clobbers a package-manager-managed location. (markspec isn't on crates.io, so this is defensive/future-proofing rather than a common path.)

## Tests

- `pm_detect_test.ts`: `~/.cargo/bin` → `cargo` with the hint command (flips the prior `user-local` expectation).
- `tests/e2e/self_upgrade_test.ts`: a PM-managed-refusal e2e mirroring the brew case (exit 2, mentions `Cargo` + `cargo install markspec --force`).

## Verification

- Pre-push `just check` green (lint + test + type-check).

Per the #575 decision to refuse cargo for consistency/safety.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
