### PR TITLE
refactor(repo)!: split profile-authoring skills into a separate bundle

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -5,6 +5,14 @@ Core AI-assistance content for MarkSpec consumer projects, managed via
 any profile chain. Every profile bundle should `requires:` this bundle
 (directly, or transitively via the default profile).
 
+This registry ships two bundles:
+
+- **`markspec-core`** — authoring literacy for every consumer project (entry
+  authoring, write loop, diagnostics, requirement style, prose review,
+  traceability review).
+- **`markspec-profile-authoring`** — tooling for people building a MarkSpec
+  _profile package_. Installed à la carte; `requires: markspec-core`.
+
 ## Install
 
 Install the full core bundle:
@@ -25,12 +33,23 @@ To install one item without the rest, pass the item name as a filter:
 upskill add ./skills markspec-entry-authoring
 ```
 
+### Profile-authoring bundle
+
+If you are authoring a MarkSpec profile package (not just authoring requirements
+in a consumer project), install the profile-authoring tools — this pulls in
+`markspec-core` transitively via `requires:`:
+
+```bash
+upskill add driftsys/markspec:skills/markspec-profile-authoring.bundle.yaml
+```
+
 ## Layout
 
 ```text
 skills/
 ├── README.md                                  this file
-├── markspec-core.bundle.yaml                  one-shot install of the bundle
+├── markspec-core.bundle.yaml                  authoring-literacy bundle
+├── markspec-profile-authoring.bundle.yaml     profile-package authoring bundle
 ├── markspec-core-rules/RULE.md                always-on authoring invariants
 ├── markspec-entry-authoring/SKILL.md          entry-block format
 ├── markspec-write-loop/SKILL.md               insert → fmt → check
@@ -44,7 +63,7 @@ skills/
 └── markspec-traceability-review/AGENT.md      audit traceability gaps
 ```
 
-## Items
+## `markspec-core` items
 
 ### Rule
 
@@ -54,23 +73,30 @@ skills/
 
 ### Skills
 
-| Item                                | Triggers when…                                                      |
-| ----------------------------------- | ------------------------------------------------------------------- |
-| `markspec-entry-authoring`          | Writing or reviewing a MarkSpec entry block — format and trailers   |
-| `markspec-write-loop`               | Adding a new entry — canonical `insert → fmt → check` sequence      |
-| `markspec-diagnostics`              | Validator output contains MSL- codes — covers every family and fix  |
-| `markspec-requirement-style`        | Choosing how to write a requirement body — EARS vs Gherkin vs prose |
-| `markspec-ears`                     | Writing EARS-style requirements — all five patterns with do/don't   |
-| `markspec-gherkin`                  | Writing Gherkin acceptance criteria — Given/When/Then with examples |
-| `markspec-prose-review`             | Reviewing entry bodies for prose quality against the core checklist |
-| `markspec-profile-bundle-authoring` | Creating or extending a MarkSpec profile's upskill bundle           |
+| Item                         | Triggers when…                                                      |
+| ---------------------------- | ------------------------------------------------------------------- |
+| `markspec-entry-authoring`   | Writing or reviewing a MarkSpec entry block — format and trailers   |
+| `markspec-write-loop`        | Adding a new entry — canonical `insert → fmt → check` sequence      |
+| `markspec-diagnostics`       | Validator output contains MSL- codes — covers every family and fix  |
+| `markspec-requirement-style` | Choosing how to write a requirement body — EARS vs Gherkin vs prose |
+| `markspec-ears`              | Writing EARS-style requirements — all five patterns with do/don't   |
+| `markspec-gherkin`           | Writing Gherkin acceptance criteria — Given/When/Then with examples |
+| `markspec-prose-review`      | Reviewing entry bodies for prose quality against the core checklist |
 
 ### Agents
 
-| Item                               | Purpose                                                                |
-| ---------------------------------- | ---------------------------------------------------------------------- |
-| `markspec-scaffold-profile-bundle` | Reads `markspec.yaml` and scaffolds the `skills/` bundle manifest      |
-| `markspec-traceability-review`     | Audits the corpus for missing derivations, untested requirements, gaps |
+| Item                           | Purpose                                                                |
+| ------------------------------ | ---------------------------------------------------------------------- |
+| `markspec-traceability-review` | Audits the corpus for missing derivations, untested requirements, gaps |
+
+## `markspec-profile-authoring` items
+
+Install à la carte when building a profile package (`requires: markspec-core`):
+
+| Item                                | Kind  | Purpose                                                           |
+| ----------------------------------- | ----- | ----------------------------------------------------------------- |
+| `markspec-profile-bundle-authoring` | skill | Creating or extending a MarkSpec profile's upskill bundle         |
+| `markspec-scaffold-profile-bundle`  | agent | Reads `markspec.yaml` and scaffolds the `skills/` bundle manifest |
 
 ## Format
 

--- a/skills/markspec-core.bundle.yaml
+++ b/skills/markspec-core.bundle.yaml
@@ -1,7 +1,7 @@
 schema: 1
 name: markspec-core
 description: |
-  Profile-agnostic MarkSpec literacy — entry authoring, write loop, diagnostics, requirement writing patterns (EARS/Gherkin), prose review, traceability audit, and profile bundle authoring.
+  Profile-agnostic MarkSpec literacy — entry authoring, write loop, diagnostics, requirement writing patterns (EARS/Gherkin), prose review, and traceability audit.
 license: MIT
 items:
   rules:
@@ -13,11 +13,9 @@ items:
   - markspec-requirement-style
   - markspec-ears
   - markspec-gherkin
-  - markspec-profile-bundle-authoring
   - markspec-prose-review
   agents:
-  - markspec-scaffold-profile-bundle
   - markspec-traceability-review
 metadata:
-  version: 0.2.0
+  version: 0.3.0
   author: driftsys

--- a/skills/markspec-profile-authoring.bundle.yaml
+++ b/skills/markspec-profile-authoring.bundle.yaml
@@ -1,0 +1,16 @@
+schema: 1
+name: markspec-profile-authoring
+description: |
+  Authoring tools for MarkSpec profile packages — scaffolding a profile's upskill bundle and registering its rules / skills / agents. Builds on markspec-core literacy; install à la carte when authoring a profile, not in every consumer project.
+license: MIT
+items:
+  rules: []
+  skills:
+  - markspec-profile-bundle-authoring
+  agents:
+  - markspec-scaffold-profile-bundle
+requires:
+  - { name: "markspec-core" }
+metadata:
+  version: 0.1.0
+  author: driftsys


### PR DESCRIPTION
## Why

`markspec-core` contained the "how to author a profile **package**" content — the `markspec-profile-bundle-authoring` skill and `markspec-scaffold-profile-bundle` agent. Two problems:

1. **Wrong audience.** Every consumer project pulls `markspec-core` transitively via the `extends:`/`requires:` chain, so every requirements-authoring project was also installing profile-package tooling it will ~never use — clutter on the agent's skill-selection surface.
2. **Inverted layering.** The foundation knew about its own meta-tooling. The correct arrow is the opposite: profile-authoring is a specialized layer that **builds on** core.

## What changed

Move both items into a new **`markspec-profile-authoring`** bundle that `requires: markspec-core` (a profile author is also an authoring engineer, and the skill explicitly references core conventions). **The on-disk `SKILL.md` / `AGENT.md` files do not move** — only bundle membership.

- `skills/markspec-core.bundle.yaml` — drop the two items, trim the description, bump `0.2.0 → 0.3.0`.
- `skills/markspec-profile-authoring.bundle.yaml` — **new** manifest (`0.1.0`): the two items + `requires: markspec-core`.
- `skills/README.md` — two-bundle intro, à-la-carte install command, split items tables.

`markspec-traceability-review` stays in core — it audits a *consumer* corpus, so it's an engineer/lead task, not profile tooling.

## Verification

- `dprint check` + `upskill lint skills/` clean (one pre-existing, unrelated `fence-lang` warning in `markspec-gherkin`).
- Throwaway-project installs confirm both directions:
  - `markspec-core` alone → 7 skills + `markspec-traceability-review` only; **profile-authoring items absent**.
  - `markspec-profile-authoring` → its 2 items **plus** all of core via `requires:` (33 files).

## ⚠️ Breaking (bundle)

Installing `markspec-core` no longer ships `markspec-profile-bundle-authoring` or `markspec-scaffold-profile-bundle`. Profile authors install `markspec-profile-authoring` instead. Pre-1.0, no migration shim (per the no-migration-until-1.0 rule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
