### PR TITLE
fix(docs): serve /schemas/ landing page and fix project.yaml $schema URL

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -87,8 +87,8 @@
     </a>
     <a href="schemas/">
       Config Schemas
-      <span>JSON Schemas for profile manifests, .markspec.yaml, and the
-        lockfile</span>
+      <span>JSON Schemas for project.yaml, profile manifests, .markspec.yaml,
+        and the lockfile</span>
     </a>
   </body>
 </html>

--- a/docs/spec/language/language.md
+++ b/docs/spec/language/language.md
@@ -1313,7 +1313,8 @@ Slugs use the GFM algorithm: lowercase, spaces to hyphens, punctuation stripped.
 ### 6.1 Project properties
 
 Shared across all documents. Every property always resolves. The `project.yaml`
-schema is defined at `https://driftsys.github.io/schemas/project/v1.json`.
+schema is defined at
+`https://driftsys.github.io/markspec/schemas/project/v1.json`.
 
 | Property       | Source                        | Fallback                    |
 | -------------- | ----------------------------- | --------------------------- |

--- a/packages/markspec/cli/init/scaffolders/project_yaml.ts
+++ b/packages/markspec/cli/init/scaffolders/project_yaml.ts
@@ -9,7 +9,8 @@
 import { join } from "@std/path";
 import type { MemFs } from "../fake_fs.ts";
 
-const SCHEMA_URL = "https://driftsys.github.io/schemas/project/v1.json";
+const SCHEMA_URL =
+  "https://driftsys.github.io/markspec/schemas/project/v1.json";
 
 export interface ProjectYamlInput {
   /** Final segment of the target dir; basis for the `name` field. */

--- a/packages/markspec/core/config/project_schema_test.ts
+++ b/packages/markspec/core/config/project_schema_test.ts
@@ -1,0 +1,46 @@
+import { assertEquals } from "@std/assert";
+
+const PROJECT_SCHEMA_URL = new URL(
+  "../../../../schemas/project/v1.json",
+  import.meta.url,
+);
+
+async function loadProjectSchema(): Promise<Record<string, unknown>> {
+  return JSON.parse(await Deno.readTextFile(PROJECT_SCHEMA_URL));
+}
+
+Deno.test("project schema: $id is the canonical URL", async () => {
+  const schema = await loadProjectSchema();
+  assertEquals(
+    schema.$id,
+    "https://driftsys.github.io/markspec/schemas/project/v1.json",
+  );
+});
+
+Deno.test("project schema: requires name and documents known keys", async () => {
+  const schema = await loadProjectSchema();
+  const props = new Set(
+    Object.keys((schema.properties ?? {}) as Record<string, unknown>),
+  );
+  // `name` is the only field parseProjectConfig requires.
+  assertEquals(schema.required, ["name"]);
+  // Every key the parser recognises plus the scaffolder/manifest metadata
+  // fields must be documented so editors offer them.
+  for (
+    const key of [
+      "$schema",
+      "name",
+      "version",
+      "description",
+      "repository",
+      "license",
+      "category",
+      "labels",
+      "parents",
+      "parent-fallback",
+      "caption-conventions",
+    ]
+  ) {
+    assertEquals(props.has(key), true, `missing property: ${key}`);
+  }
+});

--- a/project.yaml
+++ b/project.yaml
@@ -1,4 +1,4 @@
-"$schema": https://driftsys.github.io/schemas/project/v1.json
+"$schema": https://driftsys.github.io/markspec/schemas/project/v1.json
 name: io.driftsys.markspec
 version: "0.8.0"
 category: [specification, tool]

--- a/schemas/index.html
+++ b/schemas/index.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>MarkSpec Config Schemas</title>
+    <link rel="stylesheet" href="../theme/markspec.css">
+    <link rel="stylesheet" href="../spec/FontAwesome/css/font-awesome.css">
+    <style>
+      body {
+        font-family: var(--font-sans, sans-serif);
+        max-width: 600px;
+        margin: 80px auto;
+        padding: 0 20px;
+        color: var(--ms-text, #333);
+      }
+      .github-link {
+        position: fixed;
+        top: 16px;
+        right: 16px;
+        font-size: 1.5rem;
+        color: var(--ms-secondary, #666);
+        text-decoration: none;
+        line-height: 1;
+      }
+      .github-link:hover {
+        color: var(--ms-text, #333);
+      }
+      h1 {
+        font-size: 1.8rem;
+        margin-bottom: 0.5rem;
+      }
+      p {
+        color: var(--ms-secondary, #666);
+        margin-bottom: 2rem;
+      }
+      a.card {
+        display: block;
+        padding: 16px 20px;
+        margin-bottom: 12px;
+        border: 1px solid var(--ms-border, #ddd);
+        border-radius: 6px;
+        text-decoration: none;
+        color: var(--ms-accent, #0072b2);
+        font-weight: 500;
+      }
+      a.card:hover {
+        background: var(--ms-bg-code, #f8f8f8);
+        border-color: var(--ms-accent, #0072b2);
+      }
+      a.card code {
+        font-family: var(--font-mono, monospace);
+        font-size: 0.85rem;
+        font-weight: 400;
+      }
+      a.card span {
+        display: block;
+        color: var(--ms-secondary, #888);
+        font-size: 0.85rem;
+        font-weight: 400;
+        margin-top: 4px;
+      }
+      .home {
+        display: inline-block;
+        margin-top: 1rem;
+        color: var(--ms-secondary, #888);
+        font-size: 0.9rem;
+      }
+    </style>
+  </head>
+  <body>
+    <a href="https://github.com/driftsys/markspec" title="Git repository" aria-label="Git repository" class="github-link">
+      <i class="fa fa-github"></i>
+    </a>
+    <h1>MarkSpec Config Schemas</h1>
+    <p>JSON Schemas for MarkSpec configuration files. Reference one from a config
+      file's <code>$schema</code> key for editor validation and autocomplete.</p>
+    <a class="card" href="project/v1.json">
+      <code>project/v1.json</code>
+      <span>The <code>project.yaml</code> project manifest — name, version,
+        labels, parents, caption conventions.</span>
+    </a>
+    <a class="card" href="markspec/v1.json">
+      <code>markspec/v1.json</code>
+      <span>The <code>.markspec.yaml</code> consumer binding — activated profile
+        chain and default-profile opt-out.</span>
+    </a>
+    <a class="card" href="profile/v1.json">
+      <code>profile/v1.json</code>
+      <span>A profile's <code>markspec.yaml</code> manifest — id, version,
+        extends chain, type and attribute declarations.</span>
+    </a>
+    <a class="card" href="lock/v1.json">
+      <code>lock/v1.json</code>
+      <span>The <code>markspec.lock</code> lockfile — upstream version pins, sync
+        mappings, and the per-edge identity ledger.</span>
+    </a>
+    <a class="home" href="../">← MarkSpec documentation</a>
+  </body>
+</html>

--- a/schemas/project/v1.json
+++ b/schemas/project/v1.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://driftsys.github.io/markspec/schemas/project/v1.json",
+  "title": "MarkSpec project manifest",
+  "description": "Schema for a project's project.yaml. Unknown keys are permitted to match the loader, which ignores keys it does not recognise.",
+  "type": "object",
+  "required": ["name"],
+  "properties": {
+    "$schema": { "type": "string" },
+    "name": {
+      "type": "string",
+      "description": "Project name. Reverse-DNS form recommended (e.g. io.driftsys.markspec)."
+    },
+    "version": {
+      "type": "string",
+      "description": "Project version. Falls back to `git describe` when absent."
+    },
+    "description": {
+      "type": "string",
+      "description": "One-line project summary."
+    },
+    "repository": {
+      "type": "string",
+      "description": "Source repository URL. Falls back to `git remote get-url origin` when absent."
+    },
+    "license": {
+      "type": "string",
+      "description": "SPDX license identifier. Defaults to `proprietary` when absent."
+    },
+    "category": {
+      "type": "array",
+      "description": "Free-form classification tags (e.g. specification, tool).",
+      "items": { "type": "string" }
+    },
+    "labels": {
+      "type": "array",
+      "description": "Project-wide labels applied to every entry.",
+      "items": { "type": "string" }
+    },
+    "parents": {
+      "type": "array",
+      "description": "Upstream project base URLs for federated reference resolution.",
+      "items": { "type": "string", "format": "uri" }
+    },
+    "parent-fallback": {
+      "type": "string",
+      "format": "uri",
+      "description": "Fallback base URL used when a parent reference cannot be resolved."
+    },
+    "caption-conventions": {
+      "type": "object",
+      "description": "Per-keyword caption placement: where the caption sits relative to its block.",
+      "propertyNames": {
+        "enum": ["Figure", "Table", "Listing", "Feature", "Equation", "List"]
+      },
+      "additionalProperties": { "enum": ["above", "below"] }
+    }
+  }
+}


### PR DESCRIPTION
## Problem

`https://driftsys.github.io/markspec/schemas/` returns **404**. The "Config Schemas" card on the docs landing page links to `schemas/`, a directory.

## Root cause

GitHub Pages serves a directory path only when that directory contains an `index.html`. The other cards (`guide/`, `spec/`, `model/`, `typography/`) work because **mdBook generates an `index.html` in each**. The schemas directory is just raw JSON files copied verbatim by `cp -R schemas/. _site/schemas/` — there was no `schemas/index.html`, so the bare path had nothing to serve. Verified against the live site: the bare directory 404s, but every individual schema file (`schemas/{markspec,profile,lock}/v1.json`) returns 200.

## Fix

**Part A — the reported 404**
- Add `schemas/index.html`: a styled landing page (mirrors the docs landing page) listing all four schemas. The existing `pages.yaml` copy step ships it automatically and `paths: schemas/**` self-triggers the deploy — no workflow change.
- Update the `docs/index.html` card description to mention `project.yaml`.

**Part B — a latent bug found while investigating**

The `project.yaml` `$schema` URL (`https://driftsys.github.io/schemas/project/v1.json`) was doubly broken: missing the `/markspec/` Pages path segment, and pointing at a `project/v1.json` that was **never authored** — so every `markspec init`-scaffolded `project.yaml` (and the repo's own) carried a 404 schema link. The language spec §6.1 even documented the schema as existing.
- Author `schemas/project/v1.json` (fields derived from language spec §6.1 + the config loader; lenient `additionalProperties` to match the loader, which ignores unknown keys).
- Correct the URL in the init scaffolder, the repo's own `project.yaml`, and `docs/spec/language/language.md`.

## Tests

- TDD (red→green) for `schemas/project/v1.json`: canonical `$id` + documented key set (`packages/markspec/core/config/project_schema_test.ts`).
- `just test` green: **3233 passed, 0 failed, 2 ignored**. `deno fmt --check` + `dprint check` pass.

## Notes

- No tracking issue exists for this specific live-site bug (the `#137`/`#591` "site API schemas" are the traceability JSON API, a different surface).
- Possible follow-up: a structural guard test asserting every published schema is linked from `schemas/index.html` and every link resolves — would have caught this class of bug. Left out to keep the change surgical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
