### PR TITLE
feat(release): add aarch64-unknown-linux-gnu target

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,6 +26,9 @@ jobs:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
             binary: markspec
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+            binary: markspec
           - target: x86_64-apple-darwin
             os: macos-latest
             binary: markspec

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -141,13 +141,13 @@ Pre-built binaries are attached to every GitHub Release. Download the archive
 for your platform, extract the `markspec` binary, and place it anywhere on your
 `PATH`.
 
-| Platform         | File                                     |
-| ---------------- | ---------------------------------------- |
-| macOS (Apple)    | `markspec-macos-aarch64.tar.gz`          |
-| macOS (Intel)    | `markspec-macos-x86_64.tar.gz`           |
-| Linux (x86_64)   | `markspec-linux-x86_64.tar.gz`           |
-| Linux (aarch64)  | `markspec-linux-aarch64.tar.gz`          |
-| Windows (x86_64) | `markspec-x86_64-pc-windows-msvc.tar.gz` |
+| Platform         | File                                        |
+| ---------------- | ------------------------------------------- |
+| macOS (Apple)    | `markspec-aarch64-apple-darwin.tar.gz`      |
+| macOS (Intel)    | `markspec-x86_64-apple-darwin.tar.gz`       |
+| Linux (x86_64)   | `markspec-x86_64-unknown-linux-gnu.tar.gz`  |
+| Linux (aarch64)  | `markspec-aarch64-unknown-linux-gnu.tar.gz` |
+| Windows (x86_64) | `markspec-x86_64-pc-windows-msvc.tar.gz`    |
 
 ### Deno (from source)
 

--- a/install.sh
+++ b/install.sh
@@ -22,7 +22,8 @@ detect_target() {
   case "$os" in
     Linux)
       case "$arch" in
-        x86_64) echo "x86_64-unknown-linux-gnu" ;;
+        x86_64)  echo "x86_64-unknown-linux-gnu" ;;
+        aarch64) echo "aarch64-unknown-linux-gnu" ;;
         *) echo "error: unsupported architecture: $arch" >&2; exit 1 ;;
       esac
       ;;

--- a/packages/markspec/cli/commands/self_upgrade.ts
+++ b/packages/markspec/cli/commands/self_upgrade.ts
@@ -128,7 +128,7 @@ async function runSelfUpgrade(
       VERSION,
       null,
       "",
-      `unsupported platform: ${Deno.build.os}/${Deno.build.arch}. Supported: linux-x64, darwin-x64, darwin-arm64, windows-x64.`,
+      `unsupported platform: ${Deno.build.os}/${Deno.build.arch}. Supported: linux-x64, linux-arm64, darwin-x64, darwin-arm64, windows-x64.`,
     );
   }
   const target = detectTarget(platform);

--- a/packages/markspec/core/self_upgrade/target.ts
+++ b/packages/markspec/core/self_upgrade/target.ts
@@ -3,8 +3,8 @@
  *
  * Map (os, arch) → the GitHub release target string used in tarball
  * names. Targets match those produced by the Release workflow:
- *   x86_64-unknown-linux-gnu, x86_64-apple-darwin,
- *   aarch64-apple-darwin, x86_64-pc-windows-msvc.
+ *   x86_64-unknown-linux-gnu, aarch64-unknown-linux-gnu,
+ *   x86_64-apple-darwin, aarch64-apple-darwin, x86_64-pc-windows-msvc.
  *
  * Pure functions — no I/O, no Deno.* APIs. The CLI passes
  * `Deno.build.os` / `Deno.build.arch` strings to platformFromBuild;
@@ -22,6 +22,7 @@ export interface Platform {
 
 export type Target =
   | "x86_64-unknown-linux-gnu"
+  | "aarch64-unknown-linux-gnu"
   | "x86_64-apple-darwin"
   | "aarch64-apple-darwin"
   | "x86_64-pc-windows-msvc";
@@ -30,6 +31,7 @@ export type Target =
 export function detectTarget(platform: Platform): Target | undefined {
   const { os, arch } = platform;
   if (os === "linux" && arch === "x86_64") return "x86_64-unknown-linux-gnu";
+  if (os === "linux" && arch === "aarch64") return "aarch64-unknown-linux-gnu";
   if (os === "darwin" && arch === "x86_64") return "x86_64-apple-darwin";
   if (os === "darwin" && arch === "aarch64") return "aarch64-apple-darwin";
   if (os === "windows" && arch === "x86_64") return "x86_64-pc-windows-msvc";

--- a/packages/markspec/core/self_upgrade/target_test.ts
+++ b/packages/markspec/core/self_upgrade/target_test.ts
@@ -27,8 +27,11 @@ Deno.test("detectTarget: windows x86_64 → x86_64-pc-windows-msvc", () => {
   );
 });
 
-Deno.test("detectTarget: linux aarch64 (no build target shipped) → undefined", () => {
-  assertEquals(detectTarget({ os: "linux", arch: "aarch64" }), undefined);
+Deno.test("detectTarget: linux aarch64 → aarch64-unknown-linux-gnu", () => {
+  assertEquals(
+    detectTarget({ os: "linux", arch: "aarch64" }),
+    "aarch64-unknown-linux-gnu",
+  );
 });
 
 Deno.test("detectTarget: windows aarch64 (not shipped) → undefined", () => {

--- a/tests/e2e/self_upgrade_test.ts
+++ b/tests/e2e/self_upgrade_test.ts
@@ -21,6 +21,9 @@ const TARGET = (() => {
   if (Deno.build.os === "linux" && Deno.build.arch === "x86_64") {
     return "x86_64-unknown-linux-gnu";
   }
+  if (Deno.build.os === "linux" && Deno.build.arch === "aarch64") {
+    return "aarch64-unknown-linux-gnu";
+  }
   if (Deno.build.os === "darwin" && Deno.build.arch === "x86_64") {
     return "x86_64-apple-darwin";
   }


### PR DESCRIPTION
## Summary

Adds **`aarch64-unknown-linux-gnu`** (Linux arm64) to MarkSpec's release
targets, so the install script, `self-upgrade`, and the docs all support
Linux arm64. Closes #632 (Epic #631).

Today the Release workflow builds `x86_64-unknown-linux-gnu`, both Darwin
arches, and Windows x64 — but no Linux arm64. As a result `install.sh` exits
with `unsupported architecture: aarch64`, `self-upgrade` errors, and
`installation.md` advertises a download that doesn't exist.

## Changes

The release target set is encoded in four places that must agree — all four
are updated, plus the e2e helper and unit test:

| File | Change |
| --- | --- |
| `.github/workflows/release.yaml` | New `aarch64-unknown-linux-gnu` build-matrix row (cross-compiled on `ubuntu-latest`) |
| `install.sh` | Map Linux `aarch64` → `aarch64-unknown-linux-gnu` |
| `core/self_upgrade/target.ts` | Add the target to the `Target` union + `detectTarget` branch (SSOT) |
| `core/self_upgrade/target_test.ts` | Flip the `linux/aarch64 → undefined` case to expect the new target |
| `cli/commands/self_upgrade.ts` | List `linux-arm64` in the supported-platform message |
| `tests/e2e/self_upgrade_test.ts` | Teach the `TARGET` fixture helper the new triple |
| `docs/guide/installation.md` | Fix the manual-download table to the **real** triple-named assets (every row was using non-existent friendly names) |

Deno cross-compiles the target from the existing x86_64 runner via the
`--target` plumbing already in `scripts/compile_binary.ts` — **no arm runner
or QEMU needed**.

## Test plan

- `just check` green locally — 3230 passed, 0 failed; lint + typecheck clean;
  `shellcheck install.sh` clean.
- Unit: `detectTarget({os:'linux',arch:'aarch64'})` → `aarch64-unknown-linux-gnu`.
- **CI is the authoritative gate for the new artifact**: a local host compile
  cannot exercise the cross-target. The Release workflow's matrix now
  cross-compiles and publishes `markspec-aarch64-unknown-linux-gnu.tar.gz`
  (+ `.sha256`) on the next tag.

## Motivation

Unblocks a multi-arch (`amd64` + `arm64`) `markspec` image on
`ghcr.io/driftsys/dock`, which needs a Linux arm64 binary to satisfy its
two-arch invariant.
