### PR TITLE
fix(repo): make install.sh POSIX-clean so `curl … | sh` works

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -129,6 +129,14 @@ jobs:
           }
           Write-Host "install.ps1 parses cleanly."
 
+  sh-installer:
+    name: POSIX installer syntax
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Lint install.sh (POSIX sh)
+        run: shellcheck -s sh install.sh
+
   compile-smoke:
     name: Compiled binary smoke
     runs-on: ubuntu-latest

--- a/install.sh
+++ b/install.sh
@@ -1,14 +1,18 @@
-#!/bin/bash
+#!/bin/sh
 # Install markspec — downloads the latest release binary for the current platform.
 #
 # Usage:
-#   curl -fsSL https://raw.githubusercontent.com/driftsys/markspec/main/install.sh | bash
+#   curl -fsSL https://raw.githubusercontent.com/driftsys/markspec/main/install.sh | sh
 #
 # Environment variables:
 #   MARKSPEC_INSTALL_DIR  Installation directory (default: $HOME/.local/bin)
 #   MARKSPEC_VERSION      Version to install (default: latest)
 
-set -euo pipefail
+# `local` (SC3043) is not in POSIX, but every real /bin/sh — dash, busybox
+# ash — supports it, so it is a documented non-blocker rather than a reason
+# to fall back to subshell-scoped workarounds.
+# shellcheck disable=SC3043
+set -eu
 
 REPO="driftsys/markspec"
 INSTALL_DIR="${MARKSPEC_INSTALL_DIR:-$HOME/.local/bin}"
@@ -40,12 +44,20 @@ detect_target() {
 
 get_version() {
   if [ -n "${MARKSPEC_VERSION:-}" ]; then
-    echo "$MARKSPEC_VERSION"
-  else
-    gh release view --repo "$REPO" --json tagName -q .tagName 2>/dev/null \
-      || curl -fsSL "https://api.github.com/repos/$REPO/releases/latest" \
-           | grep '"tag_name"' | head -1 | cut -d'"' -f4
+    printf '%s\n' "$MARKSPEC_VERSION"
+    return
   fi
+
+  if version=$(gh release view --repo "$REPO" --json tagName -q .tagName 2>/dev/null); then
+    printf '%s\n' "$version"
+    return
+  fi
+
+  # gh unavailable — fall back to the REST API. Capture the fallible curl on
+  # its own line so `set -e` catches a failure (pipefail is not POSIX).
+  body=$(curl -fsSL "https://api.github.com/repos/$REPO/releases/latest") \
+    || { echo "error: could not reach GitHub API" >&2; exit 1; }
+  printf '%s\n' "$body" | grep '"tag_name"' | head -1 | cut -d'"' -f4
 }
 
 main() {


### PR DESCRIPTION
Closes #638.

`install.sh` is documented and intended to be run as `curl … | sh`, but it was a
bash script (`#!/bin/bash` + `set -o pipefail`). Where `/bin/sh` is not bash —
Debian/Ubuntu (dash), Alpine/busybox — piping to `sh` aborted immediately with
`sh: 1: set: Illegal option -o pipefail`. macOS hid the bug: its `/bin/sh` is
bash-in-POSIX-mode, which happens to accept `pipefail`.

`curl … | sh` is the conventional idiom (rustup, docker, deno, starship, k3s all
ship POSIX-clean installers for it), and every doc in this repo already invokes
the script with `| sh`. The script was one bashism away from matching.

## Changes

**`install.sh`:**

- `#!/bin/bash` → `#!/bin/sh`, and the usage comment's `| bash` → `| sh` (the
  only doc outlier — all `docs/` already use `| sh`).
- `set -euo pipefail` → `set -eu`.
- Restructure `get_version()` so the REST-API fallback captures the fallible
  `curl` on its own line (`body=$(curl …) || { …; exit 1; }`); `set -e` now
  catches the failure, which is exactly what `pipefail` used to do. The other
  pipeline (the `$PATH` check) already relied on `grep`'s own exit status, so
  pipefail was never load-bearing there.
- Keep the three `local` uses (dash/busybox ash all support them) and document
  that intent with a file-level `# shellcheck disable=SC3043`, so the file is
  clean under its new `sh` shell type instead of emitting three new warnings.

**`ci.yaml` — regression guard:**

- Add a `POSIX installer syntax` job (`shellcheck -s sh install.sh` on
  `ubuntu-latest`), mirroring the existing `PowerShell installer syntax` job
  that already gates `install.ps1`. The repo already treats installer-script
  syntax as CI-worthy; this just adds the POSIX half that was missing — and it
  is precisely the check that would have caught this bug (`shellcheck -s sh`
  flags `set -o pipefail` as SC3040). This closes the whole class of
  "bashism invisible on the macOS dev platform," not just this one line.

## Verification (dash + shellcheck available locally)

- **Before:** `dash ./install.sh` → `set: Illegal option -o pipefail`.
- **After:** `shellcheck -s sh install.sh` is clean (exit 0); `dash -n install.sh`
  parses; all four `get_version` branches behave correctly under dash with the
  network stubbed out:
  - `MARKSPEC_VERSION` set → prints it, returns early
  - `gh` success → prints tag
  - `gh` fails, `curl` ok → REST fallback pipeline yields the tag
  - `gh` fails, `curl` fails → `error: could not reach GitHub API`, exit 1

No doc change is needed beyond the script's own usage comment — `docs/` already
reference `install.sh` on `main` with `| sh`, so they become correct automatically.
