### PR TITLE
feat(cli): add GitHub Copilot MCP install client

### DIFF
--- a/docs/guide/ai-agents.md
+++ b/docs/guide/ai-agents.md
@@ -145,6 +145,61 @@ markspec mcp install --client opencode --scope workspace \
 The `--scope=user` flag is not supported for `opencode` — the config is always
 project-scoped (`opencode.json` at the repo root).
 
+### GitHub Copilot CLI
+
+`markspec mcp install --client copilot` writes a Copilot-shaped MCP entry. It is
+the one dual-scope client:
+
+| Scope       | Path                         | Notes                              |
+| ----------- | ---------------------------- | ---------------------------------- |
+| `workspace` | `.github/mcp.json`           | Default; committable, per-repo     |
+| `user`      | `~/.copilot/mcp-config.json` | Per-user, applies to every project |
+
+```sh
+markspec mcp install --client copilot                  # → .github/mcp.json
+markspec mcp install --client copilot --scope user      # → ~/.copilot/mcp-config.json
+markspec mcp install --client copilot --scope workspace \
+  --binary-path /opt/markspec/bin/markspec
+```
+
+The entry nests under `mcpServers.markspec` like Claude Desktop, but the
+local-server shape differs — it adds `type` and `tools`:
+
+```json
+{
+  "mcpServers": {
+    "markspec": {
+      "type": "local",
+      "command": "markspec",
+      "args": ["mcp"],
+      "tools": ["*"]
+    }
+  }
+}
+```
+
+An omitted `--scope` defaults to `workspace`, matching the per-repo model of
+`markspec init`. The `.github/mcp.json` path (verified against
+`GitHub Copilot CLI 1.0.66`) is deliberately distinct from the `claude-code`
+client's `.mcp.json` so the two clients never contend for one file.
+
+**Editor / agent-mode surface.** `--client copilot` covers Copilot's _CLI_
+surfaces only — the file-based sources the terminal reads (`.github/mcp.json`,
+`~/.copilot/mcp-config.json`). Copilot's _in-editor_ agent mode is served
+differently: the `driftsys.markspec-ide` extension (below) registers the MCP
+server **programmatically** via VS Code's
+`lm.registerMcpServerDefinitionProvider` API (VS Code 1.101+), so it lands in
+the same agent-mode tool registry as a `.vscode/mcp.json` entry — without
+markspec writing that file. The extension route reaches only the in-editor
+agent; it cannot reach the Copilot CLI or a GitHub-hosted coding agent, which is
+why those file-based surfaces need `--client copilot`.
+
+This follows the **sanctioned-surfaces** policy: markspec writes MCP config only
+via a vendor CLI or a user/workspace file the client reads, never a file an app
+manages as its own private state. See
+[#637](https://github.com/driftsys/markspec/issues/637) for the policy's wider
+application to the Claude clients.
+
 ### VS Code (Copilot / Claude)
 
 The VS Code extension registers the MCP server automatically — no extra

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -689,7 +689,8 @@ markspec mcp install --client <client>
 
 | Flag            | Type   | Default             | Description                                                                                                                |
 | --------------- | ------ | ------------------- | -------------------------------------------------------------------------------------------------------------------------- |
-| `--client`      | string | —                   | Client ID: `claude-desktop`, `cursor`, `vscode`.                                                                           |
+| `--client`      | string | —                   | Client ID: `claude-desktop`, `claude-code`, `cursor`, `opencode`, `vscode`, `copilot`.                                     |
+| `--scope`       | string | client default      | Config scope: `user` or `workspace`. Honoured by `copilot`; other clients are fixed to one scope.                          |
 | `--binary-path` | string | invoked binary name | Explicit path to the `markspec` binary. Default writes the invoked name (resolves via `PATH`, surviving package upgrades). |
 
 **Examples:**
@@ -698,6 +699,8 @@ markspec mcp install --client <client>
 markspec mcp install --client claude-desktop
 markspec mcp install --client cursor
 markspec mcp install --client vscode
+markspec mcp install --client copilot                 # → .github/mcp.json
+markspec mcp install --client copilot --scope user     # → ~/.copilot/mcp-config.json
 markspec mcp install --client claude-desktop --binary-path /opt/markspec/bin/markspec
 ```
 

--- a/packages/markspec/cli/commands/mcp_cmd.ts
+++ b/packages/markspec/cli/commands/mcp_cmd.ts
@@ -21,7 +21,7 @@ export const mcpCmd = new Command()
   .description("Install or print MCP server configuration for a client")
   .option(
     "--client <client:string>",
-    "Client ID (claude-desktop|claude-code|cursor|opencode|vscode)",
+    "Client ID (claude-desktop|claude-code|cursor|opencode|vscode|copilot)",
     { required: true },
   )
   .option("--scope <scope:string>", "Config scope: user|workspace")

--- a/packages/markspec/cli/install/adapters.ts
+++ b/packages/markspec/cli/install/adapters.ts
@@ -19,7 +19,8 @@ export type McpClientId =
   | "claude-code"
   | "cursor"
   | "opencode"
-  | "vscode";
+  | "vscode"
+  | "copilot";
 
 export const LSP_EDITOR_IDS: readonly LspEditorId[] = [
   "vscode",
@@ -32,6 +33,7 @@ export const MCP_CLIENT_IDS: readonly McpClientId[] = [
   "cursor",
   "opencode",
   "vscode",
+  "copilot",
 ];
 
 /** Max Levenshtein distance to emit a "did you mean" suggestion. */

--- a/packages/markspec/cli/install/adapters_test.ts
+++ b/packages/markspec/cli/install/adapters_test.ts
@@ -11,6 +11,7 @@ Deno.test("MCP_CLIENT_IDS contains expected clients", () => {
   assertEquals(MCP_CLIENT_IDS.includes("claude-desktop"), true);
   assertEquals(MCP_CLIENT_IDS.includes("cursor"), true);
   assertEquals(MCP_CLIENT_IDS.includes("vscode"), true);
+  assertEquals(MCP_CLIENT_IDS.includes("copilot"), true);
 });
 
 Deno.test("suggestId: returns closest match within distance 3", () => {

--- a/packages/markspec/cli/install/mcp_adapters_copilot.ts
+++ b/packages/markspec/cli/install/mcp_adapters_copilot.ts
@@ -1,0 +1,56 @@
+/**
+ * @module cli/install/mcp_adapters_copilot
+ *
+ * `copilot` MCP install adapter — the first dual-scope managed-block
+ * client (#635). GitHub Copilot's config sources, in the Copilot CLI's
+ * own precedence order (verified against `GitHub Copilot CLI 1.0.66`):
+ *
+ * | Scope     | Path                          |
+ * | --------- | ----------------------------- |
+ * | user      | `~/.copilot/mcp-config.json`  |
+ * | workspace | `.github/mcp.json`            |
+ *
+ * `--scope=workspace` writes `.github/mcp.json` (distinct from the
+ * `claude-code` client's `.mcp.json`, which Copilot CLI 1.0.66 also
+ * reads — targeting `.github/mcp.json` keeps the two clients from
+ * fighting over one file). `--scope=user` writes
+ * `~/.copilot/mcp-config.json`. The orchestrator defaults an omitted
+ * scope to `workspace`, matching the per-repo model of `markspec init`.
+ *
+ * The local-server schema differs from `claude-code`: it adds `type`
+ * and `tools`. Both scopes nest the entry under `mcpServers.<name>`.
+ *
+ * Scope covers Copilot's *CLI* surfaces only. The Copilot editor /
+ * agent-mode surface reads `.vscode/mcp.json` — a VS-Code-owned file
+ * already covered by the `vscode` client's extension auto-registration,
+ * not a Copilot-specific write. See docs/guide/ai-agents.md and #637 for
+ * the sanctioned-surfaces policy.
+ */
+
+import { join } from "@std/path";
+import type { McpAdapter, RenderBlockInput } from "./adapters.ts";
+
+export const copilotDescriptor: McpAdapter = {
+  id: "copilot",
+  // Both scopes nest under `mcpServers.<name>`, like claude-desktop /
+  // claude-code — only the local-server shape and file path differ.
+  jsonPath: ["mcpServers", "markspec"],
+  resolveConfigPath(scope, cwd, home, _appData, workspaceRoot) {
+    if (scope === "workspace") {
+      const root = workspaceRoot ?? cwd;
+      return join(root, ".github", "mcp.json");
+    }
+    // user scope
+    return join(home, ".copilot", "mcp-config.json");
+  },
+  renderBlock(input: RenderBlockInput): Record<string, unknown> {
+    // Verified schema (Copilot CLI 1.0.66): `type: "local"` + `tools`
+    // alongside the `command` / `args` pair the other clients emit.
+    return {
+      type: "local",
+      command: input.binaryPath,
+      args: ["mcp"],
+      tools: ["*"],
+    };
+  },
+};

--- a/packages/markspec/cli/install/mcp_adapters_copilot_test.ts
+++ b/packages/markspec/cli/install/mcp_adapters_copilot_test.ts
@@ -1,0 +1,63 @@
+import { assertEquals } from "@std/assert";
+import { join } from "@std/path";
+import { copilotDescriptor } from "./mcp_adapters_copilot.ts";
+
+Deno.test("copilotDescriptor: id and jsonPath", () => {
+  assertEquals(copilotDescriptor.id, "copilot");
+  assertEquals(copilotDescriptor.jsonPath, ["mcpServers", "markspec"]);
+});
+
+Deno.test("copilotDescriptor: workspace scope → <root>/.github/mcp.json", () => {
+  const path = copilotDescriptor.resolveConfigPath(
+    "workspace",
+    "/tmp/cwd",
+    "/home/u",
+    undefined,
+    "/tmp/repo",
+  );
+  assertEquals(path, join("/tmp/repo", ".github", "mcp.json"));
+});
+
+Deno.test("copilotDescriptor: workspace scope falls back to cwd when no workspaceRoot", () => {
+  const path = copilotDescriptor.resolveConfigPath(
+    "workspace",
+    "/tmp/cwd",
+    "/home/u",
+    undefined,
+    undefined,
+  );
+  assertEquals(path, join("/tmp/cwd", ".github", "mcp.json"));
+});
+
+Deno.test("copilotDescriptor: user scope → ~/.copilot/mcp-config.json", () => {
+  const path = copilotDescriptor.resolveConfigPath(
+    "user",
+    "/tmp/cwd",
+    "/home/u",
+    undefined,
+    "/tmp/repo",
+  );
+  assertEquals(path, join("/home/u", ".copilot", "mcp-config.json"));
+});
+
+Deno.test("copilotDescriptor: renderBlock is Copilot local schema with type + tools", () => {
+  const block = copilotDescriptor.renderBlock({ binaryPath: "markspec" });
+  assertEquals(block, {
+    type: "local",
+    command: "markspec",
+    args: ["mcp"],
+    tools: ["*"],
+  });
+});
+
+Deno.test("copilotDescriptor: renderBlock honors an explicit binary path", () => {
+  const block = copilotDescriptor.renderBlock({
+    binaryPath: "/opt/markspec/bin/markspec",
+  });
+  assertEquals(block, {
+    type: "local",
+    command: "/opt/markspec/bin/markspec",
+    args: ["mcp"],
+    tools: ["*"],
+  });
+});

--- a/packages/markspec/cli/install/mcp_orchestrator.ts
+++ b/packages/markspec/cli/install/mcp_orchestrator.ts
@@ -29,6 +29,7 @@ import {
 } from "./mcp_adapters.ts";
 import { claudeCodeDescriptor } from "./mcp_adapters_claude_code.ts";
 import { opencodeDescriptor } from "./mcp_adapters_opencode.ts";
+import { copilotDescriptor } from "./mcp_adapters_copilot.ts";
 import { applyJsonBlock, removeJsonBlock } from "./managed_block.ts";
 import { writeBackup } from "./backup.ts";
 import { renderDiff } from "./preview.ts";
@@ -105,17 +106,20 @@ export async function runMcpInstall(
     };
   }
 
-  // 4. Managed-block flow — claude-desktop, claude-code, or opencode.
+  // 4. Managed-block flow — claude-desktop, claude-code, opencode, copilot.
   if (
     clientId === "claude-desktop" ||
     clientId === "claude-code" ||
-    clientId === "opencode"
+    clientId === "opencode" ||
+    clientId === "copilot"
   ) {
     const adapter: McpAdapter = clientId === "claude-desktop"
       ? claudeDesktopDescriptor
       : clientId === "claude-code"
       ? claudeCodeDescriptor
-      : opencodeDescriptor;
+      : clientId === "opencode"
+      ? opencodeDescriptor
+      : copilotDescriptor;
     return await runManagedBlockFlow(adapter, options);
   }
 
@@ -129,8 +133,8 @@ export async function runMcpInstall(
 }
 
 /**
- * Shared managed-block flow used by claude-desktop, claude-code, and opencode.
- * Reads current content, computes next via `applyJsonBlock` /
+ * Shared managed-block flow used by claude-desktop, claude-code, opencode,
+ * and copilot. Reads current content, computes next via `applyJsonBlock` /
  * `removeJsonBlock`, handles --print / --force / atomic write /
  * sidecar backup.
  */
@@ -141,6 +145,11 @@ async function runManagedBlockFlow(
   const isClaudeDesktop = adapter.id === "claude-desktop";
   const isProjectScoped = adapter.id === "claude-code" ||
     adapter.id === "opencode";
+  // Copilot is the one dual-scope client: --scope=workspace →
+  // .github/mcp.json, --scope=user → ~/.copilot/mcp-config.json. It
+  // rejects neither scope; an omitted scope defaults to workspace
+  // (per-repo, matching `markspec init`).
+  const isDualScope = adapter.id === "copilot";
 
   if (isClaudeDesktop && options.scope === "workspace") {
     return {
@@ -192,16 +201,24 @@ async function runManagedBlockFlow(
   };
   const isTty = options.env?.isTty ?? Deno.stdin.isTerminal();
 
-  // Resolve the target config path. claude-desktop uses "user" (default
-  // when scope is omitted); claude-code and opencode use "workspace" with
-  // workspaceRoot=cwd.
-  const scope: "user" | "workspace" = isProjectScoped ? "workspace" : "user";
+  // Resolve the effective scope. claude-desktop is user-only; claude-code
+  // and opencode are workspace-only; copilot honours --scope and defaults
+  // to workspace when omitted. The unknown-scope guard above has already
+  // narrowed options.scope to user | workspace | undefined.
+  let scope: "user" | "workspace";
+  if (isProjectScoped) {
+    scope = "workspace";
+  } else if (isDualScope) {
+    scope = options.scope === "user" ? "user" : "workspace";
+  } else {
+    scope = "user"; // claude-desktop
+  }
   const configPath = adapter.resolveConfigPath(
     scope,
     cwd,
     readHome(),
     readAppData(),
-    isProjectScoped ? cwd : undefined,
+    scope === "workspace" ? cwd : undefined,
   );
 
   // 5. Read current content. Missing file → empty string.

--- a/packages/markspec/cli/install/mcp_orchestrator_test.ts
+++ b/packages/markspec/cli/install/mcp_orchestrator_test.ts
@@ -9,6 +9,8 @@ import { runMcpInstall } from "./mcp_orchestrator.ts";
 const REPO_CWD = join("/", "tmp", "some-repo");
 const REPO_MCP_JSON = join(REPO_CWD, ".mcp.json");
 const REPO_OPENCODE_JSON = join(REPO_CWD, "opencode.json");
+const REPO_COPILOT_WORKSPACE = join(REPO_CWD, ".github", "mcp.json");
+const USER_COPILOT_CONFIG = join("/home/u", ".copilot", "mcp-config.json");
 
 Deno.test("runMcpInstall: unknown client → exit 1 with suggestion", async () => {
   const r = await runMcpInstall({
@@ -128,4 +130,63 @@ Deno.test("runMcpInstall: --client=opencode --scope=user is rejected", async () 
     result.stderr,
     "--scope=user is not supported for --client=opencode",
   );
+});
+
+// ---------------------------------------------------------------------------
+// copilot — the first dual-scope managed-block client (#635). Accepts both
+// --scope=workspace (.github/mcp.json) and --scope=user
+// (~/.copilot/mcp-config.json); defaults to workspace when scope is omitted.
+// ---------------------------------------------------------------------------
+
+Deno.test("runMcpInstall: --client=copilot --scope=workspace → .github/mcp.json with type+tools", async () => {
+  const result = await runMcpInstall({
+    client: "copilot",
+    scope: "workspace",
+    binaryPath: "markspec",
+    print: true,
+    env: { cwd: REPO_CWD, home: "/home/u", isTty: true },
+  });
+  assertEquals(result.exitCode, 0);
+  // Copilot local-server schema differs from claude-code: adds type + tools.
+  assertStringIncludes(result.stdout, `"mcpServers"`);
+  assertStringIncludes(result.stdout, `"markspec"`);
+  assertStringIncludes(result.stdout, `"type": "local"`);
+  assertStringIncludes(result.stdout, `"tools"`);
+  assertStringIncludes(result.stderr, REPO_COPILOT_WORKSPACE);
+});
+
+Deno.test("runMcpInstall: --client=copilot --scope=user → ~/.copilot/mcp-config.json", async () => {
+  const result = await runMcpInstall({
+    client: "copilot",
+    scope: "user",
+    binaryPath: "markspec",
+    print: true,
+    env: { cwd: REPO_CWD, home: "/home/u", isTty: true },
+  });
+  assertEquals(result.exitCode, 0);
+  assertStringIncludes(result.stdout, `"type": "local"`);
+  assertStringIncludes(result.stderr, USER_COPILOT_CONFIG);
+});
+
+Deno.test("runMcpInstall: --client=copilot with no scope defaults to workspace", async () => {
+  const result = await runMcpInstall({
+    client: "copilot",
+    binaryPath: "markspec",
+    print: true,
+    env: { cwd: REPO_CWD, home: "/home/u", isTty: true },
+  });
+  assertEquals(result.exitCode, 0);
+  assertStringIncludes(result.stderr, REPO_COPILOT_WORKSPACE);
+});
+
+Deno.test("runMcpInstall: --client=copilot --scope=global → unknown scope error", async () => {
+  const result = await runMcpInstall({
+    client: "copilot",
+    scope: "global",
+    binaryPath: "markspec",
+    print: true,
+    env: { cwd: REPO_CWD, home: "/home/u", isTty: true },
+  });
+  assertEquals(result.exitCode, 1);
+  assertStringIncludes(result.stderr, "unknown scope 'global'");
 });

--- a/tests/e2e/mcp_install_test.ts
+++ b/tests/e2e/mcp_install_test.ts
@@ -136,13 +136,16 @@ const CLI_ENTRY = fromFileUrl(
 async function runMcpInstallE2e(
   args: string[],
   homeDir: string,
+  cwd?: string,
 ): Promise<{ code: number; stdout: string; stderr: string }> {
   // Inherit the parent environment so Windows-specific vars
   // (SYSTEMROOT, TMP, PATH, …) reach the subprocess — Deno needs them
   // to function on Windows. Strip GIT_* like the shared helper does.
   // Then override HOME / USERPROFILE / APPDATA to point at the temp
   // dir so the orchestrator writes there instead of the real user
-  // config locations.
+  // config locations. Pass `cwd` to anchor workspace-scoped writes
+  // (e.g. copilot's .github/mcp.json) to a temp repo dir the caller
+  // owns and can read back / clean up.
   const parentEnv = Deno.env.toObject();
   const env: Record<string, string> = {};
   for (const [k, v] of Object.entries(parentEnv)) {
@@ -161,6 +164,7 @@ async function runMcpInstallE2e(
       CLI_ENTRY,
       ...args,
     ],
+    cwd,
     stdout: "piped",
     stderr: "piped",
     clearEnv: true,
@@ -436,5 +440,271 @@ Deno.test(
     } finally {
       await Deno.remove(homeDir, { recursive: true });
     }
+  },
+);
+
+// ---------------------------------------------------------------------------
+// copilot (#635) — dual-scope client. Workspace → .github/mcp.json,
+// user → ~/.copilot/mcp-config.json. Schema adds type:"local" + tools:["*"].
+// ---------------------------------------------------------------------------
+
+/** Copilot user-scope config path under an overridden HOME. */
+function copilotUserConfigPath(homeDir: string): string {
+  return join(homeDir, ".copilot", "mcp-config.json");
+}
+
+Deno.test(
+  "mcp install copilot: --scope=workspace --print emits type+tools for .github/mcp.json",
+  async () => {
+    const { code, stdout, stderr } = await markspec(
+      [
+        "mcp",
+        "install",
+        "--client=copilot",
+        "--scope=workspace",
+        "--print",
+      ],
+      { permissions: ["--allow-env"] },
+    );
+    assertEquals(code, 0);
+    assertStringIncludes(stdout, '"mcpServers"');
+    assertStringIncludes(stdout, '"markspec"');
+    assertStringIncludes(stdout, '"type": "local"');
+    assertStringIncludes(stdout, '"tools"');
+    assertStringIncludes(stderr.replaceAll("\\", "/"), ".github/mcp.json");
+    assertStringIncludes(stderr, "would write to ");
+  },
+);
+
+Deno.test(
+  "mcp install copilot: --scope=user --print targets ~/.copilot/mcp-config.json",
+  async () => {
+    // Override HOME to a fresh temp dir so the print reads no pre-existing
+    // ~/.copilot/mcp-config.json (which would trigger the idempotence
+    // no-op and emit empty stdout on a machine that already has markspec
+    // wired into Copilot).
+    const homeDir = await Deno.makeTempDir();
+    try {
+      const { code, stdout, stderr } = await runMcpInstallE2e(
+        ["mcp", "install", "--client=copilot", "--scope=user", "--print"],
+        homeDir,
+      );
+      assertEquals(code, 0, stderr);
+      assertStringIncludes(stdout, '"type": "local"');
+      assertStringIncludes(
+        stderr.replaceAll("\\", "/"),
+        ".copilot/mcp-config.json",
+      );
+    } finally {
+      await Deno.remove(homeDir, { recursive: true });
+    }
+  },
+);
+
+Deno.test(
+  "mcp install copilot: no --scope defaults to workspace (.github/mcp.json)",
+  async () => {
+    const { code, stderr } = await markspec(
+      ["mcp", "install", "--client=copilot", "--print"],
+      { permissions: ["--allow-env"] },
+    );
+    assertEquals(code, 0);
+    assertStringIncludes(stderr.replaceAll("\\", "/"), ".github/mcp.json");
+  },
+);
+
+Deno.test(
+  "mcp install copilot: --scope=workspace --force writes .github/mcp.json",
+  async () => {
+    const { code, stderr } = await markspec(
+      [
+        "mcp",
+        "install",
+        "--client=copilot",
+        "--scope=workspace",
+        "--force",
+      ],
+      { permissions: ["--allow-env"] },
+    );
+    assertEquals(code, 0, stderr);
+    assertStringIncludes(stderr.replaceAll("\\", "/"), ".github/mcp.json");
+    assertStringIncludes(stderr, "wrote ");
+  },
+);
+
+Deno.test(
+  "mcp install copilot: --scope=user write merges (not clobbers), is idempotent, and removes",
+  async () => {
+    const homeDir = await Deno.makeTempDir();
+    try {
+      const configPath = copilotUserConfigPath(homeDir);
+      // Pre-seed a sibling server so we prove managed-entry merge, not clobber.
+      await Deno.mkdir(dirname(configPath), { recursive: true });
+      await Deno.writeTextFile(
+        configPath,
+        JSON.stringify(
+          { mcpServers: { other: { type: "local", command: "other" } } },
+          null,
+          2,
+        ),
+      );
+
+      const install = await runMcpInstallE2e(
+        [
+          "mcp",
+          "install",
+          "--client=copilot",
+          "--scope=user",
+          "--binary-path=markspec",
+          "--force",
+        ],
+        homeDir,
+      );
+      assertEquals(install.code, 0, install.stderr);
+      assertStringIncludes(install.stderr, "wrote ");
+
+      const parsed = JSON.parse(await Deno.readTextFile(configPath));
+      // Sibling survives (merge, not clobber).
+      assertEquals(parsed.mcpServers.other.command, "other");
+      // Managed entry carries the Copilot local schema.
+      assertEquals(parsed.mcpServers.markspec, {
+        type: "local",
+        command: "markspec",
+        args: ["mcp"],
+        tools: ["*"],
+      });
+
+      // Re-install is a no-op.
+      const again = await runMcpInstallE2e(
+        [
+          "mcp",
+          "install",
+          "--client=copilot",
+          "--scope=user",
+          "--binary-path=markspec",
+          "--force",
+        ],
+        homeDir,
+      );
+      assertEquals(again.code, 0, again.stderr);
+      assertStringIncludes(again.stderr, "already up to date");
+
+      // Remove strips only the markspec entry.
+      const removed = await runMcpInstallE2e(
+        [
+          "mcp",
+          "install",
+          "--client=copilot",
+          "--scope=user",
+          "--remove",
+          "--force",
+        ],
+        homeDir,
+      );
+      assertEquals(removed.code, 0, removed.stderr);
+      assertStringIncludes(removed.stderr, "wrote ");
+      const afterRemove = JSON.parse(await Deno.readTextFile(configPath));
+      assertEquals(afterRemove.mcpServers.markspec, undefined);
+      assertEquals(afterRemove.mcpServers.other.command, "other");
+    } finally {
+      await Deno.remove(homeDir, { recursive: true });
+    }
+  },
+);
+
+Deno.test(
+  "mcp install copilot: --scope=workspace write verifies content, preserves top-level + sibling keys, and removes",
+  async () => {
+    const repoDir = await Deno.makeTempDir();
+    const homeDir = await Deno.makeTempDir();
+    try {
+      const configPath = join(repoDir, ".github", "mcp.json");
+      // Pre-seed a top-level sibling ($schema) AND a sibling server so we
+      // prove neither is clobbered by the managed-entry write.
+      await Deno.mkdir(dirname(configPath), { recursive: true });
+      await Deno.writeTextFile(
+        configPath,
+        JSON.stringify(
+          {
+            $schema: "https://example.invalid/copilot.schema.json",
+            mcpServers: { other: { type: "local", command: "other" } },
+          },
+          null,
+          2,
+        ),
+      );
+
+      const install = await runMcpInstallE2e(
+        [
+          "mcp",
+          "install",
+          "--client=copilot",
+          "--scope=workspace",
+          "--binary-path=markspec",
+          "--force",
+        ],
+        homeDir,
+        repoDir,
+      );
+      assertEquals(install.code, 0, install.stderr);
+      assertStringIncludes(install.stderr, "wrote ");
+
+      const parsed = JSON.parse(await Deno.readTextFile(configPath));
+      // Top-level sibling and server sibling both survive (merge, not clobber).
+      assertEquals(
+        parsed.$schema,
+        "https://example.invalid/copilot.schema.json",
+      );
+      assertEquals(parsed.mcpServers.other.command, "other");
+      // Managed entry carries the exact Copilot local schema (strong check,
+      // not a substring).
+      assertEquals(parsed.mcpServers.markspec, {
+        type: "local",
+        command: "markspec",
+        args: ["mcp"],
+        tools: ["*"],
+      });
+
+      // Remove strips only the markspec entry from the workspace file.
+      const removed = await runMcpInstallE2e(
+        [
+          "mcp",
+          "install",
+          "--client=copilot",
+          "--scope=workspace",
+          "--remove",
+          "--force",
+        ],
+        homeDir,
+        repoDir,
+      );
+      assertEquals(removed.code, 0, removed.stderr);
+      assertStringIncludes(removed.stderr, "wrote ");
+      const afterRemove = JSON.parse(await Deno.readTextFile(configPath));
+      assertEquals(afterRemove.mcpServers.markspec, undefined);
+      assertEquals(
+        afterRemove.$schema,
+        "https://example.invalid/copilot.schema.json",
+      );
+      assertEquals(afterRemove.mcpServers.other.command, "other");
+    } finally {
+      await Deno.remove(repoDir, { recursive: true });
+      await Deno.remove(homeDir, { recursive: true });
+    }
+  },
+);
+
+Deno.test(
+  "mcp install copilot: non-TTY without --force → exit 1 with remediation",
+  async () => {
+    // The shared markspec() helper pipes stdin, so the subprocess is
+    // non-TTY. Without --force (and without --print) the dual-scope
+    // resolution must still fall through to the non-TTY abort.
+    const { code, stderr } = await markspec(
+      ["mcp", "install", "--client=copilot", "--scope=workspace"],
+      { permissions: ["--allow-env"] },
+    );
+    assertEquals(code, 1);
+    assertStringIncludes(stderr, "--force");
   },
 );


### PR DESCRIPTION
Closes #635.

Adds a `copilot` client target to `markspec mcp install` — the one client that previously required a hand-authored MCP config.

## What

`markspec mcp install --client copilot` — the first **dual-scope** managed-block client (verified against `GitHub Copilot CLI 1.0.66`):

| Scope | Path | Default |
|---|---|---|
| `workspace` | `<root>/.github/mcp.json` | ✅ (per-repo, matches `markspec init`) |
| `user` | `~/.copilot/mcp-config.json` | |

Schema nests under `mcpServers.markspec` and adds the Copilot local-server fields:

```json
{ "mcpServers": { "markspec": { "type": "local", "command": "markspec", "args": ["mcp"], "tools": ["*"] } } }
```

`--print` / `--remove` / `--binary-path` / backup / atomic-write reuse the existing managed-block merge flow (merge, not clobber).

## How

- New `copilotDescriptor` (`mcp_adapters_copilot.ts`); registered in `MCP_CLIENT_IDS` + `--client` help.
- The orchestrator's scope derivation is generalized to honour `--scope` for the dual-scope client and default an omitted scope to `workspace`. The resolved `(scope, workspaceRoot)` pair is **byte-identical to before** for `claude-desktop`, `claude-code`, and `opencode`.
- `.github/mcp.json` (workspace) is deliberately distinct from `claude-code`'s `.mcp.json` so the two never contend for one file.
- `markspec init` is untouched (it uses its own descriptor map).

## Acceptance criteria

- [x] `--client copilot` accepted and listed in `--help`.
- [x] `--scope workspace` writes/merges `.github/mcp.json` with the `type`/`tools` schema.
- [x] `--scope user` writes/merges `~/.copilot/mcp-config.json`.
- [x] `--print` / `--remove` / `--binary-path` behave as other clients (managed-entry merge — proven by tests that seed both a sibling server and a top-level `$schema` key and assert both survive).
- [x] Editor/app surface decision documented: `--client copilot` is **CLI-only**. The in-editor agent-mode surface is served by the `driftsys.markspec-ide` extension's programmatic `registerMcpServerDefinitionProvider` registration (no `.vscode/mcp.json` written) — which the CLI/cloud surfaces cannot reach. Claude-client naming + the sanctioned-surfaces policy are tracked separately in #637.

## Tests

`just build` green (lint + `deno fmt --check` + `dprint check` + typecheck + 3248 tests + compile). MCP-install tests grew 25 → 42, covering both scopes' `--print`/write/remove, idempotence, top-level-key clobber protection, non-TTY safety, and default-scope resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)