### PR TITLE
test(repo): pass --quiet to e2e subprocess to fix cold-cache snapshot flake

### DIFF
--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -66,6 +66,11 @@ export async function markspec(
     const cmd = new Deno.Command("deno", {
       args: [
         "run",
+        // --quiet suppresses Deno's own `Download`/`Check` progress lines.
+        // On a cold module cache they otherwise leak into the captured
+        // subprocess stderr and corrupt stderr-snapshot assertions — a flake
+        // that only surfaces on CI runners with an unwarmed cache.
+        "--quiet",
         ...permissions,
         CLI_ENTRY,
         ...args,
@@ -145,7 +150,9 @@ export async function markspecPersist(
     if (!k.startsWith("GIT_")) safeEnv[k] = v;
   }
   const cmd = new Deno.Command("deno", {
-    args: ["run", ...permissions, CLI_ENTRY, ...args],
+    // --quiet: strip Deno's Download/Check progress from captured stderr —
+    // see markspec() above.
+    args: ["run", "--quiet", ...permissions, CLI_ENTRY, ...args],
     cwd,
     stdout: "piped",
     stderr: "piped",
@@ -188,7 +195,9 @@ export async function markspecInDir(
     safeEnv[k] = v;
   }
   const cmd = new Deno.Command("deno", {
-    args: ["run", ...allowList, CLI_ENTRY, ...args],
+    // --quiet: strip Deno's Download/Check progress from captured stderr —
+    // see markspec() above.
+    args: ["run", "--quiet", ...allowList, CLI_ENTRY, ...args],
     cwd: dir,
     stdout: "piped",
     stderr: "piped",


### PR DESCRIPTION
## Problem

The e2e test `lsp install neovim: workspace requested but no marker → fallback
(snapshot stderr)` (`tests/e2e/lsp_install_test.ts`) intermittently fails on CI —
observed on `ubuntu-latest` during CI for #639, while `macos-latest` and
`windows-latest` passed, and it never reproduces locally.

Root cause: the three shared e2e helpers (`markspec`, `markspecPersist`,
`markspecInDir` in `tests/e2e/helpers.ts`) spawn the CLI via `deno run` and
capture the subprocess stderr verbatim. On a **cold module cache**, Deno prints
its own `Download …` / `Check …` progress lines to that stderr. The failing test
snapshots `stderr.split("\n")[0]`, so a stray `Download` line at the top of
stderr corrupts the snapshot:

```
- "…Download https://registry.npmjs.org/rehype-stringify"   (actual, on cold cache)
+ "markspec lsp install: no workspace marker found, using --scope=user"  (expected)
```

It only bites when a CI runner's cache is unwarmed when that particular
subprocess runs — hence flaky-on-ubuntu-only.

## Fix

Add `--quiet` to the `deno run` invocation in all three helpers. `deno run
--quiet` suppresses Deno's own progress/diagnostic output **without** touching
the program's stdout/stderr, so the captured stderr contains only what the CLI
actually wrote. This eliminates the entire class of stderr-snapshot flakes, not
just this one test.

## Verification

- **Deterministic reproduction** — running only the snapshot test under a fresh
  `DENO_DIR` (forcing the subprocess to re-download) reproduces the failure
  every time:
  - **Before:** `stderr[0]` = `Download https://jsr.io/@cliffy/command/meta.json` → snapshot mismatch, exit 1.
  - **After:** `stderr[0]` = the real fallback message → passes, exit 0.
- **Full e2e suite** (the only surface these helpers touch): `544 passed, 0 failed`.

No production code changes — test-harness only.
