### PR TITLE
chore(ci): scope dependabot actions bumps to pass commit lint

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,10 @@ updates:
         patterns:
           - "*"
     commit-message:
-      prefix: "chore"
+      # `(deps)` scope is required so the generated message passes the
+      # git-std Conventional-commits CI gate (a bare `chore:` has no scope
+      # and fails; `deps` is an allowed scope).
+      prefix: "chore(deps)"
     open-pull-requests-limit: 5
     labels:
       - "dependencies"


### PR DESCRIPTION
Dependabot's `github-actions` group used `commit-message.prefix: "chore"`, producing a **scope-less** `chore: bump the actions group …` message that fails the git-std **Conventional-commits** CI gate — see #636, where that check is the only failure.

Change the prefix to `chore(deps)` so generated bumps carry an allowed scope (`deps`) and pass the gate.

### Follow-up for #636

This only affects **newly generated** messages. Once this lands, comment `@dependabot recreate` on #636 to regenerate its commit with the new prefix; it should then go green and be mergeable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
