### PR TITLE
fix(core): stop misparsing colons in body content as trailer attributes

### DIFF
--- a/packages/markspec/core/parser/markdown.ts
+++ b/packages/markspec/core/parser/markdown.ts
@@ -410,6 +410,11 @@ function extractEntry(
       const colonMatch = COLON_SPLIT_RE.exec(trimmed);
       if (!colonMatch) break; // stop at non-colon line
       const key = colonMatch[1].trim();
+      // A genuine trailer key is a single token; it never contains internal
+      // whitespace or a pipe. A colon inside prose ("modes are: fast") or a
+      // Markdown table row ("| Fast | latency: 200ms |") is body content, not
+      // a malformed trailer — stop scanning at it (#648).
+      if (/[\s|]/.test(key)) break;
       if (ATTR_LINE_RE.test(trimmed)) {
         // Valid attr line in body → already caught by P020
         continue;

--- a/tests/e2e/parse_identity_diagnostics_test.ts
+++ b/tests/e2e/parse_identity_diagnostics_test.ts
@@ -8,7 +8,7 @@
  * Each test verifies that the correct diagnostic code surfaces in stderr.
  */
 
-import { assertEquals, assertStringIncludes } from "@std/assert";
+import { assert, assertEquals, assertStringIncludes } from "@std/assert";
 import { markspec } from "./helpers.ts";
 
 // ===========================================================================
@@ -146,6 +146,84 @@ Deno.test("validate: invalid trailer key chars → MSL-P022", async () => {
   });
   assertEquals(code, 1, `expected exit 1, stderr: ${stderr}`);
   assertStringIncludes(stderr, "MSL-P022");
+});
+
+// ---------------------------------------------------------------------------
+// #648: a colon inside body content (a table cell or ordinary prose) must
+// NOT be misparsed as a malformed trailer. The backward body-scan heuristic
+// used to split on the first colon and flag the "key" as an invalid trailer
+// key, firing a false-positive MSL-P022 whenever a colon-bearing table row or
+// prose sentence was the last body block. A genuine trailer key is a single
+// token -- it never contains internal whitespace or a pipe.
+// ---------------------------------------------------------------------------
+
+Deno.test("validate: colon in a table cell is body content, not a trailer (#648)", async () => {
+  const { code, stderr } = await markspec(["check", "req.md"], {
+    files: {
+      "req.md": `# Test
+
+- [REQ-001] Modes table
+
+  The system shall support the modes below.
+
+  | Mode | Note |
+  | ---- | ---- |
+  | Fast | latency: under 200 ms |
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+`,
+    },
+  });
+  assertEquals(code, 0, `expected exit 0, stderr: ${stderr}`);
+  assert(
+    !stderr.includes("MSL-P02"),
+    `no parse diagnostic expected for a table-cell colon, stderr: ${stderr}`,
+  );
+});
+
+Deno.test("validate: colon in trailing prose is body content, not a trailer (#648)", async () => {
+  const { code, stderr } = await markspec(["check", "req.md"], {
+    files: {
+      "req.md": `# Test
+
+- [REQ-001] Modes prose
+
+  The system shall support the modes as follows: fast and safe.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+`,
+    },
+  });
+  assertEquals(code, 0, `expected exit 0, stderr: ${stderr}`);
+  assert(
+    !stderr.includes("MSL-P02"),
+    `no parse diagnostic expected for a prose colon, stderr: ${stderr}`,
+  );
+});
+
+Deno.test("validate: malformed trailer key after a colon table still -> MSL-P022 (#648 guard)", async () => {
+  // The whitespace/pipe guard must stay targeted: a real malformed trailer
+  // key (no internal whitespace) below a colon-bearing table must still fire.
+  const { code, stderr } = await markspec(["check", "req.md"], {
+    files: {
+      "req.md": `# Test
+
+- [REQ-001] Malformed trailer despite a table
+
+  The system shall x.
+
+  | Mode | Note |
+  | ---- | ---- |
+  | Fast | latency: under 200 ms |
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      Bad_Key: some value
+`,
+    },
+  });
+  assertEquals(code, 1, `expected exit 1, stderr: ${stderr}`);
+  assertStringIncludes(stderr, "MSL-P022");
+  assertStringIncludes(stderr, "Bad_Key");
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #648.

## Problem

`markspec check` emitted a false-positive **MSL-P022** ("trailer key contains
invalid characters") for legitimate body content containing a colon:

- a Markdown **table cell** — `| Fast | latency: under 200 ms |` → key `| Fast | latency`
- ordinary **prose** — `The supported modes are as follows: fast and safe.` → key `The supported modes are as follows`

It fired whenever such a line was the **last body block** — i.e. the normal
authoring state before `markspec fmt` (no `Id:` yet), or with a non-canonical
inline trailer. Authors had to work around it by replacing `:` with `—` in
table cells and moving colon-bearing paragraphs above their tables.

## Root cause

The backward body-scan heuristic in `core/parser/markdown.ts` (the MSL-P021 /
MSL-P022 "did a trailer get left in the body?" detector) walks trailing body
lines and splits each on its first colon via the permissive
`COLON_SPLIT_RE = /^([^:]+):\s*(.*)$/`, then flags the "key" as an invalid
trailer key. It has no notion of Markdown block structure, so a table row or a
prose sentence with a colon is mistaken for a malformed trailer. (The forward
MSL-P020 scan is unaffected because it uses the anchored `ATTR_LINE_RE`, which
table/prose lines don't match.)

## Fix

A genuine trailer key is a single token — it never contains internal whitespace
or a pipe. The backward scan now stops at any colon line whose key contains
whitespace or `|`; that line is legitimate body content, not a malformed
trailer:

```ts
const key = colonMatch[1].trim();
if (/[\s|]/.test(key)) break;
```

Real malformed trailer keys (e.g. `Bad_Key`, `not-a-key-value`) have no internal
whitespace and are unaffected — the existing MSL-P021/P022 detections still fire.

## Tests

Added three e2e cases to `tests/e2e/parse_identity_diagnostics_test.ts`:

- table-cell colon → no parse diagnostic (was MSL-P022)
- trailing prose colon → no parse diagnostic (was MSL-P022)
- a real malformed trailer key below a colon-bearing table → **still** MSL-P022
  (guards against over-suppression)

Full suite green (3250 passed), lint / typecheck / `deno fmt` / `dprint` clean.

## Follow-up (separate)

During investigation I found a distinct false positive: a body paragraph
starting with a non-caption capitalized word + colon (`Note:`, `Example:`)
trips **MSL-P020** (forward scan; those words aren't in the caption-keyword
allowlist). It's position-independent, so it's not part of this issue and needs
a different, more careful fix. Filed separately.
