### PR TITLE
fix(core): flag only recognized trailer keys as misplaced trailers (P020)

### DIFF
--- a/packages/markspec/core/parser/markdown.ts
+++ b/packages/markspec/core/parser/markdown.ts
@@ -7,7 +7,14 @@
 
 import type { Definition, List, ListItem, Paragraph, Text } from "mdast";
 import type { Attribute, Diagnostic, Entry, EntryShape } from "../model/mod.ts";
-import { IDENTITY_KEY, makeDisplayId, shapeFromIdValue } from "../model/mod.ts";
+import {
+  CORE_RELATIONS,
+  IDENTITY_KEY,
+  LOCK_EXTRA_INVERSE_KEYS,
+  makeDisplayId,
+  shapeFromIdValue,
+  UNIVERSAL_ATTRIBUTE_KEYS,
+} from "../model/mod.ts";
 import {
   ATTR_LINE_RE,
   collateAttributes,
@@ -27,6 +34,19 @@ import {
   parseTyplBlock,
   type TyplBlock,
 } from "../typl/mod.ts";
+
+/**
+ * Canonical set of trailer attribute keys the core recognizes: the union of
+ * every universal attribute, every core trace relation, and the extra inverse
+ * lock key (`Verified-by`). MSL-P020 (misplaced trailer) fires only when a
+ * body line's key is in this set; any other capitalized `Word:` lead-in
+ * (`Note:`, `Example:`, `Assumption:`) is prose, not a misplaced trailer (#654).
+ */
+const RECOGNIZED_TRAILER_KEYS: ReadonlySet<string> = new Set([
+  ...UNIVERSAL_ATTRIBUTE_KEYS,
+  ...CORE_RELATIONS.map((r) => r.attr),
+  ...LOCK_EXTRA_INVERSE_KEYS,
+]);
 
 /** Options for {@linkcode parseMarkdown}. */
 export interface ParseMarkdownOptions {
@@ -310,17 +330,10 @@ function extractEntry(
 
   // MSL-P020: trailers block is not the final indented code block.
   // Detect `Key: Value` lines in the body that likely should be trailers
-  // but are not at the final position (body content follows them).
-  // Exclude caption keywords (Figure:, Table:, etc.) which are legitimate
-  // body content, not misplaced trailer attributes.
-  const CAPTION_KEYWORDS = new Set([
-    "Figure",
-    "Table",
-    "Listing",
-    "Feature",
-    "Equation",
-    "List",
-  ]);
+  // but are not at the final position (body content follows them). Only lines
+  // whose key is a recognized trailer attribute count — see
+  // RECOGNIZED_TRAILER_KEYS — so ordinary prose (`Note:`, `Example:`) and
+  // caption lead-ins (`Figure:`, `Table:`) are left as legitimate body content.
   if (body.length > 0) {
     const bodyLines = body.split("\n");
     let inFencedBlock = false;
@@ -333,10 +346,12 @@ function extractEntry(
       }
       if (inFencedBlock) continue;
       if (!ATTR_LINE_RE.test(trimmed)) continue;
-      // Extract the key portion to check against caption keywords
+      // Only a RECOGNIZED trailer key signals a genuinely misplaced trailer.
+      // A body paragraph starting with any other capitalized word + colon
+      // (`Note:`, `Example:`, `Assumption:`) is prose, not a trailer (#654).
       const keyMatch = trimmed.match(/^([A-Z][A-Za-z-]*):/);
-      if (keyMatch && CAPTION_KEYWORDS.has(keyMatch[1])) continue;
-      // Found a Key: Value line in the body — non-final position
+      if (!keyMatch || !RECOGNIZED_TRAILER_KEYS.has(keyMatch[1])) continue;
+      // Found a misplaced trailer-like line in the body — non-final position
       diagnostics.push({
         code: "MSL-P020",
         severity: "error",

--- a/tests/e2e/parse_identity_diagnostics_test.ts
+++ b/tests/e2e/parse_identity_diagnostics_test.ts
@@ -227,6 +227,103 @@ Deno.test("validate: malformed trailer key after a colon table still -> MSL-P022
 });
 
 // ---------------------------------------------------------------------------
+// #654: MSL-P020 (misplaced trailer) must fire only for a RECOGNIZED trailer
+// key. A body paragraph that merely starts with a capitalized word + colon
+// (`Note:`, `Example:`, `Rationale:`) is prose, not a misplaced trailer, and
+// must not be flagged. A genuinely misplaced real trailer (`Id:`, `Satisfies:`)
+// in the body still fires.
+// ---------------------------------------------------------------------------
+
+Deno.test("validate: 'Note:' prose paragraph is not a misplaced trailer (#654)", async () => {
+  const { code, stderr } = await markspec(["check", "req.md"], {
+    files: {
+      "req.md": `# Test
+
+- [REQ-001] Note prose
+
+  The system shall support the modes below.
+
+  Note: fast mode brakes within 200 ms.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+`,
+    },
+  });
+  assertEquals(code, 0, `expected exit 0, stderr: ${stderr}`);
+  assert(
+    !stderr.includes("MSL-P020"),
+    `no MSL-P020 expected for a 'Note:' prose paragraph, stderr: ${stderr}`,
+  );
+});
+
+Deno.test("validate: 'Example:' prose paragraph is not a misplaced trailer (#654)", async () => {
+  const { code, stderr } = await markspec(["check", "req.md"], {
+    files: {
+      "req.md": `# Test
+
+- [REQ-001] Example prose
+
+  The system shall support the modes below.
+
+  Example: fast mode brakes within 200 ms.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+`,
+    },
+  });
+  assertEquals(code, 0, `expected exit 0, stderr: ${stderr}`);
+  assert(
+    !stderr.includes("MSL-P020"),
+    `no MSL-P020 expected for an 'Example:' prose paragraph, stderr: ${stderr}`,
+  );
+});
+
+Deno.test("validate: arbitrary 'Assumption:' prose is not a misplaced trailer (#654)", async () => {
+  // A skip-list of admonition words would miss this; only an allowlist of
+  // recognized trailer keys covers every prose lead-in. (Note: words that ARE
+  // recognized attribute keys, e.g. `Rationale`, remain flagged by design.)
+  const { code, stderr } = await markspec(["check", "req.md"], {
+    files: {
+      "req.md": `# Test
+
+- [REQ-001] Assumption prose
+
+  The system shall brake on a dry road.
+
+  Assumption: the road surface is dry.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+`,
+    },
+  });
+  assertEquals(code, 0, `expected exit 0, stderr: ${stderr}`);
+  assert(
+    !stderr.includes("MSL-P020"),
+    `no MSL-P020 expected for a 'Rationale:' prose paragraph, stderr: ${stderr}`,
+  );
+});
+
+Deno.test("validate: a misplaced real trailer in the body still → MSL-P020 (#654 guard)", async () => {
+  // The allowlist must still catch a genuinely misplaced recognized trailer.
+  const { code, stderr } = await markspec(["check", "req.md"], {
+    files: {
+      "req.md": `# Test
+
+- [REQ-001] Misplaced Satisfies
+
+  The system shall support the modes below.
+
+  Satisfies: SYS_0001
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+`,
+    },
+  });
+  assertEquals(code, 1, `expected exit 1, stderr: ${stderr}`);
+  assertStringIncludes(stderr, "MSL-P020");
+});
+
+// ---------------------------------------------------------------------------
 // MSL-P030: Authored entry has no body block
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #654.

## Problem

`markspec check` emitted a false-positive **MSL-P020** ("trailers block is not
the final indented code block") for an ordinary body paragraph that merely
starts with a capitalized word + colon — `Note:`, `Example:`, `Assumption:`, …
This blocked authors writing normal prose. Discovered while investigating #648
(fixed in #653); that fix addressed the *backward* P021/P022 scan, this one is
the distinct *forward* P020 scan.

## Root cause

The P020 forward scan flagged any body line matching `ATTR_LINE_RE`
(`^[A-Z][A-Za-z-]*: .+`) as a misplaced trailer unless its key was in a small
hard-coded **caption** allowlist (`Figure`, `Table`, `Listing`, `Feature`,
`Equation`, `List`). A denylist of words-to-ignore is inherently incomplete —
every prose lead-in not in the list false-positived.

## Fix

Invert the check to an **allowlist of recognized trailer keys**: P020 fires only
when the line's key is a real core trailer attribute — the union of
`UNIVERSAL_ATTRIBUTE_KEYS`, `CORE_RELATIONS` (the trace relations) and the extra
inverse lock key `Verified-by`, all sourced from the `model` layer (the only
layer `parser` may depend on — no new duplicated list). Any other capitalized
`Word:` lead-in is treated as body prose. The now-redundant caption allowlist is
removed (captions were never trailer keys, so they're skipped automatically).

| Body line | Before | After |
|---|---|---|
| `Note:` / `Example:` / `Assumption:` (prose) | ❌ P020 (blocks) | ✅ clean |
| `Satisfies: SYS_0001` (misplaced real trailer) | ✅ P020 | ✅ P020 |
| `Id: …` (existing P020 test) | ✅ P020 | ✅ P020 |

## Residual (by design)

A prose paragraph starting with a word that *is* a recognized attribute key
(e.g. `Rationale:` — a real universal attribute) is still flagged: at parse time
it's indistinguishable from a genuinely misplaced trailer. This narrows the
false-positive surface from "any capitalized `Word:`" to "an actual trailer-key
word," which is the intended trade (a false positive blocks the author; a rare
missed misplacement of a non-core key does not, and `insert`/`fmt` place
trailers correctly anyway).

## Tests

Added four e2e cases to `tests/e2e/parse_identity_diagnostics_test.ts`:

- `Note:`, `Example:`, `Assumption:` prose → no MSL-P020
- a misplaced `Satisfies:` in the body → still MSL-P020 (guards the allowlist)

The existing P020 test (misplaced `Id:`) and P021/P022 tests are unchanged and
still pass. Full suite green (3261 passed), lint / typecheck / `deno fmt` /
`dprint` clean.
