### PR TITLE
fix(core): restore built-in skip for common build-output dirs

### DIFF
--- a/docs/architecture/adr-027-cli-smoother-defaults.md
+++ b/docs/architecture/adr-027-cli-smoother-defaults.md
@@ -59,6 +59,18 @@ Skip precedence, in order:
    requirements and is not gitignored — previously hardcoded in the LSP walker's
    skip list, now `exclude: ["skills/"]` in the repo's own `project.yaml`.
 
+A second built-in skip covers the common build-output / dependency directories
+`node_modules`, `target`, `dist`, and `build` (`BUILTIN_SKIP_DIRS` in
+`core/discovery/mod.ts`). Unlike the hidden-dir skip it is **overridable**: it
+is applied as the _lowest_-precedence rule layer (before `.gitignore` and
+`exclude:`), so a negated `!target/` in either re-includes it under gitignore
+last-match-wins. This restores the guarantee the pre-`core/discovery` walkers
+(LSP `walkDirectory`, lockfile `collectEntries`) had via their hardcoded skip
+lists — without it, a consumer project that does not list these in `.gitignore`
+recurses into build artifacts (duplicate-ID noise, slow LSP indexing, spurious
+`MSL-L212` edge-hash entries). Added as a follow-up (#661) after the merge
+review found the unconditional skip had been dropped.
+
 Three extension-set SSOTs live in `core/discovery/mod.ts`: `SOURCE_EXTENSIONS`
 (tree-sitter-parseable source families), `MARKDOWN_EXTENSIONS` (`.md` only — the
 `fmt` scope, since the formatter never rewrites source), and

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -73,6 +73,12 @@ exclude:
   - "*.gen.md"
 ```
 
+**Built-in skips.** File discovery always skips hidden directories (names
+starting with `.`) and the common build-output / dependency directories
+`node_modules`, `target`, `dist`, and `build`, on top of `.gitignore` and
+`exclude:`. The build-output skip is overridable — re-include one with a negated
+entry in `.gitignore` or `exclude:` (e.g. `exclude: ["!target/"]`).
+
 ### Directory conventions
 
 MarkSpec does not enforce a directory layout. By convention:

--- a/packages/markspec/core/discovery/mod.ts
+++ b/packages/markspec/core/discovery/mod.ts
@@ -79,6 +79,34 @@ export interface DiscoverOptions {
 }
 
 /**
+ * Directory names pruned by default, in addition to the hidden-dir skip.
+ * These are the common build-output / dependency directories the
+ * pre-`core/discovery` walkers (LSP `walkDirectory`, lockfile
+ * `collectEntries`) hardcoded; keeping them restores that guarantee
+ * independent of a consumer's `.gitignore` — otherwise a project that does
+ * not list them recurses into build artifacts (duplicate-ID noise, slow LSP
+ * indexing, spurious `MSL-L212` edge-hash entries).
+ *
+ * Unlike the hidden-dir skip these are overridable: they are applied as the
+ * LOWEST-precedence rule layer (before `.gitignore` and `exclude:`), so a
+ * negated `!target/` entry in either re-includes them under gitignore
+ * last-match-wins.
+ */
+const BUILTIN_SKIP_DIRS: readonly string[] = [
+  "node_modules",
+  "target",
+  "dist",
+  "build",
+];
+
+/** Compiled once: the built-in skip as unanchored, directory-only gitignore
+ * rules (each matches a directory of that name at any depth). */
+const BUILTIN_SKIP_RULES: readonly GitignoreRule[] = parseGitignore(
+  BUILTIN_SKIP_DIRS.map((d) => `${d}/`).join("\n"),
+  "",
+);
+
+/**
  * Walk `root` recursively, yielding absolute paths of relevant files.
  * Entries are yielded in sorted order per directory — deterministic
  * output across filesystems. Unreadable directories are skipped.
@@ -93,7 +121,16 @@ export async function* discoverFiles(
     (options.exclude ?? []).join("\n"),
     "",
   );
-  yield* walk(root, "", excludeRules, io, extensions);
+  // Built-in build-output skips are the lowest-precedence layer: `.gitignore`
+  // (appended per-directory in `walk`) and `exclude:` both come after, so a
+  // `!target/` negation in either overrides them.
+  yield* walk(
+    root,
+    "",
+    [...BUILTIN_SKIP_RULES, ...excludeRules],
+    io,
+    extensions,
+  );
 }
 
 async function* walk(

--- a/packages/markspec/core/discovery/mod_test.ts
+++ b/packages/markspec/core/discovery/mod_test.ts
@@ -126,3 +126,61 @@ Deno.test("discovery: output is sorted (deterministic)", async () => {
     await Deno.remove(dir, { recursive: true });
   }
 });
+
+Deno.test("discovery: skips common build-output dirs (built-in, no .gitignore)", async () => {
+  const dir = await makeTree({
+    "real.md": "",
+    "node_modules/pkg/a.md": "",
+    "target/b.rs": "",
+    "dist/c.md": "",
+    "build/d.md": "",
+    "src/nested/build/e.md": "", // nested build dir also skipped
+  });
+  try {
+    assertEquals(await collect(dir), ["real.md"]);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("discovery: build-output skip is overridable via exclude negation", async () => {
+  const dir = await makeTree({ "target/keep.md": "", "real.md": "" });
+  try {
+    assertEquals(
+      await collect(dir, { exclude: ["!target/"] }),
+      ["real.md", "target/keep.md"],
+    );
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("discovery: build-output skip is overridable via .gitignore negation", async () => {
+  const dir = await makeTree({
+    ".gitignore": "!build/\n",
+    "build/keep.md": "",
+    "real.md": "",
+  });
+  try {
+    assertEquals(await collect(dir), ["build/keep.md", "real.md"]);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("discovery: explicitly naming a build dir walks its contents", async () => {
+  const dir = await makeTree({
+    "target/keep.md": "",
+    "target/sub/deep.md": "",
+  });
+  try {
+    // Root the walk *at* the build dir — its own name isn't in the
+    // root-relative paths, so the built-in skip does not prune it.
+    assertEquals(
+      await collect(join(dir, "target")),
+      ["keep.md", "sub/deep.md"],
+    );
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});


### PR DESCRIPTION
Closes #661.

Follow-up **P2** from the PR #651 review (finding #4) and ADR-027.

## Problem

`core/discovery` (the unified walker from #651) skipped only hidden directories + `.gitignore` + `project.yaml` `exclude:`. The pre-#651 walkers (LSP `walkDirectory`, lockfile `collectEntries`) unconditionally skipped `node_modules` / `target` / `dist` / `build`. Dropping that means a consumer project that doesn't list those in `.gitignore` now recurses into build artifacts — duplicate-ID noise, slow LSP indexing, and spurious `MSL-L212` edge-hash entries. This repo's own `.gitignore` masks the regression.

## Fix

Restore a built-in skip for those four directory names — but as the **lowest**-precedence rule layer (before `.gitignore` and `exclude:`), so it's **overridable**: a negated `!target/` in `.gitignore` or `exclude:` re-includes it under gitignore last-match-wins. Unlike the old hardcoded lists it lives in one place (`BUILTIN_SKIP_DIRS` in `core/discovery/mod.ts`); every discovery consumer (CLI verbs, LSP indexing, lockfile collection) inherits it.

## Tests

`core/discovery/mod_test.ts`: skips the four dirs (including nested) with no `.gitignore`; `!target/` in `exclude:` and `!build/` in `.gitignore` both re-include; rooting the walk *at* a build dir still yields its contents (explicit-path escape hatch). Full suite green (3309 passed).

## Docs

ADR-027 skip-precedence section (records it as a distinct, overridable built-in layer) + cli.md built-in-skips note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
