### PR TITLE
fix(cli): sharpen MSL-L212 message for the lock source-file widening

### DIFF
--- a/docs/architecture/adr-027-cli-smoother-defaults.md
+++ b/docs/architecture/adr-027-cli-smoother-defaults.md
@@ -190,7 +190,14 @@ affecting every command, not scoped to this change.
   `exclude:` (and `.gitignore`) for the first time.
 - `markspec.lock` byte output can change for projects with source-file entries
   after the first `markspec lock` run post-upgrade (widened collection scope,
-  described above).
+  described above). **Upgrade note (#663):** a project with trace attributes in
+  source doc comments (e.g. the `demo-aeb-*` V-model repos) that runs bare
+  `markspec check` in CI before re-running `markspec lock` gets a one-time
+  `MSL-L212` error, because the pinned edge hash was computed from the narrower
+  markdown-only corpus. This is expected; run `markspec lock` once to refresh
+  the pin. Per the standing "no migration tooling until 1.0" decision, no
+  migration is provided — the `MSL-L212` message names the source-file widening
+  as a possible cause so the failure is self-explanatory.
 
 ## Alternatives considered
 

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -520,6 +520,13 @@ markspec lock --update             # force re-resolve every upstream
 markspec lock --update github-foo  # force re-resolve one upstream
 ```
 
+**Upgrade note.** `markspec lock` now indexes source-file doc-comment entries in
+addition to Markdown. A project that pinned its lockfile with an older MarkSpec
+and has trace links in source files will see a one-time `MSL-L212` edge-drift
+error from bare `markspec check` until you run `markspec lock` once to refresh
+the pin — the requirements didn't change, only the set of files the lockfile
+indexes did.
+
 #### sync
 
 Read-only commands surfacing bound-entry state from `markspec.lock` and the

--- a/packages/markspec/cli/commands/check.ts
+++ b/packages/markspec/cli/commands/check.ts
@@ -183,7 +183,7 @@ export const checkCmd = new Command()
                 code: "MSL-L212",
                 severity: "error",
                 message:
-                  `traceability edges drifted from markspec.lock: locked ${cache.edgesCount} edge(s), current ${quads.length} (run \`markspec lock\` to refresh)`,
+                  `traceability edges drifted from markspec.lock: locked ${cache.edgesCount} edge(s), current ${quads.length} — run \`markspec lock\` to refresh. (After upgrading MarkSpec this can also fire once because traceability inputs now include source-file doc comments; re-running \`markspec lock\` clears it.)`,
                 location: { file: lockPath, line: 1, column: 1 },
               });
             }

--- a/tests/e2e/check_project_test.ts
+++ b/tests/e2e/check_project_test.ts
@@ -195,6 +195,11 @@ Deno.test("check: lockfile edge drift fails with MSL-L212", async () => {
     const drifted = await markspecInDir(run.dir, ["check"]);
     assertStringIncludes(drifted.stderr, "MSL-L212");
     assertEquals(drifted.code, 1);
+    // The message names the remedy and the #651 upgrade cause (the lock walk
+    // now also indexes source-file doc comments), so a one-time post-upgrade
+    // failure is self-explanatory.
+    assertStringIncludes(drifted.stderr, "markspec lock");
+    assertStringIncludes(drifted.stderr, "source-file");
 
     // 4. JSON consumers that group by location.file must not drop MSL-L212 —
     // the diagnostic carries a markspec.lock location (like MSL-F010 does).


### PR DESCRIPTION
Closes #663.

Follow-up **P4** from the PR #651 review (finding #5) and ADR-027.

> **Stacked on #662** (`fix/660-check-canon-drift-f011`) — both touch the in-`check` `MSL-L212` gate. Base retargets to `main` automatically when #662 merges; review this diff on top of #662.

## Problem

`markspec lock`'s walk widened from markdown-only to markdown + source doc comments (#651). A pre-existing project with trace attributes in source files (the `demo-aeb-*` V-model repos) that upgrades and runs bare `markspec check` in CI **before** re-running `markspec lock` hits a hard `MSL-L212` edge-drift error even though its requirements didn't change — the pinned edge hash was computed from the narrower corpus.

## Fix

Per the standing **"no migration tooling until 1.0"** decision, no migration is built. Instead the `MSL-L212` message now names the source-file widening as a possible cause and the one-command remedy, so the one-time post-upgrade failure is self-explanatory:

> traceability edges drifted from markspec.lock: locked N edge(s), current M — run `markspec lock` to refresh. (After upgrading MarkSpec this can also fire once because traceability inputs now include source-file doc comments; re-running `markspec lock` clears it.)

Deliberately **not** downgrading `MSL-L212` to a warning on the first post-widening run (that would need run-state tracking and weakens the CI gate) — message + release note is the agreed default.

## Tests / docs

Extends the existing `MSL-L212` drift e2e test to assert the sharpened wording (`markspec lock`, `source-file`). Release note in ADR-027 Consequences + cli.md lock section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
