### PR TITLE
fix(cli): correct the bare-invocation "no project root" message

### DIFF
--- a/docs/architecture/adr-027-cli-smoother-defaults.md
+++ b/docs/architecture/adr-027-cli-smoother-defaults.md
@@ -146,12 +146,18 @@ project root via `discoverProjectRoot`, which walks up for `project.yaml` only
 activated solely by `.markspec.yaml` with no `project.yaml` present (see
 [ADR-008](./adr-008-profile-system.md)) is not recognized as a project root for
 the no-args path, and bare invocation reports "no project root found" in that
-case, even though the error message text says "project.yaml or .markspec.yaml".
-This mismatch is pre-existing across the whole CLI (`requireProjectConfig` has
-the same gap) and is not fixed by this work — explicit file arguments are
-unaffected. Revisiting it (making no-args root discovery also honor a
-`.markspec.yaml`-only project, or correcting the message) is a product call
-affecting every command, not scoped to this change.
+case. This behavior is pre-existing across the whole CLI (`requireProjectConfig`
+has the same gap) — explicit file arguments are unaffected.
+
+**Resolution (#666):** the _message_ was the misleading part — it named
+"project.yaml or .markspec.yaml", implying a lone `.markspec.yaml` would be
+recognized. The chosen fix corrects the message (project.yaml is the required
+root marker; a `.markspec.yaml` only activates a profile per ADR-008 and does
+not mark a root) rather than widening discovery. Making no-args root discovery
+honor a `.markspec.yaml`-only project remains deferred: it is a product call
+affecting every command (and `project.yaml`'s required
+`name`/`version`/`exclude` fields mean such commands would fail later anyway),
+not scoped to this work.
 
 ## Consequences
 

--- a/packages/markspec/cli/helpers.ts
+++ b/packages/markspec/cli/helpers.ts
@@ -262,10 +262,15 @@ export async function resolveScope(
 
   if (args.length === 0) {
     if (projectRoot === undefined) {
-      console.error(
-        "error: no project root found (project.yaml or .markspec.yaml)",
-      );
+      // project.yaml is the project-root marker (it carries name / version /
+      // exclude). A `.markspec.yaml` only activates a profile (ADR-008) and
+      // does not, on its own, mark a root — so the message must not imply it
+      // does (#666).
+      console.error("error: no project root found (project.yaml required)");
       console.error(`  searched from ${Deno.cwd()} to filesystem root`);
+      console.error(
+        "  a .markspec.yaml activates a profile but does not mark a project root",
+      );
       console.error(
         "  run 'markspec init' to create one, or pass explicit files",
       );

--- a/tests/e2e/check_project_test.ts
+++ b/tests/e2e/check_project_test.ts
@@ -104,6 +104,15 @@ Deno.test("check: bare invocation without project root errors with hint", async 
   assertEquals(code, 1);
   assertStringIncludes(stderr, "no project root found");
   assertStringIncludes(stderr, "markspec init");
+  // The message names project.yaml as the required root marker and must NOT
+  // present `.markspec.yaml` as a sufficient alternative — a `.markspec.yaml`
+  // alone does not satisfy bare-invocation root discovery (#666).
+  assertStringIncludes(stderr, "project.yaml");
+  assertEquals(
+    stderr.includes("project.yaml or .markspec.yaml"),
+    false,
+    `message must not imply .markspec.yaml alone works; got: ${stderr}`,
+  );
 });
 
 Deno.test("check: clean project exits 0", async () => {


### PR DESCRIPTION
Closes #666.

Follow-up **P5** from ADR-027's Known Limitation. The maintainer deferred the decision to my recommendation; this is the **"fix the message only"** option.

## Problem

`resolveScope`'s no-root error read `(project.yaml or .markspec.yaml)`, implying a project activated solely by `.markspec.yaml` (no `project.yaml`) would be recognized by bare `check`/`lint`/`fmt`. It is not — `discoverProjectRoot` walks up for `project.yaml` only.

## Fix (message only — behavior unchanged)

`project.yaml` is the project-root marker (it carries the required `name`/`version`/`exclude` fields); `.markspec.yaml` only *activates a profile* (ADR-008). The message now says so:

```
error: no project root found (project.yaml required)
  searched from <cwd> to filesystem root
  a .markspec.yaml activates a profile but does not mark a project root
  run 'markspec init' to create one, or pass explicit files
```

**Chosen over widening discovery** (the bigger option): making no-args discovery honor a `.markspec.yaml`-only project would just move the failure to later missing-`name`/`version` errors, and it's a CLI-wide product direction that deserves its own scoped decision. ADR-027's Known Limitation is updated to record this resolution; the widening stays deferred.

## Tests

Extends the existing "no project root" e2e test to assert the message names `project.yaml` and no longer contains the misleading `project.yaml or .markspec.yaml` phrasing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
