### PR TITLE
fix(core): harden and scope the ADR-029 markdown pass (#670 review follow-ups)

### DIFF
--- a/.followup677.diff
+++ b/.followup677.diff
@@ -1,0 +1,221 @@
+diff --git a/packages/markspec/cli/commands/check.ts b/packages/markspec/cli/commands/check.ts
+index a9cd2fc7..e6a3e123 100644
+--- a/packages/markspec/cli/commands/check.ts
++++ b/packages/markspec/cli/commands/check.ts
+@@ -4,8 +4,9 @@
+  * `markspec check` — check broken refs, missing Ids, duplicates.
+  */
+ 
++import { extname, join } from "@std/path";
+ import { Command } from "@cliffy/command";
+-import { ConfigError } from "../../core/mod.ts";
++import { ConfigError, MARKDOWN_EXTENSIONS } from "../../core/mod.ts";
+ import type { CaptionConventions, Diagnostic } from "../../core/mod.ts";
+ import { loadActiveProfile, readFile, resolveScope } from "../helpers.ts";
+ 
+@@ -78,7 +79,9 @@ export const checkCmd = new Command()
+           console.error(`error: ${filePath}: file not found`);
+           Deno.exit(1);
+         }
+-        if (filePath.endsWith(".md")) mdContents.set(filePath, content);
++        if (MARKDOWN_EXTENSIONS.has(extname(filePath).toLowerCase())) {
++          mdContents.set(filePath, content);
++        }
+         const result = await parseFile(content, { file: filePath });
+         allEntries.push(...result.entries);
+         parseDiagnostics.push(...result.diagnostics);
+@@ -120,7 +123,6 @@ export const checkCmd = new Command()
+           loadMarkdownFormatter,
+           parseLockfile,
+         } = await import("../../core/mod.ts");
+-        const { join } = await import("@std/path");
+ 
+         const formatMarkdownProse = await loadMarkdownFormatter();
+ 
+diff --git a/packages/markspec/core/formatter/mod.ts b/packages/markspec/core/formatter/mod.ts
+index de801d22..fdfe9121 100644
+--- a/packages/markspec/core/formatter/mod.ts
++++ b/packages/markspec/core/formatter/mod.ts
+@@ -6,6 +6,7 @@
+  * and requirement block insertion.
+  */
+ 
++import { extname } from "@std/path";
+ import { ulid as defaultUlid } from "@std/ulid";
+ import { stringify as stringifyYaml } from "@std/yaml";
+ import type {
+@@ -19,6 +20,7 @@ import {
+   CSV_SPLITTABLE_TYPES,
+   IDENTITY_KEY,
+ } from "../model/mod.ts";
++import { MARKDOWN_EXTENSIONS } from "../discovery/mod.ts";
+ import { ATTR_LINE_RE } from "../parser/attributes.ts";
+ import { extractFrontMatter } from "../parser/frontmatter.ts";
+ import { parseMarkdown } from "../parser/markdown.ts";
+@@ -311,13 +313,27 @@ function emitBodyViaAst(
+       // external whole-file dprint view (which sees the indent) re-wraps
+       // it: a formatter ping-pong. Floor of 20 keeps a pathological indent
+       // from degenerating into one-word-per-line output.
+-      const polished = proseFormat(emittedBody, {
+-        lineWidth: Math.max(
+-          20,
+-          MARKSPEC_MARKDOWN_GLOBAL_CONFIG.lineWidth - indent,
+-        ),
+-      }).replace(/\n$/, "");
+-      if (polished !== emittedBody) {
++      let polished: string | undefined;
++      try {
++        polished = proseFormat(emittedBody, {
++          lineWidth: Math.max(
++            20,
++            MARKSPEC_MARKDOWN_GLOBAL_CONFIG.lineWidth - indent,
++          ),
++        }).replace(/\n$/, "");
++      } catch {
++        // The dprint WASM formatter can throw on a pathological body.
++        // Treat a throw exactly like a rejected rewrite: keep the
++        // canonical body and report the fallback (never crash the run).
++        diagnostics.push({
++          code: "MSL-F012",
++          severity: "info",
++          message: `${entry.displayId}: Markdown pass errored — kept ` +
++            `the canonical body`,
++          location: entry.location,
++        });
++      }
++      if (polished !== undefined && polished !== emittedBody) {
+         if (markdownSemanticallyEquivalent(emittedBody, polished)) {
+           finalBody = polished;
+         } else {
+@@ -464,7 +480,15 @@ export function format(
+   const { entries } = parseMarkdown(body, { file });
+   const diagnostics: Diagnostic[] = [...fm.diagnostics];
+ 
+-  const proseFormat = options?.formatMarkdownProse;
++  // ADR-029: the whole-document Markdown pass is Markdown-only. Gate on the
++  // file extension HERE so the invariant has one home — a caller that wires
++  // formatMarkdownProse without its own guard (e.g. a future write tool, or
++  // formatSource forwarding options with a source-file label) cannot silently
++  // reflow a source file's doc comment as Markdown. The CommonMark-semantic
++  // gate cannot catch that class, so it must be prevented, not detected. The
++  // CLI/LSP call-site guards remain as defense-in-depth.
++  const isMarkdownFile = MARKDOWN_EXTENSIONS.has(extname(file).toLowerCase());
++  const proseFormat = isMarkdownFile ? options?.formatMarkdownProse : undefined;
+   if (entries.length === 0 && !fm.hadFrontMatter && proseFormat === undefined) {
+     // No entries and no front matter — nothing to format. Returning the
+     // original `markdown` preserves the source's exact byte sequence,
+diff --git a/packages/markspec/core/formatter/mod_test.ts b/packages/markspec/core/formatter/mod_test.ts
+index 2e8b96b7..f3803842 100644
+--- a/packages/markspec/core/formatter/mod_test.ts
++++ b/packages/markspec/core/formatter/mod_test.ts
+@@ -643,3 +643,63 @@ Deno.test("format: body gate rejects destructive output with MSL-F012, keeps can
+     true,
+   );
+ });
++
++// ---------------------------------------------------------------------------
++// ADR-029 follow-ups: scope guard + throw hardening
++// ---------------------------------------------------------------------------
++
++Deno.test("format: markdown pass is disabled for non-.md files even when the callback is wired (ADR-029 scope guard in format())", () => {
++  let called = false;
++  const spy = (md: string): string => {
++    called = true;
++    return md.replace(/\n(?!$)/g, " ");
++  };
++  const src =
++    'fn main() {\n    let x = compute(1, 2);\n    println!("{}", x);\n}\n';
++  const result = format(src, { file: "main.rs", formatMarkdownProse: spy });
++  assertEquals(called, false);
++  assertEquals(result.output, src);
++});
++
++Deno.test("format: markdown pass still runs for .md files (control for the scope guard)", () => {
++  let called = false;
++  const spy = (md: string): string => {
++    called = true;
++    return md;
++  };
++  format("# Heading\n\nsome prose.\n", {
++    file: "doc.md",
++    formatMarkdownProse: spy,
++  });
++  assertEquals(called, true);
++});
++
++Deno.test("format: a throwing markdown formatter degrades to fallback, never crashes (entry body)", () => {
++  const thrower = (): string => {
++    throw new Error("simulated dprint WASM panic");
++  };
++  const input = `- [STK_9004] Throw safety
++
++  The system shall keep its canonical body when the Markdown formatter errors.
++
++      Id: 01JADYKACKQKGVGHT9K7Y6PBPE
++`;
++  const result = format(input, { file: "t.md", formatMarkdownProse: thrower });
++  assertStringIncludes(
++    result.output,
++    "The system shall keep its canonical body when the Markdown formatter errors.",
++  );
++  assertEquals(result.diagnostics.some((d) => d.code === "MSL-F012"), true);
++});
++
++Deno.test("format: a throwing markdown formatter degrades to fallback for prose segments too", () => {
++  const thrower = (): string => {
++    throw new Error("simulated dprint WASM panic");
++  };
++  const result = format("# Overview\n\nragged prose here.\n", {
++    file: "t.md",
++    formatMarkdownProse: thrower,
++  });
++  // No throw; original prose preserved.
++  assertStringIncludes(result.output, "ragged prose here.");
++});
+diff --git a/packages/markspec/core/formatter/prose.ts b/packages/markspec/core/formatter/prose.ts
+index 647e0d19..2975b5b5 100644
+--- a/packages/markspec/core/formatter/prose.ts
++++ b/packages/markspec/core/formatter/prose.ts
+@@ -60,7 +60,17 @@ export function formatProseSegments(
+       return;
+     }
+     const chunk = segment.slice(from, to).join("\n");
+-    const formatted = proseFormat(chunk).replace(/\n$/, "");
++    let formatted: string;
++    try {
++      formatted = proseFormat(chunk).replace(/\n$/, "");
++    } catch {
++      // The dprint WASM formatter can throw on a pathological fragment.
++      // Treat a throw exactly like a rejected rewrite: keep the original
++      // segment and report the fallback (never crash the whole run).
++      fallbackStarts.push(gapStart + from);
++      out.push(...segment);
++      return;
++    }
+     if (formatted === chunk) {
+       out.push(...segment);
+       return;
+diff --git a/tests/e2e/check_project_test.ts b/tests/e2e/check_project_test.ts
+index 05f97567..f2b92089 100644
+--- a/tests/e2e/check_project_test.ts
++++ b/tests/e2e/check_project_test.ts
+@@ -182,6 +182,19 @@ Deno.test("check: formatted project does not emit MSL-F010", async () => {
+   assertEquals(code, 0, stderr);
+ });
+ 
++Deno.test("check: uppercase .MD extension is covered by the MSL-F010 drift gate (case parity)", async () => {
++  const { code, stderr } = await markspec(["check"], {
++    files: {
++      ...BASE_FILES,
++      // Uppercase extension + non-canonical prose (asterisk bullet): fmt would
++      // reformat it, so the MSL-F010 gate must also see it — case parity.
++      "docs/OVERVIEW.MD": "# Overview\n\n* asterisk bullet\n",
++    },
++  });
++  assertStringIncludes(stderr, "MSL-F010");
++  assertEquals(code, 1);
++});
++
+ Deno.test("check: lockfile edge drift fails with MSL-L212", async () => {
+   // 1. Build a project and generate a lockfile that pins its edges.
+   const run = await markspecPersist(["lock"], {

--- a/packages/markspec/cli/commands/check.ts
+++ b/packages/markspec/cli/commands/check.ts
@@ -4,8 +4,9 @@
  * `markspec check` — check broken refs, missing Ids, duplicates.
  */
 
+import { extname, join } from "@std/path";
 import { Command } from "@cliffy/command";
-import { ConfigError } from "../../core/mod.ts";
+import { ConfigError, MARKDOWN_EXTENSIONS } from "../../core/mod.ts";
 import type { CaptionConventions, Diagnostic } from "../../core/mod.ts";
 import { loadActiveProfile, readFile, resolveScope } from "../helpers.ts";
 
@@ -78,7 +79,9 @@ export const checkCmd = new Command()
           console.error(`error: ${filePath}: file not found`);
           Deno.exit(1);
         }
-        if (filePath.endsWith(".md")) mdContents.set(filePath, content);
+        if (MARKDOWN_EXTENSIONS.has(extname(filePath).toLowerCase())) {
+          mdContents.set(filePath, content);
+        }
         const result = await parseFile(content, { file: filePath });
         allEntries.push(...result.entries);
         parseDiagnostics.push(...result.diagnostics);
@@ -120,7 +123,6 @@ export const checkCmd = new Command()
           loadMarkdownFormatter,
           parseLockfile,
         } = await import("../../core/mod.ts");
-        const { join } = await import("@std/path");
 
         const formatMarkdownProse = await loadMarkdownFormatter();
 

--- a/packages/markspec/core/formatter/mod.ts
+++ b/packages/markspec/core/formatter/mod.ts
@@ -6,6 +6,7 @@
  * and requirement block insertion.
  */
 
+import { extname } from "@std/path";
 import { ulid as defaultUlid } from "@std/ulid";
 import { stringify as stringifyYaml } from "@std/yaml";
 import type {
@@ -19,6 +20,7 @@ import {
   CSV_SPLITTABLE_TYPES,
   IDENTITY_KEY,
 } from "../model/mod.ts";
+import { MARKDOWN_EXTENSIONS } from "../discovery/mod.ts";
 import { ATTR_LINE_RE } from "../parser/attributes.ts";
 import { extractFrontMatter } from "../parser/frontmatter.ts";
 import { parseMarkdown } from "../parser/markdown.ts";
@@ -311,13 +313,27 @@ function emitBodyViaAst(
       // external whole-file dprint view (which sees the indent) re-wraps
       // it: a formatter ping-pong. Floor of 20 keeps a pathological indent
       // from degenerating into one-word-per-line output.
-      const polished = proseFormat(emittedBody, {
-        lineWidth: Math.max(
-          20,
-          MARKSPEC_MARKDOWN_GLOBAL_CONFIG.lineWidth - indent,
-        ),
-      }).replace(/\n$/, "");
-      if (polished !== emittedBody) {
+      let polished: string | undefined;
+      try {
+        polished = proseFormat(emittedBody, {
+          lineWidth: Math.max(
+            20,
+            MARKSPEC_MARKDOWN_GLOBAL_CONFIG.lineWidth - indent,
+          ),
+        }).replace(/\n$/, "");
+      } catch {
+        // The dprint WASM formatter can throw on a pathological body.
+        // Treat a throw exactly like a rejected rewrite: keep the
+        // canonical body and report the fallback (never crash the run).
+        diagnostics.push({
+          code: "MSL-F012",
+          severity: "info",
+          message: `${entry.displayId}: Markdown pass errored — kept ` +
+            `the canonical body`,
+          location: entry.location,
+        });
+      }
+      if (polished !== undefined && polished !== emittedBody) {
         if (markdownSemanticallyEquivalent(emittedBody, polished)) {
           finalBody = polished;
         } else {
@@ -464,7 +480,15 @@ export function format(
   const { entries } = parseMarkdown(body, { file });
   const diagnostics: Diagnostic[] = [...fm.diagnostics];
 
-  const proseFormat = options?.formatMarkdownProse;
+  // ADR-029: the whole-document Markdown pass is Markdown-only. Gate on the
+  // file extension HERE so the invariant has one home — a caller that wires
+  // formatMarkdownProse without its own guard (e.g. a future write tool, or
+  // formatSource forwarding options with a source-file label) cannot silently
+  // reflow a source file's doc comment as Markdown. The CommonMark-semantic
+  // gate cannot catch that class, so it must be prevented, not detected. The
+  // CLI/LSP call-site guards remain as defense-in-depth.
+  const isMarkdownFile = MARKDOWN_EXTENSIONS.has(extname(file).toLowerCase());
+  const proseFormat = isMarkdownFile ? options?.formatMarkdownProse : undefined;
   if (entries.length === 0 && !fm.hadFrontMatter && proseFormat === undefined) {
     // No entries and no front matter — nothing to format. Returning the
     // original `markdown` preserves the source's exact byte sequence,

--- a/packages/markspec/core/formatter/mod.ts
+++ b/packages/markspec/core/formatter/mod.ts
@@ -405,6 +405,13 @@ export interface FormatOptions {
    * pre-ADR-029 behaviour. The entry-body polish passes a per-call
    * `lineWidth` reduced by the body indent (see `emitBodyViaAst`);
    * one-arg formatter callbacks simply ignore it.
+   *
+   * The pass is Markdown-only: it runs only when {@linkcode file} has a
+   * Markdown extension (`.md`). A source-file (or absent) `file` disables
+   * it even when this callback is set — a source file's doc comment must
+   * never be reflowed as Markdown, and the semantic gate cannot catch
+   * that class of corruption. Callers that format Markdown held in memory
+   * must therefore pass a `.md`-suffixed `file`.
    */
   readonly formatMarkdownProse?: ProseFormatter;
 }
@@ -650,14 +657,16 @@ export function format(
     });
     const prose = formatProseSegments(collapsedLines, extents, proseFormat);
     if (prose.changed) changed = true;
-    for (const lineIdx of prose.fallbackStarts) {
+    for (const fallback of prose.fallbacks) {
+      const cause = fallback.reason === "error"
+        ? "errored"
+        : "produced non-equivalent output";
       diagnostics.push({
         code: "MSL-F012",
         severity: "info",
-        message:
-          "Markdown pass produced non-equivalent output for this prose " +
-          "segment — kept the original text",
-        location: { file, line: lineIdx + 1, column: 1 },
+        message: `Markdown pass ${cause} for this prose segment — kept ` +
+          `the original text`,
+        location: { file, line: fallback.line + 1, column: 1 },
       });
     }
     proseLines = prose.lines;

--- a/packages/markspec/core/formatter/mod_test.ts
+++ b/packages/markspec/core/formatter/mod_test.ts
@@ -643,3 +643,63 @@ Deno.test("format: body gate rejects destructive output with MSL-F012, keeps can
     true,
   );
 });
+
+// ---------------------------------------------------------------------------
+// ADR-029 follow-ups: scope guard + throw hardening
+// ---------------------------------------------------------------------------
+
+Deno.test("format: markdown pass is disabled for non-.md files even when the callback is wired (ADR-029 scope guard in format())", () => {
+  let called = false;
+  const spy = (md: string): string => {
+    called = true;
+    return md.replace(/\n(?!$)/g, " ");
+  };
+  const src =
+    'fn main() {\n    let x = compute(1, 2);\n    println!("{}", x);\n}\n';
+  const result = format(src, { file: "main.rs", formatMarkdownProse: spy });
+  assertEquals(called, false);
+  assertEquals(result.output, src);
+});
+
+Deno.test("format: markdown pass still runs for .md files (control for the scope guard)", () => {
+  let called = false;
+  const spy = (md: string): string => {
+    called = true;
+    return md;
+  };
+  format("# Heading\n\nsome prose.\n", {
+    file: "doc.md",
+    formatMarkdownProse: spy,
+  });
+  assertEquals(called, true);
+});
+
+Deno.test("format: a throwing markdown formatter degrades to fallback, never crashes (entry body)", () => {
+  const thrower = (): string => {
+    throw new Error("simulated dprint WASM panic");
+  };
+  const input = `- [STK_9004] Throw safety
+
+  The system shall keep its canonical body when the Markdown formatter errors.
+
+      Id: 01JADYKACKQKGVGHT9K7Y6PBPE
+`;
+  const result = format(input, { file: "t.md", formatMarkdownProse: thrower });
+  assertStringIncludes(
+    result.output,
+    "The system shall keep its canonical body when the Markdown formatter errors.",
+  );
+  assertEquals(result.diagnostics.some((d) => d.code === "MSL-F012"), true);
+});
+
+Deno.test("format: a throwing markdown formatter degrades to fallback for prose segments too", () => {
+  const thrower = (): string => {
+    throw new Error("simulated dprint WASM panic");
+  };
+  const result = format("# Overview\n\nragged prose here.\n", {
+    file: "t.md",
+    formatMarkdownProse: thrower,
+  });
+  // No throw; original prose preserved.
+  assertStringIncludes(result.output, "ragged prose here.");
+});

--- a/packages/markspec/core/formatter/mod_test.ts
+++ b/packages/markspec/core/formatter/mod_test.ts
@@ -700,6 +700,13 @@ Deno.test("format: a throwing markdown formatter degrades to fallback for prose 
     file: "t.md",
     formatMarkdownProse: thrower,
   });
-  // No throw; original prose preserved.
+  // No throw; original prose preserved; the fallback is reported with the
+  // accurate "errored" cause (not the semantic-rejection wording).
   assertStringIncludes(result.output, "ragged prose here.");
+  assertEquals(
+    result.diagnostics.some(
+      (d) => d.code === "MSL-F012" && d.message.includes("errored"),
+    ),
+    true,
+  );
 });

--- a/packages/markspec/core/formatter/prose.ts
+++ b/packages/markspec/core/formatter/prose.ts
@@ -6,8 +6,8 @@
  * the injected {@linkcode ProseFormatter} (dprint-markdown). Every
  * rewritten segment must pass {@linkcode markdownSemanticallyEquivalent}
  * against its original — a rejected segment is kept byte-identical and
- * reported via `fallbackStarts` so `format()` can emit an advisory
- * diagnostic ("never make a file worse").
+ * reported via `fallbacks` (with its reason) so `format()` can emit an
+ * advisory diagnostic ("never make a file worse").
  *
  * Entry blocks (title line → item end, trailers included) are never
  * given to dprint here; entry BODIES are polished separately inside
@@ -24,12 +24,25 @@ export interface EntryExtent {
   readonly end: number;
 }
 
+/**
+ * Why a prose segment kept its original text instead of the formatted
+ * output: the dprint formatter threw (`"error"`), or its output failed the
+ * CommonMark-semantic gate (`"non-equivalent"`). Threaded so `format()`
+ * can emit an accurate MSL-F012 cause per segment rather than collapsing
+ * both into one message.
+ */
+export interface ProseFallback {
+  readonly line: number;
+  readonly reason: "error" | "non-equivalent";
+}
+
 /** Result of {@linkcode formatProseSegments}. */
 export interface ProsePassResult {
   readonly lines: string[];
   readonly changed: boolean;
-  /** 0-based first line of each prose segment the gate rejected. */
-  readonly fallbackStarts: readonly number[];
+  /** One entry per prose segment that fell back to its original text,
+   * with the 0-based first line and the reason. */
+  readonly fallbacks: readonly ProseFallback[];
 }
 
 /**
@@ -44,7 +57,7 @@ export function formatProseSegments(
 ): ProsePassResult {
   const extents = [...entryExtents].sort((a, b) => a.start - b.start);
   const out: string[] = [];
-  const fallbackStarts: number[] = [];
+  const fallbacks: ProseFallback[] = [];
   let changed = false;
   let cursor = 0;
 
@@ -67,7 +80,7 @@ export function formatProseSegments(
       // The dprint WASM formatter can throw on a pathological fragment.
       // Treat a throw exactly like a rejected rewrite: keep the original
       // segment and report the fallback (never crash the whole run).
-      fallbackStarts.push(gapStart + from);
+      fallbacks.push({ line: gapStart + from, reason: "error" });
       out.push(...segment);
       return;
     }
@@ -76,7 +89,7 @@ export function formatProseSegments(
       return;
     }
     if (!markdownSemanticallyEquivalent(chunk, formatted)) {
-      fallbackStarts.push(gapStart + from);
+      fallbacks.push({ line: gapStart + from, reason: "non-equivalent" });
       out.push(...segment);
       return;
     }
@@ -100,5 +113,5 @@ export function formatProseSegments(
   }
   if (cursor < lines.length) flushProse(cursor, lines.length);
 
-  return { lines: out, changed, fallbackStarts };
+  return { lines: out, changed, fallbacks };
 }

--- a/packages/markspec/core/formatter/prose.ts
+++ b/packages/markspec/core/formatter/prose.ts
@@ -60,7 +60,17 @@ export function formatProseSegments(
       return;
     }
     const chunk = segment.slice(from, to).join("\n");
-    const formatted = proseFormat(chunk).replace(/\n$/, "");
+    let formatted: string;
+    try {
+      formatted = proseFormat(chunk).replace(/\n$/, "");
+    } catch {
+      // The dprint WASM formatter can throw on a pathological fragment.
+      // Treat a throw exactly like a rejected rewrite: keep the original
+      // segment and report the fallback (never crash the whole run).
+      fallbackStarts.push(gapStart + from);
+      out.push(...segment);
+      return;
+    }
     if (formatted === chunk) {
       out.push(...segment);
       return;

--- a/packages/markspec/core/formatter/prose_test.ts
+++ b/packages/markspec/core/formatter/prose_test.ts
@@ -55,7 +55,19 @@ Deno.test("prose: gate rejects non-equivalent output, reports fallback", () => {
   const res = formatProseSegments(DOC, [{ start: 5, end: 10 }], truncate);
   assertEquals(res.changed, false);
   assertEquals(res.lines, DOC);
-  assertEquals(res.fallbackStarts.length, 2); // both prose segments rejected
+  assertEquals(res.fallbacks.length, 2); // both prose segments rejected
+  assertEquals(res.fallbacks.every((f) => f.reason === "non-equivalent"), true);
+});
+
+Deno.test("prose: a throwing formatter falls back with reason 'error'", () => {
+  const thrower = (): string => {
+    throw new Error("simulated dprint WASM panic");
+  };
+  const res = formatProseSegments(DOC, [{ start: 5, end: 10 }], thrower);
+  assertEquals(res.changed, false);
+  assertEquals(res.lines, DOC);
+  assertEquals(res.fallbacks.length, 2);
+  assertEquals(res.fallbacks.every((f) => f.reason === "error"), true);
 });
 
 Deno.test("prose: no entries — whole document is one segment", () => {

--- a/tests/e2e/check_project_test.ts
+++ b/tests/e2e/check_project_test.ts
@@ -182,6 +182,19 @@ Deno.test("check: formatted project does not emit MSL-F010", async () => {
   assertEquals(code, 0, stderr);
 });
 
+Deno.test("check: uppercase .MD extension is covered by the MSL-F010 drift gate (case parity)", async () => {
+  const { code, stderr } = await markspec(["check"], {
+    files: {
+      ...BASE_FILES,
+      // Uppercase extension + non-canonical prose (asterisk bullet): fmt would
+      // reformat it, so the MSL-F010 gate must also see it — case parity.
+      "docs/OVERVIEW.MD": "# Overview\n\n* asterisk bullet\n",
+    },
+  });
+  assertStringIncludes(stderr, "MSL-F010");
+  assertEquals(code, 1);
+});
+
 Deno.test("check: lockfile edge drift fails with MSL-L212", async () => {
   // 1. Build a project and generate a lockfile that pins its edges.
   const run = await markspecPersist(["lock"], {


### PR DESCRIPTION
## Summary

Three fast-follow fixes from the `/review` of #670 (ADR-029 whole-document Markdown formatting). All harden or correctly scope the markdown pass; none changes the feature's happy path.

## Fixes

**1. Guard the two dprint call sites against WASM formatting errors (was: crash).** `@dprint/formatter`'s `formatText` throws on plugin errors, and neither call site (`emitBodyViaAst` body polish, `formatProseSegments` prose pass) was wrapped — one pathological file would abort a whole `markspec fmt` run and crash `markspec check`. Both now degrade through the existing fallback ladder: keep the original/canonical text, emit the advisory `MSL-F012` (info), continue. The prose path routes a throw through the identical `fallbackStarts` channel a gate-rejection already uses.

**2. Move the "Markdown files only" invariant inside `format()`.** The scope guard lived only at the three call sites (fmt.ts, check.ts, lsp/server.ts); a future caller wiring `formatMarkdownProse` without its own guard would silently reflow a source file's doc comment as Markdown — and the CommonMark-semantic gate cannot catch that class (line-joining is wrap-equivalent as Markdown). `format()` now self-disables the pass unless `options.file` has a Markdown extension (single source of truth via `MARKDOWN_EXTENSIONS`). The call-site guards remain as defense-in-depth. Notably `core/formatter/source.ts` forwards options into `format()` with source-file labels — now safe.

**3. Case-insensitive `.md` match in `check`'s MSL-F010 gate.** `check.ts` used case-sensitive `filePath.endsWith(".md")`, so `README.MD` was reformatted by `fmt` (which lowercases) but never entered the drift gate — `fmt` reported drift while `check` stayed green. Now `MARKDOWN_EXTENSIONS.has(extname(filePath).toLowerCase())`, matching `fmt` and discovery. Pre-existing hole (predates #670), widened by this feature to whole-document prose drift; the RED run confirmed the discovery walk itself already lowercases, so the fix is isolated to `check.ts`.

## Tests

5 new tests, all confirmed RED before implementation:
- `format()` does NOT call the markdown callback for a `.rs` file even when it's wired (+ a `.md` control that proves it still runs).
- A throwing formatter degrades to fallback (entry-body path emits `MSL-F012`; prose-segment path keeps the original) — neither crashes `format()`.
- `check` on `docs/OVERVIEW.MD` (uppercase) fires `MSL-F010` — case parity with `fmt`.

Full `just check` green (pre-push); `deno fmt --check` + `dprint check` clean.

Follow-ups #668 (fenced-example ref-canonicalisation) and #669 (loader hardening: frozen configs, clean load-failure error, LSP MSL-F012 visibility) remain open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
