### PR TITLE
fix(core): harden dprint loader — freeze configs, clean load error, LSP fallback visibility (#669)

### DIFF
--- a/packages/markspec/cli/commands/check.ts
+++ b/packages/markspec/cli/commands/check.ts
@@ -124,7 +124,21 @@ export const checkCmd = new Command()
           parseLockfile,
         } = await import("../../core/mod.ts");
 
-        const formatMarkdownProse = await loadMarkdownFormatter();
+        let formatMarkdownProse: Awaited<
+          ReturnType<typeof loadMarkdownFormatter>
+        >;
+        try {
+          formatMarkdownProse = await loadMarkdownFormatter();
+        } catch (err) {
+          // The embedded dprint-markdown plugin could not be loaded (corrupt
+          // or missing WASM, restricted filesystem). Fail with a clean
+          // message rather than a raw stack trace.
+          const msg = err instanceof Error ? err.message : String(err);
+          console.error(
+            `error: could not load the Markdown formatter: ${msg}`,
+          );
+          Deno.exit(1);
+        }
 
         // Read markspec.lock once: its edge ledger feeds reference healing
         // (MSL-F011) and its cached edge hash feeds the lockfile gate

--- a/packages/markspec/cli/commands/check.ts
+++ b/packages/markspec/cli/commands/check.ts
@@ -8,7 +8,12 @@ import { extname, join } from "@std/path";
 import { Command } from "@cliffy/command";
 import { ConfigError, MARKDOWN_EXTENSIONS } from "../../core/mod.ts";
 import type { CaptionConventions, Diagnostic } from "../../core/mod.ts";
-import { loadActiveProfile, readFile, resolveScope } from "../helpers.ts";
+import {
+  loadActiveProfile,
+  loadMarkdownFormatterOrExit,
+  readFile,
+  resolveScope,
+} from "../helpers.ts";
 
 export const checkCmd = new Command()
   .description("Check broken refs, missing Ids, duplicates")
@@ -120,25 +125,10 @@ export const checkCmd = new Command()
           extractEdgeQuads,
           format,
           hashCanonicalEdges,
-          loadMarkdownFormatter,
           parseLockfile,
         } = await import("../../core/mod.ts");
 
-        let formatMarkdownProse: Awaited<
-          ReturnType<typeof loadMarkdownFormatter>
-        >;
-        try {
-          formatMarkdownProse = await loadMarkdownFormatter();
-        } catch (err) {
-          // The embedded dprint-markdown plugin could not be loaded (corrupt
-          // or missing WASM, restricted filesystem). Fail with a clean
-          // message rather than a raw stack trace.
-          const msg = err instanceof Error ? err.message : String(err);
-          console.error(
-            `error: could not load the Markdown formatter: ${msg}`,
-          );
-          Deno.exit(1);
-        }
+        const formatMarkdownProse = await loadMarkdownFormatterOrExit();
 
         // Read markspec.lock once: its edge ledger feeds reference healing
         // (MSL-F011) and its cached edge hash feeds the lockfile gate

--- a/packages/markspec/cli/commands/fmt.ts
+++ b/packages/markspec/cli/commands/fmt.ts
@@ -7,7 +7,12 @@
 import { Command } from "@cliffy/command";
 import { extname } from "@std/path";
 import type { LockEdge, RefIndex } from "../../core/mod.ts";
-import { loadActiveProfile, readFile, resolveScope } from "../helpers.ts";
+import {
+  loadActiveProfile,
+  loadMarkdownFormatterOrExit,
+  readFile,
+  resolveScope,
+} from "../helpers.ts";
 
 export const fmtCmd = new Command()
   .description("Stamp ULIDs, fix indentation, normalize attributes")
@@ -35,22 +40,8 @@ export const fmtCmd = new Command()
         await loadActiveProfile(projectRoot);
       }
 
-      const { format, loadMarkdownFormatter } = await import(
-        "../../core/mod.ts"
-      );
-      let formatMarkdownProse: Awaited<
-        ReturnType<typeof loadMarkdownFormatter>
-      >;
-      try {
-        formatMarkdownProse = await loadMarkdownFormatter();
-      } catch (err) {
-        // The embedded dprint-markdown plugin could not be loaded (corrupt
-        // or missing WASM, restricted filesystem). Fail with a clean message
-        // rather than a raw stack trace; nothing has been written yet.
-        const msg = err instanceof Error ? err.message : String(err);
-        console.error(`error: could not load the Markdown formatter: ${msg}`);
-        Deno.exit(1);
-      }
+      const { format } = await import("../../core/mod.ts");
+      const formatMarkdownProse = await loadMarkdownFormatterOrExit();
 
       // Project-aware reference canonicalisation/healing (issue #593, Slice 4).
       // Built once and reused for every file. File-local fmt (no project root)

--- a/packages/markspec/cli/commands/fmt.ts
+++ b/packages/markspec/cli/commands/fmt.ts
@@ -38,7 +38,19 @@ export const fmtCmd = new Command()
       const { format, loadMarkdownFormatter } = await import(
         "../../core/mod.ts"
       );
-      const formatMarkdownProse = await loadMarkdownFormatter();
+      let formatMarkdownProse: Awaited<
+        ReturnType<typeof loadMarkdownFormatter>
+      >;
+      try {
+        formatMarkdownProse = await loadMarkdownFormatter();
+      } catch (err) {
+        // The embedded dprint-markdown plugin could not be loaded (corrupt
+        // or missing WASM, restricted filesystem). Fail with a clean message
+        // rather than a raw stack trace; nothing has been written yet.
+        const msg = err instanceof Error ? err.message : String(err);
+        console.error(`error: could not load the Markdown formatter: ${msg}`);
+        Deno.exit(1);
+      }
 
       // Project-aware reference canonicalisation/healing (issue #593, Slice 4).
       // Built once and reused for every file. File-local fmt (no project root)

--- a/packages/markspec/cli/helpers.ts
+++ b/packages/markspec/cli/helpers.ts
@@ -88,6 +88,25 @@ export async function loadActiveProfile(projectRoot: string) {
 }
 
 /**
+ * Load the embedded dprint-markdown formatter, or print a clean CLI error
+ * and exit 1. The plugin can fail to load (corrupt/missing WASM, a
+ * restricted filesystem); a raw stack trace would be user-hostile. Shared
+ * by `fmt` and `check`, which both need the formatter before their
+ * write/gate loop — the load happens before any file is written. Lazily
+ * imports core so subcommands that never format don't pull the plugin in.
+ */
+export async function loadMarkdownFormatterOrExit() {
+  const { loadMarkdownFormatter } = await import("../core/mod.ts");
+  try {
+    return await loadMarkdownFormatter();
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`error: could not load the Markdown formatter: ${msg}`);
+    Deno.exit(1);
+  }
+}
+
+/**
  * Run `git` with the given args and return non-empty, trimmed stdout
  * lines. Returns `[]` on any failure (non-zero exit, `git` absent,
  * permission denied) so callers degrade gracefully instead of throwing.

--- a/packages/markspec/core/formatter/dprint.ts
+++ b/packages/markspec/core/formatter/dprint.ts
@@ -42,21 +42,29 @@ export type ProseFormatter = (
  * "lf" because `format()` operates on a pure-LF buffer and re-applies
  * the file's detected line ending on output.
  */
-export const MARKSPEC_MARKDOWN_GLOBAL_CONFIG: {
+export const MARKSPEC_MARKDOWN_GLOBAL_CONFIG: Readonly<{
   lineWidth: number;
   newLineKind: "lf";
-} = {
+}> = Object.freeze({
   lineWidth: 80,
   newLineKind: "lf",
-};
+});
 
-/** Plugin-level style knobs. See ADR-029 for the rationale per value. */
-export const MARKSPEC_MARKDOWN_PLUGIN_CONFIG: Record<string, unknown> = {
+/** Plugin-level style knobs. See ADR-029 for the rationale per value.
+ *
+ * Frozen: this is the single canonical MarkSpec style, exported through the
+ * public barrel. Freezing stops a consumer from mutating the shared object
+ * after the formatter has already baked these values in at `instantiate()`
+ * (which would drift the entry-body width budget from the whole-document
+ * formatter — see `emitBodyViaAst`). */
+export const MARKSPEC_MARKDOWN_PLUGIN_CONFIG: Readonly<
+  Record<string, unknown>
+> = Object.freeze({
   textWrap: "always",
   emphasisKind: "underscores",
   strongKind: "asterisks",
   unorderedListKind: "dashes",
-};
+});
 
 let cached: Promise<ProseFormatter> | undefined;
 

--- a/packages/markspec/core/formatter/dprint_test.ts
+++ b/packages/markspec/core/formatter/dprint_test.ts
@@ -1,5 +1,17 @@
 import { assertEquals, assertStringIncludes } from "@std/assert";
-import { loadMarkdownFormatter } from "./dprint.ts";
+import {
+  loadMarkdownFormatter,
+  MARKSPEC_MARKDOWN_GLOBAL_CONFIG,
+  MARKSPEC_MARKDOWN_PLUGIN_CONFIG,
+} from "./dprint.ts";
+
+Deno.test("MarkSpec markdown config: the exported style objects are frozen", () => {
+  // The single canonical style is exported through the public barrel;
+  // freezing stops a consumer from mutating it out from under the
+  // already-instantiated formatter (#669).
+  assertEquals(Object.isFrozen(MARKSPEC_MARKDOWN_GLOBAL_CONFIG), true);
+  assertEquals(Object.isFrozen(MARKSPEC_MARKDOWN_PLUGIN_CONFIG), true);
+});
 
 Deno.test("loadMarkdownFormatter: wraps ragged prose at 80 columns", async () => {
   const fmt = await loadMarkdownFormatter();

--- a/packages/markspec/lsp/formatting.ts
+++ b/packages/markspec/lsp/formatting.ts
@@ -54,3 +54,19 @@ export function buildFormattingEdits(
     newText: formattedText,
   }];
 }
+
+/**
+ * Build the one-line editor notice for Markdown-pass fallbacks (MSL-F012):
+ * body or prose segments whose dprint output was rejected/errored and kept
+ * as-is (#669). Returns `undefined` when there were none, so the caller
+ * logs nothing. Pure — the count and wording are unit-testable without a
+ * live LSP connection (mirrors `buildDiagnosticsHistogram`).
+ */
+export function buildF012FallbackMessage(
+  diagnostics: readonly { readonly code: string }[],
+): string | undefined {
+  const n = diagnostics.filter((d) => d.code === "MSL-F012").length;
+  if (n === 0) return undefined;
+  return `markspec: kept the original text for ${n} segment(s) — ` +
+    `the Markdown formatter was not applied (MSL-F012)`;
+}

--- a/packages/markspec/lsp/formatting_test.ts
+++ b/packages/markspec/lsp/formatting_test.ts
@@ -7,7 +7,29 @@
  */
 
 import { assertEquals } from "@std/assert";
-import { buildFormattingEdits } from "./formatting.ts";
+import {
+  buildF012FallbackMessage,
+  buildFormattingEdits,
+} from "./formatting.ts";
+
+Deno.test("buildF012FallbackMessage: undefined when no MSL-F012 diagnostics", () => {
+  assertEquals(buildF012FallbackMessage([]), undefined);
+  assertEquals(
+    buildF012FallbackMessage([{ code: "MSL-F010" }, { code: "MSL-F001" }]),
+    undefined,
+  );
+});
+
+Deno.test("buildF012FallbackMessage: counts only MSL-F012 and names the count", () => {
+  const msg = buildF012FallbackMessage([
+    { code: "MSL-F012" },
+    { code: "MSL-F010" },
+    { code: "MSL-F012" },
+  ]);
+  assertEquals(typeof msg, "string");
+  assertEquals(msg!.includes("2 segment(s)"), true);
+  assertEquals(msg!.includes("MSL-F012"), true);
+});
 
 Deno.test("buildFormattingEdits: unchanged text returns empty array", () => {
   const text = "- [STK_0001] Title\n\n  Body.\n";

--- a/packages/markspec/lsp/server.ts
+++ b/packages/markspec/lsp/server.ts
@@ -60,7 +60,10 @@ import { extendsTransitively } from "../core/profile/discipline_mode.ts";
 import { WorkspaceIndex } from "./workspace.ts";
 import { buildCodeLenses } from "./code_lens.ts";
 import { buildDocumentLinks } from "./document_links.ts";
-import { buildFormattingEdits } from "./formatting.ts";
+import {
+  buildF012FallbackMessage,
+  buildFormattingEdits,
+} from "./formatting.ts";
 import { groupDiagnosticsByFile, toLspDiagnostic } from "./diagnostics.ts";
 import { buildDiagnosticsHistogram } from "./diagnostics_histogram.ts";
 import { buildCodeActions } from "./code_actions.ts";
@@ -1336,10 +1339,22 @@ connection.onDocumentFormatting(async (params) => {
   if (isSourceFile(filePath)) return [];
 
   const currentText = document.getText();
-  const result = format(currentText, {
-    file: filePath,
-    formatMarkdownProse: await loadMarkdownFormatter(),
-  });
+  // If the WASM plugin can't load, degrade to entry-only formatting (ULID
+  // stamping, trailer normalization still apply) rather than failing the
+  // format request — format-on-save keeps working. The loader un-caches a
+  // failed load, so a later request retries.
+  let formatMarkdownProse;
+  try {
+    formatMarkdownProse = await loadMarkdownFormatter();
+  } catch (err) {
+    connection.console.error(
+      `Markdown formatter unavailable — formatting entry blocks only: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+    formatMarkdownProse = undefined;
+  }
+  const result = format(currentText, { file: filePath, formatMarkdownProse });
 
   // Surface Markdown-pass fallbacks (MSL-F012, info): a body or prose
   // segment whose dprint output was rejected/errored and kept as-is. The
@@ -1347,15 +1362,8 @@ connection.onDocumentFormatting(async (params) => {
   // (format-time diagnostics don't flow through publishDiagnostics). One
   // logMessage summary keeps the editor's output channel informed without
   // a toast per save.
-  const fallbackCount = result.diagnostics.filter((d) =>
-    d.code === "MSL-F012"
-  ).length;
-  if (fallbackCount > 0) {
-    connection.console.info(
-      `markspec: kept the original text for ${fallbackCount} ` +
-        `segment(s) — the Markdown formatter was not applied (MSL-F012)`,
-    );
-  }
+  const fallbackNotice = buildF012FallbackMessage(result.diagnostics);
+  if (fallbackNotice) connection.console.info(fallbackNotice);
 
   // On parse failure the formatter returns `output === input` and emits
   // diagnostics via its existing channel — clients see them through the

--- a/packages/markspec/lsp/server.ts
+++ b/packages/markspec/lsp/server.ts
@@ -1341,6 +1341,22 @@ connection.onDocumentFormatting(async (params) => {
     formatMarkdownProse: await loadMarkdownFormatter(),
   });
 
+  // Surface Markdown-pass fallbacks (MSL-F012, info): a body or prose
+  // segment whose dprint output was rejected/errored and kept as-is. The
+  // CLI prints these to stderr; in the editor they would otherwise vanish
+  // (format-time diagnostics don't flow through publishDiagnostics). One
+  // logMessage summary keeps the editor's output channel informed without
+  // a toast per save.
+  const fallbackCount = result.diagnostics.filter((d) =>
+    d.code === "MSL-F012"
+  ).length;
+  if (fallbackCount > 0) {
+    connection.console.info(
+      `markspec: kept the original text for ${fallbackCount} ` +
+        `segment(s) — the Markdown formatter was not applied (MSL-F012)`,
+    );
+  }
+
   // On parse failure the formatter returns `output === input` and emits
   // diagnostics via its existing channel — clients see them through the
   // ordinary publishDiagnostics flow. Returning `null` here would be wrong


### PR DESCRIPTION
Closes #669.

Three small hardening items deferred from the ADR-029 (#649) reviews — none was a correctness bug; all improve robustness/UX around the embedded dprint-markdown loader.

## Changes

1. **Freeze the exported style constants** (`core/formatter/dprint.ts`). `MARKSPEC_MARKDOWN_GLOBAL_CONFIG` / `MARKSPEC_MARKDOWN_PLUGIN_CONFIG` are exported through the public barrel and baked into the formatter once at `instantiate()`. They're now `Object.freeze`d (and typed `Readonly<…>`) so a consumer can't silently mutate the canonical style out from under the running formatter (which would drift the entry-body width budget). Unit test asserts both are frozen.

2. **Clean error on WASM load failure** (`cli/commands/fmt.ts`, `cli/commands/check.ts`). `await loadMarkdownFormatter()` was unguarded — a corrupt/missing plugin surfaced as a raw stack trace. Both now catch and emit the CLI's standard `error: could not load the Markdown formatter: <msg>` + `Deno.exit(1)`. Fails before any file is written (the loader is awaited once, before the write loop).

3. **LSP fallback visibility** (`lsp/server.ts`). `onDocumentFormatting` discarded `result.diagnostics`, so a Markdown-pass fallback (**MSL-F012**, info — note: this code was F011 in the issue title, renamed to F012 when v0.9.0's ref-canon-drift gate took F011) was silent in the editor while the CLI prints it. The handler now emits one `window/logMessage` summary line via `connection.console.info` when any F012 fallback occurred — visible in the editor's output channel, no toast-per-save.

## Testing note

Item 1 has a deterministic unit test. Items 2 and 3 are defensive/observability changes on paths that require a genuine WASM-load failure (item 2) or a real dprint semantic-gate fallback (item 3) to trigger — neither is deterministically reproducible without adding an injection seam that would be more machinery than the fix. They follow the file's existing untested patterns for `console.error`+exit and `connection.console.*` logging. Full `just check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
