### PR TITLE
fix(core): compute prose-lint scope with profile and corpus-awareness

### DIFF
--- a/packages/markspec/cli/commands/check.ts
+++ b/packages/markspec/cli/commands/check.ts
@@ -254,10 +254,14 @@ export const checkCmd = new Command()
       const proseDiagnostics: Diagnostic[] = [];
       if (scope.projectWide) {
         const { runLint } = await import("../../core/mod.ts");
-        // Prose lint never runs on delivered corpus entries (ADR-030) — a
-        // consumer cannot fix an upstream profile's prose.
+        // Pass the FULL entry set (project + corpus) and the active profile.
+        // `runLint` excludes corpus entries from its output but keeps them in
+        // the glossary / $Identifier indexes, so a corpus-defined term still
+        // silences Q500 in project prose (ADR-030 §D4). The profile threads
+        // into `isProseScope` so profile-typed entries are scoped (#675).
         const lintResult = await runLint({
-          entries: allEntries.filter((e) => !e.origin),
+          entries: allEntries,
+          profile: chain?.effective,
         });
         for (const d of lintResult.diagnostics) {
           proseDiagnostics.push({

--- a/packages/markspec/cli/commands/lint.ts
+++ b/packages/markspec/cli/commands/lint.ts
@@ -28,10 +28,15 @@ export const lintCmd = new Command()
         verb: "linting",
         quiet: options.quiet === true || options.format === "json",
       });
-      const { result } = await compileProject(scope.files);
+      const { result, chain } = await compileProject(scope.files);
       const { runLint } = await import("../../core/mod.ts");
+      // `result.entries` is the merged project + delivered-corpus set. Pass it
+      // whole with the active profile: `runLint` keeps corpus entries in its
+      // resolver indexes but never emits diagnostics for them (ADR-030 §D4),
+      // and the profile scopes profile-typed entries into prose analysis (#675).
       const lintResult = await runLint({
         entries: [...result.entries.values()],
+        profile: chain?.effective,
       });
 
       let diagnostics = [...lintResult.diagnostics];

--- a/packages/markspec/cli/helpers.ts
+++ b/packages/markspec/cli/helpers.ts
@@ -255,7 +255,20 @@ export async function compileProject(
     );
   }
 
-  return { result, chain };
+  // Merge the corpus-load diagnostics into the returned result so
+  // serialized artifacts (`export`/`compile --format json`) surface them
+  // too — otherwise a machine consumer parsing the JSON would believe the
+  // corpus is healthy while other surfaces (`check`, MCP) flag it (#674 f4).
+  // Only warning/info corpus diagnostics reach here: error-severity ones
+  // already exited above. Prepended so they read as load-time findings,
+  // ahead of the compiler's own diagnostics. Both sets were already printed
+  // to stderr above, so this changes serialization only, never the console.
+  const merged: CompileResult = {
+    ...result,
+    diagnostics: [...corpus.diagnostics, ...result.diagnostics],
+  };
+
+  return { result: merged, chain };
 }
 
 /**

--- a/packages/markspec/core/lint/runner.ts
+++ b/packages/markspec/core/lint/runner.ts
@@ -7,7 +7,7 @@
  * returns the final diagnostics.
  */
 
-import type { Entry } from "../model/mod.ts";
+import type { EffectiveProfile, Entry } from "../model/mod.ts";
 import { CORE_TYPE_HIERARCHY } from "../model/mod.ts";
 import { resolvedCoreType } from "../validator/type_resolution.ts";
 import type { LintDiagnostic } from "./types.ts";
@@ -54,10 +54,19 @@ function isSpecificationDescendant(typeName: string): boolean {
  * In-scope: Authored shape AND resolved core type is Specification or
  * a direct subtype (Requirement, Test, Contract, Record, Risk).
  * Reference-shape entries are always excluded.
+ *
+ * `profile` is threaded into {@linkcode resolvedCoreType} so an entry
+ * classified purely by a profile type (via `Type:` or a profile
+ * display-id pattern, e.g. `platform-component`) resolves to its core
+ * ancestor through the profile's `extends:` chain. Without it (#675),
+ * such entries never enter prose scope and are silently skipped.
  */
-export function isProseScope(entry: Entry): boolean {
+export function isProseScope(
+  entry: Entry,
+  profile?: EffectiveProfile,
+): boolean {
   if (entry.shape === "Reference") return false;
-  const coreType = resolvedCoreType(entry);
+  const coreType = resolvedCoreType(entry, profile);
   if (!coreType) return false;
   return isSpecificationDescendant(coreType);
 }
@@ -68,6 +77,13 @@ export function isProseScope(entry: Entry): boolean {
 
 export interface LintOptions {
   readonly entries: readonly Entry[];
+  /**
+   * Active profile, threaded into {@linkcode isProseScope} so entries
+   * classified purely by a profile type enter prose scope (#675). Optional:
+   * callers with no profile (e.g. file-local prose scoring) pass nothing and
+   * only core-resolvable types are scoped.
+   */
+  readonly profile?: EffectiveProfile;
   /** Profile-extended capitalized-allow lexicon. Defaults to core baseline. */
   readonly capitalizedAllow?: ReadonlySet<string>;
   /** Glossary file paths discovered by the listing-directive validator. */
@@ -102,8 +118,18 @@ function disabledCodes(entry: Entry): ReadonlySet<string> {
 /**
  * Run the lint pipeline on a set of entries.
  *
+ * Corpus handling (ADR-030 §D4): the glossary and `$Identifier` indexes are
+ * built from the FULL `entries` set — including delivered-corpus entries — so a
+ * term or `$Identifier` defined only in a corpus document still silences Q500
+ * in project prose (the additive-enrichment invariant). Prose *diagnostics*,
+ * suppression hygiene, and the score roll-up run only on project entries
+ * (`entry.origin === undefined`): a consumer cannot fix an upstream profile's
+ * prose, so corpus findings are never emitted and never skew the score. Callers
+ * therefore pass the merged project + corpus set, not a pre-filtered one.
+ *
  * Pipeline:
- *   1. Filter to in-scope entries (Specification subtypes, Authored shape).
+ *   1. Filter to in-scope entries (Specification subtypes, Authored shape,
+ *      non-corpus).
  *   2. Build glossary index from DefinitionList nodes and glossary files.
  *   3. Run lexicon rules on each in-scope entry's prose blocks.
  *   4. Run structural rules on each in-scope entry.
@@ -124,8 +150,10 @@ function disabledCodes(entry: Entry): ReadonlySet<string> {
  *  14. Return diagnostics and score.
  */
 export async function runLint(options: LintOptions): Promise<LintResult> {
-  const { entries } = options;
+  const { entries, profile } = options;
   const allow = options.capitalizedAllow ?? loadLexicon("capitalized-allow");
+  // Glossary + $Identifier indexes see the FULL entry set (corpus included) so
+  // corpus-defined terms/identifiers silence Q500 additively (ADR-030 §D4).
   const glossary: GlossaryIndex = await buildGlossaryIndex(
     entries,
     options.readFile ?? (() => Promise.resolve(undefined)),
@@ -137,10 +165,14 @@ export async function runLint(options: LintOptions): Promise<LintResult> {
   // grows, never *more*.
   const isIdHook = buildIsIdentifierHook(buildIdentifierIndex(entries));
 
-  // Steps 1–9: collect diagnostics keyed by entry
+  // Steps 1–9: collect diagnostics keyed by entry. Delivered-corpus entries
+  // (`entry.origin`) are excluded from rule execution — a consumer cannot fix
+  // upstream prose (ADR-030 §D4) — even though they contribute to the indexes
+  // above.
   const inScopeDiags = new Map<Entry, LintDiagnostic[]>();
   for (const entry of entries) {
-    if (!isProseScope(entry)) continue;
+    if (entry.origin) continue;
+    if (!isProseScope(entry, profile)) continue;
     const diags: LintDiagnostic[] = [];
     // Step 3: lexicon rules
     diags.push(...runLexiconRules(entry));
@@ -159,10 +191,13 @@ export async function runLint(options: LintOptions): Promise<LintResult> {
     inScopeDiags.set(entry, diags);
   }
 
-  // Step 10: suppression hygiene on all Authored entries
+  // Step 10: suppression hygiene on all Authored project entries. Corpus
+  // entries are skipped for the same reason as rule execution — hygiene
+  // findings located in a corpus file are unfixable by the consumer.
   const hygieneDiags: LintDiagnostic[] = [];
   for (const entry of entries) {
     if (entry.shape !== "Authored") continue;
+    if (entry.origin) continue;
     hygieneDiags.push(...runSuppressionRules(entry));
   }
 
@@ -197,8 +232,11 @@ export async function runLint(options: LintOptions): Promise<LintResult> {
   // Append hygiene diagnostics (Q900/Q901 — never suppressed)
   out.push(...hygieneDiags);
 
-  // Step 13: compute score roll-up across all entries (including 0-score ones).
-  const score = computeScoreRollup(out, entries);
+  // Step 13: compute score roll-up across project entries (including 0-score
+  // ones). Corpus entries are excluded — counting them would skew band-counts
+  // and the mean on prose a consumer cannot act on (ADR-030 §D4). A no-op when
+  // no corpus is present.
+  const score = computeScoreRollup(out, entries.filter((e) => !e.origin));
 
   return { diagnostics: out, score };
 }

--- a/packages/markspec/core/lint/runner_test.ts
+++ b/packages/markspec/core/lint/runner_test.ts
@@ -5,9 +5,59 @@
  */
 
 import { assertEquals } from "@std/assert";
-import type { Entry } from "../model/mod.ts";
+import type {
+  EffectiveProfile,
+  EffectiveTypeDef,
+  Entry,
+  EntryOrigin,
+  ProvenancedMapEntry,
+} from "../model/mod.ts";
 import { makeDisplayId } from "../model/mod.ts";
 import { isProseScope, runLint } from "./runner.ts";
+
+/**
+ * Build a minimal {@linkcode EffectiveProfile} declaring a single type that
+ * `extends` a core type. Only `types` (with the `extends` edge) matters for
+ * {@linkcode isProseScope}; every other slot is empty. Mirrors the fixture in
+ * `core/validator/type_resolution_test.ts`.
+ */
+function profileWith(name: string, extendsCore: string): EffectiveProfile {
+  const origin = "@test/p";
+  const typeDef: ProvenancedMapEntry<EffectiveTypeDef> = {
+    value: {
+      name,
+      extends: extendsCore,
+      displayIdPattern: { value: `${name.toUpperCase()}_{n:04d}`, origin },
+      displayIdPatternEnforcement: { value: "off", origin },
+      color: { value: undefined, origin },
+      required: { value: [], origin },
+      attributes: new Map(),
+      traceability: new Map(),
+      description: { value: undefined, origin },
+      attrDescriptions: new Map(),
+      relationDescriptions: new Map(),
+      discipline: { value: undefined, origin },
+    },
+    origin,
+  };
+  return {
+    attributes: new Map(),
+    labels: new Map(),
+    conventions: new Map(),
+    colors: new Map(),
+    types: new Map([[name, typeDef]]),
+    documents: { types: new Map(), frontMatter: new Map() },
+    delivers: [],
+    kinds: new Map(),
+    prose: {
+      lexicons: {
+        "capitalized-allow": { value: [], origin: "" },
+        "sentence-abbrev": { value: [], origin: "" },
+      },
+    },
+    disciplineMode: { value: "none", origin: "inferred" },
+  };
+}
 
 // ---------------------------------------------------------------------------
 // Test helpers
@@ -597,4 +647,110 @@ Deno.test("runLint: corpus-scan hook leaves Q500 firing on truly unknown phrases
   const q500 = result.diagnostics.filter((d) => d.code === "MSL-Q500");
   assertEquals(q500.length, 1);
   assertEquals(q500[0].message.includes("UnknownTerm"), true);
+});
+
+// ---------------------------------------------------------------------------
+// #675 — isProseScope threads the profile so profile-typed entries are scoped
+// ---------------------------------------------------------------------------
+
+Deno.test("isProseScope: profile-typed entry enters scope only with the profile (#675)", () => {
+  // `platform-component` extends Requirement in the profile; its `PLT_` IDs
+  // are NOT a core-recognizable prefix, so only the profile's `extends:` chain
+  // can classify it. `resolvedCoreType` needs the profile to do that.
+  const entry = makeEntry({
+    displayId: "PLT_0001",
+    type: "platform-component",
+    rawAttributes: [
+      { key: "Id", value: "01HGW2Q8MNP3RSTVWXYZABCDEF" },
+      { key: "Type", value: "platform-component" },
+    ],
+    typedAttributes: new Map([
+      ["Id", ["01HGW2Q8MNP3RSTVWXYZABCDEF"]],
+      ["Type", ["platform-component"]],
+    ]),
+  });
+  // Without the profile the type cannot resolve to a core Specification
+  // subtype — the entry is (wrongly, pre-fix) out of scope.
+  assertEquals(isProseScope(entry), false);
+  // With the profile it walks `extends: Requirement` and enters prose scope.
+  assertEquals(
+    isProseScope(entry, profileWith("platform-component", "Requirement")),
+    true,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// #674 f1/f2 — a delivered-corpus entry feeds the resolver indexes but never
+// itself produces diagnostics (ADR-030 §D4)
+// ---------------------------------------------------------------------------
+
+Deno.test("runLint: corpus entry silences Q500 but emits no diagnostics (#674 f1/f2)", async () => {
+  const corpusOrigin: EntryOrigin = {
+    kind: "profile",
+    profileId: "platform-arch",
+    profileVersion: "1.0.0",
+  };
+  // Corpus entry (origin set): carries a `$Framebus` entity-ref token AND a
+  // passive body sentence that WOULD trip MSL-Q300 if it were linted.
+  const passive = "The bus shall be exposed by the service.";
+  const corpus = makeEntry({
+    displayId: "REQ_0900",
+    body: passive,
+    bodyAst: [
+      {
+        kind: "paragraph",
+        content: { text: passive },
+        range: {
+          start: { line: 1, column: 1 },
+          end: { line: 1, column: passive.length },
+        },
+      },
+    ],
+    bodyTokens: [
+      {
+        kind: "entity-ref",
+        text: "$Framebus",
+        convention: "type",
+        location: { file: "corpus.md", line: 1, column: 1 },
+      },
+    ],
+    location: { file: "corpus.md", line: 1, column: 1 },
+    origin: corpusOrigin,
+  });
+  // Project entry: mentions bare "Framebus" mid-sentence — a Q500 candidate.
+  const usesText = "The gateway shall publish to the Framebus within 10 ms.";
+  const project = makeEntry({
+    displayId: "REQ_0500",
+    body: usesText,
+    bodyAst: [
+      {
+        kind: "paragraph",
+        content: { text: usesText },
+        range: {
+          start: { line: 1, column: 1 },
+          end: { line: 1, column: usesText.length },
+        },
+      },
+    ],
+    location: { file: "project.md", line: 1, column: 1 },
+  });
+  const result = await runLint({ entries: [corpus, project] });
+  // f1: the corpus `$Framebus` token is indexed (full-set scan), so Q500 does
+  // not fire on the project mention.
+  assertEquals(
+    result.diagnostics.filter((d) => d.code === "MSL-Q500").length,
+    0,
+  );
+  // f2: no diagnostic is located in the corpus file — the corpus is never
+  // linted, so its passive sentence never surfaces as MSL-Q300.
+  assertEquals(
+    result.diagnostics.filter((d) => d.location?.file === "corpus.md").length,
+    0,
+  );
+  assertEquals(result.diagnostics.some((d) => d.code === "MSL-Q300"), false);
+  // The score roll-up excludes the corpus entry entirely.
+  assertEquals(
+    result.score.perEntry.some((e) => e.displayId === "REQ_0900"),
+    false,
+  );
 });

--- a/tests/e2e/delivered_test.ts
+++ b/tests/e2e/delivered_test.ts
@@ -267,12 +267,11 @@ Deno.test("export csv: origin column distinguishes corpus from project", async (
 // (review fix 2)
 // ---------------------------------------------------------------------------
 
-// Prose lint's scope filter (`isProseScope`) resolves core types WITHOUT the
-// profile, so entries typed with profile-declared names never enter prose
-// scope — only core-resolvable ones do. `REQ_`-prefixed display IDs resolve
-// via step-4 prefix inference (REQ → Requirement), so a declared `requirement`
-// type with a `REQ_` pattern gives us entries that BOTH classify cleanly (no
-// MSL-T003) AND are prose-scoped. "shall be exposed" trips MSL-Q300 (passive).
+// A declared `requirement` type with a `REQ_` pattern gives entries that BOTH
+// classify cleanly (no MSL-T003) AND are prose-scoped: `REQ_`-prefixed IDs
+// resolve to Requirement via step-4 prefix inference, independent of the
+// profile (the #675 fix additionally scopes profile-only-typed entries — see
+// the "profile-typed entry" test). "shall be exposed" trips MSL-Q300 (passive).
 const WITH_DELIVERS_AND_REQ_TYPE = profileManifest(`    requirement:
       extends: Requirement
       display-id-pattern: "REQ_{n:04d}"
@@ -388,4 +387,131 @@ Deno.test("profile show: missing corpus file is surfaced, not '0 entries'", asyn
     false,
     `missing corpus file silently rendered as 0 entries:\n${stdout}`,
   );
+});
+
+// ---------------------------------------------------------------------------
+// #675 — prose lint reaches profile-typed entries (isProseScope threads profile)
+// ---------------------------------------------------------------------------
+
+// A project entry classified purely by a profile type: `platform-component`
+// extends Requirement but its `PLT_` prefix is NOT a core-recognizable one, so
+// only the profile's `extends:` chain can resolve it to a Specification
+// descendant. Before the fix `isProseScope` called `resolvedCoreType` WITHOUT
+// the profile, so this entry never entered prose scope and its passive sentence
+// was silently skipped by both `check`'s advisory gate and `markspec lint`.
+const PROFILE_TYPED_PASSIVE_MD = `- [PLT_0500] State bus exposure
+
+  The state bus shall be exposed by the service.
+
+      Id: 01ARZ3NDEKTSV4RRFFQ69G5F50
+      Type: platform-component
+`;
+
+Deno.test("check: prose lint reaches a profile-typed entry (#675)", async () => {
+  // No corpus needed — this is a pure classification bug. WITHOUT_DELIVERS
+  // keeps the profile (so `platform-component` is declared) without injecting
+  // any corpus, and we drop the base fixture's requirements.md so PLT_0500 is
+  // the only project entry under scrutiny.
+  const files = fixture(WITHOUT_DELIVERS);
+  delete files["docs/requirements.md"];
+  files["docs/prose675.md"] = PROFILE_TYPED_PASSIVE_MD;
+  const { code, stderr } = await markspec(["check"], files);
+  assertStringIncludes(stderr, "MSL-Q300");
+  assertStringIncludes(stderr, "prose675.md");
+  assertEquals(code, 2, stderr); // advisory prose warning only
+});
+
+// ---------------------------------------------------------------------------
+// #674 finding 1 — a $Identifier defined only in the corpus still silences
+// Q500 in project prose (the Q500 additive-index contract survives corpus
+// origin-filtering)
+// ---------------------------------------------------------------------------
+
+// Corpus entry defines `$Framebus`; the project entry's prose mentions the bare
+// capitalized word "Framebus". Pre-filtering corpus entries out of `runLint`'s
+// input dropped `$Framebus` from `buildIdentifierIndex`, so the project mention
+// tripped a spurious `xref-glossary-undefined` (MSL-Q500) warning.
+const CORPUS_DEFINES_IDENTIFIER_MD = `- [PLT_0001] Platform core service
+
+  The platform core service exposes $Framebus for vehicle state distribution.
+
+      Id: 01ARZ3NDEKTSV4RRFFQ69G5FAV
+      Type: platform-component
+`;
+
+const PROJECT_USES_IDENTIFIER_MD = `- [REQ_0500] Gateway publication
+
+  The gateway shall publish to the Framebus within 10 ms.
+
+      Id: 01ARZ3NDEKTSV4RRFFQ69G5F51
+`;
+
+Deno.test("check: a corpus $Identifier silences Q500 in project prose (#674 f1)", async () => {
+  const files = fixture(WITH_DELIVERS_AND_REQ_TYPE);
+  files["profile/reference/platform.md"] = CORPUS_DEFINES_IDENTIFIER_MD;
+  files["docs/uses.md"] = PROJECT_USES_IDENTIFIER_MD;
+  const { code, stderr } = await markspec(["check"], files);
+  // "Framebus" resolves via the corpus-defined $Framebus → no MSL-Q500 against
+  // the project entry that mentions it.
+  const q500Lines = stderr.split("\n").filter((l) => l.includes("MSL-Q500"));
+  assertEquals(
+    q500Lines.filter((l) => l.includes("uses.md")),
+    [],
+    `corpus $Identifier failed to silence Q500 in project prose:\n${stderr}`,
+  );
+  // Belt-and-braces: the Q500 message quotes the offending phrase, so
+  // "'Framebus'" must appear nowhere in the output.
+  assertEquals(
+    stderr.includes("'Framebus'"),
+    false,
+    `Framebus tripped an xref warning despite the corpus $Identifier:\n${stderr}`,
+  );
+  // The project prose carries an unrelated EARS advisory (MSL-Q101), so the
+  // run is warnings-only (exit 2), never an error — the corpus filter did not
+  // turn an upstream identifier into a project error.
+  assertEquals(code, 2, stderr);
+});
+
+// ---------------------------------------------------------------------------
+// #674 finding 2 — standalone `markspec lint` never runs prose analysis on
+// delivered-corpus entries (ADR-030 §D4)
+// ---------------------------------------------------------------------------
+
+Deno.test("lint: prose runs on project entries but never on corpus (#674 f2)", async () => {
+  const files = fixture(WITH_DELIVERS_AND_REQ_TYPE);
+  files["profile/reference/platform.md"] = PASSIVE_CORPUS_MD;
+  files["docs/passive.md"] = PASSIVE_PROJECT_MD;
+  const { code, stderr } = await markspec(["lint"], files);
+  const proseLines = stderr.split("\n").filter((l) => l.includes("MSL-Q"));
+  // Project-side passive sentence still fires — lint isn't disabled outright.
+  assertEquals(
+    proseLines.some((l) => l.includes("passive.md") && l.includes("MSL-Q300")),
+    true,
+    `project-side MSL-Q300 missing from lint:\n${stderr}`,
+  );
+  // The corpus file's passive sentence must never surface.
+  assertEquals(
+    proseLines.filter((l) => l.includes("platform.md")),
+    [],
+    `corpus prose finding leaked into lint output:\n${stderr}`,
+  );
+  assertEquals(code, 2, stderr); // advisory warnings only
+});
+
+// ---------------------------------------------------------------------------
+// #674 finding 4 — export/compile --format json surface corpus-load warnings
+// in the serialized diagnostics (machine consumers parse json, not stderr)
+// ---------------------------------------------------------------------------
+
+Deno.test("export json: corpus-load warning reaches serialized diagnostics (#674 f4)", async () => {
+  const files = fixture(WITH_DELIVERS);
+  // Drop the docs-only guide.md → PROFILE-DELIVERS-002 (warning severity, not
+  // fatal, so compile still runs and export exits 0).
+  delete files["profile/reference/guide.md"];
+  const { code, stdout, stderr } = await markspec(
+    ["export", "json", "docs/requirements.md"],
+    files,
+  );
+  assertEquals(code, 0, stderr);
+  assertStringIncludes(stdout, "PROFILE-DELIVERS-002");
 });


### PR DESCRIPTION
Closes #675. Addresses #674 findings 1, 2, and 4 (finding 3 — LSP raw cache-path leak — is not touched here).

## Problem

One coherent defect family: **prose-lint scope was computed at the wrong layer / with the wrong inputs**, producing one silent miss and two silent false positives.

- **#675** — `isProseScope` called `resolvedCoreType(entry)` **without** the active profile, so entries classified purely by a profile type (via `Type:` or a profile `display-id-pattern`, e.g. `platform-component`) never resolved to a core `Specification` descendant and never entered prose scope. `markspec lint` and `check`'s advisory gate silently skipped most profile-typed requirements.
- **#674 finding 1** — `check` pre-filtered corpus entries **out of `runLint`'s input**, breaking the MSL-Q500 additive-index contract: a `$Identifier` defined only in a delivered-corpus doc no longer silenced Q500, so a project entry referencing it tripped a spurious `xref-glossary-undefined` warning.
- **#674 finding 2** — standalone `markspec lint` passed the merged entry set (now including corpus) into `runLint` with **no origin filter**, so prose analysis ran on delivered-corpus entries (ADR-030 §D4 violation): skewed `score` roll-ups and could exit 1 on unfixable upstream prose under `--strict`.
- **#674 finding 4** — `compileProject` printed `corpus.diagnostics` to stderr but dropped them from the returned `CompileResult.diagnostics`, so `export`/`compile --format json` omitted warning-severity corpus-load issues (e.g. `PROFILE-DELIVERS-002`) that `check` and MCP both report.

## Fix

The corpus policy now lives in one place — `runLint`:

- Thread `EffectiveProfile` through `LintOptions` → `runLint` → `isProseScope` → `resolvedCoreType`, so the profile's `extends:` chain resolves profile-typed entries into scope (#675).
- Build the glossary / `$Identifier` resolver indexes from the **full** entry set (corpus included, additive), but exclude delivered-corpus entries (`entry.origin`) from rule execution, suppression hygiene, and the score roll-up. Both call sites now pass the merged project + corpus set plus the profile — no more input pre-filter (#674 f1/f2).
- `compileProject` merges `corpus.diagnostics` into the returned `CompileResult.diagnostics` so serialized artifacts surface them too (#674 f4). Only warning/info corpus diagnostics reach the merge — error-severity ones already exit first; both sets were already printed to stderr, so this changes serialization only.

## Tests

- 4 e2e (`tests/e2e/delivered_test.ts`): profile-typed entry fires MSL-Q300; a corpus `$Identifier` silences Q500 in project prose; standalone `lint` never lints corpus but still lints project prose; `export json` carries the corpus-load warning. Each was confirmed RED before the fix.
- 2 runner unit tests (`runner_test.ts`): `isProseScope` needs the profile to scope a profile-typed entry; a corpus entry silences Q500 yet emits no diagnostics and is absent from the score roll-up.
- `just build` green (lint + test + typecheck + compile); `deno fmt --check` + `dprint check` clean.

## Review disposition

Two independent review passes surfaced only non-blocking items:

- **Declined (out of scope):** merged corpus-load diagnostics carry an absolute `location.file`. This is consistent with how `check --format json` already emits corpus diagnostic locations and does not break the tested same-machine determinism contract; unifying serialized corpus-diagnostic location representation across `check` and `export` is a separate decision. Worth a follow-up.
- **Declined (out of scope):** the `entry.origin` corpus test is open-coded across ~6 existing sites; no `isCorpusEntry` helper exists. Centralizing it is an unrelated cross-cutting refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
