### PR TITLE
fix(lsp): fence-aware rename/highlights, MSL-R014 for corpus collisions

### DIFF
--- a/packages/markspec/core/mod.ts
+++ b/packages/markspec/core/mod.ts
@@ -367,6 +367,10 @@ export {
 } from "./refs/mod.ts";
 export type { RefIndex } from "./refs/mod.ts";
 
+// ── Fenced-code-block detection (#668/#679/#680) ──────────────────────────
+export { FENCE_RE, isLineFenced, walkProseLines } from "./util/fence.ts";
+export type { ProseLineCallback } from "./util/fence.ts";
+
 // ── External sync model (ADR-022) ────────────────────────────────────────
 export {
   aggregateStatusByState,

--- a/packages/markspec/core/util/fence.ts
+++ b/packages/markspec/core/util/fence.ts
@@ -42,3 +42,24 @@ export function walkProseLines(body: string, cb: ProseLineCallback): void {
     cb(line, i);
   }
 }
+
+/**
+ * Return whether `lineIndex` (0-based) is a line {@linkcode walkProseLines}
+ * would skip — either a fence-marker line itself, or content inside a
+ * fenced block. Single-line-membership counterpart to `walkProseLines`'s
+ * full-body callback walk, for callers that only need a yes/no answer for
+ * one position (e.g. an LSP request gating a cursor position, #680).
+ */
+export function isLineFenced(body: string, lineIndex: number): boolean {
+  const lines = body.split("\n");
+  let inFence = false;
+  for (let i = 0; i <= lineIndex && i < lines.length; i++) {
+    if (FENCE_RE.test(lines[i])) {
+      inFence = !inFence;
+      if (i === lineIndex) return true;
+      continue;
+    }
+    if (i === lineIndex) return inFence;
+  }
+  return false;
+}

--- a/packages/markspec/core/util/fence_test.ts
+++ b/packages/markspec/core/util/fence_test.ts
@@ -8,7 +8,7 @@
  */
 
 import { assertEquals } from "@std/assert";
-import { walkProseLines } from "./fence.ts";
+import { isLineFenced, walkProseLines } from "./fence.ts";
 
 Deno.test("walkProseLines: yields every line when there are no fences", () => {
   const body = "alpha\nbeta\ngamma";
@@ -65,4 +65,54 @@ Deno.test("walkProseLines: empty body yields nothing", () => {
   walkProseLines("", () => calls++);
   // `"".split("\n")` is `[""]`, so one empty line still goes to cb.
   assertEquals(calls, 1);
+});
+
+// --- isLineFenced ---
+
+Deno.test("isLineFenced: false for a plain line outside any fence", () => {
+  const body = ["before", "```", "code", "```", "after"].join("\n");
+  assertEquals(isLineFenced(body, 0), false);
+  assertEquals(isLineFenced(body, 4), false);
+});
+
+Deno.test("isLineFenced: true for content inside a fenced block", () => {
+  const body = ["before", "```", "code", "```", "after"].join("\n");
+  assertEquals(isLineFenced(body, 2), true);
+});
+
+Deno.test("isLineFenced: true for the fence-marker lines themselves", () => {
+  const body = ["before", "```", "code", "```", "after"].join("\n");
+  assertEquals(isLineFenced(body, 1), true);
+  assertEquals(isLineFenced(body, 3), true);
+});
+
+Deno.test("isLineFenced: true for a tilde-fenced line", () => {
+  const body = ["pre", "~~~", "verbatim", "~~~", "post"].join("\n");
+  assertEquals(isLineFenced(body, 2), true);
+});
+
+Deno.test("isLineFenced: agrees with walkProseLines across every line of a document", () => {
+  const body = [
+    "a",
+    "```md",
+    "- [REQ-001] example",
+    "```",
+    "b",
+    "~~~",
+    "c",
+    "~~~",
+    "d",
+  ].join("\n");
+  const skipped = new Set<number>();
+  const lines = body.split("\n");
+  for (let i = 0; i < lines.length; i++) skipped.add(i);
+  walkProseLines(body, (_line, i) => skipped.delete(i));
+  for (let i = 0; i < lines.length; i++) {
+    assertEquals(isLineFenced(body, i), skipped.has(i), `line ${i}`);
+  }
+});
+
+Deno.test("isLineFenced: out-of-range line index returns false", () => {
+  const body = ["a", "b"].join("\n");
+  assertEquals(isLineFenced(body, 99), false);
 });

--- a/packages/markspec/lsp/highlights.ts
+++ b/packages/markspec/lsp/highlights.ts
@@ -11,7 +11,19 @@
  * occurrence is `Read`. This matches the LSP/IDE convention where
  * a "write" highlight marks the symbol's binding location and
  * "read" marks usages.
+ *
+ * `findOccurrencesInFile` scans raw file text rather than parsed
+ * entries, so it must skip fenced code regions itself (#680, same
+ * class as the `core/refs` `canonicalizeRefs` fix in #679/#668) —
+ * otherwise an ID inside an illustrative fenced example gets
+ * highlighted as a `Read` reference to an unrelated real entry. It
+ * reuses `walkProseLines` (`core/util/fence.ts`) rather than
+ * re-implementing the fence toggle. The server separately gates
+ * `onDocumentHighlight` against a fenced cursor position (via
+ * `isLineFenced`) before calling this function.
  */
+
+import { walkProseLines } from "../core/mod.ts";
 
 /** Display-ID character set — letters, digits, dot, slash, hyphen, underscore. */
 const ID_CHAR_RE = /[A-Za-z0-9._/-]/;
@@ -35,6 +47,10 @@ export interface DocumentHighlight {
  * whole-token occurrence of `displayId`. The token at the start of
  * a Markdown list-item bracket (`- [REQ-001]`) is classified as
  * `Write` — it's the declaration. All other matches are `Read`.
+ *
+ * Lines inside a fenced code block (``` or ~~~) are skipped — an
+ * illustrative example that happens to display the same ID as sample
+ * text is not a real reference and must not be highlighted (#680).
  */
 export function findOccurrencesInFile(
   text: string,
@@ -42,9 +58,7 @@ export function findOccurrencesInFile(
 ): DocumentHighlight[] {
   if (displayId.length === 0) return [];
   const out: DocumentHighlight[] = [];
-  const lines = text.split("\n");
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i];
+  walkProseLines(text, (line, i) => {
     let start = 0;
     while (true) {
       const idx = line.indexOf(displayId, start);
@@ -72,6 +86,6 @@ export function findOccurrencesInFile(
       }
       start = idx + displayId.length;
     }
-  }
+  });
   return out;
 }

--- a/packages/markspec/lsp/highlights_test.ts
+++ b/packages/markspec/lsp/highlights_test.ts
@@ -64,6 +64,32 @@ Deno.test("findOccurrencesInFile: empty input yields empty result", () => {
   assertEquals(findOccurrencesInFile("", "REQ-001"), []);
 });
 
+// --- fenced code regions (#680) ---
+
+Deno.test("findOccurrencesInFile: skips an occurrence inside a fenced code example", () => {
+  const text = [
+    `- [REQ-001] Real requirement`,
+    ``,
+    `  Body.`,
+    ``,
+    `\`\`\`markdown`,
+    `- [REQ-001] Illustrative example`,
+    `\`\`\``,
+  ].join("\n");
+  const highlights = findOccurrencesInFile(text, "REQ-001");
+  assertEquals(highlights.length, 1);
+  assertEquals(highlights[0].kind, DocumentHighlightKindWrite);
+});
+
+Deno.test("findOccurrencesInFile: tilde fences are also honored", () => {
+  const text = [
+    `~~~`,
+    `- [REQ-001] Illustrative example`,
+    `~~~`,
+  ].join("\n");
+  assertEquals(findOccurrencesInFile(text, "REQ-001"), []);
+});
+
 Deno.test("findOccurrencesInFile: kind constants are the LSP-defined integers", () => {
   // Spec: Text=1, Read=2, Write=3.
   assertEquals(DocumentHighlightKindText, 1);

--- a/packages/markspec/lsp/references.ts
+++ b/packages/markspec/lsp/references.ts
@@ -16,6 +16,12 @@
  * `displayId` matches the target (the definition site) is also
  * skipped; the LSP server adds it back when the request's
  * `includeDeclaration` is true.
+ *
+ * Unlike `rename.ts` / `highlights.ts`, this module needs no fence
+ * awareness (#680): it walks parsed `Entry.rawAttributes`, never raw
+ * file text, and the AST-based parser never turns a fenced code
+ * example into a real `Entry` in the first place — so illustrative
+ * trailers inside a fence can never surface here.
  */
 
 import type { Entry } from "../core/model/mod.ts";

--- a/packages/markspec/lsp/references_test.ts
+++ b/packages/markspec/lsp/references_test.ts
@@ -9,6 +9,7 @@
 import { assertEquals } from "@std/assert";
 import type { Entry } from "../core/model/mod.ts";
 import { makeDisplayId } from "../core/model/mod.ts";
+import { parseFile } from "../core/mod.ts";
 import { findReferencingEntries } from "./references.ts";
 
 function makeEntry(
@@ -110,4 +111,46 @@ Deno.test("findReferencingEntries: returns empty when no entries reference the t
   ];
   const refs = findReferencingEntries(entries, "REQ-001");
   assertEquals(refs, []);
+});
+
+// --- fenced code regions (#680) ---
+//
+// Unlike rename.ts / highlights.ts, findReferencingEntries needs no
+// fence-tracking of its own: it only ever sees Entry.rawAttributes from
+// the AST-based parser, which never turns a fenced code example into a
+// real Entry in the first place. This test locks in that upstream
+// guarantee through the real parser (not hand-built Entry fixtures) so a
+// future parser change that breaks it is caught here.
+Deno.test("findReferencingEntries: an illustrative fenced example never becomes a phantom reference", async () => {
+  const md = [
+    `- [REQ-001] Real requirement`,
+    ``,
+    `  Body.`,
+    ``,
+    `      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF`,
+    ``,
+    "```markdown",
+    `- [REQ-002] Illustrative example`,
+    ``,
+    `      Satisfies: REQ-001`,
+    "```",
+    ``,
+    `- [REQ-003] Real dependent requirement`,
+    ``,
+    `  Body.`,
+    ``,
+    `      Id: 01HGW2Q8MNP3RSTVWXYZABCDEG`,
+    `      Satisfies: REQ-001`,
+  ].join("\n");
+  const result = await parseFile(md, { file: "guide.md" });
+  // The fenced example never produces a real REQ-002 entry — only REQ-001
+  // and the genuinely later REQ-003 are parsed.
+  assertEquals(
+    result.entries.map((e) => e.displayId).sort(),
+    ["REQ-001", "REQ-003"],
+  );
+  // The real REQ-003 reference is found; the phantom REQ-002 inside the
+  // fence cannot appear — it was never a real Entry to begin with.
+  const refs = findReferencingEntries(result.entries, "REQ-001");
+  assertEquals(refs.map((e) => e.displayId), ["REQ-003"]);
 });

--- a/packages/markspec/lsp/rename.ts
+++ b/packages/markspec/lsp/rename.ts
@@ -9,7 +9,20 @@
  * `REQ-001-extra` — both ends of the token must be at a non-ID
  * character. The ID character set matches the parser's display-ID
  * grammar: letters, digits, `._/-`.
+ *
+ * `findIdOccurrencesInFile` scans raw file text rather than parsed
+ * entries, so it must skip fenced code regions itself (#680, same
+ * class as the `core/refs` `canonicalizeRefs` fix in #679/#668) —
+ * otherwise renaming a real entry also rewrites the ID inside an
+ * illustrative fenced example that merely reuses the same text. It
+ * reuses `walkProseLines` (`core/util/fence.ts`) rather than
+ * re-implementing the fence toggle. `prepareRenameRange` stays
+ * single-line and fence-unaware by design — the server gates
+ * `onPrepareRename` against a fenced cursor position separately (via
+ * `isLineFenced`) using the full document text it already has.
  */
+
+import { walkProseLines } from "../core/mod.ts";
 
 /** A subset of the LSP `TextEdit` interface. */
 export interface TextEdit {
@@ -79,6 +92,10 @@ export function prepareRenameRange(
  * convention). Each occurrence's range covers only the `oldId`
  * characters — the editor uses the textual replacement to perform
  * the rename, so the range must be exact.
+ *
+ * Lines inside a fenced code block (``` or ~~~) are skipped — an
+ * illustrative example that happens to display the same ID as sample
+ * text is not a real reference and must not be rewritten (#680).
  */
 export function findIdOccurrencesInFile(
   text: string,
@@ -87,9 +104,7 @@ export function findIdOccurrencesInFile(
 ): TextEdit[] {
   if (oldId.length === 0) return [];
   const edits: TextEdit[] = [];
-  const lines = text.split("\n");
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i];
+  walkProseLines(text, (line, i) => {
     let start = 0;
     while (true) {
       const idx = line.indexOf(oldId, start);
@@ -111,6 +126,6 @@ export function findIdOccurrencesInFile(
       }
       start = idx + oldId.length;
     }
-  }
+  });
   return edits;
 }

--- a/packages/markspec/lsp/rename_test.ts
+++ b/packages/markspec/lsp/rename_test.ts
@@ -71,6 +71,50 @@ Deno.test("findIdOccurrencesInFile: no match yields empty result", () => {
   assertEquals(findIdOccurrencesInFile(text, "REQ-001", "REQ-100"), []);
 });
 
+// --- fenced code regions (#680) ---
+
+Deno.test("findIdOccurrencesInFile: skips an occurrence inside a fenced code example", () => {
+  const text = [
+    `- [REQ-001] Real requirement`,
+    ``,
+    `  Body.`,
+    ``,
+    `\`\`\`markdown`,
+    `- [REQ-001] Illustrative example`,
+    `\`\`\``,
+  ].join("\n");
+  const edits = findIdOccurrencesInFile(text, "REQ-001", "REQ-100");
+  assertEquals(edits.length, 1);
+  assertEquals(edits[0].range.start.line, 0);
+});
+
+Deno.test("findIdOccurrencesInFile: renames occurrences before and after a fenced example", () => {
+  const text = [
+    `- [REQ-001] Real requirement`,
+    ``,
+    `\`\`\`markdown`,
+    `      Satisfies: REQ-001`,
+    `\`\`\``,
+    ``,
+    `- [REQ-002] Other`,
+    ``,
+    `      Satisfies: REQ-001`,
+  ].join("\n");
+  const edits = findIdOccurrencesInFile(text, "REQ-001", "REQ-100");
+  assertEquals(edits.length, 2);
+  assertEquals(edits[0].range.start.line, 0);
+  assertEquals(edits[1].range.start.line, 8);
+});
+
+Deno.test("findIdOccurrencesInFile: tilde fences are also honored", () => {
+  const text = [
+    `~~~`,
+    `- [REQ-001] Illustrative example`,
+    `~~~`,
+  ].join("\n");
+  assertEquals(findIdOccurrencesInFile(text, "REQ-001", "REQ-100"), []);
+});
+
 // --- prepareRenameRange ---
 
 Deno.test("prepareRenameRange: returns range + placeholder when cursor is on a display ID", () => {

--- a/packages/markspec/lsp/server.ts
+++ b/packages/markspec/lsp/server.ts
@@ -45,6 +45,7 @@ import {
   type Entry,
   filterEntriesByTraceTargets,
   format,
+  isLineFenced,
   loadConfig,
   loadDeliveredCorpus,
   loadMarkdownFormatter,
@@ -1289,6 +1290,11 @@ connection.onPrepareRename((params) => {
       return null;
     }
   }
+  // A token inside a fenced illustrative example is not a live reference
+  // (#680) — findIdOccurrencesInFile would exclude it from the rename's
+  // edits anyway, so reject the rename here rather than opening an input
+  // box for a token that silently won't change.
+  if (isLineFenced(document.getText(), params.position.line)) return null;
 
   const line = document.getText({
     start: { line: params.position.line, character: 0 },
@@ -1511,6 +1517,11 @@ connection.onDocumentHighlight((params) => {
       return null;
     }
   }
+  // A token inside a fenced illustrative example is not a live reference
+  // (#680) — findOccurrencesInFile would exclude it from the results
+  // anyway, which would otherwise light up unrelated real occurrences
+  // elsewhere while leaving the cursor's own token dark.
+  if (isLineFenced(document.getText(), params.position.line)) return null;
 
   const line = document.getText({
     start: { line: params.position.line, character: 0 },

--- a/packages/markspec/lsp/workspace.ts
+++ b/packages/markspec/lsp/workspace.ts
@@ -12,7 +12,13 @@ import type {
   EffectiveProfile,
   Entry,
 } from "../core/mod.ts";
-import { parseFile, suppressDeclaredAttrR010, validate } from "../core/mod.ts";
+import {
+  attributeCorpusDiagnostics,
+  detectCorpusCollisions,
+  parseFile,
+  suppressDeclaredAttrR010,
+  validate,
+} from "../core/mod.ts";
 import { buildTypeRegistry, type TypeRegistry } from "../core/typl/mod.ts";
 
 /** A display ID paired with its entry title, for completion items. */
@@ -253,11 +259,34 @@ export class WorkspaceIndex {
    * When `profile` is supplied, core-only MSL-R010 "unknown attribute"
    * warnings are suppressed for attributes the profile declares — matching
    * the `validate` command so the editor doesn't flood with false positives.
+   *
+   * Corpus-aware post-pass (ADR-030), mirroring `check`/`compile`: a
+   * project entry re-declaring a display ID or Id already delivered by
+   * the corpus becomes MSL-R014 instead of the generic MSL-R005/R006/
+   * I007/I008 duplicate codes, whose message would otherwise embed the
+   * corpus entry's raw `.markspec/cache/…` location (#674 finding 3).
+   * `detectCorpusCollisions`/`attributeCorpusDiagnostics` no-op when no
+   * corpus was seeded. Diagnostics located in a corpus file (including
+   * the corpus↔corpus branch of MSL-R014) are still filtered out at
+   * publish time by the server's `corpusFilePaths` guard.
    */
   validateAll(profile: EffectiveProfile | null = null): readonly Diagnostic[] {
     const allEntries = this.getAllEntries();
     const result = validate(allEntries);
-    return suppressDeclaredAttrR010(result.diagnostics, allEntries, profile);
+    const suppressed = suppressDeclaredAttrR010(
+      result.diagnostics,
+      allEntries,
+      profile,
+    );
+    const collisions = detectCorpusCollisions(allEntries);
+    return [
+      ...attributeCorpusDiagnostics(
+        suppressed,
+        allEntries,
+        collisions.collidedTokens,
+      ),
+      ...collisions.diagnostics,
+    ];
   }
 
   // -----------------------------------------------------------------------

--- a/packages/markspec/lsp/workspace_test.ts
+++ b/packages/markspec/lsp/workspace_test.ts
@@ -334,3 +334,37 @@ Deno.test("WorkspaceIndex: corpus seeded first owns colliding display IDs", asyn
   const owner = index.getEntryByDisplayId(makeDisplayId("PLT_0001"));
   assertEquals(owner?.origin?.profileId, "p");
 });
+
+Deno.test("WorkspaceIndex: validateAll reports a project/corpus collision as MSL-R014, not a raw-cache-path MSL-R006 (#674 finding 3)", async () => {
+  const CORPUS_CACHE_PATH = "/repo/.markspec/cache/abc123sha/ref.md";
+  const index = new WorkspaceIndex();
+  await index.parseAndUpdateFile(CORPUS_CACHE_PATH, CORPUS_MD); // corpus fixture
+  // Simulate origin stamping the server applies on seed:
+  index.updateFile(
+    CORPUS_CACHE_PATH,
+    index.getEntriesForFile(CORPUS_CACHE_PATH).map((e) => ({
+      ...e,
+      origin: { kind: "profile", profileId: "p", profileVersion: "1.0.0" },
+    })),
+  );
+  await index.parseAndUpdateFile("/repo/a.md", PROJECT_MD_WITH_SAME_ID);
+
+  const diags = index.validateAll();
+
+  // The collision surfaces as MSL-R014, located at the project entry that
+  // re-declared the corpus-owned display ID.
+  const r014 = diags.filter((d) => d.code === "MSL-R014");
+  assertEquals(r014.length > 0, true);
+  assertEquals(r014.every((d) => d.location?.file === "/repo/a.md"), true);
+
+  // The generic duplicate codes — whose message embeds the corpus entry's
+  // raw file location — are suppressed in favor of MSL-R014.
+  assertEquals(diags.some((d) => d.code === "MSL-R006"), false);
+  assertEquals(diags.some((d) => d.code === "MSL-I008"), false);
+
+  // No diagnostic anywhere leaks the corpus entry's raw cache path.
+  assertEquals(
+    diags.some((d) => d.message.includes(CORPUS_CACHE_PATH)),
+    false,
+  );
+});


### PR DESCRIPTION
Closes #680.

## Summary

- `findIdOccurrencesInFile` (rename) and `findOccurrencesInFile` (document highlights) now skip fenced illustrative examples, mirroring the #679 `core/refs` fence fix — renaming a real entry or highlighting its occurrences no longer touches sample IDs shown in fenced code examples in spec/guide docs.
- Closed a gap the original fix left open: `onPrepareRename`/`onDocumentHighlight` in `server.ts` were still fence-blind, so a rename/highlight could be initiated from a fenced-example token and silently produce no edit/highlight there while still acting on unrelated real occurrences elsewhere. Both are now gated by a new `core/util/fence.ts` `isLineFenced` helper.
- Both scanners now reuse the existing `walkProseLines` combinator instead of hand-rolling the fence toggle a third time.
- `references.ts` needed no change — it walks parsed `Entry.rawAttributes`, and the AST-based parser never turns a fenced example into a real `Entry` in the first place. Added a regression test (via the real parser) that locks this invariant in, rather than adding no-op fence logic.
- `WorkspaceIndex.validateAll` now runs `detectCorpusCollisions`/`attributeCorpusDiagnostics`, mirroring `check`/`compile`. A project entry that re-declares a corpus-delivered display ID now surfaces as clean `MSL-R014` instead of leaking the corpus entry's raw `.markspec/cache/...` path via `MSL-R006` — addresses the LSP item in #674's finding 3 (other items in that follow-up bundle remain open, tracked separately).

## Test plan

- [x] `just build` (lint + 3443 unit/e2e tests + typecheck + compile) — green
- [x] `deno fmt --check` / `dprint check` — clean
- [x] New unit tests added/extended: `core/util/fence_test.ts` (`isLineFenced`), `lsp/rename_test.ts`, `lsp/highlights_test.ts`, `lsp/references_test.ts`, `lsp/workspace_test.ts`
- [x] Confirmed the `MSL-R014` fix is red→green: reverted `workspace.ts`'s `validateAll` while keeping the new test and confirmed it fails, then restored the fix
- [x] Ran `/code-review` (8 finder angles + verification) against the diff; fixed all CONFIRMED findings (the `prepareRename`/`documentHighlight` fence gap, and the `walkProseLines` reuse); documented two findings as intentionally deferred (mismatched fence-marker-type edge case — matches already-shipped #679 behavior; a shared `applyCorpusPostPass` helper across `compiler.ts`/`check.ts`/`workspace.ts` — out of scope, noted as follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
