### PR TITLE
refactor(core): lift check gate blocks into pure core/gates stages

### DIFF
--- a/packages/markspec/cli/commands/check.ts
+++ b/packages/markspec/cli/commands/check.ts
@@ -149,17 +149,15 @@ export const checkCmd = new Command()
 
       // Project-wide-only gates (the composite `check` gate). A file-local
       // `check <file>` stays a fast structural check, and the canonical agent
-      // path runs `fmt` before `check`.
-      const fmtDiagnostics: Diagnostic[] = [];
-      const lockDiagnostics: Diagnostic[] = [];
+      // path runs `fmt` before `check`. The diagnostic-producing computation
+      // lives in `core/gates`; the command only gathers inputs (the loaded
+      // Markdown formatter, the parsed lockfile) and calls the stages.
+      let fmtDiagnostics: Diagnostic[] = [];
+      let lockDiagnostics: Diagnostic[] = [];
       if (scope.projectWide) {
-        const {
-          buildRefIndex,
-          canonicalizeRefs,
-          detectOfflineEdgeDrift,
-          format,
-          parseLockfile,
-        } = await import("../../core/mod.ts");
+        const { fmtDriftGate, lockfileDriftGate, parseLockfile } = await import(
+          "../../core/mod.ts"
+        );
 
         const formatMarkdownProse = await loadMarkdownFormatterOrExit();
 
@@ -175,102 +173,28 @@ export const checkCmd = new Command()
         }
         const ledger = lockParse?.lockfile?.edges ?? [];
 
-        // Gate: fmt drift. Runs the SAME `format() → parse → canonicalizeRefs`
-        // sequence `markspec fmt` performs, from the same exclude-aware corpus,
-        // so bare `check` and `fmt --check` never disagree. `MSL-F010` is pure
-        // formatter drift; `MSL-F011` is reference-canonicalization drift (a
-        // ULID or stale display ID `fmt` would rewrite) — kept distinct so the
-        // author knows which fmt concern fired. Markdown only — `markspec fmt`
-        // never rewrites source files.
-        const refIndex = buildRefIndex(allEntries);
-        for (const [filePath, content] of mdContents) {
-          const formatted = format(content, {
-            file: filePath,
-            formatMarkdownProse,
-          });
-          if (formatted.changed) {
-            fmtDiagnostics.push({
-              code: "MSL-F010",
-              severity: "error",
-              message: "file is not formatted (run `markspec fmt`)",
-              location: { file: filePath, line: 1, column: 1 },
-            });
-          }
-          const parsed = await parseFile(formatted.output, { file: filePath });
-          const refResult = canonicalizeRefs(
-            formatted.output,
-            parsed.entries,
-            refIndex,
-            ledger,
-          );
-          if (refResult.changed) {
-            fmtDiagnostics.push({
-              code: "MSL-F011",
-              severity: "error",
-              message: "references are not canonical (run `markspec fmt`)",
-              location: { file: filePath, line: 1, column: 1 },
-            });
-          }
-        }
+        fmtDiagnostics = await fmtDriftGate(
+          mdContents,
+          allEntries,
+          ledger,
+          formatMarkdownProse,
+        );
 
-        // Gate: lockfile (needs the full corpus to recompute the canonical
-        // edge hash). Offline by design — upstream resolution (network) stays
-        // in `markspec lock --check`.
         if (lockParse !== undefined && lockPath !== undefined) {
-          if (!lockParse.lockfile) {
-            lockDiagnostics.push(...lockParse.diagnostics);
-          } else {
-            // Corpus-blind by design: the lockfile is not corpus-aware yet
-            // (ADR-030 defers lockfile integration), so `markspec lock`
-            // never counts corpus edges. Counting them here would raise an
-            // MSL-L212 drift error that `markspec lock` can never fix —
-            // consumer gates must not fail on upstream content the consumer
-            // cannot re-lock.
-            const projectEntries = allEntries.filter((e) => !e.origin);
-            const drift = await detectOfflineEdgeDrift(
-              projectEntries,
-              lockParse.lockfile.generatedCache,
-            );
-            if (drift.drifted) {
-              lockDiagnostics.push({
-                code: "MSL-L212",
-                severity: "error",
-                message:
-                  `traceability edges drifted from markspec.lock: locked ${drift.lockedCount} edge(s), current ${drift.currentCount} — run \`markspec lock\` to refresh. (After upgrading MarkSpec this can also fire once because traceability inputs now include source-file doc comments; re-running \`markspec lock\` clears it.)`,
-                location: { file: lockPath, line: 1, column: 1 },
-              });
-            }
-          }
+          lockDiagnostics = await lockfileDriftGate(
+            lockParse,
+            lockPath,
+            allEntries,
+          );
         }
       }
 
       // Gate: prose lint (project-wide only, advisory — warnings/info
-      // unless --strict). LintDiagnostic carries slug/group/score fields
-      // that must not leak into check's stable JSON schema — project to
-      // plain Diagnostic. `runLint`'s `readFile` option is typed for
-      // glossary-file indexing (`FileReader`, distinct from the CLI's
-      // `ReadFile`) and is only needed when `glossaryFilePaths` is
-      // supplied; omitted here since `check` passes none.
-      const proseDiagnostics: Diagnostic[] = [];
+      // unless --strict).
+      let proseDiagnostics: Diagnostic[] = [];
       if (scope.projectWide) {
-        const { runLint } = await import("../../core/mod.ts");
-        // Pass the FULL entry set (project + corpus) and the active profile.
-        // `runLint` excludes corpus entries from its output but keeps them in
-        // the glossary / $Identifier indexes, so a corpus-defined term still
-        // silences Q500 in project prose (ADR-030 §D4). The profile threads
-        // into `isProseScope` so profile-typed entries are scoped (#675).
-        const lintResult = await runLint({
-          entries: allEntries,
-          profile: chain?.effective,
-        });
-        for (const d of lintResult.diagnostics) {
-          proseDiagnostics.push({
-            code: d.code,
-            severity: d.severity,
-            message: d.message,
-            location: d.location,
-          });
-        }
+        const { proseLintGate } = await import("../../core/mod.ts");
+        proseDiagnostics = await proseLintGate(allEntries, chain?.effective);
       }
 
       // Merge parse-level (MSL-P0xx), corpus-load, pipeline, listing,

--- a/packages/markspec/core/gates/mod.ts
+++ b/packages/markspec/core/gates/mod.ts
@@ -1,0 +1,162 @@
+/**
+ * @module core/gates
+ *
+ * Composite-`check` gate stages (ADR-027). Each function is a pure,
+ * independently-testable transformation from already-gathered inputs to a
+ * `Diagnostic[]`; the CLI `check` command orchestrates them (gather inputs →
+ * call stages → merge diagnostics → render) and owns the scope policy that
+ * decides whether they run at all (project-wide only).
+ *
+ * Extracted from `cli/commands/check.ts` (#659) so the diagnostic-producing
+ * logic lives in `core` — composable, unit-testable in isolation, and reusable
+ * by future surfaces — rather than inline in the command body. The command
+ * keeps the I/O it must do (loading the Markdown prose formatter, reading
+ * `markspec.lock`) and feeds the results in.
+ *
+ * `gates` is a top-level composition layer: it depends on `formatter`,
+ * `parser`, `refs`, `lock`, and `lint`, and nothing in those depends back on
+ * it — no cycle.
+ */
+
+import type { Diagnostic, EffectiveProfile, Entry } from "../model/mod.ts";
+import { format } from "../formatter/mod.ts";
+import type { ProseFormatter } from "../formatter/dprint.ts";
+import { parseFile } from "../parser/mod.ts";
+import { buildRefIndex, canonicalizeRefs } from "../refs/mod.ts";
+import {
+  detectOfflineEdgeDrift,
+  type LockEdge,
+  type ParseLockfileResult,
+} from "../lock/mod.ts";
+import { runLint } from "../lint/mod.ts";
+
+/**
+ * Format-drift gate — the `MSL-F010` (formatter drift) and `MSL-F011`
+ * (reference-canonicalization drift) findings.
+ *
+ * Runs the SAME `format() → parse → canonicalizeRefs` sequence `markspec fmt`
+ * performs, from the same exclude-aware corpus, so bare `check` and
+ * `fmt --check` never disagree on what "formatted" means. `MSL-F010` is pure
+ * formatter drift; `MSL-F011` is reference-canonicalization drift (a ULID or
+ * stale display ID `fmt` would rewrite) — kept distinct so the author knows
+ * which fmt concern fired. Markdown only — `markspec fmt` never rewrites source
+ * files, so the caller passes only Markdown file contents.
+ *
+ * @param mdContents Markdown file path → current on-disk content.
+ * @param entries The full parsed entry set (project + corpus), used to build
+ *   the reference index `canonicalizeRefs` heals against.
+ * @param ledger The lockfile's `[[edge]]` ULID ledger (`lockfile.edges`, or
+ *   `[]` when there is no lockfile), threaded into `canonicalizeRefs`.
+ * @param formatMarkdownProse The loaded ADR-029 whole-document Markdown
+ *   formatter, or `undefined` to degrade to entry-only formatting.
+ */
+export async function fmtDriftGate(
+  mdContents: ReadonlyMap<string, string>,
+  entries: readonly Entry[],
+  ledger: readonly LockEdge[],
+  formatMarkdownProse: ProseFormatter | undefined,
+): Promise<Diagnostic[]> {
+  const diagnostics: Diagnostic[] = [];
+  const refIndex = buildRefIndex(entries);
+  for (const [filePath, content] of mdContents) {
+    const formatted = format(content, {
+      file: filePath,
+      formatMarkdownProse,
+    });
+    if (formatted.changed) {
+      diagnostics.push({
+        code: "MSL-F010",
+        severity: "error",
+        message: "file is not formatted (run `markspec fmt`)",
+        location: { file: filePath, line: 1, column: 1 },
+      });
+    }
+    const parsed = await parseFile(formatted.output, { file: filePath });
+    const refResult = canonicalizeRefs(
+      formatted.output,
+      parsed.entries,
+      refIndex,
+      ledger,
+    );
+    if (refResult.changed) {
+      diagnostics.push({
+        code: "MSL-F011",
+        severity: "error",
+        message: "references are not canonical (run `markspec fmt`)",
+        location: { file: filePath, line: 1, column: 1 },
+      });
+    }
+  }
+  return diagnostics;
+}
+
+/**
+ * Lockfile-drift gate — the `MSL-L212` offline traceability-edge drift finding.
+ *
+ * A malformed lockfile surfaces the parser's own diagnostics unchanged. An
+ * intact lockfile is compared against the current graph's canonical edge hash.
+ * Offline by design — upstream resolution (network) stays in
+ * `markspec lock --check`.
+ *
+ * Corpus-blind by design: the lockfile is not corpus-aware yet (ADR-030 defers
+ * lockfile integration), so `markspec lock` never counts corpus edges. Counting
+ * them here would raise an `MSL-L212` drift error that `markspec lock` can never
+ * fix — a consumer gate must not fail on upstream content the consumer cannot
+ * re-lock. The gate therefore filters to project-owned entries (`!e.origin`),
+ * mirroring `markspec lock`.
+ *
+ * @param lockParse The parsed `markspec.lock` (already read from disk).
+ * @param lockPath Absolute path to `markspec.lock`, used as the diagnostic
+ *   location so JSON consumers that group by `location.file` keep the finding.
+ * @param entries The full parsed entry set; corpus entries are filtered out.
+ */
+export async function lockfileDriftGate(
+  lockParse: ParseLockfileResult,
+  lockPath: string,
+  entries: readonly Entry[],
+): Promise<Diagnostic[]> {
+  if (!lockParse.lockfile) {
+    return [...lockParse.diagnostics];
+  }
+  const projectEntries = entries.filter((e) => !e.origin);
+  const drift = await detectOfflineEdgeDrift(
+    projectEntries,
+    lockParse.lockfile.generatedCache,
+  );
+  if (!drift.drifted) return [];
+  return [{
+    code: "MSL-L212",
+    severity: "error",
+    message:
+      `traceability edges drifted from markspec.lock: locked ${drift.lockedCount} edge(s), current ${drift.currentCount} — run \`markspec lock\` to refresh. (After upgrading MarkSpec this can also fire once because traceability inputs now include source-file doc comments; re-running \`markspec lock\` clears it.)`,
+    location: { file: lockPath, line: 1, column: 1 },
+  }];
+}
+
+/**
+ * Prose-lint gate — the advisory `MSL-Q` prose-analysis findings, projected to
+ * plain {@linkcode Diagnostic}s.
+ *
+ * Pass the FULL entry set (project + corpus) and the active profile.
+ * {@linkcode runLint} excludes corpus entries from its output but keeps them in
+ * the glossary / `$Identifier` indexes, so a corpus-defined term still silences
+ * Q500 in project prose (ADR-030 §D4). The profile threads into `isProseScope`
+ * so profile-typed entries are scoped (#675).
+ *
+ * `runLint`'s {@linkcode LintDiagnostic} carries `slug`/`group`/`score` fields
+ * that must not leak into `check`'s stable JSON schema — the result is projected
+ * to plain {@linkcode Diagnostic}. `runLint`'s `readFile` option (for glossary
+ * file indexing) is not needed here: `check` passes no `glossaryFilePaths`.
+ */
+export async function proseLintGate(
+  entries: readonly Entry[],
+  profile: EffectiveProfile | undefined,
+): Promise<Diagnostic[]> {
+  const lintResult = await runLint({ entries, profile });
+  return lintResult.diagnostics.map((d) => ({
+    code: d.code,
+    severity: d.severity,
+    message: d.message,
+    location: d.location,
+  }));
+}

--- a/packages/markspec/core/gates/mod_test.ts
+++ b/packages/markspec/core/gates/mod_test.ts
@@ -1,0 +1,198 @@
+/**
+ * @module core/gates/mod_test
+ *
+ * Unit tests for the composite-`check` gate stages (#659). The gates are pure
+ * functions over already-gathered inputs; these tests exercise each branch in
+ * isolation. The end-to-end wiring (scope policy, merge order, `--strict`,
+ * exit codes) is covered by `tests/e2e/check_project_test.ts`.
+ */
+
+import { assertEquals } from "@std/assert";
+import { format } from "../formatter/mod.ts";
+import { parseFile } from "../parser/mod.ts";
+import {
+  extractEdgeQuads,
+  type GeneratedCache,
+  hashCanonicalEdges,
+  type Lockfile,
+  parseLockfile,
+  type ParseLockfileResult,
+} from "../lock/mod.ts";
+import { fmtDriftGate, lockfileDriftGate, proseLintGate } from "./mod.ts";
+
+// ---------------------------------------------------------------------------
+// fmtDriftGate
+// ---------------------------------------------------------------------------
+
+const CLEAN_REQ = `# Requirements
+
+- [REQ-0001] Response time
+
+  The system shall respond within 200 ms.
+
+      Id: 01REQ000000000000000000001
+      Type: Requirement
+`;
+
+Deno.test("fmtDriftGate: a formatter-clean file emits nothing", async () => {
+  // Feed the formatter's own output back so it is clean by construction.
+  const formatted = format(CLEAN_REQ, { file: "req.md" }).output;
+  const parsed = await parseFile(formatted, { file: "req.md" });
+  const diags = await fmtDriftGate(
+    new Map([["req.md", formatted]]),
+    parsed.entries,
+    [],
+    undefined,
+  );
+  assertEquals(diags, []);
+});
+
+Deno.test("fmtDriftGate: a file missing Id: fails with MSL-F010", async () => {
+  const content = `# Doc
+
+- [REQ-0002] Unformatted
+
+  The system shall respond within 200 ms.
+
+      Type: Requirement
+`;
+  const parsed = await parseFile(content, { file: "u.md" });
+  const diags = await fmtDriftGate(
+    new Map([["u.md", content]]),
+    parsed.entries,
+    [],
+    undefined,
+  );
+  assertEquals(diags.some((d) => d.code === "MSL-F010"), true);
+});
+
+Deno.test("fmtDriftGate: a non-canonical ULID reference fails with MSL-F011, not F010", async () => {
+  // REQ-0001 declares ULID 01REQ...001; SREQ-0001 references it *by ULID*.
+  // The SREQ file is formatter-clean (no F010) but canonicalizeRefs would
+  // rewrite the ULID to the display ID REQ-0001 (F011).
+  const reqFormatted = format(CLEAN_REQ, { file: "req.md" }).output;
+  const sreq = format(
+    `# System Requirements
+
+- [SREQ-0001] Derived response time
+
+  The system shall forward responses within 100 ms.
+
+      Id: 01SREQ00000000000000000001
+      Type: Requirement
+      Satisfies: 01REQ000000000000000000001
+`,
+    { file: "sreq.md" },
+  ).output;
+
+  const reqEntries = (await parseFile(reqFormatted, { file: "req.md" }))
+    .entries;
+  const sreqEntries = (await parseFile(sreq, { file: "sreq.md" })).entries;
+
+  const diags = await fmtDriftGate(
+    new Map([["sreq.md", sreq]]),
+    [...reqEntries, ...sreqEntries],
+    [],
+    undefined,
+  );
+  assertEquals(diags.some((d) => d.code === "MSL-F011"), true);
+  assertEquals(diags.some((d) => d.code === "MSL-F010"), false);
+});
+
+// ---------------------------------------------------------------------------
+// lockfileDriftGate
+// ---------------------------------------------------------------------------
+
+/** Minimal intact lockfile carrying only the fields the gate reads. */
+function lockfileWithCache(cache: GeneratedCache): Lockfile {
+  return {
+    schema: 1,
+    meta: { markspecSchema: 1, lockedAt: "2026-01-01T00:00:00Z" },
+    upstreams: [],
+    boundEntries: [],
+    edges: [],
+    generatedCache: cache,
+  };
+}
+
+const SATISFIES_GRAPH = `# Requirements
+
+- [REQ-0001] Response time
+
+  The system shall respond within 200 ms.
+
+      Id: 01REQ000000000000000000001
+      Type: Requirement
+
+- [SREQ-0001] Derived response time
+
+  The system shall forward responses within 100 ms.
+
+      Id: 01SREQ00000000000000000001
+      Type: Requirement
+      Satisfies: REQ-0001
+`;
+
+Deno.test("lockfileDriftGate: a malformed lockfile surfaces the parser's diagnostics", async () => {
+  const lockParse = parseLockfile("this is not toml {{{");
+  assertEquals(lockParse.lockfile, undefined);
+  assertEquals(lockParse.diagnostics.length > 0, true);
+  const diags = await lockfileDriftGate(lockParse, "/x/markspec.lock", []);
+  assertEquals(diags, [...lockParse.diagnostics]);
+});
+
+Deno.test("lockfileDriftGate: an in-sync lockfile emits nothing", async () => {
+  const parsed = await parseFile(SATISFIES_GRAPH, { file: "reqs.md" });
+  const quads = extractEdgeQuads(parsed.entries);
+  const edgesHash = await hashCanonicalEdges(quads);
+  const lockParse: ParseLockfileResult = {
+    lockfile: lockfileWithCache({ edgesHash, edgesCount: quads.length }),
+    diagnostics: [],
+  };
+  const diags = await lockfileDriftGate(
+    lockParse,
+    "/x/markspec.lock",
+    parsed.entries,
+  );
+  assertEquals(diags, []);
+});
+
+Deno.test("lockfileDriftGate: a stale edge hash fails with MSL-L212 at the lockfile location", async () => {
+  const parsed = await parseFile(SATISFIES_GRAPH, { file: "reqs.md" });
+  const lockPath = "/x/markspec.lock";
+  const lockParse: ParseLockfileResult = {
+    // A hash that cannot match the real graph → drift.
+    lockfile: lockfileWithCache({ edgesHash: "0".repeat(64), edgesCount: 0 }),
+    diagnostics: [],
+  };
+  const diags = await lockfileDriftGate(lockParse, lockPath, parsed.entries);
+  assertEquals(diags.length, 1);
+  assertEquals(diags[0].code, "MSL-L212");
+  assertEquals(diags[0].location?.file, lockPath);
+});
+
+// ---------------------------------------------------------------------------
+// proseLintGate
+// ---------------------------------------------------------------------------
+
+Deno.test("proseLintGate: a vague requirement emits MSL-Q with the projected schema", async () => {
+  // "as appropriate" is a vague quantifier — a Requirement-typed authored
+  // entry is prose-scoped without a profile.
+  const content = `# Doc
+
+- [REQ-0003] Vague requirement
+
+  The system shall respond as appropriate.
+
+      Id: 01REQ000000000000000000003
+      Type: Requirement
+`;
+  const parsed = await parseFile(content, { file: "vague.md" });
+  const diags = await proseLintGate(parsed.entries, undefined);
+  const q = diags.find((d) => d.code.startsWith("MSL-Q"));
+  assertEquals(q !== undefined, true);
+  // LintDiagnostic extras must not leak into the projected Diagnostic.
+  assertEquals("slug" in q!, false);
+  assertEquals("group" in q!, false);
+  assertEquals("scoreContribution" in q!, false);
+});

--- a/packages/markspec/core/mod.ts
+++ b/packages/markspec/core/mod.ts
@@ -369,6 +369,9 @@ export {
 } from "./refs/mod.ts";
 export type { RefIndex } from "./refs/mod.ts";
 
+// ── Composite-`check` gate stages (ADR-027, #659) ─────────────────────────
+export { fmtDriftGate, lockfileDriftGate, proseLintGate } from "./gates/mod.ts";
+
 // ── Fenced-code-block detection (#668/#679/#680) ──────────────────────────
 export { FENCE_RE, isLineFenced, walkProseLines } from "./util/fence.ts";
 export type { ProseLineCallback } from "./util/fence.ts";


### PR DESCRIPTION
Closes #659.

## What

`markspec check` had grown the fmt-drift (`MSL-F010`/`MSL-F011`), lockfile-drift (`MSL-L212`), and prose-lint gates inline in the CLI command body — diagnostic-producing computation and I/O mixed into what should be pure orchestration.

This lifts each gate into a pure `core/gates` stage:

- `fmtDriftGate(mdContents, entries, ledger, formatMarkdownProse) → Diagnostic[]`
- `lockfileDriftGate(lockParse, lockPath, entries) → Diagnostic[]`
- `proseLintGate(entries, profile) → Diagnostic[]`

`check.ts` becomes orchestration only: gather inputs (load the Markdown formatter, read + parse `markspec.lock`) → call the stages → merge diagnostics → render. The project-wide-only scope policy stays in the command (a scope decision, not a computation).

`core/gates` is a new top-level composition layer (depends on `formatter` + `parser` + `refs` + `lock` + `lint`; nothing depends back on it → no cycle).

## Why

Diagnostic logic belonged in `core` (composable, unit-testable in isolation, reusable by future surfaces), not inline in the CLI layer. The gates were previously untestable without shelling the whole binary.

## Behaviour

Byte-identical — no new public behaviour:

- The existing `tests/e2e/check_project_test.ts` (18 tests) stays green **with zero changes**.
- Only three new `core/mod.ts` exports (the gate functions), the minimum.
- Gate messages, diagnostic locations, per-file ordering, and merge order are all preserved verbatim.

## Tests

- New colocated `core/gates/mod_test.ts` (7 unit tests): clean/F010/F011 for fmt-drift; malformed/in-sync/stale for lockfile-drift; MSL-Q projection (no `slug`/`group`/`scoreContribution` leak) for prose-lint.
- `just check` green (3480 passed), `deno fmt --check` + `dprint check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
