### PR TITLE
refactor(core): single shared project-entry collector (#684)

### DIFF
--- a/docs/architecture/adr-027-cli-smoother-defaults.md
+++ b/docs/architecture/adr-027-cli-smoother-defaults.md
@@ -153,16 +153,29 @@ cross-file target).
 
 ### Lock ↔ check edge-hash parity
 
-`markspec lock`'s entry collection (`cli/commands/lock.ts` `collectEntries`) and
-`check`'s `MSL-L212` gate both walk the file set via `core/discovery` with the
-same `RELEVANT_EXTENSIONS` + the same `exclude:` patterns. This is load-bearing:
-the lockfile gate recomputes the canonical edge hash from the
-currently-discovered corpus and compares it to the locked hash — if `lock` and
-`check` walked different file sets, the hash would drift spuriously on every
-run. Unifying both on `core/discovery` (rather than `lock.ts` keeping its own
-markdown-only `walkMarkdown`) is what makes the parity hold; it also widened
-`lock`'s collection to include source-file entries (a lockfile generated before
-this change needs one `markspec lock` refresh).
+`markspec lock`'s entry collection and `check`'s `MSL-L212` gate both walk the
+file set via `core/discovery` with the same default `RELEVANT_EXTENSIONS` + the
+same `exclude:` patterns. This is load-bearing: the lockfile gate recomputes the
+canonical edge hash from the currently-discovered corpus and compares it to the
+locked hash — if `lock` and `check` walked different file sets, the hash would
+drift spuriously on every run. Unifying both on `core/discovery` (rather than
+`lock.ts` keeping its own markdown-only `walkMarkdown`) is what makes the parity
+hold; it also widened `lock`'s collection to include source-file entries (a
+lockfile generated before this change needs one `markspec lock` refresh).
+
+**One shared collector (#684).** The discover→parse walk is a single core
+function — `collectProjectEntries(root, io, { exclude })` in `core/collect/` —
+that `lock` (the pinner), `compile`, `fmt`, and `doctor` all call, so "the set
+of files whose edges are hashed" has exactly one definition and cannot drift
+between pinner and checkers. It relies on `discoverFiles`' default extension
+set, so no caller pins the extensions independently (a pinned value would
+re-open the divergence). `check` is the one deliberate exception: it needs each
+file's raw content and per-file directives (the fmt-drift `mdContents` and
+listing contexts), not just the flattened entries, so it keeps its
+`resolveScope`-based loop — equivalent by construction (same discovery, same
+`exclude:`, same default extensions). Before #684 the collector lived as a
+private helper in `cli/commands/lock.ts` that `compile`/`fmt` reached into and
+`doctor` re-rolled by hand — three copies that had to stay byte-identical.
 
 **`doctor` shares the same comparison (#658).** The offline edge-hash comparison
 `check`'s `MSL-L212` gate performs is factored into one pure helper —

--- a/packages/markspec/cli/commands/check.ts
+++ b/packages/markspec/cli/commands/check.ts
@@ -90,6 +90,14 @@ export const checkCmd = new Command()
       // deno-lint-ignore no-explicit-any
       const listingContexts: any[] = [];
       const mdContents = new Map<string, string>();
+      // `check` deliberately does not use the shared `collectProjectEntries`
+      // collector (`lock`/`compile`/`fmt`/`doctor` do): it needs each file's
+      // raw content and per-file directives here (for the fmt-drift `mdContents`
+      // and the listing contexts), not just the flattened entries. Its bare-mode
+      // file set is equivalent by construction — `resolveScope` walks
+      // `core/discovery` with the same `exclude:` and default
+      // `RELEVANT_EXTENSIONS` the collector relies on — so the MSL-L212 gate
+      // still compares against exactly the set `markspec lock` pinned.
       for (const filePath of files) {
         let content: string;
         try {

--- a/packages/markspec/cli/commands/compile.ts
+++ b/packages/markspec/cli/commands/compile.ts
@@ -45,6 +45,7 @@ export const compileCmd = new Command()
       if (_options.frozen) {
         const {
           checkDrift,
+          collectProjectEntries,
           discoverProjectRoot,
           loadConfig,
           loadProfileForCommand,
@@ -52,8 +53,8 @@ export const compileCmd = new Command()
           resolveUpstreams,
         } = await import("../../core/mod.ts");
         const { join } = await import("@std/path");
+        const { denoDiscoveryIO } = await import("../helpers.ts");
         const {
-          collectEntries,
           defaultFetchUrl,
           defaultReadFile,
           loadAllMappings,
@@ -88,7 +89,12 @@ export const compileCmd = new Command()
           root,
           readFileOrUndefined,
         );
-        const entries = await collectEntries(root);
+        // Honor project.yaml `exclude:` so `--frozen`'s edge set matches the
+        // one `markspec lock` pinned — an entry under an excluded path (e.g.
+        // `skills/`) must not spuriously drift the frozen check (#684).
+        const entries = await collectProjectEntries(root, denoDiscoveryIO(), {
+          exclude: configResult.config.exclude,
+        });
         const mappings = await loadAllMappings(root);
 
         const resolved = await resolveUpstreams({

--- a/packages/markspec/cli/commands/doctor.ts
+++ b/packages/markspec/cli/commands/doctor.ts
@@ -6,11 +6,9 @@
 
 import { Command } from "@cliffy/command";
 import {
+  collectProjectEntries,
   detectOfflineEdgeDrift,
-  discoverFiles,
-  type Entry,
   isBelowFloor,
-  parseFile,
   parseLockfile,
   VERSION,
 } from "../../core/mod.ts";
@@ -77,24 +75,16 @@ export const doctorCmd = new Command()
     let lockedEdges = 0;
     let currentEdges = 0;
     if (parsedLock) {
-      const io = denoDiscoveryIO();
-      const projectEntries: Entry[] = [];
-      for await (
-        // Rely on discoverFiles' default extension set (RELEVANT_EXTENSIONS) —
-        // the same default `markspec lock`'s collectEntries relies on. Pinning
-        // it here would diverge the two edge collections if that default ever
-        // changes, breaking the parity the drift comparison depends on.
-        const file of discoverFiles(projectRoot, io, {
-          exclude: config.exclude,
-        })
-      ) {
-        const content = await readFile(file);
-        if (content === undefined) continue;
-        const parsed = await parseFile(content, { file });
-        projectEntries.push(...parsed.entries);
-      }
-      // Corpus-blind, mirroring `check`'s MSL-L212 gate: the lockfile never
-      // counts delivered-corpus edges (ADR-030), so neither do we.
+      // The shared collectProjectEntries walk is exactly what `markspec lock`
+      // pinned with (same discovery + default extensions + `exclude:`), so the
+      // two edge sets cannot diverge. Corpus-blind, mirroring `check`'s
+      // MSL-L212 gate: the lockfile never counts delivered-corpus edges
+      // (ADR-030), so neither do we.
+      const projectEntries = await collectProjectEntries(
+        projectRoot,
+        denoDiscoveryIO(),
+        { exclude: config.exclude },
+      );
       const drift = await detectOfflineEdgeDrift(
         projectEntries.filter((e) => !e.origin),
         parsedLock.generatedCache,

--- a/packages/markspec/cli/commands/fmt.ts
+++ b/packages/markspec/cli/commands/fmt.ts
@@ -49,17 +49,24 @@ export const fmtCmd = new Command()
       let refIndex: RefIndex | undefined = undefined;
       let ledger: readonly LockEdge[] = [];
       if (projectRoot !== undefined) {
-        const { buildRefIndex, loadConfig, parseLockfile } = await import(
-          "../../core/mod.ts"
-        );
-        const { collectEntries } = await import("./lock.ts");
+        const {
+          buildRefIndex,
+          collectProjectEntries,
+          loadConfig,
+          parseLockfile,
+        } = await import("../../core/mod.ts");
+        const { denoDiscoveryIO } = await import("../helpers.ts");
         const { join } = await import("@std/path");
         // Honor project.yaml `exclude:` so the canonicalisation corpus
         // matches the one `check` (MSL-L006) and `lock` use — an entry in an
         // excluded path (e.g. `skills/`) must not resolve trace references.
         const configResult = await loadConfig(projectRoot, readFile);
         const exclude = configResult?.config.exclude ?? [];
-        const projectEntries = await collectEntries(projectRoot, exclude);
+        const projectEntries = await collectProjectEntries(
+          projectRoot,
+          denoDiscoveryIO(),
+          { exclude },
+        );
         refIndex = buildRefIndex(projectEntries);
         const lockRaw = await readFile(join(projectRoot, "markspec.lock"));
         if (lockRaw !== undefined) {

--- a/packages/markspec/cli/commands/lock.ts
+++ b/packages/markspec/cli/commands/lock.ts
@@ -14,19 +14,20 @@ import { Command } from "@cliffy/command";
 import { join } from "@std/path";
 import {
   checkDrift,
+  collectProjectEntries,
   discoverProjectRoot,
   loadConfig,
   loadProfileForCommand,
   type Lockfile,
   LOCKFILE_SCHEMA_VERSION,
   type Mapping,
-  parseFile,
   parseLockfile,
   parseMapping,
   resolveUpstreams,
   serializeLockfile,
   validateMappings,
 } from "../../core/mod.ts";
+import { denoDiscoveryIO } from "../helpers.ts";
 
 interface LockOptions {
   check?: boolean;
@@ -70,7 +71,9 @@ async function runLock(options: LockOptions): Promise<void> {
   );
   const chain = profileResult.chain;
 
-  const entries = await collectEntries(projectRoot, config.exclude);
+  const entries = await collectProjectEntries(projectRoot, denoDiscoveryIO(), {
+    exclude: config.exclude,
+  });
   const mappings = await loadAllMappings(projectRoot);
 
   const mappingDiags = validateMappings(mappings);
@@ -193,18 +196,6 @@ async function readFileOrUndefined(path: string): Promise<string | undefined> {
   }
 }
 
-async function collectEntries(root: string, exclude: readonly string[] = []) {
-  const { discoverFiles } = await import("../../core/mod.ts");
-  const { denoDiscoveryIO } = await import("../helpers.ts");
-  const out = [];
-  for await (const f of discoverFiles(root, denoDiscoveryIO(), { exclude })) {
-    const content = await Deno.readTextFile(f);
-    const r = await parseFile(content, { file: f });
-    out.push(...r.entries);
-  }
-  return out;
-}
-
 async function loadAllMappings(root: string): Promise<Mapping[]> {
   const out: Mapping[] = [];
   const dir = join(root, ".markspec", "sync");
@@ -262,7 +253,6 @@ async function defaultReadFile(
 // ---------------------------------------------------------------------------
 
 export {
-  collectEntries,
   defaultFetchUrl,
   defaultReadFile,
   loadAllMappings,

--- a/packages/markspec/core/collect/mod.ts
+++ b/packages/markspec/core/collect/mod.ts
@@ -1,0 +1,50 @@
+/**
+ * @module core/collect
+ *
+ * Project-entry collection: discover every MarkSpec-relevant file under a
+ * root and parse it into a flat `Entry[]`. The single source of truth for
+ * "the set of entries whose trace edges the lockfile pins" — shared by
+ * `markspec lock` (the pinner) and its checkers (`compile`, `fmt`, `doctor`)
+ * so they cannot disagree on which files count. Previously each of those
+ * commands hand-rolled the same discover→parse loop (a `cli/commands/lock.ts`
+ * private helper the others reached into), which had to stay byte-identical
+ * by hand or the lockfile edge-hash comparison would drift spuriously.
+ */
+
+import type { Entry } from "../model/mod.ts";
+import { discoverFiles, type DiscoveryIO } from "../discovery/mod.ts";
+import { parseFile } from "../parser/mod.ts";
+
+/** Options for {@linkcode collectProjectEntries}. */
+export interface CollectOptions {
+  /** Gitignore-syntax patterns (e.g. `project.yaml` `exclude:`), anchored at
+   * `root`. Applied after `.gitignore` rules. Defaults to none. */
+  readonly exclude?: readonly string[];
+}
+
+/**
+ * Walk `root` via {@linkcode discoverFiles} — relying on its default
+ * extension set (`RELEVANT_EXTENSIONS`), the parity point every caller
+ * depends on — and parse each discovered file, returning the flattened
+ * entry list. Unreadable files are skipped. Parse diagnostics are not
+ * surfaced here: this collector exists to give the lockfile pinner and its
+ * checkers one definition of the file set; callers that need diagnostics
+ * re-parse.
+ *
+ * @param io Injected filesystem surface (keeps `core/` Node-compatible; CLI
+ *   entry points pass a Deno-backed implementation).
+ */
+export async function collectProjectEntries(
+  root: string,
+  io: DiscoveryIO,
+  opts: CollectOptions = {},
+): Promise<Entry[]> {
+  const out: Entry[] = [];
+  for await (const file of discoverFiles(root, io, { exclude: opts.exclude })) {
+    const content = await io.readFile(file);
+    if (content === undefined) continue;
+    const result = await parseFile(content, { file });
+    out.push(...result.entries);
+  }
+  return out;
+}

--- a/packages/markspec/core/collect/mod_test.ts
+++ b/packages/markspec/core/collect/mod_test.ts
@@ -1,0 +1,94 @@
+/**
+ * @module core/collect/mod_test
+ *
+ * Unit tests for {@linkcode collectProjectEntries} — the single
+ * discover-and-parse collector shared by `lock` (the edge-hash pinner)
+ * and its checkers (`compile`, `fmt`, `doctor`).
+ */
+
+import { assertEquals } from "@std/assert";
+import { join } from "@std/path";
+import type { DiscoveryIO } from "../discovery/mod.ts";
+import { collectProjectEntries } from "./mod.ts";
+
+function realIO(): DiscoveryIO {
+  return {
+    readDir: (path) => Deno.readDir(path),
+    readFile: async (path) => {
+      try {
+        return await Deno.readTextFile(path);
+      } catch {
+        return undefined;
+      }
+    },
+  };
+}
+
+async function makeTree(files: Record<string, string>): Promise<string> {
+  const dir = await Deno.makeTempDir();
+  for (const [name, content] of Object.entries(files)) {
+    const parts = name.split("/");
+    if (parts.length > 1) {
+      await Deno.mkdir(join(dir, ...parts.slice(0, -1)), { recursive: true });
+    }
+    await Deno.writeTextFile(join(dir, ...parts), content);
+  }
+  return dir;
+}
+
+const REQ_A = `# A
+
+- [REQ-0001] First
+
+  The system shall do X within 10 ms.
+
+      Id: 01REQ000000000000000000001
+      Type: requirement
+`;
+
+const REQ_B = `# B
+
+- [REQ-0002] Second
+
+  The system shall do Y within 20 ms.
+
+      Id: 01REQ000000000000000000002
+      Type: requirement
+`;
+
+const ids = (es: Awaited<ReturnType<typeof collectProjectEntries>>) =>
+  es.map((e) => String(e.displayId)).sort();
+
+Deno.test("collectProjectEntries: discovers + parses markdown entries across the tree", async () => {
+  const dir = await makeTree({ "docs/a.md": REQ_A, "docs/sub/b.md": REQ_B });
+  try {
+    const entries = await collectProjectEntries(dir, realIO());
+    assertEquals(ids(entries), ["REQ-0001", "REQ-0002"]);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("collectProjectEntries: honors exclude patterns", async () => {
+  const dir = await makeTree({ "docs/a.md": REQ_A, "vendor/b.md": REQ_B });
+  try {
+    const entries = await collectProjectEntries(dir, realIO(), {
+      exclude: ["vendor/"],
+    });
+    assertEquals(ids(entries), ["REQ-0001"]);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("collectProjectEntries: relies on the default extension set (ignores .txt)", async () => {
+  const dir = await makeTree({ "docs/a.md": REQ_A, "notes.txt": REQ_B });
+  try {
+    // No `extensions` passed — the default RELEVANT_EXTENSIONS excludes .txt,
+    // the same default `markspec lock` relies on (parity point).
+    const entries = await collectProjectEntries(dir, realIO());
+    assertEquals(ids(entries), ["REQ-0001"]);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});

--- a/packages/markspec/core/mod.ts
+++ b/packages/markspec/core/mod.ts
@@ -436,3 +436,7 @@ export type {
   DiscoveryIO,
   GitignoreRule,
 } from "./discovery/mod.ts";
+
+// ── Project-entry collection (discover + parse → Entry[]) ────────────────
+export { collectProjectEntries } from "./collect/mod.ts";
+export type { CollectOptions } from "./collect/mod.ts";

--- a/tests/e2e/compile_frozen_exclude_test.ts
+++ b/tests/e2e/compile_frozen_exclude_test.ts
@@ -1,0 +1,82 @@
+/**
+ * @module tests/e2e/compile_frozen_exclude_test
+ *
+ * E2E: `markspec compile --frozen` must collect the same file set
+ * `markspec lock` pinned — honoring `project.yaml` `exclude:`. An entry
+ * living in an excluded directory must not be counted by `--frozen`, or
+ * its edges spuriously drift the frozen check against the lockfile
+ * (which never counted them). Regression guard for the #684 shared
+ * collector closing this parity gap.
+ */
+
+import { assertEquals } from "@std/assert";
+import { markspecInDir, markspecPersist } from "./helpers.ts";
+import { CLEAN_REQ } from "./check_project_test.ts";
+
+const PROJECT_WITH_EXCLUDE =
+  `name: frozen-exclude-e2e\nversion: 0.1.0\nexclude:\n  - excluded/\n`;
+
+const PROFILE_YAML = `id: "@acme/frozen-exclude"
+version: 0.1.0
+profile:
+  types:
+    requirement:
+      extends: Requirement
+      display-id-pattern: "REQ-{n:04d}"
+    system-requirement:
+      extends: Requirement
+      display-id-pattern: "SREQ-{n:04d}"
+      traceability:
+        Satisfies:
+          target: [requirement]
+          cardinality: 0..3
+          required: false
+`;
+
+/** A system requirement (with a trace edge) that lives in an EXCLUDED dir. */
+const EXCLUDED_SREQ = `# System Requirements
+
+- [SREQ-0001] Derived response time
+
+  The system shall forward responses within 100 ms.
+
+      Id: 01SREQ00000000000000000001
+      Type: system-requirement
+      Satisfies: REQ-0001
+`;
+
+Deno.test("compile --frozen honors project.yaml exclude (no spurious lock drift)", async () => {
+  const files = {
+    "project.yaml": PROJECT_WITH_EXCLUDE,
+    ".markspec.yaml": `profiles:\n  - ./profiles/p\n`,
+    "profiles/p/markspec.yaml": PROFILE_YAML,
+    "docs/req.md": CLEAN_REQ,
+    // Its trace edge (SREQ-0001 → REQ-0001) must NOT be pinned or checked —
+    // it is under an excluded path.
+    "excluded/sreq.md": EXCLUDED_SREQ,
+  };
+  const run = await markspecPersist(["lock"], {
+    files,
+    permissions: ["--allow-net", "--allow-env", "--allow-run"],
+  });
+  try {
+    assertEquals(run.code, 0, `lock failed: ${run.stderr}`);
+
+    // `lock` pinned WITHOUT the excluded entry's edge. `compile --frozen`
+    // must collect the same set — if it includes the excluded entry, its
+    // edge drifts the canonical hash and checkDrift emits MSL-L212 (exit 1).
+    const frozen = await markspecInDir(
+      run.dir,
+      ["compile", "--frozen", "docs/req.md"],
+      ["--allow-net", "--allow-env", "--allow-run"],
+    );
+    assertEquals(
+      frozen.stderr.includes("MSL-L212"),
+      false,
+      `unexpected frozen drift: ${frozen.stderr}`,
+    );
+    assertEquals(frozen.code, 0, frozen.stderr);
+  } finally {
+    await Deno.remove(run.dir, { recursive: true });
+  }
+});


### PR DESCRIPTION
Closes #684.

## What

`markspec lock` (the edge-hash **pinner**) and its **checkers** computed "the set of files whose trace edges the lockfile pins" through **three** independent discover→parse loops:

- a private `collectEntries` in `cli/commands/lock.ts` that `compile` and `fmt` reached into (cross-command imports),
- a hand-rolled copy in `doctor` (added in #682).

They agreed only by staying byte-identical **by hand** — a future divergence (an added filter, a different `parseFile` option, a pinned extension set) would make a checker report *phantom* drift, or *miss* real drift, relative to what `lock` pinned. This is the review finding from #682 that #684 tracked.

## How

Extract one exported core helper — `collectProjectEntries(root, io, { exclude })` in **`core/collect/`** — and route `lock`, `compile`, `fmt`, and `doctor` through it. Injected-IO (Node-safe, no `Deno.*`); relies on `discoverFiles`' default extension set (`RELEVANT_EXTENSIONS`) so no caller pins the extensions independently (a pinned value would re-open the divergence — the exact footgun #682's review caught in `doctor`).

**Behaviour-preserving:** same discovery + parse, returns `Entry[]`. `lock`'s private `collectEntries` is deleted; `compile`/`fmt` now import from core instead of reaching into a command module.

**`check` stays on its `resolveScope` loop by design** — it needs each file's raw *content* + per-file *directives* (the fmt-drift `mdContents` and listing contexts), not just entries. Its bare-mode file set is equivalent by construction (same discovery, same `exclude:`, same default extensions) — documented inline and in ADR-027.

## Tests

- **Unit** — `core/collect/mod_test.ts`: `collectProjectEntries` discovers + parses across a tree, honors `exclude`, and relies on the default extension set (ignores `.txt`).
- **Regression** — the `lock` / `compile` / `fmt` / `doctor` e2e are the behaviour-preserving guard (70 affected pass, incl. the lock↔doctor and lock↔check in-sync/drift parity). Full suite: **3488 passed, 0 failed**.

## Docs

ADR-027 "Lock ↔ check edge-hash parity" section documents the single collector and the `check` exception; net **−53 lines** from removing the duplicated loops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Rider fix (surfaced by review)

`compile --frozen` now passes `project.yaml` `exclude:` to the collector. It previously collected with no `exclude`, so a project excluding an entry-bearing path (e.g. this repo's `skills/`) would spuriously drift the frozen check (`MSL-L212`) against a lockfile that never counted those entries. New e2e `compile_frozen_exclude_test.ts` guards it (RED before, GREEN after). Full suite: **3507 passed**.
