### PR TITLE
fix(mcp): fall back to .markspec.yaml directory when no project.yaml exists

### DIFF
--- a/docs/architecture/adr-028-mcp-project-discovery.md
+++ b/docs/architecture/adr-028-mcp-project-discovery.md
@@ -133,10 +133,11 @@ multiple projects. Tracked as follow-up #645.
 - `Project` remains a plain, set-once, synchronously-constructed value — no new
   async re-resolution path, no new mutable state for tools/resources to reason
   about.
-- A `.markspec.yaml`-only candidate still detects a project
-  (`markspecDetected = true`) but can leave `projectRoot` undefined, exactly as
-  before this ADR (`discoverProjectRoot` only recognizes `project.yaml`).
-  Tracked as follow-up #647.
+- A `.markspec.yaml`-only candidate (`markspecDetected = true`, no
+  `project.yaml` anywhere upward) resolves `projectRoot` to the directory
+  containing `.markspec.yaml` (#647, fixed). Compile-backed tools work fully for
+  these projects; `Project.config` stays `undefined` since no `project.yaml`
+  exists to load.
 
 ## Alternatives considered
 

--- a/packages/markspec/mcp/project.ts
+++ b/packages/markspec/mcp/project.ts
@@ -15,6 +15,7 @@ import {
   compile,
   type CompileResult,
   type DeliveredDocument,
+  discoverMarkspecRoot,
   discoverProjectRoot,
   type EffectiveProfile,
   loadConfig,
@@ -202,7 +203,13 @@ export type InvalidationHandler = (
 
 /** Project context handle returned by {@linkcode createProject}. */
 export interface Project {
-  /** Discovered project root, or undefined when no `project.yaml` was found. */
+  /**
+   * Discovered project root, or undefined when neither `project.yaml` nor
+   * `.markspec.yaml` was found. Prefers the directory containing
+   * `project.yaml`; when only `.markspec.yaml` is found (a project
+   * activated per ADR-008 without a `project.yaml`), falls back to that
+   * directory (#647) so compile-backed tools still work.
+   */
   readonly projectRoot: string | undefined;
   /**
    * `true` when the workspace contains either `project.yaml` or
@@ -311,7 +318,12 @@ export async function createProject(env: ProjectEnv): Promise<Project> {
   for (const candidate of candidates) {
     if (await detectMarkspecProject(candidate, env.readFile)) {
       markspecDetected = true;
-      projectRoot = await discoverProjectRoot(candidate, env.readFile);
+      // A `.markspec.yaml`-only activation (no `project.yaml` anywhere
+      // upward) is valid per ADR-008; fall back to its directory so
+      // compile-backed tools still get a projectRoot instead of throwing
+      // "no project.yaml found" (#647).
+      projectRoot = await discoverProjectRoot(candidate, env.readFile) ??
+        await discoverMarkspecRoot(candidate, env.readFile);
       break;
     }
   }
@@ -501,7 +513,7 @@ export async function createProject(env: ProjectEnv): Promise<Project> {
     async getCompiled(): Promise<CompileResult> {
       if (!projectRoot) {
         throw new Error(
-          "MarkSpec MCP server: no project.yaml found. " +
+          "MarkSpec MCP server: no MarkSpec project found. " +
             "Operations require project context.",
         );
       }
@@ -518,7 +530,7 @@ export async function createProject(env: ProjectEnv): Promise<Project> {
     async forceRefresh(): Promise<CompileResult> {
       if (!projectRoot) {
         throw new Error(
-          "MarkSpec MCP server: no project.yaml found. " +
+          "MarkSpec MCP server: no MarkSpec project found. " +
             "Operations require project context.",
         );
       }

--- a/packages/markspec/mcp/project_test.ts
+++ b/packages/markspec/mcp/project_test.ts
@@ -93,6 +93,32 @@ Deno.test("createProject: returns null when no project.yaml", async () => {
   assertEquals(proj.projectRoot, undefined);
 });
 
+// ---------------------------------------------------------------------------
+// .markspec.yaml-only fallback (#647) — a project activated per ADR-008
+// without a project.yaml must still resolve a projectRoot so compile-backed
+// tools work instead of throwing.
+// ---------------------------------------------------------------------------
+
+Deno.test("createProject: falls back to .markspec.yaml directory when no project.yaml exists", async () => {
+  const { env } = makeEnv({
+    [join(PROJ, ".markspec.yaml")]: { content: "profiles: []\n", mtime: 1 },
+    [REQ_MD_PATH]: { content: REQ_DOC, mtime: 1 },
+  });
+  const proj = await createProject(env);
+  assertEquals(proj.markspecDetected, true);
+  assertEquals(proj.projectRoot, PROJ);
+});
+
+Deno.test("getCompiled: succeeds for a .markspec.yaml-only project", async () => {
+  const { env } = makeEnv({
+    [join(PROJ, ".markspec.yaml")]: { content: "profiles: []\n", mtime: 1 },
+    [REQ_MD_PATH]: { content: REQ_DOC, mtime: 1 },
+  });
+  const proj = await createProject(env);
+  const result = await proj.getCompiled();
+  assertExists(result.entries.get(makeDisplayId("STK_TEST_0001")));
+});
+
 Deno.test("getCompiled: compiles and caches result", async () => {
   const { env } = makeEnv({
     [PROJECT_YAML_PATH]: { content: PROJECT_YAML, mtime: 1 },


### PR DESCRIPTION
## Summary

- Closes #647.
- A `.markspec.yaml`-only project (valid activation per ADR-008, no `project.yaml` anywhere upward) previously left `projectRoot` `undefined` even though `markspecDetected` was `true`, so the soft gate never fired and `getCompiled()`/`forceRefresh()` threw an internal `"no project.yaml found"` error instead of working.
- `createProject` now falls back to `discoverMarkspecRoot`'s directory when `discoverProjectRoot` finds nothing upward, so compile-backed tools (`entry_search`, `validate`, etc.) work fully for `.markspec.yaml`-only projects. `Project.config` stays `undefined` in this case since there's no `project.yaml` to load — confirmed via grep that no MCP tool/resource actually consumes `project.config` today.
- Updated ADR-028's Consequences section (which explicitly tracked this as follow-up #647) to reflect the fix.

## Test plan

- [x] Added a red→green unit test pair in `project_test.ts` verifying `projectRoot` falls back correctly and `getCompiled()` succeeds for a `.markspec.yaml`-only project; confirmed both fail without the `project.ts` fix.
- [x] `just build` (lint + test + typecheck + compile) passes.
- [x] Pre-push hook's full `just check` passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
