### PR TITLE
fix(core): detect and collapse soft-wrapped entry titles (#686)

### DIFF
--- a/docs/spec/language/language.md
+++ b/docs/spec/language/language.md
@@ -250,7 +250,8 @@ without tooling.
 A list item starting with `- [DISPLAY_ID]` followed by a title on the same line,
 and indented body content on subsequent lines. The display ID is the entry's
 human-readable identifier. The title is the rest of the first line after the
-closing `]`.
+closing `]`. A title that soft-wraps onto a second physical line is one logical
+title; `markspec fmt` collapses it back onto a single line.
 
 ```markdown
 - [DISPLAY_ID] Title
@@ -1471,6 +1472,8 @@ Summary rules (MSL-S\*) activate only on `summary` documents.
 
 - **Attribute blocks** — sorted to canonical order, trailing backslashes
   normalized.
+- **Entry titles** — a title soft-wrapped across multiple physical lines is
+  collapsed to a single line (§1).
 - **Reference definitions** — moved to end of file, sorted alphabetically within
   groups.
 - **Alerts** — markers uppercased, spacing normalized.

--- a/packages/markspec/core/formatter/mod.ts
+++ b/packages/markspec/core/formatter/mod.ts
@@ -515,11 +515,45 @@ export function format(
     const indent = (entry.location.column - 1) + 2;
     let attrs = [...entry.rawAttributes];
 
+    const titleLineIdx = entry.location.line - 1;
+
+    // #686: a title that soft-wraps onto extra physical lines is a single
+    // Markdown paragraph, but the line-based passes here and in
+    // `emitBodyViaAst` (which takes `titleLineIdx + 1` as the body start)
+    // assume the title occupies one physical line. Collapse the wrapped
+    // title onto a single line so Id stamping and body splicing land on the
+    // right lines and the continuation is not clobbered or dropped. The
+    // parser already folded the title text on the model side; this repairs
+    // the raw buffer to match. The scan runs from the title line to the
+    // first blank line (the title/body separator), bounded above by the
+    // attribute block so a malformed entry with no blank line before its
+    // trailer cannot swallow it.
+    if (titleLineIdx >= 0 && titleLineIdx < lines.length) {
+      const attrRange = findAttributeBlockRange(
+        lines,
+        entry.location.line,
+        indent,
+      );
+      const limit = attrRange ? attrRange.start : lines.length;
+      let titleEnd = titleLineIdx;
+      while (titleEnd + 1 < limit && lines[titleEnd + 1].trim() !== "") {
+        titleEnd++;
+      }
+      if (titleEnd > titleLineIdx) {
+        const collapsed = lines[titleLineIdx].replace(/\s+$/, "") + " " +
+          lines
+            .slice(titleLineIdx + 1, titleEnd + 1)
+            .map((l) => l.trim())
+            .join(" ");
+        lines.splice(titleLineIdx, titleEnd - titleLineIdx + 1, collapsed);
+        changed = true;
+      }
+    }
+
     // Title-line bullet canonicalisation per spec §3.2: rewrite `*`
     // or `+` to `-`. The list-item position from the parser is the
     // line carrying the bullet marker; we only touch the marker
     // character itself, leaving the rest of the title alone.
-    const titleLineIdx = entry.location.line - 1;
     if (titleLineIdx >= 0 && titleLineIdx < lines.length) {
       const titleLine = lines[titleLineIdx];
       const markerCol = entry.location.column - 1;

--- a/packages/markspec/core/formatter/mod_test.ts
+++ b/packages/markspec/core/formatter/mod_test.ts
@@ -710,3 +710,63 @@ Deno.test("format: a throwing markdown formatter degrades to fallback for prose 
     true,
   );
 });
+
+// ---------------------------------------------------------------------------
+// Soft-wrapped title lines (#686)
+// ---------------------------------------------------------------------------
+
+Deno.test("format: collapses a soft-wrapped title to one line and stamps Id", () => {
+  // #686: an entry whose bracket-title line wraps onto a second physical
+  // line was silently skipped — no Id minted, no diagnostic. The formatter
+  // must detect it, collapse the title to a single line, and stamp an Id
+  // without dropping or duplicating the wrapped continuation or the body.
+  const md = [
+    "- [FREQ_0001] The system shall compute a very long descriptive title that",
+    "  wraps onto a second physical line for readability",
+    "",
+    "  The system shall compute the value within 200 ms.",
+    "",
+    "      Satisfies: STK_0001",
+    "",
+  ].join("\n");
+  const result = format(md, { generateUlid: mockUlid() });
+  assertEquals(result.changed, true);
+  // Title collapsed onto a single physical line.
+  assertStringIncludes(
+    result.output,
+    "- [FREQ_0001] The system shall compute a very long descriptive title " +
+      "that wraps onto a second physical line for readability\n",
+  );
+  // Id stamped — no longer silently skipped.
+  assertStringIncludes(result.output, `Id: ${MOCK_ULID}`);
+  // Body preserved; continuation line neither clobbered nor duplicated.
+  assertStringIncludes(
+    result.output,
+    "The system shall compute the value within 200 ms.",
+  );
+  assertEquals(
+    result.output.split("wraps onto a second physical line").length - 1,
+    1,
+    "the wrapped continuation text must appear exactly once",
+  );
+  // Idempotent: re-formatting the output changes nothing.
+  const second = format(result.output, { generateUlid: mockUlid() });
+  assertEquals(second.output, result.output);
+});
+
+Deno.test("format: collapses a title wrapped across three physical lines", () => {
+  const md = [
+    "- [FREQ_0002] Alpha",
+    "  beta",
+    "  gamma",
+    "",
+    "  Body prose.",
+    "",
+    "      Satisfies: STK_0001",
+    "",
+  ].join("\n");
+  const result = format(md, { generateUlid: mockUlid() });
+  assertStringIncludes(result.output, "- [FREQ_0002] Alpha beta gamma\n");
+  assertStringIncludes(result.output, `Id: ${MOCK_ULID}`);
+  assertStringIncludes(result.output, "Body prose.");
+});

--- a/packages/markspec/core/parser/markdown.ts
+++ b/packages/markspec/core/parser/markdown.ts
@@ -77,14 +77,34 @@ export interface ParseMarkdownOptions {
  */
 const SLUG_RE = /^[A-Za-z]([A-Za-z0-9._/-]*[A-Za-z0-9])?$/;
 
-/** Match `[...]` at the start of a list item paragraph. Captures: [1] = display ID, [2] = title. */
-const ENTRY_START_RE = /^\[([^\]]+)\]\s*(.*)$/;
+/**
+ * Match `[...]` at the start of a list item paragraph. Captures:
+ * [1] = display ID, [2] = title.
+ *
+ * The title group is `[\s\S]*` (not `.*`) so a title that soft-wraps onto
+ * a second physical line is still captured — remark keeps a soft-wrapped
+ * paragraph as one text node with an embedded `\n`, which `.` would not
+ * cross, leaving the entry silently undetected (#686). {@linkcode collapseTitle}
+ * then folds the wrapped title back to a single logical line.
+ */
+const ENTRY_START_RE = /^\[([^\]]+)\]\s*([\s\S]*)$/;
 
 /** Match `[]` at the start — empty brackets. */
 const EMPTY_BRACKET_RE = /^\[\]\s*(.*)$/;
 
 /** Match `[` at the start without a closing `]` on the same logical content — unterminated. */
 const UNTERMINATED_BRACKET_RE = /^\[[^\]]*$/;
+
+/**
+ * Fold a title that may span multiple soft-wrapped physical lines (one
+ * Markdown paragraph) into a single logical line: every run of whitespace
+ * — including the embedded newlines remark preserves inside the paragraph
+ * text node — collapses to a single space, matching how a soft-wrapped
+ * line renders (#686).
+ */
+function collapseTitle(raw: string): string {
+  return raw.replace(/\s+/g, " ").trim();
+}
 
 /**
  * Find the `Id:` attribute on an entry. Returns undefined when absent. If
@@ -226,7 +246,7 @@ function extractEntry(
     const match = ENTRY_START_RE.exec(textValue);
     if (match) {
       displayId = match[1];
-      title = match[2].trim();
+      title = collapseTitle(match[2]);
     } else if (EMPTY_BRACKET_RE.test(textValue)) {
       // MSL-P001: bracketed content is empty — `- [] Title`
       const entryLine = item.position?.start.line ?? 1;
@@ -278,11 +298,12 @@ function extractEntry(
     // Title comes from subsequent text nodes in the paragraph
     if (displayId && paragraph.children.length > 1) {
       const rest = paragraph.children.slice(1);
-      title = rest
-        .filter((n): n is Text => n.type === "text")
-        .map((n) => n.value)
-        .join("")
-        .trim();
+      title = collapseTitle(
+        rest
+          .filter((n): n is Text => n.type === "text")
+          .map((n) => n.value)
+          .join(""),
+      );
     }
   }
 

--- a/packages/markspec/core/parser/markdown_test.ts
+++ b/packages/markspec/core/parser/markdown_test.ts
@@ -752,3 +752,33 @@ Deno.test("parseMarkdown: inline typl parse error is bridged to file-relative di
   assertEquals(typlDiag.location?.file, "test.md");
   assertEquals((typlDiag.location?.line ?? 0) >= 1, true);
 });
+
+// ---------------------------------------------------------------------------
+// Soft-wrapped title lines (#686)
+// ---------------------------------------------------------------------------
+
+Deno.test("parseMarkdown: detects entry whose title soft-wraps onto a second line", () => {
+  // A soft-wrapped title is one Markdown paragraph, so remark hands the
+  // parser a single text node containing an embedded newline. The entry
+  // must still be detected (previously silently skipped — #686), with the
+  // wrapped title collapsed to a single logical line.
+  const md = [
+    "- [FREQ_0001] The system shall compute a very long descriptive title that",
+    "  wraps onto a second physical line for readability",
+    "",
+    "  The system shall compute the value within 200 ms.",
+    "",
+    `      Id: ${ULID}`,
+  ].join("\n");
+  const { entries } = parseMarkdown(md, { file: "test.md" });
+  assertEquals(entries.length, 1);
+  const [entry] = entries;
+  assertEquals(entry.displayId, "FREQ_0001");
+  assertEquals(
+    entry.title,
+    "The system shall compute a very long descriptive title that wraps " +
+      "onto a second physical line for readability",
+  );
+  // The wrapped continuation belongs to the title, not the body.
+  assertEquals(entry.body, "The system shall compute the value within 200 ms.");
+});

--- a/tests/e2e/format_test.ts
+++ b/tests/e2e/format_test.ts
@@ -1018,3 +1018,41 @@ Deno.test("fmt: never rewrites source files passed explicitly (ADR-029 scope gua
   assertEquals(code, 0);
   assertEquals(await readFile("main.rs"), rust);
 });
+
+// ---------------------------------------------------------------------------
+// Soft-wrapped bracket-title entries (#686)
+// ---------------------------------------------------------------------------
+
+Deno.test("fmt: stamps a wrapped-title entry instead of silently skipping it (#686)", async () => {
+  // Regression: when the `- [ID] Title` line wrapped onto a second physical
+  // line, fmt treated the block as not-an-entry — no Id minted, no
+  // diagnostic. Expected: the wrapped title collapses to one line and an
+  // Id is stamped.
+  const input = [
+    "# Requirements",
+    "",
+    "- [FREQ_0001] The system shall compute a very long descriptive title that",
+    "  wraps onto a second physical line for readability",
+    "",
+    "  The system shall compute the value within 200 ms.",
+    "",
+    "      Satisfies: STK_0001",
+    "",
+  ].join("\n");
+  const { code, readFile } = await runFormat({ "req.md": input });
+  assertEquals(code, 0);
+  const output = await readFile("req.md");
+  // A real ULID (Crockford base32, 26 chars) was minted.
+  assertMatch(output, /^\s*Id: [0-9A-HJKMNP-TV-Z]{26}$/m);
+  // Title collapsed onto a single physical line.
+  assertStringIncludes(
+    output,
+    "- [FREQ_0001] The system shall compute a very long descriptive title " +
+      "that wraps onto a second physical line for readability\n",
+  );
+  // Body preserved.
+  assertStringIncludes(
+    output,
+    "The system shall compute the value within 200 ms.",
+  );
+});


### PR DESCRIPTION
Closes #686.

## Problem

A `- [ID] Title` entry whose bracket-title line **soft-wraps onto a second physical line** was silently skipped by `markspec fmt` — no `Id:` minted, no diagnostic — and was invisible to `markspec check`. Found twice, independently, during SEED skill evals.

**Root cause (single).** remark keeps a soft-wrapped paragraph as one `text` node with an embedded `\n`:

```
"[FREQ_0001] Long title that\nwraps onto a second line"
```

`ENTRY_START_RE = /^\[([^\]]+)\]\s*(.*)$/` — the title group `.*` cannot cross the `\n`, and `$` cannot match mid-string, so the match fails and the entry is never detected. Both symptoms (`fmt` skips, `check` sees nothing) trace here.

## Fix — heal + collapse (issue's first-listed option)

- **parser** (`core/parser/markdown.ts`): match the title across the soft-wrap (`[\s\S]*`) and fold it to a single logical line via `collapseTitle` (whitespace runs, incl. the embedded newline, → one space — how a soft-wrapped line renders). Body extraction already skips the whole title paragraph, so the continuation is never misattributed to the body.
- **formatter** (`core/formatter/mod.ts`): the write-back is line-based and assumes the title is one physical line (`emitBodyViaAst` uses `titleLineIdx + 1` as the body start). Collapse the multi-line title onto one physical line **before** Id stamping and body reconstruction, so the continuation is neither clobbered nor dropped. The collapse scan is bounded above by the attribute block so a malformed no-blank-line entry can't swallow its trailer.

Result: `fmt` stamps the Id, collapses the title, and is **idempotent**; `check` recognizes the entry.

### Before → after (`markspec fmt`)

```
- [FREQ_0001] The system shall compute a very long descriptive title that
  wraps onto a second physical line for readability

  Body within 200 ms.

      Satisfies: STK_0001
```

```
- [FREQ_0001] The system shall compute a very long descriptive title that wraps onto a second physical line for readability

  Body within 200 ms.

      Id: 01K…            ← stamped
      Satisfies: STK_0001
```

## No regression

The spec §1 rule "a `- [ID]` with no indented body is a normal list item, not an entry" is preserved: a wrapped bracket item **without** a body is still not an entry. The change only makes a wrapped title behave identically to the single-line equivalent (which was already an entry when it had a body).

## Tests & docs

- **parser unit** — detection + title/body split for a wrapped title.
- **formatter unit** — collapse + stamp + no-loss + idempotence (incl. a 3-physical-line title).
- **e2e** — `fmt` acceptance (real ULID minted, title on one line, body preserved).
- **docs** — `language.md` §1 and the MarkSpec normalization list.

`just build` + full `just check` green (3488 tests). `deno fmt --check` and `dprint check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
