### PR TITLE
fix(cli): watchdog install commands against a stalled config read (#634)

### DIFF
--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -961,6 +961,26 @@ markspec lsp install --editor zed
 markspec lsp install --editor vscode --binary-path /opt/markspec/bin/markspec
 ```
 
+#### Install timeout (never hang)
+
+`mcp install` and `lsp install` read the target config file before writing.
+Under extreme host load — many concurrent `markspec` processes, a contended
+filesystem, or a locked config file — that read can stall. Rather than hang
+silently, both commands run under a watchdog: if the work does not finish within
+a deadline, they print a diagnostic to stderr and exit non-zero (`1`).
+
+The deadline defaults to 10 seconds (normal runs finish in well under one).
+Override it with the `MARKSPEC_INSTALL_TIMEOUT_MS` environment variable — for
+example `MARKSPEC_INSTALL_TIMEOUT_MS=30000` to wait 30 seconds on a slow host. A
+missing, blank, or non-positive value keeps the 10-second default.
+
+**Limitation.** The watchdog runs inside the process, so it can only fire once
+the runtime has started. If a launch wedges even earlier — in the operating
+system's process loader, which can happen under heavy fork/exec pressure — no
+in-process timer can catch it. In that case, supervise the command externally
+(`timeout 15 markspec mcp install …`) or register the server through your client
+directly, e.g. `claude mcp add markspec -- markspec mcp`.
+
 ### Not yet implemented
 
 These commands are registered but print an error and exit:

--- a/packages/markspec/cli/commands/lsp_cmd.ts
+++ b/packages/markspec/cli/commands/lsp_cmd.ts
@@ -60,16 +60,42 @@ export const lspCmd = new Command()
         remove?: boolean;
       },
     ) => {
+      const {
+        DeadlineExceeded,
+        resolveInstallDeadlineMs,
+        withDeadline,
+      } = await import("../install/deadline.ts");
       const { runLspInstall } = await import("../install/orchestrator.ts");
-      const result = await runLspInstall({
-        editor: options.editor,
-        scope: options.scope,
-        binaryPath: options.binaryPath,
-        print: options.print,
-        force: options.force,
-        noColor: options.color === false,
-        remove: options.remove,
-      });
+      const deadlineMs = resolveInstallDeadlineMs();
+      let result;
+      try {
+        // Never hang (#634): a config read wedged under host load trips
+        // the watchdog into a fast diagnostic + non-zero exit instead of
+        // an uninterruptible silent stall.
+        result = await withDeadline(
+          runLspInstall({
+            editor: options.editor,
+            scope: options.scope,
+            binaryPath: options.binaryPath,
+            print: options.print,
+            force: options.force,
+            noColor: options.color === false,
+            remove: options.remove,
+          }),
+          deadlineMs,
+        );
+      } catch (err) {
+        if (err instanceof DeadlineExceeded) {
+          await Deno.stderr.write(
+            new TextEncoder().encode(
+              `error: lsp install for editor '${options.editor}' timed out after ${deadlineMs}ms ` +
+                `(host IO/lock contention?). Raise MARKSPEC_INSTALL_TIMEOUT_MS to wait longer.\n`,
+            ),
+          );
+          Deno.exit(1);
+        }
+        throw err;
+      }
       if (result.stdout) {
         await Deno.stdout.write(new TextEncoder().encode(result.stdout));
       }

--- a/packages/markspec/cli/commands/mcp_cmd.ts
+++ b/packages/markspec/cli/commands/mcp_cmd.ts
@@ -54,18 +54,45 @@ export const mcpCmd = new Command()
         remove?: boolean;
       },
     ) => {
+      const {
+        DeadlineExceeded,
+        resolveInstallDeadlineMs,
+        withDeadline,
+      } = await import("../install/deadline.ts");
       const { runMcpInstall } = await import(
         "../install/mcp_orchestrator.ts"
       );
-      const result = await runMcpInstall({
-        client: options.client,
-        scope: options.scope,
-        binaryPath: options.binaryPath,
-        print: options.print,
-        force: options.force,
-        noColor: options.color === false,
-        remove: options.remove,
-      });
+      const deadlineMs = resolveInstallDeadlineMs();
+      let result;
+      try {
+        // Never hang (#634): a config read wedged under host load trips
+        // the watchdog into a fast diagnostic + non-zero exit instead of
+        // an uninterruptible silent stall.
+        result = await withDeadline(
+          runMcpInstall({
+            client: options.client,
+            scope: options.scope,
+            binaryPath: options.binaryPath,
+            print: options.print,
+            force: options.force,
+            noColor: options.color === false,
+            remove: options.remove,
+          }),
+          deadlineMs,
+        );
+      } catch (err) {
+        if (err instanceof DeadlineExceeded) {
+          await Deno.stderr.write(
+            new TextEncoder().encode(
+              `error: mcp install for client '${options.client}' timed out after ${deadlineMs}ms ` +
+                `(host IO/lock contention?). Raise MARKSPEC_INSTALL_TIMEOUT_MS to wait longer, ` +
+                `or register through Claude Code directly: claude mcp add markspec -- markspec mcp\n`,
+            ),
+          );
+          Deno.exit(1);
+        }
+        throw err;
+      }
       if (result.stdout) {
         await Deno.stdout.write(new TextEncoder().encode(result.stdout));
       }

--- a/packages/markspec/cli/install/deadline.ts
+++ b/packages/markspec/cli/install/deadline.ts
@@ -1,0 +1,91 @@
+/**
+ * @module cli/install/deadline
+ *
+ * "Never hang" watchdog for the install commands (`markspec mcp install`,
+ * `markspec lsp install`). Both actions resolve a config path and read it
+ * with a single `Deno.readTextFile`; under extreme host load (many
+ * concurrent `markspec` processes, a contended filesystem, or a locked
+ * config file) that read can park in an uninterruptible `read()` syscall,
+ * leaving the command wedged with zero output until `kill -9` (#634).
+ *
+ * `withDeadline` races the install work against a timer so the wedge
+ * becomes a fast, diagnosable failure instead of a silent hang. Because
+ * `Deno.readTextFile` runs on the blocking threadpool, the JS event loop
+ * stays live and the timer still fires while the read is stuck; the CLI
+ * action then prints a diagnostic and `Deno.exit`s.
+ *
+ * Limit (documented, not hidden): if a process instead wedges *before*
+ * the runtime's event loop starts (e.g. in dyld under fork/exec
+ * pressure), no JS — including this timer — runs, so the watchdog cannot
+ * fire. It rescues the reachable async-I/O stall, which is the common
+ * and fixable case.
+ */
+
+/** Default install-command watchdog deadline, in milliseconds. Normal
+ * runs finish in well under a second, so 10 s is a wide margin that never
+ * trips a legitimately-progressing invocation. */
+export const DEFAULT_INSTALL_DEADLINE_MS = 10_000;
+
+/** Environment variable overriding the install watchdog deadline (ms). */
+export const INSTALL_DEADLINE_ENV = "MARKSPEC_INSTALL_TIMEOUT_MS";
+
+/** Error thrown by {@linkcode withDeadline} when the timer wins the race. */
+export class DeadlineExceeded extends Error {
+  /** The deadline, in milliseconds, that was exceeded. */
+  readonly ms: number;
+  constructor(ms: number) {
+    super(`operation exceeded ${ms}ms deadline`);
+    this.name = "DeadlineExceeded";
+    this.ms = ms;
+  }
+}
+
+/**
+ * Resolve the install watchdog deadline from the environment, falling
+ * back to {@linkcode DEFAULT_INSTALL_DEADLINE_MS}.
+ *
+ * A missing, blank, non-numeric, zero, or negative value falls back to
+ * the default so a malformed override can never silently disable the
+ * watchdog. `getEnv` is injectable for testability; it defaults to the
+ * process environment.
+ */
+export function resolveInstallDeadlineMs(
+  getEnv: (key: string) => string | undefined = defaultGetEnv,
+): number {
+  const raw = getEnv(INSTALL_DEADLINE_ENV);
+  if (raw === undefined) return DEFAULT_INSTALL_DEADLINE_MS;
+  const n = Number(raw.trim());
+  if (!Number.isFinite(n) || n <= 0) return DEFAULT_INSTALL_DEADLINE_MS;
+  return n;
+}
+
+/** Read an env var, treating a denied `--allow-env` permission as unset —
+ * the install commands run in contexts without env access (the e2e CLI
+ * harness grants only read/write), and a missing override must fall back
+ * to the default, never crash. Mirrors the orchestrators' own guarded
+ * `Deno.env.get` calls (readHome / readAppData). */
+function defaultGetEnv(key: string): string | undefined {
+  try {
+    return Deno.env.get(key);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Race `work` against a `ms`-millisecond timer.
+ *
+ * Resolves with `work`'s value when it settles first; rejects with
+ * {@linkcode DeadlineExceeded} when the timer wins. The timer is always
+ * cleared once the race settles so it cannot keep the event loop alive
+ * after a fast resolve.
+ */
+export function withDeadline<T>(work: Promise<T>, ms: number): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const deadline = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new DeadlineExceeded(ms)), ms);
+  });
+  return Promise.race([work, deadline]).finally(() => {
+    if (timer !== undefined) clearTimeout(timer);
+  });
+}

--- a/packages/markspec/cli/install/deadline_test.ts
+++ b/packages/markspec/cli/install/deadline_test.ts
@@ -1,0 +1,47 @@
+import { assertEquals, assertInstanceOf, assertRejects } from "@std/assert";
+import {
+  DeadlineExceeded,
+  DEFAULT_INSTALL_DEADLINE_MS,
+  resolveInstallDeadlineMs,
+  withDeadline,
+} from "./deadline.ts";
+
+Deno.test("withDeadline: resolves with work's value when work settles first", async () => {
+  const value = await withDeadline(Promise.resolve(42), 1000);
+  assertEquals(value, 42);
+});
+
+Deno.test("withDeadline: rejects with DeadlineExceeded when work stalls past the deadline", async () => {
+  // A promise that never settles — models a wedged async syscall.
+  const stalled = new Promise<never>(() => {});
+  const err = await assertRejects(() => withDeadline(stalled, 20));
+  assertInstanceOf(err, DeadlineExceeded);
+  assertEquals(err.ms, 20);
+});
+
+Deno.test("withDeadline: clears the timer on fast resolve (no leaked timer)", async () => {
+  // If the timer were not cleared, Deno's default op/resource sanitizer
+  // would fail this test with a leaked-timer error.
+  await withDeadline(Promise.resolve("ok"), 60_000);
+});
+
+Deno.test("resolveInstallDeadlineMs: default when the env var is unset", () => {
+  assertEquals(
+    resolveInstallDeadlineMs(() => undefined),
+    DEFAULT_INSTALL_DEADLINE_MS,
+  );
+});
+
+Deno.test("resolveInstallDeadlineMs: parses a valid positive override", () => {
+  assertEquals(resolveInstallDeadlineMs(() => "500"), 500);
+});
+
+Deno.test("resolveInstallDeadlineMs: falls back on empty / NaN / zero / negative", () => {
+  for (const bad of ["", "  ", "abc", "0", "-1", "NaN", "Infinity"]) {
+    assertEquals(
+      resolveInstallDeadlineMs(() => bad),
+      DEFAULT_INSTALL_DEADLINE_MS,
+      `expected fallback for ${JSON.stringify(bad)}`,
+    );
+  }
+});

--- a/packages/markspec/cli/install/mcp_orchestrator.ts
+++ b/packages/markspec/cli/install/mcp_orchestrator.ts
@@ -33,6 +33,8 @@ import { copilotDescriptor } from "./mcp_adapters_copilot.ts";
 import { applyJsonBlock, removeJsonBlock } from "./managed_block.ts";
 import { writeBackup } from "./backup.ts";
 import { renderDiff } from "./preview.ts";
+import { readConfigText } from "./read_config.ts";
+import { writeConfigText } from "./write_config.ts";
 
 /** Options accepted by {@linkcode runMcpInstall}. */
 export interface McpInstallOptions {
@@ -221,22 +223,25 @@ async function runManagedBlockFlow(
     scope === "workspace" ? cwd : undefined,
   );
 
-  // 5. Read current content. Missing file → empty string.
+  // 5. Read current content. Missing file → empty string. The read goes
+  // through readConfigText (Deno.open) rather than Deno.readTextFile so a
+  // stalled read keeps the event loop alive and the install watchdog can
+  // fire instead of hanging silently (#634).
   let current = "";
   let fileExists = true;
   try {
-    current = await Deno.readTextFile(configPath);
-  } catch (err) {
-    if (err instanceof Deno.errors.NotFound) {
-      current = "";
+    const existing = await readConfigText(configPath);
+    if (existing === undefined) {
       fileExists = false;
     } else {
-      return {
-        stdout: "",
-        stderr: `error: cannot read ${configPath}: ${(err as Error).message}\n`,
-        exitCode: 1,
-      };
+      current = existing;
     }
+  } catch (err) {
+    return {
+      stdout: "",
+      stderr: `error: cannot read ${configPath}: ${(err as Error).message}\n`,
+      exitCode: 1,
+    };
   }
 
   // 6. Compute next content.
@@ -318,7 +323,10 @@ async function runManagedBlockFlow(
 
   const tmpPath = `${configPath}.tmp`;
   try {
-    await Deno.writeTextFile(tmpPath, next);
+    // writeConfigText (Deno.open) rather than Deno.writeTextFile so a
+    // stalled write keeps the event loop alive and the install watchdog
+    // can fire instead of hanging silently (#634).
+    await writeConfigText(tmpPath, next);
     await Deno.rename(tmpPath, configPath);
   } catch (err) {
     try {

--- a/packages/markspec/cli/install/orchestrator.ts
+++ b/packages/markspec/cli/install/orchestrator.ts
@@ -30,6 +30,8 @@ import { findWorkspaceRoot, NO_WORKSPACE_MARKER_STDERR } from "./workspace.ts";
 import { applyLuaBlock, removeLuaBlock } from "./managed_block.ts";
 import { writeBackup } from "./backup.ts";
 import { renderDiff } from "./preview.ts";
+import { readConfigText } from "./read_config.ts";
+import { writeConfigText } from "./write_config.ts";
 
 /** Options accepted by {@linkcode runLspInstall}. */
 export interface LspInstallOptions {
@@ -153,24 +155,27 @@ export async function runLspInstall(
     workspaceRoot,
   );
 
-  // 4. Read current file content. Missing file → empty string.
+  // 4. Read current file content. Missing file → empty string. The
+  // read goes through readConfigText (Deno.open) rather than
+  // Deno.readTextFile so a stalled read keeps the event loop alive and
+  // the install watchdog can fire instead of hanging silently (#634).
   let current = "";
   let fileExists = true;
   try {
-    current = await Deno.readTextFile(configPath);
-  } catch (err) {
-    if (err instanceof Deno.errors.NotFound) {
-      current = "";
+    const existing = await readConfigText(configPath);
+    if (existing === undefined) {
       fileExists = false;
     } else {
-      return {
-        stdout: "",
-        stderr: `${stderrPreamble}error: cannot read ${configPath}: ${
-          (err as Error).message
-        }\n`,
-        exitCode: 1,
-      };
+      current = existing;
     }
+  } catch (err) {
+    return {
+      stdout: "",
+      stderr: `${stderrPreamble}error: cannot read ${configPath}: ${
+        (err as Error).message
+      }\n`,
+      exitCode: 1,
+    };
   }
 
   // 5. Compute next content. Block rendering is only needed for the
@@ -262,7 +267,10 @@ export async function runLspInstall(
   // files on crash mid-write.
   const tmpPath = `${configPath}.tmp`;
   try {
-    await Deno.writeTextFile(tmpPath, next);
+    // writeConfigText (Deno.open) rather than Deno.writeTextFile so a
+    // stalled write keeps the event loop alive and the install watchdog
+    // can fire instead of hanging silently (#634).
+    await writeConfigText(tmpPath, next);
     await Deno.rename(tmpPath, configPath);
   } catch (err) {
     // Best-effort cleanup of the staged tmp file.

--- a/packages/markspec/cli/install/read_config.ts
+++ b/packages/markspec/cli/install/read_config.ts
@@ -1,0 +1,43 @@
+/**
+ * @module cli/install/read_config
+ *
+ * Loop-safe config read for the install orchestrators.
+ *
+ * The install watchdog ({@linkcode ../install/deadline.ts}) can only fire
+ * while the JS event loop keeps running. `Deno.readTextFile` does not
+ * satisfy that: a read that parks in a blocking `open()`/`read()` syscall
+ * (a contended filesystem, a locked config file, a special file) starves
+ * the event loop, so a `setTimeout`-based watchdog wrapped around it never
+ * gets a turn (#634).
+ *
+ * `Deno.open` and `FsFile` stream reads are offloaded to the blocking
+ * threadpool, so the event loop stays live even while the open/read is
+ * stuck — which lets the watchdog win the race and turn a wedge into a
+ * fast diagnostic. This helper reads through that offloaded path while
+ * preserving `readTextFile`'s "missing file → treat as empty" contract.
+ */
+
+/**
+ * Read `path` as UTF-8 text through the offloaded `Deno.open` path so a
+ * stalled open/read does not starve the event loop.
+ *
+ * Returns `undefined` when the file does not exist (the caller treats a
+ * missing config as empty). Any other error — permissions, IO — is
+ * re-thrown for the caller to surface, matching the prior
+ * `Deno.readTextFile` + `NotFound` handling.
+ */
+export async function readConfigText(
+  path: string,
+): Promise<string | undefined> {
+  let file: Deno.FsFile;
+  try {
+    file = await Deno.open(path, { read: true });
+  } catch (err) {
+    if (err instanceof Deno.errors.NotFound) return undefined;
+    throw err;
+  }
+  // Consuming `file.readable` closes the underlying handle when the
+  // stream ends, so no explicit `file.close()` is needed (and adding one
+  // would risk a double-close "Bad resource ID").
+  return await new Response(file.readable).text();
+}

--- a/packages/markspec/cli/install/read_config_test.ts
+++ b/packages/markspec/cli/install/read_config_test.ts
@@ -1,0 +1,65 @@
+import { assertEquals } from "@std/assert";
+import { join } from "@std/path";
+import { readConfigText } from "./read_config.ts";
+
+Deno.test("readConfigText: returns file contents for an existing file", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const path = join(dir, "config.json");
+    await Deno.writeTextFile(path, '{"hello":"world"}');
+    assertEquals(await readConfigText(path), '{"hello":"world"}');
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("readConfigText: returns undefined for a missing file", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    assertEquals(await readConfigText(join(dir, "nope.json")), undefined);
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("readConfigText: reads an empty file as empty string", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const path = join(dir, "empty.json");
+    await Deno.writeTextFile(path, "");
+    assertEquals(await readConfigText(path), "");
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test({
+  // The load-bearing property behind #634: a read that blocks (FIFO with
+  // no writer) must NOT starve the event loop, so a concurrent timer can
+  // still fire. Deno.readTextFile fails this; readConfigText (Deno.open)
+  // must pass it. POSIX-only.
+  name: "readConfigText: a blocked read leaves the event loop alive",
+  ignore: Deno.build.os === "windows",
+  // The read is intentionally left blocked (the FIFO never gets a writer),
+  // so its open() op stays pending past the test — expected, not a leak.
+  sanitizeOps: false,
+  sanitizeResources: false,
+  async fn() {
+    const dir = await Deno.makeTempDir();
+    try {
+      const fifo = join(dir, "fifo");
+      const mk = await new Deno.Command("mkfifo", { args: [fifo] }).output();
+      assertEquals(mk.code, 0);
+      // Race the never-resolving read against a short timer. If the read
+      // starved the loop, the timer would never resolve and this test
+      // would hang; a passing test proves the loop stayed alive.
+      const timer = new Promise<string>((resolve) =>
+        setTimeout(() => resolve("timer-won"), 100)
+      );
+      const winner = await Promise.race([readConfigText(fifo), timer]);
+      assertEquals(winner, "timer-won");
+    } finally {
+      await Deno.remove(dir, { recursive: true });
+    }
+  },
+});

--- a/packages/markspec/cli/install/write_config.ts
+++ b/packages/markspec/cli/install/write_config.ts
@@ -1,0 +1,40 @@
+/**
+ * @module cli/install/write_config
+ *
+ * Loop-safe config write for the install orchestrators — the write-path
+ * counterpart to {@linkcode ./read_config.ts}'s `readConfigText`.
+ *
+ * `Deno.writeTextFile` fuses open+write into one op that starves the event
+ * loop when it stalls (a contended filesystem, a special file), so the
+ * install watchdog ({@linkcode ./deadline.ts}) can never get a turn to
+ * fire. `Deno.open` and `FsFile.write` are offloaded to the blocking
+ * threadpool, keeping the loop alive so a stalled write becomes a fast
+ * diagnostic instead of a silent hang (#634).
+ */
+
+/**
+ * Write `content` as UTF-8 text to `path` through the offloaded
+ * `Deno.open` path so a stalled open/write does not starve the event
+ * loop. Creates the file if missing and truncates it otherwise, matching
+ * `Deno.writeTextFile`'s default behaviour. The write loops until every
+ * byte is flushed (a single `FsFile.write` may be partial).
+ */
+export async function writeConfigText(
+  path: string,
+  content: string,
+): Promise<void> {
+  const file = await Deno.open(path, {
+    write: true,
+    create: true,
+    truncate: true,
+  });
+  try {
+    const data = new TextEncoder().encode(content);
+    let offset = 0;
+    while (offset < data.length) {
+      offset += await file.write(data.subarray(offset));
+    }
+  } finally {
+    file.close();
+  }
+}

--- a/packages/markspec/cli/install/write_config_test.ts
+++ b/packages/markspec/cli/install/write_config_test.ts
@@ -1,0 +1,68 @@
+import { assertEquals } from "@std/assert";
+import { join } from "@std/path";
+import { writeConfigText } from "./write_config.ts";
+
+Deno.test("writeConfigText: creates a new file with the given content", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const path = join(dir, "out.json");
+    await writeConfigText(path, '{"a":1}');
+    assertEquals(await Deno.readTextFile(path), '{"a":1}');
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("writeConfigText: truncates and overwrites an existing file", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const path = join(dir, "out.json");
+    await Deno.writeTextFile(path, "old-longer-content");
+    await writeConfigText(path, "new");
+    assertEquals(await Deno.readTextFile(path), "new");
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("writeConfigText: writes an empty string", async () => {
+  const dir = await Deno.makeTempDir();
+  try {
+    const path = join(dir, "empty.json");
+    await writeConfigText(path, "");
+    assertEquals(await Deno.readTextFile(path), "");
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test({
+  // The load-bearing property behind #634 for the write path: a write that
+  // blocks (FIFO with no reader) must NOT starve the event loop, so a
+  // concurrent timer can still fire. Deno.writeTextFile fails this;
+  // writeConfigText (Deno.open) must pass it. POSIX-only.
+  name: "writeConfigText: a blocked write leaves the event loop alive",
+  ignore: Deno.build.os === "windows",
+  // The write is intentionally left blocked (the FIFO never gets a
+  // reader), so its open() op stays pending past the test — expected.
+  sanitizeOps: false,
+  sanitizeResources: false,
+  async fn() {
+    const dir = await Deno.makeTempDir();
+    try {
+      const fifo = join(dir, "fifo");
+      const mk = await new Deno.Command("mkfifo", { args: [fifo] }).output();
+      assertEquals(mk.code, 0);
+      const timer = new Promise<string>((resolve) =>
+        setTimeout(() => resolve("timer-won"), 100)
+      );
+      const winner = await Promise.race([
+        writeConfigText(fifo, "blocked"),
+        timer,
+      ]);
+      assertEquals(winner, "timer-won");
+    } finally {
+      await Deno.remove(dir, { recursive: true });
+    }
+  },
+});

--- a/tests/e2e/mcp_install_timeout_test.ts
+++ b/tests/e2e/mcp_install_timeout_test.ts
@@ -1,0 +1,116 @@
+import { assertEquals, assertStringIncludes } from "@std/assert";
+
+// Blackbox: drives the CLI binary via Deno.Command. Imports nothing from
+// source modules (the e2e boundary). Recomputes CLI_ENTRY rather than
+// reusing helpers.ts's markspec() because this test needs a pre-created
+// FIFO config file and a custom env var, which that helper does not expose.
+const CLI_ENTRY = new URL(
+  "../../packages/markspec/main.ts",
+  import.meta.url,
+).pathname;
+
+/**
+ * #634 — `markspec mcp install` must never hang silently. A config file
+ * that blocks on read (here a FIFO with no writer — `readTextFile` parks
+ * in the `open()`/`read()` syscall exactly as the reported host stall did)
+ * must trip the install watchdog: a stderr diagnostic and a non-zero exit,
+ * not an uninterruptible hang.
+ *
+ * FIFOs are POSIX-only; skip on Windows (the watchdog logic itself is
+ * covered cross-platform by cli/install/deadline_test.ts).
+ */
+Deno.test({
+  name:
+    "mcp install: a read-stalled .mcp.json trips the watchdog (diagnostic + exit 1), not a hang",
+  ignore: Deno.build.os === "windows",
+  async fn() {
+    const dir = await Deno.makeTempDir();
+    try {
+      const fifo = `${dir}/.mcp.json`;
+      const mk = await new Deno.Command("mkfifo", { args: [fifo] }).output();
+      assertEquals(mk.code, 0, "mkfifo should create the FIFO");
+
+      const cmd = new Deno.Command("deno", {
+        args: [
+          "run",
+          "--allow-read",
+          "--allow-write",
+          "--allow-env",
+          "--allow-run",
+          CLI_ENTRY,
+          "mcp",
+          "install",
+          "--client",
+          "claude-code",
+          "--print",
+          "--no-color",
+        ],
+        cwd: dir,
+        // Short deadline keeps the test fast; merged with the parent env,
+        // so PATH etc. are inherited.
+        env: { MARKSPEC_INSTALL_TIMEOUT_MS: "500" },
+        stdout: "piped",
+        stderr: "piped",
+      });
+      const { code, stderr } = await cmd.output();
+      const err = new TextDecoder().decode(stderr);
+
+      assertEquals(code, 1, `expected exit 1, got ${code}; stderr:\n${err}`);
+      assertStringIncludes(err, "timed out");
+      // The diagnostic must name the workaround so a stuck user is unblocked.
+      assertStringIncludes(err, "claude mcp add");
+    } finally {
+      await Deno.remove(dir, { recursive: true });
+    }
+  },
+});
+
+/**
+ * #634, write path — with `--force`, the config is staged to
+ * `<config>.tmp` before an atomic rename. A write that blocks (a FIFO at
+ * the tmp path with no reader — `writeConfigText` parks in `open()`) must
+ * trip the watchdog too, not hang. POSIX-only.
+ */
+Deno.test({
+  name:
+    "mcp install --force: a write-stalled .mcp.json.tmp trips the watchdog (diagnostic + exit 1)",
+  ignore: Deno.build.os === "windows",
+  async fn() {
+    const dir = await Deno.makeTempDir();
+    try {
+      // The atomic-write staging path is `<configPath>.tmp`; make it a
+      // FIFO so the write blocks on open().
+      const fifo = `${dir}/.mcp.json.tmp`;
+      const mk = await new Deno.Command("mkfifo", { args: [fifo] }).output();
+      assertEquals(mk.code, 0, "mkfifo should create the tmp FIFO");
+
+      const cmd = new Deno.Command("deno", {
+        args: [
+          "run",
+          "--allow-read",
+          "--allow-write",
+          "--allow-env",
+          "--allow-run",
+          CLI_ENTRY,
+          "mcp",
+          "install",
+          "--client",
+          "claude-code",
+          "--force",
+          "--no-color",
+        ],
+        cwd: dir,
+        env: { MARKSPEC_INSTALL_TIMEOUT_MS: "500" },
+        stdout: "piped",
+        stderr: "piped",
+      });
+      const { code, stderr } = await cmd.output();
+      const err = new TextDecoder().decode(stderr);
+
+      assertEquals(code, 1, `expected exit 1, got ${code}; stderr:\n${err}`);
+      assertStringIncludes(err, "timed out");
+    } finally {
+      await Deno.remove(dir, { recursive: true });
+    }
+  },
+});


### PR DESCRIPTION
Closes #634.

## Problem

`markspec mcp install --client claude-code` (and `lsp install`) could hang
indefinitely with **zero output** under extreme host load, clearable only with
`kill -9`. `--version` / `--help` returned instantly with the same binary.

## Root-cause investigation (systematic-debugging)

The reachable install path is pure file I/O — one config read, then a JSON block
edit; no subprocess, no locks, no module side-effects. On an unloaded host it
returns in ~50–250 ms and is **not reproducible** without the load. Two findings
shaped the fix:

1. **The reported wedge is pre-runtime.** The issue's own evidence — 96 K
   footprint parked at `_dyld_start` — means the process wedged in the OS
   process loader *before the Deno runtime started*. No in-process code runs
   there, so **no in-process watchdog can fire** for that exact case. It's
   environmental, as the reporter suspected.
2. **A plain watchdog is theater for the fused file ops.** Empirically,
   both `Deno.readTextFile` and `Deno.writeTextFile` on a stalled file
   (proved with a FIFO — writer-less for read, reader-less for write)
   **starve the event loop**, so a `setTimeout` watchdog wrapped around
   them never gets a turn. `Deno.open` (async) does *not* starve the loop.

## The fix (watchdog + `Deno.open` read + docs)

Real in-process hardening that bounds an in-code read stall:

- **`withDeadline`** wraps both install actions. On timeout →
  stderr diagnostic + exit `1` (project exit-code policy). Deadline defaults to
  **10 s**, overridable via **`MARKSPEC_INSTALL_TIMEOUT_MS`** (env read is
  permission-guarded so it also works without `--allow-env`).
- **`readConfigText` / `writeConfigText`** route both orchestrators' config
  read *and* staged (`--force`) write through `Deno.open` (offloaded to the
  blocking threadpool → loop stays alive → the watchdog can win the race),
  preserving the missing-file→empty and atomic-write contracts.
- **Docs** (`guide/cli.md`) state the honest limitation: the watchdog can't
  catch a pre-runtime loader wedge; supervise externally (`timeout 15 …`) or use
  `claude mcp add markspec -- markspec mcp`.

**Scope note:** this does *not* claim to fix the reported `_dyld_start` wedge
(unfixable in-process). It converts an in-code read stall from an
uninterruptible silent hang into a fast, diagnosable failure, and documents the
external mitigation for the pre-runtime case.

## Verification

- New unit tests: `withDeadline` / `resolveInstallDeadlineMs`, and loop-alive
  proofs for `readConfigText` (blocked read) and `writeConfigText` (blocked
  write).
- New e2e tests: a FIFO-stalled `.mcp.json` read and a FIFO-stalled
  `.mcp.json.tmp` write (`--force`) both trip the watchdog (exit 1 +
  diagnostic in <1 s) — the read case hung 4 s+ and needed `kill -9` before
  the fix.
- `just build` green (3501 passed, 0 failed) + `deno fmt --check` + `dprint
  check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
