### PR TITLE
fix(core): still flag spaced-key trailer typos as MSL-P022 (#697)

### DIFF
--- a/packages/markspec/core/parser/markdown.ts
+++ b/packages/markspec/core/parser/markdown.ts
@@ -446,11 +446,22 @@ function extractEntry(
       const colonMatch = COLON_SPLIT_RE.exec(trimmed);
       if (!colonMatch) break; // stop at non-colon line
       const key = colonMatch[1].trim();
-      // A genuine trailer key is a single token; it never contains internal
-      // whitespace or a pipe. A colon inside prose ("modes are: fast") or a
-      // Markdown table row ("| Fast | latency: 200ms |") is body content, not
-      // a malformed trailer — stop scanning at it (#648).
-      if (/[\s|]/.test(key)) break;
+      // A colon inside prose ("modes are: fast") or a Markdown table row
+      // ("| Fast | latency: 200ms |") is body content, not a malformed
+      // trailer — stop scanning at it (#648). A pipe always means a table
+      // cell. Internal whitespace usually means prose, EXCEPT a space-for-
+      // hyphen typo of a real trailer key (`Verified by` for `Verified-by`):
+      // that is a malformed trailer the author intended and must still fire
+      // MSL-P022 rather than silently dropping the trace link (#697). Detect
+      // it by normalising spaces to hyphens and checking the recognised
+      // trailer-key vocabulary.
+      if (key.includes("|")) break;
+      if (
+        /\s/.test(key) &&
+        !RECOGNIZED_TRAILER_KEYS.has(key.replace(/\s+/g, "-"))
+      ) {
+        break;
+      }
       if (ATTR_LINE_RE.test(trimmed)) {
         // Valid attr line in body → already caught by P020
         continue;

--- a/tests/e2e/parse_identity_diagnostics_test.ts
+++ b/tests/e2e/parse_identity_diagnostics_test.ts
@@ -226,6 +226,32 @@ Deno.test("validate: malformed trailer key after a colon table still -> MSL-P022
   assertStringIncludes(stderr, "Bad_Key");
 });
 
+// #697: a trailer key mistyped with a space instead of a hyphen (e.g.
+// `Verified by:` for `Verified-by:`) is a malformed trailer the author
+// intended, not prose -- it must still fire MSL-P022, not be silently
+// swallowed (which would drop the trace link with no error). Regression from
+// the #648 whitespace guard, which broke the backward scan on ANY internal
+// whitespace in the key.
+Deno.test("validate: spaced-key trailer typo still -> MSL-P022 (#697)", async () => {
+  const { code, stderr } = await markspec(["check", "req.md"], {
+    files: {
+      "req.md": `# Test
+
+- [REQ-001] Spaced trailer key typo
+
+  The system shall support the modes below.
+
+  Verified by: TST_0001
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+`,
+    },
+  });
+  assertEquals(code, 1, `expected exit 1, stderr: ${stderr}`);
+  assertStringIncludes(stderr, "MSL-P022");
+  assertStringIncludes(stderr, "Verified by");
+});
+
 // ---------------------------------------------------------------------------
 // #654: MSL-P020 (misplaced trailer) must fire only for a RECOGNIZED trailer
 // key. A body paragraph that merely starts with a capitalized word + colon


### PR DESCRIPTION
Closes #697.

## Problem

`markspec check`/`fmt` silently dropped a trace link when a trailer key was
mistyped with a space instead of a hyphen (`Verified by:` for `Verified-by:`).
The #648 whitespace guard broke the trailer backward-scan on any internal
whitespace, so the line was treated as body prose — exit 0, no diagnostic,
trace link lost. For a traceability tool that is worse than the false
positive it fixed.

## Fix

Narrow the guard in `packages/markspec/core/parser/markdown.ts`: a `|` still
means a table cell; internal whitespace still means prose **except** when the
space-normalised key matches a recognised trailer key (`Verified by` →
`Verified-by`), which is a malformed trailer the author intended → MSL-P022
fires as before. The #648 table/prose colon cases stay silent.

## Tests

- New e2e regression in `tests/e2e/parse_identity_diagnostics_test.ts`: a
  spaced-key trailer typo now fires MSL-P022 (watched it fail first).
- All #648/#654 guard tests stay green (26/26 in that file).
- `just build` passes (lint + test + typecheck + compile).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
