### PR TITLE
fix(mcp): resolve project-root candidate before the upward walk (#701)

### DIFF
--- a/packages/markspec/mcp/project.ts
+++ b/packages/markspec/mcp/project.ts
@@ -10,7 +10,7 @@
  * without filesystem access.
  */
 
-import { join } from "@std/path";
+import { isAbsolute, join, resolve } from "@std/path";
 import {
   compile,
   type CompileResult,
@@ -63,7 +63,14 @@ export async function detectMarkspecProject(
   cwd: string,
   readFile: ReadFile,
 ): Promise<boolean> {
-  let dir = cwd;
+  // The `parent === dir` root check below only reaches a fixed point for
+  // absolute paths (`join("/", "..") === "/"`); a RELATIVE candidate
+  // (`--root ./typo`, `MARKSPEC_PROJECT_ROOT=../x`) would otherwise grow `../`
+  // forever and loop indefinitely (#701). Resolve only when the path is
+  // relative — an already-absolute path is left verbatim so we don't rewrite
+  // separators or prepend a drive letter on Windows (which would break callers
+  // that pass POSIX-style absolute paths matched against an OS-native `join`).
+  let dir = isAbsolute(cwd) ? cwd : resolve(cwd);
   while (true) {
     if (await readFile(join(dir, "project.yaml")) !== undefined) return true;
     if (await readFile(join(dir, ".markspec.yaml")) !== undefined) return true;

--- a/packages/markspec/mcp/project_test.ts
+++ b/packages/markspec/mcp/project_test.ts
@@ -119,6 +119,26 @@ Deno.test("getCompiled: succeeds for a .markspec.yaml-only project", async () =>
   assertExists(result.entries.get(makeDisplayId("STK_TEST_0001")));
 });
 
+// #701: a RELATIVE override candidate (`--root ./typo`,
+// `MARKSPEC_PROJECT_ROOT=../foo`) that does not resolve to a real project must
+// not send the upward walk into an infinite loop. The `parent === dir`
+// termination only holds once `dir` is absolute, so the walk must resolve the
+// candidate first. Deterministic guard: cap the read count so a
+// non-terminating walk fails loudly instead of hanging the suite.
+Deno.test("detectMarkspecProject terminates for a relative non-resolving candidate (#701)", async () => {
+  let reads = 0;
+  const readFile = (_path: string): Promise<string | undefined> => {
+    if (++reads > 1000) {
+      throw new Error(
+        `did not terminate: walked ${reads} reads (infinite loop)`,
+      );
+    }
+    return Promise.resolve(undefined);
+  };
+  const found = await detectMarkspecProject("../does-not-exist-xyz", readFile);
+  assertEquals(found, false);
+});
+
 Deno.test("getCompiled: compiles and caches result", async () => {
   const { env } = makeEnv({
     [PROJECT_YAML_PATH]: { content: PROJECT_YAML, mtime: 1 },


### PR DESCRIPTION
Closes #701.

## Problem

`markspec mcp --root ./relative` or `MARKSPEC_PROJECT_ROOT=../foo` (any
relative override candidate that doesn't resolve to a real project) sent
`detectMarkspecProject`'s upward walk into an infinite loop: it started from
an unresolved `cwd`, and the `parent === dir` root check only reaches a fixed
point for absolute paths. The MCP server hung at startup with unbounded
CPU/memory and no error.

## Fix

Resolve the candidate to an absolute path before the walk
(`let dir = resolve(cwd)`), matching `discoverProjectRoot` in core/config.

## Tests

- New deterministic unit test in `packages/markspec/mcp/project_test.ts`: a
  relative non-resolving candidate must terminate. The read count is capped so
  a looping walk fails loudly instead of hanging the suite — watched it fail
  first (`walked 1001 reads`), then pass.
- Full `project_test.ts` green (35/35).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
