### PR TITLE
fix(core): make the MSL-F011 gate corpus-blind like fmt (#698)

### DIFF
--- a/packages/markspec/core/gates/mod.ts
+++ b/packages/markspec/core/gates/mod.ts
@@ -43,8 +43,9 @@ import { runLint } from "../lint/mod.ts";
  * files, so the caller passes only Markdown file contents.
  *
  * @param mdContents Markdown file path → current on-disk content.
- * @param entries The full parsed entry set (project + corpus), used to build
- *   the reference index `canonicalizeRefs` heals against.
+ * @param entries The full parsed entry set (project + corpus). Only
+ *   project-owned entries (`!e.origin`) build the reference index
+ *   `canonicalizeRefs` heals against — `markspec fmt` is corpus-blind (ADR-030).
  * @param ledger The lockfile's `[[edge]]` ULID ledger (`lockfile.edges`, or
  *   `[]` when there is no lockfile), threaded into `canonicalizeRefs`.
  * @param formatMarkdownProse The loaded ADR-029 whole-document Markdown
@@ -57,7 +58,13 @@ export async function fmtDriftGate(
   formatMarkdownProse: ProseFormatter | undefined,
 ): Promise<Diagnostic[]> {
   const diagnostics: Diagnostic[] = [];
-  const refIndex = buildRefIndex(entries);
+  // Corpus-blind by design (ADR-030): `markspec fmt` never loads the delivered
+  // corpus, so it can only canonicalize references into project-owned entries.
+  // Building the heal index over the full set (including corpus) would flag an
+  // MSL-F011 drift that `fmt` can never fix — a permanently red gate for any
+  // consumer using a delivered corpus. Filter to `!e.origin`, mirroring
+  // lockfileDriftGate.
+  const refIndex = buildRefIndex(entries.filter((e) => !e.origin));
   for (const [filePath, content] of mdContents) {
     const formatted = format(content, {
       file: filePath,

--- a/packages/markspec/core/gates/mod_test.ts
+++ b/packages/markspec/core/gates/mod_test.ts
@@ -99,6 +99,49 @@ Deno.test("fmtDriftGate: a non-canonical ULID reference fails with MSL-F011, not
   assertEquals(diags.some((d) => d.code === "MSL-F010"), false);
 });
 
+Deno.test("fmtDriftGate: a ULID reference to a delivered-corpus entry does not fire MSL-F011 (#698)", async () => {
+  // SREQ-0001 (project) references REQ-0001 (delivered corpus) by raw ULID.
+  // `markspec fmt` is corpus-blind — it never loads the delivered corpus, so
+  // it cannot rewrite that ULID to a display ID. The gate must be corpus-blind
+  // too; otherwise it reports MSL-F011 drift that `fmt` can never heal — a
+  // permanently red gate for any project using a delivered corpus (ADR-030),
+  // mirroring the `!e.origin` filter lockfileDriftGate already applies.
+  const reqFormatted = format(CLEAN_REQ, { file: "req.md" }).output;
+  const sreq = format(
+    `# System Requirements
+
+- [SREQ-0001] Derived response time
+
+  The system shall forward responses within 100 ms.
+
+      Id: 01SREQ00000000000000000001
+      Type: Requirement
+      Satisfies: 01REQ000000000000000000001
+`,
+    { file: "sreq.md" },
+  ).output;
+
+  const reqEntries = (await parseFile(reqFormatted, { file: "req.md" }))
+    .entries;
+  const sreqEntries = (await parseFile(sreq, { file: "sreq.md" })).entries;
+
+  // Mark REQ-0001 as delivered corpus (ADR-030).
+  const corpusOrigin = {
+    kind: "profile",
+    profileId: "@acme/platform",
+    profileVersion: "1.0.0",
+  } as const;
+  const corpusEntries = reqEntries.map((e) => ({ ...e, origin: corpusOrigin }));
+
+  const diags = await fmtDriftGate(
+    new Map([["sreq.md", sreq]]),
+    [...corpusEntries, ...sreqEntries],
+    [],
+    undefined,
+  );
+  assertEquals(diags.some((d) => d.code === "MSL-F011"), false);
+});
+
 // ---------------------------------------------------------------------------
 // lockfileDriftGate
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #698.

## Problem

`MSL-F011` (reference-canonicalization drift) fired a permanent false
positive for any project using an ADR-030 delivered corpus. `fmtDriftGate`
built its heal index from the full entry set (project + corpus), but
`markspec fmt` is corpus-blind — it never loads the delivered corpus. So a
project entry referencing a corpus entry by raw ULID was flagged
non-canonical by `check`, yet `fmt` could not rewrite it → CI stuck red with
no remedy.

## Fix

Filter the reference-heal index to project-owned entries (`!e.origin`),
mirroring the filter `lockfileDriftGate` already applies for the same
corpus-blind reason. Now `check` and `fmt` agree on what is canonical.

## Tests

- New unit test in `packages/markspec/core/gates/mod_test.ts`: a project
  entry that references a delivered-corpus entry by raw ULID must not fire
  MSL-F011 — watched it fail first (F011 fired), then pass.
- Full `core/gates/mod_test.ts` green (8/8), including the existing
  project-to-project F011 test (real canonicalization still flagged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
