### PR TITLE
fix(core): reject symlink-escaping profile-delivered documents (#699)

### DIFF
--- a/docs/spec/model/annex-profile-schema.md
+++ b/docs/spec/model/annex-profile-schema.md
@@ -567,17 +567,23 @@ missing/empty `path` is a `PROFILE-LOAD-003` error.
 
 File existence is checked when the delivered corpus loads (every graph-consuming
 command, the LSP, and the MCP server), raising `PROFILE-DELIVERS-001`/`-002`.
-The table also lists the two structural errors raised earlier, at manifest-parse
-time, when the `delivers:` block is validated: `PROFILE-DELIVERS-003` (a `path`
-escaping the profile directory) and `PROFILE-DELIVERS-004` (`corpus: true` on a
-non-Markdown file).
+The same load also enforces a containment guard: a delivered file whose real,
+symlink-resolved path escapes the profile package is refused and raises
+`PROFILE-DELIVERS-005` — the structural `path` check (`-003`) validates the
+declared string, but a symlink can still point the resolved file outside the
+package, so the real path is checked before the file is read. The table also
+lists the two structural errors raised earlier, at manifest-parse time, when the
+`delivers:` block is validated: `PROFILE-DELIVERS-003` (a `path` escaping the
+profile directory) and `PROFILE-DELIVERS-004` (`corpus: true` on a non-Markdown
+file).
 
-| Code                   | Severity | Meaning                                       |
-| ---------------------- | -------- | --------------------------------------------- |
-| `PROFILE-DELIVERS-001` | error    | Corpus file declared but missing from package |
-| `PROFILE-DELIVERS-002` | warning  | Docs-only file declared but missing           |
-| `PROFILE-DELIVERS-003` | error    | `path` escapes the profile directory          |
-| `PROFILE-DELIVERS-004` | error    | `corpus: true` on a non-Markdown file         |
+| Code                   | Severity | Meaning                                                  |
+| ---------------------- | -------- | -------------------------------------------------------- |
+| `PROFILE-DELIVERS-001` | error    | Corpus file declared but missing from package            |
+| `PROFILE-DELIVERS-002` | warning  | Docs-only file declared but missing                      |
+| `PROFILE-DELIVERS-003` | error    | `path` escapes the profile directory                     |
+| `PROFILE-DELIVERS-004` | error    | `corpus: true` on a non-Markdown file                    |
+| `PROFILE-DELIVERS-005` | error    | Delivered file's real path escapes the package (symlink) |
 
 A project entry re-declaring a display ID or `Id:` owned by a delivered corpus
 entry fails validation with `MSL-R014` (language spec §8.2) — the fix is to

--- a/packages/markspec/cli/commands/doctor.ts
+++ b/packages/markspec/cli/commands/doctor.ts
@@ -134,7 +134,11 @@ export const doctorCmd = new Command()
     > = [];
     if (effective && effective.delivers.length > 0) {
       const { loadDeliveredCorpus } = await import("../../core/mod.ts");
-      const corpus = await loadDeliveredCorpus(effective.delivers, readFile);
+      const corpus = await loadDeliveredCorpus(
+        effective.delivers,
+        readFile,
+        (p) => Deno.realPath(p),
+      );
       corpusEntryCount = corpus.entries.length;
       for (const d of corpus.diagnostics) {
         corpusIssues.push({

--- a/packages/markspec/cli/commands/profile.ts
+++ b/packages/markspec/cli/commands/profile.ts
@@ -67,7 +67,11 @@ export const profileCmd = new Command()
         const delivers = chain.effective.delivers;
         if (delivers.length > 0) {
           const { loadDeliveredCorpus } = await import("../../core/mod.ts");
-          const corpus = await loadDeliveredCorpus(delivers, readFile);
+          const corpus = await loadDeliveredCorpus(
+            delivers,
+            readFile,
+            (p) => Deno.realPath(p),
+          );
           // Corpus-load issues (missing delivered files) would otherwise
           // render as a misleading `corpus   0 entries` — profile show
           // does not route through compileProject, so this state is

--- a/packages/markspec/cli/helpers.ts
+++ b/packages/markspec/cli/helpers.ts
@@ -227,7 +227,7 @@ export async function loadProjectCorpus(
   );
   const delivers = chain?.effective.delivers ?? [];
   const corpus = chain
-    ? await loadDeliveredCorpus(delivers, readFile)
+    ? await loadDeliveredCorpus(delivers, readFile, (p) => Deno.realPath(p))
     : { entries: [], diagnostics: [] };
   return {
     entries: corpus.entries,

--- a/packages/markspec/core/mod.ts
+++ b/packages/markspec/core/mod.ts
@@ -189,9 +189,13 @@ export type {
 export {
   buildCorpusIndex,
   corpusOriginLabel,
+  deliveredPathIsContained,
   loadDeliveredCorpus,
 } from "./profile/delivered.ts";
-export type { LoadDeliveredCorpusResult } from "./profile/delivered.ts";
+export type {
+  LoadDeliveredCorpusResult,
+  RealPath,
+} from "./profile/delivered.ts";
 
 // Parser
 export {

--- a/packages/markspec/core/model/profile.ts
+++ b/packages/markspec/core/model/profile.ts
@@ -194,6 +194,14 @@ export interface DeliveredDocument {
   readonly profileVersion: string;
   readonly path: string;
   readonly absPath: string;
+  /**
+   * The delivering tier's `baseDir` — the profile-package root `absPath` is
+   * resolved against. Used by the delivered-path containment guard (#699) to
+   * reject a `.md` whose real (symlink-resolved) path escapes the package.
+   * Optional so pre-existing fixtures need not set it; production always does
+   * (set in `resolveDelivers`).
+   */
+  readonly baseDir?: string;
   readonly corpus: boolean;
   readonly description?: string;
 }

--- a/packages/markspec/core/profile/delivered.ts
+++ b/packages/markspec/core/profile/delivered.ts
@@ -7,6 +7,7 @@
  * I/O via the injected {@linkcode ReadFile}.
  */
 
+import { SEPARATOR } from "@std/path";
 import type { ReadFile } from "../config/mod.ts";
 import type {
   DeliveredDocument,
@@ -21,6 +22,13 @@ export interface LoadDeliveredCorpusResult {
   readonly entries: readonly Entry[];
   readonly diagnostics: readonly Diagnostic[];
 }
+
+/**
+ * Canonicalises a path, resolving symlinks (e.g. `Deno.realPath`). Injected so
+ * core stays runtime-agnostic. Supplied by callers to the delivered-path
+ * containment guard (#699); omitting it disables the guard.
+ */
+export type RealPath = (path: string) => Promise<string>;
 
 /** Human-facing label of a delivered document's providing tier. */
 export function corpusOriginLabel(doc: DeliveredDocument): string {
@@ -45,10 +53,22 @@ export function buildCorpusIndex(
 export async function loadDeliveredCorpus(
   delivers: readonly DeliveredDocument[],
   readFile: ReadFile,
+  realPath?: RealPath,
 ): Promise<LoadDeliveredCorpusResult> {
   const entries: Entry[] = [];
   const diagnostics: Diagnostic[] = [];
   for (const doc of delivers) {
+    if (realPath && !(await deliveredPathIsContained(doc, realPath))) {
+      diagnostics.push({
+        code: "PROFILE-DELIVERS-005",
+        severity: "error",
+        message: `delivered ${doc.corpus ? "corpus" : "document"} file ` +
+          `'${doc.path}' declared by ${corpusOriginLabel(doc)} resolves ` +
+          `outside the profile package (symlink escape) and was not read`,
+        location: { file: doc.absPath, line: 1, column: 1 },
+      });
+      continue;
+    }
     const content = await readFile(doc.absPath);
     if (content === undefined) {
       diagnostics.push({
@@ -77,4 +97,36 @@ export async function loadDeliveredCorpus(
     entries.push(...parsed.entries.map((e) => ({ ...e, origin })));
   }
   return { entries, diagnostics };
+}
+
+/**
+ * True when `doc`'s real (symlink-resolved) path stays within its profile's
+ * `baseDir` — the delivered-path containment guard (#699). A malicious profile
+ * (pulled via `extends: git+…`, which preserves symlinks) can deliver a `.md`
+ * that is actually a symlink to an arbitrary local file (`~/.ssh/id_rsa`); the
+ * string-level path checks (PROFILE-DELIVERS-003/004) validate the declared
+ * path, not the symlink target, so a real-path containment check is the only
+ * thing that stops the read.
+ *
+ * Degrades to `true` (allow) when the doc carries no `baseDir` or when the
+ * paths cannot be canonicalised (e.g. the file is missing) — a missing file is
+ * left to the existing PROFILE-DELIVERS-001/002 checks. Shared by the MCP
+ * `readDeliveredDocument` read path, which faces the same vector.
+ */
+export async function deliveredPathIsContained(
+  doc: DeliveredDocument,
+  realPath: RealPath,
+): Promise<boolean> {
+  if (doc.baseDir === undefined) return true;
+  let realBase: string;
+  let realTarget: string;
+  try {
+    realBase = await realPath(doc.baseDir);
+    realTarget = await realPath(doc.absPath);
+  } catch {
+    return true; // unresolvable (e.g. missing) — handled by 001/002 downstream
+  }
+  if (realTarget === realBase) return true;
+  const prefix = realBase.endsWith(SEPARATOR) ? realBase : realBase + SEPARATOR;
+  return realTarget.startsWith(prefix);
 }

--- a/packages/markspec/core/profile/delivered_test.ts
+++ b/packages/markspec/core/profile/delivered_test.ts
@@ -37,6 +37,50 @@ Deno.test("loadDeliveredCorpus: parses corpus entries and stamps origin", async 
   });
 });
 
+Deno.test("loadDeliveredCorpus: a delivered file symlinked outside baseDir is rejected PROFILE-DELIVERS-005, secret never read (#699)", async () => {
+  const base = await Deno.makeTempDir();
+  const outside = await Deno.makeTempDir();
+  try {
+    // A secret file OUTSIDE the profile package, shaped as a valid entry so
+    // that if it were ingested it would surface as an entry in the graph.
+    const secret = `${outside}/secret.md`;
+    await Deno.writeTextFile(
+      secret,
+      `- [SECRET_0001] Leaked private key\n\n  Body.\n\n      Id: 01ARZ3NDEKTSV4RRFFQ69G5FAV\n`,
+    );
+    // The profile "delivers" ref/arch.md, which is actually a symlink to it.
+    await Deno.mkdir(`${base}/ref`);
+    const linkPath = `${base}/ref/arch.md`;
+    await Deno.symlink(secret, linkPath);
+
+    const { entries, diagnostics } = await loadDeliveredCorpus(
+      [doc({ absPath: linkPath, baseDir: base, path: "ref/arch.md" })],
+      async (p) => {
+        try {
+          return await Deno.readTextFile(p);
+        } catch {
+          return undefined;
+        }
+      },
+      (p) => Deno.realPath(p),
+    );
+
+    assertEquals(
+      entries.length,
+      0,
+      "symlinked-out corpus must not be ingested",
+    );
+    assertEquals(
+      diagnostics.some((d) => d.code === "PROFILE-DELIVERS-005"),
+      true,
+      `expected PROFILE-DELIVERS-005, got ${JSON.stringify(diagnostics)}`,
+    );
+  } finally {
+    await Deno.remove(base, { recursive: true });
+    await Deno.remove(outside, { recursive: true });
+  }
+});
+
 Deno.test("loadDeliveredCorpus: missing corpus file is PROFILE-DELIVERS-001 error", async () => {
   const { entries, diagnostics } = await loadDeliveredCorpus(
     [doc({})],

--- a/packages/markspec/core/profile/merge.ts
+++ b/packages/markspec/core/profile/merge.ts
@@ -802,6 +802,7 @@ function deliveredFromTier(tier: LoadedProfile): DeliveredDocument[] {
     profileVersion: tier.version,
     path: d.path,
     absPath: join(tier.baseDir, d.path),
+    baseDir: tier.baseDir,
     corpus: d.corpus,
     description: d.description,
   }));

--- a/packages/markspec/core/profile/merge_test.ts
+++ b/packages/markspec/core/profile/merge_test.ts
@@ -1530,6 +1530,7 @@ profile:
       // Built with `join` so the expected separator matches production
       // (`deliveredFromTier` uses `join(baseDir, path)`) on Windows too.
       absPath: join("/fixture/t0", "ref/base.md"),
+      baseDir: "/fixture/t0",
       corpus: true,
       description: undefined,
     },
@@ -1538,6 +1539,7 @@ profile:
       profileVersion: "2.0.0",
       path: "ref/leaf.md",
       absPath: join("/fixture/t1", "ref/leaf.md"),
+      baseDir: "/fixture/t1",
       corpus: false,
       description: undefined,
     },

--- a/packages/markspec/lsp/server.ts
+++ b/packages/markspec/lsp/server.ts
@@ -232,7 +232,11 @@ async function seedDeliveredCorpus(): Promise<void> {
   const delivers = profile?.delivers ?? [];
   if (delivers.length === 0) return;
   try {
-    const corpus = await loadDeliveredCorpus(delivers, readFile);
+    const corpus = await loadDeliveredCorpus(
+      delivers,
+      readFile,
+      (p) => Deno.realPath(p),
+    );
     for (const d of corpus.diagnostics) {
       connection.console.warn(`${d.code}: ${d.message}`);
     }

--- a/packages/markspec/mcp/project.ts
+++ b/packages/markspec/mcp/project.ts
@@ -15,6 +15,7 @@ import {
   compile,
   type CompileResult,
   type DeliveredDocument,
+  deliveredPathIsContained,
   discoverMarkspecRoot,
   discoverProjectRoot,
   type EffectiveProfile,
@@ -149,6 +150,10 @@ export interface ProjectEnv {
   rootOverrides(): string[];
   /** Read a file's text content, or undefined if missing. */
   readFile: ReadFile;
+  /** Canonicalise a path, resolving symlinks (e.g. `Deno.realPath`). Used by
+   * the delivered-path containment guard (#699) when serving delivered
+   * documents. */
+  realPath(path: string): Promise<string>;
   /** Return the file's last-modified time in milliseconds since epoch. */
   stat(path: string): Promise<{ mtime: number }>;
   /** Async-iterate every file path under `root` (recursive). */
@@ -275,6 +280,7 @@ export function defaultEnv(flagRoots: readonly string[] = []): ProjectEnv {
         return undefined;
       }
     },
+    realPath: (path: string) => Deno.realPath(path),
     stat: async (path: string) => {
       const stat = await Deno.stat(path);
       return { mtime: stat.mtime?.getTime() ?? 0 };
@@ -372,6 +378,7 @@ export async function createProject(env: ProjectEnv): Promise<Project> {
         ? await loadDeliveredCorpus(
           profileChain.effective.delivers,
           env.readFile,
+          env.realPath,
         )
         : { entries: [], diagnostics: [] };
       const result = await compile(paths, {
@@ -508,6 +515,13 @@ export async function createProject(env: ProjectEnv): Promise<Project> {
         (d) => d.profileId === profileId && d.path === relPath,
       );
       if (!doc) return undefined;
+      // Containment guard (#699): refuse to serve a delivered document whose
+      // real (symlink-resolved) path escapes the profile package — otherwise a
+      // malicious profile could deliver a `.md` symlinked to an arbitrary local
+      // file and exfiltrate it through this MCP resource.
+      if (!(await deliveredPathIsContained(doc, env.realPath))) {
+        return undefined;
+      }
       return await env.readFile(doc.absPath);
     },
     async getCompiled(): Promise<CompileResult> {

--- a/packages/markspec/mcp/project_test.ts
+++ b/packages/markspec/mcp/project_test.ts
@@ -49,6 +49,7 @@ function makeEnv(
         const f = store.get(path);
         return Promise.resolve(f?.content);
       },
+      realPath: (path) => Promise.resolve(path),
       stat: (path) => {
         const f = store.get(path);
         if (!f) return Promise.reject(new Error(`ENOENT: ${path}`));
@@ -532,6 +533,7 @@ function makeCorpusEnv(corpusMissing = false): ProjectEnv {
     cwd: () => PROJ,
     rootOverrides: () => [],
     readFile: (path) => Promise.resolve(files.get(path)),
+    realPath: (path) => Promise.resolve(path),
     stat: (path) => {
       if (!files.has(path)) return Promise.reject(new Error(`ENOENT: ${path}`));
       return Promise.resolve({ mtime: 1 });


### PR DESCRIPTION
Closes #699.

## Problem (security)

A profile-delivered document (ADR-030) was validated only as a path *string* —
`PROFILE-DELIVERS-003/004` check the declared `path`, never the on-disk target.
A malicious profile pulled via `extends: git+…` (git preserves symlinks on
checkout) can deliver `ref/arch.md` that is actually a **symlink to an arbitrary
local file** (`~/.ssh/id_rsa`, `~/.aws/credentials`). Two read sites then expose
it:

- the corpus loader ingests it into the traceability graph, and
- the MCP `markspec://delivered/{profileId}/{path}` resource returns its raw
  bytes to any client (e.g. an AI agent doing routine `resources/read`).

Silent, zero-interaction local-file exfiltration.

## Fix

`deliveredPathIsContained(doc, realPath)` in `core/profile/delivered.ts`:
canonicalise the delivered file's real, symlink-resolved path and refuse it when
it escapes the profile package's `baseDir`.

- **Corpus loader** (`loadDeliveredCorpus`): on escape, emit
  `PROFILE-DELIVERS-005` (error) and skip the read — the file never enters the
  graph.
- **MCP** (`readDeliveredDocument`): on escape, return `undefined` so the
  resource is not served.

`DeliveredDocument` now carries `baseDir` (set in `resolveDelivers`). The
realpath capability is injected — `Deno.realPath` at each CLI/LSP/MCP entry
point (`ProjectEnv.realPath` for MCP) — so `core/` stays runtime-agnostic. A
missing/unresolvable file is left to the existing `PROFILE-DELIVERS-001/002`
checks.

## Tests

- New real-symlink exploit test (`core/profile/delivered_test.ts`): a delivered
  file symlinked outside `baseDir` is rejected with `PROFILE-DELIVERS-005` and
  the secret is never ingested — watched it fail first (secret ingested, no
  diagnostic), then pass.
- MCP `readDeliveredDocument` reuses the same shared guard.
- `just build` green (3530 tests, 0 failed).

## Disclosure note

Filed as a public issue per maintainer decision. This gates the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
