### PR TITLE
fix(cli): refuse to overwrite read-only profile-delivered documents (#700)

### DIFF
--- a/packages/markspec/cli/commands/fmt.ts
+++ b/packages/markspec/cli/commands/fmt.ts
@@ -8,6 +8,7 @@ import { Command } from "@cliffy/command";
 import { extname } from "@std/path";
 import type { LockEdge, RefIndex } from "../../core/mod.ts";
 import {
+  assertNotDeliveredTarget,
   loadActiveProfile,
   loadMarkdownFormatterOrExit,
   readFile,
@@ -36,9 +37,15 @@ export const fmtCmd = new Command()
 
       const { discoverProjectRoot } = await import("../../core/mod.ts");
       const projectRoot = await discoverProjectRoot(Deno.cwd(), readFile);
-      if (projectRoot !== undefined) {
-        await loadActiveProfile(projectRoot);
-      }
+      const chain = projectRoot !== undefined
+        ? await loadActiveProfile(projectRoot)
+        : null;
+
+      // Delivered corpus/docs files are read-only (ADR-030). Refuse an
+      // explicitly-named target that resolves to one rather than overwriting
+      // the profile package's file (#700). Project-wide scope never includes
+      // corpus files (they live outside the walk / under `exclude:`).
+      if (!scope.projectWide) assertNotDeliveredTarget(scope.files, chain);
 
       const { format } = await import("../../core/mod.ts");
       const formatMarkdownProse = await loadMarkdownFormatterOrExit();

--- a/packages/markspec/cli/commands/insert.ts
+++ b/packages/markspec/cli/commands/insert.ts
@@ -6,7 +6,7 @@
  */
 
 import { Command } from "@cliffy/command";
-import { compileProject } from "../helpers.ts";
+import { assertNotDeliveredTarget, compileProject } from "../helpers.ts";
 import { nextDisplayId, resolveTypePattern } from "./id_helpers.ts";
 
 export const insertCmd = new Command()
@@ -33,6 +33,9 @@ export const insertCmd = new Command()
         console.error(`error: insert requires a profile; none configured`);
         Deno.exit(1);
       }
+      // Delivered corpus/docs files are read-only (ADR-030) — never append to
+      // a profile package's file (#700).
+      assertNotDeliveredTarget([filePath], chain);
       const pattern = resolveTypePattern(typeName, chain, "insert");
       const displayId = nextDisplayId(pattern, result.entries.values());
 

--- a/packages/markspec/cli/helpers.ts
+++ b/packages/markspec/cli/helpers.ts
@@ -24,8 +24,39 @@ import type {
   ProfileChain,
   ReadFile,
 } from "../core/mod.ts";
+import { resolve } from "@std/path";
 
 export { CORE_SCHEMA_VERSION, VERSION };
+
+/**
+ * Refuse to operate on a profile-delivered document (ADR-030). Delivered
+ * corpus/docs files are read-only — sourced from a profile package, not the
+ * author's own work. A write command (`fmt`, `insert`) given an explicit path
+ * that resolves to a delivered document must not overwrite the package's file
+ * (#700); machine formats intentionally surface a corpus entry's real absolute
+ * path, so it is easy to name one by accident. Compares each target's resolved
+ * absolute path to the active chain's delivered index; on a match prints an
+ * error and exits 1. No-op when the chain has no delivered documents.
+ */
+export function assertNotDeliveredTarget(
+  files: readonly string[],
+  chain: ProfileChain | null | undefined,
+): void {
+  const delivers = chain?.effective.delivers ?? [];
+  if (delivers.length === 0) return;
+  for (const file of files) {
+    const abs = resolve(file);
+    const doc = delivers.find((d) => d.absPath === abs);
+    if (doc) {
+      console.error(
+        `error: ${file}: profile-delivered documents are read-only ` +
+          `(delivered by ${corpusOriginLabel(doc)}); edit it in its profile ` +
+          `package, not here`,
+      );
+      Deno.exit(1);
+    }
+  }
+}
 
 /** Print "not yet implemented" to stderr and exit 1. */
 export function notImplemented(name: string): () => void {

--- a/tests/e2e/delivered_test.ts
+++ b/tests/e2e/delivered_test.ts
@@ -515,3 +515,27 @@ Deno.test("export json: corpus-load warning reaches serialized diagnostics (#674
   assertEquals(code, 0, stderr);
   assertStringIncludes(stdout, "PROFILE-DELIVERS-002");
 });
+
+// ---------------------------------------------------------------------------
+// #700: delivered documents are read-only. A write command (`fmt`, `insert`)
+// given an explicit path that resolves to a profile-delivered document must
+// refuse rather than overwrite the profile package's file.
+// ---------------------------------------------------------------------------
+
+Deno.test("fmt: refuses to overwrite an explicitly-named delivered corpus file (#700)", async () => {
+  const { code, stderr } = await markspec(
+    ["fmt", "profile/reference/platform.md"],
+    fixture(WITH_DELIVERS),
+  );
+  assertEquals(code, 1, `expected exit 1, stderr: ${stderr}`);
+  assertStringIncludes(stderr, "read-only");
+});
+
+Deno.test("insert: refuses to append to an explicitly-named delivered corpus file (#700)", async () => {
+  const { code, stderr } = await markspec(
+    ["insert", "stakeholder-requirement", "profile/reference/platform.md"],
+    fixture(WITH_DELIVERS),
+  );
+  assertEquals(code, 1, `expected exit 1, stderr: ${stderr}`);
+  assertStringIncludes(stderr, "read-only");
+});


### PR DESCRIPTION
Closes #700.

## Problem

`markspec fmt` and `markspec insert` had no corpus/`origin` guard for explicit
file arguments (ADR-030 §D5's "no write into a profile's cache/local dir" holds
only for discovery scope). Since `--format json` / `show` / `compile`
deliberately emit a corpus entry's **real absolute path**, an agent running the
canonical `insert → fmt → check` loop — or simply `markspec fmt <that-path>` —
would silently overwrite:

- a `git+`/`npm:`-cached profile's file (shared by every project on the machine
  using that version), or
- a `./local` profile author's real source file.

## Fix

`assertNotDeliveredTarget(files, chain)` in `cli/helpers.ts`: resolve each
explicit target to an absolute path and compare against the active chain's
delivered index; on a match, print a "profile-delivered documents are read-only"
error and exit 1.

- `fmt` guards explicit args (`!scope.projectWide` — project-wide discovery
  never includes corpus files; they live outside the walk / under `exclude:`).
- `insert` guards its single target.

## Tests

- New e2e in `tests/e2e/delivered_test.ts`: `fmt` and `insert` on a
  `profile/reference/platform.md` delivered corpus file both exit 1 with a
  read-only error — watched them fail first (the write was allowed), then pass.
- `just build` green (3532 tests, 0 failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
