### PR TITLE
test(core): guarantee check treats unknown code-span DSLs + fence tags as opaque

### DIFF
--- a/docs/spec/internal/markspec-prose-analysis.md
+++ b/docs/spec/internal/markspec-prose-analysis.md
@@ -103,6 +103,20 @@ further by default:
 `prose.scope.blocks` (§4.1) opts the opt-in blocks in. The never-row is not
 profile-overridable (it would contradict core-data-model §2.5).
 
+**Unknown DSL content is opaque (stability guarantee, #719).** A fenced block is
+verbatim regardless of its info-string: an unknown language tag (`uxil`) is
+skipped exactly like `rust`, so no rule sees inside it. The uxil
+declaration/citation surface embedded in inline code spans — lowercase `ux:`
+refs, leading-slash / dot element forms, and `$`-prefixed shape citations — is
+likewise inert to every active rule, which lets the `@ampere/seed` profile host
+those vocabularies via an external linter before uxil lands in core (epic #717,
+Tier 1). The guarantee is scoped to that DSL surface, **not** to arbitrary text:
+inline code spans are not yet _structurally_ excluded (rules read a paragraph's
+verbatim `content.text`, which includes the span), so an uppercase modal keyword
+or a PascalCase term inside a span is still analyzed. Closing that structural
+gap is deferred follow-up #733. Regression-locked by
+`tests/e2e/opaque_dsl_test.ts`.
+
 ### 1.3 Intent and non-goals
 
 - **Inline markers are signal.** `ModalMarker` and `EntityRef` (core-data-model

--- a/docs/spec/language/language.md
+++ b/docs/spec/language/language.md
@@ -214,11 +214,11 @@ fn debounce_input(raw: u16, window_ms: u32) -> u16 {
 
 **Opaque DSL content.** A fenced block whose language identifier is unknown to
 the toolchain is passed through verbatim — never parsed, reformatted, or
-prose-analyzed. Inline code spans carrying an unknown declaration or citation
-DSL — for example the interaction-reference form `ux:media.home/play` — are
-likewise left untouched by `markspec fmt` and `markspec check`. External
-profiles rely on this to host their own embedded vocabularies before those
-vocabularies land in core.
+prose-analyzed. `markspec fmt` also leaves inline code spans byte-for-byte
+unchanged, and an unknown reference DSL embedded in a span — for example the
+interaction-reference form `ux:media.home/play` — draws no `markspec check`
+diagnostic. External profiles rely on this to host their own embedded
+vocabularies before those vocabularies land in core.
 
 #### Math
 

--- a/docs/spec/language/language.md
+++ b/docs/spec/language/language.md
@@ -212,6 +212,14 @@ fn debounce_input(raw: u16, window_ms: u32) -> u16 {
 ```
 ````
 
+**Opaque DSL content.** A fenced block whose language identifier is unknown to
+the toolchain is passed through verbatim — never parsed, reformatted, or
+prose-analyzed. Inline code spans carrying an unknown declaration or citation
+DSL — for example the interaction-reference form `ux:media.home/play` — are
+likewise left untouched by `markspec fmt` and `markspec check`. External
+profiles rely on this to host their own embedded vocabularies before those
+vocabularies land in core.
+
 #### Math
 
 Inline and block math expressions:

--- a/packages/markspec/core/parser/body_tokens_test.ts
+++ b/packages/markspec/core/parser/body_tokens_test.ts
@@ -121,6 +121,20 @@ Deno.test("scope: modal inside ```rust code fence is NOT emitted", () => {
   }
 });
 
+Deno.test("scope: unknown info-string fence is verbatim — no tokens emitted (#719)", () => {
+  // Verbatim-line skipping keys on block kind (`code`), not on a known
+  // language identifier, so an UNKNOWN info-string (e.g. `uxil`) is opaque
+  // exactly like `rust`: a modal verb and a `$Ref` inside it emit nothing.
+  const body =
+    "Prose with shall and $Vehicle.\n\n```uxil\nux:media.home : screen SHALL $Foo\n```\n";
+  const tokens = tokensOf(body);
+  const inFence = tokens.filter((t) => t.location.line >= 3);
+  assertEquals(inFence.length, 0, "no tokens from inside an unknown-tag fence");
+  // The prose modal + entity-ref on line 1 are still emitted (sanity).
+  assertEquals(tokens.filter((t) => t.kind === "modal").length, 1);
+  assertEquals(tokens.filter((t) => t.kind === "entity-ref").length, 1);
+});
+
 Deno.test("scope: entity-ref inside $$ math block is NOT emitted", () => {
   const body = "Use $Vehicle here.\n\n$$\n$x = 1$\n$$\n";
   const refs = tokensOf(body).filter((t) => t.kind === "entity-ref");

--- a/tests/e2e/opaque_dsl_test.ts
+++ b/tests/e2e/opaque_dsl_test.ts
@@ -1,0 +1,196 @@
+/**
+ * @module tests/e2e/opaque_dsl_test
+ *
+ * E2E regression suite for the #719 stability guarantee: `markspec check`
+ * treats unknown DSL content as opaque. Two content kinds must never draw a
+ * diagnostic, a format rewrite, or prose analysis:
+ *
+ *   1. inline code spans carrying an unknown declaration / citation DSL —
+ *      e.g. `ux:media.home/play`, `ux:media.home : screen @ ready`,
+ *      `/play : activate`, `.confirm_dialog @ default`, the scheme-less wire
+ *      form `media.home/play`, and a `$`-prefixed typl shape citation;
+ *   2. fenced blocks with an unknown info-string — e.g. ```uxil.
+ *
+ * The guarantee lets the `@ampere/seed` profile host the uxil vocabularies
+ * via an external linter before uxil lands in core (epic #717, Staging
+ * Tier 1). Locking it here means a future change to prose lint, the
+ * formatter, or the typl surfaces cannot silently start flagging unknown
+ * code-span DSLs.
+ *
+ * Scope note (see docs/spec/internal/markspec-prose-analysis.md §1.2 and the
+ * language spec's "Opaque DSL content" guarantee): this covers the uxil DSL
+ * surface — lowercase `ux:` refs, leading-slash / dot element forms, and
+ * `$`-prefixed shape citations — all of which are inert to every active lint
+ * rule. It does NOT promise that ARBITRARY prose inside a code span is exempt:
+ * an uppercase modal keyword or a PascalCase term in a span is still analyzed.
+ * Closing that structural gap is deferred follow-up #733.
+ */
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { join } from "@std/path";
+import { markspec, markspecPersist } from "./helpers.ts";
+
+// A minimal project whose profile declares one `requirement` type. The
+// profile pins `markspec-schema` so PROFILE-SCHEMA-002 stays silent.
+const PROJECT_YAML = "name: uxil-opaque-e2e\nversion: 0.1.0\n";
+const MARKSPEC_YAML = "profiles:\n  - ./profiles/p\n";
+const PROFILE_YAML = `markspec-schema: "1"
+id: "@acme/uxil-opaque"
+version: 0.1.0
+profile:
+  types:
+    requirement:
+      extends: Requirement
+      display-id-pattern: "REQ-{n:04d}"
+`;
+
+/**
+ * The fixture document. Its prose is EARS-clean (event-driven, one lowercase
+ * modal, no untoleranced numbers, no PascalCase) so the ONLY content that
+ * could draw a diagnostic is the unknown DSL — all four uxil declaration
+ * forms, a `ux:` citation, the scheme-less wire form, a camelCase tag, a
+ * `$`-shape citation, and an unknown ```uxil fenced block.
+ *
+ * Authored in fmt-canonical form: `markspec fmt` is a no-op on it (asserted
+ * by the "fmt verbatim" test below). Built as a line array with literal
+ * backticks — double-quoted strings need no backtick escaping.
+ */
+const UX_DOC = [
+  "# UX Contract",
+  "",
+  "- [REQ-0001] Open media detail on play tap",
+  "",
+  "  When the driver taps the play control `ux:media.home/play`, the system shall",
+  "  present the media detail surface. The root surface is",
+  "  `ux:media.home : screen @ loading, error, ready`, the element is",
+  "  `/play : activate`, and the child surface is `.confirm_dialog @ default`. The",
+  "  scheme-less wire form `media.home/play` and camelCase `mediaHome/playButton`",
+  "  stay literal, and the payload cites `$MediaEvent`.",
+  "",
+  "  ```uxil",
+  "  ux:media.home : screen @ loading, error, ready",
+  "    /play : activate -> ux:media.detail",
+  "    .confirm_dialog @ default",
+  "  ```",
+  "",
+  "      Id: 01REQ000000000000000000001",
+  "      Type: requirement",
+  "",
+].join("\n");
+
+const BASE_FILES: Record<string, string> = {
+  "project.yaml": PROJECT_YAML,
+  ".markspec.yaml": MARKSPEC_YAML,
+  "profiles/p/markspec.yaml": PROFILE_YAML,
+  "docs/req.md": UX_DOC,
+};
+
+// ---------------------------------------------------------------------------
+// 1. Project-wide `check` (the composite gate — runs the advisory prose lint,
+//    so Q500 is in scope) passes clean.
+// ---------------------------------------------------------------------------
+
+Deno.test(
+  "check: unknown code-span DSLs + unknown fence pass project-wide check clean (#719)",
+  async () => {
+    const { code, stderr } = await markspec(["check"], { files: BASE_FILES });
+    assertEquals(code, 0, `check should exit 0; stderr:\n${stderr}`);
+    assertEquals(
+      /MSL-/.test(stderr),
+      false,
+      `no MSL-* diagnostics expected on unknown DSL content; stderr:\n${stderr}`,
+    );
+    assertEquals(
+      stderr.includes("Q500"),
+      false,
+      `no Q500 expected on unknown DSL content; stderr:\n${stderr}`,
+    );
+  },
+);
+
+// ---------------------------------------------------------------------------
+// 2. Prose lint produces zero diagnostics on the DSL content.
+// ---------------------------------------------------------------------------
+
+Deno.test(
+  "lint: unknown code-span DSLs + unknown fence produce no prose diagnostics (#719)",
+  async () => {
+    const { stdout } = await markspec(
+      ["lint", "--format", "json", "docs/req.md"],
+      { files: BASE_FILES },
+    );
+    const parsed = JSON.parse(stdout) as {
+      diagnostics: Array<{ code: string; message: string }>;
+    };
+    assertEquals(
+      parsed.diagnostics.length,
+      0,
+      `expected no diagnostics; got: ${JSON.stringify(parsed.diagnostics)}`,
+    );
+  },
+);
+
+// ---------------------------------------------------------------------------
+// 3. The formatter leaves the unknown fence + every `ux:` code span verbatim.
+//    `markspec fmt` must be a no-op on the whole (already-canonical) document.
+// ---------------------------------------------------------------------------
+
+Deno.test(
+  "fmt: unknown fence + ux: code spans pass through verbatim (#719)",
+  async () => {
+    const run = await markspecPersist(["fmt", "docs/req.md"], {
+      files: BASE_FILES,
+    });
+    try {
+      assertEquals(run.code, 0, `fmt should exit 0; stderr:\n${run.stderr}`);
+      const after = await Deno.readTextFile(join(run.dir, "docs/req.md"));
+      // Whole-document equality is the strongest statement of "fmt does
+      // nothing here": the ux: spans and the ```uxil fence are byte-identical.
+      assertEquals(
+        after,
+        UX_DOC,
+        "fmt must leave the ux: spans and the unknown fence byte-identical",
+      );
+      // Explicit tokens, for a localized failure message if the above drifts.
+      assertStringIncludes(after, "`ux:media.home/play`");
+      assertStringIncludes(after, "`/play : activate`");
+      assertStringIncludes(after, "`.confirm_dialog @ default`");
+      assertStringIncludes(after, "`mediaHome/playButton`");
+      assertStringIncludes(after, "`$MediaEvent`");
+      assertStringIncludes(after, "```uxil");
+    } finally {
+      await Deno.remove(run.dir, { recursive: true });
+    }
+  },
+);
+
+// ---------------------------------------------------------------------------
+// 4. The typl surfaces do not claim `ux:`-scheme code spans. A colon-bearing
+//    `ux:` span looks superficially like the typl inline `$Name : type` form
+//    but must NOT be extracted — `entry.types` stays absent.
+// ---------------------------------------------------------------------------
+
+Deno.test(
+  "compile: ux:-scheme code spans are not parsed as typl (#719)",
+  async () => {
+    const { code, stdout } = await markspec(
+      ["compile", "--format", "json", "docs/req.md"],
+      { files: BASE_FILES },
+    );
+    assertEquals(code, 0);
+    const parsed = JSON.parse(stdout) as {
+      entries: Record<string, { types?: unknown }>;
+    };
+    const entry = parsed.entries["REQ-0001"];
+    assertEquals(
+      entry !== undefined,
+      true,
+      "REQ-0001 should be present in compile output",
+    );
+    assertEquals(
+      entry.types,
+      undefined,
+      "ux: code spans must not populate entry.types (not typl declarations)",
+    );
+  },
+);

--- a/tests/e2e/opaque_dsl_test.ts
+++ b/tests/e2e/opaque_dsl_test.ts
@@ -78,6 +78,21 @@ const UX_DOC = [
   "",
 ].join("\n");
 
+/**
+ * The unknown-info-string fenced block, exactly as it appears in {@linkcode
+ * UX_DOC}. The "fmt verbatim" test asserts this block survives byte-for-byte —
+ * scoped to the DSL guarantee rather than the whole document, since `fmt`
+ * reflows the surrounding EARS prose through dprint (a future embedded-dprint
+ * bump could rewrap that sentence while leaving the DSL untouched).
+ */
+const UX_FENCE = [
+  "  ```uxil",
+  "  ux:media.home : screen @ loading, error, ready",
+  "    /play : activate -> ux:media.detail",
+  "    .confirm_dialog @ default",
+  "  ```",
+].join("\n");
+
 const BASE_FILES: Record<string, string> = {
   "project.yaml": PROJECT_YAML,
   ".markspec.yaml": MARKSPEC_YAML,
@@ -144,20 +159,27 @@ Deno.test(
     try {
       assertEquals(run.code, 0, `fmt should exit 0; stderr:\n${run.stderr}`);
       const after = await Deno.readTextFile(join(run.dir, "docs/req.md"));
-      // Whole-document equality is the strongest statement of "fmt does
-      // nothing here": the ux: spans and the ```uxil fence are byte-identical.
-      assertEquals(
+      // The #719 guarantee is that the DSL content survives fmt verbatim — NOT
+      // that the surrounding prose is untouched. `fmt` reflows entry-body prose
+      // through dprint, so asserting whole-document equality would raise a
+      // false "opaque DSL broken" signal on an orthogonal embedded-dprint bump.
+      // Assert exactly the guarantee: the unknown fence block and every ux:
+      // span survive byte-for-byte.
+      assertStringIncludes(
         after,
-        UX_DOC,
-        "fmt must leave the ux: spans and the unknown fence byte-identical",
+        UX_FENCE,
+        "the unknown ```uxil fence must pass through fmt verbatim",
       );
-      // Explicit tokens, for a localized failure message if the above drifts.
       assertStringIncludes(after, "`ux:media.home/play`");
+      assertStringIncludes(
+        after,
+        "`ux:media.home : screen @ loading, error, ready`",
+      );
       assertStringIncludes(after, "`/play : activate`");
       assertStringIncludes(after, "`.confirm_dialog @ default`");
+      assertStringIncludes(after, "`media.home/play`");
       assertStringIncludes(after, "`mediaHome/playButton`");
       assertStringIncludes(after, "`$MediaEvent`");
-      assertStringIncludes(after, "```uxil");
     } finally {
       await Deno.remove(run.dir, { recursive: true });
     }


### PR DESCRIPTION
Closes #719.

Part of epic #717 (Staging Tier 1). Locks the stability guarantee that `markspec check` treats unknown DSL content as opaque, so the `@ampere/seed` profile can host the uxil vocabularies via an external linter before uxil lands in core.

## What

Scope A — lock + document, **no production change**. The uxil DSL surface — lowercase `ux:` refs, leading-slash/dot element forms, `$`-prefixed typl shape citations, and fenced blocks with an unknown info-string — is already inert to every active `check` / `lint` / `fmt` rule. This PR pins that with regression coverage + a documented guarantee.

## Evidence (why no production change)

A representative doc (all four uxil declaration forms + a `ux:` citation + the scheme-less wire form + a camelCase tag + a `$`-shape citation + an unknown `uxil` fence):

- `markspec check` → exit 0, no MSL-*, no Q500
- `markspec lint` → zero diagnostics
- `markspec fmt` → byte-identical (spans + fence untouched)
- `markspec compile` → `entry.types` absent (`ux:` not parsed as typl)

## Changes

- `tests/e2e/opaque_dsl_test.ts` — the named #719 regression suite (check / lint / fmt / compile).
- `packages/markspec/core/parser/body_tokens_test.ts` — unit: an unknown info-string fence is verbatim (no tokens), like a known one.
- `docs/spec/language/language.md` — "Opaque DSL content" note.
- `docs/spec/internal/markspec-prose-analysis.md` §1.2 — stability guarantee, scoped honestly.

## Scope boundary (honest)

The guarantee covers the uxil DSL surface, **not** arbitrary text. Inline code spans are not yet _structurally_ excluded from prose lint / the MSL-M060 modal scanner, so an uppercase modal keyword or a PascalCase term inside a span is still analyzed. Empirically `` `SHALL` `` fires MSL-M060 and `` `SHALL` and `HomeScreen` `` fires MSL-Q500. Closing that structural gap is deferred follow-up #733 (Scope B) — deliberately out of this story's "smallest-first, no new behavior" scope.

## Verification

`just check` (3535 passed, 0 failed), `deno fmt --check`, `dprint check`, `just compile` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
