### PR TITLE
fix(core): parse directive comments consistently before the trailer (#687)

### DIFF
--- a/docs/spec/language/language.md
+++ b/docs/spec/language/language.md
@@ -895,6 +895,11 @@ payload.
 5. A new `markspec:` line or `-->` terminates the payload.
 6. Range directives closed by `<!-- markspec:end NAME -->`.
 
+A `markspec:` directive comment is permitted anywhere inside an entry body and
+is inert there — it is not entry content and never a trailer line, regardless of
+its position relative to the trailer block or of whitespace after `<!--`. Only
+non-directive raw HTML in a body is rejected (MSL-B043).
+
 ### 3.2 Document directives
 
 Placed in the first HTML comment after the H1 heading.

--- a/packages/markspec/core/parser/directives.ts
+++ b/packages/markspec/core/parser/directives.ts
@@ -24,6 +24,25 @@ const COMMENT_RE = /^<!--([\s\S]*?)-->$/;
 const DIRECTIVE_RE = /^markspec:(\S+)\s?(.*)?$/;
 
 /**
+ * A whole-line markspec directive comment: `<!-- markspec:<rest> -->`
+ * occupying the line on its own (optional surrounding whitespace, and
+ * optional whitespace after `<!--`). This is the single definition the
+ * validator's body carve-out (spec §2.4.1) and the parser's trailer
+ * heuristics both consult, so they can never disagree on what a directive
+ * comment is (#687).
+ */
+const DIRECTIVE_COMMENT_LINE_RE = /^\s*<!--\s*markspec:[\s\S]*?-->\s*$/;
+
+/**
+ * Return `true` when `line` is a standalone `<!-- markspec:* -->` directive
+ * comment. Accepts the line trimmed or with surrounding whitespace, and both
+ * the spaced (`<!-- markspec:`) and no-space (`<!--markspec:`) forms.
+ */
+export function isMarkspecDirectiveComment(line: string): boolean {
+  return DIRECTIVE_COMMENT_LINE_RE.test(line);
+}
+
+/**
  * Detect MarkSpec directives in a Markdown string.
  *
  * Walks the mdast AST looking for `html` nodes that are HTML comments.

--- a/packages/markspec/core/parser/directives_test.ts
+++ b/packages/markspec/core/parser/directives_test.ts
@@ -5,7 +5,7 @@
  */
 
 import { assertEquals } from "@std/assert";
-import { detectDirectives } from "./directives.ts";
+import { detectDirectives, isMarkspecDirectiveComment } from "./directives.ts";
 
 // ---------------------------------------------------------------------------
 // Single directive
@@ -138,4 +138,30 @@ Deno.test("detectDirectives: uses '<unknown>' when no file specified", () => {
   const directives = detectDirectives(md);
   assertEquals(directives.length, 1);
   assertEquals(directives[0].location.file, "<unknown>");
+});
+
+// ---------------------------------------------------------------------------
+// isMarkspecDirectiveComment predicate
+// ---------------------------------------------------------------------------
+
+Deno.test("isMarkspecDirectiveComment: truth table", () => {
+  // Accepted — directive comments, spaced and no-space, indented or not.
+  assertEquals(
+    isMarkspecDirectiveComment("<!-- markspec:pending Q-001 -->"),
+    true,
+  );
+  assertEquals(
+    isMarkspecDirectiveComment("<!--markspec:pending Q-001-->"),
+    true,
+  );
+  assertEquals(isMarkspecDirectiveComment("   <!-- markspec:deck -->  "), true);
+  assertEquals(
+    isMarkspecDirectiveComment("<!-- markspec:Q-001 anything -->"),
+    true,
+  );
+  // Rejected — non-directive comment, HTML tag, plain prose, empty.
+  assertEquals(isMarkspecDirectiveComment("<!-- Q-001 -->"), false);
+  assertEquals(isMarkspecDirectiveComment("<div>x</div>"), false);
+  assertEquals(isMarkspecDirectiveComment("Verified by: tests/foo.rs"), false);
+  assertEquals(isMarkspecDirectiveComment(""), false);
 });

--- a/packages/markspec/core/parser/markdown.ts
+++ b/packages/markspec/core/parser/markdown.ts
@@ -22,6 +22,7 @@ import {
   splitBodyAndAttributes,
 } from "./attributes.ts";
 import { extractBodyTokens } from "./body_tokens.ts";
+import { isMarkspecDirectiveComment } from "./directives.ts";
 import { processor } from "./remark.ts";
 import { buildBodyAstWithTree } from "../ast/build.ts";
 import type { LineMap } from "./line_map.ts";
@@ -443,6 +444,13 @@ function extractEntry(
     for (let i = bodyLines.length - 1; i >= 0; i--) {
       const trimmed = bodyLines[i].trim();
       if (!trimmed) continue; // skip trailing blanks
+      // A `<!-- markspec:* -->` directive comment is legitimate body
+      // content (spec §2.4.1), not a trailer line — skip it so its
+      // `<!--markspec` colon-prefix is never mistaken for a malformed
+      // trailer key. `continue` (not `break`) keeps scanning earlier lines,
+      // so a genuine leaked-trailer typo sitting above a directive comment
+      // still fires MSL-P022 (#687, preserves #697).
+      if (isMarkspecDirectiveComment(trimmed)) continue;
       const colonMatch = COLON_SPLIT_RE.exec(trimmed);
       if (!colonMatch) break; // stop at non-colon line
       const key = colonMatch[1].trim();

--- a/packages/markspec/core/parser/markdown_test.ts
+++ b/packages/markspec/core/parser/markdown_test.ts
@@ -782,3 +782,62 @@ Deno.test("parseMarkdown: detects entry whose title soft-wraps onto a second lin
   // The wrapped continuation belongs to the title, not the body.
   assertEquals(entry.body, "The system shall compute the value within 200 ms.");
 });
+
+// ---------------------------------------------------------------------------
+// Directive-comment-aware trailer scan (#687)
+// ---------------------------------------------------------------------------
+
+Deno.test("parseMarkdown: directive comment as last body element — no MSL-P022 (#687)", () => {
+  // No-space form, body indent (2 spaces), trailer-adjacent.
+  const bodyIndent = `- [STK_0001] Title
+
+  Body prose within 200 ms.
+
+  <!--markspec:pending Q-001-->
+
+      Id: ${ULID}
+`;
+  // No-space form, trailer indent (6 spaces), directly above Id:.
+  const trailerIndent = `- [STK_0002] Title
+
+  Body prose within 200 ms.
+
+      <!--markspec:pending Q-001-->
+      Id: ${ULID}
+`;
+  for (const md of [bodyIndent, trailerIndent]) {
+    const { diagnostics } = parseMarkdown(md);
+    const p02x = diagnostics.filter((d) =>
+      d.code === "MSL-P022" || d.code === "MSL-P021" || d.code === "MSL-P020"
+    );
+    assertEquals(p02x, []);
+  }
+});
+
+Deno.test("parseMarkdown: directive comment mid-body — still clean (#687)", () => {
+  const md = `- [STK_0003] Title
+
+  Body prose within 200 ms.
+
+  <!--markspec:pending Q-001-->
+
+  Trailing prose so the comment is not the last body element.
+
+      Id: ${ULID}
+`;
+  const { diagnostics } = parseMarkdown(md);
+  assertEquals(diagnostics.filter((d) => d.code.startsWith("MSL-P02")), []);
+});
+
+Deno.test("parseMarkdown: real spaced-key trailer typo still MSL-P022 (#697 regression guard)", () => {
+  const md = `- [STK_0004] Title
+
+  Body prose within 200 ms.
+
+      Verified by: tests/foo.rs
+      Id: ${ULID}
+`;
+  const { diagnostics } = parseMarkdown(md);
+  const p022 = diagnostics.filter((d) => d.code === "MSL-P022");
+  assertEquals(p022.length, 1);
+});

--- a/packages/markspec/core/validator/body_blocks.ts
+++ b/packages/markspec/core/validator/body_blocks.ts
@@ -30,6 +30,7 @@
 
 import type { Diagnostic, Entry } from "../model/mod.ts";
 import type { BodyBlock } from "../ast/nodes.ts";
+import { isMarkspecDirectiveComment } from "../parser/directives.ts";
 
 /**
  * HTML tag detection. Matches an opening, closing, or self-closing tag
@@ -44,20 +45,12 @@ const HTML_TAG_RE = /<\/?[A-Za-z][A-Za-z0-9]*(\s[^>]*)?\/?>/;
 const HTML_COMMENT_RE = /<!--[\s\S]*?-->/;
 
 /**
- * A whole-line markspec directive comment: `<!-- markspec:<rest> -->`
- * occupying the line on its own (optional leading/trailing
- * whitespace). The directive form is the one exception spec §2.4.1
- * carves out from the "no raw HTML" rule.
- */
-const MARKSPEC_DIRECTIVE_LINE_RE = /^\s*<!--\s*markspec:[\s\S]*?-->\s*$/;
-
-/**
  * Return `true` when `line` contains raw HTML the body model forbids:
  * any tag, or any comment that isn't a standalone markspec directive.
  */
 function hasForbiddenHtml(line: string): boolean {
   if (HTML_TAG_RE.test(line)) return true;
-  if (HTML_COMMENT_RE.test(line) && !MARKSPEC_DIRECTIVE_LINE_RE.test(line)) {
+  if (HTML_COMMENT_RE.test(line) && !isMarkspecDirectiveComment(line)) {
     return true;
   }
   return false;
@@ -145,7 +138,7 @@ function violationsFromBlock(
       } else if (block.subkind === "html") {
         // Block-level HTML: check if it is a markspec directive (exempt)
         // or forbidden HTML. The `raw` field carries the verbatim source.
-        if (!MARKSPEC_DIRECTIVE_LINE_RE.test(block.raw)) {
+        if (!isMarkspecDirectiveComment(block.raw)) {
           out.push({ diag: RAW_HTML_DIAG, bodyLine });
         }
       }

--- a/packages/markspec/core/validator/body_blocks_test.ts
+++ b/packages/markspec/core/validator/body_blocks_test.ts
@@ -144,6 +144,13 @@ Deno.test("validateBodyBlocks: markspec directive comment → allowed, no MSL-B0
   assertEquals(b043, []);
 });
 
+Deno.test("validateBodyBlocks: no-space directive comment allowed, no MSL-B043 (#687 parity)", () => {
+  const body = "Body text.\n\n<!--markspec:pending Q-001-->\n\nMore body.";
+  const entry = makeEntry("REQ-001", body);
+  const diags = validateBodyBlocks(entry);
+  assertEquals(diags.filter((d) => d.code === "MSL-B043"), []);
+});
+
 Deno.test("validateBodyBlocks: excluded construct inside fenced code block — NOT flagged", () => {
   // PR 5 migration: AST does not emit prose-bearing nodes for code blocks,
   // so headings / HR / HTML inside fenced code are automatically excluded.

--- a/tests/e2e/directive_comment_trailer_test.ts
+++ b/tests/e2e/directive_comment_trailer_test.ts
@@ -1,0 +1,22 @@
+import { assertEquals } from "@std/assert";
+import { markspec } from "./helpers.ts";
+
+const ULID = "01HGW2Q8MNP3RSTVWXYZABCDEF";
+
+Deno.test("check: no-space directive comment before trailer is not MSL-P022 (#687)", async () => {
+  const input = `# Doc
+
+- [STK_0001] Title
+
+  Body prose within 200 ms.
+
+  <!--markspec:pending Q-001-->
+
+      Id: ${ULID}
+`;
+  const { code, stderr } = await markspec(["check", "req.md"], {
+    "req.md": input,
+  });
+  assertEquals(code, 0);
+  assertEquals(stderr.includes("MSL-P022"), false);
+});


### PR DESCRIPTION
Closes #687.

## Problem

A `<!-- markspec:* -->` directive comment used as the **last body element before an entry's trailer** was mis-parsed as a malformed trailer key and fired **MSL-P022** — but only in the no-space form (`<!--markspec:…-->`) and only trailer-adjacent, so the *same* comment was valid mid-body. The verdict depended on position and on incidental whitespace after `<!--`.

## Root cause

Two independently maintained notions of "directive comment":

- the validator's body carve-out (`core/validator/body_blocks.ts`) accepted any `<!-- markspec:* -->` line;
- the parser's MSL-P022 backward trailer scan (`core/parser/markdown.ts`) had no concept of directive comments and colon-split `<!--markspec:…` into a bogus key.

The spaced form escaped only incidentally, via the #648/#697 whitespace-key guard.

## Fix

- **Shared predicate** `isMarkspecDirectiveComment` in `core/parser/directives.ts` — a single definition both the parser and validator consult.
- **Parser**: skip directive-comment lines in the MSL-P022 backward scan. `splitBodyAndAttributes` always pushes such a line into the body, so that scan is the only site that can see one (the P020 forward scan and attrLines loop never receive one — verified). `continue` (not `break`) keeps a genuine spaced-key trailer typo *above* the comment firing MSL-P022 — **#697 preserved**.
- **Validator DRY**: `body_blocks.ts` now uses the shared predicate, removing the duplicate regex that caused the drift.
- **Docs**: `language.md` states directive comments are inert anywhere in an entry body, independent of position and of whitespace after `<!--`.

## Tests

- Parser unit: no-space directive comment as the last body element (body indent + trailer indent) → no MSL-P02x; mid-body stays clean.
- **#697 regression guard**: a real `Verified by:` spaced-key typo still fires MSL-P022.
- Directives unit: `isMarkspecDirectiveComment` truth table.
- Validator unit: parity (still flags non-directive raw HTML; accepts directive comments).
- e2e `check` acceptance on the trailer-adjacent no-space case.
- Full `just check` green: lint, 3536 tests / 0 failed, type-check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
