### PR TITLE
refactor(core): extract shared declaration-surface machinery (typl surfaces → core/decl)

### DIFF
--- a/packages/markspec/core/decl/mod.ts
+++ b/packages/markspec/core/decl/mod.ts
@@ -1,0 +1,22 @@
+/**
+ * @module core/decl
+ *
+ * Shared declaration-surface machinery (uxil epic #717 §A). DSL-agnostic
+ * walkers that extract declaration sites from an entry body's three
+ * embedding surfaces — fenced code blocks, bullet paragraphs, and inline
+ * code spans — parameterized by a recognizer. typl consumes these today;
+ * uxil (§B) and the table surface (S3) ride on the same substrate.
+ */
+
+export type {
+  BlockDeclaration,
+  FenceRecognizer,
+  InlineDeclaration,
+  TextRecognizer,
+} from "./surfaces.ts";
+export {
+  extractBulletDeclarations,
+  extractFenceDeclarations,
+  extractInlineDeclarations,
+  stripCodeSpanDelimiters,
+} from "./surfaces.ts";

--- a/packages/markspec/core/decl/surfaces.ts
+++ b/packages/markspec/core/decl/surfaces.ts
@@ -24,8 +24,7 @@
  * output is unchanged.
  */
 
-import type { BodyBlock } from "../ast/nodes.ts";
-import type { SourceRange } from "../ast/nodes.ts";
+import type { BodyBlock, SourceRange } from "../ast/nodes.ts";
 import type { BodyToken, SourceLocation } from "../model/mod.ts";
 
 /**

--- a/packages/markspec/core/decl/surfaces.ts
+++ b/packages/markspec/core/decl/surfaces.ts
@@ -1,0 +1,167 @@
+/**
+ * @module core/decl/surfaces
+ *
+ * DSL-agnostic declaration-surface machinery. Walks a MarkSpec entry body
+ * and extracts every *declaration site* on each of the three embedding
+ * surfaces, returning a common declaration node:
+ *
+ *   - **fence** — a fenced code block whose info-string a DSL claims
+ *     (e.g. ```typl). {@linkcode extractFenceDeclarations}
+ *   - **bullet** — a list item whose first paragraph is a declaration.
+ *     {@linkcode extractBulletDeclarations}
+ *   - **inline** — a CommonMark code span whose text is a declaration.
+ *     {@linkcode extractInlineDeclarations}
+ *
+ * Each walker is parameterized by a *recognizer* — the only DSL-specific
+ * input — and knows nothing about typl, uxil, or any concrete vocabulary.
+ * A DSL host (typl today; uxil and the table surface later) supplies the
+ * recognizer and consumes the returned {@linkcode BlockDeclaration} /
+ * {@linkcode InlineDeclaration} nodes.
+ *
+ * Extracted from the typl surface adapters (ADR-019) so §A of the uxil
+ * epic (#717) can share one substrate. typl's fence / bullet / inline
+ * modules are thin adapters over these functions and their observable
+ * output is unchanged.
+ */
+
+import type { BodyBlock } from "../ast/nodes.ts";
+import type { SourceRange } from "../ast/nodes.ts";
+import type { BodyToken, SourceLocation } from "../model/mod.ts";
+
+/**
+ * A declaration found on a block surface (fenced code block or bullet
+ * paragraph). Carries the raw DSL `source` and the node's body-relative
+ * {@linkcode SourceRange} — the anchor a DSL host uses to bridge parse
+ * diagnostics back to file positions.
+ */
+export interface BlockDeclaration {
+  /** Raw DSL source: the fence body, or the bullet's paragraph text. */
+  readonly source: string;
+  /** Source range of the fence, or of the bullet's first paragraph. */
+  readonly range: SourceRange;
+}
+
+/**
+ * A declaration found in an inline code span. Carries the raw DSL
+ * `source` (backtick delimiters stripped) and the span's file-relative
+ * {@linkcode SourceLocation} (the position `Entry.bodyTokens` records).
+ */
+export interface InlineDeclaration {
+  /** Raw DSL source: the code span's inner text, backticks stripped. */
+  readonly source: string;
+  /** File-relative location of the code span. */
+  readonly location: SourceLocation;
+}
+
+/** Recognizer for the fence surface: does this info-string host the DSL? */
+export type FenceRecognizer = (lang: string | undefined) => boolean;
+
+/** Recognizer for the bullet / inline surfaces: is this text a declaration? */
+export type TextRecognizer = (text: string) => boolean;
+
+/**
+ * Walk a body AST and return every fenced code block whose info-string
+ * satisfies `matchLang`. Recurses into container nodes (ListNode via
+ * ListItemNode.blocks) so fences nested inside list items are found.
+ *
+ * BlockquoteNode and NoteNode carry only InlineContent (not nested
+ * BodyBlock[]), so they are not recursed into. Returns declarations in
+ * source order (depth-first traversal).
+ */
+export function extractFenceDeclarations(
+  blocks: readonly BodyBlock[],
+  matchLang: FenceRecognizer,
+): readonly BlockDeclaration[] {
+  const results: BlockDeclaration[] = [];
+  for (const block of blocks) {
+    if (block.kind === "code" && matchLang(block.lang)) {
+      results.push({ source: block.text, range: block.range });
+    } else if (block.kind === "list") {
+      for (const item of block.items) {
+        results.push(...extractFenceDeclarations(item.blocks, matchLang));
+      }
+    }
+  }
+  return results;
+}
+
+/**
+ * Walk a body AST and return every bullet-list item whose first paragraph
+ * satisfies `matchText`. Recurses through ListNode → ListItemNode.blocks
+ * for nested lists. Mixed lists are supported: items whose first paragraph
+ * matches are extracted; non-matching bullets are left alone.
+ *
+ * Returns declarations in source order (depth-first).
+ */
+export function extractBulletDeclarations(
+  blocks: readonly BodyBlock[],
+  matchText: TextRecognizer,
+): readonly BlockDeclaration[] {
+  const results: BlockDeclaration[] = [];
+  for (const block of blocks) {
+    if (block.kind === "list") {
+      for (const item of block.items) {
+        if (item.blocks.length === 0) continue;
+        const first = item.blocks[0];
+        if (first.kind === "paragraph") {
+          if (matchText(first.content.text)) {
+            results.push({ source: first.content.text, range: first.range });
+          }
+        }
+        // Recurse into nested blocks (the item may itself contain a list).
+        if (item.blocks.length > 1) {
+          results.push(
+            ...extractBulletDeclarations(item.blocks.slice(1), matchText),
+          );
+        } else if (first.kind === "list") {
+          results.push(...extractBulletDeclarations([first], matchText));
+        }
+      }
+    }
+  }
+  return results;
+}
+
+/**
+ * Strip the surrounding backtick delimiter(s) from an inline-code token's
+ * `text` field. `body_tokens.ts` stores inline-code text as `` `value` ``
+ * (with backtick delimiters); a DSL recognizer and parser need the inner
+ * value only.
+ *
+ * Handles both single-backtick (`` `…` ``) and double-backtick (` ``…`` `)
+ * delimiters. Returns the original string unchanged when it does not start
+ * and end with a matching backtick fence.
+ */
+export function stripCodeSpanDelimiters(text: string): string {
+  if (text.startsWith("``") && text.endsWith("``") && text.length > 4) {
+    return text.slice(2, -2);
+  }
+  if (text.startsWith("`") && text.endsWith("`") && text.length > 2) {
+    return text.slice(1, -1);
+  }
+  return text;
+}
+
+/**
+ * Filter `bodyTokens` to inline-code spans whose contents (backticks
+ * stripped) satisfy `matchText`. Returns declarations in source order
+ * (the bodyTokens contract guarantees source order).
+ *
+ * `inline-code` tokens store their `text` field with surrounding backtick
+ * delimiters (e.g. `` `$X : signal` ``). This function strips those
+ * delimiters via {@linkcode stripCodeSpanDelimiters} before recognizing
+ * and before setting `source`, so the DSL parser receives the raw source.
+ */
+export function extractInlineDeclarations(
+  bodyTokens: readonly BodyToken[],
+  matchText: TextRecognizer,
+): readonly InlineDeclaration[] {
+  const results: InlineDeclaration[] = [];
+  for (const token of bodyTokens) {
+    if (token.kind !== "inline-code") continue;
+    const inner = stripCodeSpanDelimiters(token.text);
+    if (!matchText(inner)) continue;
+    results.push({ source: inner, location: token.location });
+  }
+  return results;
+}

--- a/packages/markspec/core/decl/surfaces_test.ts
+++ b/packages/markspec/core/decl/surfaces_test.ts
@@ -1,0 +1,212 @@
+/**
+ * @module core/decl/surfaces_test
+ *
+ * Unit tests for the DSL-agnostic declaration-surface walkers. Fixtures use
+ * a deliberately NON-typl vocabulary — `foo`-tagged fences, `@`-prefixed
+ * bullet text, `#`-prefixed inline text — so the tests prove the machinery
+ * carries no typl-specific knowledge and works for any recognizer.
+ */
+
+import { assertEquals } from "@std/assert";
+import type {
+  BodyBlock,
+  CodeNode,
+  ListItemNode,
+  ListNode,
+  ParagraphNode,
+} from "../ast/nodes.ts";
+import type { BodyToken } from "../model/mod.ts";
+import {
+  extractBulletDeclarations,
+  extractFenceDeclarations,
+  extractInlineDeclarations,
+  stripCodeSpanDelimiters,
+} from "./surfaces.ts";
+
+// --- fixture builders (mirror the typl surface tests) ----------------------
+
+function code(lang: string | undefined, text: string, line = 1): CodeNode {
+  return {
+    kind: "code",
+    lang,
+    text,
+    range: {
+      start: { line, column: 1 },
+      end: { line: line + text.split("\n").length + 1, column: 4 },
+    },
+  };
+}
+
+function para(text: string, line = 1): ParagraphNode {
+  return {
+    kind: "paragraph",
+    content: { text },
+    range: {
+      start: { line, column: 1 },
+      end: { line, column: text.length + 1 },
+    },
+  };
+}
+
+function item(blocks: BodyBlock[], line = 1): ListItemNode {
+  return {
+    blocks,
+    range: { start: { line, column: 1 }, end: { line, column: 1 } },
+  };
+}
+
+function list(items: ListItemNode[]): ListNode {
+  return {
+    kind: "list",
+    ordered: false,
+    spread: false,
+    items,
+    range: {
+      start: { line: 1, column: 1 },
+      end: { line: items.length, column: 1 },
+    },
+  };
+}
+
+function inlineCode(text: string, line = 1, column = 1): BodyToken {
+  return {
+    kind: "inline-code",
+    text,
+    location: { file: "x.md", line, column },
+  };
+}
+
+// --- fence surface ---------------------------------------------------------
+
+const isFoo = (lang: string | undefined) => lang === "foo";
+
+Deno.test("extractFenceDeclarations: empty input → empty result", () => {
+  assertEquals(extractFenceDeclarations([], isFoo), []);
+});
+
+Deno.test("extractFenceDeclarations: ignores fences the recognizer rejects", () => {
+  const blocks: BodyBlock[] = [
+    code("rust", "fn x() {}"),
+    code(undefined, "bare"),
+  ];
+  assertEquals(extractFenceDeclarations(blocks, isFoo), []);
+});
+
+Deno.test("extractFenceDeclarations: finds a matching fence with its range", () => {
+  const fence = code("foo", "decl body");
+  const result = extractFenceDeclarations([fence], isFoo);
+  assertEquals(result.length, 1);
+  assertEquals(result[0].source, "decl body");
+  assertEquals(result[0].range, fence.range);
+});
+
+Deno.test("extractFenceDeclarations: multiple fences in source order", () => {
+  const f1 = code("foo", "A", 1);
+  const f2 = code("rust", "skip", 3);
+  const f3 = code("foo", "B", 5);
+  const result = extractFenceDeclarations([f1, f2, f3], isFoo);
+  assertEquals(result.map((r) => r.source), ["A", "B"]);
+});
+
+Deno.test("extractFenceDeclarations: recurses into list-item children", () => {
+  const nested = code("foo", "nested", 2);
+  const blocks: BodyBlock[] = [list([item([nested], 2)])];
+  const result = extractFenceDeclarations(blocks, isFoo);
+  assertEquals(result.length, 1);
+  assertEquals(result[0].source, "nested");
+  assertEquals(result[0].range, nested.range);
+});
+
+// --- bullet surface --------------------------------------------------------
+
+const isAt = (text: string) => text.startsWith("@");
+
+Deno.test("extractBulletDeclarations: empty input → empty result", () => {
+  assertEquals(extractBulletDeclarations([], isAt), []);
+});
+
+Deno.test("extractBulletDeclarations: ignores non-list blocks", () => {
+  assertEquals(extractBulletDeclarations([para("@nope")], isAt), []);
+});
+
+Deno.test("extractBulletDeclarations: finds a matching bullet with its range", () => {
+  const p = para("@decl one");
+  const blocks: BodyBlock[] = [list([item([p])])];
+  const result = extractBulletDeclarations(blocks, isAt);
+  assertEquals(result.length, 1);
+  assertEquals(result[0].source, "@decl one");
+  assertEquals(result[0].range, p.range);
+});
+
+Deno.test("extractBulletDeclarations: mixed list — only matching items", () => {
+  const blocks: BodyBlock[] = [
+    list([
+      item([para("@a")]),
+      item([para("prose bullet")]),
+      item([para("@b")]),
+    ]),
+  ];
+  const result = extractBulletDeclarations(blocks, isAt);
+  assertEquals(result.map((r) => r.source), ["@a", "@b"]);
+});
+
+Deno.test("extractBulletDeclarations: recurses into nested list-in-item", () => {
+  const inner = list([item([para("@inner")])]);
+  const blocks: BodyBlock[] = [list([item([para("@outer"), inner])])];
+  const result = extractBulletDeclarations(blocks, isAt);
+  assertEquals(result.map((r) => r.source), ["@outer", "@inner"]);
+});
+
+// --- inline surface --------------------------------------------------------
+
+const isHash = (text: string) => text.startsWith("#");
+
+Deno.test("extractInlineDeclarations: empty input → empty result", () => {
+  assertEquals(extractInlineDeclarations([], isHash), []);
+});
+
+Deno.test("extractInlineDeclarations: ignores non-inline-code tokens", () => {
+  const tokens: BodyToken[] = [
+    {
+      kind: "modal",
+      text: "#nope",
+      case: "lower",
+      location: { file: "x.md", line: 1, column: 1 },
+    },
+  ];
+  assertEquals(extractInlineDeclarations(tokens, isHash), []);
+});
+
+Deno.test("extractInlineDeclarations: ignores inline-code the recognizer rejects", () => {
+  assertEquals(extractInlineDeclarations([inlineCode("`foo()`")], isHash), []);
+});
+
+Deno.test("extractInlineDeclarations: finds a matching span, strips backticks, keeps location", () => {
+  const span = inlineCode("`#decl one`", 4, 7);
+  const result = extractInlineDeclarations([span], isHash);
+  assertEquals(result.length, 1);
+  assertEquals(result[0].source, "#decl one");
+  assertEquals(result[0].location, span.location);
+});
+
+Deno.test("extractInlineDeclarations: multiple spans in source order", () => {
+  const tokens = [
+    inlineCode("`#a`", 1),
+    inlineCode("`foo`", 2),
+    inlineCode("`#b`", 3),
+  ];
+  assertEquals(
+    extractInlineDeclarations(tokens, isHash).map((r) => r.source),
+    ["#a", "#b"],
+  );
+});
+
+// --- backtick stripping ----------------------------------------------------
+
+Deno.test("stripCodeSpanDelimiters: single, double, and non-fenced", () => {
+  assertEquals(stripCodeSpanDelimiters("`x`"), "x");
+  assertEquals(stripCodeSpanDelimiters("``x``"), "x");
+  assertEquals(stripCodeSpanDelimiters("no ticks"), "no ticks");
+  assertEquals(stripCodeSpanDelimiters("`"), "`"); // too short to strip
+  assertEquals(stripCodeSpanDelimiters("``"), "``"); // too short to strip
+});

--- a/packages/markspec/core/typl/bullet.ts
+++ b/packages/markspec/core/typl/bullet.ts
@@ -2,72 +2,32 @@
  * @module typl/bullet
  *
  * Bullet-glossary surface adapter — recognises CommonMark bullet list
- * items whose first paragraph matches typl syntax (`$X : ...` binding
- * or `type X = ...` typedef). Mixed lists are supported: items that
- * match are treated as typl declarations; non-matching bullets are
- * left alone.
- *
- * Each matching item produces one TyplBulletExtraction; the parser
- * integration calls parseTyplBlock on each `source` independently.
- * Per-item position-bridging uses the item's range and formula
- * documented in bridgeTyplDiagnostic.
+ * items whose first paragraph is a typl declaration (`$X : …` binding or
+ * `type X = …` typedef). A thin wrapper over the shared
+ * declaration-surface machinery (core/decl): it supplies typl's text
+ * recognizer and re-exports the common declaration node as
+ * {@linkcode TyplBulletExtraction}. Mixed lists are supported — matching
+ * items are extracted, non-matching bullets are left alone.
  *
  * See ADR-019.
  */
-import type { BodyBlock, ParagraphNode, SourceRange } from "../ast/nodes.ts";
+import type { BodyBlock } from "../ast/nodes.ts";
+import {
+  type BlockDeclaration,
+  extractBulletDeclarations,
+} from "../decl/mod.ts";
+import { isTyplDeclarationText } from "./recognize.ts";
 
-/** A single typl bullet item found inside a body. */
-export interface TyplBulletExtraction {
-  /** The typl source from one matching bullet item (paragraph text). */
-  readonly source: string;
-  /** Source range of the bullet's first paragraph. */
-  readonly range: SourceRange;
-}
-
-/** Matches a typl binding bullet (paragraph text). */
-const BULLET_BINDING_RE = /^\$[A-Za-z_][A-Za-z0-9_]*\s*:/;
-
-/** Matches a typl typedef bullet (paragraph text). */
-const BULLET_TYPEDEF_RE = /^type\s+[A-Za-z_][A-Za-z0-9_]*\s*=/;
-
-function isTyplBulletText(text: string): boolean {
-  return BULLET_BINDING_RE.test(text) || BULLET_TYPEDEF_RE.test(text);
-}
+/** A single typl bullet item found inside a body: `{ source, range }`. */
+export type TyplBulletExtraction = BlockDeclaration;
 
 /**
- * Walk a body AST and return every bullet-list item whose first
- * paragraph matches typl syntax. Recurses through ListNode →
- * ListItemNode.blocks for nested lists (typl bullets inside a nested
- * list are picked up).
- *
- * Returns matches in source order (depth-first).
+ * Walk a body AST and return every bullet-list item whose first paragraph
+ * is a typl declaration, in source order (depth-first, recursing into
+ * nested lists). Delegates traversal to {@linkcode extractBulletDeclarations}.
  */
 export function extractTyplBullets(
   blocks: readonly BodyBlock[],
 ): readonly TyplBulletExtraction[] {
-  const results: TyplBulletExtraction[] = [];
-  for (const block of blocks) {
-    if (block.kind === "list") {
-      for (const item of block.items) {
-        if (item.blocks.length === 0) continue;
-        const first = item.blocks[0];
-        if (first.kind === "paragraph") {
-          const para = first as ParagraphNode;
-          if (isTyplBulletText(para.content.text)) {
-            results.push({
-              source: para.content.text,
-              range: para.range,
-            });
-          }
-        }
-        // Recurse into nested blocks (the item may itself contain a list)
-        if (item.blocks.length > 1) {
-          results.push(...extractTyplBullets(item.blocks.slice(1)));
-        } else if (first.kind === "list") {
-          results.push(...extractTyplBullets([first]));
-        }
-      }
-    }
-  }
-  return results;
+  return extractBulletDeclarations(blocks, isTyplDeclarationText);
 }

--- a/packages/markspec/core/typl/fence.ts
+++ b/packages/markspec/core/typl/fence.ts
@@ -2,45 +2,29 @@
  * @module typl/fence
  *
  * Fence surface adapter — extracts typl source from fenced code blocks
- * whose info-string is "typl". Operates on the canonical body AST
- * (BodyBlock[]) produced by core/ast/build.ts.
+ * whose info-string is "typl". A thin wrapper over the shared
+ * declaration-surface machinery (core/decl): it supplies typl's fence
+ * recognizer and re-exports the common declaration node as
+ * {@linkcode TyplFenceExtraction}.
  *
- * This module is parser-side only — it returns the raw typl source and
- * its source range. PR 3 will wire the extracted source through
- * parseTyplBlock and attach results to Entry.types.
+ * See ADR-019.
  */
-import type { BodyBlock, SourceRange } from "../ast/nodes.ts";
+import type { BodyBlock } from "../ast/nodes.ts";
+import {
+  type BlockDeclaration,
+  extractFenceDeclarations,
+} from "../decl/mod.ts";
 
-/** A single typl fence found inside a body. */
-export interface TyplFenceExtraction {
-  /** The verbatim typl source from inside the fence (CodeNode.text). */
-  readonly source: string;
-  /** Source range of the whole fence (opening ``` through closing ```). */
-  readonly range: SourceRange;
-}
+/** A single typl fence found inside a body: `{ source, range }`. */
+export type TyplFenceExtraction = BlockDeclaration;
 
 /**
- * Walk a body AST and return every typl fence found. Recurses into
- * container nodes (ListNode via ListItemNode.blocks) so typl fences
- * nested inside list items are discovered.
- *
- * BlockquoteNode and NoteNode carry only InlineContent (not nested
- * BodyBlock[]), so they are not recursed into.
- *
- * Returns fences in source order (depth-first traversal).
+ * Walk a body AST and return every typl fence (```typl) found, in source
+ * order (depth-first, recursing into list items). Delegates traversal to
+ * {@linkcode extractFenceDeclarations}.
  */
 export function extractTyplFences(
   blocks: readonly BodyBlock[],
 ): readonly TyplFenceExtraction[] {
-  const results: TyplFenceExtraction[] = [];
-  for (const block of blocks) {
-    if (block.kind === "code" && block.lang === "typl") {
-      results.push({ source: block.text, range: block.range });
-    } else if (block.kind === "list") {
-      for (const item of block.items) {
-        results.push(...extractTyplFences(item.blocks));
-      }
-    }
-  }
-  return results;
+  return extractFenceDeclarations(blocks, (lang) => lang === "typl");
 }

--- a/packages/markspec/core/typl/inline.ts
+++ b/packages/markspec/core/typl/inline.ts
@@ -1,76 +1,34 @@
 /**
  * @module typl/inline
  *
- * Inline backtick surface adapter — recognises typl declarations
- * wrapped in CommonMark code spans, e.g. `` `$X : signal float[0..300]` ``
- * scattered through entry prose.
- *
- * Filters Entry.bodyTokens (ADR-016) for `inline-code` tokens whose text
- * matches typl syntax. Each matching span produces one
- * TyplInlineExtraction; the parser integration calls parseTyplBlock on
- * each `source` independently.
+ * Inline backtick surface adapter — recognises typl declarations wrapped
+ * in CommonMark code spans, e.g. `` `$X : signal float[0..300]` ``
+ * scattered through entry prose. A thin wrapper over the shared
+ * declaration-surface machinery (core/decl): it supplies typl's text
+ * recognizer and re-exports the common declaration node as
+ * {@linkcode TyplInlineExtraction}. The shared machinery strips the
+ * backtick delimiters `Entry.bodyTokens` (ADR-016) records before
+ * recognizing, so `source` is the raw typl text.
  *
  * See ADR-019.
  */
-import type { BodyToken, SourceLocation } from "../model/mod.ts";
+import type { BodyToken } from "../model/mod.ts";
+import {
+  extractInlineDeclarations,
+  type InlineDeclaration,
+} from "../decl/mod.ts";
+import { isTyplDeclarationText } from "./recognize.ts";
 
-/** A single typl inline-code declaration found in an entry body. */
-export interface TyplInlineExtraction {
-  /** The typl source from one matching code span (text between backticks). */
-  readonly source: string;
-  /** File-relative location of the code span. */
-  readonly location: SourceLocation;
-}
-
-/** Matches a typl binding span (code-span text). */
-const INLINE_BINDING_RE = /^\$[A-Za-z_][A-Za-z0-9_]*\s*:/;
-
-/** Matches a typl typedef span (code-span text). */
-const INLINE_TYPEDEF_RE = /^type\s+[A-Za-z_][A-Za-z0-9_]*\s*=/;
-
-function isTyplInlineText(text: string): boolean {
-  return INLINE_BINDING_RE.test(text) || INLINE_TYPEDEF_RE.test(text);
-}
+/** A single typl inline-code declaration: `{ source, location }`. */
+export type TyplInlineExtraction = InlineDeclaration;
 
 /**
- * Strip the surrounding backtick delimiter(s) from an inline-code token's
- * `text` field. `body_tokens.ts` stores inline-code text as `` `value` ``
- * (with backtick delimiters). The typl patterns and `parseTyplBlock` need
- * the inner value only.
- *
- * Handles both single-backtick (`` `…` ``) and double-backtick (` ``…`` `)
- * delimiters. Returns the original string unchanged when it does not start
- * and end with a matching backtick fence.
- */
-function stripBackticks(text: string): string {
-  if (text.startsWith("``") && text.endsWith("``") && text.length > 4) {
-    return text.slice(2, -2);
-  }
-  if (text.startsWith("`") && text.endsWith("`") && text.length > 2) {
-    return text.slice(1, -1);
-  }
-  return text;
-}
-
-/**
- * Filter bodyTokens to inline-code spans whose contents match typl
- * syntax. Returns extractions in source order (the bodyTokens contract
- * guarantees source order).
- *
- * `inline-code` tokens in `bodyTokens` store their `text` field with
- * surrounding backtick delimiters (e.g., `` `$X : signal` ``). This
- * function strips those delimiters before pattern-matching and before
- * setting `source`, so `parseTyplBlock` receives the raw typl source.
+ * Filter `Entry.bodyTokens` to inline-code spans whose contents are typl
+ * declarations, in source order. Delegates to
+ * {@linkcode extractInlineDeclarations}.
  */
 export function extractTyplInlines(
   bodyTokens: readonly BodyToken[],
 ): readonly TyplInlineExtraction[] {
-  const results: TyplInlineExtraction[] = [];
-  for (const token of bodyTokens) {
-    if (token.kind !== "inline-code") continue;
-    const inner = stripBackticks(token.text);
-    if (!isTyplInlineText(inner)) continue;
-    results.push({ source: inner, location: token.location });
-  }
-  return results;
+  return extractInlineDeclarations(bodyTokens, isTyplDeclarationText);
 }

--- a/packages/markspec/core/typl/recognize.ts
+++ b/packages/markspec/core/typl/recognize.ts
@@ -1,0 +1,22 @@
+/**
+ * @module typl/recognize
+ *
+ * typl declaration recognizer — the DSL-specific predicate the shared
+ * declaration-surface machinery (core/decl) is parameterized by. A typl
+ * declaration is a binding (`$Name : …`) or a typedef (`type Name = …`).
+ * The bullet and inline surfaces share this text recognizer; the fence
+ * surface is recognized by its `typl` info-string (see fence.ts).
+ *
+ * See ADR-019.
+ */
+
+/** Matches a typl binding: `$Name :`. */
+const BINDING_RE = /^\$[A-Za-z_][A-Za-z0-9_]*\s*:/;
+
+/** Matches a typl typedef: `type Name =`. */
+const TYPEDEF_RE = /^type\s+[A-Za-z_][A-Za-z0-9_]*\s*=/;
+
+/** True when `text` begins a typl binding or typedef declaration. */
+export function isTyplDeclarationText(text: string): boolean {
+  return BINDING_RE.test(text) || TYPEDEF_RE.test(text);
+}


### PR DESCRIPTION
Closes #720.

Foundation for the uxil epic (#717 §A). Extracts typl's three declaration surfaces into DSL-agnostic machinery under `core/decl/` that the table surface (S3), the base-resolution engine (S4), and uxil (S7) will ride on. **Pure refactor — typl's observable output is byte-identical.**

## What & why

The three surface adapters (`typl/fence.ts`, `bullet.ts`, `inline.ts`) differed only in a *recognizer* — the `typl` info-string, and the `$Name :` / `type X =` regexes. The AST traversal, list recursion, and backtick-stripping were identical boilerplate. This lifts that boilerplate into shared walkers parameterized by the recognizer.

## Changes

- **`core/decl/` (new)** — `extractFenceDeclarations`, `extractBulletDeclarations`, `extractInlineDeclarations`, and `stripCodeSpanDelimiters`, returning common `BlockDeclaration {source, range}` / `InlineDeclaration {source, location}` nodes. Colocated `surfaces_test.ts` (16 tests) uses a deliberately **non-typl** vocabulary (`foo` fences, `@`-bullets, `#`-inline) to prove the machinery carries no DSL-specific knowledge.
- **typl adapters** — `fence.ts` / `bullet.ts` / `inline.ts` are now thin wrappers that supply typl's recognizer; `TyplFenceExtraction` / `TyplBulletExtraction` / `TyplInlineExtraction` alias the common nodes (same `.source` / `.range` / `.location` fields and values).
- **`typl/recognize.ts` (new)** — the shared `$Name` / `type X` recognizer, hoisted out of the duplicate copies in `bullet.ts` + `inline.ts`.
- **Untouched:** `parser/markdown.ts` (its three per-surface loops + diagnostic-offset math) and the typl grammar / validator / registry. Scope is surfaces only, as agreed.

## Dependency flow

`core/decl/` → `ast` + `model` (down only); `typl` → `core/decl/`. No cycle. `core/decl/` is internal (not surfaced through `core/mod.ts`) since typl is its only consumer today.

## Byte-identical gate

The full existing typl unit suite (fence/bullet/inline/grammar/validator/registry) and the `typl_*` e2e tests pass **unchanged** — those tests assert on exactly `.source` / `.range` / `.location`, so identical values = identical output.

## Verification

`just check` **3545 passed / 0 failed** (+16 new decl tests), `deno fmt --check`, `dprint check`, `just compile` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
