### PR TITLE
feat(core): entry-local base-resolution engine for declaration surfaces

### DIFF
--- a/packages/markspec/core/decl/mod.ts
+++ b/packages/markspec/core/decl/mod.ts
@@ -4,8 +4,10 @@
  * Shared declaration-surface machinery (uxil epic #717 §A). DSL-agnostic
  * walkers that extract declaration sites from an entry body's three
  * embedding surfaces — fenced code blocks, bullet paragraphs, and inline
- * code spans — parameterized by a recognizer. typl consumes these today;
- * uxil (§B) and the table surface (S3) ride on the same substrate.
+ * code spans — parameterized by a recognizer, plus the entry-local
+ * base-resolution engine (S4) that resolves relative refs against the base
+ * an enclosing declaration establishes. typl consumes these today; uxil
+ * (§B) and the table surface (S3) ride on the same substrate.
  */
 
 export type {
@@ -20,3 +22,6 @@ export {
   extractInlineDeclarations,
   stripCodeSpanDelimiters,
 } from "./surfaces.ts";
+
+export type { BaseScope, RefOps, RefResolution, RootCheck } from "./resolve.ts";
+export { checkSingleRoot, resolveRef } from "./resolve.ts";

--- a/packages/markspec/core/decl/resolve.ts
+++ b/packages/markspec/core/decl/resolve.ts
@@ -1,0 +1,121 @@
+/**
+ * @module core/decl/resolve
+ *
+ * Entry-local base-resolution engine (uxil epic #717 §A). The DSL-agnostic
+ * *normative rule set* for resolving a relative reference against the base
+ * an enclosing declaration established. typl's published tier and uxil both
+ * consume it; the engine knows nothing about either vocabulary.
+ *
+ * The six rules from #722, and where each lives:
+ *
+ *   1. Only *declarations* create bases; *citations* never do. — The caller
+ *      sets {@linkcode BaseScope.base} only for declaration scopes; a scope
+ *      built from a citation leaves it `undefined`.
+ *   2. Bases are entry-local (no document-ambient scope). — The engine only
+ *      ever walks the `parent` chain it is given; there is no global lookup.
+ *   3. Innermost base wins. — {@linkcode resolveRef} returns on the first
+ *      ancestor (nearest first) that carries a base.
+ *   4. Scope is structural, never sequential. — The engine follows `parent`
+ *      links only; siblings are unreachable, so reordering declarations can
+ *      never rebind a ref.
+ *   5. Exactly one root declaration per declaring entry. —
+ *      {@linkcode checkSingleRoot}.
+ *   6. Declarations/citations sit in code spans. — A surface concern
+ *      (core/decl/surfaces + the DSL recognizer); the engine sees only the
+ *      already-extracted ref token.
+ *
+ * The caller builds the {@linkcode BaseScope} chain from the entry's
+ * structural nesting (list membership, table membership) — that mapping is
+ * DSL- and surface-specific and lands with the table surface (S3) and the
+ * DSL consumers (S5/S7).
+ */
+
+/**
+ * A structural scope in an entry's declaration tree. {@linkcode resolveRef}
+ * walks `parent` links from innermost to outermost.
+ *
+ * `base` is the base a *declaration* established at this scope, or
+ * `undefined` when this scope establishes none (a citation scope, or a
+ * structural container that declares nothing). Because the engine reaches
+ * enclosing scopes only through `parent`, siblings are invisible to one
+ * another and ordering within a level is irrelevant — the scope is purely
+ * structural (rule 4).
+ */
+export interface BaseScope {
+  /** The base declared at this scope, if any. */
+  readonly base?: string;
+  /** The enclosing scope, or `undefined` at the entry root. */
+  readonly parent?: BaseScope;
+}
+
+/**
+ * The DSL-specific reference operations the engine is parameterized by.
+ * Keeping these injected is what makes the engine vocabulary-agnostic: typl
+ * dotted paths and uxil `ux:` URIs supply their own notions of "absolute"
+ * and of how a base combines with a relative ref.
+ */
+export interface RefOps {
+  /** True when `ref` is already absolute and needs no base. */
+  readonly isAbsolute: (ref: string) => boolean;
+  /** Combine an enclosing `base` with a relative `ref` into a full ref. */
+  readonly join: (base: string, ref: string) => string;
+}
+
+/**
+ * Outcome of {@linkcode resolveRef}. `no-base-in-scope` is returned for a
+ * relative ref that finds no base in any ancestor; the DSL host maps that
+ * reason to its own diagnostic code (typl TYPL-0xx, uxil UXIL-0xx).
+ */
+export type RefResolution =
+  | { readonly ok: true; readonly ref: string }
+  | { readonly ok: false; readonly reason: "no-base-in-scope" };
+
+/**
+ * Resolve `ref` at `scope`. An absolute ref passes through unchanged. A
+ * relative ref is joined with the base of the nearest enclosing scope that
+ * carries one (innermost wins, rule 3); a single join with that base only —
+ * bases are not accumulated up the chain, because each scope's `base` is
+ * already its fully-qualified prefix. A relative ref with no base in any
+ * ancestor yields `{ ok: false, reason: "no-base-in-scope" }`.
+ *
+ * `scope` may be `undefined` (a ref at the very top with no enclosing
+ * declaration); a relative ref there is likewise `no-base-in-scope`.
+ */
+export function resolveRef(
+  ref: string,
+  scope: BaseScope | undefined,
+  ops: RefOps,
+): RefResolution {
+  if (ops.isAbsolute(ref)) return { ok: true, ref };
+  for (let s: BaseScope | undefined = scope; s !== undefined; s = s.parent) {
+    if (s.base !== undefined) return { ok: true, ref: ops.join(s.base, ref) };
+  }
+  return { ok: false, reason: "no-base-in-scope" };
+}
+
+/**
+ * Outcome of {@linkcode checkSingleRoot}. On failure, `roots` carries the
+ * offending set so the DSL host can locate each one for its diagnostic.
+ */
+export type RootCheck<T> =
+  | { readonly ok: true; readonly root: T }
+  | {
+    readonly ok: false;
+    readonly reason: "no-root" | "multiple-roots";
+    readonly roots: readonly T[];
+  };
+
+/**
+ * Enforce the one-root invariant (rule 5): a declaring entry must have
+ * exactly one root declaration. Returns the sole root on success, or a
+ * `no-root` / `multiple-roots` failure carrying the offending set. Generic
+ * over the DSL's root-declaration type — the engine only counts.
+ */
+export function checkSingleRoot<T>(roots: readonly T[]): RootCheck<T> {
+  if (roots.length === 1) return { ok: true, root: roots[0] };
+  return {
+    ok: false,
+    reason: roots.length === 0 ? "no-root" : "multiple-roots",
+    roots,
+  };
+}

--- a/packages/markspec/core/decl/resolve_test.ts
+++ b/packages/markspec/core/decl/resolve_test.ts
@@ -1,0 +1,116 @@
+/**
+ * @module core/decl/resolve_test
+ *
+ * Unit tests for the DSL-agnostic base-resolution engine — one test per
+ * normative rule from #722. Fixtures use a toy DSL: an absolute ref starts
+ * with `abs:`, and `join` combines base + `/` + ref. Neither typl nor uxil
+ * vocabulary appears, proving the engine carries no DSL knowledge.
+ */
+
+import { assertEquals } from "@std/assert";
+import {
+  type BaseScope,
+  checkSingleRoot,
+  type RefOps,
+  resolveRef,
+} from "./resolve.ts";
+
+const OPS: RefOps = {
+  isAbsolute: (ref) => ref.startsWith("abs:"),
+  join: (base, ref) => `${base}/${ref}`,
+};
+
+// --- resolveRef ------------------------------------------------------------
+
+Deno.test("resolveRef: absolute ref passes through unchanged (no base needed)", () => {
+  // Absolute even when no scope carries a base.
+  assertEquals(resolveRef("abs:home", undefined, OPS), {
+    ok: true,
+    ref: "abs:home",
+  });
+  // Absolute even when a base IS in scope — it is not applied.
+  const scope: BaseScope = { base: "root" };
+  assertEquals(resolveRef("abs:home", scope, OPS), {
+    ok: true,
+    ref: "abs:home",
+  });
+});
+
+Deno.test("resolveRef: relative ref joins the innermost base", () => {
+  const scope: BaseScope = { base: "root" };
+  assertEquals(resolveRef("leaf", scope, OPS), { ok: true, ref: "root/leaf" });
+});
+
+Deno.test("resolveRef: innermost base wins over an outer base (single join, not cumulative)", () => {
+  const scope: BaseScope = { base: "inner", parent: { base: "outer" } };
+  // Only the innermost base is applied, exactly once — not "outer/inner/x".
+  assertEquals(resolveRef("x", scope, OPS), { ok: true, ref: "inner/x" });
+});
+
+Deno.test("resolveRef: skips base-less scopes, uses the nearest ancestor that has one", () => {
+  const scope: BaseScope = {
+    // innermost: a structural container with no base of its own
+    parent: { parent: { base: "grandparent" } },
+  };
+  assertEquals(resolveRef("x", scope, OPS), {
+    ok: true,
+    ref: "grandparent/x",
+  });
+});
+
+Deno.test("resolveRef: relative ref with no base in scope → error", () => {
+  // A chain of base-less scopes, and the undefined-scope case.
+  const scope: BaseScope = { parent: {} };
+  assertEquals(resolveRef("x", scope, OPS), {
+    ok: false,
+    reason: "no-base-in-scope",
+  });
+  assertEquals(resolveRef("x", undefined, OPS), {
+    ok: false,
+    reason: "no-base-in-scope",
+  });
+});
+
+Deno.test("resolveRef: structural not sequential — siblings do not share bases, order is irrelevant", () => {
+  // Two sibling scopes under a base-less root. Sibling A declares a base;
+  // sibling B declares none. Resolving in B must NOT see A's base — the
+  // engine only follows `parent`, never siblings (rule 4).
+  const root: BaseScope = {};
+  const siblingA: BaseScope = { base: "a", parent: root };
+  const siblingB: BaseScope = { parent: root };
+
+  assertEquals(resolveRef("x", siblingA, OPS), { ok: true, ref: "a/x" });
+  assertEquals(resolveRef("x", siblingB, OPS), {
+    ok: false,
+    reason: "no-base-in-scope",
+  });
+  // Declaring a second sibling C after B — and in any order — cannot change
+  // B's resolution, because the engine never reaches a sibling.
+  const _siblingC: BaseScope = { base: "c", parent: root };
+  assertEquals(resolveRef("x", siblingB, OPS), {
+    ok: false,
+    reason: "no-base-in-scope",
+  });
+});
+
+// --- checkSingleRoot -------------------------------------------------------
+
+Deno.test("checkSingleRoot: exactly one root → ok with that root", () => {
+  assertEquals(checkSingleRoot(["only"]), { ok: true, root: "only" });
+});
+
+Deno.test("checkSingleRoot: zero roots → no-root", () => {
+  assertEquals(checkSingleRoot([]), {
+    ok: false,
+    reason: "no-root",
+    roots: [],
+  });
+});
+
+Deno.test("checkSingleRoot: multiple roots → multiple-roots with the offending set", () => {
+  assertEquals(checkSingleRoot(["a", "b"]), {
+    ok: false,
+    reason: "multiple-roots",
+    roots: ["a", "b"],
+  });
+});

--- a/packages/markspec/core/decl/resolve_test.ts
+++ b/packages/markspec/core/decl/resolve_test.ts
@@ -71,26 +71,33 @@ Deno.test("resolveRef: relative ref with no base in scope → error", () => {
   });
 });
 
-Deno.test("resolveRef: structural not sequential — siblings do not share bases, order is irrelevant", () => {
-  // Two sibling scopes under a base-less root. Sibling A declares a base;
-  // sibling B declares none. Resolving in B must NOT see A's base — the
-  // engine only follows `parent`, never siblings (rule 4).
+Deno.test("resolveRef: structural not sequential — a sibling's base is invisible to its siblings", () => {
+  // Three sibling scopes under a base-less root. A and B each declare their
+  // OWN base; C declares none. Resolving in A uses only A's base, in B only
+  // B's — never the other sibling's — and C, having no base of its own, falls
+  // through to the base-less root rather than borrowing a sibling's base. The
+  // engine follows `parent` links only, never siblings (rule 4). Order is
+  // irrelevant by construction: the API exposes no sibling ordering at all.
   const root: BaseScope = {};
   const siblingA: BaseScope = { base: "a", parent: root };
-  const siblingB: BaseScope = { parent: root };
+  const siblingB: BaseScope = { base: "b", parent: root };
+  const siblingC: BaseScope = { parent: root };
 
   assertEquals(resolveRef("x", siblingA, OPS), { ok: true, ref: "a/x" });
-  assertEquals(resolveRef("x", siblingB, OPS), {
+  assertEquals(resolveRef("x", siblingB, OPS), { ok: true, ref: "b/x" });
+  assertEquals(resolveRef("x", siblingC, OPS), {
     ok: false,
     reason: "no-base-in-scope",
   });
-  // Declaring a second sibling C after B — and in any order — cannot change
-  // B's resolution, because the engine never reaches a sibling.
-  const _siblingC: BaseScope = { base: "c", parent: root };
-  assertEquals(resolveRef("x", siblingB, OPS), {
-    ok: false,
-    reason: "no-base-in-scope",
-  });
+});
+
+Deno.test("resolveRef: an explicitly empty base still wins innermost (presence, not truthiness)", () => {
+  // The guard is `base !== undefined`, not a truthiness check: a declaration
+  // that establishes an empty-string base is a *present* base and must win
+  // innermost, not fall through to an outer base. Pins that a later
+  // `if (s.base)` "simplification" would be a regression.
+  const scope: BaseScope = { base: "", parent: { base: "outer" } };
+  assertEquals(resolveRef("x", scope, OPS), { ok: true, ref: "/x" });
 });
 
 // --- checkSingleRoot -------------------------------------------------------


### PR DESCRIPTION
Closes #722.

uxil epic (#717 §A). The DSL-agnostic **normative rule set** for resolving a relative reference against the base an enclosing declaration establishes. typl's published tier (S5) and uxil (S7) both consume it; the engine carries no vocabulary.

## API (`core/decl/resolve.ts`)

- `resolveRef(ref, scope, ops)` — an absolute ref passes through unchanged; a relative ref joins the base of the **nearest enclosing scope** that carries one (innermost wins, single join — bases are not accumulated up the chain); no base in any ancestor → `{ ok: false, reason: "no-base-in-scope" }`.
- `checkSingleRoot(roots)` — the one-root invariant; else `{ ok: false, reason: "no-root" | "multiple-roots", roots }`.
- Scope is an abstract `BaseScope { base?, parent? }` chain; ref syntax is injected via `RefOps { isAbsolute, join }`. So the engine is vocabulary-agnostic and needs **neither** the table surface (S3) **nor** a DSL consumer to land.

## The six rules → where each lives

1. Only declarations create bases — the caller sets `BaseScope.base` only for declaration scopes.
2. Bases are entry-local — the engine only walks the `parent` chain it's handed; no global lookup.
3. Innermost base wins — `resolveRef` returns on the first ancestor with a base.
4. **Structural, not sequential** — the engine follows `parent` links only, never siblings, so reordering declarations can't rebind a ref. (Directly tested.)
5. Exactly one root per entry — `checkSingleRoot`.
6. Declarations sit in code spans — a surface concern (S2 + the DSL recognizer); the engine sees only the extracted ref token.

## Diagnostics

The engine returns **typed reasons** (`no-base-in-scope`, `no-root`, `multiple-roots`) that map 1:1 to the three diagnostics in the issue. Messages + codes stay DSL-owned (typl TYPL-0xx, uxil UXIL-0xx in S9) — matching the existing typl diagnostics model, keeping the engine DSL-agnostic.

## Scope boundary

Engine + per-rule tests only (9 tests: innermost-wins, single-join-not-cumulative, base-less-scope skip, no-base error, structural-not-sequential + order-independence, absolute passthrough, one-root ×3). Building `BaseScope` chains from real surfaces — including the table-caption base ("caption base surfaced to the resolver (S4)") — is **S3** and the DSL consumers (**S5/S7**). `core/decl/` stays internal (no `core/mod.ts` re-export); its consumers live inside `core/`.

## Verification

`just check` **3564 passed / 0 failed**, `deno fmt --check`, `dprint check`, `just compile` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
