### PR TITLE
docs(docs): sync overview, CLI reference, and templates with the shipped toolchain

### DIFF
--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,7 +1,9 @@
 # MarkSpec Architecture Overview
 
 This document gives the narrative tour of MarkSpec's architecture. For the
-decisions behind it, see the [ADRs](./) in this directory.
+decisions behind it, see the [ADRs](./) in this directory. Every decision
+referenced below links to its ADR; the closing
+[reading order](#reading-order-for-new-contributors) threads them into a path.
 
 ## Who MarkSpec is for
 
@@ -34,7 +36,7 @@ default profile     ·  Generic types (requirement, note, term, reference),
 core                ·  Two entry shapes (identified, referenced), single `Id:`
                        with ULID-or-URI format discrimination, typed-edge
                        graph, attribute schema, rule evaluator, entry-source
-                        pipeline, typography pipeline.
+                       pipeline, typography pipeline.
 ```
 
 Each layer is optional relative to the one above it. Core runs standalone.
@@ -57,11 +59,14 @@ The core is deliberately small and semantics-free. It ships:
   slug) ([ADR-002](./adr-002-entry-model.md),
   [ADR-009](./adr-009-core-profile-boundary.md)).
 - **Typed-edge graph** — cross-references are labelled with relation names
-  declared by the active profile; the core resolves and validates them.
+  declared by the active profile; the core resolves and validates them. Display
+  IDs are the canonical authored form of a trace value
+  ([ADR-026](./adr-026-display-id-trace-resolution.md)).
 - **Attribute-schema machinery** — generic `Key: Value` trailers with value
   types, origin, cardinality; profiles populate the vocabulary.
 - **Generic rule evaluator** — predicates over the graph; dormant without
-  profile rules.
+  profile rules. Diagnostics follow a versioned code scheme
+  ([ADR-012](./adr-012-diagnostic-code-scheme.md)).
 - **Entry-source pipeline** — adapters for Markdown and code doc comments.
   Future: tree-sitter-based language adapters, SBOM tools
   ([ADR-011](./adr-011-language-pack-and-dependency-ingestion.md)).
@@ -116,7 +121,10 @@ Examples that typically ship as separate profile packages:
 
 See [ADR-008](./adr-008-profile-system.md) for distribution and
 [ADR-011 §6](./adr-011-language-pack-and-dependency-ingestion.md) for the
-coding-standard rule-profile pattern.
+coding-standard rule-profile pattern. A profile can also **deliver documents** —
+ship Markdown files (a traceable corpus or docs-only material) that consumers
+inherit through the `extends:` chain
+([ADR-030](./adr-030-profile-delivered-documents.md)).
 
 ## What the language pack adds
 
@@ -142,9 +150,86 @@ not re-implement manifest parsers. See
 [ADR-011](./adr-011-language-pack-and-dependency-ingestion.md) for the full
 design.
 
+## The body model and formatting pipeline
+
+An entry's body is not opaque prose — the core parses it into a canonical model
+so analysis and formatting are lossless and deterministic.
+
+- **Canonical body-AST** ([ADR-014](./adr-014-canonical-body-ast.md)) — the
+  load-bearing model of an entry body; the formatter falls back to a safe string
+  path only where the build/render inverse is not total.
+- **AST-equivalence formatting contract**
+  ([ADR-015](./adr-015-ast-equivalence-formatting-contract.md)) — `markspec fmt`
+  must satisfy `build(format(x)) ≈ normalizeBodyAst(build(x))`; this gate is
+  what makes reformatting provably content-preserving.
+- **Body-token AST** ([ADR-016](./adr-016-body-token-ast.md)) — a flat
+  `bodyTokens` stream is the single extraction layer for modal verbs, EARS
+  triggers, Gherkin keywords, `$Identifier` entity refs, and inline code.
+- **Whole-document formatting**
+  ([ADR-029](./adr-029-whole-document-markdown-formatting.md)) — `markspec fmt`
+  formats the entire Markdown document via an embedded dprint plugin, gated by a
+  CommonMark-semantic equivalence comparator.
+- **Document directive, not a resolution step**
+  ([ADR-013](./adr-013-document-directive-not-a-resolution-step.md)) — the
+  family-hint document directive is a `fmt` concern, deliberately kept out of
+  the validator's type-resolution chain.
+
+## Classification, types, and identifiers
+
+Above the raw graph, the core derives structure and lets profiles constrain it.
+
+- **Discipline classification**
+  ([ADR-017](./adr-017-discipline-classification.md),
+  [ADR-018](./adr-018-core-discipline-ssot.md)) — SW/HW discipline is derived
+  from the `Allocated-to` graph, with a single source of truth in the core that
+  profiles extend but never override.
+- **typl type DSL** ([ADR-019](./adr-019-typl-type-dsl.md)) — an inline
+  constraint/type declaration language for entry attributes, with three
+  authoring surfaces and a corpus-wide type registry.
+- **Interface as contract** ([ADR-024](./adr-024-interface-as-contract.md)) —
+  software/hardware interfaces are re-parented from `Component` to `Contract`
+  (an interface is a specification, not a building block), with symmetric
+  `Provides`/`Requires` links.
+- **Counter-less display IDs**
+  ([ADR-025](./adr-025-counter-less-display-id-pattern.md)) — named (not
+  numbered) `display-id-pattern`s so component-style IDs like `SWC_LIGHT_CTRL`
+  classify by prefix without an explicit `Type:`.
+- **Display-ID trace resolution**
+  ([ADR-026](./adr-026-display-id-trace-resolution.md)) — display IDs are the
+  canonical authored form for trace values; a permissive existence check
+  (`MSL-L006`) and a lockfile `[[edge]]` ULID ledger keep renames healable.
+
+## Tooling, indexing, and distribution
+
+The surfaces around the core — CLI ergonomics, prose analysis, indexing,
+external sync, and agent integration — are their own line of decisions.
+
+- **Smoother CLI defaults** ([ADR-027](./adr-027-cli-smoother-defaults.md)) —
+  bare `check` / `lint` / `fmt` default to whole-project scope via
+  gitignore-aware discovery, and `check` becomes the composite gate (structure +
+  traceability + fmt drift + lockfile drift + advisory prose lint).
+- **Prose-analysis flagship**
+  ([ADR-021](./adr-021-prose-analysis-flagship-build.md)) — 16 active `MSL-Q`
+  rules plus the flagship `xref-glossary-undefined` check and a band-count score
+  roll-up, surfaced by `markspec lint` and `markspec score`.
+- **Lockfile and external sync**
+  ([ADR-022](./adr-022-lockfile-and-external-sync.md)) — `markspec.lock` pins
+  upstream profile/language-pack versions and tracks sync state
+  (`markspec lock`, `markspec sync status|log|show`).
+- **On-demand SQLite indexing** ([ADR-020](./adr-020-sqlite-indexing-eval.md)) —
+  the evaluation scope for Phase 1 of background indexing: no filesystem
+  watcher, surgical invalidation, a lockfile-pinned federated cache.
+- **MCP agent integration** ([ADR-023](./adr-023-mcp-trigger-language.md),
+  [ADR-028](./adr-028-mcp-project-discovery.md)) — the MCP server's agent-facing
+  trigger language and soft project-detection gate, plus how `markspec mcp`
+  resolves its project root from an ordered candidate list.
+
 ## Reading order for new contributors
 
-If you are new to MarkSpec and want the full picture:
+If you are new to MarkSpec, read the anchoring decisions first, then follow the
+line that matches what you are working on.
+
+**Start here — the anchor:**
 
 1. [ADR-001 — Markdown Format](./adr-001-markdown-format.md) — what MarkSpec
    considers valid input.
@@ -152,15 +237,36 @@ If you are new to MarkSpec and want the full picture:
    principle that organizes everything else.
 3. [ADR-002 — Entry Model](./adr-002-entry-model.md) — the two-shape entry model
    the core implements.
-4. [ADR-008 — Profile System](./adr-008-profile-system.md) — how vocabulary and
-   rules live outside the core.
-5. [ADR-010 — Default Profile](./adr-010-default-profile.md) — the out-of-box
-   experience.
-6. [ADR-011 — Language Pack and Dependency Ingestion](./adr-011-language-pack-and-dependency-ingestion.md)
+4. [ADR-008 — Profile System](./adr-008-profile-system.md) and
+   [ADR-010 — Default Profile](./adr-010-default-profile.md) — how vocabulary
+   and rules live outside the core, and the out-of-box experience.
+5. [ADR-011 — Language Pack and Dependency Ingestion](./adr-011-language-pack-and-dependency-ingestion.md)
    — how code and dependencies enter the model.
 
-For document-level structure and rendering, see
-[ADR-004](./adr-004-book-structure.md) (book),
-[ADR-007](./adr-007-document-structure.md) (front matter),
-[ADR-003](./adr-003-diagram-authoring.md) (diagrams),
-[ADR-005](./adr-005-cli-architecture.md) (CLI).
+**Then, by topic:**
+
+- **Documents & rendering:** [ADR-007](./adr-007-document-structure.md) (front
+  matter), [ADR-004](./adr-004-book-structure.md) (book),
+  [ADR-003](./adr-003-diagram-authoring.md) (diagrams),
+  [ADR-006](./adr-006-property-model.md) (observed properties),
+  [ADR-005](./adr-005-cli-architecture.md) (CLI architecture).
+- **Body model & formatting:** [ADR-014](./adr-014-canonical-body-ast.md),
+  [ADR-015](./adr-015-ast-equivalence-formatting-contract.md),
+  [ADR-016](./adr-016-body-token-ast.md),
+  [ADR-029](./adr-029-whole-document-markdown-formatting.md),
+  [ADR-013](./adr-013-document-directive-not-a-resolution-step.md),
+  [ADR-012](./adr-012-diagnostic-code-scheme.md).
+- **Classification, types & IDs:**
+  [ADR-017](./adr-017-discipline-classification.md),
+  [ADR-018](./adr-018-core-discipline-ssot.md),
+  [ADR-019](./adr-019-typl-type-dsl.md),
+  [ADR-024](./adr-024-interface-as-contract.md),
+  [ADR-025](./adr-025-counter-less-display-id-pattern.md),
+  [ADR-026](./adr-026-display-id-trace-resolution.md).
+- **Tooling, sync & agents:** [ADR-027](./adr-027-cli-smoother-defaults.md),
+  [ADR-021](./adr-021-prose-analysis-flagship-build.md),
+  [ADR-022](./adr-022-lockfile-and-external-sync.md),
+  [ADR-020](./adr-020-sqlite-indexing-eval.md),
+  [ADR-023](./adr-023-mcp-trigger-language.md),
+  [ADR-028](./adr-028-mcp-project-discovery.md),
+  [ADR-030](./adr-030-profile-delivered-documents.md).

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -101,6 +101,40 @@ Profile configuration (`.markspec.yaml` and profile manifests) is covered in the
 
 ## Commands
 
+### Project setup
+
+#### init
+
+Scaffold a new MarkSpec project — writes `project.yaml`, `.markspec.yaml`, and
+(unless opted out) client MCP configs and skills.
+
+```sh
+markspec init [target-dir]
+```
+
+| Flag            | Type   | Default | Description                                                              |
+| --------------- | ------ | ------- | ------------------------------------------------------------------------ |
+| `--client`      | string | —       | Force write for the named client (repeatable): `claude-code`, `opencode` |
+| `--all-clients` | bool   | false   | Write configs for `claude-code` + `opencode` regardless of detection     |
+| `--no-mcp`      | bool   | false   | Skip all MCP scaffolding                                                 |
+| `--no-skills`   | bool   | false   | Skip `upskill add`                                                       |
+| `--profile`     | string | —       | Profile spec (conflicts with `--no-profile`)                             |
+| `--no-profile`  | bool   | false   | Core-only mode (`default-profile: false`)                                |
+| `--binary-path` | string | —       | Absolute path to the markspec binary for MCP configs                     |
+| `--dry-run`     | bool   | false   | Report decisions, write nothing                                          |
+| `--force`       | bool   | false   | Overwrite skip-on-exists files; required for a non-empty dir or non-TTY  |
+| `--format`      | string | `text`  | Summary format: `json`, `text`                                           |
+
+**Examples:**
+
+```sh
+markspec init                                             # scaffold in cwd
+markspec init ./my-project                                # scaffold in a new subdir
+markspec init --profile git+https://github.com/org/profile
+markspec init --all-clients --binary-path /opt/markspec/bin/markspec
+markspec init --dry-run --format json                     # report, write nothing
+```
+
 ### Authoring
 
 #### fmt
@@ -544,6 +578,29 @@ markspec lint --format json
 markspec lint docs/requirements.md
 ```
 
+#### score
+
+Score a single piece of requirement prose against the PA-3 rule catalog. Unlike
+`lint`, which walks a file's entries, `score` takes prose directly — useful for
+a review-time or editor-integration check of one requirement.
+
+```sh
+markspec score --text "The system shall …"
+```
+
+| Flag       | Type   | Default | Description                                                            |
+| ---------- | ------ | ------- | ---------------------------------------------------------------------- |
+| `--text`   | string | —       | Inline prose to score                                                  |
+| `--id`     | string | —       | Identifier to echo back in the result                                  |
+| `--format` | string | —       | Output format: `json`, `text` (default: `text` on a TTY, `json` piped) |
+
+**Examples:**
+
+```sh
+markspec score --text "The controller shall respond within 200 ms."
+markspec score --id SRS_BRK_0001 --text "The system shall be fast." --format json
+```
+
 ### Lockfile and external sync
 
 #### lock
@@ -809,6 +866,31 @@ fields omitted (its validity is `check`'s / `lock`'s concern, not `doctor`'s).
 The drift warning uses the non-`MSL` `doctor` code `lockfile-edge-drift`, listed
 in the shared `diagnostics` array. See the `lock` [Upgrade note](#lock) for the
 one-time post-upgrade drift and how to clear it.
+
+### Maintenance
+
+#### self-upgrade
+
+Download and atomically replace the running `markspec` binary with the latest
+release (or a pinned version).
+
+```sh
+markspec self-upgrade
+```
+
+| Flag        | Type   | Default | Description                                          |
+| ----------- | ------ | ------- | ---------------------------------------------------- |
+| `--check`   | bool   | false   | Check only; exit `1` if a newer release is available |
+| `--version` | string | —       | Pin a specific release (downgrade allowed)           |
+| `--format`  | string | `text`  | Output format: `json`, `text`                        |
+
+**Examples:**
+
+```sh
+markspec self-upgrade              # upgrade to the latest release
+markspec self-upgrade --check      # CI/cron: exit 1 when an update exists
+markspec self-upgrade --version 0.10.2
+```
 
 ### AI agent integration
 

--- a/docs/templates/adr-nnn-topic.md
+++ b/docs/templates/adr-nnn-topic.md
@@ -16,13 +16,7 @@
 ## Decision
 
 <!-- State the decision, then capture each design choice as a SAD or ICD
-     requirement using MarkSpec entry blocks.
-
-     Use SAD for internal architecture decisions.
-     Use ICD for interface contracts between components or systems.
-     Replace XXX with your project/domain abbreviation (e.g., BRK, NAV, COM).
-     Replace NNNN with the next number in your project sequence.
-     Leave Id empty — tooling assigns the ULID on commit. -->
+     entry block. A worked example follows. -->
 
 Write one entry block per decision point. Use `SAD_` for internal architecture
 and `ICD_` for interface contracts; replace `XXX` with your project abbreviation

--- a/docs/templates/adr-nnn-topic.md
+++ b/docs/templates/adr-nnn-topic.md
@@ -24,22 +24,21 @@
      Replace NNNN with the next number in your project sequence.
      Leave Id empty — tooling assigns the ULID on commit. -->
 
-- [SAD_XXX_NNNN] Decision title
+Write one entry block per decision point. Use `SAD_` for internal architecture
+and `ICD_` for interface contracts; replace `XXX` with your project abbreviation
+and `NNNN` with the next number. Leave `Id:` empty — `markspec fmt` stamps the
+ULID — and remove attributes you do not use rather than leaving them blank.
 
-  <!-- One or two paragraphs describing what the system shall do and why.
-       Use "shall" for normative statements.
+```markdown
+- [SAD_BRK_0001] Interrupt-driven acquisition pipeline
 
-       Example: "The sensor pipeline shall use an interrupt-driven architecture
-       with a lock-free ring buffer to decouple acquisition from processing." -->
+  The sensor pipeline shall use an interrupt-driven architecture with a
+  lock-free ring buffer to decouple acquisition from processing.
 
       Id:
-      Satisfies:
-      Labels:
-
-  <!-- Id: left empty, assigned by `markspec doc format`.
-       Satisfies: upstream requirement ID (e.g., STK_BRK_0001, SYS_BRK_0042).
-       Labels: classification tags (e.g., ASIL-B, security, performance).
-       Remove unused attributes rather than leaving them blank. -->
+      Satisfies: STK_BRK_0001
+      Labels: ASIL-B
+```
 
 <!-- Add more entry blocks as needed. One block per distinct decision point.
      Mix SAD and ICD blocks when the decision spans both internal architecture

--- a/docs/templates/sad-nnn-topic.md
+++ b/docs/templates/sad-nnn-topic.md
@@ -20,28 +20,32 @@
 
 <!-- ![Architecture diagram](diagrams/sad-nnn-architecture.svg) -->
 
-- [SAD_XXX_NNNN] Architectural decision title
+```markdown
+- [SAD_BRK_0001] Lock-free acquisition buffer
 
-  <!-- Example: "The acquisition module shall use a lock-free ring buffer
-       to decouple sensor sampling from processing." -->
+  The acquisition module shall use a lock-free ring buffer to decouple sensor
+  sampling from processing.
 
       Id:
-      Satisfies:
-      Labels:
+      Satisfies: STK_BRK_0001
+      Labels: ASIL-B
+```
 
 ## Interfaces
 
 <!-- One ICD entry per external interface between the components above.
      Describe protocol, data format, direction, rate, and constraints. -->
 
-- [ICD_XXX_NNNN] Interface title
+```markdown
+- [ICD_BRK_0001] Sensor frame publication interface
 
-  <!-- Example: "The sensor gateway shall expose a CAN 2.0B interface
-       publishing filtered sensor frames at 100 Hz." -->
+  The sensor gateway shall expose a CAN 2.0B interface publishing filtered
+  sensor frames at 100 Hz.
 
       Id:
-      Satisfies:
-      Labels:
+      Satisfies: SAD_BRK_0001
+      Labels: ASIL-B
+```
 
 ## Constraints
 


### PR DESCRIPTION
A documentation-consistency audit of `main` found three gaps between the published docs and the shipped toolchain. This PR closes all three (docs-only — no code changes).

## What changed

1. **`docs/architecture/overview.md` — extended to all 30 ADRs.** The narrative tour and its reading-order list previously stopped at ADR-011; ADR-012–030 (diagnostics scheme, the body-AST/formatting line, discipline classification, typl, interface-as-contract, display-ID trace, lockfile/sync, MCP, smoother CLI defaults, delivered documents) had zero mention. Rewrote the tour so every ADR 001–030 is placed in a causal reading order, each with a one-line summary. AGENTS.md points readers here for "a reading order," so the front door now matches the ADR set.

2. **`docs/guide/cli.md` — added the three missing command sections.** `markspec init`, `markspec score`, and `markspec self-upgrade` were registered in `main.ts` but had no reference section. Added `#### init` (new `### Project setup` group), `#### score` (beside `#### lint`), and `#### self-upgrade` (new `### Maintenance` group), each authored from the command's real `--help` and cross-checked against its Cliffy definition. Every registered command is now documented or listed under `### Not yet implemented`.

3. **`docs/templates/{adr,sad}-nnn-topic.md` — templates now pass `markspec check`.** The example entry blocks were live entries with empty placeholder trailers and HTML guidance comments inside the entry body, which tripped MSL-B043 / P020 / P021 / R003. A live template entry can never pass `check` (empty placeholders + no hand-written ULID allowed), so the examples are now wrapped in `` ```markdown `` fences (illustrative, not live). Also fixed a stale `markspec doc format` → `markspec fmt` verb.

## Verification

- `markspec check docs/` — templates clean; the only remaining output is the by-design `docs/examples/` profile-scope warnings (those files showcase entry types this repo's lightweight STK/SAD profile doesn't declare).
- `dprint check` — clean on all four touched files.
- `main.ts` ↔ `cli.md` reconciliation — every command documented (only `completions`, `deck`, `version` intentionally absent).
- All 30 ADR links in `overview.md` resolve to real files.
- Pre-push `just check` (lint + test + typecheck) green: 3582 tests passed.

## Follow-ups (not in this PR)

- **`cli.md` `score` batch mode:** the section documents the `--text` one-shot surface (matching `--help`); `score` also accepts JSONL on stdin for batch scoring (exit 0/1/2). Worth a one-line note in a later pass.
- **`docs/wip/` is not gitignored** the way `docs/superpowers/` is. Consider adding the gitignore entry to match, or gardening the in-flight design doc there.
- **Local `.claude/` installs may carry stale `format`/`validate`/`hook` verbs** — the repo's `skills/` source is already correct; re-pin the global bundle (`upskill add … --global --force`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
