### PR TITLE
feat(core): federated upstream slice 1 — origin union + snapshot hydration

### DIFF
--- a/docs/wip/2026-07-04-federated-upstream-resolution-design.md
+++ b/docs/wip/2026-07-04-federated-upstream-resolution-design.md
@@ -1,0 +1,518 @@
+# Federated upstream resolution — design
+
+- **Date:** 2026-07-04 (revised same day after org-SSOT alignment)
+- **Status:** draft, awaiting spec review
+- **Scope:** true peer-to-peer cross-repository references — a downstream repo's
+  entry traces (`Satisfies:`, `Derived-from:`, …) to an entry authored in
+  another repository, resolved and validated by `markspec check`; plus the
+  program root project that aggregates the overall picture.
+
+## 1. Problem
+
+MarkSpec today has exactly one working cross-repo entry-sharing mechanism:
+profile-delivered corpus (ADR-030), which ships a shared baseline _inside a
+profile package_. Peer-to-peer references — repo B's requirement satisfying a
+live entry in repo A — do not resolve: the federation protocol is designed
+(compile-output spec §5, `language.md` §3.2, issue #22) but the resolution side
+was never built. `resolveRegistries` pins an upstream's manifest hash into
+`markspec.lock`, yet nothing ever reads an upstream's entries.
+
+Target topology is a mix: product→component references up the V-model, peer
+repos (ICDs), shared standards resolution (RefHub-style registries), and a
+root/program repo that needs the overall picture.
+
+## 2. Prior art this design builds on
+
+| Piece                             | Where                                          | Reused as                                         |
+| --------------------------------- | ---------------------------------------------- | ------------------------------------------------- |
+| Org project-manifest contract     | `driftsys/schemas` `project/v1.json` + README  | The declaration surface (SSOT for `project.yaml`) |
+| Lockfile + `resolveUpstreams`     | ADR-022, `core/lock/`                          | Pinning + drift machinery; new upstream row kind  |
+| Registry pinning                  | `core/lock/resolve.ts::resolveRegistries`      | Extended from pin-only to pin+snapshot            |
+| `Entry.origin` read-only citizens | ADR-030, `core/profile/delivered.ts`           | Same model, new origin kind `upstream`            |
+| Compile output (`/api/`)          | compile-output spec, `core/compiler/schema.ts` | The interchange format (already emitted today)    |
+| `[[edge]]` ULID ledger            | ADR-026                                        | Unchanged; already records target ULIDs           |
+| Reserved `MSL-T014`               | `language.md` §8                               | Lands as the post-federation unresolved-ref code  |
+
+Issue #22's acceptance criteria (live fetch, 7-day TTL) are superseded by this
+design's lock-mediated model and will be rewritten. The legacy
+`parents:`/`parent-fallback:` config keys are retired (see §4.1 and D9).
+
+## 3. Decisions
+
+- **D1 — Topology:** support authored project dependencies, peer repos, and
+  standards registries through the org contract's two relationship fields.
+- **D2 — Acquisition is implied by the declaration field, not a `kind` flag:**
+  `dependencies:` are projects → git repositories → clone at pinned version and
+  compile in-process. `references:` are citation sources → published sites →
+  fetch the published index. Two fetchers internally; selection by field. A
+  `kind` discriminator was considered and dropped; it can return later as a
+  non-breaking org-schema addition (see §5 #8).
+- **D3 — Network model:** lock-mediated. Only `markspec lock` touches the
+  network; `check`/`compile`/LSP/MCP resolve offline from the pinned cache.
+  Deterministic output preserved (clig.dev rule).
+- **D4 — Depth:** upstream entries join the compiled graph as read-only citizens
+  via `Entry.origin` — the ADR-030 model with a new origin kind. The
+  dependency/reference split adds a _coverage_ distinction, not a data-shape one
+  (§4.7).
+- **D5 — Namespacing:** one flat display-ID space (project + corpus + all
+  upstreams). Any collision is a hard diagnostic naming both origins. No
+  qualified-ref grammar.
+- **D6 — Interchange:** the compiled-JSON output `markspec compile` already
+  emits (`manifest.json` + `compiled.json` / NDJSON pair) is the canonical
+  interchange. The git fetcher produces the same JSON by compiling the checkout
+  in-process; a published reference serves it directly. Type classification
+  happens upstream with the upstream's own profile — the consumer never needs
+  it.
+- **D7 — Version tracking:** two-level, npm/cargo-style, carried by
+  `projectRef.version`. The manifest declares _intent_; `markspec.lock` records
+  the _resolved pin_ (exact sha) plus the _resolution kind_ (`tag` | `branch` |
+  `sha`). Intent semantics: exact tag = frozen baseline; branch name = track
+  head; **absent = auto mode** (prefer latest release tag, else default-branch
+  head).
+- **D8 — Unreleased references are authorized but gated:** pinning a dependency
+  to an unreleased state (branch/sha resolution) is allowed during development
+  and surfaces as a non-blocking advisory; under `check --strict` any
+  non-tag-resolved pin fails (pin-level gate), and references to entries that
+  exist only outside the pinned baseline fail resolution once the pin moves to a
+  tag (content-level gate). See §4.4.
+- **D9 — Org schema is the SSOT for `project.yaml`:** markspec's local
+  `schemas/project/v1.json` is retired in favour of
+  `https://driftsys.github.io/schemas/project/v1.json` (closed schema,
+  `name`+`version` required). markspec tool config leaves `project.yaml`
+  entirely (§4.10).
+- **D10 — Core stays pure:** core gains only pure pieces (origin model,
+  hydration, corpus loader with injected `readFile`). Fetchers (HTTP, git,
+  tarball) live at the lock/CLI layer beside `resolveUpstreams`. Core never
+  grows a network or git dependency; Node compatibility preserved.
+
+## 4. Design
+
+### 4.1 Declaration surface — org `project.yaml` contract
+
+`project.yaml` follows the org contract (`driftsys/schemas` `project/v1.json`):
+relationships are declared with `dependencies:` and `references:`, each a list
+of `projectRef` (`url` required; `version`, `name` optional):
+
+```yaml
+name: io.acme.aeb-brake-controller
+version: "1.2.0"
+
+dependencies:                       # projects this project uses (git repos)
+  - url: git@github.com:acme/aeb-product.git
+    name: product                    # short id: cache dir, lock rows, badges
+    # version absent → auto mode: latest release tag, else default branch
+  - url: git@github.com:acme/aeb-icd.git
+    name: icd
+    version: "v2.1.0"                # frozen baseline (exact tag)
+  - url: ../aeb-sensor               # local path clone — sibling dev loop
+    name: sensor
+    version: "main"                  # deliberately track unreleased head
+
+references:                          # citation sources (published sites)
+  - url: https://driftsys.github.io/refhub
+    name: refhub                     # was parent-fallback — now explicit
+```
+
+- **`dependencies:`** — projects this project uses. URL is a git repository
+  (remote or local path). Entries participate fully in traceability: the
+  compiler expects links across the boundary and reports coverage gaps.
+- **`references:`** — registries and external sources this project cites. URL is
+  a published site serving the compile-output artifacts. Traceability leaves:
+  links resolve to them, no deeper chain or coverage expected. `file://` URLs
+  are accepted (e2e vehicle).
+- **`name`** on a projectRef is the upstream id (cache directory, lockfile rows,
+  diagnostics, origin badges); derived from the URL when absent.
+- **`version`** carries the intent per D7. The lockfile records what it resolved
+  to.
+- The legacy `parents:` / `parent-fallback:` keys are removed (pre-1.0, no
+  back-compat per project policy). RefHub is no longer an implicit fallback — it
+  is an ordinary explicit `references:` entry.
+- Where a project _publishes its own_ `/api/` output is CI/build configuration
+  (`compile --output` + a publish workflow), never `project.yaml`.
+
+### 4.2 Lock flows and lockfile rows
+
+The git/network scan happens in exactly three flows, all inside `markspec lock`
+— never during `check`/`compile`/LSP:
+
+| Flow       | Trigger                                                    | Behaviour                                                                                                             |
+| ---------- | ---------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| First lock | `lock` with a new dependency/reference                     | Resolve intent → exact sha, acquire + compile (or fetch), snapshot to cache, write pin                                |
+| Restore    | `lock` when pins exist but cache doesn't (CI, fresh clone) | Fetch _exactly the pinned sha_ (intent is NOT re-resolved), verify snapshot hash, repopulate cache; error on mismatch |
+| Update     | `lock --update` / `--update=<id>`                          | Re-resolve the declared intent against the remote, move the pin if changed, refresh snapshot                          |
+
+Each upstream gets a lockfile row (extending the ADR-022 `[[upstream.*]]`
+family; exact TOML naming is plan-time detail):
+
+```toml
+[[upstream.dependency]]
+id = "product"
+url = "git@github.com:acme/aeb-product.git"
+intent = "auto" # auto | <tag> | <branch>
+resolved = "tag:v2.1.0" # resolution kind + name: tag|branch|sha
+sha = "3cdde94…" # exact commit
+snapshot = "sha256:…" # hash of the cached compiled JSON
+locked-at = "2026-07-04T…"
+
+[[upstream.reference]]
+id = "refhub"
+url = "https://driftsys.github.io/refhub"
+manifest-hash = "sha256:…"
+snapshot = "sha256:…"
+locked-at = "2026-07-04T…"
+```
+
+Snapshots live under `.markspec/cache/upstreams/<id>/` (gitignored). The
+`MSL-L212` drift gate gains one case: a locked upstream whose cache snapshot is
+missing or hash-mismatched → error instructing `markspec lock`.
+
+### 4.3 Dependency acquisition — the ladder
+
+The acquisition cost is bounded by _lock events_, not daily work: `check`,
+`compile`, and the LSP only read the cached snapshot. A dependency is acquired
+once per pin movement per machine.
+
+**v1 mechanics (built now):**
+
+1. **Never clone to resolve.** Version-intent resolution is `git ls-remote` only
+   (tags + heads) — a few KB even against huge repos. Auto/tag intents
+   semver-sort the tag list (default pattern `v*`).
+2. **Never fetch history.** Acquire the tree at one sha: prefer the forge
+   tarball endpoint when the URL is a recognized GitHub/GitLab host (one authed
+   API request, no `.git` directory); else fall back to
+   `git clone --depth 1 --filter=blob:none` at the sha. Full clones never
+   happen.
+3. **Content-addressed cache.** Snapshots are immutable per sha — acquire once,
+   reuse until the pin moves. Compile runs in-process on the acquired tree
+   (`compileProject`), producing the same JSON a published reference serves.
+4. **CI recipe (documented in the guide):** cache `.markspec/cache/upstreams/`
+   keyed on the lockfile hash, so CI pays acquisition only when a pin actually
+   moved.
+
+v1 constraint: the acquired dependency tree must be self-contained enough to
+compile — its profile chain resolvable from its own tree (a profile-fetch during
+`lock` is acceptable; `lock` is the designated online step).
+
+**Escalation — owner-publishes (designed, not built):** when a specific repo is
+too big to ship around, its own CI runs `compile --output` on main-merge/tag and
+publishes its `/api/`. One build by the owner replaces N consumers each cloning
+and compiling — the Maven insight, with git hosting + Pages as the registry.
+This reuses the `references:` fetcher machinery and is the moment the deferred
+`kind` addition (D2) returns to let a _dependency_ be acquired from a published
+site.
+
+**Deferred — shared remote snapshot cache:** an org-level cache keyed
+`(repo, sha)` (the true Maven/Gradle remote-cache analogue; ADR-020's
+"lockfile-pinned federated cache"). Slots behind the same cache interface later;
+needs infrastructure; YAGNI now.
+
+Dropped: per-file forge-API crawling — the file set isn't known without
+discovery, so it degenerates into many round-trips that lose to one tarball.
+
+### 4.4 Release assurance
+
+Two stacked guarantees:
+
+1. **Pin-level** — the release gate (`check --strict`, release CI) requires
+   every dependency row to be tag-resolved. A `branch:`/`sha:` row fails with a
+   message naming the dependency and the remedy (upstream cuts a tag, then
+   `lock --update`). Organizationally this enforces "you cannot release against
+   a dependency that never baselined."
+2. **Content-level** — after `lock --update` moves a pin to a tag, the cache
+   holds the _tag's_ entries. A reference to an ID that exists only on `main`
+   now fails resolution (MSL-T014) — the correct failure at the correct moment:
+   the trace referenced unreleased requirements.
+
+Below `--strict`, a branch-resolved pin produces a non-blocking project-level
+advisory ("dependency 'icd' is pinned to an unreleased state (main @ abc123)"),
+following the gentle-by-default posture.
+
+`references:` entries have no tags; they are released-by-publication (the
+publisher publishes their baseline). Their manifest may carry the upstream's
+`project.yaml` version so the lockfile records `refhub@1.4.0`.
+
+### 4.5 Interchange and hydration
+
+`SerializedEntry` (`core/compiler/schema.ts`) is already a lossless `Entry`
+projection. New pieces, all pure core (D10):
+
+- `EntryOrigin` becomes the discriminated union its doc comment anticipates:
+
+  ```ts
+  export type EntryOrigin =
+    | { kind: "profile"; profileId: string; profileVersion: string }
+    | { kind: "upstream"; upstreamId: string; version: string };
+  ```
+
+  `formatEntryOrigin` gains a switch; the upstream label is
+  `<upstreamId>@<version>` (e.g. `product@v2.1.0`).
+- `deserializeCompileResult` — inverse of `serializeCompileResult` (rebuild the
+  `typedAttributes` map), guarded by a schema-skew check: a snapshot whose
+  `markspecSchemaVersion` / `generator.coreSchema` doesn't match is rejected
+  with a "re-lock with a compatible markspec version" diagnostic, never a silent
+  misparse.
+- `loadUpstreamCorpus` — sibling of `loadDeliveredCorpus`: reads the cached
+  snapshot for each locked upstream (injected `readFile`, no I/O of its own),
+  hydrates `Entry[]`, stamps
+  `origin = { kind: "upstream", upstreamId,
+  version }`.
+- **Authoritative-source rule:** hydration _skips_ snapshot entries that already
+  carry an `origin` — an upstream's re-export of _its_ upstreams' entries (or
+  its profile corpus) never enters the consumer's graph. Every entry joins an
+  aggregate only from its authoring repo (or the consumer's own profile corpus).
+  This is what makes the diamond/root pattern (§4.9) collision-free: when the
+  root pulls both A and B, and A's snapshot also contains B's entries, only B's
+  own snapshot supplies them. Publishers still publish everything
+  (`serializeCompileResult` is unchanged), so a root project's published `/api/`
+  carries the full program picture.
+
+### 4.6 Feed sites and read-only semantics
+
+Upstream entries seed at the same three sites as the ADR-030 corpus, in
+declaration order (dependencies, then references), before project files:
+
+- CLI compiler (`compileProject`), immediately after delivered corpus
+- LSP server — `seedUpstreamCorpus()` beside `seedDeliveredCorpus()`, re-seeded
+  when lockfile/cache change
+- MCP server — via the shared compile cache
+
+Read-only semantics are mostly free because upstream entries have **no local
+`.md` file** — they exist only as hydrated objects: `fmt`/`insert` cannot touch
+them, rename is blocked by the existing `origin` guard, diagnostics for them are
+never published. The one new rule: **go-to-definition is a no-op** for upstream
+entries (their `location.file` is an upstream-repo path that does not exist
+locally). Hover, `show`, `context`, completion work from the hydrated entry.
+
+### 4.7 Validator behaviour
+
+- **Resolution:** trace targets resolve against the flat union project +
+  corpus + dependencies + references. `MSL-L006` and broken-ref diagnostics stop
+  firing for IDs found upstream.
+- **`MSL-T014` lands:** when any dependency/reference is declared,
+  unresolved-after-chain refs fire T014 instead of L006, with a message naming
+  the searched set ("not found in project or upstreams: product, icd, refhub").
+- **Coverage semantics differ by field (org contract):** `dependencies:`
+  participate in coverage analysis — at the root, a product requirement with no
+  component coverage is a reported gap. `references:` are leaves — no coverage
+  expectation ever points at or from them.
+- **Collisions:** the ADR-030 collision pass generalizes. project↔upstream,
+  upstream↔upstream, upstream↔corpus all produce the `MSL-R014` shape with a
+  message naming both origins and the remedy. No precedence — every collision is
+  a diagnostic; internal first-entry-wins (declaration order) merely keeps the
+  graph functional while the error shows.
+- **Upstream entries are validation-exempt, not edge-inert:** no prose lint, no
+  structural checks, and refs _from_ upstream entries never produce
+  _unresolved-ref_ diagnostics (their validation happened upstream; transitive
+  upstreams are not pulled — §5 #2). But when such a ref _does_ resolve inside
+  the flat union — component A's entry satisfying component B's entry, both
+  hydrated at the root — the edge joins the graph like any other. This is what
+  makes the §4.9 aggregate matrix complete.
+- **Unreleased-pin advisory:** per §4.4, advisory by default, blocking under
+  `--strict`.
+
+### 4.8 Surface-by-surface
+
+| Surface                           | Behaviour                                                                                  |
+| --------------------------------- | ------------------------------------------------------------------------------------------ |
+| `check`                           | Bigger resolution set; new L212 drift case; T014; collision + unreleased diagnostics       |
+| `show` / `context` / `dependents` | Work on upstream entries; `context` walks into the upstream chain; origin badge shown      |
+| `report` (coverage/matrix)        | Upstream entries appear with origin; dependencies count toward coverage, references don't  |
+| LSP completion                    | Upstream IDs offered with `— from product@v2.1.0` badge (existing `origin` plumbing)       |
+| LSP hover / highlights            | Work; definition → no-op                                                                   |
+| MCP                               | `entry_show`/`entry_list`/`entry_context` see them via compile cache; no new resource kind |
+| `lint` / `fmt` / `score`          | Untouched — project-scoped                                                                 |
+| `[[edge]]` ledger                 | Unchanged — project-side edges to upstream ULIDs already fit the row shape                 |
+
+### 4.9 The program root project — the overall picture
+
+A root (program/product) repository provides the aggregate view. It is a usage
+pattern, not a mechanism — it falls out of §4.1–4.8:
+
+- The root declares **every member repo** in its `dependencies:`. It may author
+  few or no entries of its own (typically program-level STK, or nothing).
+- All repos' entries hydrate into the root's one flat graph, and cross-component
+  edges resolve there (§4.7), so **program-wide `report` (coverage, traceability
+  matrix), `dependents`, and `context` work at the root** — both ends of every
+  cross-repo edge are present.
+- The root's committed `markspec.lock` **is the program baseline record**: which
+  version of each repo constitutes the program, diffable and auditable per PR.
+- The root's `check --strict` is the **program release gate**: every repo
+  tag-baselined (§4.4 guarantee 1) and every cross-repo reference resolving
+  within those baselines (guarantee 2).
+- The root's `markspec compile --output api/` publishes the **program-wide
+  manifest + index** — the "overall picture" artifact. Entries carry their
+  origin badges, so the published aggregate shows which repo authored what. This
+  is exactly the input the #591 traceability website renders.
+- Recommendation: the root should use the same profile chain as its member repos
+  (or a program profile extending them) so shared corpora and type vocabularies
+  are present when aggregating.
+- **Membership is curated config, not discovery.** How the root knows the other
+  repos: its `dependencies:` list _is_ the program membership list —
+  `project.yaml` declares which repos are in the program (intent),
+  `markspec.lock` records which exact version of each (resolved baseline).
+  Onboarding a component is two reviewed PRs: the component adds its own
+  dependencies; the root adds one `dependencies:` entry + re-locks. No
+  auto-discovery (org scanning, naming conventions, self-registration) — program
+  composition is a configuration item, and an implicit, network-derived
+  membership list would defeat the baseline record. The detector for an
+  unplugged repo is the root's coverage report: requirements meant to be
+  satisfied by a missing component surface as coverage gaps.
+
+### 4.10 Schema SSOT and tool-config migration
+
+`project.yaml` validates against the org contract (`driftsys/schemas`
+`project/v1.json`) — closed schema, `name` + `version` required. Consequences
+inside markspec:
+
+| Local artifact                      | Disposition                                                                                                                                                                            |
+| ----------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `schemas/project/v1.json`           | **Retired.** Org schema is SSOT; markspec's loader validates the org shape.                                                                                                            |
+| `exclude:` (project.yaml)           | **Migrates to `.markspec.yaml`** — tool config, disallowed by the closed org schema.                                                                                                   |
+| `caption-conventions:`              | **Migrates to `.markspec.yaml`** — same reason.                                                                                                                                        |
+| `labels:` as vocabulary             | **Retired from project.yaml.** Org semantics: labels are tags _on_ the project; the vocabulary is governed by the process/profile. markspec's vocabulary constraint lives in profiles. |
+| `version:` optional + git-describe  | **Becomes required** per org schema (the release-bump flow already writes it).                                                                                                         |
+| `schemas/markspec/v1.json`          | Kept local (markspec tool binding); grows the migrated tool-config keys.                                                                                                               |
+| `schemas/profile/`, `schemas/lock/` | Kept local; org `markspec/lock` overlap flagged for reconciliation (§9).                                                                                                               |
+
+## 5. Non-features (explicit)
+
+1. **Peer-to-peer reverse visibility** — a member repo cannot know its
+   downstreams under one-directional pinning; the supported way to see the
+   overall picture (including cross-repo `dependents`) is the root project
+   pattern (§4.9). Rendering that aggregate as a website/dashboard stays #591
+   territory.
+2. **Transitive federation** — direct dependencies/references only; refs from
+   upstream entries are validation-exempt so this never false-errors. The
+   program graph is the composition of each repo's committed lockfile.
+3. **Live/TTL fetching** — rejected (determinism); issue #22 to be rewritten.
+4. **Namespace-qualified refs** — rejected; revisit only if flat+error hurts in
+   practice.
+5. **Vendoring snapshots into the repo** — cache stays gitignored (lockfile spec
+   §6 deferral stands).
+6. **Entry-level release status** (draft entries inside a baseline) — profile
+   territory, deferred.
+7. **Cross-repo rename-heal / edge-ledger changes** — v1 records edges from the
+   project side only.
+8. **`kind` discriminator on projectRef** — deferred; acquisition is implied by
+   the field (D2). Returns as a non-breaking org-schema addition if a
+   closed-source dependency with a published API gets real.
+9. **Shared remote snapshot cache** — deferred (§4.3); ADR-020 trajectory.
+10. **Publish-target configuration in `project.yaml`** — where a project
+    publishes its own `/api/` is CI/build config, never manifest data.
+
+## 6. Slices
+
+| # | Slice                         | Contents                                                                                                                                                                                                                                            | Depends on |
+| - | ----------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- |
+| 1 | Origin + hydration core       | `EntryOrigin` union, `formatEntryOrigin`, `deserializeCompileResult` + skew guard, `loadUpstreamCorpus`                                                                                                                                             | —          |
+| 2 | Org manifest adoption + lock  | Org-schema `project.yaml` loader (`dependencies`/`references`, projectRef), tool-config migration to `.markspec.yaml`, reference fetcher (`https`/`file`), cache write, lockfile rows, restore/update flows, L212 case, retire local project schema | 1          |
+| 3 | Git dependency fetcher        | `ls-remote` intent resolution + semver tag sort, forge tarball / shallow-filter clone, sha-keyed cache, in-process compile, resolution-kind recording                                                                                               | 2          |
+| 4 | Graph integration + validator | Three feed sites, flat resolution, MSL-T014, generalized R014, coverage semantics (deps vs refs), unreleased advisory + `--strict`                                                                                                                  | 1, 2       |
+| 5 | LSP + MCP surfaces            | Completion badges, hover, definition no-op, read-only decorations                                                                                                                                                                                   | 4          |
+| 6 | Docs + spec                   | Guide recipes (multi-repo + root project + CI cache), language.md §3.2 + T014, compile-output spec §5 as-built, rewrite issue #22, ADR at gardening                                                                                                 | 4          |
+
+External prerequisite for slice 2: the org-schemas PR (§9, Change B) — the
+version-intent contract should land in `driftsys/schemas` before markspec
+implements it.
+
+## 7. Testing
+
+- **Unit:** hydration round-trip (`deserialize(serialize(x))` ≍ `x` modulo
+  origin); collision-pass tables; semver tag sort; schema-skew rejection;
+  org-manifest loader (valid/invalid projectRef shapes).
+- **E2E (blackbox):** two temp projects — compile A to `/api/`, point B's
+  `references:` at it via `file://`; and a local bare-repo fixture with tags as
+  a `dependencies:` entry (no network). Assert through the CLI only: `lock`
+  pins, `check` resolves a cross-project `Satisfies:`, broken ID → T014,
+  colliding ID → R014, deleted cache → drift gate, branch-resolved pin →
+  advisory and `--strict` failure, auto mode picks the newest tag.
+- **E2E root pattern:** three temp projects — root depends on A and B, where A
+  also depends on B (diamond). Assert: no duplicate/collision diagnostics
+  (authoritative-source rule), A→B edge present in the root's matrix report,
+  `dependents` at root crosses the repo boundary, coverage report flags a
+  product requirement no component satisfies, and the root's published `/api/`
+  counts equal A-authored + B-authored + root-authored entries.
+- **Snapshots:** diagnostic wording for T014, collision, drift, and the
+  unreleased advisory.
+
+## 8. Alternatives considered
+
+- **Keep `parents:` / rename to `upstreams:`** — both rejected. "Parent" is
+  semantically inverted at the root project (children listed as parents) and
+  already means three other things in MarkSpec (profile extends, type hierarchy,
+  book directive). `upstreams:` would collide with the org contract's `upstream`
+  field (fork lineage). The org contract's `dependencies`/`references` split is
+  adopted instead — it also encodes the coverage distinction the flat list left
+  implicit.
+- **`kind: git|registry` discriminator on projectRef** — dropped: acquisition is
+  implied by the field (dependencies = repos, references = published sites).
+  Explicit-but-redundant today; recoverable as a non-breaking addition when a
+  real case appears.
+- **Markdown interchange (reuse `loadDeliveredCorpus` literally)** — rejected:
+  consumer would need the upstream's profile chain for type classification
+  (silent misclassification under profile drift), and references/standards have
+  no `.md` sources, forcing a JSON path anyway.
+- **Thin existence-only index (`displayId, ulid, title, type`)** — rejected at
+  the depth fork in favour of full graph citizens; the compiled output already
+  exists, so the thinner format saves little.
+- **Live fetch + TTL cache (issue #22's original model)** — rejected: check
+  output would depend on network state, violating the deterministic-output rule
+  and making CI flaky.
+- **Namespace-qualified refs (`product/STK_0001`)** — rejected: new token
+  grammar in every trace surface (parser, LSP, rename, skills) for a collision
+  problem that prefix discipline + a hard diagnostic handles.
+- **Git submodules / subtrees as the root manifest** — rejected: they vendor
+  full sources where compiled snapshots are needed, force the root to
+  re-implement per-member compilation with worse ergonomics, cannot express
+  registries or version intent, and add clone/CI tax. `markspec.lock` already
+  provides exact pins plus the intent layer, restore flow, and diffable baseline
+  record.
+- **Per-file forge-API reads instead of tarball** — rejected: the file set isn't
+  known without discovery; many round-trips lose to one tarball.
+- **Explicit-only version intent (no auto mode)** — rejected: "prefer baseline,
+  fall back to unreleased" is the correct default posture and removes a decision
+  from every declaration site.
+- **Hub mode (member repos resolve siblings via the root's aggregate)** —
+  deferred (2026-07-04, "aggregate for sure, not sure hub's worth it"). Members
+  would declare one dependency — the root — and opt into its re-exports, giving
+  one-pin program coherence and O(N) config at the cost of members never moving
+  ahead of the root's last publish. Not worth the coupling until the O(N²)
+  `dependencies:` maintenance actually hurts; v1 keeps per-repo direct
+  dependencies + the aggregation-only root (§4.9). The authoritative-source rule
+  (§4.5) is the hook a future hub opt-in would relax.
+
+## 9. Cross-repo follow-ups and reconciliations
+
+1. **`driftsys/schemas` PR (Change B):** document the `projectRef.version`
+   intent contract (exact tag = frozen; branch = track head; absent = auto) in
+   `project/README.md` + schema description/examples, and sharpen the per-field
+   guidance (dependencies → repository URLs, references → published-site URLs).
+   Non-breaking; prerequisite for slice 2.
+2. **`process:` vs `.markspec.yaml` profiles:** the org contract's `process`
+   field maps onto MarkSpec profiles. Reconciling activation (`.markspec.yaml`
+   `profiles:` list vs `process:` projectRefs) is a separate design effort — out
+   of scope here; file an issue.
+3. **Lock-schema overlap:** the org repo's `markspec/lock/v1.json` ("frozen
+   sidecar `.markspec.lock`") vs ADR-022's `markspec.lock` — reconcile naming
+   and shape before slice 2 extends lockfile rows.
+4. **Site-API schema alignment:** the org repo's 12 `markspec/*` schemas (entry,
+   index, traceability-graph, coverage, …) should be checked against the
+   compile-output artifacts our interchange relies on — plan-time review in
+   slice 2/6.
+5. **Guide drift:** `docs/guide/cli.md` claims `project.yaml` has no JSON schema
+   while `schemas/project/v1.json` exists (same family as #709); slice 6
+   rewrites the config reference against the org SSOT anyway.
+
+## 10. Open questions (plan-time, not blocking)
+
+- Exact lockfile TOML row naming (`[[upstream.dependency]]` /
+  `[[upstream.reference]]` vs extending `[[upstream.registry]]`) and its
+  parser/serializer round-trip details.
+- Diagnostic code assignment beyond T014 (collision reuses the R014 shape;
+  whether the unreleased advisory gets an L-family or new code) — align with the
+  ADR-012 phased catalogue at plan time.
+- Whether the published manifest gains an optional `project.version` field so
+  reference lockfile rows can record `refhub@1.4.0` (needs a compile-output spec
+  touch, and intersects follow-up §9 #4).
+- Forge tarball support matrix (GitHub/GitLab/self-hosted; auth via ambient
+  `gh`/`glab` credentials vs git credential helper) — slice 3 detail.

--- a/docs/wip/2026-07-04-federated-upstream-slice1-plan.md
+++ b/docs/wip/2026-07-04-federated-upstream-slice1-plan.md
@@ -1,0 +1,985 @@
+# Federated Upstream Resolution — Slice 1: Origin + Hydration Core — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the pure-core foundation for cross-repo references: the
+`EntryOrigin` discriminated union, entry hydration from compiled-JSON snapshots,
+and `loadUpstreamCorpus` with the authoritative-source rule.
+
+**Architecture:** Slice 1 of the federated-upstream-resolution design
+(`docs/wip/2026-07-04-federated-upstream-resolution-design.md`, §4.5 + D10).
+Everything here is pure core — no network, no git, no Deno APIs beyond an
+injected `readFile`. Fetchers and lockfile integration come in slices 2–3;
+nothing in this slice is wired into CLI/LSP/MCP yet (that is slice 4).
+
+**Tech Stack:** Deno/TypeScript strict, `@std/assert`, colocated unit tests
+(`<module>_test.ts`), Conventional Commits.
+
+## Global Constraints
+
+- Work in a git worktree (repo rule). After `git worktree add`, run
+  `./bootstrap` and verify `ls grammars/*.wasm` lists 9 files; if not, run
+  `deno task fetch-grammars` or copy from the main checkout.
+- Core must stay Node-compatible: no `Deno.*` in `packages/markspec/core/`
+  library code — file access only via injected `readFile`.
+- Zero warnings from `deno check` / `deno lint` / tests.
+- Format before committing: `deno fmt` (TS) — and `dprint fmt` for the two
+  `docs/wip/*.md` files.
+- Conventional Commits, imperative mood, scope `core` for everything under
+  `packages/markspec/core/`.
+- Commit messages with backticks: write the message to the scratchpad and use
+  `git commit -F <file>` (harness heredoc limitation).
+- `deno check` entry points:
+  `deno check packages/markspec/main.ts packages/markspec/core/mod.ts packages/markspec/lsp/server.ts packages/markspec/mcp/server.ts`
+
+## Task 0: Worktree setup + carry the spec/plan
+
+**Files:**
+
+- Create: worktree at `.claude/worktrees/federated-upstream-slice1` (or
+  EnterWorktree tool), branch `feat/federated-upstream-slice1`
+- Add: `docs/wip/2026-07-04-federated-upstream-resolution-design.md`,
+  `docs/wip/2026-07-04-federated-upstream-slice1-plan.md`
+
+- [ ] **Step 1: Create the worktree and bootstrap**
+
+Run (from the main checkout):
+
+```bash
+git worktree add .claude/worktrees/federated-upstream-slice1 -b feat/federated-upstream-slice1
+cd .claude/worktrees/federated-upstream-slice1
+./bootstrap
+ls grammars/*.wasm | wc -l   # expected: 9
+```
+
+If the count is not 9:
+`cp /Users/sebastientasson/Workspace/driftsys/markspec/grammars/*.wasm grammars/`
+
+- [ ] **Step 2: Copy the two docs/wip files into the worktree and commit**
+
+```bash
+mkdir -p docs/wip
+cp /Users/sebastientasson/Workspace/driftsys/markspec/docs/wip/2026-07-04-federated-upstream-*.md docs/wip/
+git add docs/wip/
+git commit -m "docs(core): add federated-upstream design spec and slice-1 plan"
+```
+
+(Bash tool note: `cd` into the worktree in the first Bash call of every session;
+file tools must use absolute worktree paths.)
+
+## Task 1: `EntryOrigin` discriminated union
+
+**Files:**
+
+- Modify: `packages/markspec/core/model/mod.ts` (the `EntryOrigin` interface at
+  ~line 427 and `formatEntryOrigin` at ~line 440)
+- Modify: `packages/markspec/core/validator/corpus.ts:90,106` (the two
+  `.profileId` comparisons)
+- Modify: `packages/markspec/core/mod.ts` (barrel: add `sameOriginSource`)
+- Test: `packages/markspec/core/model/entry_origin_test.ts` (exists — extend)
+
+**Interfaces:**
+
+- Consumes: existing `EntryOrigin` interface, `formatEntryOrigin`.
+- Produces (later tasks + slices rely on these exact shapes):
+
+  ```ts
+  export type EntryOrigin =
+    | {
+      readonly kind: "profile";
+      readonly profileId: string;
+      readonly profileVersion: string;
+    }
+    | {
+      readonly kind: "upstream";
+      readonly upstreamId: string;
+      readonly version: string;
+    };
+  export function formatEntryOrigin(origin: EntryOrigin): string;
+  export function sameOriginSource(a: EntryOrigin, b: EntryOrigin): boolean;
+  ```
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `packages/markspec/core/model/entry_origin_test.ts`:
+
+```ts
+Deno.test("formatEntryOrigin: upstream origin renders id@version", () => {
+  const origin: EntryOrigin = {
+    kind: "upstream",
+    upstreamId: "product",
+    version: "v2.1.0",
+  };
+  assertEquals(formatEntryOrigin(origin), "product@v2.1.0");
+});
+
+Deno.test("sameOriginSource: same profile id, different version → true", () => {
+  const a: EntryOrigin = {
+    kind: "profile",
+    profileId: "@acme/safety",
+    profileVersion: "1.0.0",
+  };
+  const b: EntryOrigin = {
+    kind: "profile",
+    profileId: "@acme/safety",
+    profileVersion: "2.0.0",
+  };
+  assertEquals(sameOriginSource(a, b), true);
+});
+
+Deno.test("sameOriginSource: different upstream ids → false", () => {
+  const a: EntryOrigin = {
+    kind: "upstream",
+    upstreamId: "product",
+    version: "v1",
+  };
+  const b: EntryOrigin = { kind: "upstream", upstreamId: "icd", version: "v1" };
+  assertEquals(sameOriginSource(a, b), false);
+});
+
+Deno.test("sameOriginSource: profile vs upstream → false", () => {
+  const a: EntryOrigin = {
+    kind: "profile",
+    profileId: "product",
+    profileVersion: "1",
+  };
+  const b: EntryOrigin = { kind: "upstream", upstreamId: "product", version: "1" };
+  assertEquals(sameOriginSource(a, b), false);
+});
+```
+
+Add `sameOriginSource` to the test file's import from `./mod.ts`.
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run: `deno test packages/markspec/core/model/entry_origin_test.ts` Expected:
+FAIL — `sameOriginSource` not exported; upstream literal not assignable to
+`EntryOrigin`.
+
+- [ ] **Step 3: Implement the union in `core/model/mod.ts`**
+
+Replace the `EntryOrigin` interface and `formatEntryOrigin` (keep the existing
+doc comments, extend them):
+
+```ts
+export type EntryOrigin =
+  | {
+    readonly kind: "profile";
+    readonly profileId: string;
+    readonly profileVersion: string;
+  }
+  | {
+    readonly kind: "upstream";
+    readonly upstreamId: string;
+    readonly version: string;
+  };
+
+export function formatEntryOrigin(origin: EntryOrigin): string {
+  switch (origin.kind) {
+    case "profile":
+      return `${origin.profileId}@${origin.profileVersion}`;
+    case "upstream":
+      return `${origin.upstreamId}@${origin.version}`;
+  }
+}
+
+/**
+ * Whether two origins come from the same source (same profile id or same
+ * upstream id), ignoring versions. Used by the corpus collision pass to
+ * decide "same owner" — version bumps must not split ownership.
+ */
+export function sameOriginSource(a: EntryOrigin, b: EntryOrigin): boolean {
+  if (a.kind === "profile" && b.kind === "profile") {
+    return a.profileId === b.profileId;
+  }
+  if (a.kind === "upstream" && b.kind === "upstream") {
+    return a.upstreamId === b.upstreamId;
+  }
+  return false;
+}
+```
+
+- [ ] **Step 4: Fix the two narrowing sites in `core/validator/corpus.ts`**
+
+Line ~90: replace `displayOwner.origin!.profileId !== e.origin.profileId` with
+`!sameOriginSource(displayOwner.origin!, e.origin)`.
+
+Line ~106: replace `idOwner.origin!.profileId !== e.origin.profileId` with
+`!sameOriginSource(idOwner.origin!, e.origin)`.
+
+Add `sameOriginSource` to the file's import from `../model/mod.ts`.
+
+- [ ] **Step 5: Export from the barrel**
+
+In `packages/markspec/core/mod.ts`, add `sameOriginSource` next to the existing
+`formatEntryOrigin` export.
+
+- [ ] **Step 6: Type-check the workspace and run the model + validator tests**
+
+Run:
+
+```bash
+deno check packages/markspec/main.ts packages/markspec/core/mod.ts packages/markspec/lsp/server.ts packages/markspec/mcp/server.ts
+deno test packages/markspec/core/model/ packages/markspec/core/validator/ --allow-read --allow-write --allow-env
+```
+
+Expected: check clean (every other consumer uses `formatEntryOrigin`, which
+still narrows internally); all tests PASS. If `deno check` reports further
+`.profileId` accesses on `EntryOrigin`, fix each with `sameOriginSource` or a
+`kind === "profile"` narrow — do not cast.
+
+- [ ] **Step 7: Commit**
+
+```bash
+deno fmt packages/markspec/core/
+git add -A packages/markspec/core/
+git commit -m "feat(core): EntryOrigin discriminated union with upstream kind"
+```
+
+## Task 2: `deserializeEntry` — inverse of `serializeEntry`
+
+**Files:**
+
+- Create: `packages/markspec/core/compiler/deserialize.ts`
+- Test: `packages/markspec/core/compiler/deserialize_test.ts`
+
+**Interfaces:**
+
+- Consumes: `SerializedEntry`, `serializeEntry` from `./schema.ts`; `Entry` from
+  `../model/mod.ts`.
+- Produces:
+
+  ```ts
+  export function deserializeEntry(s: SerializedEntry): Entry;
+  ```
+
+  Contract: `deserializeEntry(JSON.parse(JSON.stringify(serializeEntry(e))))`
+  deep-equals `e` for entries without `properties.sync` (which serialization
+  strips by design). `typedAttributes` is rebuilt as a `Map`; an absent
+  serialized field becomes an empty `Map`. `origin` passes through verbatim —
+  the authoritative-source skip is the loader's job (Task 4), not the
+  deserializer's.
+
+- [ ] **Step 1: Write the failing round-trip test**
+
+Create `packages/markspec/core/compiler/deserialize_test.ts`:
+
+```ts
+import { assertEquals } from "@std/assert";
+import { parseFile } from "../parser/mod.ts";
+import { serializeEntry } from "./schema.ts";
+import { deserializeEntry } from "./deserialize.ts";
+
+const FIXTURE = `# Sample
+
+- [STK_0001] Braking distance
+
+  The system shall stop the vehicle within 40 m from 100 km/h.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      Labels: ASIL-B
+
+- [SYS_0001] Threat assessment
+
+  The system shall compute a threat level within 200 ms.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEG
+      Satisfies: STK_0001
+`;
+
+Deno.test("deserializeEntry: JSON wire round-trip preserves the entry", async () => {
+  const { entries } = await parseFile(FIXTURE, { file: "/proj/sample.md" });
+  for (const entry of entries) {
+    const wire = JSON.parse(JSON.stringify(serializeEntry(entry)));
+    assertEquals(deserializeEntry(wire), entry);
+  }
+});
+
+Deno.test("deserializeEntry: origin passes through verbatim", async () => {
+  const { entries } = await parseFile(FIXTURE, { file: "/proj/sample.md" });
+  const withOrigin = {
+    ...entries[0],
+    origin: {
+      kind: "upstream" as const,
+      upstreamId: "product",
+      version: "v1.0.0",
+    },
+  };
+  const wire = JSON.parse(JSON.stringify(serializeEntry(withOrigin)));
+  assertEquals(deserializeEntry(wire).origin, withOrigin.origin);
+});
+```
+
+Note: if `parseFile` lives elsewhere or takes different options, mirror the
+usage in `packages/markspec/lsp/workspace.ts` (`parseFile(content, { file })`
+imported from `core/mod.ts`) — import from the internal module path within core.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run:
+`deno test packages/markspec/core/compiler/deserialize_test.ts --allow-read --allow-env`
+Expected: FAIL — module `./deserialize.ts` not found.
+
+- [ ] **Step 3: Implement `deserialize.ts`**
+
+```ts
+/**
+ * @module compiler/deserialize
+ *
+ * Hydration of compiled-JSON snapshots back into core {@linkcode Entry}
+ * values — the inverse of `./schema.ts`. Consumed by the upstream corpus
+ * loader (`core/upstream/`): a dependency's or reference's published
+ * compile output is deserialized here before joining the consumer's graph.
+ *
+ * Pure module: no I/O, no Deno APIs.
+ */
+
+import type { Entry } from "../model/mod.ts";
+import type { SerializedEntry } from "./schema.ts";
+
+/**
+ * Rebuild an {@linkcode Entry} from its serialized wire form. Inverse of
+ * `serializeEntry`: restores `typedAttributes` from a plain record to a
+ * `Map` (absent → empty). All other fields — including `origin` — pass
+ * through verbatim.
+ */
+export function deserializeEntry(s: SerializedEntry): Entry {
+  const { typedAttributes, ...rest } = s;
+  return {
+    ...rest,
+    typedAttributes: new Map(Object.entries(typedAttributes ?? {})),
+  } as Entry;
+}
+```
+
+If the round-trip test reveals field-presence mismatches (e.g. the original
+entry has an absent optional key that survives as `undefined`), normalize in
+`deserializeEntry` by deleting `undefined`-valued keys before returning — match
+whatever the test shows; the contract is deep-equality with the
+pre-serialization entry.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run:
+`deno test packages/markspec/core/compiler/deserialize_test.ts --allow-read --allow-env`
+Expected: PASS (both tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+deno fmt packages/markspec/core/compiler/
+git add packages/markspec/core/compiler/deserialize.ts packages/markspec/core/compiler/deserialize_test.ts
+git commit -m "feat(core): deserializeEntry inverse of serializeEntry"
+```
+
+## Task 3: Snapshot schema guard + compiled/NDJSON entry extraction
+
+**Files:**
+
+- Modify: `packages/markspec/core/compiler/deserialize.ts`
+- Test: `packages/markspec/core/compiler/deserialize_test.ts` (extend)
+
+**Interfaces:**
+
+- Consumes: `ManifestJson` shape from `./manifest.ts` (`markspecSchemaVersion`,
+  `generator.coreSchema`, `entries` block); `Diagnostic` from `../model/mod.ts`;
+  `CORE_SCHEMA_VERSION` (find with
+  `grep -rn "CORE_SCHEMA_VERSION" packages/markspec/core/ --include="*.ts" | grep -v test | grep "="`
+  and import from its defining module, not the barrel).
+- Produces:
+
+  ```ts
+  export function checkSnapshotSchema(
+    manifest: unknown,
+    manifestPath: string,
+  ): Diagnostic | undefined;
+  export function extractSerializedEntries(
+    manifest: unknown,
+    readSnapshotFile: (relPath: string) => string | undefined,
+    manifestPath: string,
+  ): { entries: SerializedEntry[]; diagnostics: Diagnostic[] };
+  ```
+
+  `extractSerializedEntries` follows the manifest's `entries` block: `inline` →
+  parse `compiled.json` and take `Object.values(json.entries)`; `ndjson` → split
+  the file on newlines, `JSON.parse` each non-empty line. Diagnostic codes
+  (loader-family, following the `PROFILE-DELIVERS-00x` precedent):
+  `UPSTREAM-SNAPSHOT-001` schema skew (error), `UPSTREAM-SNAPSHOT-002`
+  missing/unreadable snapshot file (error), `UPSTREAM-SNAPSHOT-003` malformed
+  JSON (error).
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `deserialize_test.ts`:
+
+```ts
+import { checkSnapshotSchema, extractSerializedEntries } from "./deserialize.ts";
+
+const GOOD_MANIFEST = {
+  markspecSchemaVersion: 1,
+  generator: { release: "0.0.0-test", coreSchema: 1 },
+  project: { name: "up", root: "/up" },
+  counts: { entries: 1, edges: 0, byType: {} },
+  entries: { format: "inline", file: "compiled.json" },
+  edges: { format: "inline", file: "compiled.json" },
+  sqliteMirror: null,
+  federation: [],
+  reserved: {},
+};
+
+Deno.test("checkSnapshotSchema: matching versions → undefined", () => {
+  assertEquals(checkSnapshotSchema(GOOD_MANIFEST, "/c/manifest.json"), undefined);
+});
+
+Deno.test("checkSnapshotSchema: core-schema skew → UPSTREAM-SNAPSHOT-001", () => {
+  const skewed = { ...GOOD_MANIFEST, generator: { release: "9", coreSchema: 99 } };
+  const d = checkSnapshotSchema(skewed, "/c/manifest.json");
+  assertEquals(d?.code, "UPSTREAM-SNAPSHOT-001");
+  assertEquals(d?.severity, "error");
+});
+
+Deno.test("extractSerializedEntries: inline compiled.json", async () => {
+  const { entries } = await parseFile(FIXTURE, { file: "/up/sample.md" });
+  const compiled = JSON.stringify({
+    entries: Object.fromEntries(
+      entries.map((e) => [e.displayId, serializeEntry(e)]),
+    ),
+  });
+  const result = extractSerializedEntries(
+    GOOD_MANIFEST,
+    (rel) => (rel === "compiled.json" ? compiled : undefined),
+    "/c/manifest.json",
+  );
+  assertEquals(result.diagnostics, []);
+  assertEquals(result.entries.length, 2);
+});
+
+Deno.test("extractSerializedEntries: ndjson block", async () => {
+  const { entries } = await parseFile(FIXTURE, { file: "/up/sample.md" });
+  const ndjson = entries.map((e) => JSON.stringify(serializeEntry(e))).join("\n") + "\n";
+  const manifest = {
+    ...GOOD_MANIFEST,
+    entries: { format: "ndjson", file: "entries.ndjson", index: "entries.idx" },
+  };
+  const result = extractSerializedEntries(
+    manifest,
+    (rel) => (rel === "entries.ndjson" ? ndjson : undefined),
+    "/c/manifest.json",
+  );
+  assertEquals(result.diagnostics, []);
+  assertEquals(result.entries.length, 2);
+});
+
+Deno.test("extractSerializedEntries: missing snapshot file → UPSTREAM-SNAPSHOT-002", () => {
+  const result = extractSerializedEntries(
+    GOOD_MANIFEST,
+    () => undefined,
+    "/c/manifest.json",
+  );
+  assertEquals(result.entries, []);
+  assertEquals(result.diagnostics[0]?.code, "UPSTREAM-SNAPSHOT-002");
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run:
+`deno test packages/markspec/core/compiler/deserialize_test.ts --allow-read --allow-env`
+Expected: FAIL — `checkSnapshotSchema` / `extractSerializedEntries` not
+exported.
+
+- [ ] **Step 3: Implement in `deserialize.ts`**
+
+```ts
+/** Result of {@linkcode extractSerializedEntries}. */
+export interface ExtractedEntries {
+  readonly entries: SerializedEntry[];
+  readonly diagnostics: Diagnostic[];
+}
+
+/**
+ * Reject a snapshot whose schema versions don't match this build — a
+ * skewed snapshot must never silently misparse. Returns the diagnostic to
+ * publish, or `undefined` when the snapshot is compatible.
+ */
+export function checkSnapshotSchema(
+  manifest: unknown,
+  manifestPath: string,
+): Diagnostic | undefined {
+  const m = manifest as {
+    markspecSchemaVersion?: unknown;
+    generator?: { coreSchema?: unknown };
+  };
+  if (
+    m?.markspecSchemaVersion === 1 &&
+    m?.generator?.coreSchema === CORE_SCHEMA_VERSION
+  ) {
+    return undefined;
+  }
+  return {
+    code: "UPSTREAM-SNAPSHOT-001",
+    severity: "error",
+    message:
+      `upstream snapshot schema mismatch (manifest v${String(m?.markspecSchemaVersion)}, ` +
+      `core-schema ${String(m?.generator?.coreSchema)} vs expected 1/${CORE_SCHEMA_VERSION}); ` +
+      `re-run 'markspec lock' with a compatible markspec version`,
+    location: { file: manifestPath, line: 1, column: 1 },
+  };
+}
+
+/**
+ * Follow the manifest's `entries` block and return the raw serialized
+ * entries. `readSnapshotFile` resolves a path relative to the snapshot
+ * directory (injected — this module does no I/O).
+ */
+export function extractSerializedEntries(
+  manifest: unknown,
+  readSnapshotFile: (relPath: string) => string | undefined,
+  manifestPath: string,
+): ExtractedEntries {
+  const diagnostics: Diagnostic[] = [];
+  const block = (manifest as { entries?: { format?: string; file?: string } })
+    ?.entries;
+  const file = block?.file;
+  if (!file || (block?.format !== "inline" && block?.format !== "ndjson")) {
+    diagnostics.push(malformed(manifestPath, "manifest entries block missing or unknown format"));
+    return { entries: [], diagnostics };
+  }
+  const raw = readSnapshotFile(file);
+  if (raw === undefined) {
+    diagnostics.push({
+      code: "UPSTREAM-SNAPSHOT-002",
+      severity: "error",
+      message:
+        `upstream snapshot file '${file}' is missing or unreadable; ` +
+        `run 'markspec lock' to restore the cache`,
+      location: { file: manifestPath, line: 1, column: 1 },
+    });
+    return { entries: [], diagnostics };
+  }
+  try {
+    if (block.format === "inline") {
+      const json = JSON.parse(raw) as { entries?: Record<string, SerializedEntry> };
+      return { entries: Object.values(json.entries ?? {}), diagnostics };
+    }
+    const entries = raw
+      .split("\n")
+      .filter((line) => line.trim().length > 0)
+      .map((line) => JSON.parse(line) as SerializedEntry);
+    return { entries, diagnostics };
+  } catch (err) {
+    diagnostics.push(malformed(
+      manifestPath,
+      `snapshot file '${file}' is not valid JSON: ${err instanceof Error ? err.message : String(err)}`,
+    ));
+    return { entries: [], diagnostics };
+  }
+}
+
+function malformed(file: string, detail: string): Diagnostic {
+  return {
+    code: "UPSTREAM-SNAPSHOT-003",
+    severity: "error",
+    message: `malformed upstream snapshot: ${detail}`,
+    location: { file, line: 1, column: 1 },
+  };
+}
+```
+
+Add the imports: `Diagnostic` (type) from `../model/mod.ts` and
+`CORE_SCHEMA_VERSION` from the module the grep in **Interfaces** located.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run:
+`deno test packages/markspec/core/compiler/deserialize_test.ts --allow-read --allow-env`
+Expected: PASS (all tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+deno fmt packages/markspec/core/compiler/
+git add packages/markspec/core/compiler/
+git commit -m "feat(core): snapshot schema guard and serialized-entry extraction"
+```
+
+## Task 4: `loadUpstreamCorpus` with the authoritative-source rule
+
+**Files:**
+
+- Create: `packages/markspec/core/upstream/mod.ts`
+- Test: `packages/markspec/core/upstream/mod_test.ts`
+
+**Interfaces:**
+
+- Consumes: `deserializeEntry`, `checkSnapshotSchema`,
+  `extractSerializedEntries` (Tasks 2–3); `Entry`, `Diagnostic` from
+  `../model/mod.ts`.
+- Produces (slice 2's lock command and slice 4's feed sites consume these):
+
+  ```ts
+  /** One locked upstream's cached snapshot (dir written by `markspec lock`). */
+  export interface UpstreamSnapshotRef {
+    readonly id: string; // projectRef name — cache dir, badges
+    readonly version: string; // resolved version label (tag/branch@sha)
+    readonly dir: string; // absolute path to .markspec/cache/upstreams/<id>
+  }
+  export interface LoadUpstreamCorpusResult {
+    readonly entries: Entry[];
+    readonly diagnostics: Diagnostic[];
+  }
+  export type ReadFile = (path: string) => Promise<string | undefined>;
+  export async function loadUpstreamCorpus(
+    upstreams: readonly UpstreamSnapshotRef[],
+    readFile: ReadFile,
+  ): Promise<LoadUpstreamCorpusResult>;
+  ```
+
+  Behavior: per upstream, read `<dir>/manifest.json` (missing → 002, bad JSON →
+  003, skew → 001; skip that upstream, keep going); extract entries; **skip any
+  serialized entry that already carries an `origin`** (authoritative-source
+  rule, design §4.5); stamp the rest with
+  `origin = { kind: "upstream", upstreamId: id, version }`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `packages/markspec/core/upstream/mod_test.ts`:
+
+```ts
+import { assertEquals } from "@std/assert";
+import { parseFile } from "../parser/mod.ts";
+import { serializeEntry } from "../compiler/schema.ts";
+import { loadUpstreamCorpus } from "./mod.ts";
+
+const UP_A_MD = `# A
+
+- [SYS_0001] Threat assessment
+
+  The system shall compute a threat level within 200 ms.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEG
+`;
+
+async function snapshotFiles(
+  dir: string,
+  md: string,
+  file: string,
+  reexport?: { upstreamId: string; version: string },
+): Promise<Map<string, string>> {
+  const { entries } = await parseFile(md, { file });
+  const serialized = entries.map((e) =>
+    serializeEntry(
+      reexport ? { ...e, origin: { kind: "upstream" as const, ...reexport } } : e,
+    )
+  );
+  const manifest = {
+    markspecSchemaVersion: 1,
+    generator: { release: "0.0.0-test", coreSchema: 1 },
+    project: { name: "up", root: "/up" },
+    counts: { entries: serialized.length, edges: 0, byType: {} },
+    entries: { format: "inline", file: "compiled.json" },
+    edges: { format: "inline", file: "compiled.json" },
+    sqliteMirror: null,
+    federation: [],
+    reserved: {},
+  };
+  const compiled = {
+    entries: Object.fromEntries(serialized.map((s) => [s.displayId, s])),
+  };
+  return new Map([
+    [`${dir}/manifest.json`, JSON.stringify(manifest)],
+    [`${dir}/compiled.json`, JSON.stringify(compiled)],
+  ]);
+}
+
+function readerFor(files: Map<string, string>) {
+  return (path: string) => Promise.resolve(files.get(path));
+}
+
+Deno.test("loadUpstreamCorpus: hydrates and stamps upstream origin", async () => {
+  const files = await snapshotFiles("/c/up/product", UP_A_MD, "/up/a.md");
+  const result = await loadUpstreamCorpus(
+    [{ id: "product", version: "v2.1.0", dir: "/c/up/product" }],
+    readerFor(files),
+  );
+  assertEquals(result.diagnostics, []);
+  assertEquals(result.entries.length, 1);
+  assertEquals(result.entries[0].displayId, "SYS_0001");
+  assertEquals(result.entries[0].origin, {
+    kind: "upstream",
+    upstreamId: "product",
+    version: "v2.1.0",
+  });
+});
+
+Deno.test("loadUpstreamCorpus: authoritative-source rule skips re-exports", async () => {
+  // product's snapshot re-exports an entry it pulled from 'icd' — skip it.
+  const files = await snapshotFiles("/c/up/product", UP_A_MD, "/up/a.md", {
+    upstreamId: "icd",
+    version: "v1.0.0",
+  });
+  const result = await loadUpstreamCorpus(
+    [{ id: "product", version: "v2.1.0", dir: "/c/up/product" }],
+    readerFor(files),
+  );
+  assertEquals(result.diagnostics, []);
+  assertEquals(result.entries, []);
+});
+
+Deno.test("loadUpstreamCorpus: missing manifest → 002, other upstreams still load", async () => {
+  const files = await snapshotFiles("/c/up/product", UP_A_MD, "/up/a.md");
+  const result = await loadUpstreamCorpus(
+    [
+      { id: "ghost", version: "v0", dir: "/c/up/ghost" },
+      { id: "product", version: "v2.1.0", dir: "/c/up/product" },
+    ],
+    readerFor(files),
+  );
+  assertEquals(result.diagnostics.length, 1);
+  assertEquals(result.diagnostics[0].code, "UPSTREAM-SNAPSHOT-002");
+  assertEquals(result.entries.length, 1);
+});
+
+Deno.test("loadUpstreamCorpus: schema skew → 001, upstream skipped", async () => {
+  const files = await snapshotFiles("/c/up/product", UP_A_MD, "/up/a.md");
+  const manifest = JSON.parse(files.get("/c/up/product/manifest.json")!);
+  manifest.generator.coreSchema = 99;
+  files.set("/c/up/product/manifest.json", JSON.stringify(manifest));
+  const result = await loadUpstreamCorpus(
+    [{ id: "product", version: "v2.1.0", dir: "/c/up/product" }],
+    readerFor(files),
+  );
+  assertEquals(result.diagnostics[0].code, "UPSTREAM-SNAPSHOT-001");
+  assertEquals(result.entries, []);
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `deno test packages/markspec/core/upstream/ --allow-read --allow-env`
+Expected: FAIL — module `./mod.ts` not found.
+
+- [ ] **Step 3: Implement `core/upstream/mod.ts`**
+
+```ts
+/**
+ * @module upstream
+ *
+ * Upstream corpus loader — hydrates the cached compiled-JSON snapshots
+ * that `markspec lock` writes under `.markspec/cache/upstreams/<id>/`
+ * into read-only graph citizens carrying an `upstream` origin.
+ *
+ * Design: docs/wip/2026-07-04-federated-upstream-resolution-design.md §4.5.
+ * Sibling of `core/profile/delivered.ts` (`loadDeliveredCorpus`), same
+ * purity rules: no I/O of its own — file access via the injected
+ * {@linkcode ReadFile}.
+ */
+
+import type { Diagnostic, Entry } from "../model/mod.ts";
+import {
+  checkSnapshotSchema,
+  deserializeEntry,
+  extractSerializedEntries,
+} from "../compiler/deserialize.ts";
+
+/** One locked upstream's cached snapshot (dir written by `markspec lock`). */
+export interface UpstreamSnapshotRef {
+  /** projectRef `name` — cache directory, lockfile rows, origin badges. */
+  readonly id: string;
+  /** Resolved version label recorded by the lockfile (e.g. `v2.1.0`). */
+  readonly version: string;
+  /** Absolute path to `.markspec/cache/upstreams/<id>`. */
+  readonly dir: string;
+}
+
+/** Result of {@linkcode loadUpstreamCorpus}. */
+export interface LoadUpstreamCorpusResult {
+  readonly entries: Entry[];
+  readonly diagnostics: Diagnostic[];
+}
+
+/** File reader injected by the caller (CLI/LSP own the I/O). */
+export type ReadFile = (path: string) => Promise<string | undefined>;
+
+/**
+ * Hydrate every locked upstream's cached snapshot into `Entry[]`.
+ *
+ * Per upstream: read `<dir>/manifest.json`, reject schema skew
+ * (UPSTREAM-SNAPSHOT-001), extract the serialized entries, and stamp each
+ * with `origin = { kind: "upstream", upstreamId, version }`.
+ *
+ * Authoritative-source rule (design §4.5): a snapshot entry that already
+ * carries an `origin` is a re-export of some other source's entry (the
+ * upstream's own corpus or its upstreams) and is skipped — every entry
+ * joins an aggregate only from its authoring project. A failing upstream
+ * contributes diagnostics but never aborts the others.
+ */
+export async function loadUpstreamCorpus(
+  upstreams: readonly UpstreamSnapshotRef[],
+  readFile: ReadFile,
+): Promise<LoadUpstreamCorpusResult> {
+  const entries: Entry[] = [];
+  const diagnostics: Diagnostic[] = [];
+  for (const up of upstreams) {
+    const manifestPath = `${up.dir}/manifest.json`;
+    const manifestRaw = await readFile(manifestPath);
+    if (manifestRaw === undefined) {
+      diagnostics.push({
+        code: "UPSTREAM-SNAPSHOT-002",
+        severity: "error",
+        message:
+          `upstream '${up.id}' snapshot manifest is missing or unreadable; ` +
+          `run 'markspec lock' to restore the cache`,
+        location: { file: manifestPath, line: 1, column: 1 },
+      });
+      continue;
+    }
+    let manifest: unknown;
+    try {
+      manifest = JSON.parse(manifestRaw);
+    } catch (err) {
+      diagnostics.push({
+        code: "UPSTREAM-SNAPSHOT-003",
+        severity: "error",
+        message: `malformed upstream snapshot: manifest is not valid JSON: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+        location: { file: manifestPath, line: 1, column: 1 },
+      });
+      continue;
+    }
+    const skew = checkSnapshotSchema(manifest, manifestPath);
+    if (skew) {
+      diagnostics.push(skew);
+      continue;
+    }
+    // Snapshot files are read relative to the upstream's cache dir. The
+    // extractor is sync; pre-read the single file the manifest points at.
+    const block = (manifest as { entries?: { file?: string } }).entries;
+    const relFile = block?.file;
+    const snapshotContent = relFile !== undefined
+      ? await readFile(`${up.dir}/${relFile}`)
+      : undefined;
+    const extracted = extractSerializedEntries(
+      manifest,
+      (rel) => (rel === relFile ? snapshotContent : undefined),
+      manifestPath,
+    );
+    diagnostics.push(...extracted.diagnostics);
+    for (const s of extracted.entries) {
+      if (s.origin !== undefined) continue; // authoritative-source rule
+      const entry = deserializeEntry(s);
+      entries.push({
+        ...entry,
+        origin: { kind: "upstream", upstreamId: up.id, version: up.version },
+      });
+    }
+  }
+  return { entries, diagnostics };
+}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `deno test packages/markspec/core/upstream/ --allow-read --allow-env`
+Expected: PASS (all 4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+deno fmt packages/markspec/core/upstream/
+git add packages/markspec/core/upstream/
+git commit -m "feat(core): loadUpstreamCorpus with authoritative-source rule"
+```
+
+## Task 5: Barrel exports + full gate
+
+**Files:**
+
+- Modify: `packages/markspec/core/mod.ts`
+
+**Interfaces:**
+
+- Produces (the public API slices 2/4 import from `core/mod.ts`):
+  `loadUpstreamCorpus`, `UpstreamSnapshotRef` (type), `LoadUpstreamCorpusResult`
+  (type), `deserializeEntry`, `checkSnapshotSchema`, `extractSerializedEntries`,
+  `sameOriginSource` (already exported in Task 1).
+
+- [ ] **Step 1: Add the exports**
+
+In `packages/markspec/core/mod.ts`, following the existing grouping style (value
+exports and `export type` blocks), add:
+
+```ts
+export {
+  checkSnapshotSchema,
+  deserializeEntry,
+  extractSerializedEntries,
+} from "./compiler/deserialize.ts";
+export { loadUpstreamCorpus } from "./upstream/mod.ts";
+export type {
+  LoadUpstreamCorpusResult,
+  UpstreamSnapshotRef,
+} from "./upstream/mod.ts";
+```
+
+(Match the barrel's actual conventions — if it re-exports via grouped
+`export { … } from` lists per module, extend those lists instead.)
+
+- [ ] **Step 2: Run the full gate**
+
+Run:
+
+```bash
+just fmt
+just check
+```
+
+Expected: lint clean, type-check clean, all tests pass. Fix anything red before
+proceeding (zero-warnings rule).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add -A
+git commit -m "feat(core): export upstream corpus loader from the core barrel"
+```
+
+## Task 6: PR
+
+- [ ] **Step 1: Push and open the PR**
+
+Write the PR body to the scratchpad first (backtick-safe), then:
+
+```bash
+git push -u origin feat/federated-upstream-slice1   # ≥300s timeout: pre-push hook runs full just check
+gh pr create --title "feat(core): federated upstream slice 1 — origin union + snapshot hydration" --body-file <scratchpad>/pr-body.md
+```
+
+PR body must state: slice 1 of the federated-upstream design
+(`docs/wip/2026-07-04-federated-upstream-resolution-design.md`), pure core, no
+behavior wired into CLI/LSP/MCP yet; list the new public API. There is no
+tracking issue yet — no `Closes #N` line (or file the epic/story issues first if
+the user wants issue tracking, and reference the story).
+
+- [ ] **Step 2: Run `/review` on the PR and post findings as a PR comment**
+      (repo rule).
+
+## Self-review notes (against the design spec)
+
+- Spec §4.5 EntryOrigin union → Task 1. `formatEntryOrigin` switch → Task 1.
+- Spec §4.5 `deserializeCompileResult` is delivered as `deserializeEntry` +
+  `extractSerializedEntries` (entries are the only consumed payload —
+  links/forward/reverse are rebuilt by the consumer's compile; YAGNI on
+  hydrating them). Slice 4 revisits if the root graph needs upstream links
+  directly.
+- Spec §4.5 skew guard → Task 3 (UPSTREAM-SNAPSHOT-001).
+- Spec §4.5 authoritative-source rule → Task 4 (skip + dedicated test, including
+  the diamond re-export case).
+- Spec D10 purity → no Deno APIs anywhere in the new modules; injected
+  `ReadFile`.
+- NOT in this slice (per spec slicing): project.yaml parsing, lockfile rows,
+  fetchers, feed sites, validator changes, LSP/MCP — slices 2–5.

--- a/packages/markspec/core/compiler/deserialize.ts
+++ b/packages/markspec/core/compiler/deserialize.ts
@@ -18,21 +18,24 @@ import type { SerializedEntry } from "./schema.ts";
  * `Map` (absent → empty). All other fields — including `origin` — pass
  * through verbatim.
  *
- * `type` is re-keyed explicitly (rather than left to the `...rest`
- * spread) to restore field-presence parity with a freshly parsed
- * {@linkcode Entry}: the parser always includes `type` as an own
- * property (`undefined` when no profile classified the entry), but
- * `JSON.stringify` drops `undefined`-valued keys entirely, so the wire
- * form loses the key when it round-trips through `JSON.parse`. Without
- * this, `deserializeEntry(wire)` would be missing the `type` key while
- * the original entry still carries it (with value `undefined`),
- * breaking the deep-equality round-trip contract.
+ * `type` and `id` are re-keyed explicitly (rather than left to the
+ * `...rest` spread) to restore field-presence parity with a freshly
+ * parsed {@linkcode Entry}: the parser always includes both as own
+ * properties (`type` is `undefined` when no profile classified the
+ * entry; `id` is `undefined` on Reference-shaped entries with no `Id:`
+ * trailer), but `JSON.stringify` drops `undefined`-valued keys
+ * entirely, so the wire form loses the keys when it round-trips
+ * through `JSON.parse`. Without this, `deserializeEntry(wire)` would
+ * be missing those keys while the original entry still carries them
+ * (with value `undefined`), breaking the deep-equality round-trip
+ * contract.
  */
 export function deserializeEntry(s: SerializedEntry): Entry {
-  const { typedAttributes, type, ...rest } = s;
+  const { typedAttributes, type, id, ...rest } = s;
   return {
     ...rest,
     type,
+    id,
     typedAttributes: new Map(Object.entries(typedAttributes ?? {})),
   } as Entry;
 }

--- a/packages/markspec/core/compiler/deserialize.ts
+++ b/packages/markspec/core/compiler/deserialize.ts
@@ -9,7 +9,8 @@
  * Pure module: no I/O, no Deno APIs.
  */
 
-import type { Entry } from "../model/mod.ts";
+import type { Diagnostic, Entry } from "../model/mod.ts";
+import { CORE_SCHEMA_VERSION } from "../mod.ts";
 import type { SerializedEntry } from "./schema.ts";
 
 /**
@@ -38,4 +39,110 @@ export function deserializeEntry(s: SerializedEntry): Entry {
     id,
     typedAttributes: new Map(Object.entries(typedAttributes ?? {})),
   } as Entry;
+}
+
+/** Result of {@linkcode extractSerializedEntries}. */
+export interface ExtractedEntries {
+  readonly entries: SerializedEntry[];
+  readonly diagnostics: Diagnostic[];
+}
+
+/**
+ * Reject a snapshot whose schema versions don't match this build — a
+ * skewed snapshot must never silently misparse. Returns the diagnostic to
+ * publish, or `undefined` when the snapshot is compatible.
+ */
+export function checkSnapshotSchema(
+  manifest: unknown,
+  manifestPath: string,
+): Diagnostic | undefined {
+  const m = manifest as {
+    markspecSchemaVersion?: unknown;
+    generator?: { coreSchema?: unknown };
+  };
+  if (
+    m?.markspecSchemaVersion === 1 &&
+    m?.generator?.coreSchema === CORE_SCHEMA_VERSION
+  ) {
+    return undefined;
+  }
+  return {
+    code: "UPSTREAM-SNAPSHOT-001",
+    severity: "error",
+    message:
+      `upstream snapshot schema mismatch (manifest v${
+        String(m?.markspecSchemaVersion)
+      }, ` +
+      `core-schema ${
+        String(m?.generator?.coreSchema)
+      } vs expected 1/${CORE_SCHEMA_VERSION}); ` +
+      `re-run 'markspec lock' with a compatible markspec version`,
+    location: { file: manifestPath, line: 1, column: 1 },
+  };
+}
+
+/**
+ * Follow the manifest's `entries` block and return the raw serialized
+ * entries. `readSnapshotFile` resolves a path relative to the snapshot
+ * directory (injected — this module does no I/O).
+ */
+export function extractSerializedEntries(
+  manifest: unknown,
+  readSnapshotFile: (relPath: string) => string | undefined,
+  manifestPath: string,
+): ExtractedEntries {
+  const diagnostics: Diagnostic[] = [];
+  const block = (manifest as { entries?: { format?: string; file?: string } })
+    ?.entries;
+  const file = block?.file;
+  if (!file || (block?.format !== "inline" && block?.format !== "ndjson")) {
+    diagnostics.push(
+      malformed(
+        manifestPath,
+        "manifest entries block missing or unknown format",
+      ),
+    );
+    return { entries: [], diagnostics };
+  }
+  const raw = readSnapshotFile(file);
+  if (raw === undefined) {
+    diagnostics.push({
+      code: "UPSTREAM-SNAPSHOT-002",
+      severity: "error",
+      message: `upstream snapshot file '${file}' is missing or unreadable; ` +
+        `run 'markspec lock' to restore the cache`,
+      location: { file: manifestPath, line: 1, column: 1 },
+    });
+    return { entries: [], diagnostics };
+  }
+  try {
+    if (block.format === "inline") {
+      const json = JSON.parse(raw) as {
+        entries?: Record<string, SerializedEntry>;
+      };
+      return { entries: Object.values(json.entries ?? {}), diagnostics };
+    }
+    const entries = raw
+      .split("\n")
+      .filter((line) => line.trim().length > 0)
+      .map((line) => JSON.parse(line) as SerializedEntry);
+    return { entries, diagnostics };
+  } catch (err) {
+    diagnostics.push(malformed(
+      manifestPath,
+      `snapshot file '${file}' is not valid JSON: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    ));
+    return { entries: [], diagnostics };
+  }
+}
+
+function malformed(file: string, detail: string): Diagnostic {
+  return {
+    code: "UPSTREAM-SNAPSHOT-003",
+    severity: "error",
+    message: `malformed upstream snapshot: ${detail}`,
+    location: { file, line: 1, column: 1 },
+  };
 }

--- a/packages/markspec/core/compiler/deserialize.ts
+++ b/packages/markspec/core/compiler/deserialize.ts
@@ -38,7 +38,7 @@ export function deserializeEntry(s: SerializedEntry): Entry {
     type,
     id,
     typedAttributes: new Map(Object.entries(typedAttributes ?? {})),
-  } as Entry;
+  };
 }
 
 /** Result of {@linkcode extractSerializedEntries}. */
@@ -116,17 +116,25 @@ export function extractSerializedEntries(
     return { entries: [], diagnostics };
   }
   try {
+    let candidates: unknown[];
     if (block.format === "inline") {
-      const json = JSON.parse(raw) as {
-        entries?: Record<string, SerializedEntry>;
-      };
-      return { entries: Object.values(json.entries ?? {}), diagnostics };
+      const json = JSON.parse(raw) as { entries?: Record<string, unknown> };
+      candidates = Object.values(json.entries ?? {});
+    } else {
+      candidates = raw
+        .split("\n")
+        .filter((line) => line.trim().length > 0)
+        .map((line) => JSON.parse(line));
     }
-    const entries = raw
-      .split("\n")
-      .filter((line) => line.trim().length > 0)
-      .map((line) => JSON.parse(line) as SerializedEntry);
-    return { entries, diagnostics };
+    const { valid, rejectedCount } = partitionEntryCandidates(candidates);
+    if (rejectedCount > 0) {
+      diagnostics.push(malformed(
+        manifestPath,
+        `snapshot file '${file}' contains ${rejectedCount} non-object ` +
+          `entry value(s)`,
+      ));
+    }
+    return { entries: valid, diagnostics };
   } catch (err) {
     diagnostics.push(malformed(
       manifestPath,
@@ -136,6 +144,33 @@ export function extractSerializedEntries(
     ));
     return { entries: [], diagnostics };
   }
+}
+
+/**
+ * Keep only candidates that are non-null, non-array plain objects — the
+ * shape a serialized entry must have. A snapshot line/value that parses
+ * as valid JSON but isn't an object (`null`, a bare string, a number, an
+ * array) would otherwise crash downstream (`deserializeEntry` destructures
+ * fields off it) or produce a garbage entry with an `undefined` displayId.
+ * Rejected candidates are dropped silently here; the caller emits a single
+ * summary diagnostic when `rejectedCount > 0`.
+ */
+function partitionEntryCandidates(
+  candidates: readonly unknown[],
+): { valid: SerializedEntry[]; rejectedCount: number } {
+  const valid: SerializedEntry[] = [];
+  let rejectedCount = 0;
+  for (const candidate of candidates) {
+    if (
+      typeof candidate === "object" && candidate !== null &&
+      !Array.isArray(candidate)
+    ) {
+      valid.push(candidate as SerializedEntry);
+    } else {
+      rejectedCount++;
+    }
+  }
+  return { valid, rejectedCount };
 }
 
 function malformed(file: string, detail: string): Diagnostic {

--- a/packages/markspec/core/compiler/deserialize.ts
+++ b/packages/markspec/core/compiler/deserialize.ts
@@ -1,0 +1,38 @@
+/**
+ * @module compiler/deserialize
+ *
+ * Hydration of compiled-JSON snapshots back into core {@linkcode Entry}
+ * values — the inverse of `./schema.ts`. Consumed by the upstream corpus
+ * loader (`core/upstream/`): a dependency's or reference's published
+ * compile output is deserialized here before joining the consumer's graph.
+ *
+ * Pure module: no I/O, no Deno APIs.
+ */
+
+import type { Entry } from "../model/mod.ts";
+import type { SerializedEntry } from "./schema.ts";
+
+/**
+ * Rebuild an {@linkcode Entry} from its serialized wire form. Inverse of
+ * `serializeEntry`: restores `typedAttributes` from a plain record to a
+ * `Map` (absent → empty). All other fields — including `origin` — pass
+ * through verbatim.
+ *
+ * `type` is re-keyed explicitly (rather than left to the `...rest`
+ * spread) to restore field-presence parity with a freshly parsed
+ * {@linkcode Entry}: the parser always includes `type` as an own
+ * property (`undefined` when no profile classified the entry), but
+ * `JSON.stringify` drops `undefined`-valued keys entirely, so the wire
+ * form loses the key when it round-trips through `JSON.parse`. Without
+ * this, `deserializeEntry(wire)` would be missing the `type` key while
+ * the original entry still carries it (with value `undefined`),
+ * breaking the deep-equality round-trip contract.
+ */
+export function deserializeEntry(s: SerializedEntry): Entry {
+  const { typedAttributes, type, ...rest } = s;
+  return {
+    ...rest,
+    type,
+    typedAttributes: new Map(Object.entries(typedAttributes ?? {})),
+  } as Entry;
+}

--- a/packages/markspec/core/compiler/deserialize_test.ts
+++ b/packages/markspec/core/compiler/deserialize_test.ts
@@ -138,3 +138,90 @@ Deno.test("extractSerializedEntries: missing snapshot file → UPSTREAM-SNAPSHOT
   assertEquals(result.entries, []);
   assertEquals(result.diagnostics[0]?.code, "UPSTREAM-SNAPSHOT-002");
 });
+
+Deno.test("extractSerializedEntries: unknown entries format → UPSTREAM-SNAPSHOT-003", () => {
+  const manifest = {
+    ...GOOD_MANIFEST,
+    entries: { format: "exotic", file: "x" },
+  };
+  const result = extractSerializedEntries(
+    manifest,
+    () => "{}",
+    "/c/manifest.json",
+  );
+  assertEquals(result.entries, []);
+  assertEquals(result.diagnostics.length, 1);
+  assertEquals(result.diagnostics[0].code, "UPSTREAM-SNAPSHOT-003");
+  assertEquals(result.diagnostics[0].severity, "error");
+});
+
+Deno.test("extractSerializedEntries: entries block missing file → UPSTREAM-SNAPSHOT-003", () => {
+  const manifest = { ...GOOD_MANIFEST, entries: { format: "inline" } };
+  const result = extractSerializedEntries(
+    manifest,
+    () => "{}",
+    "/c/manifest.json",
+  );
+  assertEquals(result.entries, []);
+  assertEquals(result.diagnostics.length, 1);
+  assertEquals(result.diagnostics[0].code, "UPSTREAM-SNAPSHOT-003");
+  assertEquals(result.diagnostics[0].severity, "error");
+});
+
+Deno.test("extractSerializedEntries: invalid inline JSON → UPSTREAM-SNAPSHOT-003", () => {
+  const result = extractSerializedEntries(
+    GOOD_MANIFEST,
+    () => "{ not json",
+    "/c/manifest.json",
+  );
+  assertEquals(result.entries, []);
+  assertEquals(result.diagnostics.length, 1);
+  assertEquals(result.diagnostics[0].code, "UPSTREAM-SNAPSHOT-003");
+  assertEquals(result.diagnostics[0].severity, "error");
+});
+
+Deno.test("extractSerializedEntries: invalid NDJSON line → UPSTREAM-SNAPSHOT-003", async () => {
+  const { entries } = await parseFile(FIXTURE, { file: "/up/sample.md" });
+  const ndjson = JSON.stringify(serializeEntry(entries[0])) + "\n{ not json\n";
+  const manifest = {
+    ...GOOD_MANIFEST,
+    entries: { format: "ndjson", file: "entries.ndjson" },
+  };
+  const result = extractSerializedEntries(
+    manifest,
+    (rel) => (rel === "entries.ndjson" ? ndjson : undefined),
+    "/c/manifest.json",
+  );
+  assertEquals(result.entries, []);
+  assertEquals(result.diagnostics.length, 1);
+  assertEquals(result.diagnostics[0].code, "UPSTREAM-SNAPSHOT-003");
+  assertEquals(result.diagnostics[0].severity, "error");
+});
+
+Deno.test("extractSerializedEntries: empty and whitespace-only NDJSON lines are filtered", async () => {
+  const { entries } = await parseFile(FIXTURE, { file: "/up/sample.md" });
+  const manifest = {
+    ...GOOD_MANIFEST,
+    entries: { format: "ndjson", file: "entries.ndjson" },
+  };
+
+  // Empty body → no entries, no diagnostics.
+  const empty = extractSerializedEntries(
+    manifest,
+    () => "",
+    "/c/manifest.json",
+  );
+  assertEquals(empty.entries, []);
+  assertEquals(empty.diagnostics, []);
+
+  // Whitespace-only lines interleaved with real ones are skipped.
+  const ndjson = "\n   \n" + JSON.stringify(serializeEntry(entries[0])) +
+    "\n\t\n" + JSON.stringify(serializeEntry(entries[1])) + "\n  \n";
+  const padded = extractSerializedEntries(
+    manifest,
+    () => ndjson,
+    "/c/manifest.json",
+  );
+  assertEquals(padded.diagnostics, []);
+  assertEquals(padded.entries.length, 2);
+});

--- a/packages/markspec/core/compiler/deserialize_test.ts
+++ b/packages/markspec/core/compiler/deserialize_test.ts
@@ -1,0 +1,43 @@
+import { assertEquals } from "@std/assert";
+import { parseFile } from "../parser/mod.ts";
+import { serializeEntry } from "./schema.ts";
+import { deserializeEntry } from "./deserialize.ts";
+
+const FIXTURE = `# Sample
+
+- [STK_0001] Braking distance
+
+  The system shall stop the vehicle within 40 m from 100 km/h.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      Labels: ASIL-B
+
+- [SYS_0001] Threat assessment
+
+  The system shall compute a threat level within 200 ms.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEG
+      Satisfies: STK_0001
+`;
+
+Deno.test("deserializeEntry: JSON wire round-trip preserves the entry", async () => {
+  const { entries } = await parseFile(FIXTURE, { file: "/proj/sample.md" });
+  for (const entry of entries) {
+    const wire = JSON.parse(JSON.stringify(serializeEntry(entry)));
+    assertEquals(deserializeEntry(wire), entry);
+  }
+});
+
+Deno.test("deserializeEntry: origin passes through verbatim", async () => {
+  const { entries } = await parseFile(FIXTURE, { file: "/proj/sample.md" });
+  const withOrigin = {
+    ...entries[0],
+    origin: {
+      kind: "upstream" as const,
+      upstreamId: "product",
+      version: "v1.0.0",
+    },
+  };
+  const wire = JSON.parse(JSON.stringify(serializeEntry(withOrigin)));
+  assertEquals(deserializeEntry(wire).origin, withOrigin.origin);
+});

--- a/packages/markspec/core/compiler/deserialize_test.ts
+++ b/packages/markspec/core/compiler/deserialize_test.ts
@@ -1,7 +1,11 @@
 import { assertEquals } from "@std/assert";
 import { parseFile } from "../parser/mod.ts";
 import { serializeEntry } from "./schema.ts";
-import { deserializeEntry } from "./deserialize.ts";
+import {
+  checkSnapshotSchema,
+  deserializeEntry,
+  extractSerializedEntries,
+} from "./deserialize.ts";
 
 const FIXTURE = `# Sample
 
@@ -61,4 +65,76 @@ Deno.test("deserializeEntry: origin passes through verbatim", async () => {
   };
   const wire = JSON.parse(JSON.stringify(serializeEntry(withOrigin)));
   assertEquals(deserializeEntry(wire).origin, withOrigin.origin);
+});
+
+const GOOD_MANIFEST = {
+  markspecSchemaVersion: 1,
+  generator: { release: "0.0.0-test", coreSchema: 1 },
+  project: { name: "up", root: "/up" },
+  counts: { entries: 1, edges: 0, byType: {} },
+  entries: { format: "inline", file: "compiled.json" },
+  edges: { format: "inline", file: "compiled.json" },
+  sqliteMirror: null,
+  federation: [],
+  reserved: {},
+};
+
+Deno.test("checkSnapshotSchema: matching versions → undefined", () => {
+  assertEquals(
+    checkSnapshotSchema(GOOD_MANIFEST, "/c/manifest.json"),
+    undefined,
+  );
+});
+
+Deno.test("checkSnapshotSchema: core-schema skew → UPSTREAM-SNAPSHOT-001", () => {
+  const skewed = {
+    ...GOOD_MANIFEST,
+    generator: { release: "9", coreSchema: 99 },
+  };
+  const d = checkSnapshotSchema(skewed, "/c/manifest.json");
+  assertEquals(d?.code, "UPSTREAM-SNAPSHOT-001");
+  assertEquals(d?.severity, "error");
+});
+
+Deno.test("extractSerializedEntries: inline compiled.json", async () => {
+  const { entries } = await parseFile(FIXTURE, { file: "/up/sample.md" });
+  const compiled = JSON.stringify({
+    entries: Object.fromEntries(
+      entries.map((e) => [e.displayId, serializeEntry(e)]),
+    ),
+  });
+  const result = extractSerializedEntries(
+    GOOD_MANIFEST,
+    (rel) => (rel === "compiled.json" ? compiled : undefined),
+    "/c/manifest.json",
+  );
+  assertEquals(result.diagnostics, []);
+  assertEquals(result.entries.length, 2);
+});
+
+Deno.test("extractSerializedEntries: ndjson block", async () => {
+  const { entries } = await parseFile(FIXTURE, { file: "/up/sample.md" });
+  const ndjson =
+    entries.map((e) => JSON.stringify(serializeEntry(e))).join("\n") + "\n";
+  const manifest = {
+    ...GOOD_MANIFEST,
+    entries: { format: "ndjson", file: "entries.ndjson", index: "entries.idx" },
+  };
+  const result = extractSerializedEntries(
+    manifest,
+    (rel) => (rel === "entries.ndjson" ? ndjson : undefined),
+    "/c/manifest.json",
+  );
+  assertEquals(result.diagnostics, []);
+  assertEquals(result.entries.length, 2);
+});
+
+Deno.test("extractSerializedEntries: missing snapshot file → UPSTREAM-SNAPSHOT-002", () => {
+  const result = extractSerializedEntries(
+    GOOD_MANIFEST,
+    () => undefined,
+    "/c/manifest.json",
+  );
+  assertEquals(result.entries, []);
+  assertEquals(result.diagnostics[0]?.code, "UPSTREAM-SNAPSHOT-002");
 });

--- a/packages/markspec/core/compiler/deserialize_test.ts
+++ b/packages/markspec/core/compiler/deserialize_test.ts
@@ -225,3 +225,48 @@ Deno.test("extractSerializedEntries: empty and whitespace-only NDJSON lines are 
   assertEquals(padded.diagnostics, []);
   assertEquals(padded.entries.length, 2);
 });
+
+Deno.test("extractSerializedEntries: inline non-object entry value (null) → UPSTREAM-SNAPSHOT-003, no crash", () => {
+  const compiled = JSON.stringify({ entries: { X: null } });
+  const result = extractSerializedEntries(
+    GOOD_MANIFEST,
+    (rel) => (rel === "compiled.json" ? compiled : undefined),
+    "/c/manifest.json",
+  );
+  assertEquals(result.entries, []);
+  assertEquals(result.diagnostics.length, 1);
+  assertEquals(result.diagnostics[0].code, "UPSTREAM-SNAPSHOT-003");
+  assertEquals(result.diagnostics[0].severity, "error");
+});
+
+Deno.test("extractSerializedEntries: NDJSON line 'null' → UPSTREAM-SNAPSHOT-003, no crash", () => {
+  const manifest = {
+    ...GOOD_MANIFEST,
+    entries: { format: "ndjson", file: "entries.ndjson" },
+  };
+  const result = extractSerializedEntries(
+    manifest,
+    (rel) => (rel === "entries.ndjson" ? "null\n" : undefined),
+    "/c/manifest.json",
+  );
+  assertEquals(result.entries, []);
+  assertEquals(result.diagnostics.length, 1);
+  assertEquals(result.diagnostics[0].code, "UPSTREAM-SNAPSHOT-003");
+  assertEquals(result.diagnostics[0].severity, "error");
+});
+
+Deno.test("extractSerializedEntries: NDJSON primitive lines (number, string) → UPSTREAM-SNAPSHOT-003, no garbage entries", () => {
+  const manifest = {
+    ...GOOD_MANIFEST,
+    entries: { format: "ndjson", file: "entries.ndjson" },
+  };
+  const result = extractSerializedEntries(
+    manifest,
+    (rel) => (rel === "entries.ndjson" ? '5\n"abc"\n' : undefined),
+    "/c/manifest.json",
+  );
+  assertEquals(result.entries, []);
+  assertEquals(result.diagnostics.length, 1);
+  assertEquals(result.diagnostics[0].code, "UPSTREAM-SNAPSHOT-003");
+  assertEquals(result.diagnostics[0].severity, "error");
+});

--- a/packages/markspec/core/compiler/deserialize_test.ts
+++ b/packages/markspec/core/compiler/deserialize_test.ts
@@ -28,6 +28,27 @@ Deno.test("deserializeEntry: JSON wire round-trip preserves the entry", async ()
   }
 });
 
+// A references document (basename `references.md`) with a slug display ID
+// and no `Id:` trailer produces a Reference-shaped entry whose `id` is an
+// own key with value `undefined` — the field-presence case that
+// `JSON.stringify` would otherwise erase from the wire form.
+const REFERENCE_FIXTURE = `# References
+
+- [iso-26262] ISO 26262 Road vehicles — Functional safety
+
+  Part 6: product development at the software level.
+`;
+
+Deno.test("deserializeEntry: round-trip preserves a Reference-shaped entry", async () => {
+  const { entries } = await parseFile(REFERENCE_FIXTURE, {
+    file: "/proj/references.md",
+  });
+  assertEquals(entries.length, 1);
+  assertEquals(entries[0].shape, "Reference");
+  const wire = JSON.parse(JSON.stringify(serializeEntry(entries[0])));
+  assertEquals(deserializeEntry(wire), entries[0]);
+});
+
 Deno.test("deserializeEntry: origin passes through verbatim", async () => {
   const { entries } = await parseFile(FIXTURE, { file: "/proj/sample.md" });
   const withOrigin = {

--- a/packages/markspec/core/compiler/mod_test.ts
+++ b/packages/markspec/core/compiler/mod_test.ts
@@ -799,7 +799,11 @@ Deno.test("compile: corpusEntries resolves a project Satisfies: target with no M
 
   const corpusEntry = result.entries.get(makeDisplayId("PLT_0001"));
   assertExists(corpusEntry);
-  assertEquals(corpusEntry.origin?.profileId, "platform-arch");
+  assertEquals(corpusEntry.origin, {
+    kind: "profile",
+    profileId: "platform-arch",
+    profileVersion: "1.2.0",
+  });
 
   const forward = result.forward.get(makeDisplayId("STK_0001")) ?? [];
   assertEquals(

--- a/packages/markspec/core/mod.ts
+++ b/packages/markspec/core/mod.ts
@@ -445,3 +445,17 @@ export type {
 // ── Project-entry collection (discover + parse → Entry[]) ────────────────
 export { collectProjectEntries } from "./collect/mod.ts";
 export type { CollectOptions } from "./collect/mod.ts";
+
+// ── Compiled-snapshot deserialization (federated upstream, slice 1) ──────
+export {
+  checkSnapshotSchema,
+  deserializeEntry,
+  extractSerializedEntries,
+} from "./compiler/deserialize.ts";
+
+// ── Upstream corpus loader (federated upstream, slice 1) ─────────────────
+export { loadUpstreamCorpus } from "./upstream/mod.ts";
+export type {
+  LoadUpstreamCorpusResult,
+  UpstreamSnapshotRef,
+} from "./upstream/mod.ts";

--- a/packages/markspec/core/mod.ts
+++ b/packages/markspec/core/mod.ts
@@ -27,6 +27,7 @@ export {
   MIXED_DISCIPLINE,
   PALETTE_HUES,
   REFHUB_URL,
+  sameOriginSource,
 } from "./model/mod.ts";
 export type {
   Attribute,

--- a/packages/markspec/core/model/entry_origin_test.ts
+++ b/packages/markspec/core/model/entry_origin_test.ts
@@ -9,7 +9,7 @@
 
 import { assertEquals } from "@std/assert";
 import type { EntryOrigin } from "./mod.ts";
-import { formatEntryOrigin } from "./mod.ts";
+import { formatEntryOrigin, sameOriginSource } from "./mod.ts";
 
 Deno.test("formatEntryOrigin: joins profile id and version with '@'", () => {
   const origin: EntryOrigin = {
@@ -18,4 +18,51 @@ Deno.test("formatEntryOrigin: joins profile id and version with '@'", () => {
     profileVersion: "2.1.0",
   };
   assertEquals(formatEntryOrigin(origin), "@acme/safety@2.1.0");
+});
+
+Deno.test("formatEntryOrigin: upstream origin renders id@version", () => {
+  const origin: EntryOrigin = {
+    kind: "upstream",
+    upstreamId: "product",
+    version: "v2.1.0",
+  };
+  assertEquals(formatEntryOrigin(origin), "product@v2.1.0");
+});
+
+Deno.test("sameOriginSource: same profile id, different version → true", () => {
+  const a: EntryOrigin = {
+    kind: "profile",
+    profileId: "@acme/safety",
+    profileVersion: "1.0.0",
+  };
+  const b: EntryOrigin = {
+    kind: "profile",
+    profileId: "@acme/safety",
+    profileVersion: "2.0.0",
+  };
+  assertEquals(sameOriginSource(a, b), true);
+});
+
+Deno.test("sameOriginSource: different upstream ids → false", () => {
+  const a: EntryOrigin = {
+    kind: "upstream",
+    upstreamId: "product",
+    version: "v1",
+  };
+  const b: EntryOrigin = { kind: "upstream", upstreamId: "icd", version: "v1" };
+  assertEquals(sameOriginSource(a, b), false);
+});
+
+Deno.test("sameOriginSource: profile vs upstream → false", () => {
+  const a: EntryOrigin = {
+    kind: "profile",
+    profileId: "product",
+    profileVersion: "1",
+  };
+  const b: EntryOrigin = {
+    kind: "upstream",
+    upstreamId: "product",
+    version: "1",
+  };
+  assertEquals(sameOriginSource(a, b), false);
 });

--- a/packages/markspec/core/model/entry_origin_test.ts
+++ b/packages/markspec/core/model/entry_origin_test.ts
@@ -3,8 +3,10 @@
  *
  * Unit test for {@linkcode formatEntryOrigin} — the shared
  * `<profileId>@<profileVersion>` label for a delivered-corpus origin (ADR-030,
- * #674). The `corpusOriginLabel` twin (`core/profile/delivered.ts`) is covered
- * by the delivered-corpus loader tests.
+ * #674) — and {@linkcode sameOriginSource} — whether two origins come from
+ * the same source regardless of version. The `corpusOriginLabel` twin
+ * (`core/profile/delivered.ts`) is covered by the delivered-corpus loader
+ * tests.
  */
 
 import { assertEquals } from "@std/assert";

--- a/packages/markspec/core/model/mod.ts
+++ b/packages/markspec/core/model/mod.ts
@@ -584,10 +584,12 @@ export interface Entry {
    */
   readonly derivedDiscipline?: Discipline;
   /**
-   * Set on entries injected from a profile-delivered corpus document
-   * (ADR-030). Consumers treat such entries as read-only: `fmt` and rename
-   * never touch them, and validation findings inside them are downgraded
-   * to attributed warnings.
+   * Provenance of an entry not authored in the project's own files:
+   * injected from a profile-delivered corpus document (ADR-030,
+   * `kind: "profile"`) or hydrated from a locked upstream snapshot
+   * (`kind: "upstream"`). Consumers treat any origin-carrying entry as
+   * read-only: `fmt` and rename never touch them, and validation findings
+   * inside them are downgraded to attributed warnings.
    */
   readonly origin?: EntryOrigin;
 }

--- a/packages/markspec/core/model/mod.ts
+++ b/packages/markspec/core/model/mod.ts
@@ -422,23 +422,50 @@ export interface EntryProperties {
  * Provenance of an entry that did not originate in the project's own files
  * (ADR-030). Absent on project-authored entries. `kind` is a discriminant so
  * future origins (e.g. ADR-011 SBOM-generated dependency entries) can reuse
- * the slot.
+ * the slot. The `upstream` member covers entries hydrated from another
+ * repository's traceability graph (federated-upstream epic).
  */
-export interface EntryOrigin {
-  readonly kind: "profile";
-  readonly profileId: string;
-  readonly profileVersion: string;
-}
+export type EntryOrigin =
+  | {
+    readonly kind: "profile";
+    readonly profileId: string;
+    readonly profileVersion: string;
+  }
+  | {
+    readonly kind: "upstream";
+    readonly upstreamId: string;
+    readonly version: string;
+  };
 
 /**
- * Human-facing `<profileId>@<profileVersion>` label for an entry's
- * delivered-corpus origin (ADR-030). The single formatter for the origin
+ * Human-facing `<profileId>@<profileVersion>` (or `<upstreamId>@<version>`)
+ * label for an entry's origin (ADR-030). The single formatter for the origin
  * idiom shared across the validator, reporter, CLI, LSP, and MCP surfaces.
  * Its {@linkcode DeliveredDocument} twin is `corpusOriginLabel`
  * (`core/profile/delivered.ts`) — same string shape, different input type.
  */
 export function formatEntryOrigin(origin: EntryOrigin): string {
-  return `${origin.profileId}@${origin.profileVersion}`;
+  switch (origin.kind) {
+    case "profile":
+      return `${origin.profileId}@${origin.profileVersion}`;
+    case "upstream":
+      return `${origin.upstreamId}@${origin.version}`;
+  }
+}
+
+/**
+ * Whether two origins come from the same source (same profile id or same
+ * upstream id), ignoring versions. Used by the corpus collision pass to
+ * decide "same owner" — version bumps must not split ownership.
+ */
+export function sameOriginSource(a: EntryOrigin, b: EntryOrigin): boolean {
+  if (a.kind === "profile" && b.kind === "profile") {
+    return a.profileId === b.profileId;
+  }
+  if (a.kind === "upstream" && b.kind === "upstream") {
+    return a.upstreamId === b.upstreamId;
+  }
+  return false;
 }
 
 /**

--- a/packages/markspec/core/upstream/mod.ts
+++ b/packages/markspec/core/upstream/mod.ts
@@ -93,6 +93,22 @@ export async function loadUpstreamCorpus(
     // extractor is sync; pre-read the single file the manifest points at.
     const block = (manifest as { entries?: { file?: string } }).entries;
     const relFile = block?.file;
+    // The manifest is untrusted input (a hostile or corrupted upstream) —
+    // reject a data-file path that could escape the cache directory
+    // before ever joining it into a read. Latent today (fixtures only);
+    // becomes live once slice 2 populates caches from remote sites (repo
+    // precedent #699 treated the analogous symlink case as a security
+    // blocker).
+    if (relFile !== undefined && isUnsafeRelPath(relFile)) {
+      diagnostics.push({
+        code: "UPSTREAM-SNAPSHOT-003",
+        severity: "error",
+        message:
+          "malformed upstream snapshot: snapshot data-file path escapes the cache directory",
+        location: { file: manifestPath, line: 1, column: 1 },
+      });
+      continue;
+    }
     const snapshotContent = relFile !== undefined
       ? await readFile(`${up.dir}/${relFile}`)
       : undefined;
@@ -112,4 +128,20 @@ export async function loadUpstreamCorpus(
     }
   }
   return { entries, diagnostics };
+}
+
+/** Absolute path prefix — POSIX `/…` or a Windows drive letter (`C:\…` /
+ * `C:/…`). */
+const ABSOLUTE_PATH_RE = /^(\/|[A-Za-z]:[\\/])/;
+
+/** A `..` path segment anywhere in the string, POSIX or Windows separators. */
+const PARENT_SEGMENT_RE = /(^|[\\/])\.\.([\\/]|$)/;
+
+/**
+ * Reject a manifest-controlled relative path that could escape the
+ * upstream's cache directory when joined as `${up.dir}/${relPath}` —
+ * an absolute path or any `..` segment both qualify.
+ */
+function isUnsafeRelPath(relPath: string): boolean {
+  return ABSOLUTE_PATH_RE.test(relPath) || PARENT_SEGMENT_RE.test(relPath);
 }

--- a/packages/markspec/core/upstream/mod.ts
+++ b/packages/markspec/core/upstream/mod.ts
@@ -1,0 +1,115 @@
+/**
+ * @module upstream
+ *
+ * Upstream corpus loader — hydrates the cached compiled-JSON snapshots
+ * that `markspec lock` writes under `.markspec/cache/upstreams/<id>/`
+ * into read-only graph citizens carrying an `upstream` origin.
+ *
+ * Design: docs/wip/2026-07-04-federated-upstream-resolution-design.md §4.5.
+ * Sibling of `core/profile/delivered.ts` (`loadDeliveredCorpus`), same
+ * purity rules: no I/O of its own — file access via the injected
+ * {@linkcode ReadFile}.
+ */
+
+import type { Diagnostic, Entry } from "../model/mod.ts";
+import {
+  checkSnapshotSchema,
+  deserializeEntry,
+  extractSerializedEntries,
+} from "../compiler/deserialize.ts";
+
+/** One locked upstream's cached snapshot (dir written by `markspec lock`). */
+export interface UpstreamSnapshotRef {
+  /** projectRef `name` — cache directory, lockfile rows, origin badges. */
+  readonly id: string;
+  /** Resolved version label recorded by the lockfile (e.g. `v2.1.0`). */
+  readonly version: string;
+  /** Absolute path to `.markspec/cache/upstreams/<id>`. */
+  readonly dir: string;
+}
+
+/** Result of {@linkcode loadUpstreamCorpus}. */
+export interface LoadUpstreamCorpusResult {
+  readonly entries: Entry[];
+  readonly diagnostics: Diagnostic[];
+}
+
+/** File reader injected by the caller (CLI/LSP own the I/O). */
+export type ReadFile = (path: string) => Promise<string | undefined>;
+
+/**
+ * Hydrate every locked upstream's cached snapshot into `Entry[]`.
+ *
+ * Per upstream: read `<dir>/manifest.json`, reject schema skew
+ * (UPSTREAM-SNAPSHOT-001), extract the serialized entries, and stamp each
+ * with `origin = { kind: "upstream", upstreamId, version }`.
+ *
+ * Authoritative-source rule (design §4.5): a snapshot entry that already
+ * carries an `origin` is a re-export of some other source's entry (the
+ * upstream's own corpus or its upstreams) and is skipped — every entry
+ * joins an aggregate only from its authoring project. A failing upstream
+ * contributes diagnostics but never aborts the others.
+ */
+export async function loadUpstreamCorpus(
+  upstreams: readonly UpstreamSnapshotRef[],
+  readFile: ReadFile,
+): Promise<LoadUpstreamCorpusResult> {
+  const entries: Entry[] = [];
+  const diagnostics: Diagnostic[] = [];
+  for (const up of upstreams) {
+    const manifestPath = `${up.dir}/manifest.json`;
+    const manifestRaw = await readFile(manifestPath);
+    if (manifestRaw === undefined) {
+      diagnostics.push({
+        code: "UPSTREAM-SNAPSHOT-002",
+        severity: "error",
+        message:
+          `upstream '${up.id}' snapshot manifest is missing or unreadable; ` +
+          `run 'markspec lock' to restore the cache`,
+        location: { file: manifestPath, line: 1, column: 1 },
+      });
+      continue;
+    }
+    let manifest: unknown;
+    try {
+      manifest = JSON.parse(manifestRaw);
+    } catch (err) {
+      diagnostics.push({
+        code: "UPSTREAM-SNAPSHOT-003",
+        severity: "error",
+        message: `malformed upstream snapshot: manifest is not valid JSON: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+        location: { file: manifestPath, line: 1, column: 1 },
+      });
+      continue;
+    }
+    const skew = checkSnapshotSchema(manifest, manifestPath);
+    if (skew) {
+      diagnostics.push(skew);
+      continue;
+    }
+    // Snapshot files are read relative to the upstream's cache dir. The
+    // extractor is sync; pre-read the single file the manifest points at.
+    const block = (manifest as { entries?: { file?: string } }).entries;
+    const relFile = block?.file;
+    const snapshotContent = relFile !== undefined
+      ? await readFile(`${up.dir}/${relFile}`)
+      : undefined;
+    const extracted = extractSerializedEntries(
+      manifest,
+      (rel) => (rel === relFile ? snapshotContent : undefined),
+      manifestPath,
+    );
+    diagnostics.push(...extracted.diagnostics);
+    for (const s of extracted.entries) {
+      if (s.origin !== undefined) continue; // authoritative-source rule
+      const entry = deserializeEntry(s);
+      entries.push({
+        ...entry,
+        origin: { kind: "upstream", upstreamId: up.id, version: up.version },
+      });
+    }
+  }
+  return { entries, diagnostics };
+}

--- a/packages/markspec/core/upstream/mod_test.ts
+++ b/packages/markspec/core/upstream/mod_test.ts
@@ -50,6 +50,17 @@ function readerFor(files: Map<string, string>) {
   return (path: string) => Promise.resolve(files.get(path));
 }
 
+/** Wrap {@linkcode readerFor} to record every requested path — lets the
+ * skew test pin that the snapshot data file is never read (ordering
+ * contract: skew check before any data-file read). */
+function recordingReaderFor(files: Map<string, string>, requested: string[]) {
+  const inner = readerFor(files);
+  return (path: string) => {
+    requested.push(path);
+    return inner(path);
+  };
+}
+
 Deno.test("loadUpstreamCorpus: hydrates and stamps upstream origin", async () => {
   const files = await snapshotFiles("/c/up/product", UP_A_MD, "/up/a.md");
   const result = await loadUpstreamCorpus(
@@ -104,5 +115,56 @@ Deno.test("loadUpstreamCorpus: schema skew → 001, upstream skipped", async () 
     readerFor(files),
   );
   assertEquals(result.diagnostics[0].code, "UPSTREAM-SNAPSHOT-001");
+  assertEquals(result.entries, []);
+});
+
+Deno.test("loadUpstreamCorpus: skew check runs before any data-file read", async () => {
+  // Ordering pin (contract 1): a skewed snapshot must never reach the
+  // data file — assert on the paths the reader was asked for, not just
+  // the outcome. Reordering the loader to pre-read compiled.json before
+  // (or regardless of) the skew check would fail this test even though
+  // the 001-diagnostic outcome stays the same.
+  const files = await snapshotFiles("/c/up/product", UP_A_MD, "/up/a.md");
+  const manifest = JSON.parse(files.get("/c/up/product/manifest.json")!);
+  manifest.generator.coreSchema = 99;
+  files.set("/c/up/product/manifest.json", JSON.stringify(manifest));
+  const requested: string[] = [];
+  const result = await loadUpstreamCorpus(
+    [{ id: "product", version: "v2.1.0", dir: "/c/up/product" }],
+    recordingReaderFor(files, requested),
+  );
+  assertEquals(result.diagnostics[0].code, "UPSTREAM-SNAPSHOT-001");
+  assertEquals(requested.includes("/c/up/product/manifest.json"), true);
+  assertEquals(requested.includes("/c/up/product/compiled.json"), false);
+});
+
+Deno.test("loadUpstreamCorpus: no upstreams → empty result", async () => {
+  const result = await loadUpstreamCorpus([], readerFor(new Map()));
+  assertEquals(result.entries, []);
+  assertEquals(result.diagnostics, []);
+});
+
+Deno.test("loadUpstreamCorpus: empty snapshot entries → no entries, no diagnostics", async () => {
+  const files = await snapshotFiles("/c/up/product", UP_A_MD, "/up/a.md");
+  files.set("/c/up/product/compiled.json", JSON.stringify({ entries: {} }));
+  const result = await loadUpstreamCorpus(
+    [{ id: "product", version: "v2.1.0", dir: "/c/up/product" }],
+    readerFor(files),
+  );
+  assertEquals(result.diagnostics, []);
+  assertEquals(result.entries, []);
+});
+
+Deno.test("loadUpstreamCorpus: missing snapshot data file → 002", async () => {
+  // Data-file-level failure: valid manifest, but the compiled.json it
+  // names is gone — distinct from the manifest-level 002 tested above.
+  const files = await snapshotFiles("/c/up/product", UP_A_MD, "/up/a.md");
+  files.delete("/c/up/product/compiled.json");
+  const result = await loadUpstreamCorpus(
+    [{ id: "product", version: "v2.1.0", dir: "/c/up/product" }],
+    readerFor(files),
+  );
+  assertEquals(result.diagnostics.length, 1);
+  assertEquals(result.diagnostics[0].code, "UPSTREAM-SNAPSHOT-002");
   assertEquals(result.entries, []);
 });

--- a/packages/markspec/core/upstream/mod_test.ts
+++ b/packages/markspec/core/upstream/mod_test.ts
@@ -1,0 +1,108 @@
+import { assertEquals } from "@std/assert";
+import { parseFile } from "../parser/mod.ts";
+import { serializeEntry } from "../compiler/schema.ts";
+import { loadUpstreamCorpus } from "./mod.ts";
+
+const UP_A_MD = `# A
+
+- [SYS_0001] Threat assessment
+
+  The system shall compute a threat level within 200 ms.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEG
+`;
+
+async function snapshotFiles(
+  dir: string,
+  md: string,
+  file: string,
+  reexport?: { upstreamId: string; version: string },
+): Promise<Map<string, string>> {
+  const { entries } = await parseFile(md, { file });
+  const serialized = entries.map((e) =>
+    serializeEntry(
+      reexport
+        ? { ...e, origin: { kind: "upstream" as const, ...reexport } }
+        : e,
+    )
+  );
+  const manifest = {
+    markspecSchemaVersion: 1,
+    generator: { release: "0.0.0-test", coreSchema: 1 },
+    project: { name: "up", root: "/up" },
+    counts: { entries: serialized.length, edges: 0, byType: {} },
+    entries: { format: "inline", file: "compiled.json" },
+    edges: { format: "inline", file: "compiled.json" },
+    sqliteMirror: null,
+    federation: [],
+    reserved: {},
+  };
+  const compiled = {
+    entries: Object.fromEntries(serialized.map((s) => [s.displayId, s])),
+  };
+  return new Map([
+    [`${dir}/manifest.json`, JSON.stringify(manifest)],
+    [`${dir}/compiled.json`, JSON.stringify(compiled)],
+  ]);
+}
+
+function readerFor(files: Map<string, string>) {
+  return (path: string) => Promise.resolve(files.get(path));
+}
+
+Deno.test("loadUpstreamCorpus: hydrates and stamps upstream origin", async () => {
+  const files = await snapshotFiles("/c/up/product", UP_A_MD, "/up/a.md");
+  const result = await loadUpstreamCorpus(
+    [{ id: "product", version: "v2.1.0", dir: "/c/up/product" }],
+    readerFor(files),
+  );
+  assertEquals(result.diagnostics, []);
+  assertEquals(result.entries.length, 1);
+  assertEquals(result.entries[0].displayId, "SYS_0001");
+  assertEquals(result.entries[0].origin, {
+    kind: "upstream",
+    upstreamId: "product",
+    version: "v2.1.0",
+  });
+});
+
+Deno.test("loadUpstreamCorpus: authoritative-source rule skips re-exports", async () => {
+  // product's snapshot re-exports an entry it pulled from 'icd' — skip it.
+  const files = await snapshotFiles("/c/up/product", UP_A_MD, "/up/a.md", {
+    upstreamId: "icd",
+    version: "v1.0.0",
+  });
+  const result = await loadUpstreamCorpus(
+    [{ id: "product", version: "v2.1.0", dir: "/c/up/product" }],
+    readerFor(files),
+  );
+  assertEquals(result.diagnostics, []);
+  assertEquals(result.entries, []);
+});
+
+Deno.test("loadUpstreamCorpus: missing manifest → 002, other upstreams still load", async () => {
+  const files = await snapshotFiles("/c/up/product", UP_A_MD, "/up/a.md");
+  const result = await loadUpstreamCorpus(
+    [
+      { id: "ghost", version: "v0", dir: "/c/up/ghost" },
+      { id: "product", version: "v2.1.0", dir: "/c/up/product" },
+    ],
+    readerFor(files),
+  );
+  assertEquals(result.diagnostics.length, 1);
+  assertEquals(result.diagnostics[0].code, "UPSTREAM-SNAPSHOT-002");
+  assertEquals(result.entries.length, 1);
+});
+
+Deno.test("loadUpstreamCorpus: schema skew → 001, upstream skipped", async () => {
+  const files = await snapshotFiles("/c/up/product", UP_A_MD, "/up/a.md");
+  const manifest = JSON.parse(files.get("/c/up/product/manifest.json")!);
+  manifest.generator.coreSchema = 99;
+  files.set("/c/up/product/manifest.json", JSON.stringify(manifest));
+  const result = await loadUpstreamCorpus(
+    [{ id: "product", version: "v2.1.0", dir: "/c/up/product" }],
+    readerFor(files),
+  );
+  assertEquals(result.diagnostics[0].code, "UPSTREAM-SNAPSHOT-001");
+  assertEquals(result.entries, []);
+});

--- a/packages/markspec/core/upstream/mod_test.ts
+++ b/packages/markspec/core/upstream/mod_test.ts
@@ -168,3 +168,52 @@ Deno.test("loadUpstreamCorpus: missing snapshot data file → 002", async () => 
   assertEquals(result.diagnostics[0].code, "UPSTREAM-SNAPSHOT-002");
   assertEquals(result.entries, []);
 });
+
+Deno.test("loadUpstreamCorpus: isolation — a non-object entry value in one upstream doesn't abort the others", async () => {
+  // Regression pin for the loader's documented isolation contract: a
+  // malformed entry value (valid JSON, wrong shape) in one upstream's
+  // snapshot must not reject the whole call or block a sibling upstream
+  // from loading.
+  const badFiles = await snapshotFiles("/c/up/bad", UP_A_MD, "/up/a.md");
+  badFiles.set(
+    "/c/up/bad/compiled.json",
+    JSON.stringify({ entries: { X: null } }),
+  );
+  const goodFiles = await snapshotFiles("/c/up/product", UP_A_MD, "/up/a.md");
+  const files = new Map([...badFiles, ...goodFiles]);
+  const result = await loadUpstreamCorpus(
+    [
+      { id: "bad", version: "v1.0.0", dir: "/c/up/bad" },
+      { id: "product", version: "v2.1.0", dir: "/c/up/product" },
+    ],
+    readerFor(files),
+  );
+  assertEquals(result.diagnostics.length, 1);
+  assertEquals(result.diagnostics[0].code, "UPSTREAM-SNAPSHOT-003");
+  assertEquals(result.entries.length, 1);
+  assertEquals(result.entries[0].origin, {
+    kind: "upstream",
+    upstreamId: "product",
+    version: "v2.1.0",
+  });
+});
+
+Deno.test("loadUpstreamCorpus: relFile escaping the cache dir → 003, never read outside the upstream dir", async () => {
+  const files = await snapshotFiles("/c/up/product", UP_A_MD, "/up/a.md");
+  const manifest = JSON.parse(files.get("/c/up/product/manifest.json")!);
+  manifest.entries = { format: "inline", file: "../../evil.json" };
+  files.set("/c/up/product/manifest.json", JSON.stringify(manifest));
+  const requested: string[] = [];
+  const result = await loadUpstreamCorpus(
+    [{ id: "product", version: "v2.1.0", dir: "/c/up/product" }],
+    recordingReaderFor(files, requested),
+  );
+  assertEquals(result.diagnostics.length, 1);
+  assertEquals(result.diagnostics[0].code, "UPSTREAM-SNAPSHOT-003");
+  assertEquals(result.entries, []);
+  assertEquals(requested.includes("/c/up/product/manifest.json"), true);
+  assertEquals(
+    requested.some((p) => p.includes("evil.json")),
+    false,
+  );
+});

--- a/packages/markspec/core/validator/corpus.ts
+++ b/packages/markspec/core/validator/corpus.ts
@@ -15,7 +15,7 @@
  */
 
 import type { Diagnostic, Entry } from "../model/mod.ts";
-import { formatEntryOrigin } from "../model/mod.ts";
+import { formatEntryOrigin, sameOriginSource } from "../model/mod.ts";
 
 /** Generic duplicate detectors superseded by MSL-R014 for corpus collisions. */
 const GENERIC_DUP_CODES: ReadonlySet<string> = new Set([
@@ -87,7 +87,7 @@ export function detectCorpusCollisions(
     const displayOwner = corpusByDisplayId.get(e.displayId);
     if (
       displayOwner !== e && displayOwner &&
-      displayOwner.origin!.profileId !== e.origin.profileId
+      !sameOriginSource(displayOwner.origin!, e.origin)
     ) {
       collided.add(e.displayId);
       diagnostics.push({
@@ -103,7 +103,7 @@ export function detectCorpusCollisions(
       const idOwner = corpusById.get(e.id);
       if (
         idOwner !== e && idOwner &&
-        idOwner.origin!.profileId !== e.origin.profileId
+        !sameOriginSource(idOwner.origin!, e.origin)
       ) {
         collided.add(e.id);
         diagnostics.push({

--- a/packages/markspec/lsp/workspace_test.ts
+++ b/packages/markspec/lsp/workspace_test.ts
@@ -332,7 +332,11 @@ Deno.test("WorkspaceIndex: corpus seeded first owns colliding display IDs", asyn
   );
   await index.parseAndUpdateFile("/repo/a.md", PROJECT_MD_WITH_SAME_ID);
   const owner = index.getEntryByDisplayId(makeDisplayId("PLT_0001"));
-  assertEquals(owner?.origin?.profileId, "p");
+  assertEquals(owner?.origin, {
+    kind: "profile",
+    profileId: "p",
+    profileVersion: "1.0.0",
+  });
 });
 
 Deno.test("WorkspaceIndex: validateAll reports a project/corpus collision as MSL-R014, not a raw-cache-path MSL-R006 (#674 finding 3)", async () => {


### PR DESCRIPTION
Slice 1 of the federated-upstream-resolution design (docs/wip/2026-07-04-federated-upstream-resolution-design.md, carried on this branch): the pure-core foundation for cross-repo traceability references. No behavior is wired into CLI/LSP/MCP yet — that is slice 4; fetchers and lockfile integration are slices 2-3.

## What this adds (all pure core, no I/O of its own)

- `EntryOrigin` becomes the discriminated union its doc comment anticipated: `profile` (ADR-030, unchanged) + new `upstream` kind; `formatEntryOrigin` switches on kind; new `sameOriginSource` helper replaces the two unnarrowed `.profileId` comparisons in the corpus collision pass.
- `deserializeEntry` — exact inverse of `serializeEntry` (wire round-trip is whole-entry deep equality; `type`/`id` field presence restored to parser-canonical shape).
- `checkSnapshotSchema` + `extractSerializedEntries` — snapshot reading for both compile-output forms (inline `compiled.json` and NDJSON), with `UPSTREAM-SNAPSHOT-001` (schema skew, rejected before any data-file read — pinned by a recording-reader test), `-002` (missing file), `-003` (malformed JSON / non-object entry values / path escape).
- `loadUpstreamCorpus` — hydrates cached upstream snapshots into read-only `Entry[]` stamped `origin: { kind: "upstream", upstreamId, version }`, with per-upstream failure isolation and the authoritative-source rule (already-origin-carrying snapshot entries are re-exports and are skipped — what makes the diamond/root-aggregation topology collision-free).

## Hardening (from the whole-branch review)

- Valid-JSON-but-non-object entry values (e.g. a `null` NDJSON line from a truncated cache write) are dropped with a `-003` diagnostic instead of crashing the loader and aborting sibling upstreams.
- Manifest-controlled data-file paths are containment-checked (absolute paths and `..` segments rejected) — closing the latent traversal analogous to #699 before slice 2 populates caches from remote sources.

## Tests

26 focused tests across `core/compiler/deserialize_test.ts` (16) and `core/upstream/mod_test.ts` (10), all through the real parse pipeline; full gate green (`just check`: 3612 tests at final count, deno check/lint/dprint clean).

## Working-memory note (accepted debt, visible per the wip-gate rule)

`docs/wip/` on this branch carries the epic's design spec + slice-1 plan. They remain live working memory for slices 2-6 of this epic; gardening into durable records (ADR + guide) is slice 6's explicit deliverable. Reason: archiving the spec now would orphan the 5 remaining slices that execute against it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
