### PR TITLE
fix(lsp): resolve dependents CodeLens references server-side

### DIFF
--- a/editors/vscode/src/codeLensCommands.test.ts
+++ b/editors/vscode/src/codeLensCommands.test.ts
@@ -1,6 +1,9 @@
 import { test } from "node:test";
 import { strict as assert } from "node:assert";
-import { parseCodeLensTarget } from "./codeLensCommands";
+import {
+  parseCodeLensTarget,
+  parseReferenceLocations,
+} from "./codeLensCommands";
 
 test("parseCodeLensTarget: well-formed [uri, position] → open", () => {
   const result = parseCodeLensTarget([
@@ -88,4 +91,55 @@ test("parseCodeLensTarget: extra trailing args are tolerated", () => {
     line: 5,
     character: 2,
   });
+});
+
+test("parseReferenceLocations: well-formed locations array", () => {
+  const result = parseReferenceLocations([
+    "file:///foo/bar.md",
+    { line: 0, character: 0 },
+    [
+      { uri: "file:///foo/a.md", line: 3, character: 0 },
+      { uri: "file:///foo/b.md", line: 7, character: 0 },
+    ],
+  ]);
+  assert.deepEqual(result, [
+    { uri: "file:///foo/a.md", line: 3, character: 0 },
+    { uri: "file:///foo/b.md", line: 7, character: 0 },
+  ]);
+});
+
+test("parseReferenceLocations: missing third argument → empty list", () => {
+  assert.deepEqual(
+    parseReferenceLocations(["file:///foo/bar.md", { line: 0, character: 0 }]),
+    [],
+  );
+});
+
+test("parseReferenceLocations: non-array third argument → empty list", () => {
+  assert.deepEqual(
+    parseReferenceLocations([
+      "file:///foo/bar.md",
+      { line: 0, character: 0 },
+      "not-an-array",
+    ]),
+    [],
+  );
+});
+
+test("parseReferenceLocations: malformed entries are dropped individually", () => {
+  const result = parseReferenceLocations([
+    "file:///foo/bar.md",
+    { line: 0, character: 0 },
+    [
+      { uri: "file:///foo/a.md", line: 3, character: 0 },
+      { uri: 42, line: 3, character: 0 },
+      { uri: "file:///foo/b.md", line: -1, character: 0 },
+      { uri: "file:///foo/c.md", line: 5, character: Number.NaN },
+      null,
+      "garbage",
+    ],
+  ]);
+  assert.deepEqual(result, [
+    { uri: "file:///foo/a.md", line: 3, character: 0 },
+  ]);
 });

--- a/editors/vscode/src/codeLensCommands.ts
+++ b/editors/vscode/src/codeLensCommands.ts
@@ -9,13 +9,21 @@
  *     resolves, or `[]` when it doesn't (the LSP still emits the lens so
  *     the author can see the unresolved reference).
  *   - `markspec.openReferences` — clicking the "↑ N dependents" lens.
- *     Arguments are always `[uri, { line, character }]`.
+ *     Arguments are `[uri, { line, character }, locations]`, where
+ *     `locations` is the server-resolved list of referencing entries
+ *     (each `{uri, line, character}`) — the LSP already computed this
+ *     via `findReferencingEntries` when it built the lens, so the
+ *     client hands it straight to `editor.action.showReferences`
+ *     rather than re-deriving it from a cursor position (the lens's
+ *     position sits on the entry's `- [ID]` line start, which is not
+ *     itself a display-ID token `vscode.executeReferenceProvider`
+ *     could resolve).
  *
- * The parser below validates the rehydrated payload (VS Code reconstitutes
+ * The parsers below validate the rehydrated payload (VS Code reconstitutes
  * `arguments` as plain objects across the LSP boundary, not as `Position`
- * instances) and returns a discriminated union the extension dispatches on.
- * Defended against malformed payloads from a buggy / hostile LSP build —
- * the handler should surface an info message rather than throw.
+ * instances) and return a discriminated union / filtered list the extension
+ * dispatches on. Defended against malformed payloads from a buggy / hostile
+ * LSP build — the handler should degrade gracefully rather than throw.
  */
 
 /** Discriminated result of {@linkcode parseCodeLensTarget}. */
@@ -54,4 +62,42 @@ export function parseCodeLensTarget(args: readonly unknown[]): CodeLensTarget {
     return { kind: "missing" };
   }
   return { kind: "open", uri, line, character };
+}
+
+/** One resolved reference location — a subset of the LSP `Location` shape. */
+export interface ReferenceLocation {
+  readonly uri: string;
+  readonly line: number;
+  readonly character: number;
+}
+
+/**
+ * Parse the third `markspec.openReferences` argument: the server-resolved
+ * list of referencing entries' locations. Filters out malformed entries
+ * (wrong shape, non-string uri, non-finite/negative position) individually
+ * rather than rejecting the whole list, and tolerates a missing/non-array
+ * third argument by returning an empty list.
+ */
+export function parseReferenceLocations(
+  args: readonly unknown[],
+): ReferenceLocation[] {
+  const raw = args[2];
+  if (!Array.isArray(raw)) return [];
+  const out: ReferenceLocation[] = [];
+  for (const item of raw) {
+    if (item === null || typeof item !== "object") continue;
+    const uri = (item as { uri?: unknown }).uri;
+    const line = (item as { line?: unknown }).line;
+    const character = (item as { character?: unknown }).character;
+    if (
+      typeof uri !== "string" || uri.length === 0 ||
+      typeof line !== "number" || !Number.isFinite(line) || line < 0 ||
+      typeof character !== "number" || !Number.isFinite(character) ||
+      character < 0
+    ) {
+      continue;
+    }
+    out.push({ uri, line, character });
+  }
+  return out;
 }

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -18,6 +18,7 @@ import {
   LanguageModelChatMessage,
   languages,
   lm,
+  Location,
   McpStdioServerDefinition,
   type OutputChannel,
   Position,
@@ -28,7 +29,10 @@ import {
   window,
   workspace,
 } from "vscode";
-import { parseCodeLensTarget } from "./codeLensCommands";
+import {
+  parseCodeLensTarget,
+  parseReferenceLocations,
+} from "./codeLensCommands";
 import process from "node:process";
 import * as nodePath from "node:path";
 import {
@@ -220,11 +224,22 @@ export function activate(context: ExtensionContext): void {
       async (...args: unknown[]) => {
         const target = parseCodeLensTarget(args);
         if (target.kind === "missing") return;
+        // The lens's own position sits at the entry's line start (not a
+        // display-ID token), so it can't be re-resolved client-side via
+        // `vscode.executeReferenceProvider` — the LSP already resolved the
+        // referencing entries' locations when it built the lens
+        // (`findReferencingEntries`); use those directly.
+        const locations = parseReferenceLocations(args).map((loc) =>
+          new Location(
+            Uri.parse(loc.uri),
+            new Position(loc.line, loc.character),
+          )
+        );
         await commands.executeCommand(
           "editor.action.showReferences",
           Uri.parse(target.uri),
           new Position(target.line, target.character),
-          [],
+          locations,
         );
       },
     ),

--- a/packages/markspec/lsp/code_lens.ts
+++ b/packages/markspec/lsp/code_lens.ts
@@ -5,7 +5,12 @@
  * kinds of lenses per entry, positioned on the entry's title line:
  *
  *   - "↑ N dependents" (when N > 0) — clicks dispatch
- *     `markspec.openReferences` with `[uri, position]` arguments.
+ *     `markspec.openReferences` with `[uri, position, locations]`
+ *     arguments, where `locations` is the resolved list of referencing
+ *     entries' `{uri, line, character}` positions (from
+ *     `findReferencingEntries`) for the client to hand straight to
+ *     `editor.action.showReferences` — no client-side position lookup
+ *     needed.
  *   - "↓ Satisfies: ID — Title" per `Satisfies:` value — clicks
  *     dispatch `markspec.openDefinition` with `[targetUri, targetPosition]`
  *     when the target resolves, or `[]` when it doesn't (lens still
@@ -20,6 +25,7 @@
 
 import type { DisplayId, Entry } from "../core/mod.ts";
 import { buildIncomingCount } from "./incoming_index.ts";
+import { findReferencingEntries } from "./references.ts";
 
 /** A subset of the LSP `Command` interface. */
 export interface Command {
@@ -77,12 +83,18 @@ export function buildCodeLenses(
     // ↑ N dependents
     const depCount = incomingCount.get(entry.displayId) ?? 0;
     if (depCount > 0) {
+      const referencing = findReferencingEntries(allEntries, entry.displayId);
+      const referenceLocations = referencing.map((ref) => ({
+        uri: pathToUri(ref.location.file),
+        line: Math.max(0, ref.location.line - 1),
+        character: 0,
+      }));
       out.push({
         range,
         command: {
           title: depCount === 1 ? "↑ 1 dependent" : `↑ ${depCount} dependents`,
           command: "markspec.openReferences",
-          arguments: [uri, position],
+          arguments: [uri, position, referenceLocations],
         },
       });
     }

--- a/packages/markspec/lsp/code_lens_test.ts
+++ b/packages/markspec/lsp/code_lens_test.ts
@@ -82,6 +82,7 @@ Deno.test("buildCodeLenses: entry with 1 dependent yields singular '1 dependent'
   assertEquals(depLens?.command?.arguments, [
     "file:///proj/r.md",
     { line: 0, character: 0 },
+    [{ uri: "file:///proj/r.md", line: 9, character: 0 }],
   ]);
 });
 
@@ -109,6 +110,33 @@ Deno.test("buildCodeLenses: entry with N>1 dependents yields plural lens", () =>
   const lenses = buildCodeLenses([target], [target, a, b], idUri);
   const depLens = lenses.find((l) => l.command?.title.startsWith("↑"));
   assertEquals(depLens?.command?.title, "↑ 2 dependents");
+  assertEquals(depLens?.command?.arguments?.[2], [
+    { uri: "file:///proj/r.md", line: 9, character: 0 },
+    { uri: "file:///proj/r.md", line: 19, character: 0 },
+  ]);
+});
+
+Deno.test("buildCodeLenses: dependent lens locations resolve across files", () => {
+  const target = fakeEntry({
+    displayId: "XREQ_001",
+    title: "Target",
+    file: "/proj/xreq.md",
+    line: 5,
+  });
+  const child = fakeEntry({
+    displayId: "FREQ_001",
+    title: "Child",
+    file: "/proj/freq.md",
+    line: 20,
+    satisfies: "XREQ_001",
+  });
+  const lenses = buildCodeLenses([target], [target, child], idUri);
+  const depLens = lenses.find((l) => l.command?.title.startsWith("↑"));
+  assertEquals(depLens?.command?.arguments, [
+    "file:///proj/xreq.md",
+    { line: 4, character: 0 },
+    [{ uri: "file:///proj/freq.md", line: 19, character: 0 }],
+  ]);
 });
 
 Deno.test("buildCodeLenses: entry with Satisfies to resolved target emits '↓ Satisfies: ID — Title'", () => {


### PR DESCRIPTION
## Summary

- The "↑ N dependents" CodeLens's `markspec.openReferences` command hardcoded an empty locations array to `editor.action.showReferences`, so the peek view never showed any actual dependents — the LSP's back-navigation from a target entry to what satisfies it was silently broken.
- Client-side resolution via `vscode.executeReferenceProvider` isn't viable either: entry positions are always stored at column 0 (the `-` of `- [ID]`), which `displayIdAtPosition` can't resolve to a display-ID token.
- `buildCodeLenses` now resolves the referencing entries' locations server-side via `findReferencingEntries` and embeds them as a third command argument, mirroring how the "↓ Satisfies" lens already embeds its resolved target location. The extension parses and forwards them directly.

Closes #748.

## Test plan

- [x] `deno test packages/markspec/lsp/code_lens_test.ts` — 9/9 pass, including new coverage for the resolved locations (single dependent, multiple dependents, cross-file resolution)
- [x] `npm test` in `editors/vscode/` — 71/71 pass, including a full `tsc` compile of `extension.ts`
- [x] `just check` — ran as the pre-push hook, passed
