### PR TITLE
fix(lsp): refresh codeLens and inlayHint after cross-file changes

### DIFF
--- a/packages/markspec/lsp/server.ts
+++ b/packages/markspec/lsp/server.ts
@@ -12,6 +12,7 @@
  */
 
 import {
+  CodeLensRefreshRequest,
   type CompletionItem,
   CompletionItemKind,
   type CompletionList,
@@ -21,6 +22,7 @@ import {
   type FileEvent,
   type InitializeParams,
   type InitializeResult,
+  InlayHintRefreshRequest,
   InsertTextFormat,
   ProposedFeatures,
   StreamMessageReader,
@@ -341,6 +343,15 @@ function publishAllDiagnostics(): void {
       });
     }
   }
+
+  // Cross-file validation just re-ran, so any already-open document's
+  // "↑ N dependents" codeLens / "(N dependents)" inlay hint may now be
+  // stale — the client only re-requests textDocument/codeLens|inlayHint
+  // on its own document changing, never on a change to a *different*
+  // file. Fire-and-forget: an older client that never declared refresh
+  // support may reject the request, which must not block diagnostics.
+  connection.sendRequest(CodeLensRefreshRequest.type).catch(() => {});
+  connection.sendRequest(InlayHintRefreshRequest.type).catch(() => {});
 }
 
 // Debounced cross-file validation (1000ms)

--- a/tests/e2e/lsp_code_lens_test.ts
+++ b/tests/e2e/lsp_code_lens_test.ts
@@ -107,6 +107,66 @@ Deno.test("lsp codeLens: returns empty array for non-MarkSpec file", async () =>
   }
 });
 
+Deno.test("lsp codeLens: a cross-file Satisfies edge triggers workspace/codeLens/refresh", async () => {
+  // Regression test for #752: opening a target entry with zero known
+  // dependents, then opening a second file that adds a Satisfies edge
+  // to it, must invalidate the target's cached codeLens client-side —
+  // otherwise the "↑ N dependents" lens never updates once a document
+  // is already open. The server can only do that by sending
+  // `workspace/codeLens/refresh` (LSP 3.16+); there is no other signal
+  // that tells the client to re-request `textDocument/codeLens`.
+  const targetMd = `- [STK_AEB_0001] Target requirement
+
+  Body.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+`;
+  const client = await LspTestClient.create({
+    "project.yaml": "name: test-project\n",
+    "target.md": targetMd,
+  });
+  try {
+    await client.initialize();
+
+    const targetUri = toFileUrl(join(client.workDir, "target.md")).href;
+    await client.notify("textDocument/didOpen", {
+      textDocument: {
+        uri: targetUri,
+        languageId: "markdown",
+        version: 1,
+        text: targetMd,
+      },
+    });
+    await new Promise((r) => setTimeout(r, 500));
+
+    const before = await client.request("textDocument/codeLens", {
+      textDocument: { uri: targetUri },
+    }) as CodeLens[];
+    assertEquals(before, [], "no dependents before the child file opens");
+
+    const childMd = `- [SAD_AEB_0001] Child architecture item
+
+  Body.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEG
+      Satisfies: STK_AEB_0001
+`;
+    const childUri = toFileUrl(join(client.workDir, "child.md")).href;
+    await client.notify("textDocument/didOpen", {
+      textDocument: {
+        uri: childUri,
+        languageId: "markdown",
+        version: 1,
+        text: childMd,
+      },
+    });
+
+    await client.waitForNotification("workspace/codeLens/refresh", 5000);
+  } finally {
+    await client.shutdown();
+  }
+});
+
 Deno.test("lsp codeLens: isolated entry yields no lenses", async () => {
   const md = `- [STK_AEB_0001] Isolated requirement
 

--- a/tests/e2e/lsp_inlay_hint_test.ts
+++ b/tests/e2e/lsp_inlay_hint_test.ts
@@ -107,6 +107,59 @@ Deno.test("lsp inlayHint: returns empty array for non-MarkSpec file", async () =
   }
 });
 
+Deno.test("lsp inlayHint: a cross-file Satisfies edge triggers workspace/inlayHint/refresh", async () => {
+  // Regression test for #752: same staleness class as the codeLens
+  // refresh test — opening a second file that adds a Satisfies edge
+  // to an already-open target must invalidate that target's cached
+  // "(N dependents)" inlay hint. The server can only do that by
+  // sending `workspace/inlayHint/refresh` (LSP 3.16+).
+  const targetMd = `- [STK_AEB_0001] Target requirement
+
+  Body.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+`;
+  const client = await LspTestClient.create({
+    "project.yaml": "name: test-project\n",
+    "target.md": targetMd,
+  });
+  try {
+    await client.initialize();
+
+    const targetUri = toFileUrl(join(client.workDir, "target.md")).href;
+    await client.notify("textDocument/didOpen", {
+      textDocument: {
+        uri: targetUri,
+        languageId: "markdown",
+        version: 1,
+        text: targetMd,
+      },
+    });
+    await new Promise((r) => setTimeout(r, 500));
+
+    const childMd = `- [SAD_AEB_0001] Child architecture item
+
+  Body.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEG
+      Satisfies: STK_AEB_0001
+`;
+    const childUri = toFileUrl(join(client.workDir, "child.md")).href;
+    await client.notify("textDocument/didOpen", {
+      textDocument: {
+        uri: childUri,
+        languageId: "markdown",
+        version: 1,
+        text: childMd,
+      },
+    });
+
+    await client.waitForNotification("workspace/inlayHint/refresh", 5000);
+  } finally {
+    await client.shutdown();
+  }
+});
+
 Deno.test("lsp inlayHint: isolated entry yields no hints", async () => {
   // Single entry, no Satisfies refs, default-profile opted out → no
   // type inference, no dependents.


### PR DESCRIPTION
## Summary

- An entry's "↑ N dependents" CodeLens and "(N dependents)" inlay hint went stale across files: the LSP client only re-requests `textDocument/codeLens`/`textDocument/inlayHint` when the document itself changes, never when a *different* file adds an incoming reference to one of its entries (or during the initial project index, if the document was already open).
- The server never sent `workspace/codeLens/refresh` or `workspace/inlayHint/refresh` (LSP 3.16+) — confirmed via `grep -rn "codeLens/refresh\|inlayHint/refresh\|RefreshRequest" packages/markspec/lsp/`, zero hits before this change.
- `publishAllDiagnostics()` in `server.ts` already re-runs cross-file validation on every edit, on save, after profile reload, and after the initial full-project index — both refresh requests now fire there (fire-and-forget, so an older client without refresh support can't block diagnostics). No `editors/vscode` changes needed: `vscode-languageclient`'s default capabilities already declare refresh support and handle it internally.

Closes #752.

## Test plan

- [x] New e2e regression tests in `tests/e2e/lsp_code_lens_test.ts` and `tests/e2e/lsp_inlay_hint_test.ts`: open a target entry with zero known dependents, then open a second file that adds a `Satisfies:` edge to it, and assert the corresponding `workspace/*/refresh` request arrives. Both were red before the fix, green after.
- [x] `just check` — lint, fmt, full test suite (3614 tests), type-check — all pass
