### PR TITLE
fix(core): resolve remaining typl published-tier review findings

### DIFF
--- a/packages/markspec/core/compiler/mod.ts
+++ b/packages/markspec/core/compiler/mod.ts
@@ -24,7 +24,7 @@ import {
   suppressDeclaredAttrR010,
   validate,
 } from "../validator/mod.ts";
-import { type TypeRegistry, validateTypl } from "../typl/mod.ts";
+import { buildTypeRegistry, type TypeRegistry } from "../typl/mod.ts";
 import { buildEffectiveDisciplineRegistry } from "../profile/discipline_registry.ts";
 import { ATTR_TO_LINK_KIND } from "./constants.ts";
 import { classifyDiscipline } from "./discipline_classifier.ts";
@@ -354,12 +354,12 @@ export async function compile(
   const forward = buildAdjacency(links, (l) => l.from);
   const reverse = buildAdjacency(links, (l) => l.to);
 
-  // Build the corpus typl registry. validateTypl is also called inside
-  // validate() (via validationDiagnostics) for the cross-entry TYPL
-  // diagnostics. Here we call it again only to capture the registry — the
-  // diagnostics are already included in validationDiagnostics, so we discard
-  // them to avoid duplicates in the output.
-  const { registry: typeRegistry } = validateTypl([...entries.values()]);
+  // Build the corpus typl registry directly — validate() (called above)
+  // already ran the full validateTypl pass (citation resolution, TYPL-009,
+  // etc.) for validationDiagnostics; re-running it here just to get
+  // `.registry` would redo that work a second time per compile/show/
+  // context/report/export/MCP call.
+  const typeRegistry = buildTypeRegistry([...entries.values()]);
 
   let diagnostics: Diagnostic[] = [
     ...parseDiagnostics,

--- a/packages/markspec/core/decl/duplicates.ts
+++ b/packages/markspec/core/decl/duplicates.ts
@@ -1,0 +1,41 @@
+/**
+ * @module core/decl/duplicates
+ *
+ * DSL-agnostic "declared exactly once" scan over a corpus-wide registry
+ * (uxil epic #717 §A, #754). Both typl's dotted-name bindings (TYPL-009)
+ * and uxil's own registry (#726) need the identical shape: a
+ * `Map<name, T[]>` where any name with more than one declaration is a
+ * violation. The engine only counts and groups — the DSL host supplies
+ * the registry, narrows which names to check via `predicate`, and maps
+ * each {@linkcode DuplicateDeclaration} to its own diagnostic code.
+ */
+
+/**
+ * One corpus-wide multiple-declaration violation: `name` was declared
+ * more than once. `first` is the earliest declaration (registry
+ * insertion order); `duplicates` are the rest, in the same order.
+ */
+export interface DuplicateDeclaration<T> {
+  readonly name: string;
+  readonly first: T;
+  readonly duplicates: readonly T[];
+}
+
+/**
+ * Scan `registry` for names declared more than once. Returns one entry
+ * per offending name, in `registry`'s iteration order. `predicate`
+ * narrows which names are checked at all (e.g. typl's "only dotted,
+ * published names" rule); defaults to checking every name.
+ */
+export function findDuplicateDeclarations<T>(
+  registry: ReadonlyMap<string, readonly T[]>,
+  predicate: (name: string) => boolean = () => true,
+): readonly DuplicateDeclaration<T>[] {
+  const out: DuplicateDeclaration<T>[] = [];
+  for (const [name, decls] of registry) {
+    if (decls.length < 2) continue;
+    if (!predicate(name)) continue;
+    out.push({ name, first: decls[0], duplicates: decls.slice(1) });
+  }
+  return out;
+}

--- a/packages/markspec/core/decl/duplicates_test.ts
+++ b/packages/markspec/core/decl/duplicates_test.ts
@@ -1,0 +1,33 @@
+import { assertEquals } from "@std/assert";
+import { findDuplicateDeclarations } from "./duplicates.ts";
+
+Deno.test("findDuplicateDeclarations: empty registry → empty result", () => {
+  assertEquals(findDuplicateDeclarations(new Map()), []);
+});
+
+Deno.test("findDuplicateDeclarations: single declaration per name → not a duplicate", () => {
+  const registry = new Map([["a", ["decl-a"]]]);
+  assertEquals(findDuplicateDeclarations(registry), []);
+});
+
+Deno.test("findDuplicateDeclarations: two+ declarations → first plus the rest, in order", () => {
+  const registry = new Map([
+    ["a", ["decl-a"]],
+    ["b", ["b1", "b2", "b3"]],
+  ]);
+  assertEquals(findDuplicateDeclarations(registry), [
+    { name: "b", first: "b1", duplicates: ["b2", "b3"] },
+  ]);
+});
+
+Deno.test("findDuplicateDeclarations: predicate narrows which names are checked", () => {
+  const registry = new Map([
+    ["a.b", ["1", "2"]],
+    ["plain", ["1", "2"]],
+  ]);
+  const dotted = findDuplicateDeclarations(
+    registry,
+    (name) => name.includes("."),
+  );
+  assertEquals(dotted.map((d) => d.name), ["a.b"]);
+});

--- a/packages/markspec/core/decl/mod.ts
+++ b/packages/markspec/core/decl/mod.ts
@@ -18,7 +18,6 @@ export type {
   TextRecognizer,
 } from "./surfaces.ts";
 export {
-  extractBulletDeclarations,
   extractFenceDeclarations,
   extractInlineDeclarations,
   extractNestedBulletDeclarations,
@@ -30,3 +29,6 @@ export { extractTableDeclarations } from "./table.ts";
 
 export type { BaseScope, RefOps, RefResolution, RootCheck } from "./resolve.ts";
 export { checkSingleRoot, resolveRef } from "./resolve.ts";
+
+export type { DuplicateDeclaration } from "./duplicates.ts";
+export { findDuplicateDeclarations } from "./duplicates.ts";

--- a/packages/markspec/core/decl/surfaces.ts
+++ b/packages/markspec/core/decl/surfaces.ts
@@ -8,7 +8,7 @@
  *   - **fence** — a fenced code block whose info-string a DSL claims
  *     (e.g. ```typl). {@linkcode extractFenceDeclarations}
  *   - **bullet** — a list item whose first paragraph is a declaration.
- *     {@linkcode extractBulletDeclarations}
+ *     {@linkcode extractNestedBulletDeclarations}
  *   - **inline** — a CommonMark code span whose text is a declaration.
  *     {@linkcode extractInlineDeclarations}
  *
@@ -85,22 +85,6 @@ export function extractFenceDeclarations(
 }
 
 /**
- * Walk a body AST and return every bullet-list item whose first paragraph
- * satisfies `matchText`. Recurses through ListNode → ListItemNode.blocks
- * for nested lists. Mixed lists are supported: items whose first paragraph
- * matches are extracted; non-matching bullets are left alone.
- *
- * Returns declarations in source order (depth-first).
- */
-export function extractBulletDeclarations(
-  blocks: readonly BodyBlock[],
-  matchText: TextRecognizer,
-): readonly BlockDeclaration[] {
-  return extractNestedBulletDeclarations(blocks, matchText)
-    .map(({ source, range }) => ({ source, range }));
-}
-
-/**
  * A bullet declaration with its structural parent: the index (into the
  * returned array) of the nearest enclosing extracted declaration, or
  * `undefined` at top level. Parents always precede children in the
@@ -113,10 +97,14 @@ export interface NestedBlockDeclaration extends BlockDeclaration {
 }
 
 /**
- * Nesting-aware variant of {@linkcode extractBulletDeclarations}: same
- * declarations in the same depth-first source order, plus a `parent`
- * link per declaration. A DSL host walks the links to build the
- * {@linkcode BaseScope} chain a nested declaration resolves against.
+ * Walk a body AST and return every bullet-list item whose first paragraph
+ * satisfies `matchText`, in depth-first source order, each with a `parent`
+ * link to its nearest enclosing extracted declaration (or `undefined` at
+ * top level). Recurses through ListNode → ListItemNode.blocks for nested
+ * lists. Mixed lists are supported: items whose first paragraph matches
+ * are extracted; non-matching bullets are left alone. A DSL host walks
+ * the `parent` links to build the {@linkcode BaseScope} chain a nested
+ * declaration resolves against.
  */
 export function extractNestedBulletDeclarations(
   blocks: readonly BodyBlock[],

--- a/packages/markspec/core/decl/surfaces_test.ts
+++ b/packages/markspec/core/decl/surfaces_test.ts
@@ -17,7 +17,6 @@ import type {
 } from "../ast/nodes.ts";
 import type { BodyToken } from "../model/mod.ts";
 import {
-  extractBulletDeclarations,
   extractFenceDeclarations,
   extractInlineDeclarations,
   extractNestedBulletDeclarations,
@@ -118,28 +117,29 @@ Deno.test("extractFenceDeclarations: recurses into list-item children", () => {
   assertEquals(result[0].range, nested.range);
 });
 
-// --- bullet surface --------------------------------------------------------
+// --- bullet surface ----------------------------------------------------
 
 const isAt = (text: string) => text.startsWith("@");
 
-Deno.test("extractBulletDeclarations: empty input → empty result", () => {
-  assertEquals(extractBulletDeclarations([], isAt), []);
+Deno.test("extractNestedBulletDeclarations: empty input → empty result", () => {
+  assertEquals(extractNestedBulletDeclarations([], isAt), []);
 });
 
-Deno.test("extractBulletDeclarations: ignores non-list blocks", () => {
-  assertEquals(extractBulletDeclarations([para("@nope")], isAt), []);
+Deno.test("extractNestedBulletDeclarations: ignores non-list blocks", () => {
+  assertEquals(extractNestedBulletDeclarations([para("@nope")], isAt), []);
 });
 
-Deno.test("extractBulletDeclarations: finds a matching bullet with its range", () => {
+Deno.test("extractNestedBulletDeclarations: finds a matching bullet with its range", () => {
   const p = para("@decl one");
   const blocks: BodyBlock[] = [list([item([p])])];
-  const result = extractBulletDeclarations(blocks, isAt);
+  const result = extractNestedBulletDeclarations(blocks, isAt);
   assertEquals(result.length, 1);
   assertEquals(result[0].source, "@decl one");
   assertEquals(result[0].range, p.range);
+  assertEquals(result[0].parent, undefined);
 });
 
-Deno.test("extractBulletDeclarations: mixed list — only matching items", () => {
+Deno.test("extractNestedBulletDeclarations: mixed list — only matching items", () => {
   const blocks: BodyBlock[] = [
     list([
       item([para("@a")]),
@@ -147,18 +147,18 @@ Deno.test("extractBulletDeclarations: mixed list — only matching items", () =>
       item([para("@b")]),
     ]),
   ];
-  const result = extractBulletDeclarations(blocks, isAt);
+  const result = extractNestedBulletDeclarations(blocks, isAt);
   assertEquals(result.map((r) => r.source), ["@a", "@b"]);
 });
 
-Deno.test("extractBulletDeclarations: recurses into nested list-in-item", () => {
+Deno.test("extractNestedBulletDeclarations: recurses into nested list-in-item", () => {
   const inner = list([item([para("@inner")])]);
   const blocks: BodyBlock[] = [list([item([para("@outer"), inner])])];
-  const result = extractBulletDeclarations(blocks, isAt);
+  const result = extractNestedBulletDeclarations(blocks, isAt);
   assertEquals(result.map((r) => r.source), ["@outer", "@inner"]);
 });
 
-// --- nested bullet surface (parent links) ----------------------------------
+// --- bullet surface: parent links follow nesting ------------------------
 
 const isDecl = (text: string) => text.startsWith("DECL");
 
@@ -187,15 +187,6 @@ Deno.test("extractNestedBulletDeclarations: parent links follow nesting", () => 
   assertEquals(out[1].parent, 0);
   assertEquals(out[2].parent, 1);
   assertEquals(out[3].parent, 0);
-});
-
-Deno.test("extractBulletDeclarations output is unchanged by the delegation", () => {
-  const blocks: BodyBlock[] = [
-    list([item([para("DECL a")]), item([para("DECL b")])]),
-  ];
-  const flat = extractBulletDeclarations(blocks, isDecl);
-  assertEquals(flat.map((d) => d.source), ["DECL a", "DECL b"]);
-  assertEquals("parent" in flat[0], false);
 });
 
 // --- inline surface --------------------------------------------------------

--- a/packages/markspec/core/typl/assemble.ts
+++ b/packages/markspec/core/typl/assemble.ts
@@ -21,7 +21,7 @@
 import type { BodyBlock } from "../ast/nodes.ts";
 import type { BodyToken, Diagnostic } from "../model/mod.ts";
 import type { Binding, Typedef, TyplBlock } from "./ast.ts";
-import { type BaseScope, resolveRef } from "../decl/mod.ts";
+import { type BaseScope, checkSingleRoot, resolveRef } from "../decl/mod.ts";
 import { bridgeTyplDiagnostic } from "./bridge.ts";
 import { typlDiagnostic } from "./diagnostics.ts";
 import { extractTyplFences } from "./fence.ts";
@@ -42,6 +42,34 @@ interface SurfaceBlock {
   readonly bulletParent?: number;
 }
 
+/** One root-candidate namespace binding, for {@linkcode checkSingleRoot}. */
+interface RootCandidate {
+  readonly path: string;
+  readonly blockIndex: number;
+  readonly position: { line: number; column: number };
+}
+
+/**
+ * Assemble one entry's typl declarations into its `Entry.types` block.
+ *
+ * Extracts declarations from the three embedding surfaces (fenced code,
+ * bullet glossary, inline code spans), resolves every relative `$.x` name
+ * against the root/nested-namespace bases in scope (see the module doc's
+ * resolution rules), and aggregates the result.
+ *
+ * @param bodyAst - The entry body's parsed block AST (fence + bullet
+ *   surfaces walk this).
+ * @param bodyTokens - The entry body's flat token stream (the inline
+ *   surface walks this).
+ * @param file - Source file path, for bridging diagnostics back to
+ *   file-relative positions.
+ * @param bodyStartLine - 1-based line the entry body starts on, added to
+ *   each surface's body-relative range to get a file-relative line.
+ * @returns `types` — the assembled `TyplBlock`, omitted when the entry
+ *   declares nothing (no bindings, no typedefs, no root namespace) — plus
+ *   any diagnostics raised during extraction or resolution (TYPL-010,
+ *   TYPL-012, and bridged parse diagnostics).
+ */
 export function assembleTyplTypes(
   bodyAst: readonly BodyBlock[],
   bodyTokens: readonly BodyToken[],
@@ -120,22 +148,42 @@ export function assembleTyplTypes(
   // ── Pass A: find the root ────────────────────────────────────────────
   // Root candidate = an ABSOLUTE namespace binding with no namespace
   // ancestor in its bullet chain (a relative namespace can never be a
-  // root — it needs a base itself). First candidate in source order wins
-  // (order-independent for authors: the root scopes the whole body);
-  // every additional candidate fires TYPL-012 and establishes nothing.
-  let rootPath: string | undefined;
+  // root — it needs a base itself). checkSingleRoot (core/decl) enforces
+  // the one-root invariant; its bare contract also flags zero candidates
+  // as a failure ("no-root"), but an entry with no namespace binding at
+  // all is a normal, error-free shape here — only "multiple-roots"
+  // produces diagnostics, first candidate in source order wins (order-
+  // independent for authors: the root scopes the whole body).
+  const rootCandidates: RootCandidate[] = [];
   for (let i = 0; i < blocks.length; i++) {
     for (const binding of blocks[i].bindings) {
       if (binding.kind !== "namespace") continue;
       if (!TYPL_REF_OPS.isAbsolute(binding.name)) continue;
       if (hasNamespaceAncestor(i)) continue;
-      if (rootPath === undefined) {
-        rootPath = typlPathOf(binding.name);
-      } else {
-        emit("TYPL-012", { first: `$${rootPath}` }, i, binding.position);
-      }
+      rootCandidates.push({
+        path: typlPathOf(binding.name),
+        blockIndex: i,
+        position: binding.position,
+      });
     }
   }
+  const rootCheck = checkSingleRoot(rootCandidates);
+  let rootPath: string | undefined;
+  if (rootCheck.ok) {
+    rootPath = rootCheck.root.path;
+  } else if (rootCheck.reason === "multiple-roots") {
+    rootPath = rootCheck.roots[0].path;
+    for (let k = 1; k < rootCheck.roots.length; k++) {
+      const extra = rootCheck.roots[k];
+      emit(
+        "TYPL-012",
+        { first: `$${rootPath}` },
+        extra.blockIndex,
+        extra.position,
+      );
+    }
+  }
+  // "no-root" → rootPath stays undefined; not an error.
 
   // basePathOfBlock[i] = the base path blocks[i] provides to its bullet
   // subtree, or undefined. One base slot per block: a block with several

--- a/packages/markspec/core/typl/bullet.ts
+++ b/packages/markspec/core/typl/bullet.ts
@@ -6,40 +6,27 @@
  * `type X = …` typedef). A thin wrapper over the shared
  * declaration-surface machinery (core/decl): it supplies typl's text
  * recognizer and re-exports the common declaration node as
- * {@linkcode TyplBulletExtraction}. Mixed lists are supported — matching
- * items are extracted, non-matching bullets are left alone.
+ * {@linkcode TyplNestedBulletExtraction}. Mixed lists are supported —
+ * matching items are extracted, non-matching bullets are left alone.
  *
  * See ADR-019.
  */
 import type { BodyBlock } from "../ast/nodes.ts";
 import {
-  type BlockDeclaration,
-  extractBulletDeclarations,
   extractNestedBulletDeclarations,
   type NestedBlockDeclaration,
 } from "../decl/mod.ts";
 import { isTyplDeclarationText } from "./recognize.ts";
 
-/** A single typl bullet item found inside a body: `{ source, range }`. */
-export type TyplBulletExtraction = BlockDeclaration;
-
-/**
- * Walk a body AST and return every bullet-list item whose first paragraph
- * is a typl declaration, in source order (depth-first, recursing into
- * nested lists). Delegates traversal to {@linkcode extractBulletDeclarations}.
- */
-export function extractTyplBullets(
-  blocks: readonly BodyBlock[],
-): readonly TyplBulletExtraction[] {
-  return extractBulletDeclarations(blocks, isTyplDeclarationText);
-}
-
 /** A typl bullet declaration with its structural parent link (#723). */
 export type TyplNestedBulletExtraction = NestedBlockDeclaration;
 
 /**
- * Nesting-aware variant of {@linkcode extractTyplBullets}: same items in
- * the same order, plus parent links for base-resolution scope chains.
+ * Walk a body AST and return every bullet-list item whose first paragraph
+ * is a typl declaration, in source order (depth-first, recursing into
+ * nested lists), each with a `parent` link for base-resolution scope
+ * chains. Delegates traversal to
+ * {@linkcode extractNestedBulletDeclarations}.
  */
 export function extractTyplBulletsNested(
   blocks: readonly BodyBlock[],

--- a/packages/markspec/core/typl/bullet_test.ts
+++ b/packages/markspec/core/typl/bullet_test.ts
@@ -5,7 +5,7 @@ import type {
   ListNode,
   ParagraphNode,
 } from "../ast/nodes.ts";
-import { extractTyplBullets } from "./bullet.ts";
+import { extractTyplBulletsNested } from "./bullet.ts";
 
 function para(text: string, line = 1): ParagraphNode {
   return {
@@ -41,45 +41,46 @@ function list(items: ListItemNode[], ordered = false): ListNode {
   };
 }
 
-Deno.test("extractTyplBullets: empty input → empty result", () => {
-  assertEquals(extractTyplBullets([]), []);
+Deno.test("extractTyplBulletsNested: empty input → empty result", () => {
+  assertEquals(extractTyplBulletsNested([]), []);
 });
 
-Deno.test("extractTyplBullets: ignores non-list blocks", () => {
+Deno.test("extractTyplBulletsNested: ignores non-list blocks", () => {
   const blocks: BodyBlock[] = [
     para("This is a paragraph, not a list", 1),
   ];
-  assertEquals(extractTyplBullets(blocks), []);
+  assertEquals(extractTyplBulletsNested(blocks), []);
 });
 
-Deno.test("extractTyplBullets: ignores list with no typl-shaped items", () => {
+Deno.test("extractTyplBulletsNested: ignores list with no typl-shaped items", () => {
   const blocks: BodyBlock[] = [
     list([
       item([para("regular bullet 1")]),
       item([para("regular bullet 2")]),
     ]),
   ];
-  assertEquals(extractTyplBullets(blocks), []);
+  assertEquals(extractTyplBulletsNested(blocks), []);
 });
 
-Deno.test("extractTyplBullets: finds typl binding bullet", () => {
+Deno.test("extractTyplBulletsNested: finds typl binding bullet", () => {
   const p = para("$Speed : signal float[0..300]", 5);
   const blocks: BodyBlock[] = [list([item([p])])];
-  const result = extractTyplBullets(blocks);
+  const result = extractTyplBulletsNested(blocks);
   assertEquals(result.length, 1);
   assertEquals(result[0].source, "$Speed : signal float[0..300]");
   assertEquals(result[0].range, p.range);
+  assertEquals(result[0].parent, undefined);
 });
 
-Deno.test("extractTyplBullets: finds typl typedef bullet", () => {
+Deno.test("extractTyplBulletsNested: finds typl typedef bullet", () => {
   const p = para("type Frame = { id: int[0..255] }", 5);
   const blocks: BodyBlock[] = [list([item([p])])];
-  const result = extractTyplBullets(blocks);
+  const result = extractTyplBulletsNested(blocks);
   assertEquals(result.length, 1);
   assertEquals(result[0].source, "type Frame = { id: int[0..255] }");
 });
 
-Deno.test("extractTyplBullets: mixed list — only typl items extracted", () => {
+Deno.test("extractTyplBulletsNested: mixed list — only typl items extracted", () => {
   const p1 = para("regular intro bullet", 3);
   const p2 = para("$A : signal", 4);
   const p3 = para("another regular bullet", 5);
@@ -94,7 +95,7 @@ Deno.test("extractTyplBullets: mixed list — only typl items extracted", () => 
       item([p5]),
     ]),
   ];
-  const result = extractTyplBullets(blocks);
+  const result = extractTyplBulletsNested(blocks);
   assertEquals(result.length, 3);
   assertEquals(result.map((r) => r.source), [
     "$A : signal",
@@ -103,10 +104,11 @@ Deno.test("extractTyplBullets: mixed list — only typl items extracted", () => 
   ]);
 });
 
-Deno.test("extractTyplBullets: recurses into nested list-in-item", () => {
+Deno.test("extractTyplBulletsNested: recurses into nested list-in-item, parent links follow nesting", () => {
   // An item whose first block is a paragraph AND second block is a nested
   // list containing typl bullets — both the outer paragraph (if it matches)
-  // and the nested matching items should be returned.
+  // and the nested matching items should be returned, with the inner one's
+  // `parent` pointing back at the outer one's index.
   const outer = para("$Outer : signal", 3);
   const inner = para("$Inner : event", 5);
   const blocks: BodyBlock[] = [
@@ -114,22 +116,24 @@ Deno.test("extractTyplBullets: recurses into nested list-in-item", () => {
       item([outer, list([item([inner])])]),
     ]),
   ];
-  const result = extractTyplBullets(blocks);
+  const result = extractTyplBulletsNested(blocks);
   assertEquals(result.length, 2);
   assertEquals(result.map((r) => r.source), [
     "$Outer : signal",
     "$Inner : event",
   ]);
+  assertEquals(result[0].parent, undefined);
+  assertEquals(result[1].parent, 0);
 });
 
-Deno.test("extractTyplBullets: ignores `$` not followed by colon (not a binding)", () => {
+Deno.test("extractTyplBulletsNested: ignores `$` not followed by colon (not a binding)", () => {
   const p = para("$Foo is a great name", 3);
   const blocks: BodyBlock[] = [list([item([p])])];
-  assertEquals(extractTyplBullets(blocks), []);
+  assertEquals(extractTyplBulletsNested(blocks), []);
 });
 
-Deno.test("extractTyplBullets: ignores `type` not followed by `=` (not a typedef)", () => {
+Deno.test("extractTyplBulletsNested: ignores `type` not followed by `=` (not a typedef)", () => {
   const p = para("type of error", 3);
   const blocks: BodyBlock[] = [list([item([p])])];
-  assertEquals(extractTyplBullets(blocks), []);
+  assertEquals(extractTyplBulletsNested(blocks), []);
 });

--- a/packages/markspec/core/typl/mod.ts
+++ b/packages/markspec/core/typl/mod.ts
@@ -29,11 +29,8 @@ export { extractTyplFences } from "./fence.ts";
 
 export { bridgeTyplDiagnostic } from "./bridge.ts";
 
-export type {
-  TyplBulletExtraction,
-  TyplNestedBulletExtraction,
-} from "./bullet.ts";
-export { extractTyplBullets, extractTyplBulletsNested } from "./bullet.ts";
+export type { TyplNestedBulletExtraction } from "./bullet.ts";
+export { extractTyplBulletsNested } from "./bullet.ts";
 
 export type { TyplInlineExtraction } from "./inline.ts";
 export { extractTyplInlines } from "./inline.ts";

--- a/packages/markspec/core/typl/resolve.ts
+++ b/packages/markspec/core/typl/resolve.ts
@@ -11,9 +11,15 @@
  */
 import type { RefOps } from "../decl/mod.ts";
 
-/** True for `$.x` / `$.a.b` — a relative published ref. */
+/**
+ * True for `$.x` / `$.a.b` — a relative published ref. The first segment
+ * must start with a letter/underscore (matching `BINDING_RE` in
+ * recognize.ts and {@linkcode isPublishedTyplName}'s first-segment rule);
+ * a digit-leading first segment would be citable here but never
+ * declarable, a permanent dead end (#754).
+ */
 export function isRelativeTyplName(name: string): boolean {
-  return /^\$\.[A-Za-z0-9_]+(?:\.[A-Za-z0-9_]+)*$/.test(name);
+  return /^\$\.[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z0-9_]+)*$/.test(name);
 }
 
 /** True for `$a.b` / `$a.b.c` — an absolute published name (≥2 segments). */

--- a/packages/markspec/core/typl/resolve_test.ts
+++ b/packages/markspec/core/typl/resolve_test.ts
@@ -16,6 +16,16 @@ Deno.test("resolve: name predicates", () => {
   assertEquals(typlPathOf("$powertrain.brake"), "powertrain.brake");
 });
 
+Deno.test("resolve: digit-leading first segment is rejected, matching BINDING_RE (#754)", () => {
+  // A citable name that could never be declared (BINDING_RE requires the
+  // first segment to start with a letter/underscore) is a dead end — the
+  // predicate must reject it too, not just the declaration recognizer.
+  assertEquals(isRelativeTyplName("$.1abc"), false);
+  // A digit-leading segment after the first is unaffected — BINDING_RE
+  // allows it there too.
+  assertEquals(isRelativeTyplName("$.a.1b"), true);
+});
+
 Deno.test("resolve: relative joins innermost base", () => {
   const scope = { base: "powertrain.brake", parent: { base: "powertrain" } };
   const r = resolveRef("$.pedal_position", scope, TYPL_REF_OPS);

--- a/packages/markspec/core/typl/validator.ts
+++ b/packages/markspec/core/typl/validator.ts
@@ -23,7 +23,7 @@
 import type { Diagnostic, Entry } from "../model/mod.ts";
 import type { Binding, Shape } from "./ast.ts";
 import { extractTyplCitations } from "./citations.ts";
-import { resolveRef } from "../decl/mod.ts";
+import { findDuplicateDeclarations, resolveRef } from "../decl/mod.ts";
 import { typlDiagnostic } from "./diagnostics.ts";
 import { buildTypeRegistry, type TypeRegistry } from "./registry.ts";
 import { TYPL_REF_OPS } from "./resolve.ts";
@@ -45,12 +45,13 @@ export function validateTypl(
   // corpus-wide — every declaration after the first is TYPL-009. Plain
   // (entry-local) names have no cross-entry rule: TYPL-002/003 are
   // retired (deprecated, never emitted — see diagnostics.ts).
-  for (const [name, decls] of registry.bindings) {
-    if (decls.length < 2) continue;
-    if (!name.includes(".")) continue;
-    const first = decls[0];
-    for (let i = 1; i < decls.length; i++) {
-      const dup = decls[i];
+  for (
+    const { name, first, duplicates } of findDuplicateDeclarations(
+      registry.bindings,
+      (name) => name.includes("."),
+    )
+  ) {
+    for (const dup of duplicates) {
       const td = typlDiagnostic(
         "TYPL-009",
         {


### PR DESCRIPTION
Closes #754.

## Summary

Follow-up debt from the automated `/review` of PR #749 (typl published/namespaced tier, #723) — the two correctness bugs were fixed directly on that PR; this closes out the six remaining, lower-severity findings.

- **Grammar dead-end**: `isRelativeTyplName`'s first segment allowed a digit-leading name (`$.1abc`) that `BINDING_RE` could never recognize as a declaration — citable but never declarable. Narrowed to match `BINDING_RE`/`isPublishedTyplName`'s existing first-segment rule.
- **`checkSingleRoot` bypass**: `assemble.ts`'s Pass A hand-rolled "first candidate wins, rest are TYPL-012" instead of calling `core/decl`'s `checkSingleRoot`, built for exactly this rule. Now collects root candidates and routes them through it, treating its `no-root` outcome as the normal "no namespace binding" case.
- **TYPL-009 generalization**: extracted a DSL-agnostic `findDuplicateDeclarations` helper in `core/decl/`, replacing the bespoke loop in `validator.ts`. Sets up #726 (uxil, same epic) to reuse it instead of duplicating.
- **Double-validate perf**: `compiler/mod.ts` called `validate()` (which runs `validateTypl` internally) and then called `validateTypl` again just to get `.registry`, discarding its diagnostics. Since #723 added a citation-validation loop to `validateTypl`, this ran the heavier work twice per `compile`/`show`/`context`/`report`/`export`/MCP call. Now calls `buildTypeRegistry` directly for the registry-only need.
- **Dead code**: deleted `extractTyplBullets`/`TyplBulletExtraction` (typl/bullet.ts) and the `extractBulletDeclarations` (flat) it wrapped in `core/decl/surfaces.ts` — both superseded by the nested variant since #723, with zero production callers. Converted their tests to exercise `extractTyplBulletsNested` directly instead, which previously had only indirect coverage via `assemble_test.ts`.
- **Missing doc comment**: added the `/** */` on `assembleTyplTypes`.

## Test plan

- [x] `just build` — 3653 passed, 0 failed, 2 ignored
- [x] New unit tests: digit-leading grammar rejection, `findDuplicateDeclarations`
- [x] Existing `assemble_test.ts` (zero-root / multi-root TYPL-012), `validator_test.ts` (TYPL-009), and `compiler/mod_test.ts` (`typeRegistry`) suites pass unchanged, confirming the refactors are behavior-preserving
- [x] `bullet_test.ts` converted to `extractTyplBulletsNested`, gaining direct parent-link coverage it lacked before

🤖 Generated with [Claude Code](https://claude.com/claude-code)
