### PR TITLE
feat(lsp): align typl hover and completion with the published tier

### DIFF
--- a/docs/guide/typl.md
+++ b/docs/guide/typl.md
@@ -216,10 +216,13 @@ need a flat lookup table.
 
 The MarkSpec LSP provides two typl affordances when you open a Markdown file:
 
-- **Hover** — hovering over a `$Name` token shows its kind, shape, and which
-  entry declared it.
-- **Completion** — inside a `typl` fence or after `$`, the LSP offers names
-  already declared in the workspace as completion candidates.
+- **Hover** — hovering over a `$Name` token shows its kind, shape, and where it
+  is declared. A dotted published name (`$powertrain.brake.pedal_position`)
+  shows its full path and declaring file; a relative `$.name` reference resolves
+  against the entry's root namespace.
+- **Completion** — inside a `typl` fence or after `$`, the LSP offers the
+  workspace's declared names. Inside an entry that declares a root namespace,
+  typing `$.` offers relative shorthands for that namespace's symbols.
 
 Both features require the `markspec lsp` server to be running. In VS Code,
 install the MarkSpec extension — it starts the server automatically.

--- a/packages/markspec/lsp/server.ts
+++ b/packages/markspec/lsp/server.ts
@@ -139,6 +139,7 @@ import {
   dollarNameAtPosition,
   formatTyplHoverContent,
   isDollarNameTrigger,
+  isRelativeDollarTrigger,
 } from "./typl.ts";
 import { buildVersionNotification } from "./version_notification.ts";
 
@@ -1041,7 +1042,17 @@ connection.onCompletion((params): CompletionItem[] | CompletionList => {
   if (isDollarNameTrigger(line)) {
     return time("onCompletion/dollarName", () => {
       const registry = index.getTypeRegistry();
-      const items = buildDollarNameCompletions(registry);
+      // Published tier (#750): scope relative `$.x` shorthands to the
+      // enclosing entry's root namespace, and switch to relative-only
+      // suggestions when the partial is `$.`-led.
+      const enclosing = findEnclosingEntry(
+        index.getEntriesForFile(filePath),
+        params.position.line + 1, // LSP is 0-based; Entry is 1-based.
+      );
+      const items = buildDollarNameCompletions(registry, {
+        rootNamespace: enclosing?.types?.rootNamespace,
+        relative: isRelativeDollarTrigger(line),
+      });
       return items.map((item) => ({
         label: item.label,
         detail: item.detail,
@@ -1175,7 +1186,17 @@ connection.onHover((params) => {
   const dollarName = dollarNameAtPosition(line, params.position.character);
   if (dollarName) {
     const registry = index.getTypeRegistry();
-    const hoverContent = formatTyplHoverContent(dollarName, registry);
+    // Published tier (#750): give hover the enclosing entry so it can
+    // resolve a relative `$.x` against the entry root namespace and mark a
+    // published symbol as declared "in this entry" vs. cited from another.
+    const enclosing = findEnclosingEntry(
+      index.getEntriesForFile(filePath),
+      params.position.line + 1, // LSP is 0-based; Entry is 1-based.
+    );
+    const hoverContent = formatTyplHoverContent(dollarName, registry, {
+      entryDisplayId: enclosing?.displayId,
+      rootNamespace: enclosing?.types?.rootNamespace,
+    });
     if (hoverContent) {
       return { contents: { kind: "markdown", value: hoverContent } };
     }

--- a/packages/markspec/lsp/typl.ts
+++ b/packages/markspec/lsp/typl.ts
@@ -6,92 +6,175 @@
  * references. Consume the corpus TypeRegistry from
  * core/typl/registry.ts.
  *
+ * Published tier (#723/#750): dotted names (`$powertrain.brake.pedal_position`)
+ * are declared exactly once corpus-wide and citable from any entry; relative
+ * refs (`$.pedal_position`) keep the `$` sigil and resolve against the
+ * enclosing entry's root namespace. This module recognizes both token shapes
+ * and resolves relative refs against the entry **root** only (nested-namespace
+ * bases are not persisted per line — see the S5 LSP-alignment design record).
+ *
  * See ADR-019.
  */
-import type { Shape } from "../core/typl/mod.ts";
-import type { TypeRegistry } from "../core/typl/mod.ts";
+import type { RegistryBinding, Shape, TypeRegistry } from "../core/typl/mod.ts";
+import {
+  isPublishedTyplName,
+  isRelativeTyplName,
+  TYPL_REF_OPS,
+} from "../core/typl/mod.ts";
+
+/** Token continuation set for typl refs: identifier chars plus the `.`
+ * segment separator (dotted published paths + relative `$.x`). */
+const TOKEN_CHAR_RE = /[A-Za-z0-9_.]/;
 
 /**
- * Return the `$Name` token at the given column on `line`, or
- * `undefined` when the column lies on whitespace, past the line end,
- * or outside a `$Name` token. The token starts with `$` and continues
- * through `[A-Za-z0-9_]` characters.
+ * Return the typl reference token at the given column on `line`, or
+ * `undefined` when the column lies on whitespace, past the line end, on a
+ * bare `.` separator, or outside a `$`-anchored token.
+ *
+ * A token starts with `$` and continues through `[A-Za-z0-9_.]`, so it spans
+ * dotted published names (`$powertrain.brake.pedal_position`) and the
+ * relative form (`$.pedal_position`). The `$` sigil breaks the left scan, so
+ * a `$` embedded after prose dots still yields just the sigil-led token
+ * (`path.to.$sig` → `$sig`). A trailing dot (a sentence period, or a dangling
+ * separator) is trimmed, and a bare `$` / `$.` returns `undefined`.
  */
 export function dollarNameAtPosition(
   line: string,
   column: number,
 ): string | undefined {
   if (column < 0 || column >= line.length) return undefined;
-  if (/\s/.test(line[column])) return undefined;
+  const ch = line[column];
+  if (/\s/.test(ch)) return undefined;
 
-  // Handle case where cursor is on the `$` itself.
-  if (line[column] === "$") {
-    let e = column + 1;
-    while (e < line.length && /[A-Za-z0-9_]/.test(line[e])) e++;
-    if (e - column < 2) return undefined; // bare `$` with no name
-    return line.slice(column, e);
+  let start: number;
+  let end: number;
+  if (ch === "$") {
+    start = column;
+    end = column + 1;
+    while (end < line.length && TOKEN_CHAR_RE.test(line[end])) end++;
+  } else {
+    // Cursor on a token char. A lone `.` separator is not an anchor — reject
+    // it so the cursor sitting on a sentence period never yields a token.
+    if (!TOKEN_CHAR_RE.test(ch) || ch === ".") return undefined;
+    start = column;
+    while (start > 0 && TOKEN_CHAR_RE.test(line[start - 1])) start--;
+    if (start === 0 || line[start - 1] !== "$") return undefined;
+    start--; // include the `$`
+    end = column + 1;
+    while (end < line.length && TOKEN_CHAR_RE.test(line[end])) end++;
   }
-
-  // Cursor is on an identifier char — scan left for `$`.
-  if (!/[A-Za-z0-9_]/.test(line[column])) return undefined;
-  let start = column;
-  while (start > 0 && /[A-Za-z0-9_]/.test(line[start - 1])) start--;
-  if (start === 0 || line[start - 1] !== "$") return undefined;
-  start--; // include the `$`
-  // Scan right for token end.
-  let end = column + 1;
-  while (end < line.length && /[A-Za-z0-9_]/.test(line[end])) end++;
-  const token = line.slice(start, end);
-  if (token.length < 2) return undefined; // bare `$`
+  // A typl ref never ends in a dot — trim a trailing sentence period or
+  // dangling separator so `$a.b.` in prose resolves to `$a.b`.
+  const token = line.slice(start, end).replace(/\.+$/, "");
+  if (token.length < 2) return undefined; // bare `$` (or `$.` after trim)
   return token;
 }
 
 /**
- * Format the hover content for a `$Name` from the corpus registry.
- * Returns a short Markdown block describing the kind, the shape (if
- * any), and the entries that declare this name.
+ * Context for {@linkcode formatTyplHoverContent}, supplied by the server from
+ * the entry enclosing the cursor.
+ */
+export interface TyplHoverContext {
+  /** Display ID of the enclosing entry — used to mark "declared in this
+   * entry" and to pick the relevant declaration of an entry-local name. */
+  readonly entryDisplayId?: string;
+  /** The enclosing entry's root namespace path (no `$`), when it declares one
+   * — the base a relative `$.x` ref resolves against. */
+  readonly rootNamespace?: string;
+}
+
+/**
+ * Format the hover content for a typl reference from the corpus registry.
  *
- * Returns `undefined` if the name isn't declared anywhere.
+ * Branches by token shape:
+ *
+ *   - **relative `$.x`** — resolved against `context.rootNamespace` (root
+ *     only) and rendered as the published symbol it names; `undefined` when
+ *     no root namespace is in scope (nothing to resolve against).
+ *   - **published `$a.b`** — the declared-once dotted symbol: full path,
+ *     kind, shape, and its declaring entry/file (or "this entry" when the
+ *     cursor is inside the declaring entry).
+ *   - **plain `$Name`** — an entry-local symbol; kind/shape/declaration with
+ *     no cross-entry collision framing (TYPL-002/003 are retired — two
+ *     entries declaring the same plain name are independent symbols).
+ *
+ * Returns `undefined` when the resolved name isn't declared anywhere.
  */
 export function formatTyplHoverContent(
   name: string,
   registry: TypeRegistry,
+  context?: TyplHoverContext,
 ): string | undefined {
-  const decls = registry.bindings.get(name);
-  if (!decls || decls.length === 0) return undefined;
-  const lines: string[] = [];
-  lines.push(`### ${name}`);
-  // Aggregate kinds — usually one, but cross-entry collisions can show
-  // multiple. The validator surfaces TYPL-002/003 separately.
-  const kinds = new Set(decls.map((d) => d.binding.kind));
-  const kindLabel = kinds.size === 1
-    ? [...kinds][0]
-    : `${[...kinds].join(" / ")} (collision)`;
-  lines.push("");
-  lines.push(`**Kind:** ${kindLabel}`);
-  // Show the first declaration's shape; if multiple shapes, note it.
-  const shapes = new Set(
-    decls.map((d) => JSON.stringify(d.binding.shape ?? null)),
-  );
-  if (shapes.size === 1) {
-    const shapeStr = formatShape(decls[0].binding.shape);
-    if (shapeStr) {
-      lines.push(`**Shape:** \`${shapeStr}\``);
-    }
-  } else {
-    lines.push(`**Shape:** _multiple, see TYPL-003_`);
+  // Resolve a relative ref against the entry root (root-only — see module
+  // doc). Absolute names (plain or dotted) are looked up as-is.
+  let lookupName = name;
+  if (isRelativeTyplName(name)) {
+    const root = context?.rootNamespace;
+    if (root === undefined) return undefined;
+    lookupName = TYPL_REF_OPS.join(root, name);
   }
-  // List declaration sites.
-  if (decls.length === 1) {
-    const d = decls[0];
-    lines.push(`**Declared in:** ${d.entryDisplayId} (${d.entryFile})`);
+
+  const decls = registry.bindings.get(lookupName);
+  if (!decls || decls.length === 0) return undefined;
+
+  const published = isPublishedTyplName(lookupName);
+  const primary = pickPrimaryDecl(decls, context?.entryDisplayId);
+
+  const lines: string[] = [`### ${lookupName}`, ""];
+  lines.push(
+    published
+      ? `**Kind:** ${primary.binding.kind} · **Published**`
+      : `**Kind:** ${primary.binding.kind}`,
+  );
+  const shapeStr = formatShape(primary.binding.shape);
+  if (shapeStr) lines.push(`**Shape:** \`${shapeStr}\``);
+
+  if (published) {
+    if (decls.length > 1) {
+      // Declared-once violated (TYPL-009) — surface every declaring site.
+      lines.push(`**Declared ${decls.length} times** (TYPL-009):`);
+      for (const d of decls) {
+        lines.push(`- ${d.entryDisplayId} (${d.entryFile})`);
+      }
+    } else if (
+      context?.entryDisplayId !== undefined &&
+      context.entryDisplayId === primary.entryDisplayId
+    ) {
+      lines.push(`**Declared in this entry** (${primary.entryDisplayId})`);
+    } else {
+      lines.push(
+        `**Declared in:** ${primary.entryDisplayId} (${primary.entryFile})`,
+      );
+    }
+  } else if (decls.length === 1) {
+    lines.push(
+      `**Declared in:** ${primary.entryDisplayId} (${primary.entryFile})`,
+    );
   } else {
-    lines.push(`**Declared in ${decls.length} entries:**`);
+    // Entry-local names have no cross-entry identity — list the independent
+    // declarations without the retired collision framing.
+    lines.push(
+      `**Entry-local** — declared independently in ${decls.length} entries:`,
+    );
     for (const d of decls) {
       lines.push(`- ${d.entryDisplayId} (${d.entryFile})`);
     }
   }
+
   return lines.join("\n");
+}
+
+/** Pick the declaration to feature: the one in the cursor's entry when it
+ * declares the name (entry-local relevance), else the first. */
+function pickPrimaryDecl(
+  decls: readonly RegistryBinding[],
+  entryDisplayId: string | undefined,
+): RegistryBinding {
+  if (entryDisplayId !== undefined) {
+    const own = decls.find((d) => d.entryDisplayId === entryDisplayId);
+    if (own) return own;
+  }
+  return decls[0];
 }
 
 /**
@@ -149,37 +232,94 @@ export interface TyplCompletionItem {
   readonly documentation: string;
 }
 
+/** Options for {@linkcode buildDollarNameCompletions}. */
+export interface DollarCompletionOptions {
+  /** The enclosing entry's root namespace path (no `$`), when it declares
+   * one. Enables relative `$.tail` shorthands for leaves under the root. */
+  readonly rootNamespace?: string;
+  /** `true` when the trigger is a relative partial (`$.` / `$.ped`): offer
+   * only relative shorthands. `false`/absent: flat corpus list plus this
+   * entry's relative shorthands. */
+  readonly relative?: boolean;
+}
+
 /**
- * Build completion items for `$Name` triggers. Returns one item per
- * unique name in the registry. `detail` shows the kind + shape;
- * `documentation` shows where it's declared.
+ * Build completion items for `$Name` triggers.
+ *
+ * - Relative mode (`opts.relative`) offers only `$.tail` shorthands for
+ *   published leaves under the entry's root namespace; empty when the entry
+ *   has no root namespace (a relative ref is illegal without a base).
+ * - Absolute mode offers the flat corpus list — every entry-local and
+ *   published name — plus this entry's `$.tail` shorthands when it declares a
+ *   root namespace.
+ *
+ * `detail` shows kind + shape; `documentation` shows where the name is
+ * declared (or, for a relative shorthand, what it resolves to).
  */
 export function buildDollarNameCompletions(
   registry: TypeRegistry,
+  opts: DollarCompletionOptions = {},
 ): readonly TyplCompletionItem[] {
+  const { rootNamespace, relative = false } = opts;
+  const rootPrefix = rootNamespace !== undefined
+    ? `$${rootNamespace}.`
+    : undefined;
+
+  const relativeShorthands = (): TyplCompletionItem[] => {
+    const out: TyplCompletionItem[] = [];
+    if (rootPrefix === undefined) return out;
+    for (const [name, decls] of registry.bindings) {
+      if (decls.length === 0) continue;
+      if (!name.startsWith(rootPrefix)) continue;
+      const tail = name.slice(rootPrefix.length);
+      out.push({
+        label: `$.${tail}`,
+        detail: detailOf(decls[0]),
+        documentation: `Resolves to ${name}`,
+      });
+    }
+    return out;
+  };
+
+  if (relative) return relativeShorthands();
+
   const items: TyplCompletionItem[] = [];
   for (const [name, decls] of registry.bindings) {
     if (decls.length === 0) continue;
     const first = decls[0];
-    const shape = formatShape(first.binding.shape);
-    const detail = shape
-      ? `${first.binding.kind} ${shape}`
-      : first.binding.kind;
-    const docLine = decls.length === 1
+    const documentation = decls.length === 1
       ? `Declared in ${first.entryDisplayId}`
-      : `Declared in ${decls.length} entries`;
-    items.push({ label: name, detail, documentation: docLine });
+      : name.includes(".")
+      ? `Declared in ${decls.length} entries`
+      : `Entry-local; declared independently in ${decls.length} entries`;
+    items.push({ label: name, detail: detailOf(first), documentation });
   }
+  items.push(...relativeShorthands());
   return items;
+}
+
+/** One-line "kind shape" detail for a binding declaration. */
+function detailOf(rb: RegistryBinding): string {
+  const shape = formatShape(rb.binding.shape);
+  return shape ? `${rb.binding.kind} ${shape}` : rb.binding.kind;
 }
 
 /**
  * Return true when the text before the cursor ends with a `$`-prefixed
- * partial identifier — the trigger for `$Name` completion.
- *
- * Matches `$` optionally followed by word characters (letters, digits,
- * underscore). Preceded by a non-identifier char or at line start.
+ * partial — the trigger for `$Name` completion. Fires on a plain name
+ * (`$Sp`), a bare sigil (`$`), a relative partial (`$.` / `$.ped`), and a
+ * dotted absolute partial (`$a.b`). Preceded by a non-identifier char or at
+ * line start.
  */
 export function isDollarNameTrigger(textBefore: string): boolean {
-  return /(?:^|[^A-Za-z0-9_$])\$[A-Za-z0-9_]*$/.test(textBefore);
+  return /(?:^|[^A-Za-z0-9_$])\$[A-Za-z0-9_.]*$/.test(textBefore);
+}
+
+/**
+ * Return true when the `$`-prefixed partial before the cursor is a relative
+ * ref (begins `$.`) — the discriminator that switches
+ * {@linkcode buildDollarNameCompletions} into relative mode.
+ */
+export function isRelativeDollarTrigger(textBefore: string): boolean {
+  return /(?:^|[^A-Za-z0-9_$])\$\.[A-Za-z0-9_.]*$/.test(textBefore);
 }

--- a/packages/markspec/lsp/typl_test.ts
+++ b/packages/markspec/lsp/typl_test.ts
@@ -1,12 +1,14 @@
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertStringIncludes } from "@std/assert";
 import {
   buildDollarNameCompletions,
   dollarNameAtPosition,
   formatShape,
   formatTyplHoverContent,
   isDollarNameTrigger,
+  isRelativeDollarTrigger,
 } from "./typl.ts";
 import { buildTypeRegistry } from "../core/typl/mod.ts";
+import type { Binding } from "../core/typl/mod.ts";
 import type { Entry } from "../core/model/mod.ts";
 import { makeDisplayId } from "../core/mod.ts";
 
@@ -32,6 +34,26 @@ function entry(
   } as unknown as Entry;
 }
 
+/** A resolved leaf binding as it appears in `entry.types.bindings` — the
+ * name is already fully-qualified (absolute) by the assembler. */
+function binding(
+  name: string,
+  kind: Binding["kind"],
+  shape?: Binding["shape"],
+): Binding {
+  return {
+    statementKind: "binding",
+    name,
+    kind,
+    ...(shape ? { shape } : {}),
+    position: { line: 1, column: 1 },
+  } as Binding;
+}
+
+// ---------------------------------------------------------------------------
+// dollarNameAtPosition
+// ---------------------------------------------------------------------------
+
 Deno.test("dollarNameAtPosition: detects $Name with cursor in middle", () => {
   assertEquals(dollarNameAtPosition("The $Speed value", 5), "$Speed");
   assertEquals(dollarNameAtPosition("The $Speed value", 8), "$Speed");
@@ -49,6 +71,49 @@ Deno.test("dollarNameAtPosition: detects when cursor on the $ itself", () => {
   assertEquals(dollarNameAtPosition("$Speed", 0), "$Speed");
 });
 
+Deno.test("dollarNameAtPosition: spans a dotted published name", () => {
+  const l = "cite `$powertrain.brake.pedal_position` here";
+  const want = "$powertrain.brake.pedal_position";
+  assertEquals(dollarNameAtPosition(l, l.indexOf("$")), want); // on $
+  assertEquals(dollarNameAtPosition(l, l.indexOf("brake")), want); // mid segment
+  assertEquals(dollarNameAtPosition(l, l.indexOf("pedal_position") + 3), want); // last segment
+});
+
+Deno.test("dollarNameAtPosition: spans the relative $.x form", () => {
+  const l = "see $.pedal_position now";
+  assertEquals(dollarNameAtPosition(l, l.indexOf("$")), "$.pedal_position");
+  assertEquals(dollarNameAtPosition(l, l.indexOf("pedal")), "$.pedal_position");
+});
+
+Deno.test("dollarNameAtPosition: trims a trailing sentence period", () => {
+  const l = "ends at $powertrain.brake.";
+  assertEquals(
+    dollarNameAtPosition(l, l.indexOf("brake")),
+    "$powertrain.brake",
+  );
+});
+
+Deno.test("dollarNameAtPosition: cursor on a dot separator returns undefined", () => {
+  assertEquals(dollarNameAtPosition("$a.b", 2), undefined); // the '.'
+});
+
+Deno.test("dollarNameAtPosition: prose dotted path without $ is not a token", () => {
+  assertEquals(dollarNameAtPosition("system.module.init", 8), undefined);
+});
+
+Deno.test("dollarNameAtPosition: $ breaks left-scan across prose dots", () => {
+  const l = "path.to.$sig";
+  assertEquals(dollarNameAtPosition(l, l.indexOf("sig")), "$sig");
+});
+
+Deno.test("dollarNameAtPosition: bare $. returns undefined", () => {
+  assertEquals(dollarNameAtPosition("x $. y", 2), undefined); // on $
+});
+
+// ---------------------------------------------------------------------------
+// formatTyplHoverContent
+// ---------------------------------------------------------------------------
+
 Deno.test("formatTyplHoverContent: returns undefined for unknown name", () => {
   const r = buildTypeRegistry([]);
   assertEquals(formatTyplHoverContent("$Unknown", r), undefined);
@@ -56,13 +121,12 @@ Deno.test("formatTyplHoverContent: returns undefined for unknown name", () => {
 
 Deno.test("formatTyplHoverContent: shows kind, shape, and declaration", () => {
   const e = entry("REQ_0001", "a.md", {
-    bindings: [{
-      statementKind: "binding",
-      name: "$Speed",
-      kind: "signal",
-      shape: { kind: "range", type: "float", min: 0, max: 300 },
-      position: { line: 5, column: 1 },
-    }],
+    bindings: [binding("$Speed", "signal", {
+      kind: "range",
+      type: "float",
+      min: 0,
+      max: 300,
+    })],
     typedefs: [],
   });
   const r = buildTypeRegistry([e]);
@@ -72,7 +136,110 @@ Deno.test("formatTyplHoverContent: shows kind, shape, and declaration", () => {
   assertEquals(content?.includes("float[0..300]"), true);
   assertEquals(content?.includes("REQ_0001"), true);
   assertEquals(content?.includes("a.md"), true);
+  // Entry-local names are not "Published".
+  assertEquals(content?.includes("Published"), false);
 });
+
+Deno.test("formatTyplHoverContent: published symbol shows dotted path + declaring file", () => {
+  const e = entry("ICD_BRK_0010", "icd.md", {
+    rootNamespace: "powertrain.brake",
+    bindings: [binding("$powertrain.brake.pedal_position", "signal", {
+      kind: "range",
+      type: "float",
+      min: 0,
+      max: 100,
+    })],
+    typedefs: [],
+  });
+  const r = buildTypeRegistry([e]);
+  // Hovered from a DIFFERENT entry — cites, does not declare.
+  const content = formatTyplHoverContent(
+    "$powertrain.brake.pedal_position",
+    r,
+    { entryDisplayId: "SWE_0001" },
+  );
+  assertStringIncludes(content!, "$powertrain.brake.pedal_position");
+  assertStringIncludes(content!, "Published");
+  assertStringIncludes(content!, "float[0..100]");
+  assertStringIncludes(content!, "Declared in:");
+  assertStringIncludes(content!, "ICD_BRK_0010");
+  assertStringIncludes(content!, "icd.md");
+});
+
+Deno.test("formatTyplHoverContent: published symbol from declaring entry says 'this entry'", () => {
+  const e = entry("ICD_BRK_0010", "icd.md", {
+    rootNamespace: "powertrain.brake",
+    bindings: [binding("$powertrain.brake.pedal_position", "signal", {
+      kind: "primitive",
+      type: "float",
+    })],
+    typedefs: [],
+  });
+  const r = buildTypeRegistry([e]);
+  const content = formatTyplHoverContent(
+    "$powertrain.brake.pedal_position",
+    r,
+    { entryDisplayId: "ICD_BRK_0010" },
+  );
+  assertStringIncludes(content!, "this entry");
+});
+
+Deno.test("formatTyplHoverContent: relative ref resolves against entry root namespace", () => {
+  const e = entry("ICD_BRK_0010", "icd.md", {
+    rootNamespace: "powertrain.brake",
+    bindings: [binding("$powertrain.brake.pedal_position", "signal", {
+      kind: "range",
+      type: "float",
+      min: 0,
+      max: 100,
+    })],
+    typedefs: [],
+  });
+  const r = buildTypeRegistry([e]);
+  const content = formatTyplHoverContent("$.pedal_position", r, {
+    entryDisplayId: "ICD_BRK_0010",
+    rootNamespace: "powertrain.brake",
+  });
+  assertStringIncludes(content!, "$powertrain.brake.pedal_position");
+  assertStringIncludes(content!, "float[0..100]");
+  assertStringIncludes(content!, "Published");
+});
+
+Deno.test("formatTyplHoverContent: relative ref with no root namespace returns undefined", () => {
+  const r = buildTypeRegistry([]);
+  assertEquals(
+    formatTyplHoverContent("$.pedal_position", r, { entryDisplayId: "X" }),
+    undefined,
+  );
+});
+
+Deno.test("formatTyplHoverContent: entry-local name in two entries has no collision framing", () => {
+  const shape: Binding["shape"] = {
+    kind: "range",
+    type: "float",
+    min: 0,
+    max: 300,
+  };
+  const a = entry("REQ_0001", "a.md", {
+    bindings: [binding("$Speed", "signal", shape)],
+    typedefs: [],
+  });
+  const b = entry("REQ_0002", "b.md", {
+    bindings: [binding("$Speed", "signal", shape)],
+    typedefs: [],
+  });
+  const r = buildTypeRegistry([a, b]);
+  const content = formatTyplHoverContent("$Speed", r);
+  assertStringIncludes(content!, "independently");
+  assertStringIncludes(content!, "REQ_0001");
+  assertStringIncludes(content!, "REQ_0002");
+  assertEquals(content!.includes("collision"), false);
+  assertEquals(content!.includes("TYPL-003"), false);
+});
+
+// ---------------------------------------------------------------------------
+// formatShape
+// ---------------------------------------------------------------------------
 
 Deno.test("formatShape: range / primitive / record / enum / optional", () => {
   assertEquals(formatShape({ kind: "primitive", type: "int" }), "int");
@@ -93,22 +260,15 @@ Deno.test("formatShape: range / primitive / record / enum / optional", () => {
   );
 });
 
+// ---------------------------------------------------------------------------
+// buildDollarNameCompletions
+// ---------------------------------------------------------------------------
+
 Deno.test("buildDollarNameCompletions: one item per registered name", () => {
   const e = entry("REQ_0001", "a.md", {
     bindings: [
-      {
-        statementKind: "binding",
-        name: "$Speed",
-        kind: "signal",
-        shape: { kind: "primitive", type: "float" },
-        position: { line: 1, column: 1 },
-      },
-      {
-        statementKind: "binding",
-        name: "$Brake",
-        kind: "command",
-        position: { line: 2, column: 1 },
-      },
+      binding("$Speed", "signal", { kind: "primitive", type: "float" }),
+      binding("$Brake", "command"),
     ],
     typedefs: [],
   });
@@ -119,13 +279,86 @@ Deno.test("buildDollarNameCompletions: one item per registered name", () => {
   assertEquals(speed?.detail, "signal float");
 });
 
+Deno.test("buildDollarNameCompletions: relative mode offers $.tail scoped to root", () => {
+  const e = entry("ICD_BRK_0010", "icd.md", {
+    rootNamespace: "powertrain.brake",
+    bindings: [
+      binding("$powertrain.brake.pedal_position", "signal", {
+        kind: "primitive",
+        type: "float",
+      }),
+      binding("$powertrain.brake.line_pressure", "signal", {
+        kind: "primitive",
+        type: "float",
+      }),
+    ],
+    typedefs: [],
+  });
+  const r = buildTypeRegistry([e]);
+  const items = buildDollarNameCompletions(r, {
+    rootNamespace: "powertrain.brake",
+    relative: true,
+  });
+  assertEquals(
+    items.map((i) => i.label).sort(),
+    ["$.line_pressure", "$.pedal_position"],
+  );
+  const ped = items.find((i) => i.label === "$.pedal_position");
+  assertStringIncludes(ped!.documentation, "$powertrain.brake.pedal_position");
+});
+
+Deno.test("buildDollarNameCompletions: relative mode with no root is empty", () => {
+  const e = entry("ICD_BRK_0010", "icd.md", {
+    bindings: [binding("$powertrain.brake.pedal_position", "signal")],
+    typedefs: [],
+  });
+  const r = buildTypeRegistry([e]);
+  assertEquals(buildDollarNameCompletions(r, { relative: true }).length, 0);
+});
+
+Deno.test("buildDollarNameCompletions: absolute mode adds relative shorthands", () => {
+  const e = entry("ICD_BRK_0010", "icd.md", {
+    rootNamespace: "powertrain.brake",
+    bindings: [
+      binding("$powertrain.brake.pedal_position", "signal", {
+        kind: "primitive",
+        type: "float",
+      }),
+    ],
+    typedefs: [],
+  });
+  const r = buildTypeRegistry([e]);
+  const labels = buildDollarNameCompletions(r, {
+    rootNamespace: "powertrain.brake",
+  }).map((i) => i.label);
+  assertEquals(labels.includes("$powertrain.brake.pedal_position"), true); // absolute
+  assertEquals(labels.includes("$.pedal_position"), true); // relative shorthand
+});
+
+// ---------------------------------------------------------------------------
+// triggers
+// ---------------------------------------------------------------------------
+
 Deno.test("isDollarNameTrigger: triggers on $ and partial name", () => {
   assertEquals(isDollarNameTrigger("The $Sp"), true);
   assertEquals(isDollarNameTrigger("value $"), true);
   assertEquals(isDollarNameTrigger("$Speed"), true);
 });
 
+Deno.test("isDollarNameTrigger: fires on relative and dotted partials", () => {
+  assertEquals(isDollarNameTrigger("see $."), true);
+  assertEquals(isDollarNameTrigger("see $.ped"), true);
+  assertEquals(isDollarNameTrigger("see $a.b"), true);
+});
+
 Deno.test("isDollarNameTrigger: does not trigger on non-$ context", () => {
   assertEquals(isDollarNameTrigger("Speed"), false);
   assertEquals(isDollarNameTrigger("Satisfies: "), false);
+});
+
+Deno.test("isRelativeDollarTrigger: only for $.-led partials", () => {
+  assertEquals(isRelativeDollarTrigger("see $."), true);
+  assertEquals(isRelativeDollarTrigger("see $.ped"), true);
+  assertEquals(isRelativeDollarTrigger("see $Sp"), false);
+  assertEquals(isRelativeDollarTrigger("value $"), false);
 });


### PR DESCRIPTION
Closes #750.

Follow-up to #723 / PR #749 (published typl tier). The LSP typl layer
(`lsp/typl.ts`, wired into `lsp/server.ts` hover + completion) still assumed the
pre-#749 flat-global registry; this aligns it with the published tier. **No core
change** — the registry already keys published leaves by their fully-qualified
absolute name and carries the entry `rootNamespace`.

## What changed

**Tokenizer — `dollarNameAtPosition`**

- Token grammar widened to span dots, so dotted published names
  (`$powertrain.brake.pedal_position`) and the relative `$.x` form are single
  tokens.
- The `$` sigil breaks the left scan (`path.to.$sig` → `$sig`); a cursor on a
  bare `.` separator returns nothing; a trailing sentence period is trimmed
  (`$a.b.` → `$a.b`); bare `$` / `$.` → nothing.

**Hover — `formatTyplHoverContent(name, registry, context?)`**

- New optional `context` carrying the enclosing entry's display ID + root
  namespace.
- Relative `$.x` resolves against the entry **root** namespace only.
- Published `$a.b` renders full dotted path, kind, shape, and its declaring
  entry/file — or "declared in this entry" when the cursor is inside the
  declaring entry.
- Plain `$Name` drops the retired TYPL-002/003 "collision" framing; two entries
  declaring the same plain name are shown as independent entry-local symbols.

**Completion — `buildDollarNameCompletions` + triggers**

- `$.` (relative) offers `$.tail` shorthands for leaves under the entry root
  namespace; plain `$` offers the flat corpus list **plus** this entry's
  `$.tail` shorthands.
- `isDollarNameTrigger` widened to fire on `$`, `$.`, `$.ped`, `$a.b`; new
  `isRelativeDollarTrigger`.

## Design decisions

- **Root-only relative resolution** (agreed with reporter). Nested-namespace
  bases are not persisted per line, so the LSP resolves a relative `$.x` against
  the entry root only. A `$.x` under a *nested* namespace shows **no** hover
  popup rather than a wrong one — never an incorrect answer. Matches the issue's
  "scoped to the entry's root namespace" wording. Nested-scope reconstruction is
  out of scope.
- Label-only completion insertion kept unchanged (no `textEdit` plumbing), so
  absolute-insert behavior is untouched.

## Tests

27 colocated unit tests in `lsp/typl_test.ts` (tokenizer dotted / relative /
trailing-dot / dot-separator / prose cases; hover published / relative /
entry-local-no-collision / "this entry"; completion relative + absolute
scoping; triggers). Existing tests stay green. Full `just check`: **3669
passed, 0 failed**.

## Noted (out of scope)

`docs/guide/typl.md` still documents TYPL-002/003 as active diagnostics and has
no published-tier section — pre-existing doc debt from #723/#749. This PR only
updated the LSP "Editor support" bullets its own behavior changes; a broader
published-tier guide pass is worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
