### PR TITLE
fix(repo): make install.sh's temp-dir cleanup trap survive under set -u

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -71,9 +71,11 @@ main() {
   echo "Installing markspec $version ($target)" >&2
   echo "  to: $INSTALL_DIR" >&2
 
-  local tmpdir
+  # `tmpdir` is intentionally global (not `local`): the EXIT trap fires at
+  # global scope, so a function-local would be unbound there under `set -u`
+  # and the cleanup would both error and leak the temp dir.
   tmpdir="$(mktemp -d)"
-  trap 'rm -rf "$tmpdir"' EXIT
+  trap 'rm -rf "${tmpdir:-}"' EXIT
 
   curl -fsSL "$url" -o "$tmpdir/$tarball"
   curl -fsSL "$checksum_url" -o "$tmpdir/$tarball.sha256"


### PR DESCRIPTION
## Summary

`install.sh`'s `main()` declares `tmpdir` with `local` and registers an `EXIT` trap that references it (`trap 'rm -rf "$tmpdir"' EXIT`). The trap only actually fires after `main()` returns and the script falls off the end — at which point `tmpdir` has gone out of its local scope. Under `set -eu`, referencing the now-unbound `$tmpdir` aborts the script with `tmpdir: unbound variable`.

In practice this means: **every successful `install.sh` run currently exits non-zero** — the binary is correctly downloaded, verified, and installed, but the script then crashes during its own cleanup trap on the way out.

Fix: drop `local` so `tmpdir` stays in scope through to the trap's firing point, and default-expand it in the trap (`${tmpdir:-}`) as a defensive fallback for any other exit path.

## Test plan

- [x] Reproduced the bug in isolation with a minimal `sh` script mirroring the pattern (old pattern: exits 1 with "unbound variable"; new pattern: exits 0) before writing the fix
- [x] `shellcheck -s sh install.sh` — the same check CI runs (`.github/workflows/ci.yaml`) — stays clean
- [x] `just check` — 3669 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
