### PR TITLE
docs(docs): fix stale and fictional facts across the published guide + model book

### DIFF
--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -879,7 +879,7 @@ markspec profile add <spec>
 
 ```sh
 markspec profile add ./profiles/my-profile
-markspec profile add @driftsys/iso26262
+markspec profile add @acme/compliance-profile
 ```
 
 #### profile publish

--- a/docs/guide/editor-vscode.md
+++ b/docs/guide/editor-vscode.md
@@ -166,7 +166,9 @@ markspec lsp install --editor neovim --binary-path /opt/markspec/bin/markspec
 
 - Confirm the binary is on `PATH`: `markspec --version` in a terminal.
 - Check the MarkSpec output panel (**View → Output → MarkSpec**) for LSP errors.
-- Verify the project has a `project.yaml` — `markspec check` requires one.
+- Confirm the file has MarkSpec entry blocks — diagnostics only appear for files
+  the server recognises (`.md` and supported source files with entry markers or
+  trace attributes).
 
 **"markspec: command not found"**
 

--- a/docs/guide/quickstart.md
+++ b/docs/guide/quickstart.md
@@ -37,18 +37,19 @@ markspec --version
 
 ## Step 2 — Create a project (1 min)
 
-> **Coming soon: `markspec init`**
->
-> A future release will scaffold a project with a single command. For now,
-> create the files by hand — it takes 30 seconds.
-
-Create a project directory and two configuration files:
-
 ```sh
 mkdir my-project && cd my-project
+markspec init
 ```
 
-Create `project.yaml`:
+`markspec init` writes `project.yaml` (minimal project metadata),
+`.markspec.yaml` (activates the bundled default profile), and `markspec.lock`,
+plus editor/agent config for any detected clients. See
+[AI agents and skillset](ai-agents.md#setting-up-a-new-project) for the full
+list of generated files and client-targeting flags.
+
+**Prefer to set it up by hand?** Two files are all you need. Create
+`project.yaml`:
 
 ```yaml
 name: my-project

--- a/docs/guide/recipes/ci.md
+++ b/docs/guide/recipes/ci.md
@@ -109,11 +109,14 @@ Generate a coverage or traceability matrix and upload it as an artifact:
 
 ## Caching the binary
 
-Cache `~/.local/bin/markspec` between runs to avoid downloading on every job:
+Cache `~/.local/bin/markspec` between runs to avoid downloading on every job.
+Bump the version in the cache key whenever you bump `MARKSPEC_VERSION` (or the
+"latest" you're tracking), so the cache invalidates instead of serving a stale
+binary:
 
 ```yaml
 - uses: actions/cache@v4
   with:
     path: ~/.local/bin/markspec
-    key: markspec-${{ runner.os }}-0.6.0
+    key: markspec-${{ runner.os }}-0.10.3
 ```

--- a/docs/guide/recipes/iso26262.md
+++ b/docs/guide/recipes/iso26262.md
@@ -6,31 +6,44 @@ structure, and required label vocabulary.
 
 ## Profile
 
-Activate the bundled compliance profile in `.markspec.yaml`:
+MarkSpec does not bundle a turnkey ISO 26262 / ASPICE profile — declare the
+compliance vocabulary in a **local profile** and point `.markspec.yaml` at it:
 
 ```yaml
 profiles:
-  - "@driftsys/iso26262"
+  - "./profiles/compliance"
 ```
 
-Or declare a local profile that extends it:
+with `profiles/compliance/markspec.yaml` declaring the types below. Each type
+`extends:` a core type and gets a `display-id-pattern`:
 
 ```yaml
-profiles:
-  - "./profiles/my-project"
-```
-
-with `profiles/my-project/markspec.yaml`:
-
-```yaml
-id: "my-project"
+id: "@acme/compliance"
 version: 0.1.0
-extends: "@driftsys/iso26262"
+markspec-schema: "1"
+
+profile:
+  types:
+    system-requirement:
+      extends: Requirement
+      display-id-pattern: "SYS_{n:4d}"
+      traceability:
+        Satisfies:
+          target: [stakeholder]
+    software-requirement:
+      extends: Requirement
+      display-id-pattern: "SRS_{n:4d}"
+      traceability:
+        Satisfies:
+          target: [system-requirement]
+    # … hazard (extends Risk), validation-test/unit-test (extends Test), etc.
 ```
+
+See the [Profile guide](../profiles.md) for the full manifest schema.
 
 ## Entry type vocabulary
 
-The ISO 26262 profile declares the following entry types:
+A complete compliance profile declares entry types along these lines:
 
 | Display-ID prefix | Type                 | Extends           | Level      |
 | ----------------- | -------------------- | ----------------- | ---------- |

--- a/docs/spec/model/profiles.md
+++ b/docs/spec/model/profiles.md
@@ -226,9 +226,14 @@ for the full lexical grammar and validator interaction matrix.
 The optional `profile.discipline-mode:` field declares whether the profile tiers
 requirements by discipline (`tiered`), keeps them flat with discipline derived
 via allocation (`flat`), or doesn't use discipline at all (`none`). When
-omitted, MarkSpec infers the mode from the profile's type graph — see the
-[Slice 5 design spec](../../superpowers/specs/2026-05-25-discipline-mode-flag-and-ux-design.md)
-for the full inference algorithm.
+omitted, MarkSpec infers the mode from the profile's type graph, in order:
+
+1. **`tiered`** — any requirement-shaped type declares `discipline:`.
+2. **`flat`** — the profile declares extended kinds (`profile.kinds:`), extends
+   a core discipline-bearing type (`SoftwareComponent`, `HardwareComponent`,
+   `SoftwareInterface`, `HardwareInterface`, `SoftwareUnit`, `HardwareUnit`), or
+   declares any requirement-shaped type at all (even without `discipline:`).
+3. **`none`** — otherwise; the profile contributes nothing discipline-relevant.
 
 The resolved mode shapes three behaviours today:
 


### PR DESCRIPTION
## Summary

Docs-accuracy sweep — revives and re-verifies an older, unlanded audit (its original branch had drifted 170+ commits behind `main`, so every fact was re-checked against current source rather than reapplied mechanically).

- **quickstart.md** Step 2: lead with `markspec init` (it ships — `ai-agents.md` already documents it) instead of a "coming soon" callout that contradicted it.
- **iso26262.md recipe + cli.md**: `@driftsys/iso26262` doesn't exist anywhere in the codebase (verified via grep across profile loading/tests) — reframed as a schema-valid local compliance profile example, matching `ADR-008`'s manifest structure.
- **iso26262.md recipe**: the "declare labels in `project.yaml` to enable MSL-L010 enforcement" claim is false — `MSL-L010` is an unrelated lockfile-reference code, and no code path enforces entry `Labels:` values against a profile-declared list. Replaced with the real benefit: `profile.labels:` drives known-label semantic highlighting in the LSP (`lsp/semantic_tokens.ts`, `lsp/entry_ranges.ts`).
- **editor-vscode.md** troubleshooting: "`markspec check` requires a `project.yaml`" is only true for bare invocation, not explicit-file invocation — replaced with the actual per-file recognition gate (`isMarkspecFile`/`isDocCommentContext`).
- **ci.md**: bumped the stale cache-key version placeholder (`0.6.0` → `0.10.3`) and noted it must move with the pinned/latest version to avoid serving a stale cached binary.
- **model/profiles.md**: replaced a dead link to an unpublished, gitignored internal design-spec file with the inline discipline-mode inference algorithm (`core/profile/discipline_mode.ts`'s `inferDisciplineMode`) it was pointing at.

## Test plan

- [x] Every fact independently verified against current source (`packages/markspec/core/profile/*`, `core/validator/listing.ts`, `lsp/semantic_tokens.ts`, `lsp/context.ts`, `deno.json` version) — not reapplied from the stale draft
- [x] `just build` — 3670 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
