### PR TITLE
feat(core): federated upstream slice 4 — graph integration + validator

### DIFF
--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -94,6 +94,53 @@ does not constrain which `Labels:` values entries may carry.
   tag or branch name; version-selecting resolution is planned for a future
   release.
 
+#### Upstream entries resolve in the graph
+
+Once `markspec lock` has pinned a `references:` entry, its entries join this
+project's own traceability graph as read-only, origin-tagged citizens — not just
+cached files on disk:
+
+- **Trace links resolve across the repo boundary.** A `Satisfies:` (or any other
+  trace attribute) value that names an upstream display ID resolves exactly like
+  a same-project reference. `check`, `show`, `context`, `dependents`, and
+  `report` all see the upstream entry, tagged with an `Origin:` line / column
+  showing `<upstreamId>@<version>` — see [`show`](#show) and [`report`](#report)
+  below.
+- **`MSL-T014` replaces `MSL-L006`** for a trace value that still doesn't
+  resolve once the project declares any `dependencies:`/`references:`: the
+  warning names every upstream searched, e.g.
+  `not found in project or
+  upstreams: producta, icd`. A project with no
+  declared upstreams keeps the plain `MSL-L006` behavior.
+- **A project entry that reuses an upstream's display ID or `Id:` fails `check`
+  with `MSL-R014`**, naming the colliding upstream origin — the same shape as
+  the collision that fires when a profile
+  [delivers a corpus](profiles.md#delivered-documents) (ADR-030), generalized to
+  cover upstream origins too. Fix it by renaming the project entry; upstream
+  entries are read-only.
+- **`references:` entries are traceability leaves.** `report coverage` never
+  reports one as an orphan or unsatisfied gap — a citation isn't something your
+  own project is expected to cover. `dependencies:` entries participate in
+  coverage like a project entry — but since git dependency acquisition hasn't
+  shipped yet (above), no `dependencies:` entry hydrates into the graph today,
+  so this only takes effect once that lands.
+- **Upstream entries are validation-exempt, not edge-inert.** No structural
+  checks or prose lint run against them — that already happened in their own
+  repo's `check` — but they remain full resolution targets: a project entry's
+  trace link to one still resolves, and so does an edge between two upstream
+  entries once both are hydrated into the same graph.
+
+**Root/program project pattern.** A root or program repository that references
+every member repo aggregates the whole program's graph for free: each member's
+entries hydrate into the root's compile, cross-repo trace edges resolve there,
+and `report`, `dependents`, and `context` run against the entire program from
+the root — both ends of every cross-repo edge are present. A repo referenced
+through more than one path (a diamond — e.g. the root references both a
+component and something that itself references that component) is still counted
+exactly once: an upstream snapshot's own re-exported entries are skipped in
+favor of that entry's authoring repo, so aggregating never double-counts or
+collides.
+
 ### .markspec.yaml
 
 `.markspec.yaml` carries markspec's own tool configuration: profile binding
@@ -271,7 +318,10 @@ reference values:
   `markspec.lock` records the stable `target-ulid`; `fmt` uses it to rewrite the
   stale display ID to the target's new name.
 - **Unresolved references are left as-is** — `markspec check` reports them via
-  MSL-L006.
+  `MSL-L006`, or `MSL-T014` when the project declares `dependencies:`/
+  `references:` (see
+  [Upstream entries resolve in the graph](#upstream-entries-resolve-in-the-graph)
+  above).
 
 Neither action is performed when no `project.yaml` is discoverable (file-local
 invocation). `fmt` reads the edge ledger but never writes `markspec.lock`; the
@@ -315,15 +365,15 @@ gate below over the whole corpus in one pass, merging findings into a single
 diagnostics stream (one text renderer, one `--format json` array, one exit-code
 computation):
 
-| Gate                               | Severity                                     | What it checks                                                                                                                                                                                       |
-| ---------------------------------- | -------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Parse + structure + attributes     | as today                                     | Malformed entry blocks, missing `Id:`, duplicate display IDs, malformed attributes.                                                                                                                  |
-| Traceability (incl. `MSL-L006`)    | as today (`MSL-L006` = warning)              | Broken `Satisfies:`/`Derived-from:`/etc. references; `MSL-L006` flags a trace value that doesn't resolve to any entry.                                                                               |
-| Listing documents                  | as today                                     | Listing-file conventions (e.g. `SUMMARY.md` structure).                                                                                                                                              |
-| Format drift (`MSL-F010`)          | **error**                                    | The file's whitespace/attribute form differs from what `markspec fmt` would produce — i.e. it wasn't formatted before commit.                                                                        |
-| Reference-canon drift (`MSL-F011`) | **error**                                    | A trace value is a ULID or stale display ID that `markspec fmt` would rewrite to its canonical display ID (ADR-026 canonicalization). Distinct from `MSL-F010` so you know which fmt concern to fix. |
-| Lockfile drift (`MSL-L212`)        | **error** (only when `markspec.lock` exists) | Traceability edges have changed since `markspec lock` last ran. Checked offline against the on-disk `markspec.lock` (no network).                                                                    |
-| Prose lint (`MSL-Q*`)              | **advisory warning**                         | The same rules `markspec lint` runs (modal verbs, EARS, passive voice, INCOSE lexicon, …).                                                                                                           |
+| Gate                               | Severity                                     | What it checks                                                                                                                                                                                                                                                                       |
+| ---------------------------------- | -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Parse + structure + attributes     | as today                                     | Malformed entry blocks, missing `Id:`, duplicate display IDs, malformed attributes.                                                                                                                                                                                                  |
+| Traceability (incl. `MSL-L006`)    | as today (`MSL-L006` = warning)              | Broken `Satisfies:`/`Derived-from:`/etc. references; `MSL-L006` flags a trace value that doesn't resolve to any entry — or `MSL-T014` when the project declares `dependencies:`/`references:` (see [Upstream entries resolve in the graph](#upstream-entries-resolve-in-the-graph)). |
+| Listing documents                  | as today                                     | Listing-file conventions (e.g. `SUMMARY.md` structure).                                                                                                                                                                                                                              |
+| Format drift (`MSL-F010`)          | **error**                                    | The file's whitespace/attribute form differs from what `markspec fmt` would produce — i.e. it wasn't formatted before commit.                                                                                                                                                        |
+| Reference-canon drift (`MSL-F011`) | **error**                                    | A trace value is a ULID or stale display ID that `markspec fmt` would rewrite to its canonical display ID (ADR-026 canonicalization). Distinct from `MSL-F010` so you know which fmt concern to fix.                                                                                 |
+| Lockfile drift (`MSL-L212`)        | **error** (only when `markspec.lock` exists) | Traceability edges have changed since `markspec lock` last ran. Checked offline against the on-disk `markspec.lock` (no network).                                                                                                                                                    |
+| Prose lint (`MSL-Q*`)              | **advisory warning**                         | The same rules `markspec lint` runs (modal verbs, EARS, passive voice, INCOSE lexicon, …).                                                                                                                                                                                           |
 
 **`markspec check <file>` (file-local) runs structural validation only.** The
 format-drift, lockfile, and prose-lint gates, and the `MSL-L006` trace-existence
@@ -373,9 +423,11 @@ markspec show --format json STK_PRJ_0001 docs/requirements.md
 ```
 
 When the active profile [delivers a corpus](profiles.md#delivered-documents)
-(ADR-030), an entry injected from that corpus prints an extra `Origin:` line and
-its `Source:` renders as `<profile-id>@<version>:<path>:<line>:<column>` instead
-of a raw filesystem path:
+(ADR-030), or the entry hydrates from a locked `references:` upstream (see
+[Upstream entries resolve in the graph](#upstream-entries-resolve-in-the-graph)),
+the entry prints an extra `Origin:` line and its `Source:` renders as
+`<profile-id-or-upstream-id>@<version>:<path>:<line>:<column>` instead of a raw
+filesystem path:
 
 ```text
 PLT_0001  Platform core service
@@ -483,9 +535,15 @@ markspec report traceability --label ASIL-B "docs/**/*.md"
 ```
 
 The traceability matrix carries an **Origin** column: `project` for a
-project-authored entry, or `<profile-id>@<version>` for an entry injected from a
-profile's delivered corpus (ADR-030). All three formats (`md`, `json`, `csv`)
-include it.
+project-authored entry, or `<profile-id>@<version>` / `<upstream-id>@<version>`
+for an entry injected from a profile's delivered corpus (ADR-030) or a locked
+`references:` upstream (see
+[Upstream entries resolve in the graph](#upstream-entries-resolve-in-the-graph)).
+All three formats (`md`, `json`, `csv`) include it.
+
+The coverage report treats a `references:` upstream entry as a traceability leaf
+— it never appears in the orphan/unsatisfied gap lists, since a citation isn't
+something your own project is expected to cover.
 
 #### export
 
@@ -510,11 +568,14 @@ markspec export csv "docs/**/*.md" > entries.csv
 markspec export yaml "docs/**/*.md"
 ```
 
-All three formats carry provenance (ADR-030): in `json` and `yaml`, corpus
-entries have an `origin: { kind, profileId, profileVersion }` field
-(project-authored entries omit it); in `csv`, every row has an `origin` column
-holding `<profile-id>@<version>` for corpus entries or `project` for
-project-authored ones.
+All three formats carry provenance (ADR-030): in `json` and `yaml`, a corpus
+entry has an `origin: { kind: "profile", profileId, profileVersion }` field and
+a federated-upstream entry (see
+[Upstream entries resolve in the graph](#upstream-entries-resolve-in-the-graph))
+has `origin: { kind: "upstream", upstreamId, version }` (project-authored
+entries omit it); in `csv`, every row has an `origin` column holding
+`<profile-id>@<version>` for corpus entries, `<upstream-id>@<version>` for
+upstream entries, or `project` for project-authored ones.
 
 #### insert
 

--- a/docs/spec/language/language.md
+++ b/docs/spec/language/language.md
@@ -1530,22 +1530,20 @@ carrying an `Id:` attribute.
 
 ### 8.3 Traceability (MSL-T)
 
-| ID         | Severity | Rule                                                                                              |
-| ---------- | -------- | ------------------------------------------------------------------------------------------------- |
-| `MSL-T001` | error    | `Satisfies:` target must resolve to an existing spec entry.                                       |
-| `MSL-T004` | warning  | `Derived-from:` target must resolve to an existing spec entry.                                    |
-| `MSL-T005` | error    | `References:` slug must resolve to an existing reference entry.                                   |
-| `MSL-T006` | error    | `Allocated-to:` target must resolve to an existing element entry.                                 |
-| `MSL-T007` | error    | `Realizes:` target (on elements) must resolve to an existing spec entry.                          |
-| `MSL-T008` | error    | `Verifies:` target (on tests) must resolve to an existing spec entry.                             |
-| `MSL-T009` | error    | `Tests:` target (on tests) must resolve to an existing element entry.                             |
-| `MSL-T010` | error    | `Part-of:` target must resolve to an existing element entry.                                      |
-| `MSL-T011` | error    | `Depends-on:` target must resolve to an existing element entry.                                   |
-| `MSL-T012` | error    | `Supersedes:` target must resolve to an existing same-family entry.                               |
-| `MSL-T013` | tiered   | Link target is non-active: `DRAFT` label=info; `Superseded-by:` set or `Deprecated:` set=warning. |
-
-`MSL-T014` is reserved for a future registry-chain check on `References:`
-(warning severity) when reference resolution via upstream registries lands.
+| ID         | Severity | Rule                                                                                                                                                                                         |
+| ---------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `MSL-T001` | error    | `Satisfies:` target must resolve to an existing spec entry.                                                                                                                                  |
+| `MSL-T004` | warning  | `Derived-from:` target must resolve to an existing spec entry.                                                                                                                               |
+| `MSL-T005` | error    | `References:` slug must resolve to an existing reference entry.                                                                                                                              |
+| `MSL-T006` | error    | `Allocated-to:` target must resolve to an existing element entry.                                                                                                                            |
+| `MSL-T007` | error    | `Realizes:` target (on elements) must resolve to an existing spec entry.                                                                                                                     |
+| `MSL-T008` | error    | `Verifies:` target (on tests) must resolve to an existing spec entry.                                                                                                                        |
+| `MSL-T009` | error    | `Tests:` target (on tests) must resolve to an existing element entry.                                                                                                                        |
+| `MSL-T010` | error    | `Part-of:` target must resolve to an existing element entry.                                                                                                                                 |
+| `MSL-T011` | error    | `Depends-on:` target must resolve to an existing element entry.                                                                                                                              |
+| `MSL-T012` | error    | `Supersedes:` target must resolve to an existing same-family entry.                                                                                                                          |
+| `MSL-T013` | tiered   | Link target is non-active: `DRAFT` label=info; `Superseded-by:` set or `Deprecated:` set=warning.                                                                                            |
+| `MSL-T014` | warning  | Trace target unresolved after upstream federation — the downstream project declares `dependencies:`/`references:`, but the target resolves in neither the project nor any declared upstream. |
 
 Type resolution and per-type attribute validation (spec §1.3, §1.6):
 

--- a/docs/wip/2026-07-04-federated-upstream-slice4-plan.md
+++ b/docs/wip/2026-07-04-federated-upstream-slice4-plan.md
@@ -1,0 +1,721 @@
+# Federated Upstream Resolution — Slice 4: Graph Integration + Validator — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Feed the already-cached upstream entries (slice 1's
+`loadUpstreamCorpus`, slice 2's lockfile rows + cache) into the compiled graph
+at every site, so a downstream `Satisfies:` resolves to an upstream entry; land
+`MSL-T014` for unresolved-after-federation refs; generalize the `MSL-R014`
+collision pass and coverage semantics to upstream origins; and make upstream
+entries read-only, validation-exempt graph citizens.
+
+**Architecture:** Slice 4 of the federated-upstream design
+(`docs/wip/2026-07-04-federated-upstream-resolution-design.md`, §4.6 feed sites,
+§4.7 validator behaviour, §4.8 surface table, §4.9 root/diamond pattern). The
+upstream loader, lockfile rows, and cache all exist; this slice is the WIRING +
+the validator/coverage generalization. Everything upstream entries need to be
+read-only already keys on `Entry.origin`; the gaps are: (a) nothing loads +
+feeds them yet, (b) origin entries are today _downgraded_ not _skipped_ by the
+validator, (c) `MSL-T014` and (d) coverage leaf-semantics don't exist.
+
+**Tech Stack:** Deno/TypeScript strict, `@std/assert`, colocated unit tests,
+blackbox e2e via `tests/e2e/helpers.ts`, Conventional Commits.
+
+## Plan-time scope decisions
+
+- **References are the only upstreams that load in slice 4.** Git
+  `dependencies:` aren't fetched until slice 3, so no dependency cache exists.
+  The feed path filters lockfile `[[upstream.registry]]` rows (slice-2
+  references). The row→ref mapping and coverage classification are built to also
+  accept `[[upstream.dependency]]` rows so slice 3 drops in without a validator
+  change, but slice 4 is tested end-to-end with `file://` references only.
+- **DEFERRED to slice 3** (needs dependency rows from the git fetcher, which
+  slice 4 does not produce — building the gate now would be untestable
+  end-to-end): the §4.4 unreleased-pin advisory + `check --strict` pin-level
+  gate (every `[[upstream.dependency]]` row must be tag-resolved). References
+  are released-by-publication and have no tags, so nothing to gate here.
+- **DEFERRED to slice 5** (per the design slice table): the LSP/MCP user-facing
+  surfaces — completion badges (`— from product@v2.1.0`), hover on upstream
+  entries, go-to-definition no-op, read-only decorations. Slice 4 makes upstream
+  entries _present + resolving + read-only_ at the LSP/MCP feed sites; slice 5
+  polishes the editor UX. (The completion `— from <origin>` badge already exists
+  from ADR-030 and will light up for upstream IDs for free once they enter the
+  index — that's incidental, not the slice-5 work.)
+- **`MSL-T014` severity = warning** (language.md §8.3 reserves it "warning
+  severity"), replacing the L006 warning when upstreams are declared. It does
+  NOT fail `check` on its own (matches L006); `--strict` promotes it like any
+  warning.
+- **Validation-exemption is a SKIP, not a downgrade, for `kind:"upstream"`
+  only.** Delivered corpus (`kind:"profile"`) keeps its existing
+  validate-then-downgrade behaviour (a profile-shipped baseline can carry
+  lint-worthy prose). Upstream entries are another repo's already-validated
+  compile output — never re-validated. They stay in the resolution maps (so refs
+  _to_ them resolve) but are excluded from every per-entry emitting check, and
+  refs _from_ them never fire unresolved-ref diagnostics (§4.7).
+
+## Global Constraints
+
+- **Worktree:** all work in
+  `/Users/sebastientasson/Workspace/driftsys/markspec-worktrees/federated-slice4`
+  (branch `feat/federated-upstream-slice4`, bootstrapped, 9 `grammars/*.wasm`
+  verified). Bash cwd resets between calls — `cd` into the worktree at the start
+  of every Bash call; use absolute paths with file tools.
+- Core stays Node-compatible: no `Deno.*` in `packages/markspec/core/` library
+  code — I/O only via injected callbacks. `Deno.*` is fine in `cli/`, `lsp/`,
+  `mcp/` entry points and tests.
+- Zero warnings from `deno check` / `deno lint` / tests. `deno check` entry
+  points:
+  `deno check packages/markspec/main.ts packages/markspec/core/mod.ts packages/markspec/lsp/server.ts packages/markspec/mcp/server.ts`
+- Format before committing: `deno fmt` (TS); `dprint fmt` for edited `.md`.
+- Conventional Commits, imperative mood. Allowed scopes: auto, repo, ci, spec,
+  core, cli, lsp, mcp, render, book, deck, docs, deps.
+- Commit messages containing backticks: write to a scratch file,
+  `git commit
+  -F <file>`.
+- Determinism preserved: upstream entries are injected AHEAD of project entries
+  (like corpus) so first-entry-wins graph slots resolve deterministically.
+- The authoritative-source rule (in `loadUpstreamCorpus` already) is load-
+  bearing for the root/diamond pattern — never weaken it.
+
+---
+
+### Task 1: `upstreamRefsFromLockfile` mapping helper + `loadProjectUpstreams`
+
+**Files:**
+
+- Create: `packages/markspec/core/upstream/refs.ts` (pure mapping) +
+  `packages/markspec/core/upstream/refs_test.ts`
+- Modify: `packages/markspec/core/mod.ts` (barrel export)
+- Create: a CLI loader in `packages/markspec/cli/helpers.ts` next to
+  `loadProjectCorpus` (`loadProjectUpstreams`)
+
+**Interfaces:**
+
+- Consumes: `Lockfile`, `Upstream`, `UpstreamRegistry`, `UpstreamDependency`
+  from `../lock/model.ts`; `upstreamCacheRoot` from `../lock/upstream_refs.ts`
+  (barrel: `core/mod.ts`); `UpstreamSnapshotRef`, `loadUpstreamCorpus`,
+  `ReadFile` from `./mod.ts` / `../config/mod.ts`.
+- Produces (pure core helper — every feed site uses it):
+
+  ```ts
+  /**
+   * Map a parsed lockfile's snapshot-carrying upstream rows to
+   * UpstreamSnapshotRef[] for loadUpstreamCorpus. Registry + dependency
+   * rows with a `snapshot` are included; rows without a snapshot (legacy
+   * pin-only) are skipped. `version` falls back to `"unversioned"` when the
+   * row has none (UpstreamSnapshotRef.version is required; the loader only
+   * uses it for the origin badge).
+   */
+  export function upstreamRefsFromLockfile(
+    lockfile: Lockfile,
+    projectRoot: string,
+  ): UpstreamSnapshotRef[];
+  ```
+
+  Mapping precedent is `verifyUpstreamCache` (`core/lock/cache_check.ts:40-56`):
+  filter `u.kind === "registry" || u.kind === "dependency"`, skip
+  `u.snapshot === undefined`, `dir = ${upstreamCacheRoot(projectRoot)}/${u.id}`.
+
+- Produces (CLI helper mirroring `loadProjectCorpus`, `cli/helpers.ts`):
+
+  ```ts
+  export interface ProjectUpstreams {
+    readonly entries: Entry[];
+    readonly diagnostics: readonly Diagnostic[];
+  }
+  /** Read markspec.lock, map rows → refs, hydrate via loadUpstreamCorpus.
+   * Returns empty when no lockfile / no snapshot rows. Cold-cache soft-fail:
+   * a missing/corrupt cache surfaces UPSTREAM-SNAPSHOT-00x diagnostics but
+   * never throws (mirrors loadProjectCorpus). */
+  export async function loadProjectUpstreams(
+    projectRoot: string,
+    lockfile: Lockfile | undefined,
+  ): Promise<ProjectUpstreams>;
+  ```
+
+- [ ] **Step 1: Failing tests for the pure mapping** (`refs_test.ts`)
+
+```ts
+import { assertEquals } from "@std/assert";
+import { upstreamRefsFromLockfile } from "./refs.ts";
+import type { Lockfile } from "../lock/mod.ts";
+
+function lf(upstreams: Lockfile["upstreams"]): Lockfile {
+  return {
+    schema: 1,
+    meta: { markspecSchema: 1, lockedAt: "2026-07-04T00:00:00Z" },
+    upstreams,
+    boundEntries: [],
+    edges: [],
+    generatedCache: { edgesHash: "sha256:0", edgesCount: 0 },
+  };
+}
+
+Deno.test("upstreamRefsFromLockfile: registry row → ref with cache dir", () => {
+  const refs = upstreamRefsFromLockfile(
+    lf([{
+      kind: "registry",
+      id: "refhub",
+      api: "https://x",
+      resolvedManifestHash: "sha256:a",
+      markspecSchema: 1,
+      version: "1.4.0",
+      snapshot: "sha256:b",
+      lockedAt: "2026-07-04T00:00:00Z",
+    }]),
+    "/proj",
+  );
+  assertEquals(refs, [{
+    id: "refhub",
+    version: "1.4.0",
+    dir: "/proj/.markspec/cache/upstreams/refhub",
+  }]);
+});
+
+Deno.test("upstreamRefsFromLockfile: snapshot-less row is skipped", () => {
+  const refs = upstreamRefsFromLockfile(
+    lf([{
+      kind: "registry",
+      id: "old",
+      api: "https://x",
+      resolvedManifestHash: "sha256:a",
+      markspecSchema: 1,
+    }]),
+    "/proj",
+  );
+  assertEquals(refs, []);
+});
+
+Deno.test("upstreamRefsFromLockfile: version falls back to 'unversioned'", () => {
+  const refs = upstreamRefsFromLockfile(
+    lf([{
+      kind: "registry",
+      id: "refhub",
+      api: "https://x",
+      resolvedManifestHash: "sha256:a",
+      markspecSchema: 1,
+      snapshot: "sha256:b",
+      lockedAt: "2026-07-04T00:00:00Z",
+    }]),
+    "/proj",
+  );
+  assertEquals(refs[0].version, "unversioned");
+});
+
+Deno.test("upstreamRefsFromLockfile: reference/profile (non-snapshot) rows skipped", () => {
+  const refs = upstreamRefsFromLockfile(
+    lf([
+      { kind: "reference", slug: "ISO", id: "urn:iso" },
+      {
+        kind: "profile",
+        id: "p",
+        specifier: "npm:x",
+        resolved: "1",
+        hash: "sha256:z",
+      },
+    ]),
+    "/proj",
+  );
+  assertEquals(refs, []);
+});
+```
+
+(Confirm the exact `Lockfile`/row field names against `core/lock/model.ts`
+before finalizing the fixture — mirror the real interfaces.)
+
+- [ ] **Step 2: Run to verify failure**
+
+`deno test packages/markspec/core/upstream/refs_test.ts --allow-read` → FAIL
+(module not found).
+
+- [ ] **Step 3: Implement `core/upstream/refs.ts`**
+
+```ts
+/**
+ * @module upstream/refs
+ *
+ * Map a parsed markspec.lock's snapshot-carrying upstream rows to the
+ * UpstreamSnapshotRef[] loadUpstreamCorpus consumes. Pure — no I/O.
+ */
+
+import type { Lockfile } from "../lock/model.ts";
+import { upstreamCacheRoot } from "../lock/upstream_refs.ts";
+import type { UpstreamSnapshotRef } from "./mod.ts";
+
+/** Fallback version label when a registry row carries no `version`. */
+const UNVERSIONED = "unversioned";
+
+/** See module doc. */
+export function upstreamRefsFromLockfile(
+  lockfile: Lockfile,
+  projectRoot: string,
+): UpstreamSnapshotRef[] {
+  const cacheRoot = upstreamCacheRoot(projectRoot);
+  const refs: UpstreamSnapshotRef[] = [];
+  for (const u of lockfile.upstreams) {
+    if (u.kind !== "registry" && u.kind !== "dependency") continue;
+    if (u.snapshot === undefined) continue;
+    refs.push({
+      id: u.id,
+      version: ("version" in u && u.version) ? u.version : UNVERSIONED,
+      dir: `${cacheRoot}/${u.id}`,
+    });
+  }
+  return refs;
+}
+```
+
+(`UpstreamDependency` has no `version` field — the `"version" in u` guard
+handles that; a dependency's version label comes later in slice 3. Adjust to the
+real row shapes.)
+
+Export `upstreamRefsFromLockfile` from `core/mod.ts` next to
+`loadUpstreamCorpus`.
+
+- [ ] **Step 4: Implement `loadProjectUpstreams` in `cli/helpers.ts`**
+
+Beside `loadProjectCorpus` (lines ~253-268). Reads via `Deno.readTextFile`
+(entry point — Deno OK), maps rows→refs, calls `loadUpstreamCorpus`:
+
+```ts
+export interface ProjectUpstreams {
+  readonly entries: Entry[];
+  readonly diagnostics: readonly Diagnostic[];
+}
+
+/** Hydrate locked upstream snapshots into read-only Entry[]. Empty when no
+ * lockfile or no snapshot rows; cold-cache failures surface as diagnostics,
+ * never throw (mirrors loadProjectCorpus). */
+export async function loadProjectUpstreams(
+  projectRoot: string,
+  lockfile: Lockfile | undefined,
+): Promise<ProjectUpstreams> {
+  if (!lockfile) return { entries: [], diagnostics: [] };
+  const refs = upstreamRefsFromLockfile(lockfile, projectRoot);
+  if (refs.length === 0) return { entries: [], diagnostics: [] };
+  const result = await loadUpstreamCorpus(
+    refs,
+    (p) => Deno.readTextFile(p).then((t) => t).catch(() => undefined),
+  );
+  return { entries: result.entries, diagnostics: result.diagnostics };
+}
+```
+
+(Import `upstreamRefsFromLockfile`, `loadUpstreamCorpus`, `parseLockfile`,
+`Lockfile` from `core/mod.ts`. Match the file's existing `readFile` helper if it
+already defines one.)
+
+- [ ] **Step 5: Run + commit**
+
+```bash
+deno test packages/markspec/core/upstream/ --allow-read
+deno check packages/markspec/main.ts packages/markspec/core/mod.ts
+deno fmt packages/markspec/core/ packages/markspec/cli/helpers.ts
+git add -A packages/markspec/core/ packages/markspec/cli/helpers.ts
+git commit -m "feat(core): map lockfile upstream rows to snapshot refs; loadProjectUpstreams helper"
+```
+
+### Task 2: Feed upstream entries into `compile()` (compiler + compileProject)
+
+**Files:**
+
+- Modify: `packages/markspec/core/compiler/mod.ts` (`compile` — accept upstream
+  entries; extend the Phase-5 corpus-post-pass predicate)
+- Modify: `packages/markspec/cli/helpers.ts` (`compileProject` — load + pass
+  upstream entries)
+- Test: `packages/markspec/core/compiler/mod_test.ts` (extend)
+
+**Interfaces:**
+
+- The cleanest wiring: `compile()` gains no new option — upstream entries are
+  merged into the SAME "injected ahead" bucket as corpus. Change
+  `compileProject` to concatenate corpus + upstream entries and pass them as
+  `corpusEntries` (they are all origin-carrying, read-only, injected-ahead). BUT
+  the Phase-5 post-pass guard is `if (options.corpusEntries && length > 0)` —
+  that still fires because the merged bucket is non-empty. So **no compiler
+  signature change is needed**; `compileProject` merges the two lists. This
+  keeps the change minimal and the origin-generic post-pass covers upstream.
+- Verify the Phase-5 `detectCorpusCollisions(allEntries)` (compiler/mod.ts ~377)
+  sees upstream entries → R014 works (Task 6 refines the message).
+
+- [ ] **Step 1: Failing compiler test** — a compile with an upstream-origin
+      entry in `corpusEntries` resolves a project `Satisfies:` to it and does
+      NOT produce a broken-ref/unresolved diagnostic; the upstream entry appears
+      in `result.entries`. (Follow `mod_test.ts`'s existing `compile` fixture;
+      build an upstream entry via `parseFile` + stamped
+      `origin: {kind:"upstream",…}`.)
+
+- [ ] **Step 2-3: Run red → wire `compileProject`**
+
+In `cli/helpers.ts` `compileProject` (lines ~294-315): after
+`loadProjectCorpus`, also `loadProjectUpstreams(projectRoot, lockfile)` (read
+the lockfile once via `parseLockfile` — `compileProject` needs `projectRoot`;
+confirm it's in scope, else discover it), then pass
+`corpusEntries: [...corpus.entries, ...upstreams.entries]` and prepend
+`upstreams.diagnostics` to `result.diagnostics` like corpus. Upstream load is
+soft-fail (never `Deno.exit`, unlike corpus's fatal path — a stale cache
+shouldn't kill `show`).
+
+- [ ] **Step 4-5: Run compiler + a CLI e2e smoke, commit**
+
+```bash
+deno test packages/markspec/core/compiler/ --allow-read --allow-env
+deno check packages/markspec/main.ts packages/markspec/core/mod.ts
+deno fmt packages/markspec/
+git add -A packages/markspec/
+git commit -m "feat(core): feed locked upstream entries into compile via compileProject"
+```
+
+### Task 3: Upstream entries are validation-exempt (skip, not downgrade)
+
+**Files:**
+
+- Modify: `packages/markspec/core/validator/mod.ts` (`validate` structural +
+  `checkReferences` T005/T012 — skip `kind:"upstream"` emitters)
+- Modify: `packages/markspec/core/validator/pipeline.ts` (Stages 1.5-4 per-
+  entry loops — skip upstream emitters; KEEP upstream in the resolution maps)
+- Modify: `packages/markspec/core/lint/runner.ts` (already skips `entry.origin`
+  — verify upstream covered; it is, since it keys on any origin)
+- Add: a shared `isUpstreamEntry(entry): boolean` predicate (in
+  `core/model/mod.ts` next to the origin helpers)
+- Test: `packages/markspec/core/validator/mod_test.ts`, `pipeline_test.ts`
+  (extend)
+
+**Interfaces:**
+
+- Produces: `export function isUpstreamEntry(entry: Entry): boolean` →
+  `entry.origin?.kind === "upstream"`.
+- Behaviour: per-entry EMITTING loops (structural checks, T005/T012, Stage 1.5-3
+  attribute checks, Stage 4 trace) `continue` when `isUpstreamEntry`. The
+  resolution maps (`graph`, `byDisplayId` in pipeline.ts:163-172;
+  `byDisplayId`/`byId` in mod.ts checkReferences) are built over ALL entries
+  INCLUDING upstream — so refs TO upstream resolve, refs FROM upstream are never
+  checked (their entry is skipped before the per-entry loop).
+- Delivered corpus (`kind:"profile"`) is UNCHANGED — still validated then
+  downgraded. Only `kind:"upstream"` is skipped. (Rationale in scope decisions.)
+
+- [ ] **Step 1: Failing tests** — (a) an upstream entry with deliberately
+      malformed prose / a missing required attribute produces NO diagnostic; (b)
+      an upstream entry whose `Satisfies:` points at a nonexistent ID produces
+      NO L006/broken-ref (refs from upstream are inert); (c) a PROJECT entry
+      whose `Satisfies:` points at an upstream ID resolves cleanly (upstream
+      still in the maps). Add to `pipeline_test.ts` / `mod_test.ts`.
+
+- [ ] **Step 2-3: Run red → implement**
+
+Add `isUpstreamEntry` to `core/model/mod.ts`. In each per-entry emitting loop,
+add `if (isUpstreamEntry(entry)) continue;` — but build the resolution maps
+BEFORE/independently of the skip so upstream stays a resolution target. Audit
+every loop the research named: `validate()` structural (`mod.ts`),
+`checkReferences` (`mod.ts:434`), pipeline Stages 1.5-3 + Stage 4
+(`pipeline.ts`). Do NOT skip in the map-building loops.
+
+- [ ] **Step 4-5: Run validator suites, full type-check, commit**
+
+```bash
+deno test packages/markspec/core/validator/ packages/markspec/core/lint/ --allow-read --allow-env
+deno check packages/markspec/main.ts packages/markspec/core/mod.ts packages/markspec/lsp/server.ts packages/markspec/mcp/server.ts
+deno fmt packages/markspec/core/
+git add -A packages/markspec/core/
+git commit -m "feat(core): upstream entries are validation-exempt but stay resolution targets"
+```
+
+### Task 4: Feed upstream entries into `check` (runPipeline path)
+
+**Files:**
+
+- Modify: `packages/markspec/cli/commands/check.ts` (push upstream entries into
+  `allEntries`; thread declared upstream ids for Task 5)
+- Test: `tests/e2e/check_project_test.ts` or a new e2e (a project-wide check
+  resolving a cross-file upstream Satisfies) — the real proof is Task 10's e2e
+
+**Interfaces:**
+
+- `check` already reads the lockfile + `cacheRoot` (check.ts:178-181) for drift
+  gates. Reuse `lockParse.lockfile` →
+  `loadProjectUpstreams(projectRoot,
+  lockParse.lockfile)`;
+  `allEntries.push(...upstreams.entries)` at line ~89 (after corpus). Prepend
+  upstream diagnostics to the merged set.
+- Project-wide only (like corpus): file-local `check <file>` does not load
+  upstreams.
+
+- [ ] Steps: failing e2e (project entry Satisfies an upstream ID → check exits
+      0, no L006) → wire → run
+      `deno test tests/e2e/check_project_test.ts
+  --allow-read --allow-write --allow-run --allow-env --allow-ffi --allow-net`
+      → commit
+      `feat(cli): check resolves trace targets against locked upstreams`.
+
+### Task 5: `MSL-T014` — unresolved-after-federation ref
+
+**Files:**
+
+- Modify: `packages/markspec/core/validator/traceability.ts` (emit T014 vs L006
+  based on a new "declared upstreams" input)
+- Modify: `packages/markspec/core/validator/pipeline.ts` (`PipelineOptions`
+  gains `declaredUpstreamIds?: readonly string[]`; thread to
+  `validateTraceabilityForEntry`)
+- Modify: `packages/markspec/cli/commands/check.ts` (derive declared upstream
+  ids from `config.dependencies`+`config.references` via `deriveUpstreamId`,
+  pass into `runPipeline`)
+- Modify: `packages/markspec/lsp/workspace.ts` (`validateAll` — pass declared
+  upstream ids; the LSP has config? — if not, pass `[]`, T014 only fires in
+  check; confirm)
+- Modify: `docs/spec/language/language.md` §8.3 (T014 reservation → active row)
+- Test: `packages/markspec/core/validator/traceability_test.ts`
+
+**Interfaces:**
+
+- `validateTraceabilityForEntry(entry, profile, graph, byDisplayId,
+  declaredUpstreamIds?: readonly string[])`.
+  At the L006 emit site (traceability.ts:148-163): when `declaredUpstreamIds` is
+  non-empty AND the target is unresolved (and not a URI scheme), emit `MSL-T014`
+  (warning) with message:
+  `` `${entry.displayId}: link '${linkName}' target '${v}' not found in project or upstreams: ${declaredUpstreamIds.join(", ")}` ``
+  instead of L006. When `declaredUpstreamIds` is empty, keep L006 unchanged.
+- T014 is scope-gated the same way L006 is (project-wide only).
+
+- [ ] **Step 1: Failing tests** — (a) no upstreams declared + unresolved ref →
+      L006 (unchanged); (b) upstreams declared + unresolved ref → T014 (warning)
+      with the searched-set message, NO L006; (c) upstreams declared + ref
+      resolves to an upstream entry → neither. Add to `traceability_test.ts`.
+
+- [ ] **Step 2-4: red → implement → language.md row → run**
+
+Move the language.md §8.3 T014 line from "reserved" prose to an active table row
+(`MSL-T014 | warning | trace target unresolved after upstream federation`).
+`dprint fmt` the doc.
+
+- [ ] **Step 5: Commit**
+      `feat(core): MSL-T014 for refs unresolved after upstream federation`.
+
+### Task 6: Generalize the R014 collision message to name origins
+
+**Files:**
+
+- Modify: `packages/markspec/core/validator/corpus.ts` (R014 message text →
+  origin-generic; keep the mechanism)
+- Test: `packages/markspec/core/validator/corpus_test.ts` (add `kind:"upstream"`
+  collision cases)
+
+**Interfaces:**
+
+- The detection already generalizes (keys on `e.origin`/`sameOriginSource`).
+  Only the MESSAGE is corpus-specific ("delivered corpus entries are
+  read-only"). Refine to name the origin generically and the remedy:
+  project↔upstream:
+  `` `display ID '${e.displayId}' is already provided by
+  ${formatEntryOrigin(owner.origin!)}; rename this entry — upstream and corpus
+  entries are read-only` ``.
+  For upstream↔upstream / upstream↔corpus, name both origins. Keep the
+  `'${token}'` single-quote contract that `attributeCorpusDiagnostics` keys on
+  for suppression.
+
+- [ ] Steps: failing tests (project entry colliding with an upstream ID → R014
+      naming `<upstreamId>@<version>`; two upstreams declaring the same ID →
+      R014 naming both) → refine message → run
+      `deno test
+  packages/markspec/core/validator/ --allow-read --allow-env` →
+      commit
+      `feat(core): generalize MSL-R014 collision message to upstream origins`.
+
+### Task 7: Coverage leaf-semantics for references
+
+**Files:**
+
+- Modify: `packages/markspec/core/reporter/mod.ts` (`computeCoverage` —
+  reference-origin entries are leaves)
+- Modify: `packages/markspec/cli/commands/report.ts` (pass the dep/ref
+  classification down)
+- Test: `packages/markspec/core/reporter/mod_test.ts`
+
+**Interfaces:**
+
+- `computeCoverage(result, entries, opts?: { dependencyUpstreamIds?:
+  ReadonlySet<string> })`.
+  Rule: an entry with `origin.kind === "upstream"` whose `upstreamId` is NOT in
+  `dependencyUpstreamIds` (i.e. a reference) is a LEAF — excluded from `orphans`
+  (no coverage expectation) and from `unsatisfied`. An upstream entry whose id
+  IS a declared dependency participates like a project entry (this path is inert
+  in slice 4 — no dependency entries load yet — but the mechanism is present +
+  unit-tested via a hand-built dependency-origin entry). Project + corpus
+  entries: unchanged.
+- `report.ts` builds `dependencyUpstreamIds` from `config.dependencies` via
+  `deriveUpstreamId`.
+
+- [ ] Steps: failing tests (a reference-origin entry with no `Satisfies:` is NOT
+      reported as an orphan; a reference-origin typed entry is NOT reported as
+      unsatisfied; a dependency-origin entry with no coverage IS reported) →
+      implement → run → commit
+      `feat(core): references are coverage leaves; dependencies participate`.
+
+### Task 8: LSP `seedUpstreamCorpus` + read-only guards
+
+**Files:**
+
+- Modify: `packages/markspec/lsp/server.ts` (add `seedUpstreamCorpus()`; call
+  beside `seedDeliveredCorpus()` at onInitialized + reloadProfile; add upstream
+  file paths to the read-only guard set; thread declared upstream ids to
+  `validateAll`)
+- Modify: `packages/markspec/lsp/workspace.ts` if `validateAll` needs the
+  declared-upstream-ids param (Task 5)
+
+**Interfaces:**
+
+- `seedUpstreamCorpus()` mirrors `seedDeliveredCorpus` (server.ts:237-268): drop
+  previously-seeded upstream files,
+  `upstreamRefsFromLockfile(lockfile,
+  projectRoot)` (lockfile already loaded
+  at server.ts:578-597), `loadUpstreamCorpus`, group entries by `location.file`,
+  `index.updateFile` each, and add each file path to `corpusFilePaths` (the
+  existing read-only guard set — reuse it; the guards at server.ts
+  336/346/819/854/869/1403/1485 then cover upstream files for free). Cold-cache
+  soft-fail like the delivered version.
+- Call order: seed delivered corpus, then upstream, then the project walk (so
+  origin entries win first-entry-wins).
+- Re-seed on lockfile change: register a watcher for `markspec.lock` (beside the
+  profile-file watcher at server.ts) OR re-seed in `reloadProfile`. Minimal:
+  re-seed upstream in `onInitialized` + when `markspec.lock` changes (add it to
+  the existing `DidChangeWatchedFiles` glob list).
+
+- [ ] Steps: this is LSP wiring — verify via `deno check` + a focused
+      `lsp/workspace` unit test if practical (the real proof is that upstream
+      IDs resolve in diagnostics, exercised by Task 10's CLI e2e which shares
+      the validator path). Run the full type-check +
+      `deno test packages/markspec/lsp/
+  --allow-read --allow-env`. Commit
+      `feat(lsp): seed locked upstream corpus as read-only graph citizens`.
+
+### Task 9: MCP `runCompile` upstream feeding
+
+**Files:**
+
+- Modify: `packages/markspec/mcp/project.ts` (`runCompile` — read lockfile, load
+  upstreams, feed into `compile`; add lockfile staleness to `isStale`)
+- Test: `packages/markspec/mcp/project_test.ts` (extend)
+
+**Interfaces:**
+
+- MCP has no lockfile access today. In `runCompile` (mcp/project.ts:381-455):
+  `const lockRaw = await env.readFile(join(projectRoot, "markspec.lock"));`
+  `const lockfile = lockRaw ? parseLockfile(lockRaw).lockfile : undefined;` then
+  load upstreams (via `upstreamRefsFromLockfile` + `loadUpstreamCorpus` with
+  `env.readFile`) and pass
+  `corpusEntries: [...corpus.entries,
+  ...upstream.entries]`. Add
+  `markspec.lock` mtime to `isStale` (project.ts:470-497) so a re-lock
+  invalidates the MCP cache.
+
+- [ ] Steps: failing test (MCP `entry_show` on an upstream ID returns it via the
+      compile cache) → wire → run
+      `deno test packages/markspec/mcp/ --allow-read
+  --allow-env` → commit
+      `feat(mcp): feed locked upstream corpus into the compile cache`.
+
+### Task 10: E2E — cross-repo resolution + root/diamond
+
+**Files:**
+
+- Modify/extend: `tests/e2e/federated_lock_test.ts` OR new
+  `tests/e2e/federated_resolve_test.ts`
+
+**Interfaces:** blackbox CLI only. Build on the slice-2 `file://` fixture
+(`toFileUrl(join(dir,"api"))`).
+
+- [ ] **Step 1: Scenarios**
+
+1. **Cross-repo Satisfies resolves:** A compiles to `api/` with `[SYS_0001]`; B
+   declares `references:` at A and authors `[SWE_0001]` with
+   `Satisfies:
+   SYS_0001`. `markspec lock` in B, then `markspec check` in B →
+   exit 0, NO MSL-L006/T014 for `SYS_0001`.
+2. **Broken upstream ID → T014:** B authors `Satisfies: SYS_9999` (nonexistent
+   in A). `check` → the ref reports `MSL-T014` (not L006) with `producta` in the
+   message.
+3. **Colliding ID → R014:** B authors its own `[SYS_0001]` (same ID A delivers).
+   `check` → `MSL-R014` naming the upstream origin.
+4. **Reference is a coverage leaf:** `markspec report coverage` in B → A's
+   `[SYS_0001]` is NOT listed as an orphan/uncovered (it's an upstream leaf);
+   B's own entries are.
+5. **Upstream entry appears with origin:** `markspec show SYS_0001` in B →
+   works, `Origin: producta@…`; `markspec report matrix` shows the origin
+   column.
+6. **Root/diamond (§4.9):** three projects — B and C both compile to `api/`;
+   ROOT declares `references:` at both B and C; C also references B (diamond).
+   Compile ROOT → assert: no duplicate/collision diagnostic for B's entries
+   (authoritative-source rule — C's snapshot re-exports B's entries with origin,
+   which `loadUpstreamCorpus` skips); a C→B cross-repo edge resolves in ROOT's
+   matrix; `dependents` at ROOT crosses the repo boundary; ROOT's published
+   `/api/` entry count = B-authored + C-authored + ROOT-authored.
+
+- [ ] **Step 2-3: Run + commit**
+
+```bash
+deno test tests/e2e/federated_resolve_test.ts --allow-read --allow-write --allow-run --allow-env --allow-ffi --allow-net
+deno test tests/e2e/ --allow-read --allow-write --allow-run --allow-env --allow-ffi --allow-net
+```
+
+If a scenario reveals a real bug, STOP and report — do not weaken the test.
+Commit
+`test(cli): cross-repo resolution, T014, R014, coverage, and root/diamond e2e`.
+
+### Task 11: Docs + full gate
+
+**Files:**
+
+- Modify: `docs/guide/cli.md` (the `references:` section: entries now resolve in
+  the graph; `report`/`show`/`context`/`dependents` see upstream entries; T014
+  vs L006; coverage-leaf note). `docs/spec/language/language.md` §8.3 T014 row
+  was done in Task 5 — verify.
+- The ADR + full language.md §3.2/compile-output rewrites stay slice 6.
+
+- [ ] Steps: edit guide, `dprint fmt`, then the full gate:
+
+```bash
+just fmt
+just build
+deno fmt --check && dprint check
+```
+
+Everything green. Commit
+`docs(docs): guide reflects upstream entries resolving in the graph`.
+
+### Task 12: PR
+
+- [ ] **Step 1: Push + PR** (write body to scratch, backtick-safe)
+
+```bash
+cd /Users/sebastientasson/Workspace/driftsys/markspec-worktrees/federated-slice4
+git push -u origin feat/federated-upstream-slice4   # ≥300s: pre-push runs full just check
+gh pr create --base main --title "feat(core): federated upstream slice 4 — graph integration + validator" --body-file <scratch>/pr-body.md
+```
+
+PR body: slice 4 of the design (§4.6/4.7/4.8/4.9); `Closes #744`; the feed
+sites, T014, generalized R014, coverage leaves, validation-exemption; the scope
+deferrals (unreleased-pin gate → slice 3, LSP/MCP surfaces → slice 5, git-dep
+e2e → slice 3). List new public API (`upstreamRefsFromLockfile`,
+`loadProjectUpstreams`, `isUpstreamEntry`).
+
+- [ ] **Step 2: Run `/review` on the PR, post findings as a PR comment.** Watch
+      CI (esp. Windows) to green; fix any failure.
+
+## Self-review notes (plan vs design)
+
+- §4.6 three feed sites → Tasks 2 (compiler/compileProject, covers 5 cmds), 4
+  (check), 8 (LSP), 9 (MCP). Read-only semantics: Tasks 3 (validation-exempt) +
+  8 (LSP file-path guards); the rest key on `Entry.origin` already.
+- §4.7 resolution (L006 stops for upstream IDs) → automatic via Tasks 2/4
+  (feeding into the resolution maps). T014 → Task 5. Generalized R014 → Task 6.
+  Coverage deps-vs-refs → Task 7. Validation-exempt → Task 3.
+- §4.8 surface table: `show`/`context`/`dependents`/`report` → Task 2
+  (compileProject). `check` → Task 4. LSP/MCP feed → Tasks 8/9. `lint`/`fmt`/
+  `score` untouched (already origin-exempt). `[[edge]]` ledger unchanged.
+- §4.9 root/diamond → Task 10 scenario 6 (authoritative-source rule already in
+  `loadUpstreamCorpus`).
+- DEFERRED (documented): §4.4 unreleased-pin advisory + `--strict` gate (slice
+  3, needs dependency rows); LSP/MCP user-facing surfaces (slice 5); ADR + full
+  spec rewrites (slice 6).

--- a/packages/markspec/cli/commands/check.ts
+++ b/packages/markspec/cli/commands/check.ts
@@ -7,6 +7,8 @@
 import { extname, join } from "@std/path";
 import { Command } from "@cliffy/command";
 import {
+  deriveUpstreamId,
+  loadConfig,
   loadToolConfig,
   MARKDOWN_EXTENSIONS,
   upstreamCacheRoot,
@@ -106,6 +108,26 @@ export const checkCmd = new Command()
         ? await loadProjectUpstreams(projectRoot, lockParse?.lockfile)
         : { entries: [], diagnostics: [] };
 
+      // Declared upstream ids (federated upstream, slice 4) — derived from
+      // project.yaml's `dependencies:`/`references:` via `deriveUpstreamId`.
+      // Stage 4 uses this to fire MSL-T014 (naming the searched upstream
+      // set) instead of the generic MSL-L006 for a trace target unresolved
+      // after federation. Project-wide only — file-local `check <file>`
+      // already suppresses both codes regardless (Stage 4's projectWide
+      // filter), so there is nothing to gain from computing this otherwise.
+      let declaredUpstreamIds: string[] = [];
+      if (scope.projectWide && projectRoot !== undefined) {
+        const projectConfig = await loadConfig(projectRoot, readFile);
+        if (projectConfig) {
+          declaredUpstreamIds = [
+            ...projectConfig.config.dependencies,
+            ...projectConfig.config.references,
+          ]
+            .map((ref) => deriveUpstreamId(ref))
+            .filter((id): id is string => id !== undefined);
+        }
+      }
+
       const {
         detectDirectives,
         parseFile,
@@ -160,7 +182,7 @@ export const checkCmd = new Command()
         allEntries,
         chain?.effective ?? null,
         captionConventions,
-        { projectWide: scope.projectWide },
+        { projectWide: scope.projectWide, declaredUpstreamIds },
       );
 
       // Corpus-aware post-pass (ADR-030): a project entry re-declaring a

--- a/packages/markspec/cli/commands/check.ts
+++ b/packages/markspec/cli/commands/check.ts
@@ -16,6 +16,7 @@ import {
   loadActiveProfile,
   loadMarkdownFormatterOrExit,
   loadProjectCorpus,
+  loadProjectUpstreams,
   readFile,
   renderDiagnosticLocation,
   resolveScope,
@@ -67,6 +68,25 @@ export const checkCmd = new Command()
         captionConventions = toolConfigResult.config.captionConventions;
       }
 
+      // Read + parse markspec.lock once, project-wide only, BEFORE
+      // `allEntries` is finalized — its snapshot-carrying upstream rows
+      // (federated upstream, slice 4) must join the graph ahead of
+      // `runPipeline` so a cross-repo `Satisfies:` resolves. Reused
+      // below by the fmt/lockfile drift gates so the file is read and
+      // parsed exactly once. A file-local `check <file>` skips this the
+      // same way it skips the corpus load below — it cannot distinguish
+      // a valid cross-repo target from a typo any more than MSL-L006 could.
+      const { parseLockfile } = await import("../../core/mod.ts");
+      let lockParse: ReturnType<typeof parseLockfile> | undefined;
+      let lockPath: string | undefined;
+      let cacheRoot: string | undefined;
+      if (scope.projectWide && projectRoot !== undefined) {
+        lockPath = join(projectRoot, "markspec.lock");
+        cacheRoot = upstreamCacheRoot(projectRoot);
+        const lockRaw = await readFile(lockPath);
+        if (lockRaw !== undefined) lockParse = parseLockfile(lockRaw);
+      }
+
       // Load the delivered corpus (ADR-030) — project-wide only, matching
       // the other composite gates: a file-local `check <file>` cannot
       // distinguish a corpus target from a typo any more than MSL-L006
@@ -78,6 +98,14 @@ export const checkCmd = new Command()
       );
       const corpusIndex = corpus.corpusIndex;
 
+      // Load locked upstream snapshots (federated upstream, slice 4) —
+      // project-wide only, same rationale as the corpus load above.
+      // Soft-fail (mirrors `compileProject`): a stale or missing upstream
+      // cache surfaces diagnostics but never aborts `check`.
+      const upstreams = scope.projectWide && projectRoot !== undefined
+        ? await loadProjectUpstreams(projectRoot, lockParse?.lockfile)
+        : { entries: [], diagnostics: [] };
+
       const {
         detectDirectives,
         parseFile,
@@ -87,6 +115,7 @@ export const checkCmd = new Command()
 
       const allEntries = [];
       allEntries.push(...corpus.entries);
+      allEntries.push(...upstreams.entries);
       const parseDiagnostics: Diagnostic[] = [];
       // deno-lint-ignore no-explicit-any
       const listingContexts: any[] = [];
@@ -162,24 +191,17 @@ export const checkCmd = new Command()
       let fmtDiagnostics: Diagnostic[] = [];
       let lockDiagnostics: Diagnostic[] = [];
       if (scope.projectWide) {
-        const { fmtDriftGate, lockfileDriftGate, parseLockfile } = await import(
+        const { fmtDriftGate, lockfileDriftGate } = await import(
           "../../core/mod.ts"
         );
 
         const formatMarkdownProse = await loadMarkdownFormatterOrExit();
 
-        // Read markspec.lock once: its edge ledger feeds reference healing
-        // (MSL-F011) and its cached edge hash feeds the lockfile gate
-        // (MSL-L212).
-        let lockParse: ReturnType<typeof parseLockfile> | undefined;
-        let lockPath: string | undefined;
-        let cacheRoot: string | undefined;
-        if (projectRoot !== undefined) {
-          lockPath = join(projectRoot, "markspec.lock");
-          cacheRoot = upstreamCacheRoot(projectRoot);
-          const lockRaw = await readFile(lockPath);
-          if (lockRaw !== undefined) lockParse = parseLockfile(lockRaw);
-        }
+        // markspec.lock was already read + parsed above (before allEntries
+        // was finalized, so upstream entries could join the graph); reuse
+        // `lockParse`/`lockPath`/`cacheRoot` here rather than re-reading it.
+        // Its edge ledger feeds reference healing (MSL-F011) and its cached
+        // edge hash feeds the lockfile gate (MSL-L212).
         const ledger = lockParse?.lockfile?.edges ?? [];
 
         fmtDiagnostics = await fmtDriftGate(
@@ -210,9 +232,10 @@ export const checkCmd = new Command()
         proseDiagnostics = await proseLintGate(allEntries, chain?.effective);
       }
 
-      // Merge parse-level (MSL-P0xx), corpus-load, pipeline, listing,
-      // fmt-drift, lockfile-drift, and prose-lint diagnostics.
+      // Merge upstream-load, parse-level (MSL-P0xx), corpus-load, pipeline,
+      // listing, fmt-drift, lockfile-drift, and prose-lint diagnostics.
       const allDiagnostics = [
+        ...upstreams.diagnostics,
         ...parseDiagnostics,
         ...corpus.diagnostics,
         ...pipelineDiagnostics,

--- a/packages/markspec/cli/commands/report.ts
+++ b/packages/markspec/cli/commands/report.ts
@@ -5,7 +5,7 @@
  */
 
 import { Command } from "@cliffy/command";
-import { compileProject } from "../helpers.ts";
+import { compileProject, requireProjectConfig } from "../helpers.ts";
 
 export const reportCmd = new Command()
   .description("Generate traceability matrix or coverage report")
@@ -45,13 +45,25 @@ export const reportCmd = new Command()
       }
 
       const { result: compiled, chain: _chain } = await compileProject(paths);
-      const { report } = await import("../../core/mod.ts");
+      const { deriveUpstreamId, report } = await import("../../core/mod.ts");
+
+      // Federated upstream (slice 4): an upstream entry declared under
+      // `dependencies:` participates in coverage like a project entry; one
+      // declared only under `references:` is a traceability leaf. See
+      // `computeCoverage` in `core/reporter/mod.ts`.
+      const { config } = await requireProjectConfig();
+      const dependencyUpstreamIds = new Set(
+        config.dependencies
+          .map((ref) => deriveUpstreamId(ref))
+          .filter((id): id is string => id !== undefined),
+      );
 
       const output = report(compiled, {
         kind,
         format: fmt,
         scope: options.scope,
         label: options.label,
+        dependencyUpstreamIds,
       });
 
       if (options.output) {

--- a/packages/markspec/cli/helpers.ts
+++ b/packages/markspec/cli/helpers.ts
@@ -21,6 +21,7 @@ import type {
   Diagnostic,
   DiscoveryIO,
   Entry,
+  Lockfile,
   ProfileChain,
   ReadFile,
 } from "../core/mod.ts";
@@ -265,6 +266,35 @@ export async function loadProjectCorpus(
     diagnostics: corpus.diagnostics,
     corpusIndex: buildCorpusIndex(delivers),
   };
+}
+
+/** Result of {@linkcode loadProjectUpstreams}. */
+export interface ProjectUpstreams {
+  readonly entries: Entry[];
+  readonly diagnostics: readonly Diagnostic[];
+}
+
+/**
+ * Hydrate locked upstream snapshots (federated upstream, slice 4) into
+ * read-only `Entry[]`. Maps the lockfile's snapshot-carrying upstream rows to
+ * cache directories via {@linkcode upstreamRefsFromLockfile}, then reads each
+ * cached snapshot via {@linkcode loadUpstreamCorpus}. Returns empty when
+ * there's no lockfile or no snapshot-carrying rows. Cold-cache soft-fail: a
+ * missing/corrupt cache surfaces `UPSTREAM-SNAPSHOT-00x` diagnostics but never
+ * throws — mirrors {@linkcode loadProjectCorpus}'s soft-fail posture.
+ */
+export async function loadProjectUpstreams(
+  projectRoot: string,
+  lockfile: Lockfile | undefined,
+): Promise<ProjectUpstreams> {
+  if (!lockfile) return { entries: [], diagnostics: [] };
+  const { upstreamRefsFromLockfile, loadUpstreamCorpus } = await import(
+    "../core/mod.ts"
+  );
+  const refs = upstreamRefsFromLockfile(lockfile, projectRoot);
+  if (refs.length === 0) return { entries: [], diagnostics: [] };
+  const result = await loadUpstreamCorpus(refs, readFile);
+  return { entries: result.entries, diagnostics: result.diagnostics };
 }
 
 /**

--- a/packages/markspec/cli/helpers.ts
+++ b/packages/markspec/cli/helpers.ts
@@ -25,7 +25,7 @@ import type {
   ProfileChain,
   ReadFile,
 } from "../core/mod.ts";
-import { resolve } from "@std/path";
+import { join, resolve } from "@std/path";
 
 export { CORE_SCHEMA_VERSION, VERSION };
 
@@ -309,6 +309,17 @@ export async function loadProjectUpstreams(
  * file missing from the profile package) is fatal — silently compiling with
  * a partial corpus would hide a broken profile package. The returned
  * `corpusIndex` lets callers render corpus locations without rebuilding it.
+ *
+ * Also loads locked upstream snapshots (federated upstream, slice 4) via
+ * {@linkcode loadProjectUpstreams} and injects them into the same
+ * `corpusEntries` bucket passed to `compile()` — both delivered-profile
+ * corpus and hydrated upstream entries are origin-carrying, read-only, and
+ * injected ahead of project entries, so `compile()`'s Phase-5 corpus
+ * post-pass (gated on a non-empty `corpusEntries`) covers both without a
+ * compiler signature change. Unlike the corpus load, a failed upstream load
+ * is soft-fail: a stale or missing `.markspec/cache/upstreams/` must not
+ * abort `show`/`compile`/etc., so its diagnostics are surfaced but never
+ * trigger `Deno.exit`.
  */
 export async function compileProject(
   paths: string[],
@@ -320,7 +331,7 @@ export async function compileProject(
 }> {
   const configResult = await requireProjectConfig();
   const chain = await loadActiveProfile(configResult.projectRoot);
-  const { compile } = await import("../core/mod.ts");
+  const { compile, parseLockfile } = await import("../core/mod.ts");
   const corpus = await loadProjectCorpus(chain);
   const corpusIndex = corpus.corpusIndex;
   let corpusError = false;
@@ -333,6 +344,27 @@ export async function compileProject(
   }
   if (corpusError) Deno.exit(1);
 
+  // Federated upstream (slice 4): read markspec.lock and hydrate its
+  // locked upstream snapshots. Soft-fail — no corpusError-style guard;
+  // a missing/malformed lockfile or a cold/stale upstream cache must
+  // never abort `show`/`compile`/etc.
+  const lockRaw = await readFile(
+    join(configResult.projectRoot, "markspec.lock"),
+  );
+  const lockfile = lockRaw !== undefined
+    ? parseLockfile(lockRaw).lockfile
+    : undefined;
+  const upstreams = await loadProjectUpstreams(
+    configResult.projectRoot,
+    lockfile,
+  );
+  for (const diag of upstreams.diagnostics) {
+    console.error(
+      `${diag.severity}[${diag.code}]: ` +
+        `${renderDiagnosticLocation(diag, corpusIndex)} ${diag.message}`,
+    );
+  }
+
   const withContributors = opts.withContributors ?? false;
   const result = await compile(paths, {
     readFile: (p) => Deno.readTextFile(p),
@@ -341,7 +373,7 @@ export async function compileProject(
       Deno.stat(p).then((s) => ({ mtime: s.mtime })).catch(() => undefined),
     gitFile: makeGitFile(withContributors),
     withContributors,
-    corpusEntries: corpus.entries,
+    corpusEntries: [...corpus.entries, ...upstreams.entries],
   });
 
   for (const diag of result.diagnostics) {
@@ -352,17 +384,23 @@ export async function compileProject(
     );
   }
 
-  // Merge the corpus-load diagnostics into the returned result so
-  // serialized artifacts (`export`/`compile --format json`) surface them
-  // too — otherwise a machine consumer parsing the JSON would believe the
-  // corpus is healthy while other surfaces (`check`, MCP) flag it (#674 f4).
-  // Only warning/info corpus diagnostics reach here: error-severity ones
-  // already exited above. Prepended so they read as load-time findings,
-  // ahead of the compiler's own diagnostics. Both sets were already printed
-  // to stderr above, so this changes serialization only, never the console.
+  // Merge the corpus-load and upstream-load diagnostics into the returned
+  // result so serialized artifacts (`export`/`compile --format json`)
+  // surface them too — otherwise a machine consumer parsing the JSON would
+  // believe the corpus/upstream state is healthy while other surfaces
+  // (`check`, MCP) flag it (#674 f4). Only warning/info corpus diagnostics
+  // reach here: error-severity ones already exited above; upstream
+  // diagnostics reach here regardless of severity (soft-fail). Prepended so
+  // they read as load-time findings, ahead of the compiler's own
+  // diagnostics. All three sets were already printed to stderr above, so
+  // this changes serialization only, never the console.
   const merged: CompileResult = {
     ...result,
-    diagnostics: [...corpus.diagnostics, ...result.diagnostics],
+    diagnostics: [
+      ...corpus.diagnostics,
+      ...upstreams.diagnostics,
+      ...result.diagnostics,
+    ],
   };
 
   return { result: merged, chain, corpusIndex };

--- a/packages/markspec/core/compiler/mod_test.ts
+++ b/packages/markspec/core/compiler/mod_test.ts
@@ -834,3 +834,74 @@ Deno.test("compile: project entry colliding with a corpus display ID → exactly
 
   assertEquals(result.diagnostics.filter((d) => d.code === "MSL-R006"), []);
 });
+
+// ---------------------------------------------------------------------------
+// Federated upstream (slice 4): upstream-origin entries injected via the
+// same corpusEntries bucket as delivered-profile corpus (ADR-030)
+// ---------------------------------------------------------------------------
+
+const UPSTREAM_ULID = "01ARZ3NDEKTSV4RRFFQ69G5FBW";
+
+/** Build one origin-stamped upstream entry the way `loadUpstreamCorpus`
+ * does: parse a hydrated-snapshot fixture, then stamp `origin: {kind:
+ * "upstream", ...}`. */
+async function upstreamEntries(): Promise<Entry[]> {
+  const md = `- [SYS_0001] Braking system interface
+
+  The braking system shall expose a deceleration command channel.
+
+      Id: ${UPSTREAM_ULID}
+`;
+  const { entries } = await parseFile(md, {
+    file: "/cache/upstream/brk-platform/reference/system.md",
+  });
+  return entries.map((e) => ({
+    ...e,
+    origin: {
+      kind: "upstream" as const,
+      upstreamId: "brk-platform",
+      version: "2.4.0",
+    },
+  }));
+}
+
+Deno.test("compile: upstream-origin corpusEntries resolves a project Satisfies: target with no broken-ref diagnostic", async () => {
+  const files = {
+    "/repo/reqs.md": `- [STK_0001] Deceleration request
+
+  The system shall issue a deceleration command via the braking system interface.
+
+      Id: ${ULID_A}
+      Satisfies: SYS_0001
+`,
+  };
+  const result = await compile(["/repo/reqs.md"], {
+    readFile: reader(files),
+    corpusEntries: await upstreamEntries(),
+  });
+
+  const upstreamEntry = result.entries.get(makeDisplayId("SYS_0001"));
+  assertExists(upstreamEntry);
+  assertEquals(upstreamEntry.origin, {
+    kind: "upstream",
+    upstreamId: "brk-platform",
+    version: "2.4.0",
+  });
+
+  const forward = result.forward.get(makeDisplayId("STK_0001")) ?? [];
+  assertEquals(
+    forward.some((l) => l.to === makeDisplayId("SYS_0001")),
+    true,
+  );
+
+  // No broken-ref / unresolved-target diagnostic for the resolved Satisfies:.
+  assertEquals(result.diagnostics.filter((d) => d.code === "MSL-L006"), []);
+  assertEquals(
+    result.diagnostics.some((d) =>
+      d.location?.file === "/repo/reqs.md" &&
+      /SYS_0001/.test(d.message) &&
+      d.severity === "error"
+    ),
+    false,
+  );
+});

--- a/packages/markspec/core/lock/cache_check_test.ts
+++ b/packages/markspec/core/lock/cache_check_test.ts
@@ -1,10 +1,21 @@
 import { assertEquals } from "@std/assert";
+import { join } from "@std/path";
 import { verifyUpstreamCache } from "./cache_check.ts";
 import { sha256Bytes } from "./hash.ts";
 import type { UpstreamRegistry } from "./model.ts";
 import type { ReadFile } from "./resolve.ts";
 
 const enc = new TextEncoder();
+
+/** Cache dirs used across the fixtures below, built via `join()` rather
+ * than a hardcoded forward-slash literal — `verifyUpstreamCache` reads
+ * `join(dir, "manifest.json")` / `join(dir, entriesFile)` internally
+ * (via `probeCacheSnapshot`), which normalises to backslashes on
+ * Windows. A hardcoded literal `"/root/upstreams/refhub/manifest.json"`
+ * map key would never match that request on Windows; building both
+ * sides with `join()` keeps them in exact agreement on every platform. */
+const REFHUB_DIR = join("/root/upstreams", "refhub");
+const GOOD_DIR = join("/root/upstreams", "good");
 
 /** In-memory bytes reader over a path → bytes map (missing → `{error}`). */
 function makeReadFile(files: ReadonlyMap<string, Uint8Array>): ReadFile {
@@ -34,10 +45,10 @@ Deno.test("verifyUpstreamCache: intact cache emits nothing", async () => {
   const snapshot = await sha256Bytes(dataBytes);
   const files = new Map<string, Uint8Array>([
     [
-      "/root/upstreams/refhub/manifest.json",
+      join(REFHUB_DIR, "manifest.json"),
       enc.encode(JSON.stringify({ entries: { file: "compiled.json" } })),
     ],
-    ["/root/upstreams/refhub/compiled.json", dataBytes],
+    [join(REFHUB_DIR, "compiled.json"), dataBytes],
   ]);
   const row = registryRow("refhub", snapshot);
 
@@ -69,10 +80,10 @@ Deno.test("verifyUpstreamCache: hash mismatch fails with one MSL-L212", async ()
   const dataBytes = enc.encode(JSON.stringify({ entries: {} }));
   const files = new Map<string, Uint8Array>([
     [
-      "/root/upstreams/refhub/manifest.json",
+      join(REFHUB_DIR, "manifest.json"),
       enc.encode(JSON.stringify({ entries: { file: "compiled.json" } })),
     ],
-    ["/root/upstreams/refhub/compiled.json", dataBytes],
+    [join(REFHUB_DIR, "compiled.json"), dataBytes],
   ]);
   // Deliberately wrong — does not match the sha256 of dataBytes.
   const row = registryRow("refhub", "sha256:0000000000000000");
@@ -107,7 +118,7 @@ Deno.test("verifyUpstreamCache: an unsafe entries-file path in the manifest fail
   // relying only on upstream_refs_test.ts's transitive coverage (Task 5).
   const files = new Map<string, Uint8Array>([
     [
-      "/root/upstreams/refhub/manifest.json",
+      join(REFHUB_DIR, "manifest.json"),
       enc.encode(JSON.stringify({ entries: { file: "../escape" } })),
     ],
   ]);
@@ -129,10 +140,10 @@ Deno.test("verifyUpstreamCache: multiple rows only report the broken one", async
   const snapshot = await sha256Bytes(dataBytes);
   const files = new Map<string, Uint8Array>([
     [
-      "/root/upstreams/good/manifest.json",
+      join(GOOD_DIR, "manifest.json"),
       enc.encode(JSON.stringify({ entries: { file: "compiled.json" } })),
     ],
-    ["/root/upstreams/good/compiled.json", dataBytes],
+    [join(GOOD_DIR, "compiled.json"), dataBytes],
   ]);
   const good = registryRow("good", snapshot);
   const broken = registryRow("broken", "sha256:mismatch");

--- a/packages/markspec/core/lock/upstream_refs.ts
+++ b/packages/markspec/core/lock/upstream_refs.ts
@@ -162,9 +162,9 @@ async function writeCache(
   io: UpstreamRefsIO,
 ): Promise<Diagnostic | undefined> {
   const writes: Array<[string, Uint8Array]> = [
-    [`${dir}/manifest.json`, fetched.manifestBytes],
+    [join(dir, "manifest.json"), fetched.manifestBytes],
     ...[...fetched.files].map(([rel, bytes]) =>
-      [`${dir}/${rel}`, bytes] as [string, Uint8Array]
+      [join(dir, rel), bytes] as [string, Uint8Array]
     ),
   ];
   for (const [path, bytes] of writes) {
@@ -192,7 +192,7 @@ export async function probeCacheSnapshot(
   snapshot: string,
   readFile: ReadFile,
 ): Promise<boolean> {
-  const manifestBytes = await readFile(`${dir}/manifest.json`);
+  const manifestBytes = await readFile(join(dir, "manifest.json"));
   if ("error" in manifestBytes) return false;
   let entriesFile: string | undefined;
   try {
@@ -204,7 +204,7 @@ export async function probeCacheSnapshot(
     return false;
   }
   if (entriesFile === undefined || isUnsafeRelPath(entriesFile)) return false;
-  const dataBytes = await readFile(`${dir}/${entriesFile}`);
+  const dataBytes = await readFile(join(dir, entriesFile));
   if ("error" in dataBytes) return false;
   return await sha256Bytes(dataBytes) === snapshot;
 }

--- a/packages/markspec/core/lock/upstream_refs_test.ts
+++ b/packages/markspec/core/lock/upstream_refs_test.ts
@@ -1,4 +1,5 @@
 import { assertEquals } from "@std/assert";
+import { join } from "@std/path";
 import {
   deriveUpstreamId,
   resolveProjectReferences,
@@ -10,6 +11,18 @@ import { parseFile } from "../parser/mod.ts";
 import { serializeEntry } from "../compiler/schema.ts";
 
 const enc = new TextEncoder();
+
+/** Cache dirs used by the `cache.has(...)` assertions below, built via
+ * `join()` rather than a hardcoded forward-slash literal —
+ * `resolveProjectReferences` writes through `writeCache`, which calls
+ * `join(dir, "manifest.json")` / `join(dir, rel)` internally and
+ * normalises to backslashes on Windows. A hardcoded literal
+ * `"/proj/.markspec/cache/upstreams/refhub/manifest.json"` map key
+ * would never match that write on Windows; building both sides with
+ * `join()` keeps them in exact agreement on every platform. */
+const PROJ_CACHE_ROOT = "/proj/.markspec/cache/upstreams";
+const PROJ_REFHUB_DIR = join(PROJ_CACHE_ROOT, "refhub");
+const C_REFHUB_DIR = join("/c", "refhub");
 
 function makeManifest(entriesFile = "compiled.json"): string {
   return JSON.stringify({
@@ -78,7 +91,7 @@ Deno.test("first lock: fetches, caches, and pins a reference", async () => {
   const result = await resolveProjectReferences({
     references: [{ url: "https://x.example/refhub" }],
     existing: [],
-    cacheRoot: "/proj/.markspec/cache/upstreams",
+    cacheRoot: PROJ_CACHE_ROOT,
     update: false,
     io,
     lockedAt: "2026-07-04T12:00:00Z",
@@ -92,11 +105,11 @@ Deno.test("first lock: fetches, caches, and pins a reference", async () => {
   assertEquals(row.snapshot, await sha256Bytes(enc.encode(COMPILED)));
   assertEquals(row.lockedAt, "2026-07-04T12:00:00Z");
   assertEquals(
-    cache.has("/proj/.markspec/cache/upstreams/refhub/manifest.json"),
+    cache.has(join(PROJ_REFHUB_DIR, "manifest.json")),
     true,
   );
   assertEquals(
-    cache.has("/proj/.markspec/cache/upstreams/refhub/compiled.json"),
+    cache.has(join(PROJ_REFHUB_DIR, "compiled.json")),
     true,
   );
 });
@@ -205,8 +218,8 @@ Deno.test("keep: snapshot-less existing row re-pins instead of MSL-L214", async 
   assertEquals(row.id, "refhub");
   assertEquals(row.snapshot, await sha256Bytes(enc.encode(COMPILED)));
   assertEquals(row.lockedAt, "2026-07-05T00:00:00Z");
-  assertEquals(cache.has("/c/refhub/manifest.json"), true);
-  assertEquals(cache.has("/c/refhub/compiled.json"), true);
+  assertEquals(cache.has(join(C_REFHUB_DIR, "manifest.json")), true);
+  assertEquals(cache.has(join(C_REFHUB_DIR, "compiled.json")), true);
 });
 
 Deno.test("update: refetches and moves the pin", async () => {
@@ -324,7 +337,7 @@ Deno.test("lock-written cache is loadable by loadUpstreamCorpus", async () => {
   assertEquals(locked.diagnostics, []);
   const row = locked.registries[0];
   const corpus = await loadUpstreamCorpus(
-    [{ id: row.id, version: row.version ?? "unversioned", dir: "/c/refhub" }],
+    [{ id: row.id, version: row.version ?? "unversioned", dir: C_REFHUB_DIR }],
     (path) => {
       const bytes = cache.get(path);
       return Promise.resolve(

--- a/packages/markspec/core/mod.ts
+++ b/packages/markspec/core/mod.ts
@@ -470,3 +470,6 @@ export type {
   LoadUpstreamCorpusResult,
   UpstreamSnapshotRef,
 } from "./upstream/mod.ts";
+
+// ── Lockfile → upstream-snapshot-ref mapping (federated upstream, slice 4) ──
+export { upstreamRefsFromLockfile } from "./upstream/refs.ts";

--- a/packages/markspec/core/mod.ts
+++ b/packages/markspec/core/mod.ts
@@ -20,6 +20,7 @@ export {
   DEFAULT_PROJECT_CONFIG,
   descendantsOf,
   formatEntryOrigin,
+  isUpstreamEntry,
   KNOWN_LINK_KINDS,
   LOCK_EXTRA_INVERSE_KEYS,
   makeDisplayId,

--- a/packages/markspec/core/model/mod.ts
+++ b/packages/markspec/core/model/mod.ts
@@ -476,6 +476,20 @@ export function sameOriginSource(a: EntryOrigin, b: EntryOrigin): boolean {
 }
 
 /**
+ * Whether an entry was hydrated from a locked upstream snapshot
+ * (federated-upstream epic) rather than the project's own files or a
+ * profile-delivered corpus (ADR-030). Upstream entries are validation-exempt
+ * graph citizens: every per-entry validator and lint loop skips them
+ * entirely (no structural, attribute, trace, or prose checks), while they
+ * remain resolution targets — refs FROM a project entry TO an upstream
+ * entry still resolve. This is distinct from `kind: "profile"` corpus
+ * entries, which stay fully validated and are only downgraded post-hoc.
+ */
+export function isUpstreamEntry(entry: Entry): boolean {
+  return entry.origin?.kind === "upstream";
+}
+
+/**
  * A parsed MarkSpec entry — the core AST node.
  *
  * The `shape` field discriminates the two core categories:

--- a/packages/markspec/core/reporter/mod.ts
+++ b/packages/markspec/core/reporter/mod.ts
@@ -25,6 +25,17 @@ export interface ReportOptions {
   readonly scope?: string;
   /** Filter entries by label value. */
   readonly label?: string;
+  /**
+   * Declared upstream ids from `project.yaml`'s `dependencies:` (federated
+   * upstream, slice 4), derived via `deriveUpstreamId`. Used by the
+   * `coverage` report to classify an upstream-origin entry: an id in this
+   * set participates in coverage like a project entry (a `dependencies:`
+   * upstream); an upstream-origin entry whose id is NOT in this set is a
+   * `references:` leaf, excluded from the orphan/unsatisfied gap lists.
+   * Defaults to empty — every upstream-origin entry is treated as a
+   * reference leaf.
+   */
+  readonly dependencyUpstreamIds?: ReadonlySet<string>;
 }
 
 /**
@@ -40,7 +51,12 @@ export function report(result: CompileResult, options: ReportOptions): string {
   if (options.kind === "traceability") {
     return formatTraceability(result, entries, options.format);
   }
-  return formatCoverage(result, entries, options.format);
+  return formatCoverage(
+    result,
+    entries,
+    options.format,
+    options.dependencyUpstreamIds,
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -176,10 +192,18 @@ interface CoverageStats {
   };
 }
 
+/** Options for {@linkcode computeCoverage}. */
+interface ComputeCoverageOptions {
+  /** See {@linkcode ReportOptions.dependencyUpstreamIds}. */
+  readonly dependencyUpstreamIds?: ReadonlySet<string>;
+}
+
 function computeCoverage(
   result: CompileResult,
   entries: Entry[],
+  opts: ComputeCoverageOptions = {},
 ): CoverageStats {
+  const { dependencyUpstreamIds } = opts;
   const byType: Record<string, number> = {};
   const orphans: DisplayId[] = [];
   const unsatisfied: DisplayId[] = [];
@@ -191,13 +215,24 @@ function computeCoverage(
     const t = entry.type ?? (entry.shape === "Reference" ? "ref" : "untyped");
     byType[t] = (byType[t] ?? 0) + 1;
 
+    // Federated upstream (slice 4): a `references:` upstream entry is a
+    // traceability leaf — no coverage expectation points at or from it, so
+    // it is excluded from both gap lists below. A `dependencies:` upstream
+    // entry (its upstreamId present in `dependencyUpstreamIds`) participates
+    // like a project entry — this branch is inert until slice 3 loads
+    // dependency entries, but the classification is exercised here so it's
+    // ready when they do.
+    const origin = entry.origin;
+    const isReferenceLeaf = origin?.kind === "upstream" &&
+      !(dependencyUpstreamIds?.has(origin.upstreamId) ?? false);
+
     const fwd = result.forward.get(entry.displayId) ?? [];
     const rev = result.reverse.get(entry.displayId) ?? [];
     const hasSatisfies = fwd.some((l) => l.kind === "satisfies");
 
     if (hasSatisfies) {
       withSatisfies++;
-    } else if (entry.shape === "Authored") {
+    } else if (entry.shape === "Authored" && !isReferenceLeaf) {
       withoutSatisfies++;
       orphans.push(entry.displayId);
     }
@@ -208,7 +243,8 @@ function computeCoverage(
     const hasSatisfiedBy = rev.some((l) => l.kind === "satisfies");
     if (
       entry.type &&
-      !hasSatisfiedBy
+      !hasSatisfiedBy &&
+      !isReferenceLeaf
     ) {
       unsatisfied.push(entry.displayId);
     }
@@ -227,8 +263,9 @@ function formatCoverage(
   result: CompileResult,
   entries: Entry[],
   format: ReportFormat,
+  dependencyUpstreamIds?: ReadonlySet<string>,
 ): string {
-  const stats = computeCoverage(result, entries);
+  const stats = computeCoverage(result, entries, { dependencyUpstreamIds });
 
   if (format === "json") {
     return JSON.stringify(stats, null, 2);

--- a/packages/markspec/core/reporter/mod.ts
+++ b/packages/markspec/core/reporter/mod.ts
@@ -230,7 +230,7 @@ function computeCoverage(
     const rev = result.reverse.get(entry.displayId) ?? [];
     const hasSatisfies = fwd.some((l) => l.kind === "satisfies");
 
-    if (hasSatisfies) {
+    if (hasSatisfies && !isReferenceLeaf) {
       withSatisfies++;
     } else if (entry.shape === "Authored" && !isReferenceLeaf) {
       withoutSatisfies++;

--- a/packages/markspec/core/reporter/mod_test.ts
+++ b/packages/markspec/core/reporter/mod_test.ts
@@ -50,6 +50,16 @@ function makeEntry(
   };
 }
 
+/** Clone an entry with an upstream origin (federated upstream, slice 4) —
+ * used to test the reference-vs-dependency coverage-leaf classification. */
+function withUpstreamOrigin(
+  entry: Entry,
+  upstreamId: string,
+  version = "1.0.0",
+): Entry {
+  return { ...entry, origin: { kind: "upstream", upstreamId, version } };
+}
+
 /** Build a Link between two entries. */
 function makeLink(
   from: string,
@@ -323,6 +333,74 @@ Deno.test("reporter coverage csv: contains Metric,Value header", () => {
   const output = report(result, { kind: "coverage", format: "csv" });
   assertStringIncludes(output, "Metric,Value");
   assertStringIncludes(output, "Total entries,1");
+});
+
+// ---------------------------------------------------------------------------
+// Federated-upstream coverage leaf semantics (slice 4): a `references:`
+// upstream entry is a traceability leaf — no coverage expectation points at
+// or from it. A `dependencies:` upstream entry participates like a project
+// entry (inert in slice 4, proven here via a hand-built dependency-origin
+// entry so the mechanism is ready for slice 3).
+// ---------------------------------------------------------------------------
+
+Deno.test("reporter coverage: reference-origin upstream entry with no Satisfies is not an orphan", () => {
+  const ref = withUpstreamOrigin(
+    makeEntry("UP_SYS_0001", "Upstream system req"),
+    "refhub",
+  );
+  const result = makeResult([ref], []);
+
+  // No `dependencyUpstreamIds` supplied — "refhub" is therefore a reference.
+  const output = report(result, { kind: "coverage", format: "md" });
+
+  assertEquals(output.includes("Orphan entries"), false);
+  assertStringIncludes(output, "Without Satisfies (orphans): 0");
+});
+
+Deno.test("reporter coverage: reference-origin typed upstream entry with no incoming Satisfies is not unsatisfied", () => {
+  const ref = withUpstreamOrigin(
+    makeEntry("UP_SYS_0001", "Upstream system req", { type: "SYS" }),
+    "refhub",
+  );
+  const result = makeResult([ref], []);
+
+  const output = report(result, { kind: "coverage", format: "md" });
+
+  assertEquals(output.includes("Unsatisfied parents"), false);
+});
+
+Deno.test("reporter coverage: dependency-origin upstream entry with no coverage participates like a project entry", () => {
+  const dep = withUpstreamOrigin(
+    makeEntry("UP_SYS_0001", "Upstream system req"),
+    "gitdep",
+  );
+  const result = makeResult([dep], []);
+
+  const output = report(result, {
+    kind: "coverage",
+    format: "md",
+    dependencyUpstreamIds: new Set(["gitdep"]),
+  });
+
+  assertStringIncludes(output, "Without Satisfies (orphans): 1");
+  const orphansSection = output.split("## Orphan entries")[1] ?? "";
+  assertStringIncludes(orphansSection, "UP_SYS_0001");
+});
+
+Deno.test("reporter coverage: project entry stays an orphan while a reference-leaf beside it is excluded", () => {
+  const project = makeEntry("STK_001", "Stakeholder req");
+  const ref = withUpstreamOrigin(
+    makeEntry("UP_SYS_0001", "Upstream system req"),
+    "refhub",
+  );
+  const result = makeResult([project, ref], []);
+
+  const output = report(result, { kind: "coverage", format: "md" });
+
+  assertStringIncludes(output, "Without Satisfies (orphans): 1");
+  const orphansSection = output.split("## Orphan entries")[1] ?? "";
+  assertStringIncludes(orphansSection, "STK_001");
+  assertEquals(orphansSection.includes("UP_SYS_0001"), false);
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/markspec/core/reporter/mod_test.ts
+++ b/packages/markspec/core/reporter/mod_test.ts
@@ -403,6 +403,42 @@ Deno.test("reporter coverage: project entry stays an orphan while a reference-le
   assertEquals(orphansSection.includes("UP_SYS_0001"), false);
 });
 
+// Review fix: `withSatisfies` was not gated by `!isReferenceLeaf` — a
+// reference leaf with a resolving outgoing Satisfies inflated the coverage
+// numerator even though it is excluded from the orphan/unsatisfied gap
+// lists. A reference leaf must participate in NO coverage count.
+Deno.test("reporter coverage: reference-leaf with a resolving outgoing Satisfies is NOT counted in With Satisfies", () => {
+  const ref = withUpstreamOrigin(
+    makeEntry("UP_SYS_0001", "Upstream system req"),
+    "refhub",
+  );
+  const target = withUpstreamOrigin(
+    makeEntry("UP_SYS_0002", "Upstream target req"),
+    "refhub",
+  );
+  const link = makeLink("UP_SYS_0001", "UP_SYS_0002");
+  // No `dependencyUpstreamIds` supplied — "refhub" is therefore a reference.
+  const result = makeResult([ref, target], [link]);
+
+  const output = report(result, { kind: "coverage", format: "json" });
+  const parsed = JSON.parse(output);
+  assertEquals(parsed.withSatisfies, 0);
+  assertEquals(parsed.withoutSatisfies, 0);
+});
+
+// Control: an ordinary project entry with a resolving outgoing Satisfies
+// is still counted — the gating must not over-exclude project entries.
+Deno.test("reporter coverage: project entry with a resolving outgoing Satisfies IS counted in With Satisfies", () => {
+  const stk = makeEntry("STK_001", "Stakeholder req");
+  const swe = makeEntry("SWE_001", "Software req");
+  const link = makeLink("SWE_001", "STK_001");
+  const result = makeResult([stk, swe], [link]);
+
+  const output = report(result, { kind: "coverage", format: "json" });
+  const parsed = JSON.parse(output);
+  assertEquals(parsed.withSatisfies, 1);
+});
+
 // ---------------------------------------------------------------------------
 // Scope filter tests
 // ---------------------------------------------------------------------------

--- a/packages/markspec/core/typl/validator.ts
+++ b/packages/markspec/core/typl/validator.ts
@@ -21,6 +21,7 @@
  * See ADR-019.
  */
 import type { Diagnostic, Entry } from "../model/mod.ts";
+import { isUpstreamEntry } from "../model/mod.ts";
 import type { Binding, Shape } from "./ast.ts";
 import { extractTyplCitations } from "./citations.ts";
 import { findDuplicateDeclarations, resolveRef } from "../decl/mod.ts";
@@ -31,14 +32,26 @@ import { TYPL_REF_OPS } from "./resolve.ts";
 /**
  * Validate the typl declarations across all entries.
  *
- * Returns the built corpus registry plus any diagnostics. The registry
- * is returned even when diagnostics are present so callers (compiler,
- * LSP) can use it for navigation and emission.
+ * Upstream entries (federated-upstream epic) are typl-inert: they are
+ * excluded from the working set before the registry is built, so their
+ * declarations neither emit their own TYPL diagnostics nor count toward
+ * the corpus-wide declared-once (TYPL-009) accounting — a project entry
+ * re-declaring a dotted name an upstream also publishes is not a
+ * collision. Cross-repo typl resolution is out of scope for this slice
+ * (see ADR-019 / federated-upstream design §4.7); this mirrors the
+ * validation exemption every other per-entry validator stage applies via
+ * `isUpstreamEntry`.
+ *
+ * Returns the built corpus registry (scoped to non-upstream entries)
+ * plus any diagnostics. The registry is returned even when diagnostics
+ * are present so callers (compiler, LSP) can use it for navigation and
+ * emission.
  */
 export function validateTypl(
   entries: readonly Entry[],
 ): { registry: TypeRegistry; diagnostics: readonly Diagnostic[] } {
-  const registry = buildTypeRegistry(entries);
+  const localEntries = entries.filter((entry) => !isUpstreamEntry(entry));
+  const registry = buildTypeRegistry(localEntries);
   const diagnostics: Diagnostic[] = [];
 
   // Published tier (#723): dotted names are declared exactly once
@@ -72,7 +85,7 @@ export function validateTypl(
 
   // Citation validation (#723): bare published-shaped code spans must
   // resolve (relative → entry root namespace) to a declared symbol.
-  for (const entry of entries) {
+  for (const entry of localEntries) {
     const citations = extractTyplCitations(entry.bodyTokens);
     if (citations.length === 0) continue;
     const root = entry.types?.rootNamespace;
@@ -110,7 +123,7 @@ export function validateTypl(
   }
 
   // Intra-entry undefined typedef ref (TYPL-005)
-  for (const entry of entries) {
+  for (const entry of localEntries) {
     if (!entry.types) continue;
     const localTypedefs = new Set(entry.types.typedefs.map((t) => t.name));
     for (const binding of entry.types.bindings) {

--- a/packages/markspec/core/typl/validator_test.ts
+++ b/packages/markspec/core/typl/validator_test.ts
@@ -266,3 +266,90 @@ Deno.test("validateTypl: relative citation with no root is TYPL-010", () => {
   assertEquals(diagnostics.length, 1);
   assertEquals(diagnostics[0].code, "TYPL-010");
 });
+
+// ---------------------------------------------------------------------------
+// Upstream entries (federated-upstream epic, slice 4) are typl-inert: their
+// own typl content emits no diagnostics, and their declarations do not
+// count toward the corpus-wide declared-once (TYPL-009) accounting.
+// ---------------------------------------------------------------------------
+
+Deno.test("validateTypl: upstream entry contributes no TYPL-005 diagnostic; project entry with identical content still does (control)", () => {
+  const undefinedRefBinding = {
+    statementKind: "binding" as const,
+    name: "$Brake",
+    kind: "command" as const,
+    shape: { kind: "ref" as const, name: "MissingType" },
+    position: { line: 5, column: 1 },
+  };
+  const upstreamEntry = {
+    ...entry("REQ_UP", "up.md", {
+      bindings: [undefinedRefBinding],
+      typedefs: [],
+    }),
+    origin: {
+      kind: "upstream" as const,
+      upstreamId: "acme/reqs",
+      version: "v1.0",
+    },
+  };
+  const projectEntry = entry("REQ_A", "a.md", {
+    bindings: [undefinedRefBinding],
+    typedefs: [],
+  });
+
+  // RED (pre-fix): validateTypl([upstreamEntry]) emitted TYPL-005 because
+  // the emit loop walked all entries with no upstream exclusion.
+  const upstreamOnly = validateTypl([upstreamEntry]);
+  assertEquals(upstreamOnly.diagnostics, []);
+
+  // Control: the identical undefined-ref content on a project entry still
+  // emits — and only once, attributed to the project entry's file.
+  const both = validateTypl([upstreamEntry, projectEntry]);
+  assertEquals(both.diagnostics.length, 1);
+  assertEquals(both.diagnostics[0].code, "TYPL-005");
+  assertEquals(both.diagnostics[0].location?.file, "a.md");
+});
+
+Deno.test("validateTypl: upstream declaration of a dotted name does not count toward TYPL-009 declared-once", () => {
+  const dottedBinding = (line: number) => ({
+    statementKind: "binding" as const,
+    name: "$Foo.bar",
+    kind: "signal" as const,
+    position: { line, column: 1 },
+  });
+  const projectEntry = entry("REQ_1", "a.md", {
+    bindings: [dottedBinding(3)],
+    typedefs: [],
+  });
+  const upstreamEntry = {
+    ...entry("REQ_UP", "up.md", { bindings: [dottedBinding(7)], typedefs: [] }),
+    origin: {
+      kind: "upstream" as const,
+      upstreamId: "acme/reqs",
+      version: "v1.0",
+    },
+  };
+  // RED (pre-fix): the registry included the upstream binding, so the
+  // project entry's declaration looked like the second (duplicate) one.
+  const { diagnostics } = validateTypl([projectEntry, upstreamEntry]);
+  assertEquals(diagnostics.filter((d) => d.code === "TYPL-009"), []);
+});
+
+Deno.test("validateTypl: control — two PROJECT entries declaring the same dotted name still emits TYPL-009", () => {
+  const dottedBinding = (line: number) => ({
+    statementKind: "binding" as const,
+    name: "$Foo.bar",
+    kind: "signal" as const,
+    position: { line, column: 1 },
+  });
+  const a = entry("REQ_1", "a.md", {
+    bindings: [dottedBinding(3)],
+    typedefs: [],
+  });
+  const b = entry("REQ_2", "b.md", {
+    bindings: [dottedBinding(7)],
+    typedefs: [],
+  });
+  const { diagnostics } = validateTypl([a, b]);
+  assertEquals(diagnostics.filter((d) => d.code === "TYPL-009").length, 1);
+});

--- a/packages/markspec/core/upstream/mod.ts
+++ b/packages/markspec/core/upstream/mod.ts
@@ -11,6 +11,7 @@
  * {@linkcode ReadFile}.
  */
 
+import { join } from "@std/path";
 import type { Diagnostic, Entry } from "../model/mod.ts";
 import {
   checkSnapshotSchema,
@@ -59,7 +60,7 @@ export async function loadUpstreamCorpus(
   const entries: Entry[] = [];
   const diagnostics: Diagnostic[] = [];
   for (const up of upstreams) {
-    const manifestPath = `${up.dir}/manifest.json`;
+    const manifestPath = join(up.dir, "manifest.json");
     const manifestRaw = await readFile(manifestPath);
     if (manifestRaw === undefined) {
       diagnostics.push({
@@ -112,7 +113,7 @@ export async function loadUpstreamCorpus(
       continue;
     }
     const snapshotContent = relFile !== undefined
-      ? await readFile(`${up.dir}/${relFile}`)
+      ? await readFile(join(up.dir, relFile))
       : undefined;
     const extracted = extractSerializedEntries(
       manifest,

--- a/packages/markspec/core/upstream/mod_test.ts
+++ b/packages/markspec/core/upstream/mod_test.ts
@@ -1,7 +1,21 @@
 import { assertEquals } from "@std/assert";
+import { join } from "@std/path";
 import { parseFile } from "../parser/mod.ts";
 import { serializeEntry } from "../compiler/schema.ts";
 import { loadUpstreamCorpus } from "./mod.ts";
+
+/** Cache dirs used across the fixtures below, built via `join()` rather
+ * than a hardcoded forward-slash literal — `loadUpstreamCorpus` now reads
+ * `join(up.dir, "manifest.json")` internally, which normalises to
+ * backslashes on Windows. A hardcoded literal `"/c/up/product/manifest.json"`
+ * map key would never match that request on Windows; building both sides
+ * with `join()` keeps them in exact agreement on every platform. */
+const PRODUCT_DIR = join("/c", "up", "product");
+const GHOST_DIR = join("/c", "up", "ghost");
+const BAD_DIR = join("/c", "up", "bad");
+const PRODUCT_MANIFEST = join(PRODUCT_DIR, "manifest.json");
+const PRODUCT_COMPILED = join(PRODUCT_DIR, "compiled.json");
+const BAD_COMPILED = join(BAD_DIR, "compiled.json");
 
 const UP_A_MD = `# A
 
@@ -41,8 +55,8 @@ async function snapshotFiles(
     entries: Object.fromEntries(serialized.map((s) => [s.displayId, s])),
   };
   return new Map([
-    [`${dir}/manifest.json`, JSON.stringify(manifest)],
-    [`${dir}/compiled.json`, JSON.stringify(compiled)],
+    [join(dir, "manifest.json"), JSON.stringify(manifest)],
+    [join(dir, "compiled.json"), JSON.stringify(compiled)],
   ]);
 }
 
@@ -62,9 +76,9 @@ function recordingReaderFor(files: Map<string, string>, requested: string[]) {
 }
 
 Deno.test("loadUpstreamCorpus: hydrates and stamps upstream origin", async () => {
-  const files = await snapshotFiles("/c/up/product", UP_A_MD, "/up/a.md");
+  const files = await snapshotFiles(PRODUCT_DIR, UP_A_MD, "/up/a.md");
   const result = await loadUpstreamCorpus(
-    [{ id: "product", version: "v2.1.0", dir: "/c/up/product" }],
+    [{ id: "product", version: "v2.1.0", dir: PRODUCT_DIR }],
     readerFor(files),
   );
   assertEquals(result.diagnostics, []);
@@ -79,12 +93,12 @@ Deno.test("loadUpstreamCorpus: hydrates and stamps upstream origin", async () =>
 
 Deno.test("loadUpstreamCorpus: authoritative-source rule skips re-exports", async () => {
   // product's snapshot re-exports an entry it pulled from 'icd' — skip it.
-  const files = await snapshotFiles("/c/up/product", UP_A_MD, "/up/a.md", {
+  const files = await snapshotFiles(PRODUCT_DIR, UP_A_MD, "/up/a.md", {
     upstreamId: "icd",
     version: "v1.0.0",
   });
   const result = await loadUpstreamCorpus(
-    [{ id: "product", version: "v2.1.0", dir: "/c/up/product" }],
+    [{ id: "product", version: "v2.1.0", dir: PRODUCT_DIR }],
     readerFor(files),
   );
   assertEquals(result.diagnostics, []);
@@ -92,11 +106,11 @@ Deno.test("loadUpstreamCorpus: authoritative-source rule skips re-exports", asyn
 });
 
 Deno.test("loadUpstreamCorpus: missing manifest → 002, other upstreams still load", async () => {
-  const files = await snapshotFiles("/c/up/product", UP_A_MD, "/up/a.md");
+  const files = await snapshotFiles(PRODUCT_DIR, UP_A_MD, "/up/a.md");
   const result = await loadUpstreamCorpus(
     [
-      { id: "ghost", version: "v0", dir: "/c/up/ghost" },
-      { id: "product", version: "v2.1.0", dir: "/c/up/product" },
+      { id: "ghost", version: "v0", dir: GHOST_DIR },
+      { id: "product", version: "v2.1.0", dir: PRODUCT_DIR },
     ],
     readerFor(files),
   );
@@ -106,12 +120,12 @@ Deno.test("loadUpstreamCorpus: missing manifest → 002, other upstreams still l
 });
 
 Deno.test("loadUpstreamCorpus: schema skew → 001, upstream skipped", async () => {
-  const files = await snapshotFiles("/c/up/product", UP_A_MD, "/up/a.md");
-  const manifest = JSON.parse(files.get("/c/up/product/manifest.json")!);
+  const files = await snapshotFiles(PRODUCT_DIR, UP_A_MD, "/up/a.md");
+  const manifest = JSON.parse(files.get(PRODUCT_MANIFEST)!);
   manifest.generator.coreSchema = 99;
-  files.set("/c/up/product/manifest.json", JSON.stringify(manifest));
+  files.set(PRODUCT_MANIFEST, JSON.stringify(manifest));
   const result = await loadUpstreamCorpus(
-    [{ id: "product", version: "v2.1.0", dir: "/c/up/product" }],
+    [{ id: "product", version: "v2.1.0", dir: PRODUCT_DIR }],
     readerFor(files),
   );
   assertEquals(result.diagnostics[0].code, "UPSTREAM-SNAPSHOT-001");
@@ -124,18 +138,18 @@ Deno.test("loadUpstreamCorpus: skew check runs before any data-file read", async
   // the outcome. Reordering the loader to pre-read compiled.json before
   // (or regardless of) the skew check would fail this test even though
   // the 001-diagnostic outcome stays the same.
-  const files = await snapshotFiles("/c/up/product", UP_A_MD, "/up/a.md");
-  const manifest = JSON.parse(files.get("/c/up/product/manifest.json")!);
+  const files = await snapshotFiles(PRODUCT_DIR, UP_A_MD, "/up/a.md");
+  const manifest = JSON.parse(files.get(PRODUCT_MANIFEST)!);
   manifest.generator.coreSchema = 99;
-  files.set("/c/up/product/manifest.json", JSON.stringify(manifest));
+  files.set(PRODUCT_MANIFEST, JSON.stringify(manifest));
   const requested: string[] = [];
   const result = await loadUpstreamCorpus(
-    [{ id: "product", version: "v2.1.0", dir: "/c/up/product" }],
+    [{ id: "product", version: "v2.1.0", dir: PRODUCT_DIR }],
     recordingReaderFor(files, requested),
   );
   assertEquals(result.diagnostics[0].code, "UPSTREAM-SNAPSHOT-001");
-  assertEquals(requested.includes("/c/up/product/manifest.json"), true);
-  assertEquals(requested.includes("/c/up/product/compiled.json"), false);
+  assertEquals(requested.includes(PRODUCT_MANIFEST), true);
+  assertEquals(requested.includes(PRODUCT_COMPILED), false);
 });
 
 Deno.test("loadUpstreamCorpus: no upstreams → empty result", async () => {
@@ -145,10 +159,10 @@ Deno.test("loadUpstreamCorpus: no upstreams → empty result", async () => {
 });
 
 Deno.test("loadUpstreamCorpus: empty snapshot entries → no entries, no diagnostics", async () => {
-  const files = await snapshotFiles("/c/up/product", UP_A_MD, "/up/a.md");
-  files.set("/c/up/product/compiled.json", JSON.stringify({ entries: {} }));
+  const files = await snapshotFiles(PRODUCT_DIR, UP_A_MD, "/up/a.md");
+  files.set(PRODUCT_COMPILED, JSON.stringify({ entries: {} }));
   const result = await loadUpstreamCorpus(
-    [{ id: "product", version: "v2.1.0", dir: "/c/up/product" }],
+    [{ id: "product", version: "v2.1.0", dir: PRODUCT_DIR }],
     readerFor(files),
   );
   assertEquals(result.diagnostics, []);
@@ -158,10 +172,10 @@ Deno.test("loadUpstreamCorpus: empty snapshot entries → no entries, no diagnos
 Deno.test("loadUpstreamCorpus: missing snapshot data file → 002", async () => {
   // Data-file-level failure: valid manifest, but the compiled.json it
   // names is gone — distinct from the manifest-level 002 tested above.
-  const files = await snapshotFiles("/c/up/product", UP_A_MD, "/up/a.md");
-  files.delete("/c/up/product/compiled.json");
+  const files = await snapshotFiles(PRODUCT_DIR, UP_A_MD, "/up/a.md");
+  files.delete(PRODUCT_COMPILED);
   const result = await loadUpstreamCorpus(
-    [{ id: "product", version: "v2.1.0", dir: "/c/up/product" }],
+    [{ id: "product", version: "v2.1.0", dir: PRODUCT_DIR }],
     readerFor(files),
   );
   assertEquals(result.diagnostics.length, 1);
@@ -174,17 +188,17 @@ Deno.test("loadUpstreamCorpus: isolation — a non-object entry value in one ups
   // malformed entry value (valid JSON, wrong shape) in one upstream's
   // snapshot must not reject the whole call or block a sibling upstream
   // from loading.
-  const badFiles = await snapshotFiles("/c/up/bad", UP_A_MD, "/up/a.md");
+  const badFiles = await snapshotFiles(BAD_DIR, UP_A_MD, "/up/a.md");
   badFiles.set(
-    "/c/up/bad/compiled.json",
+    BAD_COMPILED,
     JSON.stringify({ entries: { X: null } }),
   );
-  const goodFiles = await snapshotFiles("/c/up/product", UP_A_MD, "/up/a.md");
+  const goodFiles = await snapshotFiles(PRODUCT_DIR, UP_A_MD, "/up/a.md");
   const files = new Map([...badFiles, ...goodFiles]);
   const result = await loadUpstreamCorpus(
     [
-      { id: "bad", version: "v1.0.0", dir: "/c/up/bad" },
-      { id: "product", version: "v2.1.0", dir: "/c/up/product" },
+      { id: "bad", version: "v1.0.0", dir: BAD_DIR },
+      { id: "product", version: "v2.1.0", dir: PRODUCT_DIR },
     ],
     readerFor(files),
   );
@@ -199,19 +213,19 @@ Deno.test("loadUpstreamCorpus: isolation — a non-object entry value in one ups
 });
 
 Deno.test("loadUpstreamCorpus: relFile escaping the cache dir → 003, never read outside the upstream dir", async () => {
-  const files = await snapshotFiles("/c/up/product", UP_A_MD, "/up/a.md");
-  const manifest = JSON.parse(files.get("/c/up/product/manifest.json")!);
+  const files = await snapshotFiles(PRODUCT_DIR, UP_A_MD, "/up/a.md");
+  const manifest = JSON.parse(files.get(PRODUCT_MANIFEST)!);
   manifest.entries = { format: "inline", file: "../../evil.json" };
-  files.set("/c/up/product/manifest.json", JSON.stringify(manifest));
+  files.set(PRODUCT_MANIFEST, JSON.stringify(manifest));
   const requested: string[] = [];
   const result = await loadUpstreamCorpus(
-    [{ id: "product", version: "v2.1.0", dir: "/c/up/product" }],
+    [{ id: "product", version: "v2.1.0", dir: PRODUCT_DIR }],
     recordingReaderFor(files, requested),
   );
   assertEquals(result.diagnostics.length, 1);
   assertEquals(result.diagnostics[0].code, "UPSTREAM-SNAPSHOT-003");
   assertEquals(result.entries, []);
-  assertEquals(requested.includes("/c/up/product/manifest.json"), true);
+  assertEquals(requested.includes(PRODUCT_MANIFEST), true);
   assertEquals(
     requested.some((p) => p.includes("evil.json")),
     false,

--- a/packages/markspec/core/upstream/refs.ts
+++ b/packages/markspec/core/upstream/refs.ts
@@ -5,6 +5,7 @@
  * UpstreamSnapshotRef[] loadUpstreamCorpus consumes. Pure — no I/O.
  */
 
+import { join } from "@std/path";
 import type { Lockfile } from "../lock/model.ts";
 import { upstreamCacheRoot } from "../lock/upstream_refs.ts";
 import type { UpstreamSnapshotRef } from "./mod.ts";
@@ -32,7 +33,7 @@ export function upstreamRefsFromLockfile(
     refs.push({
       id: u.id,
       version: ("version" in u && u.version) ? u.version : UNVERSIONED,
-      dir: `${cacheRoot}/${u.id}`,
+      dir: join(cacheRoot, u.id),
     });
   }
   return refs;

--- a/packages/markspec/core/upstream/refs.ts
+++ b/packages/markspec/core/upstream/refs.ts
@@ -1,0 +1,39 @@
+/**
+ * @module upstream/refs
+ *
+ * Map a parsed markspec.lock's snapshot-carrying upstream rows to the
+ * UpstreamSnapshotRef[] loadUpstreamCorpus consumes. Pure — no I/O.
+ */
+
+import type { Lockfile } from "../lock/model.ts";
+import { upstreamCacheRoot } from "../lock/upstream_refs.ts";
+import type { UpstreamSnapshotRef } from "./mod.ts";
+
+/** Fallback version label when a registry row carries no `version`. */
+const UNVERSIONED = "unversioned";
+
+/**
+ * Map a parsed lockfile's snapshot-carrying upstream rows to
+ * UpstreamSnapshotRef[] for loadUpstreamCorpus. Registry + dependency
+ * rows with a `snapshot` are included; rows without a snapshot (legacy
+ * pin-only) are skipped. `version` falls back to `"unversioned"` when the
+ * row has none (UpstreamSnapshotRef.version is required; the loader only
+ * uses it for the origin badge).
+ */
+export function upstreamRefsFromLockfile(
+  lockfile: Lockfile,
+  projectRoot: string,
+): UpstreamSnapshotRef[] {
+  const cacheRoot = upstreamCacheRoot(projectRoot);
+  const refs: UpstreamSnapshotRef[] = [];
+  for (const u of lockfile.upstreams) {
+    if (u.kind !== "registry" && u.kind !== "dependency") continue;
+    if (u.snapshot === undefined) continue;
+    refs.push({
+      id: u.id,
+      version: ("version" in u && u.version) ? u.version : UNVERSIONED,
+      dir: `${cacheRoot}/${u.id}`,
+    });
+  }
+  return refs;
+}

--- a/packages/markspec/core/upstream/refs_test.ts
+++ b/packages/markspec/core/upstream/refs_test.ts
@@ -1,0 +1,82 @@
+import { assertEquals } from "@std/assert";
+import { upstreamRefsFromLockfile } from "./refs.ts";
+import type { Lockfile } from "../lock/mod.ts";
+
+function lf(upstreams: Lockfile["upstreams"]): Lockfile {
+  return {
+    schema: 1,
+    meta: { markspecSchema: 1, lockedAt: "2026-07-04T00:00:00Z" },
+    upstreams,
+    boundEntries: [],
+    edges: [],
+    generatedCache: { edgesHash: "sha256:0", edgesCount: 0 },
+  };
+}
+
+Deno.test("upstreamRefsFromLockfile: registry row → ref with cache dir", () => {
+  const refs = upstreamRefsFromLockfile(
+    lf([{
+      kind: "registry",
+      id: "refhub",
+      api: "https://x",
+      resolvedManifestHash: "sha256:a",
+      markspecSchema: 1,
+      version: "1.4.0",
+      snapshot: "sha256:b",
+      lockedAt: "2026-07-04T00:00:00Z",
+    }]),
+    "/proj",
+  );
+  assertEquals(refs, [{
+    id: "refhub",
+    version: "1.4.0",
+    dir: "/proj/.markspec/cache/upstreams/refhub",
+  }]);
+});
+
+Deno.test("upstreamRefsFromLockfile: snapshot-less row is skipped", () => {
+  const refs = upstreamRefsFromLockfile(
+    lf([{
+      kind: "registry",
+      id: "old",
+      api: "https://x",
+      resolvedManifestHash: "sha256:a",
+      markspecSchema: 1,
+    }]),
+    "/proj",
+  );
+  assertEquals(refs, []);
+});
+
+Deno.test("upstreamRefsFromLockfile: version falls back to 'unversioned'", () => {
+  const refs = upstreamRefsFromLockfile(
+    lf([{
+      kind: "registry",
+      id: "refhub",
+      api: "https://x",
+      resolvedManifestHash: "sha256:a",
+      markspecSchema: 1,
+      snapshot: "sha256:b",
+      lockedAt: "2026-07-04T00:00:00Z",
+    }]),
+    "/proj",
+  );
+  assertEquals(refs[0].version, "unversioned");
+});
+
+Deno.test("upstreamRefsFromLockfile: reference/profile (non-snapshot) rows skipped", () => {
+  const refs = upstreamRefsFromLockfile(
+    lf([
+      { kind: "reference", slug: "ISO", id: "urn:iso" },
+      {
+        kind: "profile",
+        id: "p",
+        specifier: "npm:x",
+        resolved: "1",
+        hash: "sha256:z",
+      },
+    ]),
+    "/proj",
+  );
+  assertEquals(refs, []);
+});

--- a/packages/markspec/core/upstream/refs_test.ts
+++ b/packages/markspec/core/upstream/refs_test.ts
@@ -1,6 +1,13 @@
 import { assertEquals } from "@std/assert";
+import { join } from "@std/path";
 import { upstreamRefsFromLockfile } from "./refs.ts";
 import type { Lockfile } from "../lock/mod.ts";
+import { upstreamCacheRoot } from "../lock/upstream_refs.ts";
+
+/** Expected cache dir for the `"/proj"` fixture root, built the same
+ * `join()`-based way production does — a hardcoded forward-slash literal
+ * would never match the backslash path Windows produces. */
+const REFHUB_DIR = join(upstreamCacheRoot("/proj"), "refhub");
 
 function lf(upstreams: Lockfile["upstreams"]): Lockfile {
   return {
@@ -30,7 +37,7 @@ Deno.test("upstreamRefsFromLockfile: registry row → ref with cache dir", () =>
   assertEquals(refs, [{
     id: "refhub",
     version: "1.4.0",
-    dir: "/proj/.markspec/cache/upstreams/refhub",
+    dir: REFHUB_DIR,
   }]);
 });
 

--- a/packages/markspec/core/validator/corpus.ts
+++ b/packages/markspec/core/validator/corpus.ts
@@ -57,9 +57,9 @@ export function detectCorpusCollisions(
         diagnostics.push({
           code: "MSL-R014",
           severity: "error",
-          message: `display ID '${e.displayId}' is already delivered by ` +
+          message: `display ID '${e.displayId}' is already provided by ` +
             `${formatEntryOrigin(displayOwner.origin!)}; rename this entry — ` +
-            `delivered corpus entries are read-only`,
+            `upstream and delivered-corpus entries are read-only`,
           location: e.location,
         });
       }
@@ -70,9 +70,9 @@ export function detectCorpusCollisions(
           diagnostics.push({
             code: "MSL-R014",
             severity: "error",
-            message: `Id '${e.id}' is already delivered by ` +
+            message: `Id '${e.id}' is already provided by ` +
               `${formatEntryOrigin(idOwner.origin!)}; rename this entry — ` +
-              `delivered corpus entries are read-only`,
+              `upstream and delivered-corpus entries are read-only`,
             location: e.location,
           });
         }
@@ -93,9 +93,10 @@ export function detectCorpusCollisions(
       diagnostics.push({
         code: "MSL-R014",
         severity: "error",
-        message: `display ID '${e.displayId}' is already delivered by ` +
-          `${formatEntryOrigin(displayOwner.origin!)}; delivered corpus ` +
-          `entries are read-only`,
+        message: `display ID '${e.displayId}' is provided by both ` +
+          `${formatEntryOrigin(displayOwner.origin!)} and ` +
+          `${formatEntryOrigin(e.origin)} — one must rename its entry to ` +
+          `resolve the collision`,
         location: e.location,
       });
     }
@@ -109,9 +110,10 @@ export function detectCorpusCollisions(
         diagnostics.push({
           code: "MSL-R014",
           severity: "error",
-          message: `Id '${e.id}' is already delivered by ` +
-            `${formatEntryOrigin(idOwner.origin!)}; delivered corpus entries ` +
-            `are read-only`,
+          message: `Id '${e.id}' is provided by both ` +
+            `${formatEntryOrigin(idOwner.origin!)} and ` +
+            `${formatEntryOrigin(e.origin)} — one must rename its entry to ` +
+            `resolve the collision`,
           location: e.location,
         });
       }

--- a/packages/markspec/core/validator/corpus_test.ts
+++ b/packages/markspec/core/validator/corpus_test.ts
@@ -63,6 +63,13 @@ Deno.test("detectCorpusCollisions: project entry reusing corpus display ID → M
   assertEquals(diagnostics[0].severity, "error");
   assertEquals(diagnostics[0].location?.file, "/repo/reqs.md");
   assertStringIncludes(diagnostics[0].message, "p@1.0.0");
+  // The remedy prose is origin-generic — it must not read as
+  // corpus-exclusive, since the same MSL-R014 shape now also fires for
+  // upstream origins (federated-upstream epic, slice 4).
+  assertStringIncludes(
+    diagnostics[0].message,
+    "upstream and delivered-corpus entries are read-only",
+  );
   assertEquals(collidedTokens.has("PLT_0001"), true);
 });
 
@@ -92,6 +99,10 @@ Deno.test("detectCorpusCollisions: project entry reusing corpus Id (ULID) → MS
   assertEquals(diagnostics[0].location?.file, "/repo/reqs.md");
   assertStringIncludes(diagnostics[0].message, `Id '${sharedId}'`);
   assertStringIncludes(diagnostics[0].message, "p@1.0.0");
+  assertStringIncludes(
+    diagnostics[0].message,
+    "upstream and delivered-corpus entries are read-only",
+  );
   assertEquals(collidedTokens.has(sharedId), true);
   // The project entry keeps a unique display ID, so no display-ID token collides.
   assertEquals(collidedTokens.has("REQ_0009"), false);
@@ -121,8 +132,87 @@ Deno.test("detectCorpusCollisions: corpus entries from different profiles sharin
   assertEquals(diagnostics[0].code, "MSL-R014");
   assertEquals(diagnostics[0].severity, "error");
   assertEquals(diagnostics[0].location?.file, "/cache/q/ref.md");
+  // Both origins are known (owner + colliding entry) — the design (D5:
+  // "any collision is a hard diagnostic naming both origins") requires
+  // naming both, not just the first-registered owner.
   assertStringIncludes(diagnostics[0].message, "p@1.0.0");
+  assertStringIncludes(diagnostics[0].message, "q@2.0.0");
   assertEquals(collidedTokens.has("PLT_0001"), true);
+});
+
+Deno.test("detectCorpusCollisions: project entry reusing an UPSTREAM display ID → MSL-R014 naming the upstream origin", () => {
+  const upstream = makeEntry({
+    displayId: "PLT_2001",
+    id: "01ARZ3NDEKTSV4RRFFQ69G5FD0",
+    file: "/repo/.markspec/cache/upstream/productX/ref.md",
+    origin: { kind: "upstream", upstreamId: "productX", version: "2.1.0" },
+  });
+  const project = makeEntry({
+    displayId: "PLT_2001",
+    id: "01ARZ3NDEKTSV4RRFFQ69G5FD1",
+    file: "/repo/reqs.md",
+  });
+  const { diagnostics, collidedTokens } = detectCorpusCollisions([
+    upstream,
+    project,
+  ]);
+  assertEquals(diagnostics.length, 1);
+  assertEquals(diagnostics[0].code, "MSL-R014");
+  assertEquals(diagnostics[0].severity, "error");
+  assertEquals(diagnostics[0].location?.file, "/repo/reqs.md");
+  assertStringIncludes(diagnostics[0].message, "productX@2.1.0");
+  // The remedy must be origin-generic, not corpus-specific prose — this
+  // collision was caused by an upstream entry, not a delivered corpus one.
+  assertStringIncludes(
+    diagnostics[0].message,
+    "upstream and delivered-corpus entries are read-only",
+  );
+  assertEquals(collidedTokens.has("PLT_2001"), true);
+});
+
+Deno.test("detectCorpusCollisions: two upstreams declaring the same display ID → MSL-R014 naming both upstream origins", () => {
+  const first = makeEntry({
+    displayId: "PLT_3001",
+    file: "/repo/.markspec/cache/upstream/productX/ref.md",
+    origin: { kind: "upstream", upstreamId: "productX", version: "2.1.0" },
+  });
+  const second = makeEntry({
+    displayId: "PLT_3001",
+    file: "/repo/.markspec/cache/upstream/productY/ref.md",
+    origin: { kind: "upstream", upstreamId: "productY", version: "1.0.0" },
+  });
+  const { diagnostics, collidedTokens } = detectCorpusCollisions([
+    first,
+    second,
+  ]);
+  assertEquals(diagnostics.length, 1);
+  assertEquals(diagnostics[0].code, "MSL-R014");
+  assertEquals(diagnostics[0].severity, "error");
+  assertEquals(
+    diagnostics[0].location?.file,
+    "/repo/.markspec/cache/upstream/productY/ref.md",
+  );
+  assertStringIncludes(diagnostics[0].message, "productX@2.1.0");
+  assertStringIncludes(diagnostics[0].message, "productY@1.0.0");
+  assertEquals(collidedTokens.has("PLT_3001"), true);
+});
+
+Deno.test("detectCorpusCollisions: upstream entry colliding with a profile-delivered corpus entry → MSL-R014 naming both origins", () => {
+  const corpus = makeEntry({
+    displayId: "PLT_4001",
+    file: "/cache/p/ref.md",
+    origin: { kind: "profile", profileId: "p", profileVersion: "1.0.0" },
+  });
+  const upstream = makeEntry({
+    displayId: "PLT_4001",
+    file: "/repo/.markspec/cache/upstream/productX/ref.md",
+    origin: { kind: "upstream", upstreamId: "productX", version: "2.1.0" },
+  });
+  const { diagnostics } = detectCorpusCollisions([corpus, upstream]);
+  assertEquals(diagnostics.length, 1);
+  assertEquals(diagnostics[0].code, "MSL-R014");
+  assertStringIncludes(diagnostics[0].message, "p@1.0.0");
+  assertStringIncludes(diagnostics[0].message, "productX@2.1.0");
 });
 
 Deno.test("detectCorpusCollisions: same-profile duplicate display ID stays generic (no R014)", () => {

--- a/packages/markspec/core/validator/discipline.ts
+++ b/packages/markspec/core/validator/discipline.ts
@@ -24,7 +24,12 @@ import type {
   DisplayId,
   Entry,
 } from "../model/mod.ts";
-import { CORE_KINDS, makeDisplayId, MIXED_DISCIPLINE } from "../model/mod.ts";
+import {
+  CORE_KINDS,
+  isUpstreamEntry,
+  makeDisplayId,
+  MIXED_DISCIPLINE,
+} from "../model/mod.ts";
 import {
   classifyDerivationOnly,
   parseFrozenValue,
@@ -128,6 +133,12 @@ export function validateDiscipline(
   const knownKinds = effectiveKindSet(registry);
 
   for (const entry of entries) {
+    // Upstream entries (federated-upstream epic) are validation-exempt
+    // emitters (design §4.7) — skip discipline checks sourced from an
+    // upstream entry. `entriesByDisplayId` still includes them for
+    // channel-4 (Allocated-to) derivation on project entries.
+    if (isUpstreamEntry(entry)) continue;
+
     const override = singleAttrValue(entry, "Discipline");
     if (override !== undefined && !knownKinds.has(override)) {
       out.push({

--- a/packages/markspec/core/validator/discipline_test.ts
+++ b/packages/markspec/core/validator/discipline_test.ts
@@ -59,6 +59,25 @@ Deno.test("MSL-T025: known core kind override is silent", () => {
   assertEquals(diags.some((d) => d.code === "MSL-T025"), false);
 });
 
+Deno.test("MSL-T025: upstream entry with unknown override kind is silent (upstream is validation-exempt)", () => {
+  // Upstream entries (federated-upstream epic) are validation-exempt
+  // graph citizens (design §4.7) — an unknown Discipline: kind on an
+  // upstream entry must not emit MSL-T025, even though the same value
+  // on a project entry (see "unknown override kind emits error" above)
+  // does.
+  const e = fixture({
+    displayId: makeDisplayId("REQ_001"),
+    rawAttributes: [{ key: "Discipline", value: "nonsense" }],
+    origin: { kind: "upstream", upstreamId: "acme/reqs", version: "v1.0" },
+  });
+  const diags = validateDiscipline(
+    [e],
+    new Map<DisplayId, Entry>(),
+    CORE_DISCIPLINE_REGISTRY,
+  );
+  assertEquals(diags.some((d) => d.code === "MSL-T025"), false);
+});
+
 Deno.test("MSL-T025: empty override value is silent (no false positive)", () => {
   const e = fixture({
     displayId: makeDisplayId("REQ_001"),

--- a/packages/markspec/core/validator/mod.ts
+++ b/packages/markspec/core/validator/mod.ts
@@ -20,6 +20,7 @@ import {
   CORE_TYPE_SCOPED_ATTRS,
   CSV_SPLITTABLE_TYPES,
   IDENTITY_KEY,
+  isUpstreamEntry,
   ULID_RE,
   UNIVERSAL_ATTRIBUTE_KEYS,
   URI_SCHEME_RE,
@@ -90,6 +91,12 @@ function checkStructural(
   const ids = new Map<string, Entry>();
 
   for (const entry of entries) {
+    // Upstream entries (federated-upstream epic) are validation-exempt
+    // graph citizens (design §4.7): skip every structural check entirely.
+    // Unlike `kind:"profile"` corpus entries (validated then downgraded),
+    // upstream entries never enter these checks in the first place.
+    if (isUpstreamEntry(entry)) continue;
+
     // MSL-R003: exactly one `Id:` attribute per entry.
     // Dual-emit: MSL-I002 (Reference missing Id), MSL-I003 (Authored missing
     // Id), MSL-I004 (multiple Id) — nextgen §4.2 codes alongside legacy.
@@ -455,7 +462,11 @@ function checkReferences(
 
   // MSL-T012: `Supersedes:` — the one baked-in relation. Target must
   // resolve; profile rules check type/shape compatibility separately.
+  // Upstream entries are skipped as emitters — refs FROM an upstream entry
+  // are never checked — but they remain in `byDisplayId`/`byId` above so
+  // refs TO them (from project entries) still resolve.
   for (const entry of entries) {
+    if (isUpstreamEntry(entry)) continue;
     const supersedes = entry.rawAttributes.find((a) => a.key === "Supersedes");
     if (!supersedes) continue;
     const target = supersedes.value.trim();
@@ -472,7 +483,10 @@ function checkReferences(
 
   // MSL-T005: `References:` — citations must resolve to a referenced
   // entry. This is a universal relation (citing identified → referenced).
+  // Upstream entries are skipped as emitters — same rationale as the
+  // Supersedes loop above.
   for (const entry of entries) {
+    if (isUpstreamEntry(entry)) continue;
     const citations = entry.rawAttributes.filter((a) => a.key === "References");
     for (const attr of citations) {
       // Citation format: "slug [free-text locator]"; take the first token.

--- a/packages/markspec/core/validator/mod_test.ts
+++ b/packages/markspec/core/validator/mod_test.ts
@@ -28,6 +28,7 @@ function entry(
     typedAttributes: partial.typedAttributes ?? new Map(),
     bodyTokens: partial.bodyTokens ?? [],
     types: partial.types,
+    origin: partial.origin,
   };
 }
 
@@ -422,6 +423,92 @@ Deno.test("validate: CSV attribute with empty element emits MSL-A006", () => {
   const a006 = result.diagnostics.filter((d) => d.code === "MSL-A006");
   assertEquals(a006.length, 1);
   assertEquals(a006[0].severity, "warning");
+});
+
+// ---------------------------------------------------------------------------
+// Upstream entries (federated-upstream epic, slice 4) — validation-exempt
+// graph citizens: skipped entirely from per-entry checks, but they must
+// remain resolution targets so refs TO them still resolve.
+// ---------------------------------------------------------------------------
+
+Deno.test("validate: upstream entry with missing Id emits no MSL-R003 (structural skip)", () => {
+  const result = validate([
+    entry({
+      displayId: "REQ-001",
+      origin: { kind: "upstream", upstreamId: "acme/reqs", version: "v1.0" },
+    }),
+  ]);
+  const r003 = result.diagnostics.filter((d) => d.code === "MSL-R003");
+  assertEquals(r003, []);
+});
+
+Deno.test("validate: upstream entry with unresolved Supersedes emits no MSL-T012 (refs FROM upstream are inert)", () => {
+  const result = validate([
+    entry({
+      displayId: "REQ-001",
+      rawAttributes: [
+        { key: "Id", value: ULID_A },
+        { key: "Supersedes", value: "REQ-GONE" },
+      ],
+      id: ULID_A,
+      origin: { kind: "upstream", upstreamId: "acme/reqs", version: "v1.0" },
+    }),
+  ]);
+  const t012 = result.diagnostics.filter((d) => d.code === "MSL-T012");
+  assertEquals(t012, []);
+});
+
+Deno.test("validate: upstream entry with unresolved References emits no MSL-T005 (refs FROM upstream are inert)", () => {
+  const result = validate([
+    entry({
+      displayId: "REQ-001",
+      rawAttributes: [
+        { key: "Id", value: ULID_A },
+        { key: "References", value: "UNKNOWN-STANDARD" },
+      ],
+      id: ULID_A,
+      origin: { kind: "upstream", upstreamId: "acme/reqs", version: "v1.0" },
+    }),
+  ]);
+  const t005 = result.diagnostics.filter((d) => d.code === "MSL-T005");
+  assertEquals(t005, []);
+});
+
+Deno.test("validate: PROJECT entry Supersedes an UPSTREAM entry resolves cleanly (upstream stays a resolution target)", () => {
+  const result = validate([
+    entry({
+      displayId: "REQ-001",
+      rawAttributes: [{ key: "Id", value: ULID_A }],
+      id: ULID_A,
+      origin: { kind: "upstream", upstreamId: "acme/reqs", version: "v1.0" },
+    }),
+    entry({
+      displayId: "REQ-002",
+      rawAttributes: [
+        { key: "Id", value: ULID_B },
+        { key: "Supersedes", value: "REQ-001" },
+      ],
+      id: ULID_B,
+      location: { file: "test.md", line: 5, column: 1 },
+    }),
+  ]);
+  const t012 = result.diagnostics.filter((d) => d.code === "MSL-T012");
+  assertEquals(t012, []);
+});
+
+Deno.test("validate: kind:profile corpus entry with missing Id STILL emits MSL-R003 (corpus unchanged)", () => {
+  const result = validate([
+    entry({
+      displayId: "REQ-001",
+      origin: {
+        kind: "profile",
+        profileId: "acme/profile",
+        profileVersion: "1.0.0",
+      },
+    }),
+  ]);
+  const r003 = result.diagnostics.filter((d) => d.code === "MSL-R003");
+  assertEquals(r003.length, 1);
 });
 
 Deno.test("validate: CSV attribute without empty element does not emit MSL-A006", () => {

--- a/packages/markspec/core/validator/pipeline.ts
+++ b/packages/markspec/core/validator/pipeline.ts
@@ -14,7 +14,11 @@ import type {
   EffectiveProfile,
   Entry,
 } from "../model/mod.ts";
-import { CORE_DISCIPLINE_REGISTRY, makeDisplayId } from "../model/mod.ts";
+import {
+  CORE_DISCIPLINE_REGISTRY,
+  isUpstreamEntry,
+  makeDisplayId,
+} from "../model/mod.ts";
 import { validate } from "./mod.ts";
 import {
   classifyEntriesStage,
@@ -95,7 +99,10 @@ export function runPipeline(
   // included) so unknown `Type:` values fail fast regardless of profile.
   // Also covers late-stage display-ID-shape inference (step 8 → MSL-T021)
   // and caption-adjacency rules (§2.6 → MSL-C070).
+  // Upstream entries (federated-upstream epic) are validation-exempt graph
+  // citizens (design §4.7) — skip every per-entry check in this loop.
   for (const entry of entries) {
+    if (isUpstreamEntry(entry)) continue;
     diagnostics.push(...validateCoreTypeAttribute(entry, profile));
     diagnostics.push(...inferTypeFromDisplayIdShape(entry));
     diagnostics.push(...validateCaptions(entry));
@@ -149,9 +156,12 @@ export function runPipeline(
     finalEntries = finalEntries.map((e) => normalizeListValues(e, profile));
   }
 
-  // Stage 3 — typed attributes (only when a profile is loaded).
+  // Stage 3 — typed attributes (only when a profile is loaded). Upstream
+  // entries are validation-exempt (design §4.7) — skip the emit call, but
+  // they remain in `finalEntries` for Stage 4's resolution maps below.
   if (profile !== null) {
     for (const entry of finalEntries) {
+      if (isUpstreamEntry(entry)) continue;
       const stage3 = validateAttributesForEntry(entry, profile);
       diagnostics.push(...stage3);
     }
@@ -159,7 +169,9 @@ export function runPipeline(
 
   // Stage 4 — traceability rules (only when a profile is loaded). Builds two
   // indexes: by `entry.id` (ULID) and by `entry.displayId`, so trace values
-  // resolve in either form (issue #593).
+  // resolve in either form (issue #593). Upstream entries MUST stay in both
+  // indexes — a project entry's link targeting an upstream entry must still
+  // resolve (design §4.7) — so this map-building loop is never filtered.
   if (profile !== null) {
     const graph = new Map<string, Entry>();
     const byDisplayId = new Map<string, Entry>();
@@ -168,7 +180,11 @@ export function runPipeline(
       if (!byDisplayId.has(e.displayId)) byDisplayId.set(e.displayId, e);
     }
     const projectWide = opts.projectWide !== false;
+    // Upstream entries are validation-exempt emitters (design §4.7): skip
+    // checking trace rules FROM an upstream entry. They remain resolution
+    // targets via the maps built above.
     for (const entry of finalEntries) {
+      if (isUpstreamEntry(entry)) continue;
       const stage4 = validateTraceabilityForEntry(
         entry,
         profile,

--- a/packages/markspec/core/validator/pipeline.ts
+++ b/packages/markspec/core/validator/pipeline.ts
@@ -146,6 +146,7 @@ export function runPipeline(
   // and `entry.type` is always undefined, so this stage produces the same
   // diagnostics regardless of mode.
   for (const entry of finalEntries) {
+    if (isUpstreamEntry(entry)) continue;
     diagnostics.push(...inferTypeFromLateStageChain(entry));
   }
 

--- a/packages/markspec/core/validator/pipeline.ts
+++ b/packages/markspec/core/validator/pipeline.ts
@@ -59,6 +59,16 @@ export interface PipelineOptions {
    * Defaults to `true` (full-project scope — emit MSL-L006 normally).
    */
   readonly projectWide?: boolean;
+
+  /**
+   * Declared upstream ids (federated upstream, slice 4) — derived from
+   * `project.yaml`'s `dependencies:`/`references:` via `deriveUpstreamId`.
+   * When non-empty, Stage 4 fires `MSL-T014` (warning), naming the
+   * searched upstream set, instead of `MSL-L006` for an otherwise-
+   * unresolved trace target. Defaults to empty — `MSL-L006` unchanged.
+   * Scope-gated identically to `MSL-L006` (see `projectWide` above).
+   */
+  readonly declaredUpstreamIds?: readonly string[];
 }
 
 /**
@@ -191,12 +201,19 @@ export function runPipeline(
         profile,
         graph,
         byDisplayId,
+        opts.declaredUpstreamIds,
       );
-      // Suppress MSL-L006 ("link target does not resolve") when running
-      // file-locally: the checked subset cannot distinguish a typo from a
-      // valid cross-file target. Only emit when the full entry set is present.
+      // Suppress MSL-L006 ("link target does not resolve") and its
+      // federated-upstream replacement MSL-T014 when running file-locally:
+      // the checked subset cannot distinguish a typo from a valid
+      // cross-file/upstream target. Only emit when the full entry set is
+      // present.
       diagnostics.push(
-        ...projectWide ? stage4 : stage4.filter((d) => d.code !== "MSL-L006"),
+        ...projectWide
+          ? stage4
+          : stage4.filter((d) =>
+            d.code !== "MSL-L006" && d.code !== "MSL-T014"
+          ),
       );
     }
   }

--- a/packages/markspec/core/validator/pipeline_test.ts
+++ b/packages/markspec/core/validator/pipeline_test.ts
@@ -791,6 +791,39 @@ Deno.test("runPipeline: Stage 2 — upstream entry's pre-set type is preserved, 
   assertEquals(result.entries[0].type, "foreign-req");
 });
 
+Deno.test("runPipeline: Stage 2.4 — upstream entry is exempt from late-stage MSL-T021 inference", () => {
+  const profile = buildProfileWithRequirement();
+
+  // A type-less entry whose display ID carries a path-like separator drives
+  // late-stage display-ID-shape inference (MSL-T021). As a project entry it
+  // fires; as an upstream entry it must be exempt (design §4.7).
+  const base: Entry = {
+    displayId: makeDisplayId("svc/handler"),
+    id: "01HGW2Q8MNP3RSTVWXYZABCDEF",
+    shape: "Authored",
+    source: { kind: "markdown" },
+    title: "",
+    body: "",
+    rawAttributes: [{ key: "Id", value: "01HGW2Q8MNP3RSTVWXYZABCDEF" }],
+    typedAttributes: new Map([["Id", ["01HGW2Q8MNP3RSTVWXYZABCDEF"]]]),
+    location: { file: "upstream.md", line: 1, column: 1 },
+    bodyTokens: [],
+  };
+
+  // Control: as a project entry the fixture genuinely triggers MSL-T021.
+  const projectT021 = runPipeline([{ ...base }], profile).diagnostics.filter(
+    (d) => d.code === "MSL-T021",
+  );
+  assertEquals(projectT021.length > 0, true);
+
+  // Upstream: exempt — no MSL-T021.
+  const upstreamT021 = runPipeline([{
+    ...base,
+    origin: { kind: "upstream", upstreamId: "acme/reqs", version: "v1.0" },
+  }], profile).diagnostics.filter((d) => d.code === "MSL-T021");
+  assertEquals(upstreamT021, []);
+});
+
 Deno.test("runPipeline: Stage 2.5 normalization splits comma-separated id-list values before Stage 3", () => {
   const origin = "@test/p";
   const verifiesAttr = {

--- a/packages/markspec/core/validator/pipeline_test.ts
+++ b/packages/markspec/core/validator/pipeline_test.ts
@@ -676,6 +676,10 @@ Deno.test("runPipeline: Stage 4 — PROJECT entry's required link resolves to an
 
   // Upstream target — must still be a resolution target for the project
   // entry's `Verifies:` link, even though it is itself validation-exempt.
+  // Its `type` is pre-set here to "requirement", simulating what real
+  // hydration produces: an upstream entry's type comes from its OWN
+  // compile (design §4.5/D6) — the consumer's Stage 2 never classifies
+  // it, so a hydrated snapshot always arrives with `type` already set.
   const upstreamTarget: Entry = {
     displayId: makeDisplayId("REQ-0001"),
     id: "01UPSTREAMTARGET0000000001",
@@ -683,6 +687,7 @@ Deno.test("runPipeline: Stage 4 — PROJECT entry's required link resolves to an
     source: { kind: "markdown" },
     title: "",
     body: "",
+    type: "requirement",
     rawAttributes: [
       { key: "Id", value: "01UPSTREAMTARGET0000000001" },
     ],
@@ -720,6 +725,70 @@ Deno.test("runPipeline: Stage 4 — PROJECT entry's required link resolves to an
   assertEquals(l001, []);
   assertEquals(l004, []);
   assertEquals(l006, []);
+});
+
+Deno.test("runPipeline: Stage 2 — upstream entry matching no profile type pattern emits no MSL-T001/T002/T003/T004", () => {
+  const profile = buildProfileWithRequirement();
+
+  // Upstream entry whose display ID matches the "requirement" type's
+  // pattern (REQ-{n:04d}) for none of the profile's declared types —
+  // a strict (types.size > 0) consumer profile would classify this as
+  // MSL-T003 for a project entry. Upstream entries are validation-exempt
+  // graph citizens (design §4.7): Stage 2 must not classify or emit for
+  // them at all.
+  const e: Entry = {
+    displayId: makeDisplayId("ZZZ-9999"),
+    id: "01HGW2Q8MNP3RSTVWXYZABCDEF",
+    shape: "Authored",
+    source: { kind: "markdown" },
+    title: "",
+    body: "",
+    rawAttributes: [
+      { key: "Id", value: "01HGW2Q8MNP3RSTVWXYZABCDEF" },
+    ],
+    typedAttributes: new Map([
+      ["Id", ["01HGW2Q8MNP3RSTVWXYZABCDEF"]],
+    ]),
+    location: { file: "upstream.md", line: 1, column: 1 },
+    bodyTokens: [],
+    origin: { kind: "upstream", upstreamId: "acme/reqs", version: "v1.0" },
+  };
+
+  const result = runPipeline([e], profile);
+  const classifyCodes = result.diagnostics.filter((d) =>
+    ["MSL-T001", "MSL-T002", "MSL-T003", "MSL-T004"].includes(d.code)
+  );
+  assertEquals(classifyCodes, []);
+});
+
+Deno.test("runPipeline: Stage 2 — upstream entry's pre-set type is preserved, not overwritten by classification", () => {
+  const profile = buildProfileWithRequirement();
+
+  // Display ID matches the "requirement" type's pattern (REQ-{n:04d}) —
+  // if Stage 2 classified this entry, it would overwrite `type` to
+  // "requirement". Per design §4.5/D6 an upstream entry's type comes
+  // from its OWN compile; the consumer must never re-classify it.
+  const e: Entry = {
+    displayId: makeDisplayId("REQ-0001"),
+    id: "01HGW2Q8MNP3RSTVWXYZABCDEF",
+    shape: "Authored",
+    source: { kind: "markdown" },
+    title: "",
+    body: "",
+    type: "foreign-req",
+    rawAttributes: [
+      { key: "Id", value: "01HGW2Q8MNP3RSTVWXYZABCDEF" },
+    ],
+    typedAttributes: new Map([
+      ["Id", ["01HGW2Q8MNP3RSTVWXYZABCDEF"]],
+    ]),
+    location: { file: "upstream.md", line: 1, column: 1 },
+    bodyTokens: [],
+    origin: { kind: "upstream", upstreamId: "acme/reqs", version: "v1.0" },
+  };
+
+  const result = runPipeline([e], profile);
+  assertEquals(result.entries[0].type, "foreign-req");
 });
 
 Deno.test("runPipeline: Stage 2.5 normalization splits comma-separated id-list values before Stage 3", () => {

--- a/packages/markspec/core/validator/pipeline_test.ts
+++ b/packages/markspec/core/validator/pipeline_test.ts
@@ -391,6 +391,337 @@ Deno.test("Slice 3 pipeline: validateDiscipline runs and emits MSL-T025 on unkno
   assertEquals(diagnostics.some((d) => d.code === "MSL-T025"), true);
 });
 
+// ---------------------------------------------------------------------------
+// Upstream entries (federated-upstream epic, slice 4) — validation-exempt
+// graph citizens. Stage 3 (typed attributes) and Stage 4 (traceability)
+// per-entry emit loops must skip `kind:"upstream"` entries, while the
+// Stage 4 resolution maps (`graph`/`byDisplayId`) must still include them
+// so project refs targeting an upstream entry resolve cleanly.
+// ---------------------------------------------------------------------------
+
+Deno.test("runPipeline: Stage 3 — upstream entry missing a required attribute emits no MSL-A001", () => {
+  const origin = "@test/p";
+  const rationaleAttr = {
+    name: "Rationale",
+    type: "text" as const,
+    required: true,
+    cardinality: { lower: 1, upper: 1 },
+  };
+  const reqType: ProvenancedMapEntry<EffectiveTypeDef> = {
+    origin,
+    value: {
+      name: "requirement",
+      extends: "Requirement",
+      displayIdPattern: { value: "REQ-{n:04d}", origin },
+      displayIdPatternEnforcement: { value: "off", origin },
+      color: { value: undefined, origin },
+      required: { value: ["Rationale"], origin },
+      attributes: new Map([
+        ["Rationale", { value: rationaleAttr, origin }],
+      ]),
+      traceability: new Map(),
+      description: { value: undefined, origin },
+      attrDescriptions: new Map(),
+      relationDescriptions: new Map(),
+      discipline: { value: undefined, origin },
+    },
+  };
+  const profile: EffectiveProfile = {
+    attributes: new Map(),
+    labels: new Map(),
+    conventions: new Map(),
+    colors: new Map(),
+    types: new Map([["requirement", reqType]]),
+    documents: { types: new Map(), frontMatter: new Map() },
+    delivers: [],
+    kinds: new Map(),
+    prose: {
+      lexicons: {
+        "capitalized-allow": { value: [], origin: "" },
+        "sentence-abbrev": { value: [], origin: "" },
+      },
+    },
+    disciplineMode: { value: "none", origin: "inferred" },
+  };
+
+  // Upstream entry classified as requirement but missing Rationale. A real
+  // hydrated snapshot entry would never be malformed like this, but the
+  // test proves the emit loop skips upstream entries unconditionally.
+  const e: Entry = {
+    displayId: makeDisplayId("REQ-0001"),
+    id: "01HGW2Q8MNP3RSTVWXYZABCDEF",
+    shape: "Authored",
+    source: { kind: "markdown" },
+    title: "",
+    body: "",
+    rawAttributes: [
+      { key: "Id", value: "01HGW2Q8MNP3RSTVWXYZABCDEF" },
+    ],
+    typedAttributes: new Map([
+      ["Id", ["01HGW2Q8MNP3RSTVWXYZABCDEF"]],
+    ]),
+    location: { file: "t.md", line: 1, column: 1 },
+    bodyTokens: [],
+    origin: { kind: "upstream", upstreamId: "acme/reqs", version: "v1.0" },
+  };
+
+  const result = runPipeline([e], profile);
+  const a001 = result.diagnostics.filter((d) => d.code === "MSL-A001");
+  assertEquals(a001, []);
+});
+
+Deno.test("runPipeline: Stage 3 — kind:profile corpus entry missing a required attribute STILL emits MSL-A001 (corpus unchanged)", () => {
+  const origin = "@test/p";
+  const rationaleAttr = {
+    name: "Rationale",
+    type: "text" as const,
+    required: true,
+    cardinality: { lower: 1, upper: 1 },
+  };
+  const reqType: ProvenancedMapEntry<EffectiveTypeDef> = {
+    origin,
+    value: {
+      name: "requirement",
+      extends: "Requirement",
+      displayIdPattern: { value: "REQ-{n:04d}", origin },
+      displayIdPatternEnforcement: { value: "off", origin },
+      color: { value: undefined, origin },
+      required: { value: ["Rationale"], origin },
+      attributes: new Map([
+        ["Rationale", { value: rationaleAttr, origin }],
+      ]),
+      traceability: new Map(),
+      description: { value: undefined, origin },
+      attrDescriptions: new Map(),
+      relationDescriptions: new Map(),
+      discipline: { value: undefined, origin },
+    },
+  };
+  const profile: EffectiveProfile = {
+    attributes: new Map(),
+    labels: new Map(),
+    conventions: new Map(),
+    colors: new Map(),
+    types: new Map([["requirement", reqType]]),
+    documents: { types: new Map(), frontMatter: new Map() },
+    delivers: [],
+    kinds: new Map(),
+    prose: {
+      lexicons: {
+        "capitalized-allow": { value: [], origin: "" },
+        "sentence-abbrev": { value: [], origin: "" },
+      },
+    },
+    disciplineMode: { value: "none", origin: "inferred" },
+  };
+
+  const e: Entry = {
+    displayId: makeDisplayId("REQ-0001"),
+    id: "01HGW2Q8MNP3RSTVWXYZABCDEF",
+    shape: "Authored",
+    source: { kind: "markdown" },
+    title: "",
+    body: "",
+    rawAttributes: [
+      { key: "Id", value: "01HGW2Q8MNP3RSTVWXYZABCDEF" },
+    ],
+    typedAttributes: new Map([
+      ["Id", ["01HGW2Q8MNP3RSTVWXYZABCDEF"]],
+    ]),
+    location: { file: "t.md", line: 1, column: 1 },
+    bodyTokens: [],
+    origin: {
+      kind: "profile",
+      profileId: "acme/profile",
+      profileVersion: "1.0.0",
+    },
+  };
+
+  const result = runPipeline([e], profile);
+  const a001 = result.diagnostics.find((d) => d.code === "MSL-A001");
+  if (!a001) {
+    throw new Error(
+      `expected MSL-A001, got: ${result.diagnostics.map((d) => d.code)}`,
+    );
+  }
+});
+
+Deno.test("runPipeline: Stage 4 — upstream entry's own missing required link emits no MSL-L001", () => {
+  const origin = "@test/p";
+  const requiredRule = {
+    target: ["requirement"] as const,
+    cardinality: { lower: 1, upper: Infinity },
+    required: true,
+  };
+  const testType: ProvenancedMapEntry<EffectiveTypeDef> = {
+    origin,
+    value: {
+      name: "test",
+      extends: "Requirement",
+      displayIdPattern: { value: "TEST-{n:04d}", origin },
+      displayIdPatternEnforcement: { value: "off", origin },
+      color: { value: undefined, origin },
+      required: { value: [], origin },
+      attributes: new Map(),
+      traceability: new Map([
+        ["Verifies", { value: requiredRule, origin }],
+      ]),
+      description: { value: undefined, origin },
+      attrDescriptions: new Map(),
+      relationDescriptions: new Map(),
+      discipline: { value: undefined, origin },
+    },
+  };
+  const profile: EffectiveProfile = {
+    attributes: new Map(),
+    labels: new Map(),
+    conventions: new Map(),
+    colors: new Map(),
+    types: new Map([["test", testType]]),
+    documents: { types: new Map(), frontMatter: new Map() },
+    delivers: [],
+    kinds: new Map(),
+    prose: {
+      lexicons: {
+        "capitalized-allow": { value: [], origin: "" },
+        "sentence-abbrev": { value: [], origin: "" },
+      },
+    },
+    disciplineMode: { value: "none", origin: "inferred" },
+  };
+
+  const e: Entry = {
+    displayId: makeDisplayId("TEST-0001"),
+    id: "01HGW2Q8MNP3RSTVWXYZABCDEF",
+    shape: "Authored",
+    source: { kind: "markdown" },
+    title: "",
+    body: "",
+    rawAttributes: [
+      { key: "Id", value: "01HGW2Q8MNP3RSTVWXYZABCDEF" },
+    ],
+    typedAttributes: new Map([
+      ["Id", ["01HGW2Q8MNP3RSTVWXYZABCDEF"]],
+    ]),
+    location: { file: "t.md", line: 1, column: 1 },
+    bodyTokens: [],
+    origin: { kind: "upstream", upstreamId: "acme/reqs", version: "v1.0" },
+  };
+
+  const result = runPipeline([e], profile);
+  const l001 = result.diagnostics.filter((d) => d.code === "MSL-L001");
+  assertEquals(l001, []);
+});
+
+Deno.test("runPipeline: Stage 4 — PROJECT entry's required link resolves to an UPSTREAM entry (resolution map preserved, no MSL-L006/L004)", () => {
+  const origin = "@test/p";
+  const requiredRule = {
+    target: ["requirement"] as const,
+    cardinality: { lower: 1, upper: Infinity },
+    required: true,
+  };
+  const reqType: ProvenancedMapEntry<EffectiveTypeDef> = {
+    origin,
+    value: {
+      name: "requirement",
+      extends: "Requirement",
+      displayIdPattern: { value: "REQ-{n:04d}", origin },
+      displayIdPatternEnforcement: { value: "off", origin },
+      color: { value: undefined, origin },
+      required: { value: [], origin },
+      attributes: new Map(),
+      traceability: new Map(),
+      description: { value: undefined, origin },
+      attrDescriptions: new Map(),
+      relationDescriptions: new Map(),
+      discipline: { value: undefined, origin },
+    },
+  };
+  const testType: ProvenancedMapEntry<EffectiveTypeDef> = {
+    origin,
+    value: {
+      name: "test",
+      extends: "Requirement",
+      displayIdPattern: { value: "TEST-{n:04d}", origin },
+      displayIdPatternEnforcement: { value: "off", origin },
+      color: { value: undefined, origin },
+      required: { value: [], origin },
+      attributes: new Map(),
+      traceability: new Map([
+        ["Verifies", { value: requiredRule, origin }],
+      ]),
+      description: { value: undefined, origin },
+      attrDescriptions: new Map(),
+      relationDescriptions: new Map(),
+      discipline: { value: undefined, origin },
+    },
+  };
+  const profile: EffectiveProfile = {
+    attributes: new Map(),
+    labels: new Map(),
+    conventions: new Map(),
+    colors: new Map(),
+    types: new Map([["requirement", reqType], ["test", testType]]),
+    documents: { types: new Map(), frontMatter: new Map() },
+    delivers: [],
+    kinds: new Map(),
+    prose: {
+      lexicons: {
+        "capitalized-allow": { value: [], origin: "" },
+        "sentence-abbrev": { value: [], origin: "" },
+      },
+    },
+    disciplineMode: { value: "none", origin: "inferred" },
+  };
+
+  // Upstream target — must still be a resolution target for the project
+  // entry's `Verifies:` link, even though it is itself validation-exempt.
+  const upstreamTarget: Entry = {
+    displayId: makeDisplayId("REQ-0001"),
+    id: "01UPSTREAMTARGET0000000001",
+    shape: "Authored",
+    source: { kind: "markdown" },
+    title: "",
+    body: "",
+    rawAttributes: [
+      { key: "Id", value: "01UPSTREAMTARGET0000000001" },
+    ],
+    typedAttributes: new Map([
+      ["Id", ["01UPSTREAMTARGET0000000001"]],
+    ]),
+    location: { file: "upstream.md", line: 1, column: 1 },
+    bodyTokens: [],
+    origin: { kind: "upstream", upstreamId: "acme/reqs", version: "v1.0" },
+  };
+
+  const project: Entry = {
+    displayId: makeDisplayId("TEST-0001"),
+    id: "01HGW2Q8MNP3RSTVWXYZABCDEF",
+    shape: "Authored",
+    source: { kind: "markdown" },
+    title: "",
+    body: "",
+    rawAttributes: [
+      { key: "Id", value: "01HGW2Q8MNP3RSTVWXYZABCDEF" },
+      { key: "Verifies", value: "REQ-0001" },
+    ],
+    typedAttributes: new Map([
+      ["Id", ["01HGW2Q8MNP3RSTVWXYZABCDEF"]],
+      ["Verifies", ["REQ-0001"]],
+    ]),
+    location: { file: "t.md", line: 1, column: 1 },
+    bodyTokens: [],
+  };
+
+  const result = runPipeline([project, upstreamTarget], profile);
+  const l001 = result.diagnostics.filter((d) => d.code === "MSL-L001");
+  const l004 = result.diagnostics.filter((d) => d.code === "MSL-L004");
+  const l006 = result.diagnostics.filter((d) => d.code === "MSL-L006");
+  assertEquals(l001, []);
+  assertEquals(l004, []);
+  assertEquals(l006, []);
+});
+
 Deno.test("runPipeline: Stage 2.5 normalization splits comma-separated id-list values before Stage 3", () => {
   const origin = "@test/p";
   const verifiesAttr = {

--- a/packages/markspec/core/validator/trace_types.ts
+++ b/packages/markspec/core/validator/trace_types.ts
@@ -13,7 +13,11 @@
  */
 
 import type { Diagnostic, Entry } from "../model/mod.ts";
-import { CORE_RELATIONS, CORE_TYPE_HIERARCHY } from "../model/mod.ts";
+import {
+  CORE_RELATIONS,
+  CORE_TYPE_HIERARCHY,
+  isUpstreamEntry,
+} from "../model/mod.ts";
 import { resolvedCoreType } from "./type_resolution.ts";
 
 /**
@@ -119,6 +123,12 @@ export function validateTraceTargetTypes(
   const diagnostics: Diagnostic[] = [];
 
   for (const entry of entries) {
+    // Upstream entries (federated-upstream epic) are validation-exempt
+    // emitters (design §4.7) — skip checking trace rules FROM an upstream
+    // entry. `byDisplayId`/`byId` above still include them, so a project
+    // entry's link targeting an upstream entry keeps resolving.
+    if (isUpstreamEntry(entry)) continue;
+
     // MSL-R084: Supersedes target must be the same shape as the source.
     for (const attr of entry.rawAttributes) {
       if (attr.key !== "Supersedes") continue;

--- a/packages/markspec/core/validator/trace_types_test.ts
+++ b/packages/markspec/core/validator/trace_types_test.ts
@@ -20,6 +20,7 @@ function entry(opts: {
   type?: string;
   id?: string;
   rawAttributes?: Array<{ key: string; value: string }>;
+  origin?: Entry["origin"];
 }): Entry {
   const id = opts.id ?? ULID_A;
   return {
@@ -34,6 +35,7 @@ function entry(opts: {
     location: { file: "test.md", line: 1, column: 1 },
     source: { kind: "markdown" },
     bodyTokens: [],
+    origin: opts.origin,
   };
 }
 
@@ -92,6 +94,38 @@ Deno.test("Caused-by on Record with Component target → MSL-R083 (Record-cause 
     true,
     `expected message to identify Record source role; got ${msg}`,
   );
+});
+
+Deno.test("Caused-by on upstream Record with Component target → no MSL-R083 (upstream source is validation-exempt)", () => {
+  // Same fixture shape as "Caused-by on Record with Component target →
+  // MSL-R083 (Record-cause set)" above, but the source entry carries a
+  // `kind:"upstream"` origin. Upstream entries are validation-exempt
+  // graph citizens (design §4.7) — Stage 1.6 must skip emitting from
+  // them entirely, even though the target-type mismatch would otherwise
+  // fire MSL-R083.
+  const result = validateTraceTargetTypes([
+    entry({
+      displayId: "REC-001",
+      type: "Record",
+      rawAttributes: [
+        { key: "Id", value: ULID_A },
+        { key: "Type", value: "Record" },
+        { key: "Caused-by", value: ULID_B },
+      ],
+      origin: { kind: "upstream", upstreamId: "acme/reqs", version: "v1.0" },
+    }),
+    entry({
+      displayId: "comp-1",
+      type: "Component",
+      id: ULID_B,
+      rawAttributes: [
+        { key: "Id", value: ULID_B },
+        { key: "Type", value: "Component" },
+      ],
+    }),
+  ]);
+  const r083 = result.filter((d) => d.code === "MSL-R083");
+  assertEquals(r083.length, 0);
 });
 
 Deno.test("Caused-by on Risk with Component target → OK", () => {

--- a/packages/markspec/core/validator/traceability.ts
+++ b/packages/markspec/core/validator/traceability.ts
@@ -8,7 +8,10 @@
  * attributes:
  *   - Required (MSL-L001)
  *   - Cardinality bounds (MSL-L002 upper / MSL-L003 lower)
- *   - Target match against the rule's target matchers (MSL-L004)
+ *   - Target match against the rule's target matchers (MSL-L004; skipped
+ *     when the resolved target is an upstream entry — its `type` comes from
+ *     the upstream's own profile, a vocabulary the consumer never
+ *     re-classifies against, federated upstream slice 4)
  *   - Target existence (MSL-L006, warning; scheme-qualified URIs exempt) —
  *     or MSL-T014 (warning) instead of MSL-L006 when the caller declares a
  *     non-empty upstream set (federated upstream, slice 4)
@@ -22,6 +25,7 @@ import {
   type Diagnostic,
   type EffectiveProfile,
   type Entry,
+  isUpstreamEntry,
   type TargetMatcher,
   type TraceRule,
   URI_SCHEME_RE,
@@ -188,6 +192,14 @@ export function validateTraceabilityForEntry(
         });
         continue;
       }
+      // Federated upstream (slice 4): an upstream target's `type` is
+      // classified by the upstream's OWN profile — a foreign vocabulary the
+      // consumer's profile cannot map (design §4.5/D6: the consumer never
+      // re-classifies). The link still resolves (no L006/T014 — handled
+      // above); only the consumer's own target-type enforcement is skipped
+      // for this target. A project-authored target with a mismatched type
+      // still fires MSL-L004 below.
+      if (isUpstreamEntry(target)) continue;
       if (!matchesAnyTarget(target, rule.target)) {
         diagnostics.push({
           code: "MSL-L004",

--- a/packages/markspec/core/validator/traceability.ts
+++ b/packages/markspec/core/validator/traceability.ts
@@ -9,7 +9,9 @@
  *   - Required (MSL-L001)
  *   - Cardinality bounds (MSL-L002 upper / MSL-L003 lower)
  *   - Target match against the rule's target matchers (MSL-L004)
- *   - Target existence (MSL-L006, warning; scheme-qualified URIs exempt)
+ *   - Target existence (MSL-L006, warning; scheme-qualified URIs exempt) —
+ *     or MSL-T014 (warning) instead of MSL-L006 when the caller declares a
+ *     non-empty upstream set (federated upstream, slice 4)
  *
  * Referenced entries are skipped entirely — the profile manifest parser
  * rejects `referenced.traceability` at load time, so referenced entries
@@ -86,12 +88,20 @@ export function matchesAnyTarget(
  * @param graph - Index keyed by entry.id (ULID) for target lookup
  * @param byDisplayId - Index keyed by entry.displayId for target lookup
  *                      (issue #593 — display-ID targets). Defaults to empty.
+ * @param declaredUpstreamIds - Upstream ids the downstream project declares
+ *                      via `project.yaml` `dependencies:`/`references:`
+ *                      (federated upstream, slice 4). When non-empty, an
+ *                      otherwise-unresolved trace target fires MSL-T014
+ *                      (warning), naming the searched upstream set, instead
+ *                      of the generic MSL-L006. Defaults to empty — MSL-L006
+ *                      unchanged.
  */
 export function validateTraceabilityForEntry(
   entry: Entry,
   profile: EffectiveProfile,
   graph: ReadonlyMap<string, Entry>,
   byDisplayId: ReadonlyMap<string, Entry> = new Map(),
+  declaredUpstreamIds: readonly string[] = [],
 ): Diagnostic[] {
   const diagnostics: Diagnostic[] = [];
   if (entry.shape !== "Authored") return diagnostics;
@@ -151,6 +161,23 @@ export function validateTraceabilityForEntry(
         // Scheme-qualified URIs are intentionally external — never local
         // graph targets, so they are not "broken references".
         if (URI_SCHEME_RE.test(v)) continue;
+        // Federated upstream (slice 4): when the project declares an
+        // upstream set, an unresolved target replaces MSL-L006 with
+        // MSL-T014, naming the searched set — the same target fires
+        // exactly one of the two codes, never both.
+        if (declaredUpstreamIds.length > 0) {
+          diagnostics.push({
+            code: "MSL-T014",
+            severity: "warning",
+            message:
+              `${entry.displayId}: link '${linkName}' target '${v}' not ` +
+              `found in project or upstreams: ${
+                declaredUpstreamIds.join(", ")
+              }`,
+            location: entry.location,
+          });
+          continue;
+        }
         diagnostics.push({
           code: "MSL-L006",
           severity: "warning",

--- a/packages/markspec/core/validator/traceability_test.ts
+++ b/packages/markspec/core/validator/traceability_test.ts
@@ -14,6 +14,7 @@ import type {
   EffectiveProfile,
   EffectiveTypeDef,
   Entry,
+  EntryOrigin,
   EntryShape,
   ProvenancedMapEntry,
   TraceRule,
@@ -280,6 +281,7 @@ function entryWithAttrs(opts: {
   shape: EntryShape;
   type?: string;
   attrs?: Record<string, readonly string[]>;
+  origin?: EntryOrigin;
 }): Entry {
   const attrs = opts.attrs ?? {};
   const attributes = [];
@@ -300,6 +302,7 @@ function entryWithAttrs(opts: {
     ),
     location: { file: "t.md", line: 1, column: 1 },
     bodyTokens: [],
+    origin: opts.origin,
   };
 }
 
@@ -824,4 +827,111 @@ Deno.test("validateTraceabilityForEntry: upstreams declared + ref resolves to up
   );
   assertEquals(diags.filter((d) => d.code === "MSL-L006"), []);
   assertEquals(diags.filter((d) => d.code === "MSL-T014"), []);
+});
+
+// ---------------------------------------------------------------------------
+// MSL-L004 target-type exemption for upstream targets (federated upstream,
+// review fix — the slice-4 exemption covered the source side but missed the
+// resolved-target side)
+// ---------------------------------------------------------------------------
+
+Deno.test("validateTraceabilityForEntry: upstream target with foreign type → no MSL-L004 (link still resolves)", () => {
+  const rule: TraceRule = {
+    target: ["requirement"], // downstream vocabulary
+    cardinality: { lower: 0, upper: Infinity },
+    required: false,
+  };
+  const p = profile({
+    types: [typeDef({ name: "test", traceability: { Verifies: rule } })],
+  });
+  // Upstream target classified under the UPSTREAM's own vocabulary —
+  // "SystemRequirement", not the downstream rule's "requirement".
+  const upstreamTarget = entryWithAttrs({
+    id: "01UPSTREAM0000000000000000",
+    displayId: "REQ-0001",
+    shape: "Authored",
+    type: "SystemRequirement",
+    origin: { kind: "upstream", upstreamId: "upstream-a", version: "1.0.0" },
+  });
+  const e = entryWithAttrs({
+    shape: "Authored",
+    type: "test",
+    attrs: { Verifies: ["REQ-0001"] },
+  });
+  const diags = validateTraceabilityForEntry(
+    e,
+    p,
+    graphOf([e, upstreamTarget]),
+    byDisplayIdOf([e, upstreamTarget]),
+    ["upstream-a"],
+  );
+  assertEquals(diags.filter((d) => d.code === "MSL-L004"), []);
+  assertEquals(diags.filter((d) => d.code === "MSL-L006"), []);
+  assertEquals(diags.filter((d) => d.code === "MSL-T014"), []);
+});
+
+Deno.test("validateTraceabilityForEntry: upstream target whose type DOES match rule → still resolves cleanly", () => {
+  const rule: TraceRule = {
+    target: ["requirement"],
+    cardinality: { lower: 0, upper: Infinity },
+    required: false,
+  };
+  const p = profile({
+    types: [typeDef({ name: "test", traceability: { Verifies: rule } })],
+  });
+  const upstreamTarget = entryWithAttrs({
+    id: "01UPSTREAM0000000000000001",
+    displayId: "REQ-0002",
+    shape: "Authored",
+    type: "requirement", // same-vocabulary case — matches the rule anyway
+    origin: { kind: "upstream", upstreamId: "upstream-a", version: "1.0.0" },
+  });
+  const e = entryWithAttrs({
+    shape: "Authored",
+    type: "test",
+    attrs: { Verifies: ["REQ-0002"] },
+  });
+  const diags = validateTraceabilityForEntry(
+    e,
+    p,
+    graphOf([e, upstreamTarget]),
+    byDisplayIdOf([e, upstreamTarget]),
+    ["upstream-a"],
+  );
+  assertEquals(diags, []);
+});
+
+Deno.test("validateTraceabilityForEntry: project→project target with mismatched type still fires MSL-L004 (control)", () => {
+  const rule: TraceRule = {
+    target: ["requirement"],
+    cardinality: { lower: 0, upper: Infinity },
+    required: false,
+  };
+  const p = profile({
+    types: [typeDef({ name: "test", traceability: { Verifies: rule } })],
+  });
+  // Same foreign type as the upstream case above, but NO origin — a plain
+  // project-authored target. The exemption must not over-skip this.
+  const wrongTarget = entryWithAttrs({
+    id: "01PROJECT000000000000000",
+    displayId: "REQ-0003",
+    shape: "Authored",
+    type: "SystemRequirement",
+  });
+  const e = entryWithAttrs({
+    shape: "Authored",
+    type: "test",
+    attrs: { Verifies: ["REQ-0003"] },
+  });
+  const diags = validateTraceabilityForEntry(
+    e,
+    p,
+    graphOf([e, wrongTarget]),
+    byDisplayIdOf([e, wrongTarget]),
+    ["upstream-a"],
+  );
+  const l004 = diags.find((d) => d.code === "MSL-L004");
+  if (!l004) {
+    throw new Error(`expected MSL-L004, got: ${diags.map((d) => d.code)}`);
+  }
 });

--- a/packages/markspec/core/validator/traceability_test.ts
+++ b/packages/markspec/core/validator/traceability_test.ts
@@ -728,3 +728,100 @@ Deno.test("validateTraceabilityForEntry: scheme-qualified URI target is not flag
   );
   assertEquals(diags.filter((d) => d.code === "MSL-L006"), []);
 });
+
+// ---------------------------------------------------------------------------
+// MSL-T014 — unresolved-after-federation (federated upstream, slice 4)
+// ---------------------------------------------------------------------------
+
+Deno.test("validateTraceabilityForEntry: no upstreams declared + unresolved ref → MSL-L006 (unchanged)", () => {
+  const rule: TraceRule = {
+    target: ["requirement"],
+    cardinality: { lower: 0, upper: Infinity },
+    required: false,
+  };
+  const p = profile({
+    types: [typeDef({ name: "test", traceability: { Verifies: rule } })],
+  });
+  const e = entryWithAttrs({
+    shape: "Authored",
+    type: "test",
+    attrs: { Verifies: ["REQ-9999"] }, // exists nowhere
+  });
+  const diags = validateTraceabilityForEntry(
+    e,
+    p,
+    graphOf([e]),
+    byDisplayIdOf([e]),
+    [], // no declared upstreams
+  );
+  const l006 = diags.filter((d) => d.code === "MSL-L006");
+  const t014 = diags.filter((d) => d.code === "MSL-T014");
+  assertEquals(l006.length, 1);
+  assertEquals(t014.length, 0);
+});
+
+Deno.test("validateTraceabilityForEntry: upstreams declared + unresolved ref → MSL-T014, no MSL-L006", () => {
+  const rule: TraceRule = {
+    target: ["requirement"],
+    cardinality: { lower: 0, upper: Infinity },
+    required: false,
+  };
+  const p = profile({
+    types: [typeDef({ name: "test", traceability: { Verifies: rule } })],
+  });
+  const e = entryWithAttrs({
+    shape: "Authored",
+    type: "test",
+    attrs: { Verifies: ["REQ-9999"] }, // exists nowhere
+  });
+  const diags = validateTraceabilityForEntry(
+    e,
+    p,
+    graphOf([e]),
+    byDisplayIdOf([e]),
+    ["upstream-a", "upstream-b"],
+  );
+  const l006 = diags.filter((d) => d.code === "MSL-L006");
+  const t014 = diags.filter((d) => d.code === "MSL-T014");
+  assertEquals(l006.length, 0);
+  assertEquals(t014.length, 1);
+  assertEquals(t014[0].severity, "warning");
+  const msg = t014[0].message;
+  if (
+    !msg.includes("Verifies") || !msg.includes("REQ-9999") ||
+    !msg.includes("upstream-a") || !msg.includes("upstream-b")
+  ) {
+    throw new Error(`message lacks searched-set context: ${msg}`);
+  }
+});
+
+Deno.test("validateTraceabilityForEntry: upstreams declared + ref resolves to upstream entry → neither L006 nor T014", () => {
+  const rule: TraceRule = {
+    target: ["requirement"],
+    cardinality: { lower: 0, upper: Infinity },
+    required: false,
+  };
+  const p = profile({
+    types: [typeDef({ name: "test", traceability: { Verifies: rule } })],
+  });
+  const upstreamTarget = entryWithAttrs({
+    id: "01UPSTREAM0000000000000000",
+    displayId: "REQ-0001",
+    shape: "Authored",
+    type: "requirement",
+  });
+  const e = entryWithAttrs({
+    shape: "Authored",
+    type: "test",
+    attrs: { Verifies: ["REQ-0001"] },
+  });
+  const diags = validateTraceabilityForEntry(
+    e,
+    p,
+    graphOf([e, upstreamTarget]),
+    byDisplayIdOf([e, upstreamTarget]),
+    ["upstream-a"],
+  );
+  assertEquals(diags.filter((d) => d.code === "MSL-L006"), []);
+  assertEquals(diags.filter((d) => d.code === "MSL-T014"), []);
+});

--- a/packages/markspec/core/validator/types.ts
+++ b/packages/markspec/core/validator/types.ts
@@ -15,7 +15,7 @@ import type {
   Entry,
   ProvenancedMapEntry,
 } from "../model/mod.ts";
-import { CORE_TYPES } from "../model/mod.ts";
+import { CORE_TYPES, isUpstreamEntry } from "../model/mod.ts";
 import { tryCompileDisplayIdPattern } from "./pattern.ts";
 import {
   explicitType,
@@ -260,6 +260,17 @@ export function classifyEntriesStage(
   const out: Entry[] = [];
 
   for (const entry of entries) {
+    // Upstream entries (federated-upstream epic) are validation-exempt
+    // graph citizens (design §4.7); their `type` comes from their OWN
+    // compile (design §4.5/D6) — the consumer never re-classifies. Pass
+    // the entry through unchanged: no MSL-T001..T004 emit, no type
+    // overwrite. It still lands in `out`, so it remains a resolution
+    // target for later stages (Stage 3/4 index-building).
+    if (isUpstreamEntry(entry)) {
+      out.push(entry);
+      continue;
+    }
+
     const classified = classifyEntry(entry, profile);
     diagnostics.push(...classified.diagnostics);
 

--- a/packages/markspec/lsp/server.ts
+++ b/packages/markspec/lsp/server.ts
@@ -55,6 +55,7 @@ import {
   loadMarkdownFormatter,
   loadProfileForCommand,
   loadToolConfig,
+  loadUpstreamCorpus,
   type Lockfile,
   makeDisplayId,
   parseDisplayIdPattern,
@@ -62,6 +63,7 @@ import {
   type ProjectConfig,
   targetsForRelation,
   type ToolConfig,
+  upstreamRefsFromLockfile,
   validateDisplayIdPattern,
   VERSION,
 } from "../core/mod.ts";
@@ -216,9 +218,16 @@ function _getLockfile(): Lockfile | undefined {
   return lockfile;
 }
 
-/** Absolute paths of delivered corpus files currently seeded into the
- * index (ADR-030). Diagnostics for these files are never published and
- * the files are re-seeded, not watched. */
+/** Absolute paths of delivered-corpus (ADR-030) and locked-upstream
+ * (federated-upstream slice 4) files currently seeded into the index.
+ * Diagnostics for these files are never published and the files are
+ * re-seeded, not watched. Shared by {@linkcode seedDeliveredCorpus} and
+ * {@linkcode seedUpstreamCorpus} so every existing read-only guard
+ * (diagnostics publish, buffer edit/open/close, rename, format) covers
+ * both origins without change; each seeder also tracks its own files in
+ * a private set (`upstreamFilePaths` for the latter) so one seeder's
+ * clear pass never drops the other's entries — see
+ * {@linkcode seedUpstreamCorpus}'s doc comment for why that matters. */
 const corpusFilePaths = new Set<string>();
 
 /**
@@ -264,6 +273,112 @@ async function seedDeliveredCorpus(): Promise<void> {
     // Cold-cache soft-fail (design spec §4): the index proceeds without
     // corpus rather than aborting initialization or profile reload.
     connection.console.warn(`Failed to load delivered corpus: ${err}`);
+  }
+}
+
+/** Absolute paths of locked-upstream corpus files currently seeded into
+ * the index (federated-upstream slice 4). Tracked separately from the
+ * shared `corpusFilePaths` guard set so `seedUpstreamCorpus`'s own clear
+ * pass never removes delivered-corpus (ADR-030) files that happen to
+ * share the set — each file is still added to `corpusFilePaths` too, so
+ * the existing read-only guards cover upstream files for free. */
+const upstreamFilePaths = new Set<string>();
+
+/**
+ * (Re-)seed the workspace index with the locked upstream corpus
+ * (federated-upstream slice 4: docs/wip/2026-07-04-federated-upstream-resolution-design.md).
+ * Mirrors {@linkcode seedDeliveredCorpus}: always drops the previously
+ * seeded upstream files first (so a re-lock that drops or replaces an
+ * upstream doesn't leave stale entries behind), maps the loaded
+ * `markspec.lock`'s snapshot-carrying upstream rows via
+ * {@linkcode upstreamRefsFromLockfile}, and hydrates them with
+ * {@linkcode loadUpstreamCorpus}. Entries carry `Entry.origin = { kind:
+ * "upstream", ... }`; adding their file to the shared `corpusFilePaths`
+ * set makes every existing read-only guard (diagnostics publish, buffer
+ * edit/open/close, rename, format) treat them as read-only, same as
+ * delivered corpus.
+ *
+ * Called after `seedDeliveredCorpus()` at both call sites
+ * (`onInitialized`, `reloadProfile`) so upstream entries lose
+ * "first entry wins" ties to delivered corpus but still win over the
+ * project walk that follows.
+ *
+ * Clear/re-seed interaction with `seedDeliveredCorpus` (the subtle
+ * part): `seedDeliveredCorpus` clears by iterating the *shared*
+ * `corpusFilePaths` set, so its clear pass also calls
+ * `index.removeFile` on any upstream file already tracked there —
+ * transiently dropping upstream entries from the index. That is safe
+ * only because `seedUpstreamCorpus` always runs immediately afterward
+ * at both call sites and re-adds them. `seedUpstreamCorpus` itself
+ * clears via its *own* `upstreamFilePaths` set, never the shared one,
+ * so the reverse never happens: re-seeding upstream (e.g. on a
+ * `markspec.lock`-only change) cannot remove delivered-corpus entries.
+ */
+async function seedUpstreamCorpus(): Promise<void> {
+  // Always drop the previously-seeded upstream files first — even if
+  // the reload below fails or the lockfile now declares no upstreams,
+  // stale entries from a previous lockfile must not linger in the index.
+  for (const path of upstreamFilePaths) {
+    index.removeFile(path);
+    corpusFilePaths.delete(path);
+  }
+  upstreamFilePaths.clear();
+  if (!lockfile || !projectRoot) return;
+  const refs = upstreamRefsFromLockfile(lockfile, projectRoot);
+  if (refs.length === 0) return;
+  try {
+    const corpus = await loadUpstreamCorpus(refs, readFile);
+    for (const d of corpus.diagnostics) {
+      connection.console.warn(`${d.code}: ${d.message}`);
+    }
+    const byFile = new Map<string, Entry[]>();
+    for (const e of corpus.entries) {
+      const list = byFile.get(e.location.file) ?? [];
+      list.push(e);
+      byFile.set(e.location.file, list);
+    }
+    for (const [file, entries] of byFile) {
+      index.updateFile(file, entries);
+      upstreamFilePaths.add(file);
+      corpusFilePaths.add(file);
+    }
+  } catch (err) {
+    // Cold-cache soft-fail, mirroring seedDeliveredCorpus: the index
+    // proceeds without the upstream corpus rather than aborting
+    // initialization or a profile/lockfile reload.
+    connection.console.warn(`Failed to load upstream corpus: ${err}`);
+  }
+}
+
+/**
+ * (Re-)load `markspec.lock` from disk into the module-scoped `lockfile`.
+ * A missing file sets `lockfile` to `undefined` — including on reload,
+ * so a deleted lockfile drops the upstream corpus on the next
+ * `seedUpstreamCorpus()` call. A malformed lockfile logs its parse
+ * diagnostics and leaves `lockfile` at its previous value. The LSP never
+ * writes the lockfile; drift detection stays in the CLI.
+ */
+async function reloadLockfile(): Promise<void> {
+  if (!projectRoot) return;
+  try {
+    const lockRaw = await readFile(`${projectRoot}/markspec.lock`);
+    if (lockRaw === undefined) {
+      lockfile = undefined;
+      return;
+    }
+    const parsed = parseLockfile(lockRaw);
+    if (parsed.lockfile) {
+      lockfile = parsed.lockfile;
+      connection.console.log(
+        `Loaded markspec.lock: ${lockfile.upstreams.length} upstreams, locked at ${lockfile.meta.lockedAt}`,
+      );
+    } else {
+      for (const d of parsed.diagnostics) {
+        connection.console.warn(`Lockfile parse: ${d.code}: ${d.message}`);
+      }
+    }
+  } catch {
+    /* no lockfile is fine */
   }
 }
 
@@ -572,29 +687,10 @@ connection.onInitialize(
         connection.console.warn("Failed to load profile");
       }
 
-      // Load markspec.lock if present. Used by future federated-registry
-      // pinning + stale-pin hints. The LSP never writes the lockfile;
-      // drift detection stays in the CLI.
-      try {
-        const lockRaw = await readFile(`${projectRoot}/markspec.lock`);
-        if (lockRaw !== undefined) {
-          const parsed = parseLockfile(lockRaw);
-          if (parsed.lockfile) {
-            lockfile = parsed.lockfile;
-            connection.console.log(
-              `Loaded markspec.lock: ${lockfile.upstreams.length} upstreams, locked at ${lockfile.meta.lockedAt}`,
-            );
-          } else {
-            for (const d of parsed.diagnostics) {
-              connection.console.warn(
-                `Lockfile parse: ${d.code}: ${d.message}`,
-              );
-            }
-          }
-        }
-      } catch {
-        /* no lockfile is fine */
-      }
+      // Load markspec.lock if present — feeds the locked upstream corpus
+      // (federated-upstream slice 4) via seedUpstreamCorpus() below, plus
+      // the `markspec/version` notification's stale-pin hints.
+      await reloadLockfile();
     }
 
     logEvent("info", "lifecycle", { event: "onInitialize.end" });
@@ -636,8 +732,10 @@ connection.onInitialize(
 );
 
 // ---------------------------------------------------------------------------
-// Profile reload — fires `markspec/profileChanged` after watched profile files
-// change. Debounced 500ms so rapid-fire saves coalesce into one reload.
+// Profile reload — fires `markspec/profileChanged` after watched profile
+// files change; also reloads markspec.lock and re-seeds the delivered +
+// upstream corpora, since the same watcher covers all three files.
+// Debounced 500ms so rapid-fire saves coalesce into one reload.
 // ---------------------------------------------------------------------------
 
 async function reloadProfile(): Promise<void> {
@@ -653,9 +751,17 @@ async function reloadProfile(): Promise<void> {
       "markspec/profileChanged",
       cachedProfileResponse,
     );
+    // The watched-file change that triggered this reload may be to
+    // markspec.lock itself (a re-lock) rather than the profile — refresh
+    // the module-scoped lockfile before re-seeding the upstream corpus.
+    await reloadLockfile();
     // Re-seed the delivered corpus (ADR-030) before republishing — the
     // new profile may change, add, or drop `delivers:` entirely.
     await seedDeliveredCorpus();
+    // Re-seed the locked upstream corpus (federated-upstream slice 4)
+    // after the delivered corpus — see seedUpstreamCorpus()'s doc comment
+    // for why the ordering is load-bearing.
+    await seedUpstreamCorpus();
     // Profile changes can flip MSL-R010 suppression and other
     // attribute-validity decisions — republish cross-file diagnostics.
     publishAllDiagnostics();
@@ -684,10 +790,12 @@ connection.onInitialized(async () => {
   connection.console.log(`Indexing project at ${projectRoot}...`);
 
   try {
-    // Seed the delivered corpus (ADR-030) before the project walk so
-    // corpus display IDs win "first entry wins" collisions
+    // Seed the delivered corpus (ADR-030), then the locked upstream
+    // corpus (federated-upstream slice 4), before the project walk so
+    // corpus/upstream display IDs win "first entry wins" collisions
     // deterministically, regardless of project-file parse order.
     await seedDeliveredCorpus();
+    await seedUpstreamCorpus();
 
     // Discover all relevant files (core/discovery: gitignore-aware,
     // honors .markspec.yaml `exclude:`).
@@ -760,9 +868,12 @@ connection.onInitialized(async () => {
       buildVersionNotification(VERSION, CORE_SCHEMA_VERSION, lockfile),
     );
 
-    // Register the profile-file watcher. We do this even when no profile
-    // is currently loaded so a later `.markspec.yaml` creation triggers
-    // a reload. See design doc §4 step 2.
+    // Register the profile-file + lockfile watcher. We do this even when
+    // no profile/lockfile is currently loaded so a later
+    // `.markspec.yaml`/`markspec.lock` creation triggers a reload. See
+    // design doc §4 step 2. `markspec.lock` is watched so a re-lock (new
+    // or dropped upstreams) re-seeds the upstream corpus
+    // (federated-upstream slice 4).
     if (projectRoot) {
       try {
         await connection.client.register(
@@ -775,6 +886,10 @@ connection.onInitialized(async () => {
               },
               {
                 globPattern: "**/project.yaml",
+                kind: WatchKind.Create | WatchKind.Change | WatchKind.Delete,
+              },
+              {
+                globPattern: "**/markspec.lock",
                 kind: WatchKind.Create | WatchKind.Change | WatchKind.Delete,
               },
             ],
@@ -801,8 +916,10 @@ connection.onInitialized(async () => {
 // ---------------------------------------------------------------------------
 
 connection.onDidChangeWatchedFiles((params: { changes: FileEvent[] }) => {
-  // We only watch `.markspec.yaml` + `project.yaml`, so any change here
-  // affects the profile chain. Debounce 500ms — see design doc §4.1.
+  // We only watch `.markspec.yaml`, `project.yaml`, and `markspec.lock`,
+  // so any change here affects the profile chain and/or the locked
+  // upstream corpus — `reloadProfile` reloads both. Debounce 500ms — see
+  // design doc §4.1.
   if (params.changes.length === 0) return;
   debouncedReloadProfile();
 });

--- a/packages/markspec/mcp/project.ts
+++ b/packages/markspec/mcp/project.ts
@@ -16,15 +16,21 @@ import {
   type CompileResult,
   type DeliveredDocument,
   deliveredPathIsContained,
+  type Diagnostic,
   discoverMarkspecRoot,
   discoverProjectRoot,
   type EffectiveProfile,
+  type Entry,
   loadConfig,
   loadDeliveredCorpus,
   loadProfileForCommand,
+  loadUpstreamCorpus,
+  type Lockfile,
+  parseLockfile,
   type ProfileChain,
   type ProjectConfig,
   type ReadFile,
+  upstreamRefsFromLockfile,
 } from "../core/mod.ts";
 
 /**
@@ -361,6 +367,12 @@ export async function createProject(env: ProjectEnv): Promise<Project> {
   let inFlight: Promise<CompileResult> | null = null;
   let cached: CompileResult | null = null;
   let tracked: TrackedFile[] = [];
+  // markspec.lock's mtime as of the last compile (federated upstream, slice
+  // 4). `undefined` means "no lockfile at last compile". Tracked separately
+  // from `tracked` because `markspec.lock`'s extension isn't in
+  // TRACKED_EXTENSIONS — the loop in `isStale()` would never notice it
+  // appear, change, or disappear otherwise.
+  let lockfileMtime: number | undefined;
   const handlers = new Set<InvalidationHandler>();
 
   /** Discover all tracked file paths under `projectRoot`. */
@@ -377,6 +389,46 @@ export async function createProject(env: ProjectEnv): Promise<Project> {
     return out;
   }
 
+  /**
+   * Read `markspec.lock` (if present) and hydrate its locked upstream
+   * snapshots into read-only `Entry[]` (federated upstream, slice 4).
+   * Mirrors `cli/helpers.ts`'s `compileProject` load site. Soft-fail: a
+   * missing, malformed, or cold/stale-cache lockfile must never abort a
+   * compile — the MCP server degrades to "no upstream entries" instead of
+   * throwing. Also returns the lockfile's current mtime (`undefined` when
+   * absent) so the caller can update `lockfileMtime` for `isStale()`.
+   */
+  async function loadLockedUpstreams(): Promise<
+    { entries: Entry[]; diagnostics: Diagnostic[]; mtime: number | undefined }
+  > {
+    if (!projectRoot) return { entries: [], diagnostics: [], mtime: undefined };
+    const lockPath = join(projectRoot, "markspec.lock");
+    let mtime: number | undefined;
+    try {
+      mtime = (await env.stat(lockPath)).mtime;
+    } catch {
+      mtime = undefined; // no lockfile
+    }
+    try {
+      const lockRaw = await env.readFile(lockPath);
+      const lockfile: Lockfile | undefined = lockRaw !== undefined
+        ? parseLockfile(lockRaw).lockfile
+        : undefined;
+      if (!lockfile) return { entries: [], diagnostics: [], mtime };
+      const refs = upstreamRefsFromLockfile(lockfile, projectRoot);
+      if (refs.length === 0) return { entries: [], diagnostics: [], mtime };
+      const upstream = await loadUpstreamCorpus(refs, env.readFile);
+      return {
+        entries: upstream.entries,
+        diagnostics: upstream.diagnostics,
+        mtime,
+      };
+    } catch (err) {
+      console.error(`Failed to load locked upstream corpus: ${err}`);
+      return { entries: [], diagnostics: [], mtime };
+    }
+  }
+
   /** Run compile() over current tracked set; update cache. */
   async function runCompile(): Promise<CompileResult> {
     try {
@@ -388,6 +440,8 @@ export async function createProject(env: ProjectEnv): Promise<Project> {
           env.realPath,
         )
         : { entries: [], diagnostics: [] };
+      const upstream = await loadLockedUpstreams();
+      lockfileMtime = upstream.mtime;
       const result = await compile(paths, {
         readFile: async (p: string) => {
           const content = await env.readFile(p);
@@ -397,18 +451,21 @@ export async function createProject(env: ProjectEnv): Promise<Project> {
           return content;
         },
         profile: profileChain?.effective ?? undefined,
-        corpusEntries: corpus.entries,
+        corpusEntries: [...corpus.entries, ...upstream.entries],
       });
 
-      // Surface corpus-load diagnostics (e.g. PROFILE-DELIVERS-001 for a
-      // missing delivered file) in the compiled context — CLI `check`
-      // parity: without this, the MCP validate tool reports clean on a
-      // project whose `markspec check` fails. Corpus diagnostics lead;
-      // compile diagnostics keep their own order (determinism).
-      const merged = corpus.diagnostics.length > 0
+      // Surface corpus-load and upstream-load diagnostics (e.g.
+      // PROFILE-DELIVERS-001 for a missing delivered file, or
+      // UPSTREAM-SNAPSHOT-00x for a cold/stale lock cache) in the compiled
+      // context — CLI `check` parity: without this, the MCP validate tool
+      // reports clean on a project whose `markspec check` fails. Corpus
+      // diagnostics lead, then upstream, then compile diagnostics keep
+      // their own order (determinism).
+      const extraDiagnostics = [...corpus.diagnostics, ...upstream.diagnostics];
+      const merged = extraDiagnostics.length > 0
         ? {
           ...result,
-          diagnostics: [...corpus.diagnostics, ...result.diagnostics],
+          diagnostics: [...extraDiagnostics, ...result.diagnostics],
         }
         : result;
 
@@ -469,6 +526,17 @@ export async function createProject(env: ProjectEnv): Promise<Project> {
   /** Detect any change in the tracked file set since the last compile. */
   async function isStale(): Promise<boolean> {
     if (!projectRoot) return false;
+    // 0) markspec.lock mtime change (federated upstream, slice 4) — a
+    // re-lock must invalidate the cache even though `markspec.lock` isn't a
+    // TRACKED_EXTENSIONS project file, so the loops below never notice it.
+    let currentLockMtime: number | undefined;
+    try {
+      currentLockMtime =
+        (await env.stat(join(projectRoot, "markspec.lock"))).mtime;
+    } catch {
+      currentLockMtime = undefined;
+    }
+    if (currentLockMtime !== lockfileMtime) return true;
     // 1) Any tracked file that is stale (mtime fast path → SHA256 truth gate)?
     for (const t of tracked) {
       try {

--- a/packages/markspec/mcp/project.ts
+++ b/packages/markspec/mcp/project.ts
@@ -441,7 +441,6 @@ export async function createProject(env: ProjectEnv): Promise<Project> {
         )
         : { entries: [], diagnostics: [] };
       const upstream = await loadLockedUpstreams();
-      lockfileMtime = upstream.mtime;
       const result = await compile(paths, {
         readFile: async (p: string) => {
           const content = await env.readFile(p);
@@ -483,6 +482,13 @@ export async function createProject(env: ProjectEnv): Promise<Project> {
           // File disappeared during compile — ignore.
         }
       }
+      // Commit-on-success: mirrors `tracked`/`cached` below. Assigning
+      // `lockfileMtime` here (not right after `loadLockedUpstreams()`)
+      // keeps it in lockstep with the cache it gates — if `compile()`
+      // throws above, the mtime must stay at its pre-attempt value too,
+      // or a later `isStale()` would see the new mtime as already
+      // "seen" and silently serve the stale pre-failure `cached` result.
+      lockfileMtime = upstream.mtime;
       tracked = snapshot;
       cached = merged;
       // Fire handlers AFTER cache is committed but isolate handler errors so

--- a/packages/markspec/mcp/project_test.ts
+++ b/packages/markspec/mcp/project_test.ts
@@ -831,3 +831,24 @@ Deno.test("getCompiled: malformed markspec.lock never throws — degrades to no 
   assertEquals(result.entries.size, 1);
   assertEquals(result.entries.get(makeDisplayId("SYS_UP_0001")), undefined);
 });
+
+// NOTE on a "lock-change recompile that fails" regression test: `compile()`,
+// `loadDeliveredCorpus()`, and `loadLockedUpstreams()` are all deliberately
+// defensive — every per-file read failure downgrades to a diagnostic
+// (`MSL-E000`, `PROFILE-DELIVERS-00x`) or a soft-fail return, never a thrown
+// exception (confirmed by reading `core/compiler/mod.ts`'s per-file try/catch,
+// `core/profile/delivered.ts`, and `loadLockedUpstreams()`'s own catch block).
+// There is no realistic way to make `runCompile()` throw between
+// `loadLockedUpstreams()` returning and the commit-on-success block through
+// the public `ProjectEnv` surface without fabricating a malformed in-memory
+// `Entry` that defeats the type system — too harness-heavy and disproportionate
+// per the plan's own escape hatch. The existing
+// "getCompiled: a re-lock (new markspec.lock) invalidates the cache" test above
+// already exercises the ordering-sensitive success path unchanged by the fix
+// (recompile succeeds → `lockfileMtime`/`tracked`/`cached` commit together);
+// it passes unchanged after moving the `lockfileMtime` assignment down to the
+// commit-on-success block. The ordering fix itself is a straightforward
+// same-block move verified by code reading: `lockfileMtime = upstream.mtime`
+// now sits directly beside `tracked = snapshot; cached = merged;`, so any
+// future throw between `loadLockedUpstreams()` and that block leaves all
+// three fields at their pre-attempt values together.

--- a/packages/markspec/mcp/project_test.ts
+++ b/packages/markspec/mcp/project_test.ts
@@ -738,11 +738,11 @@ function makeUpstreamEnv(withLockfile = true): {
   ]);
   if (withLockfile) {
     files.set(LOCKFILE_PATH, { content: LOCKFILE_TOML, mtime: 1 });
-    files.set(`${UPSTREAM_CACHE_DIR}/manifest.json`, {
+    files.set(join(UPSTREAM_CACHE_DIR, "manifest.json"), {
       content: UPSTREAM_MANIFEST,
       mtime: 1,
     });
-    files.set(`${UPSTREAM_CACHE_DIR}/compiled.json`, {
+    files.set(join(UPSTREAM_CACHE_DIR, "compiled.json"), {
       content: UPSTREAM_COMPILED,
       mtime: 1,
     });
@@ -808,8 +808,8 @@ Deno.test("getCompiled: a re-lock (new markspec.lock) invalidates the cache", as
   // mtime. isStale() must notice the lockfile mtime change even though
   // `markspec.lock` is not itself a TRACKED_EXTENSIONS project file.
   bumpMtime(LOCKFILE_PATH, LOCKFILE_TOML, 2);
-  bumpMtime(`${UPSTREAM_CACHE_DIR}/manifest.json`, UPSTREAM_MANIFEST, 2);
-  bumpMtime(`${UPSTREAM_CACHE_DIR}/compiled.json`, UPSTREAM_COMPILED, 2);
+  bumpMtime(join(UPSTREAM_CACHE_DIR, "manifest.json"), UPSTREAM_MANIFEST, 2);
+  bumpMtime(join(UPSTREAM_CACHE_DIR, "compiled.json"), UPSTREAM_COMPILED, 2);
 
   const second = await proj.getCompiled();
   assertExists(second.entries.get(makeDisplayId("SYS_UP_0001")));

--- a/packages/markspec/mcp/project_test.ts
+++ b/packages/markspec/mcp/project_test.ts
@@ -653,3 +653,181 @@ Deno.test("defaultEnv: rootOverrides reads flags then env vars in order", () => 
     else Deno.env.set("CLAUDE_PROJECT_DIR", prevCc);
   }
 });
+
+// ---------------------------------------------------------------------------
+// Locked upstream corpus injection (federated upstream, slice 4, Task 9)
+// ---------------------------------------------------------------------------
+
+/** Cache dir `markspec lock` writes for the `product` upstream. */
+const UPSTREAM_CACHE_DIR = join(
+  PROJ,
+  ".markspec",
+  "cache",
+  "upstreams",
+  "product",
+);
+const LOCKFILE_PATH = join(PROJ, "markspec.lock");
+
+/** A `markspec.lock` with one snapshot-carrying `[[upstream.registry]]` row. */
+const LOCKFILE_TOML = `schema = 1
+
+[meta]
+markspec-schema = 1
+locked-at = "2026-07-04T00:00:00Z"
+
+[[upstream.registry]]
+id = "product"
+api = "https://registry.example/product"
+resolved-manifest-hash = "sha256:abc"
+markspec-schema = 1
+version = "v2.1.0"
+snapshot = "sha256:deadbeef"
+
+[generated-cache]
+edges-hash = "sha256:0"
+edges-count = 0
+`;
+
+/** Manifest `markspec lock` writes into an upstream's cache dir — shape
+ * matches `checkSnapshotSchema`'s expectations (schema/coreSchema = 1,
+ * mirroring `core/upstream/mod_test.ts`'s `snapshotFiles` helper). */
+const UPSTREAM_MANIFEST = JSON.stringify({
+  markspecSchemaVersion: 1,
+  generator: { release: "0.0.0-test", coreSchema: 1 },
+  project: { name: "product", root: "/upstream-product" },
+  counts: { entries: 1, edges: 0, byType: {} },
+  entries: { format: "inline", file: "compiled.json" },
+  edges: { format: "inline", file: "compiled.json" },
+  sqliteMirror: null,
+  federation: [],
+  reserved: {},
+});
+
+/** One hand-built serialized entry — the wire shape `deserializeEntry`
+ * consumes (`core/compiler/deserialize.ts`). */
+const UPSTREAM_COMPILED = JSON.stringify({
+  entries: {
+    "SYS_UP_0001": {
+      displayId: "SYS_UP_0001",
+      title: "Upstream requirement",
+      body: "The upstream system shall do X within 10 ms.",
+      rawAttributes: [],
+      typedAttributes: {},
+      shape: "Authored",
+      location: { file: "/upstream-product/req.md", line: 1, column: 1 },
+      source: { kind: "markdown" },
+      bodyTokens: [],
+      id: "01HGW2Q8MNP3RSTVWXYZABCDEG",
+    },
+  },
+});
+
+/**
+ * Build a ProjectEnv wired for a project with a locked upstream. When
+ * `withLockfile` is `false` the lockfile (and its cache) are absent, so
+ * `getCompiled()` sees only the project's own entry — used to prove the
+ * lockfile's presence, not just the cache dir's, gates upstream injection.
+ */
+function makeUpstreamEnv(withLockfile = true): {
+  env: ProjectEnv;
+  bumpMtime: (path: string, content: string, mtime: number) => void;
+} {
+  const files = new Map<string, { content: string; mtime: number }>([
+    [PROJECT_YAML_PATH, { content: PROJECT_YAML, mtime: 1 }],
+    [REQ_MD_PATH, { content: REQ_DOC, mtime: 1 }],
+  ]);
+  if (withLockfile) {
+    files.set(LOCKFILE_PATH, { content: LOCKFILE_TOML, mtime: 1 });
+    files.set(`${UPSTREAM_CACHE_DIR}/manifest.json`, {
+      content: UPSTREAM_MANIFEST,
+      mtime: 1,
+    });
+    files.set(`${UPSTREAM_CACHE_DIR}/compiled.json`, {
+      content: UPSTREAM_COMPILED,
+      mtime: 1,
+    });
+  }
+  return {
+    env: {
+      cwd: () => PROJ,
+      rootOverrides: () => [],
+      readFile: (path) => Promise.resolve(files.get(path)?.content),
+      realPath: (path) => Promise.resolve(path),
+      stat: (path) => {
+        const f = files.get(path);
+        if (!f) return Promise.reject(new Error(`ENOENT: ${path}`));
+        return Promise.resolve({ mtime: f.mtime });
+      },
+      // Only project.yaml + req.md have tracked extensions; the lockfile
+      // and cache JSON files are walked but never picked up as tracked
+      // project files (TRACKED_EXTENSIONS excludes .lock/.json) — same
+      // "walked but ignored" shape as makeCorpusEnv's profile/ files.
+      walk: async function* () {
+        for (const path of files.keys()) yield path;
+      },
+    },
+    bumpMtime(path, content, mtime) {
+      files.set(path, { content, mtime });
+    },
+  };
+}
+
+Deno.test("getCompiled: injects the locked upstream corpus alongside project entries", async () => {
+  const { env } = makeUpstreamEnv();
+  const proj = await createProject(env);
+  const result = await proj.getCompiled();
+  // 1 project entry (STK_TEST_0001) + 1 upstream entry (SYS_UP_0001).
+  assertEquals(result.entries.size, 2);
+  assertExists(result.entries.get(makeDisplayId("SYS_UP_0001")));
+});
+
+Deno.test("getCompiled: no markspec.lock → no upstream entries, no error", async () => {
+  const { env } = makeUpstreamEnv(false);
+  const proj = await createProject(env);
+  const result = await proj.getCompiled();
+  assertEquals(result.entries.size, 1);
+  assertEquals(result.entries.get(makeDisplayId("SYS_UP_0001")), undefined);
+});
+
+Deno.test("forceRefresh: still injects the locked upstream corpus after a forced recompile", async () => {
+  const { env } = makeUpstreamEnv();
+  const proj = await createProject(env);
+  await proj.getCompiled();
+  const result = await proj.forceRefresh();
+  assertExists(result.entries.get(makeDisplayId("SYS_UP_0001")));
+});
+
+Deno.test("getCompiled: a re-lock (new markspec.lock) invalidates the cache", async () => {
+  // Start with no lockfile — first compile has no upstream entries.
+  const { env, bumpMtime } = makeUpstreamEnv(false);
+  const proj = await createProject(env);
+  const first = await proj.getCompiled();
+  assertEquals(first.entries.get(makeDisplayId("SYS_UP_0001")), undefined);
+
+  // Lock the project — the lockfile + cache now appear on disk, at a new
+  // mtime. isStale() must notice the lockfile mtime change even though
+  // `markspec.lock` is not itself a TRACKED_EXTENSIONS project file.
+  bumpMtime(LOCKFILE_PATH, LOCKFILE_TOML, 2);
+  bumpMtime(`${UPSTREAM_CACHE_DIR}/manifest.json`, UPSTREAM_MANIFEST, 2);
+  bumpMtime(`${UPSTREAM_CACHE_DIR}/compiled.json`, UPSTREAM_COMPILED, 2);
+
+  const second = await proj.getCompiled();
+  assertExists(second.entries.get(makeDisplayId("SYS_UP_0001")));
+});
+
+Deno.test("getCompiled: malformed markspec.lock never throws — degrades to no upstream entries", async () => {
+  const { env } = makeUpstreamEnv(false);
+  const brokenEnv: ProjectEnv = {
+    ...env,
+    readFile: (path) =>
+      path === LOCKFILE_PATH
+        ? Promise.resolve("this is not [[[ valid toml")
+        : env.readFile(path),
+    stat: (path) =>
+      path === LOCKFILE_PATH ? Promise.resolve({ mtime: 1 }) : env.stat(path),
+  };
+  const proj = await createProject(brokenEnv);
+  const result = await proj.getCompiled();
+  assertEquals(result.entries.size, 1);
+  assertEquals(result.entries.get(makeDisplayId("SYS_UP_0001")), undefined);
+});

--- a/tests/e2e/federated_lock_test.ts
+++ b/tests/e2e/federated_lock_test.ts
@@ -267,7 +267,118 @@ Deno.test(
 );
 
 // ---------------------------------------------------------------------------
-// 6. Migration errors — org project.yaml closed-schema validation. These are
+// 6. `check` resolves a cross-repo `Satisfies:` against a locked upstream
+// snapshot (federated-upstream epic, slice 4). Project B's entry satisfies
+// an upstream (A) entry; `check` must feed the hydrated upstream entries
+// into its own pipeline so the reference resolves — no MSL-L006. Each
+// project declares its own small profile so the entries classify cleanly
+// (an unclassified entry authoring `Satisfies:` would otherwise trip
+// unrelated MSL-T024/MSL-A005 attribute-scope warnings that have nothing to
+// do with this scenario) — mirrors `tests/e2e/check_project_test.ts`'s
+// requirement / system-requirement fixture.
+// ---------------------------------------------------------------------------
+
+const TRACE_PROFILE_A_YAML = `id: "@acme/federated-a"
+version: 0.1.0
+profile:
+  types:
+    requirement:
+      extends: Requirement
+      display-id-pattern: "STK_{n:04d}"
+`;
+
+const TRACE_REQS_A = `# Product A requirements
+
+- [STK_0001] First requirement
+
+  Body text.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      Type: requirement
+`;
+
+const TRACE_PROFILE_B_YAML = `id: "@acme/federated-b"
+version: 0.1.0
+profile:
+  types:
+    system-requirement:
+      extends: Requirement
+      display-id-pattern: "SREQ-{n:04d}"
+      traceability:
+        Satisfies:
+          target: [requirement]
+          cardinality: 0..3
+          required: false
+`;
+
+const TRACE_REQS_B = `# Product B requirements
+
+- [SREQ-0001] Derived requirement satisfying the upstream
+
+  Body text.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEH
+      Type: system-requirement
+      Satisfies: STK_0001
+`;
+
+Deno.test(
+  "check: cross-repo Satisfies against a locked upstream resolves (no MSL-L006)",
+  async () => {
+    const root = await Deno.makeTempDir();
+    const dirA = `${root}/a`;
+    const dirB = `${root}/b`;
+
+    try {
+      await Deno.mkdir(dirA, { recursive: true });
+      await Deno.mkdir(dirB, { recursive: true });
+      await Deno.writeTextFile(`${dirA}/project.yaml`, PROJECT_A_YAML);
+      await Deno.writeTextFile(
+        `${dirA}/.markspec.yaml`,
+        "profiles:\n  - ./profiles/p\n",
+      );
+      await Deno.mkdir(`${dirA}/profiles/p`, { recursive: true });
+      await Deno.writeTextFile(
+        `${dirA}/profiles/p/markspec.yaml`,
+        TRACE_PROFILE_A_YAML,
+      );
+      await Deno.writeTextFile(`${dirA}/reqs.md`, TRACE_REQS_A);
+
+      const compileA = await markspecInDir(dirA, [
+        "compile",
+        "--output",
+        "api",
+        "reqs.md",
+      ]);
+      assertEquals(compileA.code, 0, compileA.stderr);
+
+      const fileUrl = toFileUrl(join(dirA, "api")).href;
+      await Deno.writeTextFile(`${dirB}/project.yaml`, projectBYaml(fileUrl));
+      await Deno.writeTextFile(
+        `${dirB}/.markspec.yaml`,
+        "profiles:\n  - ./profiles/p\n",
+      );
+      await Deno.mkdir(`${dirB}/profiles/p`, { recursive: true });
+      await Deno.writeTextFile(
+        `${dirB}/profiles/p/markspec.yaml`,
+        TRACE_PROFILE_B_YAML,
+      );
+      await Deno.writeTextFile(`${dirB}/reqs.md`, TRACE_REQS_B);
+
+      const lock = await markspecInDir(dirB, ["lock"], LOCK_PERMISSIONS);
+      assertEquals(lock.code, 0, lock.stderr);
+
+      const check = await markspecInDir(dirB, ["check"]);
+      assertEquals(check.code, 0, check.stderr);
+      assertEquals(/MSL-L006/.test(check.stderr), false, check.stderr);
+    } finally {
+      await Deno.remove(root, { recursive: true });
+    }
+  },
+);
+
+// ---------------------------------------------------------------------------
+// 7. Migration errors — org project.yaml closed-schema validation. These are
 // independent of the A/B fixture above: any command that loads project.yaml
 // (here, `markspec lock`) surfaces a ConfigError before doing any lock work.
 // ---------------------------------------------------------------------------

--- a/tests/e2e/federated_resolve_test.ts
+++ b/tests/e2e/federated_resolve_test.ts
@@ -1,0 +1,641 @@
+/**
+ * @module tests/e2e/federated_resolve_test
+ *
+ * E2E acceptance suite for the federated-upstream epic, slice 4 (Task 10).
+ * Builds on the slice-2 `file://` projectRef fixture pattern established
+ * by `federated_lock_test.ts`: a producer project compiles a compile-output
+ * snapshot to `api/` via `markspec compile --output`, and a consumer
+ * project declares a `references:` projectRef pointing at that snapshot
+ * over a `file://` URL, then runs `markspec lock` to pin + cache it.
+ *
+ * Six scenarios (brief §Scenarios):
+ *   1. Cross-repo `Satisfies:` resolves — no MSL-L006/MSL-T014.
+ *   2. A broken upstream target fires MSL-T014 (not MSL-L006), naming the
+ *      searched upstream.
+ *   3. A project entry colliding with an upstream display ID fires
+ *      MSL-R014, naming the upstream origin.
+ *   4. `report coverage` treats a `references:` upstream entry as a
+ *      traceability leaf (excluded from the orphan gap list); a project
+ *      entry without `Satisfies:` is not.
+ *   5. `show` and `report traceability` surface an upstream entry's
+ *      `Origin:` / origin column.
+ *   6. Root/diamond (design §4.9): ROOT references both B and C; C also
+ *      references B, so C's own published snapshot re-exports B's entries
+ *      with an upstream origin already stamped. The authoritative-source
+ *      rule in `loadUpstreamCorpus` (`core/upstream/mod.ts`) skips a
+ *      snapshot entry that already carries an `origin` — so ROOT's graph
+ *      counts B's entries exactly once (via its direct reference), never
+ *      via C's re-export, and no MSL-R014 collision fires.
+ *
+ * Blackbox only — every assertion is made against exit codes, stdout,
+ * stderr, and on-disk file contents produced by the compiled CLI
+ * (`packages/markspec/main.ts`, run via `Deno.Command` through the
+ * `markspecInDir` helper). No imports from `packages/markspec/core` or
+ * any other source module.
+ */
+
+import { assertEquals, assertMatch } from "@std/assert";
+import { join, toFileUrl } from "@std/path";
+import { markspecInDir } from "./helpers.ts";
+
+// ---------------------------------------------------------------------------
+// Shared fixtures — producer "producta" (SYS_ prefix) / consumer "productb"
+// (SWE_ prefix), used by scenarios 1-5.
+// ---------------------------------------------------------------------------
+
+const PROJECT_A_YAML = `name: producta\nversion: 0.1.0\n`;
+
+/** `requirement` type only — mintable display IDs `SYS_{n:04d}`. */
+const PROFILE_A_YAML = `id: "@acme/federated-resolve-a"
+version: 0.1.0
+profile:
+  types:
+    requirement:
+      extends: Requirement
+      display-id-pattern: "SYS_{n:04d}"
+`;
+
+const REQS_A = `# Product A requirements
+
+- [SYS_0001] First requirement
+
+  Body text.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+      Type: requirement
+`;
+
+/**
+ * B's profile declares BOTH `requirement` (same `SYS_` prefix as A's own
+ * type — scenario 3 needs B to be able to author a legitimate `SYS_0001`
+ * under its own profile, so the collision is a realistic same-prefix
+ * clash, not a classification error) and `system-requirement` (the
+ * `SWE_` prefix, satisfying `requirement`).
+ */
+const PROFILE_B_YAML = `id: "@acme/federated-resolve-b"
+version: 0.1.0
+profile:
+  types:
+    requirement:
+      extends: Requirement
+      display-id-pattern: "SYS_{n:04d}"
+    system-requirement:
+      extends: Requirement
+      display-id-pattern: "SWE_{n:04d}"
+      traceability:
+        Satisfies:
+          target: [requirement]
+          cardinality: 0..3
+          required: false
+`;
+
+function projectBYaml(fileUrl: string): string {
+  return `name: productb\nversion: 0.1.0\nreferences:\n  - url: ${
+    JSON.stringify(fileUrl)
+  }\n    name: producta\n`;
+}
+
+const REQS_B_SATISFIES_OK = `# Product B requirements
+
+- [SWE_0001] Derived requirement satisfying the upstream
+
+  Body text.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEH
+      Type: system-requirement
+      Satisfies: SYS_0001
+`;
+
+const REQS_B_SATISFIES_BROKEN = `# Product B requirements
+
+- [SWE_0001] Derived requirement with a broken upstream link
+
+  Body text.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEH
+      Type: system-requirement
+      Satisfies: SYS_9999
+`;
+
+const REQS_B_COLLIDE = `# Product B requirements
+
+- [SYS_0001] An independently authored colliding requirement
+
+  Body text.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEK
+      Type: requirement
+`;
+
+const REQS_B_COVERAGE = `# Product B requirements
+
+- [SWE_0001] Derived requirement satisfying the upstream
+
+  Body text.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEH
+      Type: system-requirement
+      Satisfies: SYS_0001
+
+- [SWE_0002] Derived requirement with no upstream link
+
+  Body text.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEJ
+      Type: system-requirement
+`;
+
+/** Permissions `markspec lock` needs beyond the helper's read/write default. */
+const LOCK_PERMISSIONS = ["--allow-env", "--allow-run"];
+
+/**
+ * Compile producer A (project.yaml + `.markspec.yaml` profile + `reqs.md`)
+ * to `api/` and return its `file://` snapshot URL. Shared setup for
+ * scenarios 1-5, each of which only varies B's `reqs.md` content.
+ */
+async function setupProducerA(dirA: string): Promise<string> {
+  await Deno.mkdir(dirA, { recursive: true });
+  await Deno.writeTextFile(`${dirA}/project.yaml`, PROJECT_A_YAML);
+  await Deno.writeTextFile(
+    `${dirA}/.markspec.yaml`,
+    "profiles:\n  - ./profiles/p\n",
+  );
+  await Deno.mkdir(`${dirA}/profiles/p`, { recursive: true });
+  await Deno.writeTextFile(`${dirA}/profiles/p/markspec.yaml`, PROFILE_A_YAML);
+  await Deno.writeTextFile(`${dirA}/reqs.md`, REQS_A);
+
+  const compileA = await markspecInDir(dirA, [
+    "compile",
+    "--output",
+    "api",
+    "reqs.md",
+  ]);
+  assertEquals(compileA.code, 0, compileA.stderr);
+
+  return toFileUrl(join(dirA, "api")).href;
+}
+
+/** Write consumer B's project files (does not lock or check). */
+async function setupConsumerB(
+  dirB: string,
+  fileUrl: string,
+  reqsMd: string,
+): Promise<void> {
+  await Deno.mkdir(dirB, { recursive: true });
+  await Deno.writeTextFile(`${dirB}/project.yaml`, projectBYaml(fileUrl));
+  await Deno.writeTextFile(
+    `${dirB}/.markspec.yaml`,
+    "profiles:\n  - ./profiles/p\n",
+  );
+  await Deno.mkdir(`${dirB}/profiles/p`, { recursive: true });
+  await Deno.writeTextFile(`${dirB}/profiles/p/markspec.yaml`, PROFILE_B_YAML);
+  await Deno.writeTextFile(`${dirB}/reqs.md`, reqsMd);
+}
+
+// ---------------------------------------------------------------------------
+// 1. Cross-repo Satisfies resolves.
+// ---------------------------------------------------------------------------
+
+Deno.test(
+  "check: cross-repo Satisfies resolves against a locked upstream — no MSL-L006/MSL-T014",
+  async () => {
+    const root = await Deno.makeTempDir();
+    try {
+      const dirA = `${root}/a`;
+      const dirB = `${root}/b`;
+      const fileUrl = await setupProducerA(dirA);
+      await setupConsumerB(dirB, fileUrl, REQS_B_SATISFIES_OK);
+
+      const lock = await markspecInDir(dirB, ["lock"], LOCK_PERMISSIONS);
+      assertEquals(lock.code, 0, lock.stderr);
+
+      const check = await markspecInDir(dirB, ["check"]);
+      assertEquals(check.code, 0, check.stderr);
+      assertEquals(/MSL-L006/.test(check.stderr), false, check.stderr);
+      assertEquals(/MSL-T014/.test(check.stderr), false, check.stderr);
+    } finally {
+      await Deno.remove(root, { recursive: true });
+    }
+  },
+);
+
+// ---------------------------------------------------------------------------
+// 2. Broken upstream ID fires MSL-T014, not MSL-L006.
+// ---------------------------------------------------------------------------
+
+Deno.test(
+  "check: an unresolved upstream Satisfies target fires MSL-T014 (not MSL-L006), naming the upstream",
+  async () => {
+    const root = await Deno.makeTempDir();
+    try {
+      const dirA = `${root}/a`;
+      const dirB = `${root}/b`;
+      const fileUrl = await setupProducerA(dirA);
+      await setupConsumerB(dirB, fileUrl, REQS_B_SATISFIES_BROKEN);
+
+      const lock = await markspecInDir(dirB, ["lock"], LOCK_PERMISSIONS);
+      assertEquals(lock.code, 0, lock.stderr);
+
+      const check = await markspecInDir(dirB, ["check"]);
+      // MSL-T014 is a warning, not an error — `check` exits 2 (warnings
+      // only), not 1.
+      assertEquals(check.code, 2, check.stderr);
+      assertMatch(check.stderr, /MSL-T014/);
+      assertMatch(check.stderr, /producta/);
+      assertEquals(/MSL-L006/.test(check.stderr), false, check.stderr);
+    } finally {
+      await Deno.remove(root, { recursive: true });
+    }
+  },
+);
+
+// ---------------------------------------------------------------------------
+// 3. A colliding display ID fires MSL-R014, naming the upstream origin.
+// ---------------------------------------------------------------------------
+
+Deno.test(
+  "check: a project entry colliding with an upstream display ID fires MSL-R014 naming the upstream origin",
+  async () => {
+    const root = await Deno.makeTempDir();
+    try {
+      const dirA = `${root}/a`;
+      const dirB = `${root}/b`;
+      const fileUrl = await setupProducerA(dirA);
+      await setupConsumerB(dirB, fileUrl, REQS_B_COLLIDE);
+
+      const lock = await markspecInDir(dirB, ["lock"], LOCK_PERMISSIONS);
+      assertEquals(lock.code, 0, lock.stderr);
+
+      const check = await markspecInDir(dirB, ["check"]);
+      // MSL-R014 is an error — `check` exits 1.
+      assertEquals(check.code, 1, check.stderr);
+      assertMatch(check.stderr, /MSL-R014/);
+      assertMatch(check.stderr, /producta/);
+    } finally {
+      await Deno.remove(root, { recursive: true });
+    }
+  },
+);
+
+// ---------------------------------------------------------------------------
+// 4. A references: upstream entry is a coverage leaf, excluded from orphans;
+//    a project entry without Satisfies is not.
+// ---------------------------------------------------------------------------
+
+Deno.test(
+  "report coverage: an upstream references: leaf is excluded from orphans; an uncovered project entry is not",
+  async () => {
+    const root = await Deno.makeTempDir();
+    try {
+      const dirA = `${root}/a`;
+      const dirB = `${root}/b`;
+      const fileUrl = await setupProducerA(dirA);
+      await setupConsumerB(dirB, fileUrl, REQS_B_COVERAGE);
+
+      const lock = await markspecInDir(dirB, ["lock"], LOCK_PERMISSIONS);
+      assertEquals(lock.code, 0, lock.stderr);
+
+      const rep = await markspecInDir(dirB, [
+        "report",
+        "coverage",
+        "--format",
+        "json",
+        "reqs.md",
+      ]);
+      assertEquals(rep.code, 0, rep.stderr);
+      const stats = JSON.parse(rep.stdout);
+      const orphans: string[] = stats.gaps.orphans;
+      assertEquals(
+        orphans.includes("SYS_0001"),
+        false,
+        `orphans should not include the upstream reference leaf: ${
+          JSON.stringify(orphans)
+        }`,
+      );
+      assertEquals(
+        orphans.includes("SWE_0002"),
+        true,
+        `orphans should include B's own uncovered entry: ${
+          JSON.stringify(orphans)
+        }`,
+      );
+    } finally {
+      await Deno.remove(root, { recursive: true });
+    }
+  },
+);
+
+// ---------------------------------------------------------------------------
+// 5. `show` and `report traceability` surface an upstream entry's origin.
+// ---------------------------------------------------------------------------
+
+Deno.test(
+  "show + report traceability: an upstream entry surfaces its Origin: / origin column",
+  async () => {
+    const root = await Deno.makeTempDir();
+    try {
+      const dirA = `${root}/a`;
+      const dirB = `${root}/b`;
+      const fileUrl = await setupProducerA(dirA);
+      await setupConsumerB(dirB, fileUrl, REQS_B_SATISFIES_OK);
+
+      const lock = await markspecInDir(dirB, ["lock"], LOCK_PERMISSIONS);
+      assertEquals(lock.code, 0, lock.stderr);
+
+      const show = await markspecInDir(dirB, ["show", "SYS_0001", "reqs.md"]);
+      assertEquals(show.code, 0, show.stderr);
+      assertMatch(show.stdout, /Origin: producta@/);
+
+      const rep = await markspecInDir(dirB, [
+        "report",
+        "traceability",
+        "--format",
+        "json",
+        "reqs.md",
+      ]);
+      assertEquals(rep.code, 0, rep.stderr);
+      // deno-lint-ignore no-explicit-any
+      const rows: any[] = JSON.parse(rep.stdout);
+      const row = rows.find((r) => r.id === "SYS_0001");
+      assertEquals(row !== undefined, true, JSON.stringify(rows));
+      assertMatch(row.origin, /^producta@/);
+      // The Origin column is populated AND the cross-repo edge is present
+      // on the same row — B's SWE_0001 satisfies A's upstream SYS_0001.
+      assertMatch(row.satisfiedBy, /SWE_0001/);
+    } finally {
+      await Deno.remove(root, { recursive: true });
+    }
+  },
+);
+
+// ---------------------------------------------------------------------------
+// 6. Root/diamond (design §4.9). Three projects:
+//   - B ("productb"): standalone, authors SYSB_0001.
+//   - C ("productc"): references B, authors SYSC_0001 satisfying SYSB_0001.
+//     C's own published snapshot therefore re-exports B's SYSB_0001 with an
+//     upstream origin already stamped (origin: productb).
+//   - ROOT: references BOTH B and C. Its graph must count SYSB_0001 exactly
+//     once (via the direct B reference) — the authoritative-source rule in
+//     `loadUpstreamCorpus` skips C's re-exported copy (it already carries
+//     an `origin`) — so no MSL-R014 collision fires and the published
+//     entry count is B + C + ROOT, never B + C + ROOT + 1.
+// ---------------------------------------------------------------------------
+
+const DIAMOND_PROJECT_B_YAML = `name: productb\nversion: 0.1.0\n`;
+
+const DIAMOND_PROFILE_B_YAML = `id: "@acme/federated-resolve-diamond-b"
+version: 0.1.0
+profile:
+  types:
+    requirement:
+      extends: Requirement
+      display-id-pattern: "SYSB_{n:04d}"
+`;
+
+const DIAMOND_REQS_B = `# Product B requirements
+
+- [SYSB_0001] B root requirement
+
+  Body text.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEM
+      Type: requirement
+`;
+
+function diamondProjectYaml(
+  name: string,
+  refs: readonly { readonly url: string; readonly name: string }[],
+): string {
+  const refLines = refs
+    .map((r) => `  - url: ${JSON.stringify(r.url)}\n    name: ${r.name}\n`)
+    .join("");
+  return `name: ${name}\nversion: 0.1.0\nreferences:\n${refLines}`;
+}
+
+const DIAMOND_PROFILE_C_YAML = `id: "@acme/federated-resolve-diamond-c"
+version: 0.1.0
+profile:
+  types:
+    derived:
+      extends: Requirement
+      display-id-pattern: "SYSC_{n:04d}"
+      traceability:
+        Satisfies:
+          target: [requirement]
+          cardinality: 0..3
+          required: false
+`;
+
+const DIAMOND_REQS_C = `# Product C requirements
+
+- [SYSC_0001] C requirement satisfying B
+
+  Body text.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEN
+      Type: derived
+      Satisfies: SYSB_0001
+`;
+
+const DIAMOND_PROFILE_ROOT_YAML = `id: "@acme/federated-resolve-diamond-root"
+version: 0.1.0
+profile:
+  types:
+    root-item:
+      extends: Requirement
+      display-id-pattern: "SYSR_{n:04d}"
+`;
+
+const DIAMOND_REQS_ROOT = `# Root requirements
+
+- [SYSR_0001] Root aggregation note
+
+  Body text.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEP
+      Type: root-item
+`;
+
+async function writeMarkspecProject(
+  dir: string,
+  projectYaml: string,
+  profileYaml: string,
+  reqsMd: string,
+): Promise<void> {
+  await Deno.mkdir(dir, { recursive: true });
+  await Deno.writeTextFile(`${dir}/project.yaml`, projectYaml);
+  await Deno.writeTextFile(
+    `${dir}/.markspec.yaml`,
+    "profiles:\n  - ./profiles/p\n",
+  );
+  await Deno.mkdir(`${dir}/profiles/p`, { recursive: true });
+  await Deno.writeTextFile(`${dir}/profiles/p/markspec.yaml`, profileYaml);
+  await Deno.writeTextFile(`${dir}/reqs.md`, reqsMd);
+}
+
+Deno.test(
+  "root/diamond: ROOT counts B's entries exactly once via the direct reference, never via C's re-export — no MSL-R014",
+  async () => {
+    const root = await Deno.makeTempDir();
+    try {
+      const dirB = `${root}/b`;
+      const dirC = `${root}/c`;
+      const dirRoot = `${root}/root`;
+
+      // --- B: standalone producer ---
+      await writeMarkspecProject(
+        dirB,
+        DIAMOND_PROJECT_B_YAML,
+        DIAMOND_PROFILE_B_YAML,
+        DIAMOND_REQS_B,
+      );
+      const compileB = await markspecInDir(dirB, [
+        "compile",
+        "--output",
+        "api",
+        "reqs.md",
+      ]);
+      assertEquals(compileB.code, 0, compileB.stderr);
+      const fileUrlB = toFileUrl(join(dirB, "api")).href;
+
+      // --- C: references B, authors an entry satisfying B ---
+      await writeMarkspecProject(
+        dirC,
+        diamondProjectYaml("productc", [{ url: fileUrlB, name: "productb" }]),
+        DIAMOND_PROFILE_C_YAML,
+        DIAMOND_REQS_C,
+      );
+      const lockC = await markspecInDir(dirC, ["lock"], LOCK_PERMISSIONS);
+      assertEquals(lockC.code, 0, lockC.stderr);
+      const compileC = await markspecInDir(dirC, [
+        "compile",
+        "--output",
+        "api",
+        "reqs.md",
+      ]);
+      assertEquals(compileC.code, 0, compileC.stderr);
+      const fileUrlC = toFileUrl(join(dirC, "api")).href;
+
+      // Confirm the diamond premise: C's OWN published snapshot re-exports
+      // B's entry with an upstream origin already stamped. Without this,
+      // scenario 6 would not actually exercise the authoritative-source
+      // rule at ROOT.
+      const compiledC = JSON.parse(
+        await Deno.readTextFile(`${dirC}/api/compiled.json`),
+      );
+      assertEquals(
+        Object.keys(compiledC.entries).length,
+        2,
+        "C's own /api/ should carry its own entry plus B's re-exported entry",
+      );
+      assertEquals(
+        compiledC.entries["SYSB_0001"]?.origin?.upstreamId,
+        "productb",
+        JSON.stringify(compiledC.entries["SYSB_0001"]),
+      );
+
+      // --- ROOT: references BOTH B and C (diamond) ---
+      await writeMarkspecProject(
+        dirRoot,
+        diamondProjectYaml("root", [
+          { url: fileUrlB, name: "productb" },
+          { url: fileUrlC, name: "productc" },
+        ]),
+        DIAMOND_PROFILE_ROOT_YAML,
+        DIAMOND_REQS_ROOT,
+      );
+      const lockRoot = await markspecInDir(dirRoot, ["lock"], LOCK_PERMISSIONS);
+      assertEquals(lockRoot.code, 0, lockRoot.stderr);
+
+      const compileRoot = await markspecInDir(dirRoot, [
+        "compile",
+        "--output",
+        "api",
+        "reqs.md",
+      ]);
+      assertEquals(compileRoot.code, 0, compileRoot.stderr);
+      assertEquals(
+        /MSL-R014/.test(compileRoot.stderr),
+        false,
+        compileRoot.stderr,
+      );
+
+      const manifestRoot = JSON.parse(
+        await Deno.readTextFile(`${dirRoot}/api/manifest.json`),
+      );
+      // B-authored (1) + C-authored (1) + ROOT-authored (1) = 3 — B's
+      // entry must not be double-counted via C's re-export.
+      assertEquals(manifestRoot.counts.entries, 3);
+
+      const compiledRoot = JSON.parse(
+        await Deno.readTextFile(`${dirRoot}/api/compiled.json`),
+      );
+      assertEquals(Object.keys(compiledRoot.entries).length, 3);
+      assertEquals(
+        compiledRoot.entries["SYSB_0001"]?.origin?.upstreamId,
+        "productb",
+        "B's entry at ROOT must carry origin from the DIRECT reference, " +
+          JSON.stringify(compiledRoot.entries["SYSB_0001"]),
+      );
+      assertEquals(
+        compiledRoot.entries["SYSC_0001"]?.origin?.upstreamId,
+        "productc",
+      );
+      assertEquals(
+        compiledRoot.entries["SYSR_0001"]?.origin,
+        undefined,
+        "ROOT's own entry must not carry an upstream origin",
+      );
+
+      // check: exit 0, no collision diagnostic.
+      const checkRoot = await markspecInDir(dirRoot, ["check"]);
+      assertEquals(checkRoot.code, 0, checkRoot.stderr);
+      assertEquals(
+        /MSL-R014/.test(checkRoot.stderr),
+        false,
+        checkRoot.stderr,
+      );
+
+      // The C→B cross-repo edge resolves in ROOT's graph: `dependents` on
+      // B's entry lists C's entry as a dependent.
+      const dependents = await markspecInDir(dirRoot, [
+        "dependents",
+        "SYSB_0001",
+        "--format",
+        "json",
+        "reqs.md",
+      ]);
+      assertEquals(dependents.code, 0, dependents.stderr);
+      // deno-lint-ignore no-explicit-any
+      const depRows: any[] = JSON.parse(dependents.stdout);
+      assertEquals(
+        depRows.some((r) => r.from === "SYSC_0001" && r.kind === "satisfies"),
+        true,
+        JSON.stringify(depRows),
+      );
+
+      // Same cross-repo edge, seen from the traceability matrix: B's row
+      // shows C as a satisfier, C's row shows its own upstream origin.
+      const rep = await markspecInDir(dirRoot, [
+        "report",
+        "traceability",
+        "--format",
+        "json",
+        "reqs.md",
+      ]);
+      assertEquals(rep.code, 0, rep.stderr);
+      // deno-lint-ignore no-explicit-any
+      const rows: any[] = JSON.parse(rep.stdout);
+      const rowB = rows.find((r) => r.id === "SYSB_0001");
+      const rowC = rows.find((r) => r.id === "SYSC_0001");
+      assertEquals(rowB !== undefined, true, JSON.stringify(rows));
+      assertEquals(rowC !== undefined, true, JSON.stringify(rows));
+      assertMatch(rowB.origin, /^productb@/);
+      assertMatch(rowB.satisfiedBy, /SYSC_0001/);
+      assertMatch(rowC.origin, /^productc@/);
+      assertMatch(rowC.satisfies, /SYSB_0001/);
+    } finally {
+      await Deno.remove(root, { recursive: true });
+    }
+  },
+);


### PR DESCRIPTION
Closes #744.

Slice 4 of the federated-upstream epic (#741) — the payoff slice: locked
upstream entries now **resolve in the compiled graph**, so a downstream
`Satisfies:` (or any trace link) to an entry authored in another repository
resolves and validates. Design:
`docs/wip/2026-07-04-federated-upstream-resolution-design.md` (§4.6 feed sites,
§4.7 validator behaviour, §4.8 surfaces, §4.9 root/diamond). Executed against
`docs/wip/2026-07-04-federated-upstream-slice4-plan.md` (TDD per task, reviewed,
then a whole-branch review).

## What ships

**Four feed sites.** The already-cached upstream entries (slice 1's
`loadUpstreamCorpus`, slice 2's `[[upstream.registry]]` rows + cache) are fed
into the graph at every site, injected ahead of project entries like the
ADR-030 delivered corpus, all soft-failing on a cold cache:

- **CLI compiler** — `compileProject` (covers `compile`, `export`, `show`,
  `context`, `dependents`, `report`).
- **`check`** — the `runPipeline` path (lockfile parse hoisted, drift gates
  reuse it).
- **LSP** — `seedUpstreamCorpus()` beside `seedDeliveredCorpus()`, re-seeded on
  `markspec.lock` change; upstream files join the read-only guard set.
- **MCP** — `runCompile` reads the lockfile, feeds upstream entries; `isStale`
  invalidates on a re-lock.

**Validator behaviour.**

- **Flat resolution** — trace targets resolve against project + corpus +
  upstreams; `MSL-L006` stops firing for IDs found upstream.
- **`MSL-T014` lands** (warning) — when a project declares
  `dependencies:`/`references:`, an unresolved-after-federation ref fires T014
  naming the searched set, instead of the generic L006. (language.md §8.3
  reservation → active row.)
- **`MSL-R014` generalized** — a project ID colliding with an upstream-provided
  ID is an R014 error; the message names the origin(s) generically (project↔
  upstream, upstream↔upstream, upstream↔corpus).
- **Validation-exempt, edge-live** — `kind:"upstream"` entries are skipped from
  every per-entry emitting check (structural, T005/T012, classification,
  trace-type, discipline, late-stage inference, typed-attribute, trace, and
  typl) while remaining resolution targets; their `type` comes from their own
  compile (never re-classified). Delivered corpus (`kind:"profile"`) is
  unchanged.
- **Coverage** — `references:` entries are traceability leaves (never coverage
  gaps); `dependencies:` participate.

**Root/program pattern (§4.9).** A root repo declaring member repos aggregates
the program graph — proven end-to-end by a blackbox diamond e2e (ROOT←B, ROOT←C,
C←B): the authoritative-source rule counts B's entries exactly once (via B's
direct reference, not C's re-export), the C→B cross-repo edge resolves at ROOT,
and no collision fires.

## New public API

`upstreamRefsFromLockfile(lockfile, projectRoot)` (pure row→ref mapping),
`loadProjectUpstreams` (CLI loader), `isUpstreamEntry(entry)` predicate.

## Scope boundaries

- **References resolve; git dependencies do not yet.** Git dependency
  *acquisition* is slice 3 — the row→ref mapping and coverage classification
  already accept `[[upstream.dependency]]` rows so slice 3 drops in, but no
  dependency entries hydrate today. The §4.4 unreleased-pin advisory +
  `check --strict` pin gate is deferred to slice 3 (needs dependency rows).
- **LSP/MCP user-facing surfaces** (completion badges, hover, definition no-op,
  decorations) are slice 5 — this slice makes upstream entries present,
  resolving, and read-only at those sites.
- The ADR + `language.md` §3.2/compile-output rewrites are slice 6; only the
  user guide is updated here.

## Verification

`just build` green: **3765 passed, 0 failed, 2 ignored**; `deno fmt --check`
and `dprint check` clean. A whole-branch review returned ready-to-merge after
two fixes it caught (upstream exemption extended to `validateTypl`; MCP
lockfile-mtime committed on compile success only). The e2e suite includes the
6-scenario cross-repo resolution suite (`federated_resolve_test.ts`) — Satisfies
resolves, broken ID → T014, colliding ID → R014, reference is a coverage leaf,
origin surfaces in `show`/`report`, and the root/diamond dedup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
