### PR TITLE
fix(repo): stop bootstrap's ensure_git_std from leaking its staging dir

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -66,7 +66,7 @@ ensure_git_std() {
     printf 'git-std not found — installing\n'
   fi
 
-  local target base download_url version tmp_dir
+  local target base download_url version
   target="$(detect_target)"
 
   version="$(curl -sSf "https://api.github.com/repos/$REPO/releases/latest" \
@@ -77,6 +77,12 @@ ensure_git_std() {
   download_url="https://github.com/$REPO/releases/download/$version/$base.tar.gz"
   printf 'downloading %s\n' "$download_url"
 
+  # `tmp_dir` is intentionally global (not `local`): ensure_git_std returns
+  # and bootstrap keeps running (git std bootstrap, grammar fetch) before
+  # the script actually exits, so the EXIT trap fires well after this
+  # function's local scope would have been torn down — a `local` tmp_dir
+  # would already be unbound there, silently degrading `rm -rf` to a no-op
+  # and leaking this staging directory on every install/upgrade.
   tmp_dir="$(mktemp -d)"
   trap 'rm -rf "${tmp_dir:-}"' EXIT
 


### PR DESCRIPTION
Closes #763.

## Summary

`bootstrap`'s `ensure_git_std()` has the same EXIT-trap/local-variable scope mismatch fixed in #759 for `install.sh`: `tmp_dir` is declared `local`, but the `EXIT` trap referencing it only fires once `bootstrap` itself exits — well after `ensure_git_std` has returned and the script has gone on to run `git std bootstrap` and the grammar-fetch step.

By the time the trap fires, `tmp_dir` is already unbound. The existing `${tmp_dir:-}` guard prevents a crash (unlike `install.sh`'s pre-#759 bug), but it also means the trap silently degrades to `rm -rf ""` — a no-op. Every `./bootstrap` run that actually installs or upgrades `git-std` leaks its `mktemp -d` staging directory (the downloaded tarball, checksum file, and extracted binary) under `/tmp`, indefinitely, with no indication to the contributor.

Fix: drop `local` so `tmp_dir` stays in scope through to the trap's actual firing point — same fix shape as #759.

## Test plan

- [x] Reproduced the leak in isolation with a minimal script mirroring `bootstrap`'s exact shape (a function registers the trap and returns; the caller keeps running before the real exit) — confirmed the staging directory survives after the script exits 0
- [x] Verified the fix: same repro with `local` dropped — staging directory is actually removed
- [x] `shellcheck bootstrap` — only pre-existing warning (SC2206, unrelated, confirmed present on `main` too)
- [x] `just build` — 3721 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
