### PR TITLE
docs(docs): document the typl published tier; retire TYPL-002/003 in guide + spec

### DIFF
--- a/docs/guide/typl.md
+++ b/docs/guide/typl.md
@@ -12,7 +12,7 @@ Use typl when an entry references `$Name` identifiers that represent typed
 quantities, and you want:
 
 - **Tooling support** — LSP hover shows the kind and shape of `$Name`; the
-  compiler reports undefined references and cross-entry collisions.
+  compiler reports undefined references and duplicate published declarations.
 - **Downstream codegen** — the `typeRegistry` in
   `markspec compile --format json` maps each identifier to its shape, ready for
   RIDL emitters or custom scripts.
@@ -150,6 +150,56 @@ merges them.
 
 ---
 
+## Publishing a symbol across entries
+
+Everything above is **entry-local**: a plain `$Name` lives in the entry that
+declares it, and two entries may declare `$Speed` independently. When a signal
+is a shared contract — an interface every consumer must agree on — declare it
+**once** as a _published_ symbol and cite it from the other entries.
+
+A published symbol is a dotted, namespaced name declared exactly once across the
+whole project. Declare a namespace, then hang the leaf signals off it with
+relative `$.` references:
+
+```markdown
+- [ICD_BRAKE_0001] Brake subsystem signal interface
+
+  `$powertrain.brake : namespace`
+
+  - `$.pedal_position : signal float[0..100]` — pedal travel, percent
+  - `$.line_pressure : signal float[0..250]` — hydraulic line pressure, bar
+
+    Id: 01JZEXAMPLEULID000000000005
+```
+
+This declares two published symbols — `$powertrain.brake.pedal_position` and
+`$powertrain.brake.line_pressure`. Any other entry cites one by its full dotted
+path:
+
+```markdown
+- [SRS_BRAKE_0040] Emergency brake trigger
+
+  The controller shall engage the emergency brake when
+  `$powertrain.brake.line_pressure` drops below 50 bar within 20 ms.
+
+      Id: 01JZEXAMPLEULID000000000006
+      Satisfies: SYS_BRAKE_0007
+```
+
+Three rules to keep in mind:
+
+- **Declared once.** Re-declaring a published symbol anywhere in the project is
+  an error (TYPL-009).
+- **Citations are absolute.** The relative `$.` form only works inside the
+  declaring entry; another entry must spell out the full dotted path.
+- **A published name is never bare.** Publication needs a namespace — `$speed`
+  cannot be published as-is; give it an owner (`$vehicle.speed`).
+
+See the [language reference](../spec/language/typl.md#published-declarations)
+for the full base-resolution rules.
+
+---
+
 ## Compile output
 
 Running `markspec compile --format json` on a project that contains typl
@@ -243,28 +293,61 @@ declaration exists in the same entry.
 **Fix:** Add the typedef before the binding, or replace the ref with an inline
 shape.
 
-### TYPL-002 — kind collision across entries
+### TYPL-002 / TYPL-003 — cross-entry collisions (deprecated)
+
+`TYPL-002` (kind collision) and `TYPL-003` (shape collision) are **retired** and
+never emitted. Under the published tier, two entries that declare the same plain
+`$Name` are independent entry-local symbols, so there is no cross-entry
+consistency rule for plain names. Corpus-wide agreement is now enforced only for
+published (dotted) symbols — see TYPL-009 below.
+
+### TYPL-009 — duplicate published declaration
 
 ```
-TYPL-002: $Speed is declared as kind signal here and kind value in SYS_CTRL_0001:14.
+TYPL-009: $powertrain.brake.pedal_position is already declared in icd/brake.md:12 (published symbols are declared exactly once).
 ```
 
-**Cause:** Two entries declare `$Speed` with different kind keywords.
+**Cause:** A published (dotted) symbol is declared in more than one place. A
+published symbol must be declared exactly once across the whole project.
 
-**Fix:** Align the kind declaration across all entries that use `$Speed`. If the
-identifiers are genuinely different quantities, rename one of them.
+**Fix:** Keep the single authoritative declaration and cite it from the other
+entries by its full dotted path.
 
-### TYPL-003 — shape collision across entries
+### TYPL-010 — relative reference with no base
 
 ```
-TYPL-003: $Speed is declared with a different shape than in SYS_CTRL_0001:14.
+TYPL-010: Relative reference $.pedal_position has no namespace base in scope.
 ```
 
-**Cause:** Two entries agree on the kind but use a different shape for `$Speed`
-(e.g., `float[0..300]` in one entry, `float[0..200]` in another).
+**Cause:** A `$.` relative reference appears with no enclosing `namespace`
+declaration and no entry root namespace to resolve against.
 
-**Fix:** Decide which shape is authoritative and update the other entry. If both
-ranges are intentional, use distinct names.
+**Fix:** Declare a namespace in scope (`` `$powertrain.brake : namespace` ``),
+or write the reference as an absolute dotted path.
+
+### TYPL-011 — citation of an undeclared published symbol
+
+```
+TYPL-011: Citation of undeclared published symbol $powertrain.brake.pedal_position.
+```
+
+**Cause:** An entry cites a dotted published symbol that is never declared
+anywhere in the project.
+
+**Fix:** Declare the symbol in its owning entry, or correct the dotted path in
+the citation.
+
+### TYPL-012 — multiple root namespaces in one entry
+
+```
+TYPL-012: Multiple root namespace declarations in one entry (root is $powertrain.brake).
+```
+
+**Cause:** An entry declares more than one top-level `namespace`. An entry may
+have at most one root namespace.
+
+**Fix:** Keep a single root namespace; nest the others beneath it, or move them
+to their own entries.
 
 ### TYPL-001 — duplicate binding in the same entry
 

--- a/docs/spec/language/typl.md
+++ b/docs/spec/language/typl.md
@@ -45,19 +45,20 @@ $CurrentTrack : signal Track
 
 ## Kind vocabulary
 
-The kind vocabulary is closed. Nine keywords are defined:
+The kind vocabulary is closed. Ten keywords are defined:
 
-| Kind       | Meaning                                                               |
-| ---------- | --------------------------------------------------------------------- |
-| `value`    | A plain data value with no lifecycle semantics. Default when omitted. |
-| `event`    | A named occurrence, optionally carrying a payload.                    |
-| `signal`   | A continuously observable quantity with a measurable shape.           |
-| `command`  | A request to perform an action, optionally with parameters.           |
-| `state`    | A named mode or state-machine state.                                  |
-| `const`    | A named constant whose value does not change at runtime.              |
-| `config`   | A configuration parameter supplied before system start.               |
-| `document` | A structured artefact (log record, report, notification).             |
-| `stream`   | A sequence of values produced over time.                              |
+| Kind        | Meaning                                                                                                                                                                     |
+| ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `value`     | A plain data value with no lifecycle semantics. Default when omitted.                                                                                                       |
+| `event`     | A named occurrence, optionally carrying a payload.                                                                                                                          |
+| `signal`    | A continuously observable quantity with a measurable shape.                                                                                                                 |
+| `command`   | A request to perform an action, optionally with parameters.                                                                                                                 |
+| `state`     | A named mode or state-machine state.                                                                                                                                        |
+| `const`     | A named constant whose value does not change at runtime.                                                                                                                    |
+| `config`    | A configuration parameter supplied before system start.                                                                                                                     |
+| `document`  | A structured artefact (log record, report, notification).                                                                                                                   |
+| `stream`    | A sequence of values produced over time.                                                                                                                                    |
+| `namespace` | Declares a base path for relative references in the published tier. Scaffolding, not a symbol — it carries no shape. See [Published declarations](#published-declarations). |
 
 ---
 
@@ -257,9 +258,17 @@ identifier in-prose without interrupting the surrounding text.
 
 ## Scope
 
-In v1, typl declarations are **entry-local**. A typedef declared in one entry
-cannot be referenced by name from a different entry. Cross-entry type sharing is
-deferred to a future profile-level scope mechanism.
+typl has two declaration tiers.
+
+**Entry-local** — a plain `$Name` binding (no dots) and every `type Name`
+typedef are scoped to their declaring entry. A typedef declared in one entry
+cannot be referenced by name from another. Two entries that each declare
+`$Speed` declare two independent symbols; there is no cross-entry consistency
+rule for plain names.
+
+**Published** — a dotted `$a.b.c` binding is a corpus-wide symbol, declared
+exactly once and citable from any entry. See
+[Published declarations](#published-declarations).
 
 Within a single entry, all surfaces (fence, bullet, inline) share one namespace.
 A `$Name` binding or `type Name` declared in one surface is visible to the
@@ -267,18 +276,65 @@ others in the same entry.
 
 ---
 
+## Published declarations
+
+A **published symbol** is a `$Name` whose path has two or more dot-separated
+segments (`$powertrain.brake.pedal_position`). Unlike an entry-local plain
+`$Name`, a published symbol is declared **exactly once** across the whole corpus
+and may be cited from any entry. A published symbol cannot be a bare name —
+publication forces namespace ownership.
+
+### Namespace declarations
+
+A `namespace`-kind declaration establishes a **base** path that relative
+references resolve against. It is scaffolding, not a symbol: it carries no shape
+and is not itself subject to declared-once.
+
+```markdown
+`$powertrain.brake : namespace`
+```
+
+### Relative references
+
+A reference of the form `$.name` is **relative**: it resolves against the base
+of the nearest enclosing namespace declaration (innermost wins), falling back to
+the entry's root namespace. An absolute reference has an identifier character
+immediately after the sigil (`$powertrain.brake.pedal_position`); a relative
+reference has a dot (`$.pedal_position`). There is no form in between, and the
+`$` sigil stays on the relative form.
+
+```markdown
+- `$powertrain.brake : namespace` — brake subsystem signals
+  - `$.pedal_position : signal float[0..100]` — resolves to
+    `$powertrain.brake.pedal_position`
+  - `$.line_pressure : signal float[0..250]`
+
+  Latency budgets apply to `$.pedal_position`.
+```
+
+A cross-entry citation must be **absolute** — a relative reference never leaves
+its declaring entry. An entry may declare **at most one** root (top-level)
+namespace; a second is an error ([TYPL-012](#diagnostic-catalogue)). Zero is
+fine — that is every entry without published symbols.
+
+---
+
 ## Diagnostic catalogue
 
-| Code     | Severity | Description                                                              |
-| -------- | -------- | ------------------------------------------------------------------------ |
-| TYPL-001 | error    | Duplicate `$Name` binding within the same entry — first occurrence wins. |
-| TYPL-002 | error    | Same `$Name` declared with a different kind in another entry.            |
-| TYPL-003 | error    | Same `$Name` declared with a different shape in another entry.           |
-| TYPL-004 | error    | Typedef name redefined within the same entry.                            |
-| TYPL-005 | error    | Reference to an undefined typedef name.                                  |
-| TYPL-006 | error    | Malformed schema — unparseable shape expression.                         |
-| TYPL-007 | error    | Unknown kind keyword; expected one of the nine closed-vocabulary kinds.  |
-| TYPL-008 | error    | Literal value violates the declared constraint.                          |
+| Code     | Severity | Description                                                                                 |
+| -------- | -------- | ------------------------------------------------------------------------------------------- |
+| TYPL-001 | error    | Duplicate `$Name` binding within the same entry — first occurrence wins.                    |
+| TYPL-002 | error    | _Deprecated — retired by the published tier; never emitted._ Kind mismatch across entries.  |
+| TYPL-003 | error    | _Deprecated — retired by the published tier; never emitted._ Shape mismatch across entries. |
+| TYPL-004 | error    | Typedef name redefined within the same entry.                                               |
+| TYPL-005 | error    | Reference to an undefined typedef name.                                                     |
+| TYPL-006 | error    | Malformed schema — unparseable shape expression.                                            |
+| TYPL-007 | error    | Unknown kind keyword; expected one of the ten closed-vocabulary kinds.                      |
+| TYPL-008 | error    | Literal value violates the declared constraint.                                             |
+| TYPL-009 | error    | Published symbol declared more than once — declared-once violation.                         |
+| TYPL-010 | error    | Relative reference has no namespace base in scope.                                          |
+| TYPL-011 | error    | Citation of an undeclared published symbol.                                                 |
+| TYPL-012 | error    | More than one root namespace declaration in a single entry.                                 |
 
 ---
 


### PR DESCRIPTION
Closes #758.

Brings the typl user guide and language spec current with the published/namespaced tier (#723 / PR #749). **Docs-only — no code change.** The diagnostic catalogue is keyed off `packages/markspec/core/typl/diagnostics.ts` as the source of truth.

## `docs/spec/language/typl.md` (normative)

- **Kind vocabulary** — added `namespace` (ten kinds); noted it's published-tier scaffolding (no shape, not a symbol).
- **Scope** — rewritten around the two tiers: entry-local plain `$Name` vs published dotted `$a.b.c`. Removed the stale "cross-entry type sharing is deferred".
- **New "Published declarations" section** — dotted names (declared once corpus-wide), the `` `$a.b : namespace` `` base clause, relative `$.x` resolution (innermost base wins), absolute-only cross-entry citations, one-root rule.
- **Diagnostic catalogue** — TYPL-002/003 marked deprecated (retired, never emitted); added TYPL-009/010/011/012; fixed "nine → ten closed-vocabulary kinds".

## `docs/guide/typl.md` (tutorial)

- Reworded the stale "cross-entry collisions" mention.
- **New "Publishing a symbol across entries" section** — a worked example (namespace + relative `$.x` declaration, then citing the full dotted path from another entry) plus three rules.
- **Diagnostics section** — replaced the TYPL-002/003 subsections with a deprecation note; added TYPL-009/010/011/012 subsections (cause + fix) in the existing style.

## Verification

Full `just check` green; `deno fmt --check` + `dprint check` clean. No code touched, no tests affected.

## Noted (not fixed here)

`core/typl/diagnostics.ts:4` module header comment still says "TYPL-001 through TYPL-008" — a one-line code-comment nit, kept out of this docs-only PR to keep the scope clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
