### PR TITLE
docs(core): correct typl diagnostics header comment range to TYPL-012

### DIFF
--- a/packages/markspec/core/typl/diagnostics.ts
+++ b/packages/markspec/core/typl/diagnostics.ts
@@ -2,7 +2,7 @@
  * @module typl/diagnostics
  *
  * Diagnostic codes emitted by the typl parser and validator (TYPL-001
- * through TYPL-008). Each code carries a severity and a template; the
+ * through TYPL-012). Each code carries a severity and a template; the
  * `typlDiagnostic` helper performs `${var}` substitution.
  */
 import type { Position } from "./ast.ts";


### PR DESCRIPTION
Trivial follow-up from #768: the `core/typl/diagnostics.ts` module comment said the file defines "TYPL-001 through TYPL-008", but the catalogue now defines codes through **TYPL-012** (added by the published tier, #723). Correct the comment. Comment-only — no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
