### PR TITLE
feat(core): typl table declaration surface (#724)

### DIFF
--- a/docs/architecture/adr-019-typl-type-dsl.md
+++ b/docs/architecture/adr-019-typl-type-dsl.md
@@ -82,3 +82,29 @@ applies. `CORE_SCHEMA_VERSION` unchanged.
 Full design record: `docs/wip/2026-07-04-typl-published-tier-design.md`
 (gardened to `docs/archive/` when this branch lands). The complete namespacing
 rewrite of this ADR plus guide chapter is story #730.
+
+## Addendum: table surface (#724, 2026-07-05)
+
+S6 of the uxil epic (#717) adds a **fourth** Markdown surface: a GFM table. Each
+data row `$name | kind shape | description` is one binding — the first two cells
+are read positionally (the description column and any further columns are
+documentation), rows whose first cell is not a `$Name` are skipped, and only
+bindings (not typedefs) are expressed this way. Like its siblings it is a thin
+adapter (`core/typl/table.ts`) over the shared declaration machinery
+(`core/decl/table.ts`, S3): the row recognizer reconstructs a
+`$name : kind
+shape` source that `parseTyplBlock` parses, so a table row yields
+the identical `Binding` as the fence, bullet, or inline form.
+
+A table's `Table:` caption may carry a published base (an absolute `$a.b` name);
+the table's relative rows (`$.x`) resolve against that caption base first, then
+the entry root, through the entry-local base-resolution engine (#722 rule 3).
+The caption base is not a root declaration and never sets `rootNamespace`.
+
+This revisits the "GFM bindings table … rejected" alternative above. Two things
+changed since 2026-05-25: a shape carrying `|` (a union or enum) is authored
+with the standard GFM `\|` escape — the cell un-escapes before typl parses it —
+and ADR-029's whole-document dprint pass preserves table line structure. The
+table is therefore offered as an _additional_ surface, not the primary one;
+dense or `|`-heavy declarations still read best in a fence.
+`CORE_SCHEMA_VERSION` unchanged.

--- a/docs/guide/typl.md
+++ b/docs/guide/typl.md
@@ -99,7 +99,7 @@ table may mix declaration rows with plain notes.
   | $VehicleSpeed | signal float[0..300] | km/h, road speed |
   | $EngineRpm    | signal int[0..8000]  | crankshaft speed |
 
-      Id: 01JZEXAMPLEULID000000000004
+      Id: 01JZEXAMPLEULID000000000006
 ```
 
 A shape that contains `|` (a union or enum) must escape each pipe as `\|` so GFM
@@ -107,8 +107,9 @@ does not read it as a column break; the cell un-escapes before typl parses it
 (`| $Gear | 'P' \| 'R' \| 'N' \| 'D' | selected gear |`).
 
 A `Table:` caption adjacent to the table may carry a published base — an
-absolute `$a.b` name — which scopes the table's relative rows (`$.x`) through
-the same entry-local resolver the bullet surface uses:
+absolute name, dotted (`$a.b`) or single-segment (`$vehicle`) — which scopes the
+table's relative rows (`$.x`) through the same entry-local resolver the bullet
+surface uses:
 
 ```markdown
 - [SYS_BRAKE_0009] Brake contract
@@ -123,7 +124,9 @@ the same entry-local resolver the bullet surface uses:
       Id: 01JZEXAMPLEULID000000000005
 ```
 
-Only bindings are expressed in tables; typedefs keep the fence, bullet, or
+A table row resolves against its caption base, then the entry root. Unlike a
+bullet, a table nested inside a namespace does not inherit that namespace's
+base. Only bindings are expressed in tables; typedefs keep the fence, bullet, or
 inline surfaces.
 
 ---

--- a/docs/guide/typl.md
+++ b/docs/guide/typl.md
@@ -26,7 +26,7 @@ the identifiers are self-explanatory from prose context alone.
 
 ## Which surface should I use?
 
-Three Markdown surfaces are available. Choose based on how many declarations you
+Four Markdown surfaces are available. Choose based on how many declarations you
 need and where they live relative to prose.
 
 ### Fence — for dense or structured declarations
@@ -81,6 +81,51 @@ for more.
       Id: 01JZEXAMPLEULID000000000003
 ```
 
+### Table — for many parallel declarations
+
+Use a GFM table when an entry declares many identifiers that share the same
+columns: one row per binding, holding the `$Name`, its `kind shape`, and a
+description. The first two columns are read positionally; the description is
+documentation only. Rows whose first cell is not a `$Name` are ignored, so a
+table may mix declaration rows with plain notes.
+
+```markdown
+- [SYS_HMI_0007] Cluster display signals
+
+  The cluster shall render each signal below within its stated range.
+
+  | Signal        | Kind shape           | Description      |
+  | ------------- | -------------------- | ---------------- |
+  | $VehicleSpeed | signal float[0..300] | km/h, road speed |
+  | $EngineRpm    | signal int[0..8000]  | crankshaft speed |
+
+      Id: 01JZEXAMPLEULID000000000004
+```
+
+A shape that contains `|` (a union or enum) must escape each pipe as `\|` so GFM
+does not read it as a column break; the cell un-escapes before typl parses it
+(`| $Gear | 'P' \| 'R' \| 'N' \| 'D' | selected gear |`).
+
+A `Table:` caption adjacent to the table may carry a published base — an
+absolute `$a.b` name — which scopes the table's relative rows (`$.x`) through
+the same entry-local resolver the bullet surface uses:
+
+```markdown
+- [SYS_BRAKE_0009] Brake contract
+
+  Table: $powertrain.brake
+
+  | Signal           | Kind shape           | Description |
+  | ---------------- | -------------------- | ----------- |
+  | $.pedal_position | signal float[0..100] | pedal, %    |
+  | $.line_pressure  | signal float[0..250] | bar         |
+
+      Id: 01JZEXAMPLEULID000000000005
+```
+
+Only bindings are expressed in tables; typedefs keep the fence, bullet, or
+inline surfaces.
+
 ---
 
 ## Common patterns
@@ -128,9 +173,9 @@ $PedalPressed   : event { force_N: float[0..1500], timestamp: int }
 
 ### Mixing surfaces in one entry
 
-All three surfaces share the same namespace within an entry. You can open a
-fence for typedefs, then use bullets for bindings, or vice versa. The compiler
-merges them.
+All four surfaces share the same namespace within an entry. You can open a fence
+for typedefs, then use bullets or a table for bindings, or vice versa. The
+compiler merges them.
 
 ````markdown
 - [SYS_LOG_0004] Diagnostic log record

--- a/docs/spec/language/typl.md
+++ b/docs/spec/language/typl.md
@@ -276,9 +276,11 @@ separator; the cell un-escapes before typl parses it.
 ```
 
 A `Table:` caption adjacent to the table may carry a published base — an
-absolute `$a.b` name — that scopes the table's relative rows (`$.x`) through the
-entry-local base resolver, the same mechanism the bullet glossary uses for
-nested namespaces.
+absolute name, dotted (`$a.b`) or single-segment (`$vehicle`) — that scopes the
+table's relative rows (`$.x`) through the same entry-local base resolver the
+bullet glossary's nested namespaces use. A table row resolves against its
+caption base, then the entry root; unlike a bullet, a table nested inside a
+namespace does not inherit that namespace's base.
 
 ---
 

--- a/docs/spec/language/typl.md
+++ b/docs/spec/language/typl.md
@@ -197,7 +197,7 @@ Syntax: any shape followed by `?`. Optional wraps the innermost shape:
 
 ## Markdown surfaces
 
-typl declarations may appear in three Markdown surfaces. All three parse to the
+typl declarations may appear in four Markdown surfaces. All four parse to the
 same Shape AST.
 
 ### Fence block
@@ -253,6 +253,33 @@ identifier in-prose without interrupting the surrounding text.
       Id: 01JZEXAMPLEULID000000000003
 ```
 
+### Table
+
+Use a GFM table to declare many identifiers that share the same columns. Each
+data row holds a `$Name` in its first cell and the binding's `kind shape` in its
+second; a third description column, and any further columns, carry documentation
+and are ignored. Rows whose first cell is not a `$Name` are skipped, so
+declaration rows may be mixed with plain rows. Only bindings are recognised in a
+table — typedefs use the other three surfaces. A shape that contains `|` (a
+union or enum) must escape each pipe as `\|` so it is not read as a column
+separator; the cell un-escapes before typl parses it.
+
+```markdown
+- [SYS_HMI_0007] Cluster display signals
+
+  | Signal        | Kind shape           | Description      |
+  | ------------- | -------------------- | ---------------- |
+  | $VehicleSpeed | signal float[0..300] | km/h, road speed |
+  | $EngineRpm    | signal int[0..8000]  | crankshaft speed |
+
+      Id: 01JZEXAMPLEULID000000000004
+```
+
+A `Table:` caption adjacent to the table may carry a published base — an
+absolute `$a.b` name — that scopes the table's relative rows (`$.x`) through the
+entry-local base resolver, the same mechanism the bullet glossary uses for
+nested namespaces.
+
 ---
 
 ## Scope
@@ -261,9 +288,9 @@ In v1, typl declarations are **entry-local**. A typedef declared in one entry
 cannot be referenced by name from a different entry. Cross-entry type sharing is
 deferred to a future profile-level scope mechanism.
 
-Within a single entry, all surfaces (fence, bullet, inline) share one namespace.
-A `$Name` binding or `type Name` declared in one surface is visible to the
-others in the same entry.
+Within a single entry, all surfaces (fence, bullet, inline, table) share one
+namespace. A `$Name` binding or `type Name` declared in one surface is visible
+to the others in the same entry.
 
 ---
 

--- a/packages/markspec/core/typl/assemble.ts
+++ b/packages/markspec/core/typl/assemble.ts
@@ -126,14 +126,16 @@ export function assembleTyplTypes(
     blocks.push({ ...result.ast, file: inline.location.file, lineOffset });
   }
 
-  // Table rows (#724): each recognized data row is one binding. Its range is
-  // line-precise, so the diagnostic offset mirrors the fence surface. A
-  // `Table:` caption base — when the caption text is an absolute typl name —
-  // scopes the row's relative refs (see `scopeFor`); it is not a namespace
-  // binding, so it takes no part in Pass A root detection or Pass B.
+  // Table rows (#724): each recognized data row is one binding. Its range
+  // points AT the row's own line (like the bullet surface, not the fence
+  // whose range points at the opening ``` a line above its content), so the
+  // diagnostic offset subtracts 2, matching the bullet path. The `Table:`
+  // caption base — when the caption text is an absolute typl name — scopes
+  // the row's relative refs (see `scopeFor`); the caption base is not a
+  // namespace binding, so it takes no part in Pass A root detection or Pass B.
   for (const row of extractTyplTable(bodyAst)) {
     const result = parseTyplBlock(row.source);
-    const lineOffset = bodyStartLine + row.range.start.line - 1;
+    const lineOffset = bodyStartLine + row.range.start.line - 2;
     for (const td of result.diagnostics) {
       diagnostics.push(bridgeTyplDiagnostic(td, file, lineOffset));
     }
@@ -223,10 +225,14 @@ export function assembleTyplTypes(
   const basePathOfBlock: (string | undefined)[] = blocks.map(() => undefined);
 
   /**
-   * Scope chain for blocks[i]: a table-row block's `Table:` caption base
-   * innermost (#724), then bullet-ancestor bases innermost-first, terminated
-   * by the root base. Built immutably per call; fence/inline blocks have
-   * neither a caption base nor a bullet chain and see the root only.
+   * Scope chain for blocks[i], innermost-first, terminated by the root base.
+   * Which frames a block sees depends on its surface: a bullet block walks
+   * its bullet-ancestor bases; a table-row block contributes its `Table:`
+   * caption base (#724); fence/inline blocks have neither and see the root
+   * only. The frame kinds don't combine in practice — a table row carries no
+   * `bulletParent`, so a table nested inside a bullet-namespace subtree sees
+   * only its caption base + the root, not the enclosing bullet base (known
+   * limitation, #724). Built immutably per call.
    */
   const scopeFor = (i: number): BaseScope | undefined => {
     const chain: string[] = []; // innermost first

--- a/packages/markspec/core/typl/assemble.ts
+++ b/packages/markspec/core/typl/assemble.ts
@@ -1,8 +1,8 @@
 /**
  * @module typl/assemble
  *
- * Entry-level typl assembly (#723): extracts declarations from the three
- * surfaces (fence / bullet / inline), resolves published names through
+ * Entry-level typl assembly (#723, #724): extracts declarations from the four
+ * surfaces (fence / bullet / inline / table), resolves published names through
  * the base-resolution engine (core/decl/resolve), and aggregates the
  * result into the `Entry.types` TyplBlock. Moved out of parser/markdown.ts
  * so the parser calls one function.
@@ -11,6 +11,10 @@
  *   - a `: namespace` binding establishes a base; nested-bullet namespaces
  *     scope their subtree (innermost wins); the root namespace (no
  *     namespace ancestor) scopes the whole entry body, order-independent;
+ *   - a table's `Table:` caption may carry a base (#724); a table row
+ *     resolves against that caption base first (innermost, #722 rule 3),
+ *     then the root — the caption base is not itself a root and never sets
+ *     `rootNamespace`;
  *   - relative names (`$.x`) resolve to absolute dotted names before
  *     aggregation — Entry.types carries absolute names only;
  *   - namespace bindings are scaffolding: excluded from bindings;
@@ -27,6 +31,7 @@ import { typlDiagnostic } from "./diagnostics.ts";
 import { extractTyplFences } from "./fence.ts";
 import { extractTyplBulletsNested } from "./bullet.ts";
 import { extractTyplInlines } from "./inline.ts";
+import { extractTyplTable, typlTableCaptionBase } from "./table.ts";
 import { parseTyplBlock } from "./grammar.ts";
 import { TYPL_REF_OPS, typlPathOf } from "./resolve.ts";
 
@@ -40,6 +45,10 @@ interface SurfaceBlock {
   /** Index into the bullet-extraction array of the enclosing bullet
    * declaration. Always undefined for fence and inline blocks. */
   readonly bulletParent?: number;
+  /** Base path parsed from the enclosing table's `Table:` caption (#724);
+   * `scopeFor` uses it as the innermost scope for a table row's own
+   * bindings. Always undefined for fence, bullet, and inline blocks. */
+  readonly captionBase?: string;
 }
 
 /** One root-candidate namespace binding, for {@linkcode checkSingleRoot}. */
@@ -52,12 +61,12 @@ interface RootCandidate {
 /**
  * Assemble one entry's typl declarations into its `Entry.types` block.
  *
- * Extracts declarations from the three embedding surfaces (fenced code,
- * bullet glossary, inline code spans), resolves every relative `$.x` name
- * against the root/nested-namespace bases in scope (see the module doc's
- * resolution rules), and aggregates the result.
+ * Extracts declarations from the four embedding surfaces (fenced code,
+ * bullet glossary, inline code spans, table rows), resolves every relative
+ * `$.x` name against the caption/root/nested-namespace bases in scope (see
+ * the module doc's resolution rules), and aggregates the result.
  *
- * @param bodyAst - The entry body's parsed block AST (fence + bullet
+ * @param bodyAst - The entry body's parsed block AST (fence + bullet + table
  *   surfaces walk this).
  * @param bodyTokens - The entry body's flat token stream (the inline
  *   surface walks this).
@@ -115,6 +124,28 @@ export function assembleTyplTypes(
       );
     }
     blocks.push({ ...result.ast, file: inline.location.file, lineOffset });
+  }
+
+  // Table rows (#724): each recognized data row is one binding. Its range is
+  // line-precise, so the diagnostic offset mirrors the fence surface. A
+  // `Table:` caption base — when the caption text is an absolute typl name —
+  // scopes the row's relative refs (see `scopeFor`); it is not a namespace
+  // binding, so it takes no part in Pass A root detection or Pass B.
+  for (const row of extractTyplTable(bodyAst)) {
+    const result = parseTyplBlock(row.source);
+    const lineOffset = bodyStartLine + row.range.start.line - 1;
+    for (const td of result.diagnostics) {
+      diagnostics.push(bridgeTyplDiagnostic(td, file, lineOffset));
+    }
+    const captionBase = row.captionText !== undefined
+      ? typlTableCaptionBase(row.captionText)
+      : undefined;
+    blocks.push({
+      ...result.ast,
+      file,
+      lineOffset,
+      ...(captionBase !== undefined ? { captionBase } : {}),
+    });
   }
 
   // Emit a bridged typl diagnostic for a binding in blocks[i].
@@ -192,9 +223,10 @@ export function assembleTyplTypes(
   const basePathOfBlock: (string | undefined)[] = blocks.map(() => undefined);
 
   /**
-   * Scope chain for blocks[i]: bullet-ancestor bases innermost-first,
-   * terminated by the root base. Built immutably per call; non-bullet
-   * blocks (fence/inline) have no bullet chain and see the root only.
+   * Scope chain for blocks[i]: a table-row block's `Table:` caption base
+   * innermost (#724), then bullet-ancestor bases innermost-first, terminated
+   * by the root base. Built immutably per call; fence/inline blocks have
+   * neither a caption base nor a bullet chain and see the root only.
    */
   const scopeFor = (i: number): BaseScope | undefined => {
     const chain: string[] = []; // innermost first
@@ -211,6 +243,10 @@ export function assembleTyplTypes(
     for (let k = chain.length - 1; k >= 0; k--) {
       scope = { base: chain[k], parent: scope };
     }
+    // A table row resolves against its caption base first (#722 rule 3):
+    // innermost, above the bullet chain and the root.
+    const captionBase = blocks[i].captionBase;
+    if (captionBase !== undefined) scope = { base: captionBase, parent: scope };
     return scope;
   };
 

--- a/packages/markspec/core/typl/assemble_test.ts
+++ b/packages/markspec/core/typl/assemble_test.ts
@@ -167,6 +167,20 @@ Deno.test("assemble: a union shape survives a table cell when its pipes are GFM-
   });
 });
 
+Deno.test("assemble: a table-row parse/resolution diagnostic points at the row's line", () => {
+  // The `$.pedal` row is relative with no base → TYPL-010. The diagnostic
+  // must land on the row's own file line (line 5), not one below it.
+  const md = `- [REQ_0105] Orphan table row
+
+  | Name | Kind shape | Description |
+  | ---- | -------------------- | ----- |
+  | $.pedal | signal float[0..100] | pedal |
+`;
+  const { diagnostics } = parseMarkdown(md, { file: "a.md" });
+  const t010 = diagnostics.find((d) => d.code === "TYPL-010");
+  assertEquals(t010?.location?.line, 5);
+});
+
 Deno.test("assemble: a table composes with the fence surface in one entry", () => {
   const md = `- [REQ_0103] Mixed surfaces
 

--- a/packages/markspec/core/typl/assemble_test.ts
+++ b/packages/markspec/core/typl/assemble_test.ts
@@ -81,3 +81,107 @@ Deno.test("assemble: namespace bindings never enter Entry.types.bindings", () =>
   const { entries } = parseMarkdown(md, { file: "a.md" });
   assertEquals(entries[0].types!.bindings.map((b) => b.name), ["$local"]);
 });
+
+// ---------------------------------------------------------------------------
+// Table surface (#724 / S6) — a fourth embedding surface. Each data row
+// `$name | kind shape | description` is one binding; a `Table:` caption may
+// carry a base the entry-local resolver consumes.
+// ---------------------------------------------------------------------------
+
+/** Project a binding to its position-independent shape, for parity checks. */
+function bindingShape(b: { name: string; kind: string; shape?: unknown }) {
+  return { name: b.name, kind: b.kind, shape: b.shape };
+}
+
+Deno.test("assemble: a table row produces a binding equal to the inline surface (parity)", () => {
+  const tableMd = `- [REQ_0100] Speed contract
+
+  | Name | Kind shape | Description |
+  | ------ | -------------------- | ------------- |
+  | $speed | signal float[0..300] | vehicle speed |
+`;
+  const inlineMd = `- [REQ_0100] Speed contract
+
+  Declares \`$speed : signal float[0..300]\`.
+`;
+  const table = parseMarkdown(tableMd, { file: "a.md" });
+  const inline = parseMarkdown(inlineMd, { file: "a.md" });
+  assertEquals(
+    table.diagnostics.filter((d) => d.code.startsWith("TYPL")).length,
+    0,
+  );
+  assertEquals(
+    table.entries[0].types!.bindings.map(bindingShape),
+    inline.entries[0].types!.bindings.map(bindingShape),
+  );
+  assertEquals(table.entries[0].types!.bindings.length, 1);
+});
+
+Deno.test("assemble: a Table caption base resolves relative table rows", () => {
+  const md = `- [REQ_0101] Brake contract
+
+  Table: $powertrain.brake
+
+  | Name | Kind shape | Description |
+  | ---------------- | -------------------- | -------- |
+  | $.pedal_position | signal float[0..100] | pedal |
+  | $.line_pressure | signal float[0..250] | pressure |
+`;
+  const { entries, diagnostics } = parseMarkdown(md, { file: "a.md" });
+  assertEquals(diagnostics.filter((d) => d.code.startsWith("TYPL")).length, 0);
+  assertEquals(entries[0].types!.bindings.map((b) => b.name), [
+    "$powertrain.brake.pedal_position",
+    "$powertrain.brake.line_pressure",
+  ]);
+});
+
+Deno.test("assemble: a mixed table extracts only the typl rows", () => {
+  const md = `- [REQ_0102] Config
+
+  | Name | Kind shape | Description |
+  | ------ | -------------------- | ---------------- |
+  | $speed | signal float[0..300] | vehicle speed |
+  | note | see appendix A | not a declaration |
+`;
+  const { entries } = parseMarkdown(md, { file: "a.md" });
+  assertEquals(entries[0].types!.bindings.map((b) => b.name), ["$speed"]);
+});
+
+Deno.test("assemble: a union shape survives a table cell when its pipes are GFM-escaped", () => {
+  // ADR-019 rejected a table surface partly because literal `|` in a union
+  // breaks GFM columns. Escaping each `|` as `\|` (standard GFM) resolves it:
+  // the cell un-escapes to the full union before the recognizer sees it.
+  const md = `- [REQ_0104] Mode
+
+  | Name | Kind shape | Description |
+  | ----- | ------------------------ | ---- |
+  | $mode | 'low' \\| 'mid' \\| 'high' | mode |
+`;
+  const { entries, diagnostics } = parseMarkdown(md, { file: "a.md" });
+  assertEquals(diagnostics.filter((d) => d.code.startsWith("TYPL")).length, 0);
+  const binding = entries[0].types!.bindings[0];
+  assertEquals(binding.name, "$mode");
+  assertEquals(binding.shape, {
+    kind: "enum",
+    values: ["low", "mid", "high"],
+  });
+});
+
+Deno.test("assemble: a table composes with the fence surface in one entry", () => {
+  const md = `- [REQ_0103] Mixed surfaces
+
+  \`\`\`typl
+  $rpm : signal int[0..8000]
+  \`\`\`
+
+  | Name | Kind shape | Description |
+  | ------ | -------------------- | ------------- |
+  | $speed | signal float[0..300] | vehicle speed |
+`;
+  const { entries, diagnostics } = parseMarkdown(md, { file: "a.md" });
+  assertEquals(diagnostics.filter((d) => d.code.startsWith("TYPL")).length, 0);
+  assertEquals(entries[0].types!.bindings.map((b) => b.name), [
+    "$rpm",
+    "$speed",
+  ]);
+});

--- a/packages/markspec/core/typl/mod.ts
+++ b/packages/markspec/core/typl/mod.ts
@@ -36,11 +36,7 @@ export type { TyplInlineExtraction } from "./inline.ts";
 export { extractTyplInlines } from "./inline.ts";
 
 export type { TyplTableExtraction } from "./table.ts";
-export {
-  extractTyplTable,
-  typlTableCaptionBase,
-  typlTableRowRecognizer,
-} from "./table.ts";
+export { extractTyplTable } from "./table.ts";
 
 export type { TyplCitation } from "./citations.ts";
 export { extractTyplCitations, isTyplCitationText } from "./citations.ts";

--- a/packages/markspec/core/typl/mod.ts
+++ b/packages/markspec/core/typl/mod.ts
@@ -35,6 +35,13 @@ export { extractTyplBulletsNested } from "./bullet.ts";
 export type { TyplInlineExtraction } from "./inline.ts";
 export { extractTyplInlines } from "./inline.ts";
 
+export type { TyplTableExtraction } from "./table.ts";
+export {
+  extractTyplTable,
+  typlTableCaptionBase,
+  typlTableRowRecognizer,
+} from "./table.ts";
+
 export type { TyplCitation } from "./citations.ts";
 export { extractTyplCitations, isTyplCitationText } from "./citations.ts";
 

--- a/packages/markspec/core/typl/table.ts
+++ b/packages/markspec/core/typl/table.ts
@@ -1,0 +1,85 @@
+/**
+ * @module typl/table
+ *
+ * Table surface adapter (#724 / S6) — recognises typl declarations authored
+ * as GFM table data rows. A thin wrapper over the shared declaration-surface
+ * machinery (core/decl): each data row `$name | kind shape | description` is
+ * reduced to the declaration source `$name : kind shape` (the `description`
+ * column is human documentation and is dropped, since a typl binding carries
+ * no description), then parsed like any other surface. Rows whose first cell
+ * is not a typl name — or whose shape cell is empty — are skipped, so mixed
+ * tables and malformed rows contribute nothing.
+ *
+ * A table's `Table:` caption may carry a base: {@linkcode typlTableCaptionBase}
+ * reads an absolute typl name out of the caption text, which
+ * {@linkcode extractTyplTable}'s caller (assemble) hands to the entry-local
+ * resolver (S4) so relative rows (`$.x`) resolve against it. Only bindings are
+ * expressed in tables; typedefs (`type X = …`) keep their fence / bullet /
+ * inline surfaces.
+ *
+ * See ADR-019.
+ */
+
+import type { BodyBlock } from "../ast/nodes.ts";
+import {
+  extractTableDeclarations,
+  type RowRecognizer,
+  type TableRowDeclaration,
+} from "../decl/mod.ts";
+import { isTyplDeclarationText } from "./recognize.ts";
+import { typlPathOf } from "./resolve.ts";
+
+/** A single typl table-row declaration: `{ source, range, captionText? }`. */
+export type TyplTableExtraction = TableRowDeclaration;
+
+/**
+ * An absolute typl name (sigil + ≥1 dotted segments, no leading dot): the
+ * only shape a `Table:` caption base may take. Mirrors `isPublishedTyplName`
+ * but also admits a single-segment name (`$vehicle`) — a caption base need
+ * not be dotted.
+ */
+const ABSOLUTE_TYPL_NAME_RE = /^\$[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z0-9_]+)*$/;
+
+/**
+ * Reduce a table data row to a typl declaration source, or `undefined` to
+ * skip the row. The first cell supplies the binding name (`$name`), the
+ * second the kind + shape; the remaining cells (a description) are dropped.
+ * Returns `undefined` when the reconstructed `$name : kind shape` is not a
+ * typl declaration (non-typl row) or when either required cell is empty
+ * (malformed row).
+ */
+export const typlTableRowRecognizer: RowRecognizer = (cells) => {
+  const name = cells[0]?.trim() ?? "";
+  const decl = cells[1]?.trim() ?? "";
+  if (name === "" || decl === "") return undefined;
+  const source = `${name} : ${decl}`;
+  return isTyplDeclarationText(source) ? source : undefined;
+};
+
+/**
+ * Parse a base path out of a `Table:` caption's text, or `undefined` when
+ * the caption carries no typl base. The base is the caption's leading
+ * whitespace-delimited token when it is an absolute typl name; a trailing
+ * description (`$powertrain.brake — brake signals`) is ignored. Relative
+ * names (`$.x`) are not bases — they would need a base themselves — and a
+ * non-typl caption yields no base. The `$` sigil is stripped, matching the
+ * base paths the entry-local resolver joins against.
+ */
+export function typlTableCaptionBase(
+  captionText: string,
+): string | undefined {
+  const first = captionText.trim().split(/\s+/)[0] ?? "";
+  return ABSOLUTE_TYPL_NAME_RE.test(first) ? typlPathOf(first) : undefined;
+}
+
+/**
+ * Walk a body AST and return a declaration for every table data row that is
+ * a typl binding, in source order (recursing into list-nested tables).
+ * Delegates traversal to {@linkcode extractTableDeclarations}; each result
+ * carries the enclosing table's `captionText` when present.
+ */
+export function extractTyplTable(
+  blocks: readonly BodyBlock[],
+): readonly TyplTableExtraction[] {
+  return extractTableDeclarations(blocks, typlTableRowRecognizer);
+}

--- a/packages/markspec/core/typl/table_test.ts
+++ b/packages/markspec/core/typl/table_test.ts
@@ -1,0 +1,74 @@
+/**
+ * @module typl/table_test
+ *
+ * Unit tests for the typl table surface adapter (#724 / S6): the row
+ * recognizer that reduces a `$name | kind shape | description` data row to a
+ * typl declaration source, and the caption-base parser that reads a base out
+ * of a `Table:` caption.
+ */
+
+import { assertEquals } from "@std/assert";
+import { typlTableCaptionBase, typlTableRowRecognizer } from "./table.ts";
+
+// --- row recognizer --------------------------------------------------------
+
+Deno.test("typlTableRowRecognizer: reconstructs `$name : kind shape` from cells", () => {
+  assertEquals(
+    typlTableRowRecognizer(["$speed", "signal float[0..300]", "vehicle speed"]),
+    "$speed : signal float[0..300]",
+  );
+});
+
+Deno.test("typlTableRowRecognizer: trims surrounding whitespace in name and shape", () => {
+  assertEquals(
+    typlTableRowRecognizer(["  $speed ", "  signal  ", "desc"]),
+    "$speed : signal",
+  );
+});
+
+Deno.test("typlTableRowRecognizer: accepts a relative name for caption-base resolution", () => {
+  assertEquals(
+    typlTableRowRecognizer(["$.pedal", "signal float[0..100]", "pedal"]),
+    "$.pedal : signal float[0..100]",
+  );
+});
+
+Deno.test("typlTableRowRecognizer: skips a row whose first cell is not a typl name", () => {
+  assertEquals(
+    typlTableRowRecognizer(["note", "see appendix A", "not a declaration"]),
+    undefined,
+  );
+});
+
+Deno.test("typlTableRowRecognizer: skips a row with an empty shape cell (malformed)", () => {
+  assertEquals(typlTableRowRecognizer(["$speed", "", "desc"]), undefined);
+});
+
+Deno.test("typlTableRowRecognizer: skips a single-cell row (no shape column)", () => {
+  assertEquals(typlTableRowRecognizer(["$speed"]), undefined);
+});
+
+// --- caption-base parser ---------------------------------------------------
+
+Deno.test("typlTableCaptionBase: an absolute dotted name yields its path", () => {
+  assertEquals(typlTableCaptionBase("$powertrain.brake"), "powertrain.brake");
+});
+
+Deno.test("typlTableCaptionBase: a single-segment absolute name yields its path", () => {
+  assertEquals(typlTableCaptionBase("$vehicle"), "vehicle");
+});
+
+Deno.test("typlTableCaptionBase: ignores a trailing description after the base", () => {
+  assertEquals(
+    typlTableCaptionBase("$powertrain.brake — brake signals"),
+    "powertrain.brake",
+  );
+});
+
+Deno.test("typlTableCaptionBase: a non-typl caption yields no base", () => {
+  assertEquals(typlTableCaptionBase("Sensor thresholds"), undefined);
+});
+
+Deno.test("typlTableCaptionBase: a relative name is not a base (needs a base itself)", () => {
+  assertEquals(typlTableCaptionBase("$.pedal"), undefined);
+});


### PR DESCRIPTION
## Summary

S6 of the uxil epic (#717 §C.2): adds a **fourth typl embedding surface** — GFM
tables — on the shared declaration machinery built in S2/S3 and the
base-resolution engine from S4. Thin by design: a ~30-line adapter plus a small
wire-in to `assemble.ts`.

Each data row `$name | kind shape | description` is one binding: the first two
cells are read positionally, the description column is dropped (typl bindings
carry no description), and rows whose first cell is not a `$Name` are skipped —
so a table may mix declaration rows with plain notes. The row is reduced to a
`$name : kind shape` source and parsed through the same `parseTyplBlock` the
other surfaces use, so a table row yields the **identical `Binding`** as the
fence / bullet / inline form.

A `Table:` caption may carry an absolute base (`$a.b`); the table's relative
rows (`$.x`) resolve against that caption base first, then the entry root,
through the entry-local resolver (#722 rule 3). The caption base is not a root
declaration and never sets `rootNamespace`. Union/enum shapes containing `|` are
authored with the standard GFM `\|` escape (the cell un-escapes before typl
parses it) — resolving the concern that made ADR-019 originally reject a table
surface.

## Changes

- **`core/typl/table.ts`** (new) — `typlTableRowRecognizer`,
  `typlTableCaptionBase`, and `extractTyplTable` (a thin adapter over
  `core/decl/table.ts`), exported from `typl/mod.ts`.
- **`core/typl/assemble.ts`** — table loop (mirrors the fence loop) + caption
  base threaded into `scopeFor` as the innermost scope.
- **Tests** — recognizer + caption-base unit tests (`table_test.ts`); assemble
  parity (table ≡ inline), caption-base resolution, mixed-table, escaped-union,
  and cross-surface composition cases.
- **Docs** — ADR-019 addendum (revisits the rejected-table alternative), typl
  guide + language-reference table sections.

## Acceptance (#724)

- [x] Table-form typl declarations produce the same bindings as
      fence/bullet/inline.
- [x] Unit-test parity with existing surfaces.
- [x] Caption base wired into resolution (approved scope).

`just build` green (lint + full test suite + typecheck + compile). No
`CORE_SCHEMA_VERSION` bump.

Closes #724.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
