### PR TITLE
fix(book): rewrite cross-chapter links to their book-build output slugs

### DIFF
--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -882,6 +882,16 @@ markspec book build
 markspec book build -o dist -s docs/SUMMARY.md
 ```
 
+Each chapter's output filename is derived from its `SUMMARY.md`-declared path:
+`.md` is stripped and nested directory separators flatten to hyphens
+(`recipes/deploy.md` → `recipes-deploy.html`). A Markdown link (or link
+reference definition) in one chapter that points at another chapter's source
+path — resolved relative to the linking chapter's own directory, not the
+flattened output layout — is rewritten to that chapter's output filename,
+preserving any `#fragment`. Links to files outside the book (external URLs,
+absolute paths, or a chapter declared in `SUMMARY.md` with no backing file) are
+left untouched.
+
 ### Profile and diagnostics
 
 #### profile show

--- a/packages/markspec/book/mod.ts
+++ b/packages/markspec/book/mod.ts
@@ -17,6 +17,7 @@ export type {
 export { renderChapterHtml } from "./site/mod.ts";
 export type { RenderChapterOptions, RenderChapterResult } from "./site/mod.ts";
 
+import { normalize } from "@std/path/posix";
 import type {
   CompileResult,
   Diagnostic,
@@ -77,10 +78,20 @@ export function buildBook(
   const diagnostics: Diagnostic[] = [];
 
   const allChapters = _allChapters(structure);
+  // Only chapters with a resolved file get a slug: a chapter declared in
+  // SUMMARY.md but missing on disk (a common in-progress-book state, already
+  // tolerated below with a "chapter file not found" warning) must not have
+  // links to it confidently rewritten to a page that will never be written.
+  // Keys are normalized so a SUMMARY.md path written with a redundant form
+  // (e.g. "./index.md") still matches hrefs resolved to the plain form —
+  // see RenderChapterOptions.chapterSlugs's doc comment for the contract.
   const chapterSlugs = new Map(
     allChapters
-      .filter((c): c is Chapter & { path: string } => Boolean(c.path))
-      .map((c) => [c.path, slugForChapterPath(c.path)] as const),
+      .filter(
+        (c): c is Chapter & { path: string } =>
+          Boolean(c.path) && options.files.has(c.path!),
+      )
+      .map((c) => [normalize(c.path), slugForChapterPath(c.path)] as const),
   );
 
   for (const chapter of allChapters) {
@@ -111,9 +122,14 @@ export function buildBook(
  * both the CLI's write step and in-content cross-chapter link rewriting
  * (`RenderChapterOptions.chapterSlugs`) must agree on it, or a rewritten
  * link would point at a filename the write step never produces.
+ *
+ * Normalizes `path` first so a redundant SUMMARY.md-declared form (e.g.
+ * `"./index.md"`) still produces the same slug as its canonical form
+ * (`"index.md"` → `"index"`), rather than a mangled one (`"./index.md"`
+ * would otherwise slugify to `".-index"`).
  */
 export function slugForChapterPath(path: string): string {
-  return path.replace(/\.md$/, "").replace(/\//g, "-");
+  return normalize(path).replace(/\.md$/, "").replace(/\//g, "-");
 }
 
 /** Flatten all chapters from a structure into document order. */

--- a/packages/markspec/book/mod.ts
+++ b/packages/markspec/book/mod.ts
@@ -76,7 +76,14 @@ export function buildBook(
   const chapters: BuiltChapter[] = [];
   const diagnostics: Diagnostic[] = [];
 
-  for (const chapter of _allChapters(structure)) {
+  const allChapters = _allChapters(structure);
+  const chapterSlugs = new Map(
+    allChapters
+      .filter((c): c is Chapter & { path: string } => Boolean(c.path))
+      .map((c) => [c.path, slugForChapterPath(c.path)] as const),
+  );
+
+  for (const chapter of allChapters) {
     if (!chapter.path) continue; // skip drafts
     const markdown = options.files.get(chapter.path);
     if (!markdown) continue; // skip missing files
@@ -84,6 +91,7 @@ export function buildBook(
     const { html } = renderChapterHtml(markdown, {
       file: chapter.path,
       profile: options.profile,
+      chapterSlugs,
     });
     chapters.push({
       kind: chapter.kind,
@@ -94,6 +102,18 @@ export function buildBook(
   }
 
   return { chapters, diagnostics };
+}
+
+/**
+ * Output slug for a chapter's rendered filename, derived from its source
+ * path (e.g. `"recipes/deploy.md"` → `"recipes-deploy"`, written as
+ * `recipes-deploy.html`). The single source of truth for this mapping —
+ * both the CLI's write step and in-content cross-chapter link rewriting
+ * (`RenderChapterOptions.chapterSlugs`) must agree on it, or a rewritten
+ * link would point at a filename the write step never produces.
+ */
+export function slugForChapterPath(path: string): string {
+  return path.replace(/\.md$/, "").replace(/\//g, "-");
 }
 
 /** Flatten all chapters from a structure into document order. */

--- a/packages/markspec/book/mod_test.ts
+++ b/packages/markspec/book/mod_test.ts
@@ -11,3 +11,7 @@ Deno.test("slugForChapterPath: flattens nested directory separators to hyphens",
     "recipes-shipping-a-reference-architecture",
   );
 });
+
+Deno.test("slugForChapterPath: normalizes a redundant './' prefix before slugifying", () => {
+  assertEquals(slugForChapterPath("./index.md"), "index");
+});

--- a/packages/markspec/book/mod_test.ts
+++ b/packages/markspec/book/mod_test.ts
@@ -1,0 +1,13 @@
+import { assertEquals } from "@std/assert";
+import { slugForChapterPath } from "./mod.ts";
+
+Deno.test("slugForChapterPath: strips .md extension", () => {
+  assertEquals(slugForChapterPath("index.md"), "index");
+});
+
+Deno.test("slugForChapterPath: flattens nested directory separators to hyphens", () => {
+  assertEquals(
+    slugForChapterPath("recipes/shipping-a-reference-architecture.md"),
+    "recipes-shipping-a-reference-architecture",
+  );
+});

--- a/packages/markspec/book/site/mod.ts
+++ b/packages/markspec/book/site/mod.ts
@@ -15,7 +15,8 @@ import remarkParse from "remark-parse";
 import remarkGfm from "remark-gfm";
 import remarkRehype from "remark-rehype";
 import rehypeStringify from "rehype-stringify";
-import type { Blockquote, Root, Text } from "mdast";
+import { dirname, join, normalize } from "@std/path/posix";
+import type { Blockquote, Link, Root, Text } from "mdast";
 import type { Caption, EffectiveProfile, Entry } from "../../core/mod.ts";
 import { detectCaptions, parse, resolveEntryColor } from "../../core/mod.ts";
 
@@ -30,6 +31,17 @@ export interface RenderChapterOptions {
   readonly file?: string;
   /** Active profile, if any. Drives per-entry color resolution. */
   readonly profile?: EffectiveProfile;
+  /**
+   * Every chapter's source path (as declared in `SUMMARY.md`, e.g.
+   * `"recipes/deploy.md"`) mapped to its book-build output slug (e.g.
+   * `"recipes-deploy"`, written as `recipes-deploy.html`). When supplied,
+   * a Markdown link in this chapter that resolves — relative to this
+   * chapter's own source directory — to another chapter's path is
+   * rewritten to `<slug>.html`, preserving any `#fragment`. A link that
+   * resolves to a path absent from this map (external URL, a file outside
+   * the book, or an absolute path) is left untouched.
+   */
+  readonly chapterSlugs?: ReadonlyMap<string, string>;
 }
 
 /** Result of rendering a chapter to HTML. */
@@ -89,6 +101,11 @@ export function renderChapterHtml(
   // Merge all special regions, sorted by start line (0-based)
   const regions = _buildRegions(lines, entries, alertRegions, captions);
 
+  const chapterSlugs = options.chapterSlugs;
+  const rewriteLink = chapterSlugs
+    ? (href: string) => _resolveChapterLink(file, href, chapterSlugs)
+    : undefined;
+
   const parts: string[] = [];
   let cursor = 0; // current position (0-based line index)
   let figCounter = 0;
@@ -98,14 +115,14 @@ export function renderChapterHtml(
     // Prose before this region
     if (region.start > cursor) {
       const prose = lines.slice(cursor, region.start).join("\n");
-      if (prose.trim()) parts.push(_proseToHtml(prose));
+      if (prose.trim()) parts.push(_proseToHtml(prose, rewriteLink));
     }
 
     if (region.kind === "entry") {
-      parts.push(_entryToHtml(region.entry!, options.profile));
+      parts.push(_entryToHtml(region.entry!, options.profile, rewriteLink));
     } else if (region.kind === "alert") {
       const raw = lines.slice(region.start, region.end);
-      parts.push(_alertToHtml(region.alertType!, raw));
+      parts.push(_alertToHtml(region.alertType!, raw, rewriteLink));
     } else if (region.kind === "caption") {
       const cap = region.caption!;
       const counter = cap.kind === "figure" ? ++figCounter : ++tblCounter;
@@ -118,10 +135,49 @@ export function renderChapterHtml(
   // Trailing prose
   if (cursor < lines.length) {
     const prose = lines.slice(cursor).join("\n");
-    if (prose.trim()) parts.push(_proseToHtml(prose));
+    if (prose.trim()) parts.push(_proseToHtml(prose, rewriteLink));
   }
 
   return { html: parts.join("\n") };
+}
+
+/**
+ * Resolve a Markdown link `href` found in chapter `fromChapterPath` to
+ * another chapter's book-build output slug, or `undefined` when the href
+ * doesn't resolve to a known chapter (external URL, absolute path, or a
+ * file outside the book).
+ *
+ * Resolution happens against `fromChapterPath`'s own source directory —
+ * not the flattened output directory every chapter is written to — so a
+ * nested chapter's `../sibling.md` resolves the same way it would on
+ * disk, before `chapterSlugs`' keys (also source paths) are consulted.
+ */
+function _resolveChapterLink(
+  fromChapterPath: string,
+  href: string,
+  chapterSlugs: ReadonlyMap<string, string>,
+): string | undefined {
+  if (/^[a-z][a-z0-9+.-]*:/i.test(href)) return undefined; // scheme:// URL
+  if (href.startsWith("/") || href.startsWith("#")) return undefined; // root-relative / anchor-only
+  const hashIdx = href.indexOf("#");
+  const pathPart = hashIdx >= 0 ? href.slice(0, hashIdx) : href;
+  const fragment = hashIdx >= 0 ? href.slice(hashIdx) : "";
+  if (!pathPart) return undefined;
+  const resolved = normalize(join(dirname(fromChapterPath), pathPart));
+  const slug = chapterSlugs.get(resolved);
+  if (!slug) return undefined;
+  return `${slug}.html${fragment}`;
+}
+
+/** Recursively visit every mdast `link` node under `node`, in place. */
+function _visitLinks(node: Root, visit: (link: Link) => void): void {
+  const walk = (n: Root | Root["children"][number]): void => {
+    if (n.type === "link") visit(n as Link);
+    if ("children" in n) {
+      for (const child of n.children) walk(child);
+    }
+  };
+  walk(node);
 }
 
 // ── Region detection ──────────────────────────────────────────────────────
@@ -244,8 +300,26 @@ function _findEntryEnd(lines: readonly string[], start: number): number {
 
 // ── Renderers ─────────────────────────────────────────────────────────────
 
-function _proseToHtml(markdown: string): string {
-  return String(_htmlPipeline.processSync(markdown));
+function _proseToHtml(
+  markdown: string,
+  rewriteLink?: (href: string) => string | undefined,
+): string {
+  if (!rewriteLink) return String(_htmlPipeline.processSync(markdown));
+  // Built fresh per call (only when link rewriting is active) since the
+  // rewriter closes over this chapter's own path — unlike `_htmlPipeline`,
+  // it can't be a shared singleton.
+  const pipeline = unified()
+    .use(remarkParse)
+    .use(remarkGfm)
+    .use(() => (tree: Root) => {
+      _visitLinks(tree, (link) => {
+        const rewritten = rewriteLink(link.url);
+        if (rewritten !== undefined) link.url = rewritten;
+      });
+    })
+    .use(remarkRehype)
+    .use(rehypeStringify);
+  return String(pipeline.processSync(markdown));
 }
 
 function _escapeHtml(s: string): string {
@@ -270,6 +344,7 @@ function _entryClass(
 function _entryToHtml(
   entry: Entry,
   profile: EffectiveProfile | undefined,
+  rewriteLink?: (href: string) => string | undefined,
 ): string {
   const blockClass = _entryClass(entry, profile);
 
@@ -289,7 +364,7 @@ function _entryToHtml(
     : "";
 
   const bodyHtml = entry.body.trim()
-    ? `<div class="req-body">${_proseToHtml(entry.body)}</div>`
+    ? `<div class="req-body">${_proseToHtml(entry.body, rewriteLink)}</div>`
     : "";
 
   const metaHtml = metaAttrs.length > 0
@@ -316,12 +391,16 @@ function _entryToHtml(
 </div>`;
 }
 
-function _alertToHtml(alertType: AlertType, rawLines: string[]): string {
+function _alertToHtml(
+  alertType: AlertType,
+  rawLines: string[],
+  rewriteLink?: (href: string) => string | undefined,
+): string {
   // Strip the `> [!NOTE]` first line; remove `> ` prefix from the rest
   const contentLines = rawLines
     .slice(1)
     .map((l) => l.replace(/^>\s?/, ""));
-  const content = _proseToHtml(contentLines.join("\n"));
+  const content = _proseToHtml(contentLines.join("\n"), rewriteLink);
   const label = alertType.charAt(0).toUpperCase() + alertType.slice(1);
   return `<div class="alert ${alertType}">
   <strong class="alert-label">${label}</strong>

--- a/packages/markspec/book/site/mod.ts
+++ b/packages/markspec/book/site/mod.ts
@@ -16,7 +16,7 @@ import remarkGfm from "remark-gfm";
 import remarkRehype from "remark-rehype";
 import rehypeStringify from "rehype-stringify";
 import { dirname, join, normalize } from "@std/path/posix";
-import type { Blockquote, Link, Root, Text } from "mdast";
+import type { Blockquote, Definition, Link, Root, Text } from "mdast";
 import type { Caption, EffectiveProfile, Entry } from "../../core/mod.ts";
 import { detectCaptions, parse, resolveEntryColor } from "../../core/mod.ts";
 
@@ -32,14 +32,21 @@ export interface RenderChapterOptions {
   /** Active profile, if any. Drives per-entry color resolution. */
   readonly profile?: EffectiveProfile;
   /**
-   * Every chapter's source path (as declared in `SUMMARY.md`, e.g.
-   * `"recipes/deploy.md"`) mapped to its book-build output slug (e.g.
-   * `"recipes-deploy"`, written as `recipes-deploy.html`). When supplied,
-   * a Markdown link in this chapter that resolves — relative to this
-   * chapter's own source directory — to another chapter's path is
-   * rewritten to `<slug>.html`, preserving any `#fragment`. A link that
-   * resolves to a path absent from this map (external URL, a file outside
-   * the book, or an absolute path) is left untouched.
+   * Every chapter's source path mapped to its book-build output slug
+   * (e.g. `"recipes-deploy"`, written as `recipes-deploy.html`). When
+   * supplied, a Markdown link (or link reference definition) in this
+   * chapter that resolves — relative to this chapter's own source
+   * directory — to another chapter's path is rewritten to `<slug>.html`,
+   * preserving any `#fragment`. A link that resolves to a path absent
+   * from this map (external URL, a file outside the book, an absolute
+   * path, or a chapter declared in `SUMMARY.md` with no backing file) is
+   * left untouched.
+   *
+   * Keys MUST be `@std/path/posix`-normalized (e.g. `slugForChapterPath`'s
+   * caller should key this map with `normalize(chapter.path)`, not the raw
+   * `SUMMARY.md` path) — link resolution normalizes the href side before
+   * looking it up, so an un-normalized key (e.g. `"./index.md"` instead of
+   * `"index.md"`) would never match.
    */
   readonly chapterSlugs?: ReadonlyMap<string, string>;
 }
@@ -105,6 +112,8 @@ export function renderChapterHtml(
   const rewriteLink = chapterSlugs
     ? (href: string) => _resolveChapterLink(file, href, chapterSlugs)
     : undefined;
+  // Built once per chapter (not per prose fragment) — see _buildProseProcessor.
+  const processor = _buildProseProcessor(rewriteLink);
 
   const parts: string[] = [];
   let cursor = 0; // current position (0-based line index)
@@ -115,14 +124,14 @@ export function renderChapterHtml(
     // Prose before this region
     if (region.start > cursor) {
       const prose = lines.slice(cursor, region.start).join("\n");
-      if (prose.trim()) parts.push(_proseToHtml(prose, rewriteLink));
+      if (prose.trim()) parts.push(_proseToHtml(prose, processor));
     }
 
     if (region.kind === "entry") {
-      parts.push(_entryToHtml(region.entry!, options.profile, rewriteLink));
+      parts.push(_entryToHtml(region.entry!, options.profile, processor));
     } else if (region.kind === "alert") {
       const raw = lines.slice(region.start, region.end);
-      parts.push(_alertToHtml(region.alertType!, raw, rewriteLink));
+      parts.push(_alertToHtml(region.alertType!, raw, processor));
     } else if (region.kind === "caption") {
       const cap = region.caption!;
       const counter = cap.kind === "figure" ? ++figCounter : ++tblCounter;
@@ -135,7 +144,7 @@ export function renderChapterHtml(
   // Trailing prose
   if (cursor < lines.length) {
     const prose = lines.slice(cursor).join("\n");
-    if (prose.trim()) parts.push(_proseToHtml(prose, rewriteLink));
+    if (prose.trim()) parts.push(_proseToHtml(prose, processor));
   }
 
   return { html: parts.join("\n") };
@@ -158,7 +167,7 @@ function _resolveChapterLink(
   chapterSlugs: ReadonlyMap<string, string>,
 ): string | undefined {
   if (/^[a-z][a-z0-9+.-]*:/i.test(href)) return undefined; // scheme:// URL
-  if (href.startsWith("/") || href.startsWith("#")) return undefined; // root-relative / anchor-only
+  if (href.startsWith("/")) return undefined; // root-relative
   const hashIdx = href.indexOf("#");
   const pathPart = hashIdx >= 0 ? href.slice(0, hashIdx) : href;
   const fragment = hashIdx >= 0 ? href.slice(hashIdx) : "";
@@ -169,10 +178,21 @@ function _resolveChapterLink(
   return `${slug}.html${fragment}`;
 }
 
-/** Recursively visit every mdast `link` node under `node`, in place. */
-function _visitLinks(node: Root, visit: (link: Link) => void): void {
+/**
+ * Recursively visit every mdast `link` or `definition` node under `node`,
+ * in place. `definition` carries the URL for reference-style links
+ * (`[text][id]` + a separate `[id]: target` line, whose `linkReference`
+ * node has no `url` of its own) — both node types expose a mutable `url`
+ * string field, so callers can rewrite either uniformly.
+ */
+function _visitLinks(
+  node: Root,
+  visit: (linkOrDefinition: Link | Definition) => void,
+): void {
   const walk = (n: Root | Root["children"][number]): void => {
-    if (n.type === "link") visit(n as Link);
+    if (n.type === "link" || n.type === "definition") {
+      visit(n as Link | Definition);
+    }
     if ("children" in n) {
       for (const child of n.children) walk(child);
     }
@@ -300,26 +320,45 @@ function _findEntryEnd(lines: readonly string[], start: number): number {
 
 // ── Renderers ─────────────────────────────────────────────────────────────
 
-function _proseToHtml(
-  markdown: string,
-  rewriteLink?: (href: string) => string | undefined,
-): string {
-  if (!rewriteLink) return String(_htmlPipeline.processSync(markdown));
-  // Built fresh per call (only when link rewriting is active) since the
-  // rewriter closes over this chapter's own path — unlike `_htmlPipeline`,
-  // it can't be a shared singleton.
-  const pipeline = unified()
+/**
+ * Minimal shape `_proseToHtml` needs from a built unified processor —
+ * narrow enough that both `_htmlPipeline` and the link-rewrite variant
+ * `_buildProseProcessor` builds satisfy it structurally, without fighting
+ * unified's generic `Processor<...>` type across two different plugin
+ * chains.
+ */
+interface _ProseProcessor {
+  processSync(markdown: string): { toString(): string };
+}
+
+/**
+ * Build the prose-rendering processor for one chapter. Returns the shared
+ * `_htmlPipeline` singleton when no rewriter is supplied (the common case
+ * — most chapters, and every chapter when the book has no `chapterSlugs`
+ * map at all); otherwise builds a one-off pipeline with the link-rewrite
+ * transform installed. Called once per `renderChapterHtml` invocation —
+ * not once per prose fragment — since `rewriteLink` closes over the
+ * chapter's own path and is invariant across every fragment in it.
+ */
+function _buildProseProcessor(
+  rewriteLink: ((href: string) => string | undefined) | undefined,
+): _ProseProcessor {
+  if (!rewriteLink) return _htmlPipeline;
+  return unified()
     .use(remarkParse)
     .use(remarkGfm)
     .use(() => (tree: Root) => {
-      _visitLinks(tree, (link) => {
-        const rewritten = rewriteLink(link.url);
-        if (rewritten !== undefined) link.url = rewritten;
+      _visitLinks(tree, (node) => {
+        const rewritten = rewriteLink(node.url);
+        if (rewritten !== undefined) node.url = rewritten;
       });
     })
     .use(remarkRehype)
     .use(rehypeStringify);
-  return String(pipeline.processSync(markdown));
+}
+
+function _proseToHtml(markdown: string, processor: _ProseProcessor): string {
+  return processor.processSync(markdown).toString();
 }
 
 function _escapeHtml(s: string): string {
@@ -344,7 +383,7 @@ function _entryClass(
 function _entryToHtml(
   entry: Entry,
   profile: EffectiveProfile | undefined,
-  rewriteLink?: (href: string) => string | undefined,
+  processor: _ProseProcessor,
 ): string {
   const blockClass = _entryClass(entry, profile);
 
@@ -364,7 +403,7 @@ function _entryToHtml(
     : "";
 
   const bodyHtml = entry.body.trim()
-    ? `<div class="req-body">${_proseToHtml(entry.body, rewriteLink)}</div>`
+    ? `<div class="req-body">${_proseToHtml(entry.body, processor)}</div>`
     : "";
 
   const metaHtml = metaAttrs.length > 0
@@ -394,13 +433,13 @@ function _entryToHtml(
 function _alertToHtml(
   alertType: AlertType,
   rawLines: string[],
-  rewriteLink?: (href: string) => string | undefined,
+  processor: _ProseProcessor,
 ): string {
   // Strip the `> [!NOTE]` first line; remove `> ` prefix from the rest
   const contentLines = rawLines
     .slice(1)
     .map((l) => l.replace(/^>\s?/, ""));
-  const content = _proseToHtml(contentLines.join("\n"), rewriteLink);
+  const content = _proseToHtml(contentLines.join("\n"), processor);
   const label = alertType.charAt(0).toUpperCase() + alertType.slice(1);
   return `<div class="alert ${alertType}">
   <strong class="alert-label">${label}</strong>

--- a/packages/markspec/book/site/mod_test.ts
+++ b/packages/markspec/book/site/mod_test.ts
@@ -90,3 +90,16 @@ Deno.test("renderChapterHtml: rewrites a query-string-free link exactly, ignorin
   assertStringIncludes(html, 'href="types.html"');
   assertStringIncludes(html, 'href="/absolute/path.md"');
 });
+
+Deno.test("renderChapterHtml: rewrites reference-style links ([text][id] + [id]: target)", () => {
+  const md = `See [Entry format][ef] for details.
+
+[ef]: entry-format.md
+`;
+  const chapterSlugs = new Map([
+    ["index.md", "index"],
+    ["entry-format.md", "entry-format"],
+  ]);
+  const { html } = renderChapterHtml(md, { file: "index.md", chapterSlugs });
+  assertStringIncludes(html, 'href="entry-format.html"');
+});

--- a/packages/markspec/book/site/mod_test.ts
+++ b/packages/markspec/book/site/mod_test.ts
@@ -1,0 +1,92 @@
+import { assertStringIncludes } from "@std/assert";
+import { renderChapterHtml } from "./mod.ts";
+
+Deno.test("renderChapterHtml: rewrites a same-directory chapter link's .md extension to .html", () => {
+  const md = `# Overview
+
+See [Entry format](entry-format.md) for details.
+`;
+  const chapterSlugs = new Map([
+    ["index.md", "index"],
+    ["entry-format.md", "entry-format"],
+  ]);
+  const { html } = renderChapterHtml(md, { file: "index.md", chapterSlugs });
+  assertStringIncludes(html, 'href="entry-format.html"');
+});
+
+Deno.test("renderChapterHtml: rewrites a parent-relative link from a nested chapter, preserving the fragment", () => {
+  const md = `# Deploy
+
+See [Profiles](../profiles.md#profile-specifiers).
+`;
+  const chapterSlugs = new Map([
+    ["recipes/deploy.md", "recipes-deploy"],
+    ["profiles.md", "profiles"],
+  ]);
+  const { html } = renderChapterHtml(md, {
+    file: "recipes/deploy.md",
+    chapterSlugs,
+  });
+  assertStringIncludes(html, 'href="profiles.html#profile-specifiers"');
+});
+
+Deno.test("renderChapterHtml: leaves a link to a path not in chapterSlugs untouched", () => {
+  const md = `See [some external doc](../architecture/adr-030.md).`;
+  const chapterSlugs = new Map([["index.md", "index"]]);
+  const { html } = renderChapterHtml(md, { file: "index.md", chapterSlugs });
+  assertStringIncludes(html, 'href="../architecture/adr-030.md"');
+});
+
+Deno.test("renderChapterHtml: leaves absolute/external URLs untouched", () => {
+  const md = `See [GitHub](https://github.com/driftsys/markspec).`;
+  const chapterSlugs = new Map([["index.md", "index"]]);
+  const { html } = renderChapterHtml(md, { file: "index.md", chapterSlugs });
+  assertStringIncludes(html, 'href="https://github.com/driftsys/markspec"');
+});
+
+Deno.test("renderChapterHtml: rewrites links inside entry bodies too", () => {
+  const md = `- [STK_BRK_0001] Braking
+
+  See [Entry format](entry-format.md) for the block grammar.
+
+      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF
+`;
+  const chapterSlugs = new Map([
+    ["index.md", "index"],
+    ["entry-format.md", "entry-format"],
+  ]);
+  const { html } = renderChapterHtml(md, { file: "index.md", chapterSlugs });
+  assertStringIncludes(html, 'href="entry-format.html"');
+});
+
+Deno.test("renderChapterHtml: without chapterSlugs option, links pass through unchanged", () => {
+  const md = `See [Entry format](entry-format.md).`;
+  const { html } = renderChapterHtml(md, { file: "index.md" });
+  assertStringIncludes(html, 'href="entry-format.md"');
+});
+
+Deno.test("renderChapterHtml: rewrites a link with no leading directory reference from a nested chapter", () => {
+  // A nested chapter linking to a sibling file in the SAME subdirectory
+  // (no ../) must resolve relative to its own directory, not the book root.
+  const md = `See [Sibling](sibling.md).`;
+  const chapterSlugs = new Map([
+    ["recipes/deploy.md", "recipes-deploy"],
+    ["recipes/sibling.md", "recipes-sibling"],
+  ]);
+  const { html } = renderChapterHtml(md, {
+    file: "recipes/deploy.md",
+    chapterSlugs,
+  });
+  assertStringIncludes(html, 'href="recipes-sibling.html"');
+});
+
+Deno.test("renderChapterHtml: rewrites a query-string-free link exactly, ignoring trailing slashes in unrelated paths", () => {
+  const md = `See [Types](types.md) and [unrelated](/absolute/path.md).`;
+  const chapterSlugs = new Map([
+    ["index.md", "index"],
+    ["types.md", "types"],
+  ]);
+  const { html } = renderChapterHtml(md, { file: "index.md", chapterSlugs });
+  assertStringIncludes(html, 'href="types.html"');
+  assertStringIncludes(html, 'href="/absolute/path.md"');
+});

--- a/packages/markspec/cli/commands/book.ts
+++ b/packages/markspec/cli/commands/book.ts
@@ -36,7 +36,9 @@ export const bookCmd = new Command()
       Deno.exit(1);
     }
 
-    const { parseSummary, buildBook } = await import("../../book/mod.ts");
+    const { parseSummary, buildBook, slugForChapterPath } = await import(
+      "../../book/mod.ts"
+    );
     const { compile } = await import("../../core/mod.ts");
 
     const structure = parseSummary(summaryMd);
@@ -78,11 +80,11 @@ export const bookCmd = new Command()
     await Deno.mkdir(options.output, { recursive: true });
     const chapterLinks = result.chapters.map((c) => ({
       title: c.title,
-      slug: _slugFor(c.path),
+      slug: slugForChapterPath(c.path),
     }));
     const hasIndexChapter = chapterLinks.some((c) => c.slug === "index");
     for (const chapter of result.chapters) {
-      const slug = _slugFor(chapter.path);
+      const slug = slugForChapterPath(chapter.path);
       const outPath = join(options.output, `${slug}.html`);
       // A chapter mapped from e.g. "index.md" is the book's real homepage —
       // its own content wins over the synthesized nav-only page. But every
@@ -141,11 +143,6 @@ ${body}
 </body>
 </html>
 `;
-}
-
-/** Slug for a chapter's output filename, derived from its source path. */
-function _slugFor(path: string): string {
-  return path.replace(/\.md$/, "").replace(/\//g, "-");
 }
 
 /**

--- a/tests/e2e/book_build_test.ts
+++ b/tests/e2e/book_build_test.ts
@@ -9,7 +9,7 @@
 
 import { assertEquals, assertMatch, assertStringIncludes } from "@std/assert";
 import { fromFileUrl } from "@std/path";
-import { markspec } from "./helpers.ts";
+import { markspec, markspecPersist } from "./helpers.ts";
 
 // ── Fixtures ──────────────────────────────────────────────────────────────
 
@@ -348,6 +348,57 @@ Deno.test("book build: a chapter mapped from index.md becomes index.html — its
       `${dir}/_site/requirements.html`,
     );
     assertStringIncludes(requirementsHtml, "STK_BRK_0001");
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+// ── Cross-chapter link rewriting (#773) ────────────────────────────────────
+
+const LINKS_SUMMARY = `# Summary
+
+- [Overview](index.md)
+- [Sibling](sibling.md)
+
+# Recipes
+
+- [Deploy](recipes/deploy.md)
+`;
+
+const LINKS_INDEX_MD = `# Overview\n\nSee [Sibling](sibling.md) for details.\n`;
+const LINKS_SIBLING_MD = `# Sibling\n\nSIBLING-MARKER-TEXT.\n`;
+const LINKS_DEPLOY_MD =
+  `# Deploy\n\nSee [Sibling](../sibling.md#section) for prerequisites.\n`;
+
+const LINKS_FIXTURE = {
+  "project.yaml": PROJECT_YAML,
+  "SUMMARY.md": LINKS_SUMMARY,
+  "index.md": LINKS_INDEX_MD,
+  "sibling.md": LINKS_SIBLING_MD,
+  "recipes/deploy.md": LINKS_DEPLOY_MD,
+};
+
+Deno.test("book build: rewrites a same-directory chapter link's .md extension to .html", async () => {
+  const { code, stderr, dir } = await markspecPersist(["book", "build"], {
+    files: LINKS_FIXTURE,
+  });
+  try {
+    assertEquals(code, 0, `expected exit 0, stderr: ${stderr}`);
+    const html = await Deno.readTextFile(`${dir}/_site/index.html`);
+    assertStringIncludes(html, 'href="sibling.html"');
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("book build: rewrites a nested chapter's parent-relative link, preserving the fragment", async () => {
+  const { code, stderr, dir } = await markspecPersist(["book", "build"], {
+    files: LINKS_FIXTURE,
+  });
+  try {
+    assertEquals(code, 0, `expected exit 0, stderr: ${stderr}`);
+    const html = await Deno.readTextFile(`${dir}/_site/recipes-deploy.html`);
+    assertStringIncludes(html, 'href="sibling.html#section"');
   } finally {
     await Deno.remove(dir, { recursive: true });
   }

--- a/tests/e2e/book_build_test.ts
+++ b/tests/e2e/book_build_test.ts
@@ -403,3 +403,54 @@ Deno.test("book build: rewrites a nested chapter's parent-relative link, preserv
     await Deno.remove(dir, { recursive: true });
   }
 });
+
+// A chapter declared in SUMMARY.md whose file is intentionally never written
+// (a common in-progress-book authoring state — SUMMARY.md scaffolded ahead
+// of content) plus a chapter path with a redundant "./" prefix.
+const GHOST_SUMMARY = `# Summary
+
+- [Overview](./index.md)
+- [Ghost](ghost.md)
+`;
+
+const GHOST_INDEX_MD =
+  `# Overview\n\nSee [Ghost](ghost.md) and back to [self](./index.md).\n`;
+
+const GHOST_FIXTURE = {
+  "project.yaml": PROJECT_YAML,
+  "SUMMARY.md": GHOST_SUMMARY,
+  "index.md": GHOST_INDEX_MD,
+  // "ghost.md" is deliberately absent.
+};
+
+Deno.test("book build: a link to a chapter declared in SUMMARY.md but missing on disk is left unrewritten", async () => {
+  const { code, stderr, dir } = await markspecPersist(["book", "build"], {
+    files: GHOST_FIXTURE,
+  });
+  try {
+    assertEquals(code, 0, `expected exit 0, stderr: ${stderr}`);
+    assertStringIncludes(stderr, "warning: chapter file not found: ghost.md");
+    const html = await Deno.readTextFile(`${dir}/_site/index.html`);
+    // "ghost.md" has no backing file and will never get a ghost.html — a
+    // link to it must stay an honest (if dead) .md reference, not be
+    // confidently rewritten to a same-site page that will never exist.
+    assertStringIncludes(html, 'href="ghost.md"');
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});
+
+Deno.test("book build: a chapter path declared with a redundant './' prefix in SUMMARY.md still resolves incoming links", async () => {
+  const { code, stderr, dir } = await markspecPersist(["book", "build"], {
+    files: GHOST_FIXTURE,
+  });
+  try {
+    assertEquals(code, 0, `expected exit 0, stderr: ${stderr}`);
+    const html = await Deno.readTextFile(`${dir}/_site/index.html`);
+    // "./index.md" (as declared in SUMMARY.md) must match a link resolving
+    // to the plain, normalized "index.md" from within the same chapter.
+    assertStringIncludes(html, 'href="index.html"');
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});


### PR DESCRIPTION
Closes #773.

## Summary

`markspec book build`'s renderer ran plain remark → rehype with no awareness that chapters get renamed (`.md` → `<slug>.html`) and flattened into one output directory. Two consequences, both confirmed live against this repo's real docs before the fix:

- A link like `[Entry format](entry-format.md)` kept its `.md` extension in the rendered output — 404s against the real `entry-format.html`. Hits `docs/spec/model/index.md`'s own overview table.
- A nested chapter's relative link (e.g. `../profiles.md` from `docs/guide/recipes/shipping-a-reference-architecture.md`) resolved against the flattened output layout instead of the original source tree, landing outside the book entirely.

## Fix

- `buildBook()` (`book/mod.ts`) now computes a `chapterSlugs` map (source path → output slug) via a newly-shared `slugForChapterPath` — previously duplicated as a private `_slugFor` in `cli/commands/book.ts`, now the single source of truth both the write step and link rewriting agree on — and passes it to `renderChapterHtml`.
- `renderChapterHtml` (`book/site/mod.ts`) resolves each link's `href` against its **own chapter's source directory** (not the flattened output layout) and rewrites it to the target chapter's slug when one matches `chapterSlugs`, preserving any `#fragment`. Links to paths outside the book (external URLs, absolute paths, files not in the book) are left untouched.

## Test plan

- [x] New unit tests in `packages/markspec/book/site/mod_test.ts` (8 cases: same-dir rewrite, nested-parent-relative rewrite + fragment, untouched-when-unmapped, untouched-external-URL, rewrite-inside-entry-bodies, back-compat when `chapterSlugs` omitted, sibling-in-same-subdir, mixed known/unknown links)
- [x] New unit tests in `packages/markspec/book/mod_test.ts` for `slugForChapterPath`
- [x] New e2e tests in `tests/e2e/book_build_test.ts` reproducing both bugs end-to-end via the real CLI
- [x] Built this repo's actual docs (`just book`) and confirmed both real repro cases are fixed: `_site/model/index.html` now links `entry-format.html`/`types.html`; `_site/guide/recipes-shipping-a-reference-architecture.html` now links `profiles.html#profile-specifiers`
- [x] `just check` — 3782 passed, 0 failed
- [x] `deno fmt --check` / `dprint check` clean
