### PR TITLE
fix(lsp): upstream entries have no navigable location — guard references, workspace symbols, code lens

### DIFF
--- a/packages/markspec/lsp/code_lens.ts
+++ b/packages/markspec/lsp/code_lens.ts
@@ -24,6 +24,7 @@
  */
 
 import type { DisplayId, Entry } from "../core/mod.ts";
+import { isUpstreamEntry } from "../core/mod.ts";
 import { buildIncomingCount } from "./incoming_index.ts";
 import { findReferencingEntries } from "./references.ts";
 
@@ -84,11 +85,18 @@ export function buildCodeLenses(
     const depCount = incomingCount.get(entry.displayId) ?? 0;
     if (depCount > 0) {
       const referencing = findReferencingEntries(allEntries, entry.displayId);
-      const referenceLocations = referencing.map((ref) => ({
-        uri: pathToUri(ref.location.file),
-        line: Math.max(0, ref.location.line - 1),
-        character: 0,
-      }));
+      // Upstream entries (federated corpus, #783) carry a tree-relative
+      // location.file that pathToUri cannot convert — filter them out
+      // before conversion rather than throwing. depCount above still
+      // counts them; the rare count/location mismatch is acceptable, the
+      // invariant that matters is "no throw".
+      const referenceLocations = referencing
+        .filter((ref) => !isUpstreamEntry(ref))
+        .map((ref) => ({
+          uri: pathToUri(ref.location.file),
+          line: Math.max(0, ref.location.line - 1),
+          character: 0,
+        }));
       out.push({
         range,
         command: {
@@ -110,12 +118,18 @@ export function buildCodeLenses(
         if (target) {
           const targetLine = Math.max(0, target.location.line - 1);
           const targetPos = { line: targetLine, character: 0 };
+          // A resolved-but-upstream target keeps its informative title but
+          // becomes non-clickable — its location.file is a tree-relative
+          // path pathToUri cannot convert (#783).
+          const navigable = !isUpstreamEntry(target);
           out.push({
             range,
             command: {
               title: `↓ Satisfies: ${tok} — ${target.title}`,
               command: "markspec.openDefinition",
-              arguments: [pathToUri(target.location.file), targetPos],
+              arguments: navigable
+                ? [pathToUri(target.location.file), targetPos]
+                : [],
             },
           });
         } else {

--- a/packages/markspec/lsp/code_lens_test.ts
+++ b/packages/markspec/lsp/code_lens_test.ts
@@ -208,6 +208,98 @@ Deno.test("buildCodeLenses: entry with multiple Satisfies values yields one lens
   assertEquals(satLenses[1].command?.title, "↓ Satisfies: STK_B — B");
 });
 
+// --- upstream entries (#783) ---
+//
+// Federated-upstream entries carry a tree-relative location.file (e.g.
+// "docs/x.md") — pathToUri (@std/path toFileUrl, or any well-behaved
+// implementation) cannot convert a relative path. This stub THROWS on a
+// relative path, so any of these tests would fail if an unguarded relative
+// path reached it — the linchpin proving no relative path reaches
+// pathToUri at all.
+const throwingPathToUri = (p: string): string => {
+  if (!p.startsWith("/")) {
+    throw new Error(`relative path reached pathToUri: ${p}`);
+  }
+  return "file://" + p;
+};
+
+/** Build an upstream-origin fixture on top of {@linkcode fakeEntry}. */
+function fakeUpstreamEntry(opts: {
+  displayId: string;
+  title: string;
+  file: string;
+  line: number;
+  satisfies?: string;
+}): Entry {
+  return {
+    ...fakeEntry(opts),
+    origin: { kind: "upstream", upstreamId: "product", version: "v1" },
+    // deno-lint-ignore no-explicit-any
+  } as any;
+}
+
+Deno.test("buildCodeLenses: local entry Satisfies an upstream target — no throw, non-clickable Satisfies lens keeps the resolved title", () => {
+  const upstreamTarget = fakeUpstreamEntry({
+    displayId: "PRODUCT_SYS_0001",
+    title: "Upstream target",
+    file: "docs/x.md",
+    line: 1,
+  });
+  const child = fakeEntry({
+    displayId: "SAD_001",
+    title: "Child",
+    file: "/proj/r.md",
+    line: 10,
+    satisfies: "PRODUCT_SYS_0001",
+  });
+  const lenses = buildCodeLenses(
+    [child],
+    [upstreamTarget, child],
+    throwingPathToUri,
+  );
+  const satLens = lenses.find((l) => l.command?.title.startsWith("↓"));
+  assertEquals(
+    satLens?.command?.title,
+    "↓ Satisfies: PRODUCT_SYS_0001 — Upstream target",
+  );
+  assertEquals(satLens?.command?.arguments, []);
+});
+
+Deno.test("buildCodeLenses: upstream entry among dependents is excluded from dependents referenceLocations (no throw)", () => {
+  const target = fakeEntry({
+    displayId: "STK_001",
+    title: "Target",
+    file: "/proj/r.md",
+    line: 1,
+  });
+  const upstreamDependent = fakeUpstreamEntry({
+    displayId: "PRODUCT_SYS_0002",
+    title: "Upstream child",
+    file: "docs/x.md",
+    line: 5,
+    satisfies: "STK_001",
+  });
+  const localDependent = fakeEntry({
+    displayId: "SAD_001",
+    title: "Local child",
+    file: "/proj/r.md",
+    line: 10,
+    satisfies: "STK_001",
+  });
+  const lenses = buildCodeLenses(
+    [target],
+    [target, upstreamDependent, localDependent],
+    throwingPathToUri,
+  );
+  const depLens = lenses.find((l) => l.command?.title.startsWith("↑"));
+  // referenceLocations excludes the upstream dependent; depCount (a
+  // display count from incomingCount) still counts both, per the brief's
+  // documented acceptable mismatch.
+  assertEquals(depLens?.command?.arguments?.[2], [
+    { uri: "file:///proj/r.md", line: 9, character: 0 },
+  ]);
+});
+
 Deno.test("buildCodeLenses: multiple entries each get their own lens set", () => {
   const a = fakeEntry({
     displayId: "STK_A",

--- a/packages/markspec/lsp/definition.ts
+++ b/packages/markspec/lsp/definition.ts
@@ -42,15 +42,26 @@ export function entryToLspLocation(entry: Entry): LspLocation {
 }
 
 /**
- * Resolve the go-to-definition target for an entry. Returns the entry's
- * LSP `Location` for project- and delivered-corpus-authored entries;
- * `null` for a locked upstream entry (federated-upstream slice 5) whose
- * `location.file` is a path inside the upstream repo that does not exist
- * in this workspace — navigating there would open a non-existent file.
- * Delivered corpus (`kind:"profile"`) keeps working: its file is a real
- * local `.markspec/cache/…` path.
+ * Whether an entry has a location that can be opened in this workspace.
+ * Upstream entries (federated corpus) live in another repository and carry
+ * a tree-relative `location.file` that pathToUri cannot convert — they have
+ * no navigable local location. Project + delivered-corpus entries always do.
  */
-export function resolveDefinitionLocation(entry: Entry): LspLocation | null {
-  if (isUpstreamEntry(entry)) return null;
-  return entryToLspLocation(entry);
+export function hasNavigableLocation(entry: Entry): boolean {
+  return !isUpstreamEntry(entry);
+}
+
+/**
+ * Resolve the navigable target for an entry — used by both go-to-definition
+ * and find-references. Returns the entry's LSP `Location` for project- and
+ * delivered-corpus-authored entries; `null` for a locked upstream entry
+ * (federated-upstream slice 5) whose `location.file` is a path inside the
+ * upstream repo that does not exist in this workspace — navigating there
+ * would open a non-existent file, and converting it via `pathToUri` would
+ * throw (#783). Delivered corpus (`kind:"profile"`) keeps working: its file
+ * is a real local `.markspec/cache/…` path. Total — never throws on an
+ * upstream entry.
+ */
+export function resolveNavigableLocation(entry: Entry): LspLocation | null {
+  return hasNavigableLocation(entry) ? entryToLspLocation(entry) : null;
 }

--- a/packages/markspec/lsp/definition_test.ts
+++ b/packages/markspec/lsp/definition_test.ts
@@ -9,7 +9,11 @@
 import { assertEquals } from "@std/assert";
 import type { Entry } from "../core/model/mod.ts";
 import { makeDisplayId } from "../core/model/mod.ts";
-import { entryToLspLocation, resolveDefinitionLocation } from "./definition.ts";
+import {
+  entryToLspLocation,
+  hasNavigableLocation,
+  resolveNavigableLocation,
+} from "./definition.ts";
 
 function makeEntry(file: string, line: number, column: number): Entry {
   return {
@@ -62,23 +66,43 @@ function makeUpstreamEntry(file: string): Entry {
   };
 }
 
-Deno.test("resolveDefinitionLocation: project entry resolves to its location", () => {
+Deno.test("resolveNavigableLocation: project entry resolves to its location", () => {
   const entry = makeEntry("/abs/req.md", 5, 1);
-  const loc = resolveDefinitionLocation(entry);
+  const loc = resolveNavigableLocation(entry);
   assertEquals(loc, entryToLspLocation(entry));
 });
 
-Deno.test("resolveDefinitionLocation: upstream entry is a no-op (null)", () => {
+Deno.test("resolveNavigableLocation: upstream entry is a no-op (null)", () => {
   const entry = makeUpstreamEntry("docs/product/stk.md");
-  assertEquals(resolveDefinitionLocation(entry), null);
+  assertEquals(resolveNavigableLocation(entry), null);
 });
 
-Deno.test("resolveDefinitionLocation: delivered-corpus (profile) entry still resolves", () => {
+Deno.test("resolveNavigableLocation: delivered-corpus (profile) entry still resolves", () => {
   const entry: Entry = {
     ...makeEntry("/abs/cache/req.md", 5, 1),
     origin: { kind: "profile", profileId: "p", profileVersion: "1.0.0" },
   };
   // Delivered-corpus entries have a real local file — go-to-definition must
   // still navigate (only upstream entries are the no-op).
-  assertEquals(resolveDefinitionLocation(entry), entryToLspLocation(entry));
+  assertEquals(resolveNavigableLocation(entry), entryToLspLocation(entry));
+});
+
+// --- hasNavigableLocation ---
+
+Deno.test("hasNavigableLocation: upstream entry has no navigable location", () => {
+  const entry = makeUpstreamEntry("docs/product/stk.md");
+  assertEquals(hasNavigableLocation(entry), false);
+});
+
+Deno.test("hasNavigableLocation: project entry has a navigable location", () => {
+  const entry = makeEntry("/abs/req.md", 5, 1);
+  assertEquals(hasNavigableLocation(entry), true);
+});
+
+Deno.test("hasNavigableLocation: delivered-corpus (profile) entry has a navigable location", () => {
+  const entry: Entry = {
+    ...makeEntry("/abs/cache/req.md", 5, 1),
+    origin: { kind: "profile", profileId: "p", profileVersion: "1.0.0" },
+  };
+  assertEquals(hasNavigableLocation(entry), true);
 });

--- a/packages/markspec/lsp/server.ts
+++ b/packages/markspec/lsp/server.ts
@@ -78,7 +78,7 @@ import {
 import { groupDiagnosticsByFile, toLspDiagnostic } from "./diagnostics.ts";
 import { buildDiagnosticsHistogram } from "./diagnostics_histogram.ts";
 import { buildCodeActions } from "./code_actions.ts";
-import { entryToLspLocation, resolveDefinitionLocation } from "./definition.ts";
+import { resolveNavigableLocation } from "./definition.ts";
 import { displayIdAtPosition, formatHoverContent } from "./hover.ts";
 import { entriesToFoldingRanges } from "./folding.ts";
 import { findOccurrencesInFile } from "./highlights.ts";
@@ -1380,7 +1380,7 @@ connection.onDefinition((params) => {
   const entry = index.getEntryByDisplayId(makeDisplayId(id));
   if (!entry) return null;
 
-  return resolveDefinitionLocation(entry);
+  return resolveNavigableLocation(entry);
 });
 
 // ---------------------------------------------------------------------------
@@ -1409,12 +1409,17 @@ connection.onReferences((params) => {
   if (!id) return null;
 
   const referencing = findReferencingEntries(index.getAllEntries(), id);
-  const locations = referencing.map(entryToLspLocation);
+  const locations = referencing
+    .map(resolveNavigableLocation)
+    .filter((loc): loc is NonNullable<typeof loc> => loc !== null);
 
   // includeDeclaration: prepend the declaration's location when asked.
   if (params.context?.includeDeclaration) {
     const decl = index.getEntryByDisplayId(makeDisplayId(id));
-    if (decl) locations.unshift(entryToLspLocation(decl));
+    if (decl) {
+      const declLoc = resolveNavigableLocation(decl);
+      if (declLoc) locations.unshift(declLoc);
+    }
   }
 
   return locations;

--- a/packages/markspec/lsp/symbols.ts
+++ b/packages/markspec/lsp/symbols.ts
@@ -9,6 +9,7 @@
  */
 
 import type { Entry } from "../core/model/mod.ts";
+import { hasNavigableLocation } from "./definition.ts";
 import { pathToUri } from "./util.ts";
 
 /** LSP `SymbolKind.Class` numeric constant. */
@@ -69,6 +70,10 @@ export function entriesToWorkspaceSymbols(
   const needle = query.toLowerCase();
   const out: SymbolInformation[] = [];
   for (const entry of entries) {
+    // Upstream entries (federated corpus, #783) have no navigable local
+    // location — their location.file is a tree-relative path pathToUri
+    // cannot convert. Omit them rather than throwing.
+    if (!hasNavigableLocation(entry)) continue;
     if (needle.length > 0) {
       const matches = entry.displayId.toLowerCase().includes(needle) ||
         entry.title.toLowerCase().includes(needle);

--- a/packages/markspec/lsp/symbols_test.ts
+++ b/packages/markspec/lsp/symbols_test.ts
@@ -135,3 +135,32 @@ Deno.test("entriesToWorkspaceSymbols: kind is the Class constant", () => {
   const sym = entriesToWorkspaceSymbols(entries, "")[0];
   assertEquals(sym.kind, SymbolKindClass);
 });
+
+// --- upstream entries (#783) ---
+//
+// Federated-upstream entries carry a tree-relative location.file (e.g.
+// "docs/product/stk.md") — pathToUri (@std/path toFileUrl) throws
+// `Path must be absolute` on a relative path. Upstream entries have no
+// navigable local location, so they must be omitted rather than reaching
+// pathToUri at all.
+
+function makeUpstreamEntry(opts: {
+  displayId: string;
+  title: string;
+  line: number;
+}): Entry {
+  return {
+    ...makeEntry(opts),
+    location: { file: "docs/product/stk.md", line: opts.line, column: 1 },
+    origin: { kind: "upstream", upstreamId: "product", version: "v1" },
+  };
+}
+
+Deno.test("entriesToWorkspaceSymbols: upstream entry is omitted (no throw), project entry with same query still appears", () => {
+  const entries = [
+    makeUpstreamEntry({ displayId: "STK_001", title: "Upstream req", line: 1 }),
+    makeEntry({ displayId: "STK_002", title: "Project req", line: 5 }),
+  ];
+  const symbols = entriesToWorkspaceSymbols(entries, "req");
+  assertEquals(symbols.map((s) => s.name), ["STK_002"]);
+});


### PR DESCRIPTION
Closes #783.

Federated-upstream entries carry a **tree-relative** `location.file`; `pathToUri` (`@std/path` `toFileUrl`) throws `Path must be absolute` on it. Several LSP handlers mapped upstream entries — reachable via `index.getAllEntries()`, `findReferencingEntries`, a local entry's upstream `Satisfies:` target, or `index.getFilePaths()` — to `pathToUri(entry.location.file)` unguarded and **threw** when an upstream entry was involved (Find-All-References, workspace-symbol, and code lens on a cross-repo `Satisfies:`). Slice 5 (#745) guarded only `onDefinition`; this fixes the rest.

## Fix — one decision point + guard every exposed site

Only upstream entries carry relative paths, so the complete navigability predicate is `hasNavigableLocation(entry) = !isUpstreamEntry(entry)` (new, in `lsp/definition.ts`). Slice-5's `resolveDefinitionLocation` is renamed to `resolveNavigableLocation` (now used by both go-to-definition and find-references).

- **`onReferences`** — map referencing entries through `resolveNavigableLocation` and filter nulls; guard the `includeDeclaration` declaration too. Drops upstream referencers + an upstream declaration; all local references preserved.
- **`workspace/symbol`** (`entriesToWorkspaceSymbols`) — omit upstream entries (LSP `SymbolInformation` requires a location; an upstream entry has no local one).
- **`code_lens`** — an upstream `Satisfies:` target keeps its informative title but is non-clickable (`arguments: []`); upstream entries are filtered out of the "↑ dependents" reference locations. `code_lens.ts` stays `@std/path`-free by using the `isUpstreamEntry` semantic predicate directly.

`onDefinition` behavior is unchanged (pure rename — the old body already returned `null` for upstream). The now-unused `entryToLspLocation` import is dropped from `server.ts`.

## Verification

Linchpin test: a `pathToUri` stub that **throws** on a relative path, so any regression that lets a relative path through fails loudly; the `symbols` RED was reproduced through the real `@std/path` `toFileUrl`. `just build` green (3863 tests), fmt/dprint clean. An independent whole-file re-audit (opus) of every `pathToUri`/`location.file` site confirms **no unguarded upstream→pathToUri site remains** — each is guarded or provably operates on always-absolute local paths (open-document handlers only ever see local entries, since `getEntriesForFile` is queried with absolute paths and upstream entries are keyed under relative paths).

Accepted, documented nuance: the "↑ N dependents" count still counts upstream referrers while their locations are excluded from the click target (no-throw is the invariant that matters).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
