### PR TITLE
fix(book): fail book build on colliding chapter slugs (MSL-K001)

### DIFF
--- a/docs/architecture/adr-012-diagnostic-code-scheme.md
+++ b/docs/architecture/adr-012-diagnostic-code-scheme.md
@@ -230,3 +230,43 @@ also fires for a file-local `markspec fmt <file>`.
 
 Published in the language spec at
 [`docs/spec/language/language.md` §8.9](../spec/language/language.md).
+
+## Amendment (#778): MSL-K book-build family
+
+`markspec book build` needs a build-time diagnostic channel for a book whose
+chapter set cannot produce a coherent static site. The first such rule
+(`MSL-K001`, #778) fires when two distinct chapter source paths flatten to the
+same output slug (e.g. `recipes/deploy.md` and `recipes-deploy.md` both →
+`recipes-deploy.html`) — left undetected, the second write silently overwrites
+the first and cross-chapter link rewriting (#776) resolves links to whichever
+chapter won the write race.
+
+This introduces the `MSL-K###` family — a **bounded addition** on the same
+footing as the `MSL-F` family in the ADR-027 amendment and the `MSL-L` / `MSL-S`
+families in the ADR-022 amendment. `MSL-K###` has no current-scheme equivalent
+(the legacy scheme had no book-build family), so no code is renamed. The letter
+`K` (book) was chosen because it collides with neither the current-scheme
+families (`MSL-R/T/M/D/G/S`) nor the nextgen catalogue's `MSL-P/I/M/F`, and —
+unlike `O` — is unambiguous in a code string. The codes are stable from first
+emission.
+
+### Family overview (#778 addition)
+
+| Family     | Concern                                     | Authority |
+| ---------- | ------------------------------------------- | --------- |
+| `MSL-K###` | Book-build failures (`markspec book build`) | #778      |
+
+### MSL-K (Book build, #778)
+
+Emitted by `buildBook` into `BuildBookResult.diagnostics` and rendered to stderr
+by the CLI as `error[MSL-K001]: …`. An error-severity `MSL-K` diagnostic aborts
+`markspec book build` before any file is written (non-zero exit), so a
+wrong-content site is never produced. Unlike the `check`-gate families, `MSL-K`
+is not part of the validator contract and is not suppressible.
+
+| Code     | Severity | Concern                                                                                                                        |
+| -------- | -------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| MSL-K001 | error    | Chapter slug collision — two distinct chapter source paths flatten to the same output `.html` slug; rename one to disambiguate |
+
+Published in the language spec at
+[`docs/spec/language/language.md` §8.11](../spec/language/language.md).

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -899,6 +899,11 @@ preserving any `#fragment`. Links to files outside the book (external URLs,
 absolute paths, or a chapter declared in `SUMMARY.md` with no backing file) are
 left untouched.
 
+If two distinct chapters flatten to the same output slug (e.g.
+`recipes/deploy.md` and `recipes-deploy.md` both → `recipes-deploy.html`), the
+build fails with `error[MSL-K001]` and writes nothing rather than silently
+overwriting one chapter with the other — rename one chapter to disambiguate.
+
 ### Profile and diagnostics
 
 #### profile show

--- a/docs/spec/language/language.md
+++ b/docs/spec/language/language.md
@@ -1661,6 +1661,23 @@ amendment). The offline composite `markspec check` gate emits one of them:
 > is deferred to the sequenced ADR-012 scheme migration, not resolved here (code
 > names are a public interface — renumbering is a breaking change).
 
+### 8.11 Book build (MSL-K)
+
+Build-time diagnostics raised by `markspec book build` when a book's chapter set
+cannot produce a coherent static site. Emitted to stderr as
+`error[MSL-K001]: …`; an error aborts the build before any file is written, so a
+broken site is never emitted.
+
+| ID         | Severity | Rule                                                                                                                                                                                                      |
+| ---------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `MSL-K001` | error    | Chapter slug collision: two distinct chapter source paths flatten to the same output slug (e.g. `recipes/deploy.md` and `recipes-deploy.md` → `recipes-deploy.html`). Rename one chapter to disambiguate. |
+
+The `MSL-K` prefix is a bounded early adoption of a nextgen "book build" family,
+recorded on the same footing as the `MSL-F` formatting family (§8.9) and the
+`MSL-L` / `MSL-S` families (§8.10); see
+[ADR-012](../../architecture/adr-012-diagnostic-code-scheme.md)'s book-build
+amendment.
+
 ---
 
 ## Part 9 — Configuration

--- a/packages/markspec/book/mod.ts
+++ b/packages/markspec/book/mod.ts
@@ -82,17 +82,37 @@ export function buildBook(
   // SUMMARY.md but missing on disk (a common in-progress-book state, already
   // tolerated below with a "chapter file not found" warning) must not have
   // links to it confidently rewritten to a page that will never be written.
+  const resolvedChapters = allChapters.filter(
+    (c): c is Chapter & { path: string } =>
+      Boolean(c.path) && options.files.has(c.path!),
+  );
   // Keys are normalized so a SUMMARY.md path written with a redundant form
   // (e.g. "./index.md") still matches hrefs resolved to the plain form —
   // see RenderChapterOptions.chapterSlugs's doc comment for the contract.
   const chapterSlugs = new Map(
-    allChapters
-      .filter(
-        (c): c is Chapter & { path: string } =>
-          Boolean(c.path) && options.files.has(c.path!),
-      )
-      .map((c) => [normalize(c.path), slugForChapterPath(c.path)] as const),
+    resolvedChapters.map(
+      (c) => [normalize(c.path), slugForChapterPath(c.path)] as const,
+    ),
   );
+
+  // Two distinct chapters whose source paths flatten to the same output slug
+  // (e.g. "recipes/deploy.md" and "recipes-deploy.md") would silently
+  // overwrite each other on write, and — via cross-chapter link rewriting
+  // (#776) — send a link to the wrong content (#778). Emit an error so the
+  // CLI aborts before writing anything, rather than producing a
+  // confidently-wrong site.
+  for (
+    const collision of detectSlugCollisions(resolvedChapters.map((c) => c.path))
+  ) {
+    const quoted = collision.paths.map((p) => `'${p}'`).join(", ");
+    diagnostics.push({
+      code: "MSL-K001",
+      severity: "error",
+      message:
+        `chapter slug collision: ${quoted} map to the same output '${collision.slug}.html' — rename a chapter so each maps to a distinct output file`,
+      location: { file: collision.paths[0], line: 1, column: 1 },
+    });
+  }
 
   for (const chapter of allChapters) {
     if (!chapter.path) continue; // skip drafts
@@ -130,6 +150,51 @@ export function buildBook(
  */
 export function slugForChapterPath(path: string): string {
   return normalize(path).replace(/\.md$/, "").replace(/\//g, "-");
+}
+
+/** A group of distinct chapter source paths that flatten to the same
+ * {@linkcode slugForChapterPath} output — and would therefore write to the
+ * same `.html` file. */
+export interface SlugCollision {
+  /** The shared slug (written as `<slug>.html`). */
+  readonly slug: string;
+  /** The colliding source paths, in the order supplied (≥2). */
+  readonly paths: readonly string[];
+}
+
+/**
+ * Detect chapter source paths that flatten to the same output slug.
+ *
+ * Two distinct chapters mapping to one slug is a silent-data-loss bug: the
+ * second write overwrites the first and cross-chapter links (#776) resolve to
+ * whichever chapter won the write race (#778). `buildBook` calls this over its
+ * resolved chapters and raises `MSL-K001` for each returned group.
+ *
+ * Paths that {@linkcode normalize} to the same value are treated as one
+ * chapter (e.g. `"./index.md"` and `"index.md"` are two SUMMARY spellings of
+ * the same file, not a collision) and never flagged. Each returned group lists
+ * the distinct colliding paths in first-seen order; the result is empty when
+ * every chapter maps to a unique slug.
+ */
+export function detectSlugCollisions(
+  chapterPaths: readonly string[],
+): SlugCollision[] {
+  const bySlug = new Map<string, string[]>();
+  const seenNormalized = new Set<string>();
+  for (const path of chapterPaths) {
+    const norm = normalize(path);
+    if (seenNormalized.has(norm)) continue;
+    seenNormalized.add(norm);
+    const slug = slugForChapterPath(path);
+    const group = bySlug.get(slug) ?? [];
+    group.push(path);
+    bySlug.set(slug, group);
+  }
+  const collisions: SlugCollision[] = [];
+  for (const [slug, paths] of bySlug) {
+    if (paths.length >= 2) collisions.push({ slug, paths });
+  }
+  return collisions;
 }
 
 /** Flatten all chapters from a structure into document order. */

--- a/packages/markspec/book/mod_test.ts
+++ b/packages/markspec/book/mod_test.ts
@@ -1,5 +1,5 @@
 import { assertEquals } from "@std/assert";
-import { slugForChapterPath } from "./mod.ts";
+import { detectSlugCollisions, slugForChapterPath } from "./mod.ts";
 
 Deno.test("slugForChapterPath: strips .md extension", () => {
   assertEquals(slugForChapterPath("index.md"), "index");
@@ -14,4 +14,47 @@ Deno.test("slugForChapterPath: flattens nested directory separators to hyphens",
 
 Deno.test("slugForChapterPath: normalizes a redundant './' prefix before slugifying", () => {
   assertEquals(slugForChapterPath("./index.md"), "index");
+});
+
+Deno.test("detectSlugCollisions: none when every chapter maps to a distinct slug", () => {
+  assertEquals(
+    detectSlugCollisions(["index.md", "recipes/deploy.md", "specs.md"]),
+    [],
+  );
+});
+
+Deno.test("detectSlugCollisions: flags two distinct source paths that flatten to one slug", () => {
+  // The canonical #778 case: a nested path and a hyphenated top-level path
+  // both slugify to "recipes-deploy" and would clobber each other on write.
+  assertEquals(
+    detectSlugCollisions(["recipes/deploy.md", "recipes-deploy.md"]),
+    [{
+      slug: "recipes-deploy",
+      paths: ["recipes/deploy.md", "recipes-deploy.md"],
+    }],
+  );
+});
+
+Deno.test("detectSlugCollisions: reports colliding paths in the given order", () => {
+  const [collision] = detectSlugCollisions([
+    "recipes-deploy.md",
+    "recipes/deploy.md",
+  ]);
+  assertEquals(collision.paths, ["recipes-deploy.md", "recipes/deploy.md"]);
+});
+
+Deno.test("detectSlugCollisions: a redundant './' spelling of the same file is not a collision", () => {
+  // "./index.md" and "index.md" name the SAME file (both normalize to
+  // "index.md"); reading it under two SUMMARY spellings must not be flagged
+  // as two chapters clobbering each other.
+  assertEquals(detectSlugCollisions(["./index.md", "index.md"]), []);
+});
+
+Deno.test("detectSlugCollisions: groups three-way collisions into a single entry", () => {
+  assertEquals(
+    detectSlugCollisions(["a/b.md", "a-b.md", "specs.md"]).map((c) => c.slug),
+    ["a-b"],
+  );
+  const [collision] = detectSlugCollisions(["a/b.md", "a-b.md", "specs.md"]);
+  assertEquals(collision.paths, ["a/b.md", "a-b.md"]);
 });

--- a/packages/markspec/cli/commands/book.ts
+++ b/packages/markspec/cli/commands/book.ts
@@ -76,6 +76,14 @@ export const bookCmd = new Command()
       console.error(`${d.severity}[${d.code}]: ${d.message}`);
     }
 
+    // Abort before writing anything if the build produced an error (e.g. a
+    // chapter-slug collision, MSL-K001) — writing would silently overwrite one
+    // chapter with another and serve the wrong content (#778). Fail loud with
+    // a non-zero exit rather than emit a confidently-wrong site.
+    if (result.diagnostics.some((d) => d.severity === "error")) {
+      Deno.exit(1);
+    }
+
     // Write output
     await Deno.mkdir(options.output, { recursive: true });
     const chapterLinks = result.chapters.map((c) => ({

--- a/tests/e2e/book_build_test.ts
+++ b/tests/e2e/book_build_test.ts
@@ -454,3 +454,57 @@ Deno.test("book build: a chapter path declared with a redundant './' prefix in S
     await Deno.remove(dir, { recursive: true });
   }
 });
+
+// ── Chapter slug collision (#778) ──────────────────────────────────────────
+
+// Two distinct chapters whose source paths both flatten to the slug
+// "recipes-deploy": "recipes/deploy.md" (nested) and "recipes-deploy.md"
+// (hyphenated top-level). Left undetected, the second write silently
+// overwrites the first and #776's link rewriting sends "Deploy" links to
+// whichever chapter won the write race — a reader lands on the wrong content.
+const COLLISION_SUMMARY = `# Summary
+
+- [Deploy](recipes/deploy.md)
+- [Recipes Deploy](recipes-deploy.md)
+- [Specs](specs.md)
+`;
+
+const COLLISION_FIXTURE = {
+  "project.yaml": PROJECT_YAML,
+  "SUMMARY.md": COLLISION_SUMMARY,
+  "recipes/deploy.md": `# Deploy\n\nDEPLOY-CHAPTER-MARKER content.\n`,
+  "recipes-deploy.md":
+    `# Recipes Deploy\n\nRECIPES-DEPLOY-CHAPTER-MARKER content.\n`,
+  "specs.md": SPECS_MD,
+};
+
+Deno.test("book build: colliding chapter slugs fail the build with MSL-K001 and write nothing", async () => {
+  const { code, stderr, dir } = await markspecPersist(["book", "build"], {
+    files: COLLISION_FIXTURE,
+  });
+  try {
+    // Fail loud: a build that would silently serve the wrong chapter aborts.
+    assertEquals(code, 1, `expected exit 1, stderr: ${stderr}`);
+    assertStringIncludes(stderr, "MSL-K001");
+    // The message must name both colliding source paths and the shared slug
+    // so the author knows exactly which two chapters to disambiguate.
+    assertStringIncludes(stderr, "recipes/deploy.md");
+    assertStringIncludes(stderr, "recipes-deploy.md");
+    assertStringIncludes(stderr, "recipes-deploy.html");
+    // No output is produced — the abort happens before any file is written,
+    // so the wrong-content page never reaches disk.
+    let siteExists = true;
+    try {
+      await Deno.stat(`${dir}/_site`);
+    } catch {
+      siteExists = false;
+    }
+    assertEquals(
+      siteExists,
+      false,
+      "expected no _site output on a failed build",
+    );
+  } finally {
+    await Deno.remove(dir, { recursive: true });
+  }
+});


### PR DESCRIPTION
Closes #778.

## Problem

`slugForChapterPath` flattens a chapter's source path to an output slug by
stripping `.md` and replacing `/` with `-`. Two distinct chapters can therefore
collapse to the same slug — e.g. `recipes/deploy.md` and `recipes-deploy.md`
both → `recipes-deploy.html`. There was no collision detection: the CLI's write
loop wrote `recipes-deploy.html` twice and the second write silently clobbered
the first.

With #776's cross-chapter link rewriting, this got worse: a `[Deploy](recipes/deploy.md)`
link elsewhere is now confidently rewritten to `href="recipes-deploy.html"`, but
that file on disk holds whichever chapter won the write race. A reader clicking
"Deploy" silently lands on a *different* chapter's content — a worse failure
mode than the pre-#776 honestly-dead `.md` link.

## Fix (detect + fail loud)

- `detectSlugCollisions(chapterPaths)` (new, pure, exported from `book/mod.ts`)
  groups the resolved chapters by slug and returns every group of ≥2 **distinct**
  source paths. Redundant SUMMARY spellings of the *same* file (`./index.md` vs
  `index.md`, which normalize identically) are not flagged.
- `buildBook` raises an error-severity **`MSL-K001`** diagnostic per collision,
  naming both colliding paths and the shared output slug.
- `markspec book build` prints the diagnostic and **exits 1 before writing any
  file**, so a confidently-wrong site is never produced. The author renames one
  chapter to disambiguate.

I chose fail-loud over auto-disambiguating slugs (append `-2`): slugs stay
predictable (slug == path), URLs don't shift as chapters are added, and an
ambiguous book structure surfaces as an honest build failure rather than a
guessed layout.

## Diagnostic code

New `MSL-K` book-build family — the first book-build diagnostic. `K` (booK)
collides with neither the current-scheme families (`MSL-R/T/M/D/G/S`) nor the
nextgen catalogue (`MSL-P/I/M/F`), and is unambiguous in a code string. Recorded
as a bounded addition, same footing as the `MSL-F` (ADR-027) and `MSL-L`/`MSL-S`
(ADR-022) amendments.

## Tests

- **Unit** (`book/mod_test.ts`): `detectSlugCollisions` — distinct-slug no-op,
  the two-path collision, ordering, the `./index.md`-vs-`index.md` non-collision,
  and three-way grouping.
- **E2E** (`tests/e2e/book_build_test.ts`): a colliding book fails with exit 1,
  stderr carries `MSL-K001` + both paths + the slug, and **no `_site` is
  written**. All 13 pre-existing book-build tests still pass.
- Verified end-to-end against the compiled `dist/markspec` binary.

## Docs

- `language.md` §8.11 — new `MSL-K` book-build diagnostic table.
- `adr-012` — book-build family amendment (rationale + letter choice).
- `cli.md` — `book build` collision note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
