### PR TITLE
fix(core): resolve federated upstream slice-3 review follow-ups (#785)

### DIFF
--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -7,7 +7,8 @@ Every command supports `--help`. Commands that produce structured output support
 `--format json` for machine-readable output to stdout (diagnostics always go to
 stderr).
 
-**Exit codes:** `0` success, `1` error, `2` warnings only (`check`, `lint`).
+**Exit codes:** `0` success, `1` error, `2` warnings only (`check`, `lint`,
+`lock`).
 
 **Global options** (available on every command):
 
@@ -771,6 +772,15 @@ done by hand.
 | `MSL-L214` | `markspec lock` (restore flow) | The cache needed restoring, but the re-fetched content's hash no longer matches the pinned snapshot — the published site moved. Run `markspec lock --update=<id>` to move the pin deliberately.                                                                                             |
 | `MSL-L212` | `markspec check` (offline)     | Also covers upstream cache drift in this release: fires when a locked reference's cache under `.markspec/cache/upstreams/<id>/` is missing or its hash no longer matches `markspec.lock`, in addition to the existing traceability-edge-drift case. Either way, the fix is `markspec lock`. |
 | `MSL-L215` | `markspec check`               | A `dependencies:` pin resolved to a branch or bare sha rather than a tag — an unreleased state. Advisory by default; `markspec check --strict` promotes it to a hard error, so a release build cannot pass against an unbaselined dependency.                                               |
+| `MSL-L216` | `markspec lock`                | A `dependencies:` entry derives the same upstream id as a `references:` entry. The dependency is skipped — the reference snapshot owns the shared `.markspec/cache/upstreams/<id>/` namespace — so set a distinct `name:` on one of them. Warn-and-write: every other pin still locks.      |
+
+**Exit codes.** `markspec lock` exits `0` when every upstream resolved cleanly.
+Following the clig.dev convention (`2` for warnings only), it exits `2` — while
+still writing `markspec.lock` (warn-and-write) — when any upstream could not be
+cleanly locked (`MSL-L213`/`MSL-L214`/`MSL-L216`), so a bare `markspec lock` in
+CI surfaces a dropped or stale pin. A hard error (e.g. an invalid `project.yaml`
+or sync mapping) exits `1`. `markspec lock --check` is unaffected: it stays a
+read-only drift gate that exits `1` on drift.
 
 **`dependencies:` are acquired and compiled during `lock`.** For each declared
 `dependencies:` entry, `markspec lock` resolves the declared version intent

--- a/docs/spec/language/language.md
+++ b/docs/spec/language/language.md
@@ -1647,12 +1647,16 @@ The lockfile (`MSL-L###`) and external-sync (`MSL-S###`) diagnostic families are
 governed by [ADR-022](../../architecture/adr-022-lockfile-and-external-sync.md)
 and catalogued in
 [ADR-012](../../architecture/adr-012-diagnostic-code-scheme.md) (ADR-022
-amendment). The offline composite `markspec check` gate emits one of them:
+amendment). The offline composite `markspec check` gate and `markspec lock` emit
+these lockfile diagnostics:
 
 | ID         | Severity | Rule                                                                                                                                                                                                                                                               |
 | ---------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `MSL-L212` | error    | Canonical edge-hash drift: the project's traceability edges no longer match the hash pinned in `markspec.lock` (run `markspec lock`). Fires only when `markspec.lock` exists; checked offline (no network — upstream resolution stays in `markspec lock --check`). |
+| `MSL-L213` | warning  | An upstream `references:` or `dependencies:` entry could not be locked (unreachable remote, malformed manifest, cache-write failure). Warn-and-write: the resolvable pins still lock. Emitted by `markspec lock`, which then exits 2.                              |
+| `MSL-L214` | warning  | A `references:` restore fetched a snapshot that no longer matches the locked pin (the published site moved). The pin is kept unchanged — run `markspec lock --update=<id>` to move it. Emitted by `markspec lock`, which then exits 2.                             |
 | `MSL-L215` | warning  | A `dependencies:` pin resolved to a branch or bare sha, not a tag (an unreleased state). Advisory by default; promoted to an error under `markspec check --strict` — release builds require every dependency to be tag-pinned.                                     |
+| `MSL-L216` | warning  | An upstream id is claimed by both a `references:` and a `dependencies:` entry. The dependency is skipped (the reference snapshot owns the shared cache); set a distinct `name:` on one of them. Emitted by `markspec lock`, which then exits 2.                    |
 
 > **Prefix overlap (known, pre-existing).** The `MSL-L###` lockfile family
 > shares its prefix with §8.4's link rules (`MSL-L006`), and the `MSL-S###`

--- a/packages/markspec/cli/commands/lock.ts
+++ b/packages/markspec/cli/commands/lock.ts
@@ -61,47 +61,75 @@ function unsafeGitUrl(url: string): string | undefined {
 }
 
 /**
- * Repo-context env vars git reads to locate the repository it operates on.
- * When `markspec lock` runs inside a git hook (e.g. the pre-push hook that
- * runs the test suite), these are exported by the outer git and would be
- * inherited by our `git init`/`fetch` subprocess — redirecting dependency
- * acquisition into the ambient repo instead of the temp dir. `runGit`
- * strips them so every git subprocess discovers its own working tree.
+ * Env vars that would let an ambient git (e.g. the pre-push hook that runs
+ * the test suite, which exports GIT_DIR/GIT_WORK_TREE) or a hostile parent
+ * env redirect our dependency-acquisition subprocess away from its temp dir.
+ * Two classes are scrubbed:
+ *
+ *   1. Repo-discovery / object-store vars — redirect where git thinks its
+ *      working tree, index, and objects live.
+ *   2. Config-injection vars — `GIT_CONFIG*` would let the parent env inject
+ *      arbitrary config (e.g. a `core.fsmonitor`/`core.hooksPath` hook) into
+ *      our subprocess. Dropping `GIT_CONFIG_COUNT` neutralizes the paired
+ *      `GIT_CONFIG_KEY_<n>`/`GIT_CONFIG_VALUE_<n>` entries.
+ *
+ * The user's real `~/.gitconfig` and `/etc/gitconfig` (credential helpers,
+ * proxies) are deliberately NOT disturbed — `runGit` keeps HOME/PATH so real
+ * https/ssh remotes still authenticate; only these override hooks are removed.
  */
-const GIT_DISCOVERY_ENV_VARS = [
+const GIT_SCRUBBED_ENV_VARS = [
+  // 1. Repo discovery / object store.
   "GIT_DIR",
   "GIT_WORK_TREE",
   "GIT_INDEX_FILE",
   "GIT_COMMON_DIR",
   "GIT_OBJECT_DIRECTORY",
+  "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+  "GIT_CEILING_DIRECTORIES",
   "GIT_PREFIX",
   "GIT_NAMESPACE",
+  // 2. Config injection.
+  "GIT_CONFIG",
+  "GIT_CONFIG_GLOBAL",
+  "GIT_CONFIG_SYSTEM",
+  "GIT_CONFIG_COUNT",
+  "GIT_CONFIG_PARAMETERS",
 ] as const;
+
+/**
+ * The curated env every git subprocess runs under, computed once. Starts
+ * from a COPY of the full parent env so PATH, HOME, SSH_AUTH_SOCK, proxy
+ * vars, and credential-helper config survive (real https/ssh remotes need
+ * them), strips {@linkcode GIT_SCRUBBED_ENV_VARS}, and adds the protocol
+ * allowlist. Recomputing this per git call (≈5× per dependency) is wasted
+ * work — the process env does not change mid-lock.
+ */
+let curatedGitEnvCache: Record<string, string> | undefined;
+function curatedGitEnv(): Record<string, string> {
+  if (curatedGitEnvCache) return curatedGitEnvCache;
+  const env = { ...Deno.env.toObject() };
+  for (const key of GIT_SCRUBBED_ENV_VARS) delete env[key];
+  // Protocol allowlist — git will only speak these transports, blocking the
+  // `ext::`/`fd::` transport-helper RCE reachable from a `dependencies[].url`
+  // in an untrusted project.yaml. `file` is required: the e2e fixtures
+  // acquire from local bare-repo paths (git's `file` transport).
+  env.GIT_ALLOW_PROTOCOL = "https:ssh:git:file";
+  curatedGitEnvCache = env;
+  return env;
+}
 
 /** Run a git subprocess, returning stdout or `{ error }`. Never throws. */
 async function runGit(
   args: string[],
 ): Promise<{ stdout: string } | { error: string }> {
   try {
-    // Start from a COPY of the full parent env so PATH, HOME, SSH_AUTH_SOCK,
-    // proxy vars, and credential-helper config survive (real https/ssh
-    // remotes need them), then strip the repo-discovery vars an ambient git
-    // hook would export, and add the protocol allowlist. `clearEnv: true`
-    // makes ONLY this curated env reach git — the stripped vars can't leak
-    // back in.
-    const env = { ...Deno.env.toObject() };
-    for (const key of GIT_DISCOVERY_ENV_VARS) delete env[key];
-    // Protocol allowlist — git will only speak these transports, blocking
-    // the `ext::`/`fd::` transport-helper RCE reachable from a
-    // `dependencies[].url` in an untrusted project.yaml. `file` is
-    // required: the e2e fixtures acquire from local bare-repo paths (git's
-    // `file` transport).
-    env.GIT_ALLOW_PROTOCOL = "https:ssh:git:file";
+    // `clearEnv: true` makes ONLY the curated env reach git — the scrubbed
+    // vars can't leak back in.
     const cmd = new Deno.Command("git", {
       args,
       stdout: "piped",
       stderr: "piped",
-      env,
+      env: curatedGitEnv(),
       clearEnv: true,
     });
     const out = await cmd.output();
@@ -125,24 +153,21 @@ const denoGitIO: GitIO = {
   async acquireTree(url, sha, destDir) {
     const bad = unsafeGitUrl(url);
     if (bad) return { error: bad };
-    // Shallow fetch-by-sha, no history, no blobs until needed, then detach.
-    // (Requires the remote to allow reachable-sha fetches — GitHub/GitLab do;
-    // the e2e bare-repo fixture sets uploadpack.allowReachableSHA1InWant.)
+    // Shallow fetch-by-sha (one commit, no history), fetching from the URL
+    // directly — no named remote is needed because we detach at FETCH_HEAD
+    // and never fetch again. (Requires the remote to allow reachable-sha
+    // fetches — GitHub/GitLab do; the e2e bare-repo fixture sets
+    // uploadpack.allowReachableSHA1InWant.)
+    //
+    // No `--filter=blob:none`: `compileAcquiredTree` reads the *entire* tree,
+    // so `checkout` would fetch every filtered blob back immediately anyway —
+    // the filter saves nothing here, and dropping it also drops the promisor
+    // remote it needs to lazily backfill (which is why `remote add origin`
+    // is gone too). The `url` is validated by `unsafeGitUrl` above.
     for (
       const args of [
         ["-C", destDir, "init", "-q"],
-        ["-C", destDir, "remote", "add", "origin", url],
-        [
-          "-C",
-          destDir,
-          "fetch",
-          "-q",
-          "--depth",
-          "1",
-          "--filter=blob:none",
-          "origin",
-          sha,
-        ],
+        ["-C", destDir, "fetch", "-q", "--depth", "1", url, sha],
         ["-C", destDir, "checkout", "-q", "FETCH_HEAD"],
       ]
     ) {
@@ -328,6 +353,10 @@ async function runLock(options: LockOptions): Promise<void> {
     existing: existingDependencies,
     cacheRoot: upstreamCacheRoot(projectRoot),
     update: options.update ?? false,
+    // Cross-kind dedup: a `dependencies:` entry deriving an id already
+    // claimed by a `references:` entry is skipped (MSL-L216) so the two
+    // never clobber the shared `.markspec/cache/upstreams/<id>` namespace.
+    reservedIds: new Set(declaredReferenceIds),
     io: {
       git: denoGitIO,
       compileTree: denoCompileTree,
@@ -365,6 +394,18 @@ async function runLock(options: LockOptions): Promise<void> {
   const toml = serializeLockfile(lockfile);
   await Deno.writeTextFile(lockPath, toml);
 
+  // Every upstream diagnostic across the three resolvers — the reference /
+  // profile resolution (`resolved`), the published `references:` acquirer
+  // (`refResult`), and the git `dependencies:` acquirer (`depResult`). The
+  // JSON `diagnostics` field and the exit code both key on this combined
+  // set so a `references:`/`dependencies:` warning is neither hidden from
+  // agents consuming `--format json` nor swallowed at exit.
+  const allUpstreamDiags = [
+    ...resolved.diagnostics,
+    ...refResult.diagnostics,
+    ...depResult.diagnostics,
+  ];
+
   if (options.format === "json") {
     // JSON to stdout (machine-readable); diagnostics already emitted to stderr.
     console.log(
@@ -381,7 +422,7 @@ async function runLock(options: LockOptions): Promise<void> {
           "canonical-edges": { count: resolved.canonicalEdgeCount },
           "ledger-edges": { count: resolved.edges.length },
         },
-        diagnostics: resolved.diagnostics.map((d) => ({
+        diagnostics: allUpstreamDiags.map((d) => ({
           code: d.code,
           severity: d.severity,
           message: d.message,
@@ -394,9 +435,23 @@ async function runLock(options: LockOptions): Promise<void> {
     );
   }
 
-  Deno.exit(
-    resolved.diagnostics.some((d) => d.severity === "error") ? 1 : 0,
-  );
+  // Exit contract (clig.dev: "1 for errors, 2 for warnings only"). The
+  // lockfile is written in every non-fatal case (warn-and-write, decision
+  // 1); the exit code signals whether resolution was clean:
+  //   - any hard error → 1 (as before);
+  //   - else an upstream *acquisition* warning — a `references:`/
+  //     `dependencies:` pin that was dropped or bypassed (MSL-L213/L214/
+  //     L216, from `refResult`/`depResult`) → 2, so CI running a bare
+  //     `markspec lock` sees the dropped pin.
+  // Benign resolution advisories in `resolved.diagnostics` (e.g. MSL-L102
+  // "recording identity-only hash" when a bundled profile manifest is
+  // unresolvable) are surfaced in output but deliberately do NOT gate the
+  // exit code — they are not a locking failure.
+  const hasError = allUpstreamDiags.some((d) => d.severity === "error");
+  const upstreamAcquisitionWarned =
+    refResult.diagnostics.some((d) => d.severity === "warning") ||
+    depResult.diagnostics.some((d) => d.severity === "warning");
+  Deno.exit(hasError ? 1 : upstreamAcquisitionWarned ? 2 : 0);
 }
 
 async function readFileOrUndefined(path: string): Promise<string | undefined> {

--- a/packages/markspec/core/lock/acquire_compile.ts
+++ b/packages/markspec/core/lock/acquire_compile.ts
@@ -41,13 +41,28 @@ export async function compileAcquiredTree(
   io: AcquireCompileIO,
   release: string,
 ): Promise<CompiledSnapshot | { error: string }> {
-  const configResult = await loadConfig(treeRoot, io.readFile);
+  // Memoize by path: loadConfig, loadProfileForCommand, and loadToolConfig
+  // each walk + read the same project.yaml/.markspec.yaml, so cache the
+  // in-flight promise per path to read each file exactly once per acquired
+  // tree. The tree is immutable (just fetched at a fixed sha), so a
+  // per-call cache is sound and deterministic.
+  const readCache = new Map<string, Promise<string | undefined>>();
+  const readFile = (path: string): Promise<string | undefined> => {
+    let pending = readCache.get(path);
+    if (pending === undefined) {
+      pending = io.readFile(path);
+      readCache.set(path, pending);
+    }
+    return pending;
+  };
+
+  const configResult = await loadConfig(treeRoot, readFile);
   if (!configResult) {
     return { error: "dependency tree has no discoverable project.yaml" };
   }
-  const profileResult = await loadProfileForCommand(treeRoot, io.readFile);
+  const profileResult = await loadProfileForCommand(treeRoot, readFile);
   const profile = profileResult.chain?.effective;
-  const toolConfig = await loadToolConfig(treeRoot, io.readFile);
+  const toolConfig = await loadToolConfig(treeRoot, readFile);
 
   // Discover → relativize → normalize to POSIX separators → sort. The
   // `\\`→`/` normalization is load-bearing for cross-machine determinism:

--- a/packages/markspec/core/lock/git_intent.ts
+++ b/packages/markspec/core/lock/git_intent.ts
@@ -27,7 +27,7 @@ export interface ResolvedIntent {
   readonly resolved: string;
 }
 
-const SHA_RE = /^[0-9a-f]{40}$/;
+const SHA_RE = /^[0-9a-fA-F]{40}$/;
 /** Strip a single leading `v`/`V` so `v2.1.0` parses as semver. */
 function semverText(tag: string): string {
   return /^[vV]/.test(tag) ? tag.slice(1) : tag;
@@ -89,7 +89,10 @@ export function parseLsRemote(stdout: string): RefList {
  *   default-branch head.
  * - a name matching a tag → `tag:<name>` (tag wins if a branch shares the name).
  * - a name matching a branch → `branch:<name>`.
- * - a 40-hex string → `sha:<sha>` (passthrough; the acquire step validates it).
+ * - a 40-hex string (any case) → normalized to lowercase → `sha:<sha>` (the
+ *   acquire step validates it). Lowercasing keeps the pin byte-identical
+ *   regardless of the case a developer typed, so two lockfiles never differ
+ *   on sha case alone.
  * - otherwise → `{ error }`.
  */
 export function resolveIntent(
@@ -123,6 +126,9 @@ export function resolveIntent(
     r.kind === "branch" && r.name === intent
   );
   if (branch) return { sha: branch.sha, resolved: `branch:${branch.name}` };
-  if (SHA_RE.test(intent)) return { sha: intent, resolved: `sha:${intent}` };
+  if (SHA_RE.test(intent)) {
+    const sha = intent.toLowerCase();
+    return { sha, resolved: `sha:${sha}` };
+  }
   return { error: `intent '${intent}' matched no tag or branch on the remote` };
 }

--- a/packages/markspec/core/lock/git_intent_test.ts
+++ b/packages/markspec/core/lock/git_intent_test.ts
@@ -73,6 +73,18 @@ Deno.test("resolveIntent: bare sha passthrough", () => {
   );
 });
 
+Deno.test("resolveIntent: uppercase 40-hex sha is accepted and lowercased", () => {
+  const rl = parseLsRemote(LS_REMOTE);
+  // A mixed-case sha that matches no tag/branch must resolve as a bare-sha
+  // pin, normalized to lowercase so the lockfile is byte-identical whatever
+  // case the author typed.
+  const r = resolveIntent("ABCDEF0123456789ABCDEF0123456789ABCDEF01", rl);
+  assertEquals(r, {
+    sha: "abcdef0123456789abcdef0123456789abcdef01",
+    resolved: "sha:abcdef0123456789abcdef0123456789abcdef01",
+  });
+});
+
 Deno.test("resolveIntent: unknown ref errors", () => {
   const rl = parseLsRemote(LS_REMOTE);
   const r = resolveIntent("v9.9.9", rl);

--- a/packages/markspec/core/lock/upstream_common.ts
+++ b/packages/markspec/core/lock/upstream_common.ts
@@ -1,0 +1,58 @@
+/**
+ * @module core/lock/upstream_common
+ *
+ * Primitives shared by the two lock-mediated upstream acquirers —
+ * `upstream_refs.ts` (published `references:` snapshots) and
+ * `upstream_deps.ts` (git `dependencies:` trees). Both emit the same
+ * MSL-L213 "could not be locked" warning (differing only by the noun) and
+ * write a `[path, bytes][]` cache batch with identical error handling, so
+ * the primitive lives here once rather than duplicated in each module.
+ */
+
+import type { Diagnostic } from "../model/mod.ts";
+
+/** The two upstream kinds, used only to word the shared MSL-L213 message. */
+export type UpstreamNoun = "reference" | "dependency";
+
+/**
+ * Warn-and-write diagnostic (design §4.2, decision 1): one upstream could
+ * not be locked. Identical shape for both kinds — `noun` selects the word.
+ */
+export function upstreamNotLockable(
+  noun: UpstreamNoun,
+  id: string,
+  detail: string,
+): Diagnostic {
+  return {
+    code: "MSL-L213",
+    severity: "warning",
+    message: `upstream ${noun} '${id}' could not be locked: ${detail}`,
+    location: undefined,
+  };
+}
+
+/**
+ * Write a batch of `[absolutePath, bytes]` cache files via the injected
+ * `writeFile` (which creates parent directories). Returns an MSL-L213
+ * warning naming the clean `id` (never the raw path) on the first failure,
+ * or `undefined` when every write succeeds. Shared by both acquirers' cache
+ * writers so a cache-write-failure message is worded identically.
+ */
+export async function writeCacheFiles(
+  writes: ReadonlyArray<readonly [string, Uint8Array]>,
+  noun: UpstreamNoun,
+  id: string,
+  writeFile: (path: string, bytes: Uint8Array) => Promise<{ error?: string }>,
+): Promise<Diagnostic | undefined> {
+  for (const [path, bytes] of writes) {
+    const res = await writeFile(path, bytes);
+    if (res.error !== undefined) {
+      return upstreamNotLockable(
+        noun,
+        id,
+        `cache write of '${path}' failed (${res.error})`,
+      );
+    }
+  }
+  return undefined;
+}

--- a/packages/markspec/core/lock/upstream_deps.ts
+++ b/packages/markspec/core/lock/upstream_deps.ts
@@ -19,6 +19,7 @@ import type { Diagnostic, ProjectRef } from "../model/mod.ts";
 import type { UpstreamDependency } from "./model.ts";
 import type { ReadFile } from "./resolve.ts";
 import { deriveUpstreamId, probeCacheSnapshot } from "./upstream_refs.ts";
+import { upstreamNotLockable, writeCacheFiles } from "./upstream_common.ts";
 import { type RefList, resolveIntent } from "./git_intent.ts";
 import type { CompiledSnapshot } from "./acquire_compile.ts";
 
@@ -52,6 +53,15 @@ export interface ResolveProjectDependenciesOptions {
   readonly update: boolean | string;
   readonly io: UpstreamDepsIO;
   readonly lockedAt: string;
+  /**
+   * Upstream ids already claimed by declared `references:` entries. A
+   * dependency whose derived id collides with one is skipped with an
+   * MSL-L216 warning (warn-and-write) — the reference snapshot owns that
+   * cache namespace, and two rows under one id would clobber each other's
+   * cache and double-map the corpus. Defaults to empty (no cross-kind
+   * dedup) for callers that resolve dependencies in isolation.
+   */
+  readonly reservedIds?: ReadonlySet<string>;
 }
 
 export interface ResolveProjectDependenciesResult {
@@ -61,21 +71,41 @@ export interface ResolveProjectDependenciesResult {
 
 /** Warn-and-write diagnostic — one dependency could not be locked (decision 1). */
 function l213(id: string, detail: string): Diagnostic {
+  return upstreamNotLockable("dependency", id, detail);
+}
+
+/** Cross-kind id-collision diagnostic — a dependency id is already claimed
+ * by a `references:` entry (warn-and-write: the dependency is skipped). */
+function l216(id: string): Diagnostic {
   return {
-    code: "MSL-L213",
+    code: "MSL-L216",
     severity: "warning",
-    message: `upstream dependency '${id}' could not be locked: ${detail}`,
+    message:
+      `upstream id '${id}' is claimed by both a 'references:' entry and a ` +
+      `'dependencies:' entry — skipping the dependency (the reference ` +
+      `snapshot owns the cache); set a distinct 'name:' on one of them`,
     location: undefined,
   };
 }
 
-/** Acquire the tree at `sha` into a fresh temp dir, compile it, clean up. */
+/** Acquire the tree at `sha` into a fresh temp dir, compile it, clean up.
+ * A temp-dir creation failure is turned into a warn-and-write `{ error }`
+ * rather than propagating and aborting the whole lock. */
 async function acquireAndCompile(
   url: string,
   sha: string,
   io: UpstreamDepsIO,
 ): Promise<CompiledSnapshot | { error: string }> {
-  const tmp = await io.makeTempDir();
+  let tmp: string;
+  try {
+    tmp = await io.makeTempDir();
+  } catch (err) {
+    return {
+      error: `temp dir creation failed (${
+        err instanceof Error ? err.message : String(err)
+      })`,
+    };
+  }
   try {
     const acq = await io.git.acquireTree(url, sha, tmp);
     if (acq.error !== undefined) {
@@ -87,8 +117,11 @@ async function acquireAndCompile(
   }
 }
 
-/** Write `manifest.json` + `compiled.json` for a snapshot under `dir`. */
-async function writeSnapshotCache(
+/** Write `manifest.json` + `compiled.json` for a snapshot under `dir`. The
+ * clean `id` (not `dir`) is threaded through so a cache-write-failure
+ * warning names the upstream, not the raw cache path. */
+function writeSnapshotCache(
+  id: string,
   dir: string,
   snap: CompiledSnapshot,
   io: UpstreamDepsIO,
@@ -100,13 +133,68 @@ async function writeSnapshotCache(
     ],
     [join(dir, "compiled.json"), snap.compiledBytes],
   ];
-  for (const [path, bytes] of writes) {
-    const res = await io.writeFile(path, bytes);
-    if (res.error !== undefined) {
-      return l213(dir, `cache write of '${path}' failed (${res.error})`);
-    }
+  return writeCacheFiles(writes, "dependency", id, io.writeFile);
+}
+
+/**
+ * RESTORE — the pin exists but its cache is missing or hash-broken. Re-acquire
+ * the *pinned* sha (intent is NOT re-resolved) purely to repopulate the cache;
+ * the pin never moves. Returns a warning on any failure (unreachable, markspec
+ * version skew, or cache-write error) and `undefined` on a clean repopulate.
+ * In every case the caller keeps the existing row.
+ */
+async function restore(
+  id: string,
+  existing: UpstreamDependency,
+  dir: string,
+  io: UpstreamDepsIO,
+): Promise<Diagnostic | undefined> {
+  const snap = await acquireAndCompile(existing.url, existing.sha, io);
+  if ("error" in snap) return l213(id, `restore failed: ${snap.error}`);
+  if (snap.snapshot !== existing.snapshot) {
+    // Same sha but a different compiled hash → markspec wire-format skew
+    // (the source is byte-identical by git's guarantee). Keep the pin, do
+    // not clobber the cache; tell the user to re-pin explicitly.
+    return l213(
+      id,
+      `restore recompiled to a different snapshot (markspec version skew?) — run 'markspec lock --update=${id}' to re-pin`,
+    );
   }
-  return undefined;
+  return await writeSnapshotCache(id, dir, snap, io);
+}
+
+/**
+ * FIRST-LOCK or UPDATE — resolve the declared intent to a sha, acquire,
+ * compile, and write the cache. Returns the new pinned row, or a warning
+ * (ls-remote / intent / acquire / cache-write failure). The caller decides
+ * whether to fall back to a prior `existing` row.
+ */
+async function firstLockOrUpdate(
+  ref: ProjectRef,
+  id: string,
+  dir: string,
+  intent: string,
+  io: UpstreamDepsIO,
+  lockedAt: string,
+): Promise<UpstreamDependency | Diagnostic> {
+  const refs = await io.git.lsRemote(ref.url);
+  if ("error" in refs) return l213(id, `ls-remote failed (${refs.error})`);
+  const ri = resolveIntent(intent, refs);
+  if ("error" in ri) return l213(id, ri.error);
+  const snap = await acquireAndCompile(ref.url, ri.sha, io);
+  if ("error" in snap) return l213(id, snap.error);
+  const writeErr = await writeSnapshotCache(id, dir, snap, io);
+  if (writeErr) return writeErr;
+  return {
+    kind: "dependency",
+    id,
+    url: ref.url,
+    intent,
+    resolved: ri.resolved,
+    sha: ri.sha,
+    snapshot: snap.snapshot,
+    lockedAt,
+  };
 }
 
 export async function resolveProjectDependencies(
@@ -126,6 +214,12 @@ export async function resolveProjectDependencies(
       ));
       continue;
     }
+    // Cross-kind collision: a `references:` entry already owns this id.
+    // Skip the dependency (warn-and-write) — it must not clobber the cache.
+    if (opts.reservedIds?.has(id)) {
+      diagnostics.push(l216(id));
+      continue;
+    }
     if (seen.has(id)) {
       diagnostics.push(
         l213(id, "duplicate upstream id — set distinct 'name:'"),
@@ -143,70 +237,28 @@ export async function resolveProjectDependencies(
         dependencies.push(existing); // idempotent — no git
         continue;
       }
-      // Restore: re-acquire the *pinned* sha (intent is NOT re-resolved).
-      const snap = await acquireAndCompile(existing.url, existing.sha, opts.io);
-      if ("error" in snap) {
-        diagnostics.push(l213(id, `restore failed: ${snap.error}`));
-        dependencies.push(existing);
-        continue;
-      }
-      if (snap.snapshot !== existing.snapshot) {
-        // Same sha but a different compiled hash → markspec wire-format skew
-        // (the source is byte-identical by git's guarantee). Keep the pin,
-        // do not clobber the cache; tell the user to re-pin explicitly.
-        diagnostics.push(l213(
-          id,
-          `restore recompiled to a different snapshot (markspec version skew?) — run 'markspec lock --update=${id}' to re-pin`,
-        ));
-        dependencies.push(existing);
-        continue;
-      }
-      const writeErr = await writeSnapshotCache(dir, snap, opts.io);
-      if (writeErr) {
-        diagnostics.push(writeErr);
-        dependencies.push(existing);
-        continue;
-      }
-      dependencies.push(existing);
+      const restoreDiag = await restore(id, existing, dir, opts.io);
+      if (restoreDiag) diagnostics.push(restoreDiag);
+      dependencies.push(existing); // the pin never moves on restore
       continue;
     }
 
-    // FIRST-LOCK or UPDATE — resolve the declared intent → sha.
+    // FIRST-LOCK or UPDATE.
     const intent = ref.version ?? "auto";
-    const refs = await opts.io.git.lsRemote(ref.url);
-    if ("error" in refs) {
-      diagnostics.push(l213(id, `ls-remote failed (${refs.error})`));
-      if (existing !== undefined) dependencies.push(existing);
-      continue;
-    }
-    const ri = resolveIntent(intent, refs);
-    if ("error" in ri) {
-      diagnostics.push(l213(id, ri.error));
-      if (existing !== undefined) dependencies.push(existing);
-      continue;
-    }
-    const snap = await acquireAndCompile(ref.url, ri.sha, opts.io);
-    if ("error" in snap) {
-      diagnostics.push(l213(id, snap.error));
-      if (existing !== undefined) dependencies.push(existing);
-      continue;
-    }
-    const writeErr = await writeSnapshotCache(dir, snap, opts.io);
-    if (writeErr) {
-      diagnostics.push(writeErr);
-      if (existing !== undefined) dependencies.push(existing);
-      continue;
-    }
-    dependencies.push({
-      kind: "dependency",
+    const outcome = await firstLockOrUpdate(
+      ref,
       id,
-      url: ref.url,
+      dir,
       intent,
-      resolved: ri.resolved,
-      sha: ri.sha,
-      snapshot: snap.snapshot,
-      lockedAt: opts.lockedAt,
-    });
+      opts.io,
+      opts.lockedAt,
+    );
+    if ("code" in outcome) {
+      diagnostics.push(outcome);
+      if (existing !== undefined) dependencies.push(existing);
+    } else {
+      dependencies.push(outcome);
+    }
   }
 
   return { dependencies, diagnostics };

--- a/packages/markspec/core/lock/upstream_deps_test.ts
+++ b/packages/markspec/core/lock/upstream_deps_test.ts
@@ -148,6 +148,43 @@ Deno.test("warn-and-write: ls-remote failure is a warning, others still resolve"
   assertEquals(r.diagnostics[0].severity, "warning");
 });
 
+Deno.test("cross-kind collision: reserved reference id → MSL-L216, dependency skipped, no cache write", async () => {
+  const { io, fs, acquired } = makeIO();
+  const r = await resolveProjectDependencies({
+    dependencies: [{ url: "https://example.test/dep.git" }], // derives id "dep"
+    existing: [],
+    cacheRoot: "/cache",
+    update: false,
+    io,
+    lockedAt: "2026-07-04T00:00:00Z",
+    reservedIds: new Set(["dep"]),
+  });
+  assertEquals(r.dependencies.length, 0); // dependency skipped
+  assertEquals(r.diagnostics.length, 1);
+  assertEquals(r.diagnostics[0].code, "MSL-L216");
+  assertEquals(r.diagnostics[0].severity, "warning");
+  assertEquals(acquired, []); // never touched the network
+  // Critically: the reference snapshot's cache was NOT clobbered.
+  assertEquals(fs.has("/cache/dep/manifest.json"), false);
+  assertEquals(fs.has("/cache/dep/compiled.json"), false);
+});
+
+Deno.test("cross-kind: a non-colliding reserved id set does not block resolution", async () => {
+  const { io } = makeIO();
+  const r = await resolveProjectDependencies({
+    dependencies: [{ url: "https://example.test/dep.git" }], // derives id "dep"
+    existing: [],
+    cacheRoot: "/cache",
+    update: false,
+    io,
+    lockedAt: "2026-07-04T00:00:00Z",
+    reservedIds: new Set(["other"]),
+  });
+  assertEquals(r.diagnostics, []);
+  assertEquals(r.dependencies.length, 1);
+  assertEquals(r.dependencies[0].id, "dep");
+});
+
 Deno.test("update: re-resolves and moves the pin", async () => {
   const { io, acquired } = makeIO();
   const existing = {

--- a/packages/markspec/core/lock/upstream_refs.ts
+++ b/packages/markspec/core/lock/upstream_refs.ts
@@ -17,6 +17,7 @@ import type { Diagnostic, ProjectRef } from "../model/mod.ts";
 import type { UpstreamRegistry } from "./model.ts";
 import type { FetchUrl, ReadFile } from "./resolve.ts";
 import { sha256Bytes } from "./hash.ts";
+import { upstreamNotLockable, writeCacheFiles } from "./upstream_common.ts";
 import { checkSnapshotSchema } from "../compiler/deserialize.ts";
 import { isUnsafeRelPath } from "../util/paths.ts";
 
@@ -95,12 +96,7 @@ interface FetchedSnapshot {
 }
 
 function l213(id: string, detail: string): Diagnostic {
-  return {
-    code: "MSL-L213",
-    severity: "warning",
-    message: `upstream reference '${id}' could not be locked: ${detail}`,
-    location: undefined,
-  };
+  return upstreamNotLockable("reference", id, detail);
 }
 
 async function fetchSnapshot(
@@ -155,7 +151,7 @@ async function fetchSnapshot(
   };
 }
 
-async function writeCache(
+function writeCache(
   id: string,
   dir: string,
   fetched: FetchedSnapshot,
@@ -167,13 +163,7 @@ async function writeCache(
       [join(dir, rel), bytes] as [string, Uint8Array]
     ),
   ];
-  for (const [path, bytes] of writes) {
-    const result = await io.writeFile(path, bytes);
-    if (result.error !== undefined) {
-      return l213(id, `cache write of '${path}' failed (${result.error})`);
-    }
-  }
-  return undefined;
+  return writeCacheFiles(writes, "reference", id, io.writeFile);
 }
 
 /**

--- a/tests/e2e/federated_dependency_test.ts
+++ b/tests/e2e/federated_dependency_test.ts
@@ -22,7 +22,7 @@
  */
 
 import { assertEquals, assertMatch, assertStringIncludes } from "@std/assert";
-import { join } from "@std/path";
+import { join, toFileUrl } from "@std/path";
 import { markspecInDir } from "./helpers.ts";
 
 /**
@@ -46,9 +46,11 @@ function run(
  * The `git()` helper strips these so a fixture `git init`/`commit` in a temp
  * dir isn't redirected to the ambient repo when the suite itself runs inside
  * a git hook (e.g. the pre-push hook that runs the test suite exports
- * GIT_DIR/GIT_WORK_TREE). Mirrors the same strip the CLI's own `runGit`
- * applies in `packages/markspec/cli/commands/lock.ts` (blackbox e2e can't
- * import it).
+ * GIT_DIR/GIT_WORK_TREE). This is the repo-discovery subset of the wider
+ * scrub the CLI's own `runGit` applies in
+ * `packages/markspec/cli/commands/lock.ts` — enough for a fixture `git init`
+ * (which never touches a config-injection var), and a blackbox e2e can't
+ * import the CLI's list anyway.
  */
 const GIT_DISCOVERY_ENV_VARS = [
   "GIT_DIR",
@@ -330,6 +332,93 @@ Deno.test("branch pin trips MSL-L215 under --strict", async () => {
     const strict = await run(["check", "--strict"], proj);
     assertStringIncludes(strict.stderr, "MSL-L215");
     assertEquals(strict.code, 1);
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
+});
+
+/** A tiny publishable reference source — one unclassified entry, compiled
+ * via `compile --output` into a snapshot a `references:` URL can point at
+ * (mirrors `federated_lock_test.ts`'s project A, no profile needed). */
+const REF_REQS = [
+  "# Ref",
+  "",
+  "- [STK_0500] A published requirement",
+  "",
+  "  Body text.",
+  "",
+  "      Id: 01HGW2Q8MNP3RSTVWXYZABCDEF",
+  "",
+].join("\n");
+
+Deno.test("cross-kind id collision: a references + dependencies pair sharing an id → MSL-L216, dependency dropped", async () => {
+  const root = await Deno.makeTempDir();
+  try {
+    const { bare } = await makeUpstream(root);
+
+    // Publish a reference snapshot from a tiny source project.
+    const refsrc = join(root, "refsrc");
+    await Deno.mkdir(refsrc, { recursive: true });
+    await Deno.writeTextFile(
+      join(refsrc, "project.yaml"),
+      "name: refsrc\nversion: 0.1.0\n",
+    );
+    await Deno.writeTextFile(join(refsrc, "reqs.md"), REF_REQS);
+    const compiled = await run(
+      ["compile", "--output", "api", "reqs.md"],
+      refsrc,
+    );
+    assertEquals(compiled.code, 0, `compile stderr: ${compiled.stderr}`);
+    const fileUrl = toFileUrl(join(refsrc, "api")).href;
+
+    // The consumer declares BOTH a reference and a dependency named `shared`
+    // — they derive the same upstream id and would otherwise fight over the
+    // same `.markspec/cache/upstreams/shared` namespace.
+    const proj = join(root, "consumer");
+    await Deno.mkdir(proj, { recursive: true });
+    await Deno.writeTextFile(
+      join(proj, "project.yaml"),
+      "name: consumer\nversion: 0.1.0\n" +
+        `references:\n  - url: ${JSON.stringify(fileUrl)}\n    name: shared\n` +
+        `dependencies:\n  - url: ${bare}\n    name: shared\n`,
+    );
+
+    const lock = await run(["lock"], proj);
+    // Warn-and-write: the lockfile is written, the collision is a warning,
+    // and the presence of a warning makes lock exit 2.
+    assertEquals(lock.code, 2, `lock stderr: ${lock.stderr}`);
+    assertStringIncludes(lock.stderr, "MSL-L216");
+    const lockText = await Deno.readTextFile(join(proj, "markspec.lock"));
+    // The reference wins the shared cache namespace; the dependency row is
+    // dropped rather than clobbering it.
+    assertStringIncludes(lockText, "[[upstream.registry]]");
+    assertEquals(lockText.includes("[[upstream.dependency]]"), false);
+  } finally {
+    await Deno.remove(root, { recursive: true });
+  }
+});
+
+Deno.test("unreachable dependency: warn-and-write exits 2 and still writes the lockfile", async () => {
+  const root = await Deno.makeTempDir();
+  try {
+    const proj = join(root, "consumer");
+    await Deno.mkdir(proj, { recursive: true });
+    // A dependency URL pointing at a path that is not a git repository —
+    // ls-remote fails, so the dependency drops with an MSL-L213 warning.
+    await Deno.writeTextFile(
+      join(proj, "project.yaml"),
+      "name: consumer\nversion: 0.1.0\n" +
+        `dependencies:\n  - url: ${
+          join(root, "does-not-exist.git")
+        }\n    name: icd\n`,
+    );
+
+    const lock = await run(["lock"], proj);
+    assertEquals(lock.code, 2, `lock stderr: ${lock.stderr}`);
+    assertStringIncludes(lock.stderr, "MSL-L213");
+    // warn-and-write: the lockfile is still produced, minus the failed pin.
+    const lockText = await Deno.readTextFile(join(proj, "markspec.lock"));
+    assertEquals(lockText.includes("[[upstream.dependency]]"), false);
   } finally {
     await Deno.remove(root, { recursive: true });
   }

--- a/tests/e2e/federated_lock_test.ts
+++ b/tests/e2e/federated_lock_test.ts
@@ -217,11 +217,13 @@ Deno.test(
 
           const r = await markspecInDir(dirB, ["lock"], LOCK_PERMISSIONS);
           // Warn-and-write (decision 1): a restore mismatch is a warning,
-          // not a command-level abort. `lock` still exits 0, still emits
-          // the MSL-L214 warning on stderr, and still writes markspec.lock
-          // — keeping the existing (pre-mismatch) pin rather than adopting
-          // the moved snapshot.
-          assertEquals(r.code, 0, r.stdout + r.stderr);
+          // not a command-level abort. `lock` still writes markspec.lock —
+          // keeping the existing (pre-mismatch) pin rather than adopting the
+          // moved snapshot — and emits the MSL-L214 warning on stderr. Per
+          // the clig.dev exit contract ("2 for warnings only"), an upstream
+          // that could not be cleanly restored makes `lock` exit 2 so CI
+          // sees the stale pin, while the lockfile is still produced.
+          assertEquals(r.code, 2, r.stdout + r.stderr);
           assertMatch(r.stderr, /MSL-L214/);
           assertMatch(r.stderr, /producta/);
           assertMatch(r.stderr, /restore mismatch/);


### PR DESCRIPTION
Closes #785.

Resolves the non-blocking follow-ups from the `/review` of #784 (federated
upstream slice 3, the git dependency fetcher). The two security criticals were
fixed before #784 merged; this PR clears the remaining Important + Minor items,
defers the two genuinely-deferred ones, and updates the catalogue + CLI docs.

## Important

- **Cross-kind id collision (`MSL-L216`).** A `dependencies:` entry deriving an
  id already claimed by a `references:` entry no longer silently clobbers the
  shared `.markspec/cache/upstreams/<id>` cache namespace or double-maps the
  corpus. Declared reference ids flow into `resolveProjectDependencies` via a
  `reservedIds` set; the colliding dependency is skipped with a warn-and-write
  `MSL-L216` warning.

## Behavior

- **`markspec lock` exit code.** Now exits **2** (still writing the lockfile)
  when an upstream *acquisition* warning fires (`MSL-L213`/`L214`/`L216`), per
  the repo's clig.dev "2 for warnings only" rule, so a bare `markspec lock` in
  CI surfaces a dropped or stale pin. Benign resolution advisories (`MSL-L102`
  identity-hash for an unresolvable bundled profile) deliberately do **not**
  gate the exit code. `lock --format json` now includes the reference +
  dependency warnings, not just the resolved-set diagnostics.
- **Uppercase sha.** `git_intent` accepts a mixed-case 40-hex `version:` sha
  and normalizes the pin to lowercase — determinism: no lockfile differs on sha
  case alone.

## Robustness / cleanup

- Hermetic git env extended from 7 repo-discovery vars to also scrub
  object-store (`GIT_ALTERNATE_OBJECT_DIRECTORIES`, `GIT_CEILING_DIRECTORIES`)
  and config-injection (`GIT_CONFIG*`) redirects; the curated env is computed
  once per process rather than per git call.
- `acquireTree` fetches by URL directly — drops the redundant `remote add` and
  the pointless `--filter=blob:none`. `compileAcquiredTree` reads the whole
  tree, so `checkout` refetched every filtered blob anyway; the filter saved
  nothing, and its promisor remote was the only reason `remote add` existed
  (keeping `blob:none` while dropping `remote add`, as the issue literally
  suggested, would have broken checkout).
- A `makeTempDir` failure is now warn-and-write rather than aborting the lock.
- Shared `l213` / cache-writer extracted to `upstream_common.ts` (fixes the
  `dir`→`id` path leak in the dependency cache-write warning); collapsed the
  repeated push-existing/continue branches via `restore()`/`firstLockOrUpdate()`
  helpers; memoized the config/profile reads in `compileAcquiredTree` (kills the
  double `.markspec.yaml` read per acquired dependency).

## Deferred (kept on #785)

- The discriminated-union refactor of the `resolved` pin field — the field is
  shared across registry/profile/dependency rows (plain version strings vs
  `tag:`/`branch:`/`sha:`-prefixed), so converting one side diverges the wire
  format for a one-line `startsWith("tag:")`. Low value for the blast radius.
- Forge-tarball acquisition (design §4.3) — needs an authed host, can't be
  exercised by the offline e2e.

## Tests

- **Unit:** cross-kind collision (`MSL-L216`, dependency skipped, cache not
  clobbered), non-colliding `reservedIds` no-op, uppercase-sha lowercased.
- **E2e:** cross-kind collision (registry kept, dependency dropped, exit 2),
  unreachable-dependency exit-2 warn-and-write; the restore-mismatch scenario
  updated to the new exit-2 contract.
- `just build` + both format gates green locally; pre-push `just check` green
  (3862 passed, 0 failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
