### PR TITLE
docs(docs): fix review findings from #792's 8-angle audit (#746)

### DIFF
--- a/docs/architecture/adr-012-diagnostic-code-scheme.md
+++ b/docs/architecture/adr-012-diagnostic-code-scheme.md
@@ -171,6 +171,18 @@ Individual codes shipped to `main`:
 | MSL-L211 | error    | Profile resolved-version drift                          |
 | MSL-L212 | error    | Canonical edge hash drift                               |
 
+[ADR-031](./adr-031-federated-upstream-resolution.md) (federated upstream
+resolution) extends this same `MSL-L###` family with the `markspec lock`
+acquisition/collision diagnostics for `dependencies:`/`references:` upstreams —
+recorded here on the same footing, not a new family:
+
+| Code     | Severity | Concern                                                                               |
+| -------- | -------- | ------------------------------------------------------------------------------------- |
+| MSL-L213 | warning  | Declared upstream could not be locked (unified across `dependencies:`/`references:`)  |
+| MSL-L214 | warning  | Restore-flow snapshot hash mismatch (published site or recompile moved)               |
+| MSL-L215 | warning  | `dependencies:` pin resolved to a branch/bare sha, not a tag (error under `--strict`) |
+| MSL-L216 | warning  | An id claimed by both a `references:` and a `dependencies:` entry                     |
+
 ### MSL-S (External sync, ADR-022)
 
 | Sub-range | Concern                           |

--- a/docs/architecture/adr-022-lockfile-and-external-sync.md
+++ b/docs/architecture/adr-022-lockfile-and-external-sync.md
@@ -150,3 +150,16 @@ Slice B is foundation-only. Downstream consumers:
 
 The SSOT comparison function is `isBelowFloor(actual, floor)` exported from
 `core/lock/`.
+
+## Addendum (2026-07-05): `[[upstream.dependency]]` row + widened `[[upstream.registry]]`
+
+[ADR-031](./adr-031-federated-upstream-resolution.md) (federated upstream
+resolution) extends `markspec.lock`'s upstream tables with a new
+`[[upstream.dependency]]` row kind (pinning a `project.yaml` `dependencies:` git
+repository — `id`, `url`, `intent`, `resolved`, `sha`, `snapshot`, `locked-at`)
+and widens the existing `[[upstream.registry]]` row to also cover `references:`
+entries, alongside its pre-existing identity-only Reference use. The full row
+shapes, resolution flow, and rationale live in ADR-031; this addendum only
+records that the lockfile schema itself changed, so a reader of this ADR knows
+to look there for the current upstream-table shape rather than assuming the
+registry-only model this ADR originally described is still complete.

--- a/docs/architecture/adr-031-federated-upstream-resolution.md
+++ b/docs/architecture/adr-031-federated-upstream-resolution.md
@@ -113,7 +113,7 @@ MCP server via the shared compile cache. Read-only is structural, not a runtime
 flag — upstream entries have no local `.md` file, so `fmt`/`insert` cannot touch
 them and rename is refused by the existing `origin` guard. The one new rule:
 **go-to-definition is a no-op** for an upstream entry
-(`resolveDefinitionLocation` returns `null`) — its `location.file` is an
+(`resolveNavigableLocation` returns `null`) — its `location.file` is an
 upstream-repo path that does not exist locally. Hover, `show`, `context`, and
 completion work from the hydrated entry.
 
@@ -297,7 +297,10 @@ are byte-reproducible across machines from `(tree, markspec version)`.
   upstreams are declared, naming the searched set); `MSL-L213` (upstream could
   not be locked, unified across both fields); `MSL-L214` (restore-flow snapshot
   hash mismatch — the published site or recompile moved); `MSL-L215` (unreleased
-  pin advisory, error under `--strict`); plus the `MSL-L212` cache-drift case.
+  pin advisory, error under `--strict`); `MSL-L216` (an id claimed by both a
+  `references:` and a `dependencies:` entry — the dependency is skipped, the
+  reference snapshot owns the shared cache); plus the `MSL-L212` cache-drift
+  case.
 - `check`, `compile`, `show`, `context`, `dependents`, `report`, the LSP, and
   the MCP server all see upstream entries with their origin badge; `report`
   coverage counts `dependencies:` and ignores `references:`; LSP completion
@@ -378,11 +381,11 @@ are byte-reproducible across machines from `(tree, markspec version)`.
   `core/lock/model.ts` + `serializer.ts` (`UpstreamDependency`, extended
   `UpstreamRegistry`), `core/lock/upstream_refs.ts` (`resolveProjectReferences`,
   `MSL-L213`/`L214`), `core/lock/upstream_deps.ts`
-  (`resolveProjectDependencies`), `core/lock/git_intent.ts` (`resolveIntent`),
-  `core/lock/acquire_compile.ts` (`compileAcquiredTree`),
+  (`resolveProjectDependencies`, `MSL-L216`), `core/lock/git_intent.ts`
+  (`resolveIntent`), `core/lock/acquire_compile.ts` (`compileAcquiredTree`),
   `core/lock/pin_assurance.ts` (`MSL-L215`), `core/validator/traceability.ts`
   (`MSL-T014`), `core/compiler/manifest.ts` (`ManifestJson.project.version`,
   `federation`), `core/compiler/deserialize.ts` (`checkSnapshotSchema`,
   `deserializeEntry`), `cli/commands/lock.ts` (`denoGitIO` shallow
   fetch-by-sha), `lsp/server.ts` (`seedUpstreamCorpus`), `lsp/definition.ts`
-  (`resolveDefinitionLocation`).
+  (`resolveNavigableLocation`).

--- a/docs/guide/recipes/multi-repo-dependencies.md
+++ b/docs/guide/recipes/multi-repo-dependencies.md
@@ -65,7 +65,7 @@ url = "git@github.com:acme/aeb-icd.git"
 intent = "v2.1.0"
 resolved = "tag:v2.1.0"
 sha = "9f3c1a2e5b7d0c4f6a81b2d3e4f5069718293a4b"
-snapshot = "b1946ac92492d2347c6235b4d2611184..."
+snapshot = "sha256:b1946ac92492d2347c6235b4d2611184..."
 locked-at = "2026-07-05T12:00:00Z"
 ```
 
@@ -146,7 +146,10 @@ model different relationships and are treated differently by coverage:
   orphan or an unsatisfied gap, because a citation isn't something your own
   project is expected to cover.
 
-See [The projectRef shape](../cli.md#the-projectref-shape) for the full field
+See
+[Upstream entries resolve in the graph](../cli.md#upstream-entries-resolve-in-the-graph)
+in the CLI guide for the authoritative coverage-treatment rule, and
+[The projectRef shape](../cli.md#the-projectref-shape) for the full field
 reference shared by both lists.
 
 ## Notes
@@ -158,7 +161,9 @@ reference shared by both lists.
   `compile`, the LSP, and the MCP server read the pinned cache and never fetch.
 - **Upstream entries are read-only and validation-exempt.** No structural checks
   or prose lint run against them — that already happened in their own repo — but
-  they remain full resolution targets for cross-repo trace edges.
+  they remain full resolution targets for cross-repo trace edges. See
+  [Upstream entries resolve in the graph](../cli.md#upstream-entries-resolve-in-the-graph)
+  for the full rule.
 - **Aggregate a whole program from one root.** A root or program repo that
   depends on every member repo resolves the entire program's cross-repo graph in
   one compile — see the

--- a/docs/spec/language/ast.md
+++ b/docs/spec/language/ast.md
@@ -400,7 +400,7 @@ interface MsDirectiveEntry {
 ```markdown
 <!--
 markspec:deck
-markspec:references https://safety.company.io/registry
+markspec:disable MSL-R011
 -->
 ```
 
@@ -410,7 +410,7 @@ markspec:references https://safety.company.io/registry
 msDirective
   directives:
     { name: "deck", payload: "" }
-    { name: "references", payload: "https://safety.company.io/registry" }
+    { name: "disable", payload: "MSL-R011" }
 ```
 
 Range directives (`markspec:columns`, `markspec:disable`, `markspec:ignore`)

--- a/docs/spec/language/language.md
+++ b/docs/spec/language/language.md
@@ -1302,15 +1302,15 @@ build time: resolved to links.
 
 ### 5.2 Namespaces
 
-| Namespace | References                        | ID source         |
-| --------- | --------------------------------- | ----------------- |
-| `spec`    | Spec entries (any TYPE)           | Display ID        |
-| `test`    | Test entries                      | Display ID        |
-| `element` | Element entries                   | Display ID        |
-| `ref`     | Reference entries, registry chain | Slug              |
-| `fig`     | Figures                           | Slug from caption |
-| `tbl`     | Tables                            | Slug from caption |
-| `h`       | Headings                          | GFM anchor        |
+| Namespace | References                          | ID source         |
+| --------- | ----------------------------------- | ----------------- |
+| `spec`    | Spec entries (any TYPE)             | Display ID        |
+| `test`    | Test entries                        | Display ID        |
+| `element` | Element entries                     | Display ID        |
+| `ref`     | Reference entries, resolution chain | Slug              |
+| `fig`     | Figures                             | Slug from caption |
+| `tbl`     | Tables                              | Slug from caption |
+| `h`       | Headings                            | GFM anchor        |
 
 Slugs use the GFM algorithm: lowercase, spaces to hyphens, punctuation stripped.
 
@@ -1523,7 +1523,7 @@ Summary rules (MSL-S\*) activate only on `summary` documents.
 | `MSL-R003` | error    | Exactly one `Id:` attribute per entry.                                                                                                                                                                                                                                                              |
 | `MSL-R004` | error    | `Id:` value well-formed: bare ULID (`^[0-9A-HJKMNP-TV-Z]{26}$`) for Authored entries; scheme-qualified URI (RFC 3986) for Reference entries.                                                                                                                                                        |
 | `MSL-R005` | error    | ULID unique across repository.                                                                                                                                                                                                                                                                      |
-| `MSL-R006` | error    | Display ID unique within project and registry chain.                                                                                                                                                                                                                                                |
+| `MSL-R006` | error    | Display ID unique within project and resolution chain.                                                                                                                                                                                                                                              |
 | `MSL-R007` | warning  | When a profile declares a `display-id-pattern:` for the entry's inferred type, the display ID matches it.                                                                                                                                                                                           |
 | `MSL-R008` | error    | Slug-shaped display ID (no scheme, not a ULID) on a Reference entry must match the slug regex.                                                                                                                                                                                                      |
 | `MSL-R009` | warning  | Sequence number > 0 in patterned display IDs.                                                                                                                                                                                                                                                       |


### PR DESCRIPTION
## Summary

PR #792 (federated-upstream slice 6 garden — ADR-031, spec/guide reconciliation)
merged before the 8-angle review it triggered had finished landing its fixes —
this branch's second commit was pushed after #792 was already merged, so it
never made it into `main`. This PR carries just that fixup commit forward.

All 6 findings were verified against the actually-shipped code before fixing:

- ADR-031 cited a fabricated symbol, `resolveDefinitionLocation` — the shipped
  function is `resolveNavigableLocation`; both mentions corrected.
- `language.md` still used the retired "registry chain" term in two places
  (the `{{ref.ID}}` namespace table, MSL-R006) — reworded to "resolution
  chain" to match the same PR's own new §6.5 terminology.
- `ast.md`'s directive-parsing example still showed the retired
  `markspec:references <url>` payload — swapped for `markspec:disable
  MSL-R011`, a directive that still takes one.
- The new recipe and ADR-031 disagreed on the `snapshot` field's format
  (bare hex vs. `sha256:`-prefixed) — aligned on the prefixed form, matching
  the codebase's own test fixtures.
- The recipe restated two `cli.md` rules (coverage treatment, validation
  exemption) near-verbatim with no cross-link — added links to the specific
  `cli.md` section so future changes don't silently diverge.
- ADR-031 omitted `MSL-L216` from its Consequences list and didn't extend
  ADR-012's diagnostic-code catalogue or ADR-022's lockfile-addendum
  pattern, both established precedents for a new/extended diagnostic family
  — added the missing catalogue entries and an ADR-022 addendum.

Full review writeup: https://github.com/driftsys/markspec/pull/792#issuecomment-4885278107

## Testing

- `just check` green locally, twice (pre-commit and pre-push hooks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
