### PR TITLE
fix(core): uxil parser emits one specific diagnostic per malformed input

### DIFF
--- a/packages/markspec/core/uxil/grammar.ts
+++ b/packages/markspec/core/uxil/grammar.ts
@@ -5,6 +5,16 @@
  * ({@linkcode parseUxRef}) plus the three declaration-form parsers (added in
  * later tasks). Each returns a best-effort AST node and a list of
  * source-local {@linkcode UxilDiagnostic}s. Parse-only — no resolution.
+ *
+ * Diagnostics policy (#780): a single malformed region reports one specific
+ * code. After a parse error fires, leftover-token noise from the same
+ * region is suppressed (see {@linkcode expectEof}) rather than re-flagged
+ * as a redundant or contradictory second code, and a reserved character
+ * stops structural parsing outright (the lexer dropped the char, so the
+ * token stream is corrupt). Orthogonal region checks — the nav tail's
+ * reserved-char scan, the missing event dictionary (UXIL-006) — still
+ * co-report. Editors reparse per keystroke, so within a region errors
+ * surface progressively.
  */
 import type {
   ChildSurfaceDecl,
@@ -39,17 +49,30 @@ class Cursor {
   }
 }
 
-/** Push UXIL-002 for a reserved `?`/`#` character anywhere in `source`. */
-function scanReservedChars(source: string, diags: UxilDiagnostic[]): void {
+/**
+ * Push UXIL-002 for a reserved `?`/`#` character anywhere in `source`.
+ * Returns whether one was found — callers stop structural parsing on a hit,
+ * because the lexer silently drops the char and every diagnostic derived
+ * from the mangled token stream would be noise (#780). `baseColumn` shifts
+ * the reported column for callers scanning a slice of a larger span (the
+ * peeled `-> nav` tail), keeping positions span-relative.
+ */
+function scanReservedChars(
+  source: string,
+  diags: UxilDiagnostic[],
+  baseColumn = 0,
+): boolean {
   const idx = source.search(/[?#]/);
   if (idx >= 0) {
     diags.push(
       uxilDiagnostic("UXIL-002", { char: source[idx] }, {
         line: 1,
-        column: idx + 1,
+        column: baseColumn + idx + 1,
       }),
     );
+    return true;
   }
+  return false;
 }
 
 /** Consume `IDENT`, or push UXIL-001 describing what was expected. */
@@ -134,7 +157,13 @@ function parseKey(c: Cursor, diags: UxilDiagnostic[]): UxKey | undefined {
   return undefined;
 }
 
-/** Consume a leading `ux:` scheme if present. Returns whether it was consumed. */
+/**
+ * Consume a leading `ux:` scheme if present. Returns whether it was consumed.
+ * Known limitation (#780 case 6, S7 design doc): a surface literally named
+ * `ux` followed by `:` is greedily read as the scheme, so
+ * `parseRootDecl("ux : screen")` misparses. Revisit only if a real
+ * `ux`-named surface is ever needed.
+ */
 function consumeScheme(c: Cursor): boolean {
   if (
     c.peek().kind === "IDENT" && c.peek().value === "ux" &&
@@ -147,8 +176,14 @@ function consumeScheme(c: Cursor): boolean {
   return false;
 }
 
-/** Push UXIL-001 for any leftover tokens before EOF. */
+/**
+ * Push UXIL-001 for any leftover tokens before EOF. No-ops when a prior
+ * diagnostic exists — a specific parse error already explains the malformed
+ * tail, and re-flagging the leftovers produced the redundant second code
+ * (#780). One clear error per span; the editor reparses on the next edit.
+ */
 function expectEof(c: Cursor, diags: UxilDiagnostic[]): void {
+  if (diags.length > 0) return;
   if (!c.atEof()) {
     const t = c.peek();
     diags.push(
@@ -178,13 +213,13 @@ function parseStateSet(c: Cursor, diags: UxilDiagnostic[]): string[] {
  * Parse a `ux:` reference (citation / nav target). The scheme is optional;
  * `media.home/play` and `ux:media.home/play` yield identical AST except for
  * `hasScheme`. Returns `ref` undefined only for a wholly malformed input
- * (reserved authority, no surface).
+ * (reserved char, reserved authority, no surface).
  */
 export function parseUxRef(
   source: string,
 ): { ref?: UxRef; diagnostics: UxilDiagnostic[] } {
   const diagnostics: UxilDiagnostic[] = [];
-  scanReservedChars(source, diagnostics);
+  if (scanReservedChars(source, diagnostics)) return { diagnostics };
   const c = new Cursor(tokenize(source));
   const hasScheme = consumeScheme(c);
 
@@ -248,13 +283,17 @@ export function parseUxRef(
 /**
  * Parse a root declaration: `[ux:]surface : kind [@state, …]`. The `:` here
  * introduces the kind (not a ref key). Returns `decl` undefined only when no
- * surface is present.
+ * surface is present or a reserved char corrupted the source. A missing kind
+ * (no `:`, or a `:` with nothing after it) is UXIL-004 with a best-effort
+ * partial decl (`kind: ""`, surface and states still captured) — S8's
+ * assemble must gate uxRegistry registration on a clean parse, never on the
+ * partial decl alone (#780).
  */
 export function parseRootDecl(
   source: string,
 ): { decl?: RootDecl; diagnostics: UxilDiagnostic[] } {
   const diagnostics: UxilDiagnostic[] = [];
-  scanReservedChars(source, diagnostics);
+  if (scanReservedChars(source, diagnostics)) return { diagnostics };
   const c = new Cursor(tokenize(source));
   consumeScheme(c);
   const surface = parseSurface(c, diagnostics);
@@ -268,12 +307,19 @@ export function parseRootDecl(
     );
     return { diagnostics };
   }
+  // Missing kind — with or without the introducing `:` — is the same defect
+  // (#780 case 5): one UXIL-004, one partial-decl return shape.
+  let kind: string | undefined;
   if (c.peek().kind !== "COLON") {
     diagnostics.push(uxilDiagnostic("UXIL-004", {}, c.peek().position));
-    return { diagnostics };
+  } else {
+    c.advance();
+    if (c.peek().kind === "IDENT") {
+      kind = c.advance().value;
+    } else {
+      diagnostics.push(uxilDiagnostic("UXIL-004", {}, c.peek().position));
+    }
   }
-  c.advance();
-  const kind = expectIdent(c, diagnostics, "kind");
   const states = parseStateSet(c, diagnostics);
   expectEof(c, diagnostics);
   return {
@@ -297,7 +343,7 @@ export function parseChildSurfaceDecl(
   source: string,
 ): { decl?: ChildSurfaceDecl; diagnostics: UxilDiagnostic[] } {
   const diagnostics: UxilDiagnostic[] = [];
-  scanReservedChars(source, diagnostics);
+  if (scanReservedChars(source, diagnostics)) return { diagnostics };
   const c = new Cursor(tokenize(source));
   if (c.peek().kind !== "DOT") {
     diagnostics.push(
@@ -375,8 +421,6 @@ export function parseElementBullet(
     );
     return { diagnostics };
   }
-  scanReservedChars(span, diagnostics);
-
   // Peel off an optional `-> nav` tail before tokenizing the structured part.
   let structPart = span;
   let navSource: string | undefined;
@@ -384,6 +428,25 @@ export function parseElementBullet(
   if (arrow >= 0) {
     structPart = span.slice(0, arrow);
     navSource = span.slice(arrow + 2).trim();
+  }
+
+  // 0-based index of the trimmed nav source within the span — shifts nav
+  // diagnostic columns back to span-relative.
+  const navOffset = navSource ? span.indexOf(navSource, arrow + 2) : 0;
+  // The nav tail is an orthogonal region: every return path must still
+  // surface a reserved char in it, even when the struct part fails first.
+  const scanNavReserved = (): void => {
+    if (navSource) scanReservedChars(navSource, diagnostics, navOffset);
+  };
+
+  // Scan the structured part only — the nav tail is scanned separately
+  // (scanNavReserved / parseUxRef below), so scanning the whole span would
+  // report a single `?`/`#` in the nav target twice (#780 case 2). A hit
+  // poisons the token stream (the lexer drops the char): stop before the
+  // structure checks turn the mangled tokens into contradictory codes.
+  if (scanReservedChars(structPart, diagnostics)) {
+    scanNavReserved();
+    return { diagnostics };
   }
 
   const c = new Cursor(tokenize(structPart));
@@ -395,11 +458,15 @@ export function parseElementBullet(
         c.peek().position,
       ),
     );
+    scanNavReserved();
     return { diagnostics };
   }
   c.advance();
   const element = expectIdent(c, diagnostics, "element name");
-  if (element === undefined) return { diagnostics };
+  if (element === undefined) {
+    scanNavReserved();
+    return { diagnostics };
+  }
 
   const decl: Mut<ElementDecl> = {
     form: "element",
@@ -424,16 +491,31 @@ export function parseElementBullet(
 
   // Verb set: `: verb[, verb…]` (>= 1).
   if (c.peek().kind !== "COLON") {
-    diagnostics.push(uxilDiagnostic("UXIL-005", {}, c.peek().position));
+    if (c.peek().kind === "IDENT") {
+      // A verb is present but the introducing `:` is missing — reporting
+      // "empty verb set" here would be contradictory (#780 case 4).
+      diagnostics.push(
+        uxilDiagnostic(
+          "UXIL-001",
+          { detail: "expected ':' before the verb set" },
+          c.peek().position,
+        ),
+      );
+    } else {
+      diagnostics.push(uxilDiagnostic("UXIL-005", {}, c.peek().position));
+    }
   } else {
     c.advance();
     const verbs: string[] = [];
-    const first = expectIdent(c, diagnostics, "verb");
-    if (first !== undefined) verbs.push(first);
-    while (c.peek().kind === "COMMA") {
-      c.advance();
-      const v = expectIdent(c, diagnostics, "verb");
-      if (v !== undefined) verbs.push(v);
+    // Peek rather than expectIdent for the first verb: a truly empty set
+    // reports only UXIL-005, not a redundant UXIL-001 too (#780 case 1).
+    if (c.peek().kind === "IDENT") {
+      verbs.push(c.advance().value);
+      while (c.peek().kind === "COMMA") {
+        c.advance();
+        const v = expectIdent(c, diagnostics, "verb");
+        if (v !== undefined) verbs.push(v);
+      }
     }
     if (verbs.length === 0) {
       diagnostics.push(uxilDiagnostic("UXIL-005", {}, c.peek().position));
@@ -460,9 +542,15 @@ export function parseElementBullet(
 
   const states = parseStateSet(c, diagnostics);
   if (states.length > 0) decl.states = states;
+  // Order is load-bearing: expectEof suppresses itself once any diagnostic
+  // exists, so it MUST run before the nav and event-dictionary checks below
+  // push theirs — moving it later would let those orthogonal regions hide a
+  // real leftover-token error in the struct part.
   expectEof(c, diagnostics);
 
-  // Nav target (parsed as a ux ref; may be scheme-less / relative).
+  // Nav target (parsed as a ux ref; may be scheme-less / relative). Nav
+  // diagnostics carry positions relative to the sliced nav source — shift
+  // them by navOffset so editor squiggles land on the span's own columns.
   if (navSource !== undefined) {
     if (navSource.length === 0) {
       diagnostics.push(
@@ -474,7 +562,15 @@ export function parseElementBullet(
       );
     } else {
       const nav = parseUxRef(navSource);
-      diagnostics.push(...nav.diagnostics);
+      diagnostics.push(
+        ...nav.diagnostics.map((d) => ({
+          ...d,
+          position: {
+            line: d.position.line,
+            column: d.position.column + navOffset,
+          },
+        })),
+      );
       if (nav.ref) decl.nav = nav.ref;
     }
   }

--- a/packages/markspec/core/uxil/grammar_test.ts
+++ b/packages/markspec/core/uxil/grammar_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertStringIncludes } from "@std/assert";
 import {
   parseChildSurfaceDecl,
   parseElementBullet,
@@ -37,9 +37,33 @@ Deno.test("parseUxRef: reserved authority is UXIL-003", () => {
   assertEquals(diagnostics.map((d) => d.code), ["UXIL-003"]);
 });
 
-Deno.test("parseUxRef: reserved query char is UXIL-002", () => {
+Deno.test("parseUxRef: reserved query char is exactly one UXIL-002", () => {
+  // #780 case 3: the lexer drops the reserved char and orphans the trailing
+  // token — the orphan must not surface as a spurious UXIL-001.
   const { diagnostics } = parseUxRef("media.home?x");
-  assertEquals(diagnostics.some((d) => d.code === "UXIL-002"), true);
+  assertEquals(diagnostics.map((d) => d.code), ["UXIL-002"]);
+});
+
+Deno.test("parseRootDecl: reserved char is exactly one UXIL-002", () => {
+  // #796 review: the reserved-char scan poisons the token stream (the lexer
+  // drops the char), so downstream structure checks (here: missing kind)
+  // must not fire on the mangled tokens.
+  const { diagnostics } = parseRootDecl("media.home?x");
+  assertEquals(diagnostics.map((d) => d.code), ["UXIL-002"]);
+});
+
+Deno.test("parseElementBullet: reserved char in the struct part is exactly one UXIL-002", () => {
+  // #796 review: after the lexer drops '?', the orphaned 'x' must not turn
+  // into a contradictory "expected ':' before the verb set" (a ':' IS there).
+  const { diagnostics } = parseElementBullet("`/play?x : activate` — Press.");
+  assertEquals(diagnostics.map((d) => d.code), ["UXIL-002"]);
+});
+
+Deno.test("parseUxRef: doubled dot is exactly one UXIL-008", () => {
+  // #780 case 3: the specific surface error must not be followed by a
+  // spurious UXIL-001 for the tokens after the bad dot.
+  const { diagnostics } = parseUxRef("media..home");
+  assertEquals(diagnostics.map((d) => d.code), ["UXIL-008"]);
 });
 
 Deno.test("parseRootDecl: surface, kind, state set", () => {
@@ -53,9 +77,32 @@ Deno.test("parseRootDecl: surface, kind, state set", () => {
   assertEquals(decl?.states, ["loading", "error", "ready"]);
 });
 
-Deno.test("parseRootDecl: missing kind is UXIL-004", () => {
-  const { diagnostics } = parseRootDecl("ux:media.home");
+Deno.test("parseRootDecl: missing kind is UXIL-004 with a partial decl", () => {
+  // #780 case 5: a surface is present, so per the parser contract a
+  // best-effort decl (kind empty) is returned alongside the diagnostic.
+  const { decl, diagnostics } = parseRootDecl("ux:media.home");
   assertEquals(diagnostics.map((d) => d.code), ["UXIL-004"]);
+  assertEquals(decl?.surface, ["media", "home"]);
+  assertEquals(decl?.kind, "");
+});
+
+Deno.test("parseRootDecl: dangling colon (no kind) is also UXIL-004 + partial decl", () => {
+  // #780 case 5: this adjacent input previously reported UXIL-001 with a
+  // different return shape than the no-colon form. Both missing-kind cases
+  // must emit the same code and the same partial-decl shape.
+  const { decl, diagnostics } = parseRootDecl("ux:media.home :");
+  assertEquals(diagnostics.map((d) => d.code), ["UXIL-004"]);
+  assertEquals(decl?.surface, ["media", "home"]);
+  assertEquals(decl?.kind, "");
+});
+
+Deno.test("parseRootDecl: missing kind still captures the state set", () => {
+  // Best-effort AST: mid-edit (kind deleted, states intact) the surface and
+  // states survive so editor tooling degrades gracefully.
+  const { decl, diagnostics } = parseRootDecl("ux:media.home : @ ready");
+  assertEquals(diagnostics.map((d) => d.code), ["UXIL-004"]);
+  assertEquals(decl?.kind, "");
+  assertEquals(decl?.states, ["ready"]);
 });
 
 Deno.test("parseChildSurfaceDecl: dotted leading path + state", () => {
@@ -137,9 +184,57 @@ Deno.test("parseElementBullet: missing event dictionary is UXIL-006", () => {
   assertEquals(diagnostics.map((d) => d.code), ["UXIL-006"]);
 });
 
-Deno.test("parseElementBullet: empty verb set is UXIL-005", () => {
+Deno.test("parseElementBullet: empty verb set is exactly one UXIL-005", () => {
+  // #780 case 1: expectIdent previously added a redundant UXIL-001 for the
+  // same empty verb set.
   const { diagnostics } = parseElementBullet("`/play :` — no verb.");
-  assertEquals(diagnostics.some((d) => d.code === "UXIL-005"), true);
+  assertEquals(diagnostics.map((d) => d.code), ["UXIL-005"]);
+});
+
+Deno.test("parseElementBullet: missing ':' with verb present is a single UXIL-001", () => {
+  // #780 case 4: a verb IS present, so 'empty verb set' (UXIL-005) would be
+  // contradictory — the real defect is the omitted ':'.
+  const { decl, diagnostics } = parseElementBullet(
+    "`/play activate` — Pressing play.",
+  );
+  assertEquals(diagnostics.map((d) => d.code), ["UXIL-001"]);
+  assertStringIncludes(
+    diagnostics[0].message,
+    "expected ':' before the verb set",
+  );
+  assertEquals(decl?.verbs, []);
+});
+
+Deno.test("parseElementBullet: reserved char in the nav target is reported once, span-relative", () => {
+  // #780 case 2: the span-level scan and parseUxRef(navSource) both scanned
+  // the nav tail, double-reporting a single reserved char. The surviving
+  // diagnostic's column must stay span-relative (#796 review): the '?' sits
+  // at span column 31, not at column 11 of the sliced nav source.
+  const { diagnostics } = parseElementBullet(
+    "`/play : activate -> media.home?x` — Goes home.",
+  );
+  assertEquals(diagnostics.map((d) => d.code), ["UXIL-002"]);
+  assertEquals(diagnostics[0].position.column, 31);
+});
+
+Deno.test("parseElementBullet: reserved char in the nav survives a malformed struct part", () => {
+  // #796 review: the struct-part early return must still scan the peeled nav
+  // tail — otherwise the '?' is reported by neither scan (the pre-#780 full-
+  // span scan covered it). Struct error and nav reserved char are orthogonal
+  // regions, so both report.
+  const { diagnostics } = parseElementBullet(
+    "`foo -> media.home?x` — Goes home.",
+  );
+  assertEquals(diagnostics.map((d) => d.code), ["UXIL-001", "UXIL-002"]);
+});
+
+Deno.test("parseElementBullet: leftover token and missing dictionary co-report", () => {
+  // Pins the load-bearing order in parseElementBullet (#796 review):
+  // expectEof runs BEFORE the UXIL-006 event-dictionary check, so a real
+  // leftover-token error is never suppressed by the (orthogonal) missing-
+  // dictionary diagnostic.
+  const { diagnostics } = parseElementBullet("`/play : activate junk`");
+  assertEquals(diagnostics.map((d) => d.code), ["UXIL-001", "UXIL-006"]);
 });
 
 Deno.test("parseElementBullet: preserves a leading hyphen in the event dictionary", () => {


### PR DESCRIPTION
Closes #780.

Follow-up from the #725/#779 (S7 uxil parser) review: malformed inputs produced redundant or contradictory parse diagnostics. Root cause: the parser kept going after pushing a specific diagnostic, and a later `expectEof` (or a second reserved-char scan) re-flagged the same defect. S9 (#727) will surface these codes in the editor, so each malformed region now reports exactly one, correct code.

## Changes (all in `core/uxil/grammar.ts`)

| # | Case | Before | After |
| - | ---- | ------ | ----- |
| 1 | `` `/play :` `` empty verb set | UXIL-001 + UXIL-005 | UXIL-005 |
| 2 | reserved char in `-> nav` tail | UXIL-002 ×2 | UXIL-002 ×1, span-relative column |
| 3 | `media..home` / `media.home?x` | UXIL-008 / UXIL-002 + spurious UXIL-001 | the specific code only |
| 4 | `` `/play activate` `` (missing `:`, verb present) | contradictory UXIL-005 "empty verb set" | UXIL-001 `expected ':' before the verb set` |
| 5 | `ux:media.home` vs `ux:media.home :` (missing kind) | UXIL-004 + no decl vs UXIL-001 + decl `kind:""` | both: UXIL-004 + partial decl (`kind:""`, surface + states captured) |
| 6 | surface literally named `ux` | known limitation | unchanged (breadcrumb added on `consumeScheme`) |

Post-review hardening (see the /review comment below; found by the review, fixed in the amended commit):

- A reserved `?`/`#` now **stops structural parsing outright** in all four parsers — the lexer drops the char, so structure checks were firing on a corrupt token stream (e.g. `[UXIL-002, UXIL-004]` for `media.home?x` as a root decl).
- The peeled `-> nav` tail is scanned on **every** return path (a struct-part failure no longer swallows a reserved char in the nav).
- Nav diagnostics are re-based to **span-relative columns** at the splice point, so S9 needs no nav-specific offset handling.
- The load-bearing `expectEof`-before-nav/dictionary ordering is documented at the call site and pinned by a test.

## Design decisions (ratified with @t before implementation)

- **Suppression rule:** `expectEof` no-ops once any diagnostic exists — one clear structural error per region. Editors reparse per keystroke, so errors surface progressively. Orthogonal defects in different regions (e.g. UXIL-001 trailing junk + UXIL-006 missing event dictionary) still co-report.
- **Case 4 → UXIL-001 + detail** rather than a new code: keeps the taxonomy (001 = structural, 005 = genuinely empty verb set) and the catalogue at 001–008; a dedicated code can be minted when S9 builds an "insert `:`" quick fix.
- **Case 5 → best-effort partial decl:** honors the documented "decl undefined only when no surface" contract and matches `parseElementBullet`'s pattern (decl with `verbs: []` + UXIL-005). Mid-edit, editor tooling keeps the surface/states while the squiggle points at the missing kind. **S8 contract note (#726):** assemble must gate uxRegistry registration on a clean parse — recorded in `parseRootDecl`'s doc comment and on #726.

## Notes for reviewers

- Composes with the #786 key-clause rework: all its exact-code-list tests still pass unchanged.
- Reserved-char inputs no longer return a best-effort decl/ref (the stream is corrupt); reserved chars are rare by construction, so the trade favors diagnostic honesty.

## Testing

- 12 focused tests (one per issue case + one per review finding; the pre-existing `.some()` assertions tightened to exact code lists), TDD red→green in both rounds. Module suite: 36 passed.
- `just build` (lint + test + typecheck + compile), `deno fmt --check`, and `dprint check` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
