### PR TITLE
refactor(core): partition upstream-exempt entries once in the validator (#771)

### DIFF
--- a/docs/architecture/adr-031-federated-upstream-resolution.md
+++ b/docs/architecture/adr-031-federated-upstream-resolution.md
@@ -103,11 +103,13 @@ export type EntryOrigin =
 ```
 
 `formatEntryOrigin` renders the upstream badge as `<upstreamId>@<version>` (e.g.
-`product@v2.1.0`); `isUpstreamEntry` gates the validator and lint loops.
-`loadUpstreamCorpus` (`core/upstream/mod.ts`) — the sibling of ADR-030's
-`loadDeliveredCorpus`, same purity rules (injected `readFile`, no I/O of its
-own) — hydrates each cached snapshot into `Entry[]` and stamps the origin.
-`loadProjectUpstreams` (`core/upstream/project.ts`) wraps the
+`product@v2.1.0`). `emittableEntries` (`core/model`) partitions the validators'
+emit side once per run — upstream entries never enter an emit loop but stay in
+every resolution map (#771); `isUpstreamEntry` remains the target-side and
+reporter predicate. `loadUpstreamCorpus` (`core/upstream/mod.ts`) — the sibling
+of ADR-030's `loadDeliveredCorpus`, same purity rules (injected `readFile`, no
+I/O of its own) — hydrates each cached snapshot into `Entry[]` and stamps the
+origin. `loadProjectUpstreams` (`core/upstream/project.ts`) wraps the
 lockfile→refs→hydration chain — including the no-lockfile and empty-refs
 short-circuits — behind one call, so every feed surface shares the same
 soft-fail and diagnostic semantics (#771). Upstream entries seed at the same
@@ -379,8 +381,9 @@ are byte-reproducible across machines from `(tree, markspec version)`.
 - [ADR-032](./adr-032-process-profile-boundary.md) — settles the sibling
   `process:` ↔ profile-activation question this design scoped out (§9 #2).
 - As-built: `core/model/mod.ts` (`EntryOrigin`, `formatEntryOrigin`,
-  `isUpstreamEntry`, `ProjectRef`, `ProjectConfig`), `core/upstream/mod.ts`
-  (`loadUpstreamCorpus`), `core/upstream/refs.ts` (`upstreamRefsFromLockfile`),
+  `isUpstreamEntry`, `emittableEntries` — the #771 emit-partition helper,
+  `ProjectRef`, `ProjectConfig`), `core/upstream/mod.ts` (`loadUpstreamCorpus`),
+  `core/upstream/refs.ts` (`upstreamRefsFromLockfile`),
   `core/upstream/project.ts` (`loadProjectUpstreams`, shared by all four feed
   surfaces — #771), `core/lock/model.ts` + `serializer.ts`
   (`UpstreamDependency`, extended `UpstreamRegistry`),

--- a/docs/archive/plans/2026-07-05-771-partition-once-plan.md
+++ b/docs/archive/plans/2026-07-05-771-partition-once-plan.md
@@ -1,0 +1,563 @@
+# Partition-Once Validator Refactor (#771 PR 2) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the ~11 scattered `isUpstreamEntry` emit-loop guards with one
+named partition concept (`emittableEntries` in `core/model`), computed once per
+entry-set generation in the two orchestrators (`validate`, `runPipeline`), so a
+future validation stage cannot silently re-introduce the #765 class of leak
+(diagnostics emitted against read-only upstream entries). Plus the two
+consistency crumbs from #771: an MSL-R083 target-side upstream exemption
+(matching #765's MSL-L004 fix) and `computeCoverage` using the shared predicate.
+
+**Architecture:** `emittableEntries(entries)` lives in `core/model` beside
+`isUpstreamEntry` (every guard site already imports from model — no new edges).
+Orchestrators compute `emittable` from the input generation and `finalEmittable`
+from the post-classification generation; emit-only helpers receive the emittable
+list (guards deleted), resolution-map builders keep the full list.
+`classifyEntriesStage` keeps its pass-through branch by design (a domain rule —
+upstream `type` comes from its own compile; filtering its input would drop
+upstream from `finalEntries` or reorder first-wins ties). `validateTypl` keeps
+its own boundary filter (typl-inert upstream is that subsystem's contract) but
+expresses it via the shared helper.
+
+**Tech Stack:** Deno/TypeScript, `@std/assert`, colocated `_test.ts`.
+
+## Global Constraints
+
+- `core/mod.ts` is the library boundary; dependency flow model ← validator ←
+  compiler ← reporter, no cycles.
+- Zero warnings from `deno check` / `deno lint` / `deno test`.
+- Behavior-preserving except the one intended change (MSL-R083 no longer fires
+  when the trace TARGET is an upstream entry). Diagnostic emission order must
+  not change: iterating a filtered array preserves the relative order the
+  guarded loops produced.
+- OUT OF SCOPE: `traceability.ts:202`'s MSL-L004 target-side guard (different
+  mechanism — filters upstream _targets_, stays as-is); LSP navigability guards
+  (`definition.ts`, `code_lens.ts` — centralized in #787); the LSP
+  `WorkspaceIndex.getTypeRegistry()` building from all entries (pre-existing,
+  separate concern).
+- One squashed commit at PR time (intermediate task commits squashed in the
+  final task).
+
+---
+
+### Task 1: `emittableEntries` in core/model (+ type-guard `isUpstreamEntry`)
+
+**Files:**
+
+- Modify: `packages/markspec/core/model/mod.ts` (beside `isUpstreamEntry`)
+- Test: `packages/markspec/core/model/mod_test.ts` (or the model test file that
+  already covers `isUpstreamEntry` — check with
+  `grep -rln "isUpstreamEntry" packages/markspec/core/model/`)
+- Modify: `packages/markspec/core/mod.ts` (barrel export)
+
+**Interfaces:**
+
+- Consumes: existing `Entry`, `EntryOrigin`, `isUpstreamEntry`.
+- Produces: `emittableEntries(entries: readonly Entry[]): readonly Entry[]` —
+  Tasks 2–6 call exactly this. Also narrows `isUpstreamEntry` into a type
+  predicate:
+  `isUpstreamEntry(entry: Entry): entry is Entry & { origin:
+  Extract<EntryOrigin, { kind: "upstream" }> }`
+  — Task 6 (reporter) relies on the narrowing to read `entry.origin.upstreamId`
+  after the check.
+
+- [ ] **Step 1: Read the current `isUpstreamEntry` + write the failing test**
+
+Read `packages/markspec/core/model/mod.ts` around `isUpstreamEntry` first (its
+exact current signature and the `EntryOrigin` union). Then add to the model test
+file:
+
+```typescript
+Deno.test("emittableEntries: filters upstream, keeps project + corpus, preserves order", () => {
+  const mk = (displayId: string, origin?: Entry["origin"]): Entry =>
+    ({
+      shape: "Authored",
+      displayId,
+      title: "t",
+      body: "",
+      rawAttributes: [],
+      location: { file: "/p/a.md", line: 1, column: 1 },
+      ...(origin ? { origin } : {}),
+      // deno-lint-ignore no-explicit-any
+    }) as any;
+  const project = mk("STK_0001");
+  const corpus = mk("STD_0001", {
+    kind: "profile",
+    profileId: "p",
+    profileVersion: "1.0.0",
+  });
+  const upstream = mk("SYS_0001", {
+    kind: "upstream",
+    upstreamId: "prod",
+    version: "v1",
+  });
+  const result = emittableEntries([upstream, project, corpus]);
+  assertEquals(result.map((e) => e.displayId), ["STK_0001", "STD_0001"]);
+});
+```
+
+(Adjust the `mk` fixture to whatever minimal-Entry helper the model test file
+already uses — copy its existing pattern if one exists rather than the `as any`
+cast.)
+
+- [ ] **Step 2: Run to verify it fails** —
+      `deno test packages/markspec/core/model/` → FAIL (no export).
+
+- [ ] **Step 3: Implement**
+
+In `core/model/mod.ts`, next to `isUpstreamEntry`:
+
+```typescript
+/**
+ * The emit-side of the federated-upstream validation partition (#771;
+ * ADR-031 design §4.7). Upstream entries are read-only graph citizens:
+ * they stay in every RESOLUTION map (so project links targeting them
+ * resolve) but no validation stage may EMIT diagnostics against them.
+ * Validators loop over this filtered list; resolution-map builders keep
+ * the full input list. Adding a new validation stage? Iterate the
+ * emittable list — never the raw entry set.
+ */
+export function emittableEntries(
+  entries: readonly Entry[],
+): readonly Entry[] {
+  return entries.filter((entry) => !isUpstreamEntry(entry));
+}
+```
+
+And narrow `isUpstreamEntry` to a type predicate (keep its body unchanged):
+
+```typescript
+export function isUpstreamEntry(
+  entry: Entry,
+): entry is Entry & { origin: Extract<EntryOrigin, { kind: "upstream" }> } {
+```
+
+Add `emittableEntries` to the `core/mod.ts` barrel next to the existing
+`isUpstreamEntry` export.
+
+- [ ] **Step 4: Run to verify pass** — `deno test packages/markspec/core/model/`
+      and `deno check packages/markspec/core/mod.ts` → PASS.
+
+- [ ] **Step 5: Commit** —
+      `git commit -m "refactor(core): add emittableEntries partition helper"`
+
+---
+
+### Task 2: Acceptance anchor — comprehensive upstream-silence pipeline test
+
+This is the #765-class regression net: one upstream entry violating a rule from
+EVERY emit stage must produce ZERO diagnostics through `runPipeline`, while
+remaining a live resolution target. Write it BEFORE touching the pipeline (it
+must pass both before and after the refactor — it pins the partition, not the
+implementation).
+
+**Files:**
+
+- Test: `packages/markspec/core/validator/pipeline_test.ts` (append; follow the
+  file's existing fixture style — read it first)
+
+**Interfaces:**
+
+- Consumes: `runPipeline`, existing test fixtures/helpers in that file.
+
+- [ ] **Step 1: Read `pipeline_test.ts`'s existing upstream fixtures** (grep
+      `upstream` in it — slice 4 added some) and append a test shaped like:
+
+```typescript
+Deno.test("pipeline: upstream entry violating every emit stage stays silent but resolves", () => {
+  // Upstream entry engineered to trip, if it were emittable:
+  // - Stage 1  checkStructural: missing Id (MSL-R003/I003)
+  // - Stage 1  checkStructural: unknown attribute (MSL-R010)
+  // - Stage 1.5 validateCoreTypeAttribute: bad Type (MSL-T020)
+  // - Stage 1.5 validateModalKeywords: uppercase SHALL (MSL-M060)
+  // - Stage 1.6 trace_types: Satisfies target of wrong core type
+  // - Stage 1.7 discipline: unknown Discipline kind (MSL-T025)
+  // - Stage 4  traceability: unresolvable Satisfies (MSL-L006/T014)
+  // (exact fixture shape: copy the file's existing upstream-entry builder)
+  const upstream: Entry = {
+    ...makeEntry("UP_9999", { /* per the file's helper */ }),
+    origin: { kind: "upstream", upstreamId: "prod", version: "v1" },
+  };
+  const project = makeEntry("STK_0001", {
+    attributes: [{ key: "Satisfies", value: "UP_9999" }],
+  });
+  const result = runPipeline([upstream, project], profileFixture);
+  // Zero diagnostics attributed to the upstream entry:
+  const atUpstream = result.diagnostics.filter(
+    (d) =>
+      d.message.includes("UP_9999") &&
+      d.location?.file === upstream.location.file,
+  );
+  assertEquals(atUpstream, []);
+  // ...and the project entry's link to it resolves (no MSL-L006/T014):
+  assertEquals(
+    result.diagnostics.filter((d) =>
+      d.code === "MSL-L006" || d.code === "MSL-T014"
+    ),
+    [],
+  );
+});
+```
+
+The exact fixture construction MUST reuse the file's existing entry/profile
+builders — do not invent a parallel fixture system. If an equivalent
+upstream-silence test already exists from slice 4, EXTEND it to cover the stages
+listed above instead of duplicating.
+
+- [ ] **Step 2: Run to verify it passes on the CURRENT code** —
+      `deno test packages/markspec/core/validator/pipeline_test.ts` → PASS (the
+      guards exist today; this test is the net that must stay green through
+      Tasks 3–5).
+
+- [ ] **Step 3: Commit** —
+      `git commit -m "test(core): pin upstream validation-exemption across all pipeline stages"`
+
+---
+
+### Task 3: Partition the orchestrators (`validate`, `runPipeline`)
+
+**Files:**
+
+- Modify: `packages/markspec/core/validator/mod.ts` (`validate`,
+  `checkStructural`, `checkReferences` — guards at lines 98/469/489)
+- Modify: `packages/markspec/core/validator/pipeline.ts` (guards at
+  115/159/175/198)
+- Modify: `packages/markspec/core/validator/discipline.ts` (guard at 140)
+- Modify: `packages/markspec/core/typl/validator.ts` (filter at 53)
+
+**Interfaces:**
+
+- Consumes: Task 1's `emittableEntries` (model import — every file already
+  imports from `../model/mod.ts` / `../model/mod.ts` respectively).
+- Produces: private signature changes only —
+  `checkStructural(emittable, diagnostics)`,
+  `checkReferences(emittable, all, diagnostics)`. `validateDiscipline`'s public
+  signature is UNCHANGED (first param becomes the emittable list at the call
+  site; its internal guard is deleted).
+
+- [ ] **Step 1: `validator/mod.ts`**
+
+```typescript
+export function validate(entries: readonly Entry[]): ValidateResult {
+  const diagnostics: Diagnostic[] = [];
+
+  // Partition once (#771): upstream entries are read-only graph citizens
+  // (ADR-031 §4.7) — emit loops below iterate `emittable`; resolution
+  // maps (checkReferences) still index the full `entries` list so links
+  // TO an upstream entry keep resolving.
+  const emittable = emittableEntries(entries);
+
+  checkStructural(emittable, diagnostics);
+  checkReferences(emittable, entries, diagnostics);
+
+  const typlResult = validateTypl(entries);
+  diagnostics.push(...typlResult.diagnostics);
+
+  const valid = !diagnostics.some((d) => d.severity === "error");
+  return { diagnostics, valid };
+}
+```
+
+`checkStructural(emittable: readonly Entry[], diagnostics: Diagnostic[])`:
+delete the `if (isUpstreamEntry(entry)) continue;` and its 4-line comment;
+rename the parameter to `emittable` and note in its doc line that the caller
+pre-filtered (upstream never enters the duplicate maps — same as before, they
+were built inside the guarded loop).
+
+`checkReferences(emittable: readonly Entry[], all: readonly Entry[],
+diagnostics: Diagnostic[])`:
+the `byDisplayId`/`byId` maps build from `all`; the two emit loops (Supersedes
+at ~469, References at ~489) iterate `emittable` with their guards deleted. Keep
+the comments explaining refs TO upstream still resolve, now pointing at the
+`all`-built maps.
+
+Drop the now-unused `isUpstreamEntry` import from `validator/mod.ts`; add
+`emittableEntries`.
+
+- [ ] **Step 2: `pipeline.ts`**
+
+At the top of `runPipeline`, after `const diagnostics: Diagnostic[] = [];`:
+
+```typescript
+// Partition once (#771): emit loops iterate `emittable` /
+// `finalEmittable`; resolution maps build from the full lists so
+// upstream entries stay live link targets (ADR-031 §4.7). A new
+// stage added here must loop over the emittable list.
+const emittable = emittableEntries(entries);
+```
+
+- Stage 1.5 loop: `for (const entry of emittable) {` — guard + its comment
+  deleted (keep one line:
+  `// Emit loops iterate the emittable partition —
+  see the top of runPipeline.`
+  on the stage comment).
+- Stage 1.6: `validateTraceTargetTypes(emittable, entries)` (Task 4 changes the
+  signature — do Tasks 3+4 in one type-check cycle, or reorder the calls; they
+  land in the same commit series so either order compiles by Task 4's Step 3).
+- Stage 1.7: `entriesByDisplayId` still builds from `entries` (resolution); call
+  becomes
+  `validateDiscipline(emittable, entriesByDisplayId,
+  disciplineRegistry)`.
+- Stage 2 (`classifyEntriesStage`) and Stage 2.5 (`normalizeListValues`):
+  UNCHANGED — add a one-line comment at Stage 2:
+  `// classifyEntriesStage
+  handles upstream itself (pass-through, never re-classified) — it is a
+  transform, not an emit loop; see types.ts.`
+- After Stage 2.5, before Stage 2.4's loop... note Stage 2.4 currently runs
+  BEFORE 2.5 in source order — keep source order exactly; insert after the Stage
+  2 block:
+
+```typescript
+// Post-classification generation: Stage 2 produced new Entry objects,
+// so re-derive the emit partition for the stages below.
+const finalEmittable = emittableEntries(finalEntries);
+```
+
+Wait — Stage 2.5 REASSIGNS `finalEntries` (normalizeListValues map), so compute
+`finalEmittable` AFTER the Stage 2.5 block, and change Stage 2.4's loop... Stage
+2.4 runs before 2.5 in the current source. Precisely:
+
+- Stage 2.4 loop (`inferTypeFromLateStageChain`, guard at 159): iterate
+  `emittableEntries(finalEntries)` is wasteful twice; instead MOVE the
+  `finalEmittable` computation between Stage 2 and Stage 2.4, then have Stage
+  2.5 re-derive: Stage 2.5 maps `finalEntries` and normalization preserves
+  `origin`, so recompute once more after it. That is two filters; simpler and
+  correct: compute `let finalEmittable =
+    emittableEntries(finalEntries);`
+  after Stage 2, and after the Stage 2.5 reassignment add
+  `finalEmittable = emittableEntries(finalEntries);`.
+- Stage 3 loop (guard at 175): `for (const entry of finalEmittable) {`.
+- Stage 4: `graph`/`byDisplayId` maps still build from `finalEntries` (comment
+  already says "never filtered" — keep it); emit loop (guard at 198):
+  `for (const entry of finalEmittable) {`.
+
+- [ ] **Step 3: `discipline.ts`** — delete the guard at 140 + its comment;
+      update the doc comment:
+      `@param entries Emittable entries to walk (the
+      caller passes the #771 partition — upstream entries are exempt
+      emitters); entriesByDisplayId still covers the full set for channel-4
+      derivation.`
+      Drop the unused `isUpstreamEntry` import.
+
+- [ ] **Step 4: `typl/validator.ts`** — replace
+      `entries.filter((entry) => !isUpstreamEntry(entry))` with
+      `emittableEntries(entries)`; swap the import; trim the doc-comment
+      sentence "this mirrors the validation exemption every other per-entry
+      validator stage applies via `isUpstreamEntry`" to "this is the same #771
+      `emittableEntries` partition the validator orchestrators apply".
+
+- [ ] **Step 5: Verify** —
+      `deno check packages/markspec/core/mod.ts && deno lint packages/markspec/core/ && deno test packages/markspec/core/`
+      → all PASS including Task 2's anchor test (Task 4 must land first if the
+      Stage 1.6 call-signature change was taken here — see Task 4 Step 3 note;
+      run the full check after both).
+
+- [ ] **Step 6: Commit** —
+      `git commit -m "refactor(core): partition emit loops once in validate and runPipeline"`
+
+---
+
+### Task 4: `trace_types.ts` — partition signature + R083 target-side exemption
+
+**Files:**
+
+- Modify: `packages/markspec/core/validator/trace_types.ts`
+- Test: `packages/markspec/core/validator/trace_types_test.ts` (read first;
+  follow existing fixture style — check the filename actually used:
+  `ls packages/markspec/core/validator/*test*`)
+
+**Interfaces:**
+
+- Consumes: Task 1's `emittableEntries` concept (via caller), existing
+  `isUpstreamEntry` (target-side checks).
+- Produces:
+  `validateTraceTargetTypes(emittable: readonly Entry[], all:
+  readonly Entry[]): readonly Diagnostic[]`
+  — pipeline (Task 3 Stage 1.6) calls it with `(emittable, entries)`.
+
+- [ ] **Step 1: Write the failing target-side test**
+
+An upstream target that DOES resolve to an incompatible core type must not fire
+MSL-R083 (the #765 MSL-L004 class, target side). First read
+`type_resolution.ts`'s `resolvedCoreType` to build a fixture whose inferred core
+type is real but incompatible (e.g. an upstream entry whose `Type:` raw
+attribute or display-ID shape resolves to a core type outside the rule's allowed
+set — copy whatever incompatible-type fixture the existing R083 tests use and
+add `origin: { kind: "upstream", ... }` to the TARGET).
+
+```typescript
+Deno.test("R083: upstream target with incompatible inferred type is exempt", () => {
+  // source: project entry with e.g. `Verified-by: UP_TARGET` (pick the
+  // relation the existing R083 tests use); target: same fixture the
+  // existing R083-fires test uses, PLUS upstream origin.
+  const diags = validateTraceTargetTypes([source], [source, upstreamTarget]);
+  assertEquals(diags.filter((d) => d.code === "MSL-R083"), []);
+});
+```
+
+Also add the mirror assertion to an existing R083-fires test to pin that a
+NON-upstream target still fires (should already exist — verify, don't
+duplicate).
+
+- [ ] **Step 2: Run to verify the new test fails** (R083 fires today when the
+      inferred type resolves) — if it does NOT fail because `resolvedCoreType`
+      returns undefined for the fixture, adjust the fixture until the pre-fix
+      code fires R083; the exemption must be observable.
+
+- [ ] **Step 3: Implement**
+
+```typescript
+export function validateTraceTargetTypes(
+  emittable: readonly Entry[],
+  all: readonly Entry[],
+): readonly Diagnostic[] {
+  const byDisplayId = new Map<string, Entry>();
+  const byId = new Map<string, Entry>();
+  for (const e of all) {
+    if (!byDisplayId.has(e.displayId)) byDisplayId.set(e.displayId, e);
+    if (e.id && !byId.has(e.id)) byId.set(e.id, e);
+  }
+
+  const diagnostics: Diagnostic[] = [];
+
+  for (const entry of emittable) {
+    // (guard at old line 130 deleted)
+```
+
+In BOTH R083 loops (the `TRACE_RULES` loop and the polymorphic `Caused-by`
+loop), after `if (!resolved) continue;` add:
+
+```typescript
+// Target-side exemption (#771, matching #765's MSL-L004 fix): an
+// upstream target's type comes from a foreign vocabulary — never
+// judge core-type compatibility against it.
+if (isUpstreamEntry(resolved)) continue;
+```
+
+MSL-R084 (shape) and MSL-R081/R082 (retired/draft target) are deliberately NOT
+exempted — shape and Deprecated/DRAFT are core authored facts, not profile
+vocabulary; a retired upstream target is a real signal.
+
+Update the pipeline call site (Task 3 Stage 1.6) to
+`validateTraceTargetTypes(emittable, entries)` and this module's doc comment.
+Keep the `isUpstreamEntry` import (now target-side only).
+
+- [ ] **Step 4: Verify** — `deno test packages/markspec/core/validator/` → PASS
+      (new test + Task 2 anchor + existing R083 suite).
+
+- [ ] **Step 5: Commit** —
+      `git commit -m "refactor(core): trace_types takes the emit partition; exempt upstream R083 targets"`
+
+---
+
+### Task 5: `classifyEntriesStage` comment (no behavior change)
+
+**Files:**
+
+- Modify: `packages/markspec/core/validator/types.ts` (comment at ~263 only)
+
+- [ ] **Step 1:** Replace the guard's comment first sentence with:
+      `//
+      Deliberately NOT the #771 emittableEntries partition: this stage is a
+      TRANSFORM, not an emit loop — upstream entries must pass through into
+      the output (they stay in finalEntries as resolution targets, in
+      original order for first-entry-wins ties), and their type comes from
+      their OWN compile (design §4.5/D6) — the consumer never re-classifies.`
+      Keep the code identical.
+
+- [ ] **Step 2: Commit** —
+      `git commit -m "docs(core): document why classifyEntriesStage keeps its upstream branch"`
+
+---
+
+### Task 6: `computeCoverage` shared predicate
+
+**Files:**
+
+- Modify: `packages/markspec/core/reporter/mod.ts` (~line 226)
+
+**Interfaces:**
+
+- Consumes: Task 1's type-guard `isUpstreamEntry` (narrowing gives
+  `entry.origin.upstreamId`).
+
+- [ ] **Step 1:** Read the surrounding `computeCoverage` block, then change
+
+```typescript
+const isReferenceLeaf = origin?.kind === "upstream" &&
+  !(dependencyUpstreamIds?.has(origin.upstreamId) ?? false);
+```
+
+to use the shared predicate (exact local variable names per the surrounding code
+— if the block destructures `origin` from the entry, switch the check to the
+entry):
+
+```typescript
+const isReferenceLeaf = isUpstreamEntry(entry) &&
+  !(dependencyUpstreamIds?.has(entry.origin.upstreamId) ?? false);
+```
+
+Add `isUpstreamEntry` to the reporter's model import.
+
+- [ ] **Step 2: Verify** —
+      `deno test packages/markspec/core/reporter/ && deno test --allow-read --allow-write --allow-run --allow-env --allow-ffi tests/e2e/report_test.ts`
+      → PASS.
+
+- [ ] **Step 3: Commit** —
+      `git commit -m "refactor(core): computeCoverage uses shared isUpstreamEntry predicate"`
+
+---
+
+### Task 7: Docs — ADR-031 D4 partition sentence
+
+**Files:**
+
+- Modify: `docs/architecture/adr-031-federated-upstream-resolution.md` (§D4: the
+  sentence "`isUpstreamEntry` gates the validator and lint loops"; the as-built
+  inventory)
+
+- [ ] **Step 1:** Change the D4 sentence to:
+      `` `emittableEntries`
+      (`core/model`) partitions the validators' emit side once per run —
+      upstream entries never enter an emit loop but stay in every resolution
+      map (#771); `isUpstreamEntry` remains the target-side and reporter
+      predicate. ``
+      In the as-built list, extend the `core/model/mod.ts` parenthetical with
+      `` `emittableEntries` ``.
+
+- [ ] **Step 2:**
+      `dprint fmt docs/architecture/adr-031-federated-upstream-resolution.md`
+
+- [ ] **Step 3: Commit** —
+      `git commit -m "docs(docs): record emittableEntries partition in ADR-031"`
+
+---
+
+### Task 8: Garden, full build, squash, PR
+
+- [ ] **Step 1:** Run the `sdd-gardening` skill — this plan moves to
+      `docs/archive/plans/`; ADR-031 edit is the durable record. `docs/wip/`
+      must hold nothing from this story.
+- [ ] **Step 2:** `just fmt && just build && deno fmt --check && dprint check` →
+      all pass. Also
+      `grep -rn "isUpstreamEntry" packages/markspec/core
+      --include="*.ts" | grep -v _test`
+      and confirm the survivors are exactly: model (definition),
+      `emittableEntries` body, `types.ts` transform branch, `trace_types.ts`
+      target-side, `traceability.ts` target-side (L004), `typl` via helper
+      (gone), reporter predicate, corpus.ts if any (pre-existing). Any other
+      emit-side survivor is a missed site.
+- [ ] **Step 3:** Squash: `git reset --soft origin/main` (re-fetch first; if
+      main moved, REBASE first — #797 taught that ADR-031 attracts concurrent
+      edits), commit `-F` a message file titled
+      `refactor(core): partition upstream-exempt entries once in the validator (#771)`
+      with `Part of #771.` — NOT `Closes` (the polish PR 3 remains).
+- [ ] **Step 4:** Push (`-u`, ≥300s timeout — pre-push runs just check),
+      `gh
+      pr create --body-file …`.
+- [ ] **Step 5:** Run `/review` on the PR; post findings as a PR comment.

--- a/packages/markspec/core/mod.ts
+++ b/packages/markspec/core/mod.ts
@@ -19,6 +19,7 @@ export {
   CORE_SCHEMA_VERSION,
   DEFAULT_PROJECT_CONFIG,
   descendantsOf,
+  emittableEntries,
   formatEntryOrigin,
   isUpstreamEntry,
   KNOWN_LINK_KINDS,

--- a/packages/markspec/core/model/entry_origin_test.ts
+++ b/packages/markspec/core/model/entry_origin_test.ts
@@ -10,8 +10,13 @@
  */
 
 import { assertEquals } from "@std/assert";
-import type { EntryOrigin } from "./mod.ts";
-import { formatEntryOrigin, sameOriginSource } from "./mod.ts";
+import type { Entry, EntryOrigin } from "./mod.ts";
+import {
+  emittableEntries,
+  formatEntryOrigin,
+  makeDisplayId,
+  sameOriginSource,
+} from "./mod.ts";
 
 Deno.test("formatEntryOrigin: joins profile id and version with '@'", () => {
   const origin: EntryOrigin = {
@@ -67,4 +72,35 @@ Deno.test("sameOriginSource: profile vs upstream → false", () => {
     version: "1",
   };
   assertEquals(sameOriginSource(a, b), false);
+});
+
+function buildOriginEntry(displayId: string, origin?: EntryOrigin): Entry {
+  return {
+    displayId: makeDisplayId(displayId),
+    title: displayId,
+    body: "",
+    shape: "Authored",
+    source: { kind: "markdown" },
+    rawAttributes: [],
+    typedAttributes: new Map(),
+    location: { file: "t.md", line: 1, column: 1 },
+    bodyTokens: [],
+    ...(origin ? { origin } : {}),
+  };
+}
+
+Deno.test("emittableEntries: drops upstream, keeps project + corpus, preserves order", () => {
+  const upstream = buildOriginEntry("SYS-0001", {
+    kind: "upstream",
+    upstreamId: "product",
+    version: "v1",
+  });
+  const project = buildOriginEntry("STK-0001");
+  const corpus = buildOriginEntry("STD-0001", {
+    kind: "profile",
+    profileId: "@acme/safety",
+    profileVersion: "1.0.0",
+  });
+  const result = emittableEntries([upstream, project, corpus]);
+  assertEquals(result.map((e) => e.displayId), ["STK-0001", "STD-0001"]);
 });

--- a/packages/markspec/core/model/mod.ts
+++ b/packages/markspec/core/model/mod.ts
@@ -485,8 +485,25 @@ export function sameOriginSource(a: EntryOrigin, b: EntryOrigin): boolean {
  * entry still resolve. This is distinct from `kind: "profile"` corpus
  * entries, which stay fully validated and are only downgraded post-hoc.
  */
-export function isUpstreamEntry(entry: Entry): boolean {
+export function isUpstreamEntry(
+  entry: Entry,
+): entry is Entry & { origin: Extract<EntryOrigin, { kind: "upstream" }> } {
   return entry.origin?.kind === "upstream";
+}
+
+/**
+ * The emit side of the federated-upstream validation partition (#771;
+ * ADR-031 design §4.7). Upstream entries are read-only graph citizens:
+ * they stay in every RESOLUTION map (so project links targeting them
+ * resolve) but no validation stage may EMIT diagnostics against them.
+ * Validators loop over this filtered list; resolution-map builders keep
+ * the full input list. Adding a new validation stage? Iterate the
+ * emittable list — never the raw entry set.
+ */
+export function emittableEntries(
+  entries: readonly Entry[],
+): readonly Entry[] {
+  return entries.filter((entry) => !isUpstreamEntry(entry));
 }
 
 /**

--- a/packages/markspec/core/reporter/mod.ts
+++ b/packages/markspec/core/reporter/mod.ts
@@ -7,7 +7,7 @@
 
 import type { CompileResult } from "../compiler/mod.ts";
 import type { DisplayId, Entry } from "../model/mod.ts";
-import { formatEntryOrigin } from "../model/mod.ts";
+import { formatEntryOrigin, isUpstreamEntry } from "../model/mod.ts";
 
 /** Supported report kinds. */
 export type ReportKind = "traceability" | "coverage";
@@ -222,9 +222,8 @@ function computeCoverage(
     // like a project entry — this branch is inert until slice 3 loads
     // dependency entries, but the classification is exercised here so it's
     // ready when they do.
-    const origin = entry.origin;
-    const isReferenceLeaf = origin?.kind === "upstream" &&
-      !(dependencyUpstreamIds?.has(origin.upstreamId) ?? false);
+    const isReferenceLeaf = isUpstreamEntry(entry) &&
+      !(dependencyUpstreamIds?.has(entry.origin.upstreamId) ?? false);
 
     const fwd = result.forward.get(entry.displayId) ?? [];
     const rev = result.reverse.get(entry.displayId) ?? [];

--- a/packages/markspec/core/typl/validator.ts
+++ b/packages/markspec/core/typl/validator.ts
@@ -21,7 +21,7 @@
  * See ADR-019.
  */
 import type { Diagnostic, Entry } from "../model/mod.ts";
-import { isUpstreamEntry } from "../model/mod.ts";
+import { emittableEntries } from "../model/mod.ts";
 import type { Binding, Shape } from "./ast.ts";
 import { extractTyplCitations } from "./citations.ts";
 import { findDuplicateDeclarations, resolveRef } from "../decl/mod.ts";
@@ -38,9 +38,8 @@ import { TYPL_REF_OPS } from "./resolve.ts";
  * the corpus-wide declared-once (TYPL-009) accounting — a project entry
  * re-declaring a dotted name an upstream also publishes is not a
  * collision. Cross-repo typl resolution is out of scope for this slice
- * (see ADR-019 / federated-upstream design §4.7); this mirrors the
- * validation exemption every other per-entry validator stage applies via
- * `isUpstreamEntry`.
+ * (see ADR-019 / federated-upstream design §4.7); this is the same #771
+ * `emittableEntries` partition the validator orchestrators apply.
  *
  * Returns the built corpus registry (scoped to non-upstream entries)
  * plus any diagnostics. The registry is returned even when diagnostics
@@ -50,7 +49,7 @@ import { TYPL_REF_OPS } from "./resolve.ts";
 export function validateTypl(
   entries: readonly Entry[],
 ): { registry: TypeRegistry; diagnostics: readonly Diagnostic[] } {
-  const localEntries = entries.filter((entry) => !isUpstreamEntry(entry));
+  const localEntries = emittableEntries(entries);
   const registry = buildTypeRegistry(localEntries);
   const diagnostics: Diagnostic[] = [];
 

--- a/packages/markspec/core/validator/discipline.ts
+++ b/packages/markspec/core/validator/discipline.ts
@@ -24,12 +24,7 @@ import type {
   DisplayId,
   Entry,
 } from "../model/mod.ts";
-import {
-  CORE_KINDS,
-  isUpstreamEntry,
-  makeDisplayId,
-  MIXED_DISCIPLINE,
-} from "../model/mod.ts";
+import { CORE_KINDS, makeDisplayId, MIXED_DISCIPLINE } from "../model/mod.ts";
 import {
   classifyDerivationOnly,
   parseFrozenValue,
@@ -116,10 +111,12 @@ function channel4Kind(
  * every entry. Pure function: takes the entries, a lookup map (used by
  * later tasks for channel-4 derivation), and the effective registry.
  *
- * @param entries Entries to walk.
- * @param entriesByDisplayId Lookup map for channel-4 derivation. Tasks 5–8
- *   will use this; Task 4 ignores it but keeps the parameter to fix the
- *   signature now.
+ * @param entries Emittable entries to walk — the caller passes the #771
+ *   partition (upstream entries are exempt emitters, ADR-031 §4.7).
+ * @param entriesByDisplayId Lookup map for channel-4 derivation, built from
+ *   the FULL entry set (upstream included) so Allocated-to targets in
+ *   upstream entries still resolve. Tasks 5–8 will use this; Task 4
+ *   ignores it but keeps the parameter to fix the signature now.
  * @param registry Effective discipline registry from Slice 2's
  *   `buildEffectiveDisciplineRegistry()`, or `CORE_DISCIPLINE_REGISTRY` in
  *   core-only mode.
@@ -133,12 +130,6 @@ export function validateDiscipline(
   const knownKinds = effectiveKindSet(registry);
 
   for (const entry of entries) {
-    // Upstream entries (federated-upstream epic) are validation-exempt
-    // emitters (design §4.7) — skip discipline checks sourced from an
-    // upstream entry. `entriesByDisplayId` still includes them for
-    // channel-4 (Allocated-to) derivation on project entries.
-    if (isUpstreamEntry(entry)) continue;
-
     const override = singleAttrValue(entry, "Discipline");
     if (override !== undefined && !knownKinds.has(override)) {
       out.push({

--- a/packages/markspec/core/validator/discipline_test.ts
+++ b/packages/markspec/core/validator/discipline_test.ts
@@ -10,6 +10,7 @@ import { assertEquals } from "@std/assert";
 import {
   CORE_DISCIPLINE_REGISTRY,
   type DisplayId,
+  emittableEntries,
   type Entry,
   makeDisplayId,
 } from "../mod.ts";
@@ -70,8 +71,11 @@ Deno.test("MSL-T025: upstream entry with unknown override kind is silent (upstre
     rawAttributes: [{ key: "Discipline", value: "nonsense" }],
     origin: { kind: "upstream", upstreamId: "acme/reqs", version: "v1.0" },
   });
+  // Since #771 the exemption lives in the caller's partition: compose
+  // `emittableEntries` the way `runPipeline` Stage 1.7 does, so the test
+  // exercises the production caller contract.
   const diags = validateDiscipline(
-    [e],
+    emittableEntries([e]),
     new Map<DisplayId, Entry>(),
     CORE_DISCIPLINE_REGISTRY,
   );

--- a/packages/markspec/core/validator/mod.ts
+++ b/packages/markspec/core/validator/mod.ts
@@ -19,8 +19,8 @@ import {
   attributeSpec,
   CORE_TYPE_SCOPED_ATTRS,
   CSV_SPLITTABLE_TYPES,
+  emittableEntries,
   IDENTITY_KEY,
-  isUpstreamEntry,
   ULID_RE,
   UNIVERSAL_ATTRIBUTE_KEYS,
   URI_SCHEME_RE,
@@ -69,8 +69,14 @@ export interface ValidateResult {
 export function validate(entries: readonly Entry[]): ValidateResult {
   const diagnostics: Diagnostic[] = [];
 
-  checkStructural(entries, diagnostics);
-  checkReferences(entries, diagnostics);
+  // Partition once (#771): upstream entries are read-only graph citizens
+  // (ADR-031 §4.7) — emit loops iterate `emittable`; resolution maps
+  // (checkReferences) still index the full `entries` list so links TO an
+  // upstream entry keep resolving.
+  const emittable = emittableEntries(entries);
+
+  checkStructural(emittable, diagnostics);
+  checkReferences(emittable, entries, diagnostics);
 
   // Typl declared-once (TYPL-009), citation resolution (TYPL-010/011), and
   // undefined-typedef-refs (TYPL-005). Per-block diagnostics
@@ -82,21 +88,18 @@ export function validate(entries: readonly Entry[]): ValidateResult {
   return { diagnostics, valid };
 }
 
-/** MSL-R structural checks on individual entries and cross-entry uniqueness. */
+/** MSL-R structural checks on individual entries and cross-entry uniqueness.
+ * Receives the pre-partitioned emittable list (#771) — upstream entries never
+ * enter these checks or the duplicate maps below (same as before the
+ * partition: the maps were built inside the guarded loop). */
 function checkStructural(
-  entries: readonly Entry[],
+  emittable: readonly Entry[],
   diagnostics: Diagnostic[],
 ): void {
   const displayIds = new Map<string, Entry>();
   const ids = new Map<string, Entry>();
 
-  for (const entry of entries) {
-    // Upstream entries (federated-upstream epic) are validation-exempt
-    // graph citizens (design §4.7): skip every structural check entirely.
-    // Unlike `kind:"profile"` corpus entries (validated then downgraded),
-    // upstream entries never enter these checks in the first place.
-    if (isUpstreamEntry(entry)) continue;
-
+  for (const entry of emittable) {
     // MSL-R003: exactly one `Id:` attribute per entry.
     // Dual-emit: MSL-I002 (Reference missing Id), MSL-I003 (Authored missing
     // Id), MSL-I004 (multiple Id) — nextgen §4.2 codes alongside legacy.
@@ -438,14 +441,17 @@ function checkStructural(
   }
 }
 
-/** Cross-reference integrity checks. */
+/** Cross-reference integrity checks. Emit loops iterate the pre-partitioned
+ * `emittable` list (#771 — refs FROM an upstream entry are never checked);
+ * the resolution maps index `all` so refs TO an upstream entry resolve. */
 function checkReferences(
-  entries: readonly Entry[],
+  emittable: readonly Entry[],
+  all: readonly Entry[],
   diagnostics: Diagnostic[],
 ): void {
   // Build a display-ID index for cross-reference resolution.
   const byDisplayId = new Map<string, Entry>();
-  for (const entry of entries) {
+  for (const entry of all) {
     if (!byDisplayId.has(entry.displayId)) {
       byDisplayId.set(entry.displayId, entry);
     }
@@ -454,7 +460,7 @@ function checkReferences(
   // Also index by `Id:` value so references may target ULIDs or URIs
   // directly (profile tooling commonly accepts either).
   const byId = new Map<string, Entry>();
-  for (const entry of entries) {
+  for (const entry of all) {
     if (entry.id && !byId.has(entry.id)) {
       byId.set(entry.id, entry);
     }
@@ -462,11 +468,7 @@ function checkReferences(
 
   // MSL-T012: `Supersedes:` — the one baked-in relation. Target must
   // resolve; profile rules check type/shape compatibility separately.
-  // Upstream entries are skipped as emitters — refs FROM an upstream entry
-  // are never checked — but they remain in `byDisplayId`/`byId` above so
-  // refs TO them (from project entries) still resolve.
-  for (const entry of entries) {
-    if (isUpstreamEntry(entry)) continue;
+  for (const entry of emittable) {
     const supersedes = entry.rawAttributes.find((a) => a.key === "Supersedes");
     if (!supersedes) continue;
     const target = supersedes.value.trim();
@@ -483,10 +485,7 @@ function checkReferences(
 
   // MSL-T005: `References:` — citations must resolve to a referenced
   // entry. This is a universal relation (citing identified → referenced).
-  // Upstream entries are skipped as emitters — same rationale as the
-  // Supersedes loop above.
-  for (const entry of entries) {
-    if (isUpstreamEntry(entry)) continue;
+  for (const entry of emittable) {
     const citations = entry.rawAttributes.filter((a) => a.key === "References");
     for (const attr of citations) {
       // Citation format: "slug [free-text locator]"; take the first token.

--- a/packages/markspec/core/validator/pipeline.ts
+++ b/packages/markspec/core/validator/pipeline.ts
@@ -16,7 +16,7 @@ import type {
 } from "../model/mod.ts";
 import {
   CORE_DISCIPLINE_REGISTRY,
-  isUpstreamEntry,
+  emittableEntries,
   makeDisplayId,
 } from "../model/mod.ts";
 import { validate } from "./mod.ts";
@@ -97,6 +97,12 @@ export function runPipeline(
 ): PipelineResult {
   const diagnostics: Diagnostic[] = [];
 
+  // Partition once (#771): emit loops iterate `emittable` /
+  // `finalEmittable`; resolution maps build from the full lists so
+  // upstream entries stay live link targets (ADR-031 §4.7). A new stage
+  // added to this pipeline must loop over the emittable list.
+  const emittable = emittableEntries(entries);
+
   // Stage 1 — core hygiene. When a profile is loaded, suppress MSL-R010
   // warnings for attributes the profile actually declares (Stage 3's scope
   // validates them directly — the core-only R010 check would be noise).
@@ -109,10 +115,7 @@ export function runPipeline(
   // included) so unknown `Type:` values fail fast regardless of profile.
   // Also covers late-stage display-ID-shape inference (step 8 → MSL-T021)
   // and caption-adjacency rules (§2.6 → MSL-C070).
-  // Upstream entries (federated-upstream epic) are validation-exempt graph
-  // citizens (design §4.7) — skip every per-entry check in this loop.
-  for (const entry of entries) {
-    if (isUpstreamEntry(entry)) continue;
+  for (const entry of emittable) {
     diagnostics.push(...validateCoreTypeAttribute(entry, profile));
     diagnostics.push(...inferTypeFromDisplayIdShape(entry));
     diagnostics.push(...validateCaptions(entry));
@@ -125,8 +128,9 @@ export function runPipeline(
 
   // Stage 1.6 — cross-file trace target-type compatibility (MSL-R083).
   // Runs project-wide because targets may live in any entry; needs the
-  // whole batch indexed.
-  diagnostics.push(...validateTraceTargetTypes(entries));
+  // whole batch indexed (resolution side) while emitting only from the
+  // partition.
+  diagnostics.push(...validateTraceTargetTypes(emittable, entries));
 
   // Stage 1.7 — discipline attribute validation (ADR-017 Slice 3).
   // Runs in both core-only and profile modes. In core-only mode the
@@ -139,10 +143,12 @@ export function runPipeline(
     entries.map((e) => [makeDisplayId(e.displayId), e] as const),
   );
   diagnostics.push(
-    ...validateDiscipline(entries, entriesByDisplayId, disciplineRegistry),
+    ...validateDiscipline(emittable, entriesByDisplayId, disciplineRegistry),
   );
 
   // Stage 2 — classification (only when a profile is loaded).
+  // classifyEntriesStage handles upstream itself (pass-through, never
+  // re-classified) — it is a transform, not an emit loop; see types.ts.
   let finalEntries: readonly Entry[] = entries;
   if (profile !== null) {
     const stage2 = classifyEntriesStage(entries, profile);
@@ -150,13 +156,17 @@ export function runPipeline(
     diagnostics.push(...stage2.diagnostics);
   }
 
+  // Post-classification generation: Stage 2 produced new Entry objects,
+  // so re-derive the emit partition for the stages below (and again after
+  // Stage 2.5's normalization pass reassigns `finalEntries`).
+  let finalEmittable = emittableEntries(finalEntries);
+
   // Stage 2.4 — late-stage inference warnings (MSL-T021 for steps 5/6).
   // Runs after Stage 2 so that profile-classified `entry.type` suppresses
   // the warning correctly. In core-only mode `finalEntries === entries`
   // and `entry.type` is always undefined, so this stage produces the same
   // diagnostics regardless of mode.
-  for (const entry of finalEntries) {
-    if (isUpstreamEntry(entry)) continue;
+  for (const entry of finalEmittable) {
     diagnostics.push(...inferTypeFromLateStageChain(entry));
   }
 
@@ -165,14 +175,15 @@ export function runPipeline(
   // didn't see so that Stage 3 sees already-split values.
   if (profile !== null) {
     finalEntries = finalEntries.map((e) => normalizeListValues(e, profile));
+    finalEmittable = emittableEntries(finalEntries);
   }
 
   // Stage 3 — typed attributes (only when a profile is loaded). Upstream
-  // entries are validation-exempt (design §4.7) — skip the emit call, but
-  // they remain in `finalEntries` for Stage 4's resolution maps below.
+  // entries are validation-exempt (design §4.7) — outside the emit
+  // partition, but they remain in `finalEntries` for Stage 4's resolution
+  // maps below.
   if (profile !== null) {
-    for (const entry of finalEntries) {
-      if (isUpstreamEntry(entry)) continue;
+    for (const entry of finalEmittable) {
       const stage3 = validateAttributesForEntry(entry, profile);
       diagnostics.push(...stage3);
     }
@@ -191,11 +202,10 @@ export function runPipeline(
       if (!byDisplayId.has(e.displayId)) byDisplayId.set(e.displayId, e);
     }
     const projectWide = opts.projectWide !== false;
-    // Upstream entries are validation-exempt emitters (design §4.7): skip
-    // checking trace rules FROM an upstream entry. They remain resolution
-    // targets via the maps built above.
-    for (const entry of finalEntries) {
-      if (isUpstreamEntry(entry)) continue;
+    // Upstream entries are validation-exempt emitters (design §4.7): trace
+    // rules FROM an upstream entry are never checked. They remain
+    // resolution targets via the maps built above.
+    for (const entry of finalEmittable) {
       const stage4 = validateTraceabilityForEntry(
         entry,
         profile,

--- a/packages/markspec/core/validator/pipeline_test.ts
+++ b/packages/markspec/core/validator/pipeline_test.ts
@@ -902,3 +902,111 @@ Deno.test("runPipeline: Stage 2.5 normalization splits comma-separated id-list v
   // Stage 3 should see split values → no MSL-A004.
   assertEquals(result.diagnostics.filter((d) => d.code === "MSL-A004"), []);
 });
+
+Deno.test("runPipeline: upstream entry violating every emit stage stays silent but resolves (#771 partition anchor)", () => {
+  const profile = buildProfileWithRequirement();
+
+  // One upstream entry engineered to trip a rule in EVERY per-entry emit
+  // surface, were it emittable:
+  // - Stage 1  checkStructural: missing Id (MSL-R003/I003), empty title
+  //   (MSL-P010), unknown attribute (MSL-R010)
+  // - Stage 1  checkReferences: unresolvable Supersedes (MSL-T012),
+  //   unresolvable References citation (MSL-T005)
+  // - Stage 1.5 validateCoreTypeAttribute: unknown Type value (MSL-T020)
+  // - Stage 1.6 trace_types: Satisfies target carrying Deprecated
+  //   (MSL-R081)
+  // - Stage 1.7 discipline: unknown Discipline kind (MSL-T025)
+  // This is the #765-class regression net: it pins the partition itself,
+  // so a future stage that forgets the emittable list fails here.
+  const upstream: Entry = {
+    displayId: makeDisplayId("UP-0001"),
+    shape: "Authored",
+    source: { kind: "markdown" },
+    title: "",
+    body: "",
+    type: "foreign-req",
+    rawAttributes: [
+      { key: "Frobnicate", value: "x" },
+      { key: "Type", value: "not-a-type" },
+      { key: "Supersedes", value: "GHOST-0001" },
+      { key: "References", value: "ghost-slug" },
+      { key: "Discipline", value: "quantum" },
+      { key: "Satisfies", value: "REQ-0002" },
+    ],
+    typedAttributes: new Map(),
+    location: { file: "upstream.md", line: 1, column: 1 },
+    bodyTokens: [],
+    origin: { kind: "upstream", upstreamId: "acme/reqs", version: "v1.0" },
+  };
+
+  // Retired project entry — the upstream's Satisfies target (MSL-R081 bait:
+  // a project source pointing here would warn "target is retired").
+  const retired: Entry = {
+    displayId: makeDisplayId("REQ-0002"),
+    id: "01T2T2T2T2T2T2T2T2T2T2T2T2",
+    shape: "Authored",
+    source: { kind: "markdown" },
+    title: "Retired requirement",
+    body: "",
+    rawAttributes: [
+      { key: "Id", value: "01T2T2T2T2T2T2T2T2T2T2T2T2" },
+      { key: "Deprecated", value: "superseded 2026-01" },
+    ],
+    typedAttributes: new Map([["Id", ["01T2T2T2T2T2T2T2T2T2T2T2T2"]]]),
+    location: { file: "t.md", line: 1, column: 1 },
+    bodyTokens: [],
+  };
+
+  // Project entry whose link targets the upstream entry — resolution must
+  // keep working while the upstream stays silent.
+  const project: Entry = {
+    displayId: makeDisplayId("REQ-0001"),
+    id: "01HGW2Q8MNP3RSTVWXYZABCDEF",
+    shape: "Authored",
+    source: { kind: "markdown" },
+    title: "Project requirement",
+    body: "",
+    rawAttributes: [
+      { key: "Id", value: "01HGW2Q8MNP3RSTVWXYZABCDEF" },
+      { key: "Supersedes", value: "UP-0001" },
+    ],
+    typedAttributes: new Map([["Id", ["01HGW2Q8MNP3RSTVWXYZABCDEF"]]]),
+    location: { file: "t.md", line: 1, column: 1 },
+    bodyTokens: [],
+  };
+
+  const result = runPipeline([upstream, project, retired], profile);
+
+  // None of the upstream entry's baited codes may fire...
+  const baitCodes = [
+    "MSL-R003",
+    "MSL-I003",
+    "MSL-P010",
+    "MSL-R010",
+    "MSL-T012",
+    "MSL-T005",
+    "MSL-T020",
+    "MSL-T025",
+    "MSL-R081",
+  ];
+  assertEquals(
+    result.diagnostics.filter((d) => baitCodes.includes(d.code)),
+    [],
+  );
+  // ...no diagnostic of any code may be attributed to the upstream entry...
+  assertEquals(
+    result.diagnostics.filter(
+      (d) =>
+        d.message.includes("UP-0001") ||
+        d.location?.file === "upstream.md",
+    ),
+    [],
+  );
+  // ...and the upstream entry stayed a live resolution target: the project
+  // entry's Supersedes resolved (a missing target would be MSL-T012 at the
+  // project entry, already excluded above) and passed through to output.
+  assertEquals(
+    result.entries.some((e) => e.displayId === "UP-0001"),
+    true,
+  );
+});

--- a/packages/markspec/core/validator/trace_types.ts
+++ b/packages/markspec/core/validator/trace_types.ts
@@ -108,27 +108,29 @@ function isTargetTypeCompatible(
  *
  * Unresolved targets are silently skipped — they're caught elsewhere
  * (MSL-R080 / MSL-T012 / MSL-T005). Targets without a resolvable core
- * type are also skipped (no compat call to make).
+ * type are also skipped (no compat call to make). Upstream TARGETS are
+ * exempt from the MSL-R083 type-compat checks (#771) — their type comes
+ * from a foreign vocabulary, the target-side twin of #765's MSL-L004 fix.
+ *
+ * @param emittable The #771 emit partition — trace rules are never
+ *   checked FROM an upstream entry.
+ * @param all The full entry set (upstream included) — resolution maps
+ *   index it so links TO an upstream entry keep resolving.
  */
 export function validateTraceTargetTypes(
-  entries: readonly Entry[],
+  emittable: readonly Entry[],
+  all: readonly Entry[],
 ): readonly Diagnostic[] {
   const byDisplayId = new Map<string, Entry>();
   const byId = new Map<string, Entry>();
-  for (const e of entries) {
+  for (const e of all) {
     if (!byDisplayId.has(e.displayId)) byDisplayId.set(e.displayId, e);
     if (e.id && !byId.has(e.id)) byId.set(e.id, e);
   }
 
   const diagnostics: Diagnostic[] = [];
 
-  for (const entry of entries) {
-    // Upstream entries (federated-upstream epic) are validation-exempt
-    // emitters (design §4.7) — skip checking trace rules FROM an upstream
-    // entry. `byDisplayId`/`byId` above still include them, so a project
-    // entry's link targeting an upstream entry keeps resolving.
-    if (isUpstreamEntry(entry)) continue;
-
+  for (const entry of emittable) {
     // MSL-R084: Supersedes target must be the same shape as the source.
     for (const attr of entry.rawAttributes) {
       if (attr.key !== "Supersedes") continue;
@@ -152,6 +154,10 @@ export function validateTraceTargetTypes(
         const target = attr.value.trim();
         const resolved = byId.get(target) ?? byDisplayId.get(target);
         if (!resolved) continue;
+        // Target-side exemption (#771, matching #765's MSL-L004 fix): an
+        // upstream target's type comes from a foreign vocabulary — never
+        // judge core-type compatibility against it.
+        if (isUpstreamEntry(resolved)) continue;
         const targetType = resolvedCoreType(resolved);
         if (!targetType) continue;
         if (isTargetTypeCompatible(targetType, rule.allowedTargetTypes)) {
@@ -189,6 +195,9 @@ export function validateTraceTargetTypes(
         const target = attr.value.trim();
         const resolved = byId.get(target) ?? byDisplayId.get(target);
         if (!resolved) continue;
+        // Target-side exemption (#771) — same rationale as the
+        // TRACE_RULES loop above.
+        if (isUpstreamEntry(resolved)) continue;
         const targetType = resolvedCoreType(resolved);
         if (!targetType) continue;
         if (isTargetTypeCompatible(targetType, sourceRole.allowed)) continue;

--- a/packages/markspec/core/validator/trace_types_test.ts
+++ b/packages/markspec/core/validator/trace_types_test.ts
@@ -9,8 +9,14 @@
 
 import { assertEquals } from "@std/assert";
 import { validateTraceTargetTypes } from "./trace_types.ts";
-import type { Entry } from "../model/mod.ts";
-import { makeDisplayId } from "../model/mod.ts";
+import type { Diagnostic, Entry } from "../model/mod.ts";
+import { emittableEntries, makeDisplayId } from "../model/mod.ts";
+
+/** Compose the #771 emit partition the way `runPipeline` Stage 1.6 does —
+ * tests exercise the same caller contract the production pipeline uses. */
+function run(entries: readonly Entry[]): readonly Diagnostic[] {
+  return validateTraceTargetTypes(emittableEntries(entries), entries);
+}
 
 const ULID_A = "01HGW2Q8MNP3RSTVWXYZABCDEF";
 const ULID_B = "01HGW2Q8MNP3RSTVWXYZABCDEG";
@@ -40,7 +46,7 @@ function entry(opts: {
 }
 
 Deno.test("Caused-by on Record with Requirement target → OK", () => {
-  const result = validateTraceTargetTypes([
+  const result = run([
     entry({
       displayId: "REC-001",
       type: "Record",
@@ -65,7 +71,7 @@ Deno.test("Caused-by on Record with Requirement target → OK", () => {
 });
 
 Deno.test("Caused-by on Record with Component target → MSL-R083 (Record-cause set)", () => {
-  const result = validateTraceTargetTypes([
+  const result = run([
     entry({
       displayId: "REC-001",
       type: "Record",
@@ -103,7 +109,7 @@ Deno.test("Caused-by on upstream Record with Component target → no MSL-R083 (u
   // graph citizens (design §4.7) — Stage 1.6 must skip emitting from
   // them entirely, even though the target-type mismatch would otherwise
   // fire MSL-R083.
-  const result = validateTraceTargetTypes([
+  const result = run([
     entry({
       displayId: "REC-001",
       type: "Record",
@@ -128,8 +134,39 @@ Deno.test("Caused-by on upstream Record with Component target → no MSL-R083 (u
   assertEquals(r083.length, 0);
 });
 
+Deno.test("Caused-by on Record with UPSTREAM Component target → no MSL-R083 (target-side exemption, #771)", () => {
+  // Mirror of "Caused-by on Record with Component target → MSL-R083"
+  // above, but the TARGET carries a `kind:"upstream"` origin. An upstream
+  // target's type comes from a foreign vocabulary — core-type
+  // compatibility must never be judged against it (the target-side twin
+  // of #765's MSL-L004 fix).
+  const result = run([
+    entry({
+      displayId: "REC-001",
+      type: "Record",
+      rawAttributes: [
+        { key: "Id", value: ULID_A },
+        { key: "Type", value: "Record" },
+        { key: "Caused-by", value: ULID_B },
+      ],
+    }),
+    entry({
+      displayId: "comp-1",
+      type: "Component",
+      id: ULID_B,
+      rawAttributes: [
+        { key: "Id", value: ULID_B },
+        { key: "Type", value: "Component" },
+      ],
+      origin: { kind: "upstream", upstreamId: "acme/reqs", version: "v1.0" },
+    }),
+  ]);
+  const r083 = result.filter((d) => d.code === "MSL-R083");
+  assertEquals(r083.length, 0);
+});
+
 Deno.test("Caused-by on Risk with Component target → OK", () => {
-  const result = validateTraceTargetTypes([
+  const result = run([
     entry({
       displayId: "RSK-001",
       type: "Risk",
@@ -158,7 +195,7 @@ Deno.test("Caused-by on Requirement (neither Record nor Risk) → no MSL-R083 (s
   // rule applies only to Record / Risk; if the source is neither (or
   // unresolved), the check is silent — a useful diagnostic would need
   // attribute-applicability rules, not type-target mismatch.
-  const result = validateTraceTargetTypes([
+  const result = run([
     entry({
       displayId: "REQ-001",
       type: "Requirement",
@@ -191,7 +228,7 @@ Deno.test("Caused-by on Requirement (neither Record nor Risk) → no MSL-R083 (s
 const ULID_C = "01HGW2Q8MNP3RSTVWXYZABCDEH";
 
 Deno.test("Provides: SoftwareInterface target → no MSL-R083 (Contract subtype)", () => {
-  const result = validateTraceTargetTypes([
+  const result = run([
     entry({
       displayId: "SWC-001",
       type: "SoftwareComponent",
@@ -216,7 +253,7 @@ Deno.test("Provides: SoftwareInterface target → no MSL-R083 (Contract subtype)
 });
 
 Deno.test("Provides: plain Contract target → no MSL-R083", () => {
-  const result = validateTraceTargetTypes([
+  const result = run([
     entry({
       displayId: "SWC-001",
       type: "SoftwareComponent",
@@ -241,7 +278,7 @@ Deno.test("Provides: plain Contract target → no MSL-R083", () => {
 });
 
 Deno.test("Tests: SoftwareInterface target → no MSL-R083 (Contract subtype)", () => {
-  const result = validateTraceTargetTypes([
+  const result = run([
     entry({
       displayId: "TST-001",
       type: "Test",
@@ -266,7 +303,7 @@ Deno.test("Tests: SoftwareInterface target → no MSL-R083 (Contract subtype)", 
 });
 
 Deno.test("Requires: HardwareInterface target → no MSL-R083 (Contract subtype)", () => {
-  const result = validateTraceTargetTypes([
+  const result = run([
     entry({
       displayId: "HWC-001",
       type: "HardwareComponent",

--- a/packages/markspec/core/validator/types.ts
+++ b/packages/markspec/core/validator/types.ts
@@ -260,12 +260,12 @@ export function classifyEntriesStage(
   const out: Entry[] = [];
 
   for (const entry of entries) {
-    // Upstream entries (federated-upstream epic) are validation-exempt
-    // graph citizens (design §4.7); their `type` comes from their OWN
-    // compile (design §4.5/D6) — the consumer never re-classifies. Pass
-    // the entry through unchanged: no MSL-T001..T004 emit, no type
-    // overwrite. It still lands in `out`, so it remains a resolution
-    // target for later stages (Stage 3/4 index-building).
+    // Deliberately NOT the #771 emittableEntries partition: this stage is
+    // a TRANSFORM, not an emit loop — upstream entries must pass through
+    // into the output (they stay in finalEntries as resolution targets,
+    // in original order for first-entry-wins ties), and their `type`
+    // comes from their OWN compile (design §4.5/D6) — the consumer never
+    // re-classifies. No MSL-T001..T004 emit, no type overwrite.
     if (isUpstreamEntry(entry)) {
       out.push(entry);
       continue;


### PR DESCRIPTION
Part of #771 — PR 2 of 3: the partition-once altitude refactor. (PR 1 was #797, the feed-site consolidation; the polish batch remains.) Does not close the issue.

## What

**One partition instead of eleven guards.** `emittableEntries` (`core/model`, beside `isUpstreamEntry`) is now the single named concept for "upstream entries are read-only graph citizens: never emit against them, always resolve to them" (ADR-031 §4.7). The orchestrators partition once per entry-set generation — `validate()` at its top; `runPipeline()` for the input generation and again for the post-classification generation (Stage 2 produces new `Entry` objects) — and feed emit loops the emittable list while resolution maps keep the full list.

Collapsed guard sites: `validator/mod.ts` (`checkStructural`, `checkReferences` ×2), `pipeline.ts` (Stages 1.5, 2.4, 3, 4), `discipline.ts`, `trace_types.ts`, `typl/validator.ts` (its typl-inert boundary now expressed via the shared helper). PR #765 proved this scatter fragile — `validateTypl` and the `MSL-L004` target check both shipped without the guard until review caught them; a future stage now gets the partition by construction.

**Deliberately kept:** `classifyEntriesStage`'s upstream branch (a transform, not an emit loop — pass-through preserves resolution targets and first-entry-wins order; upstream `type` comes from its own compile), and `traceability.ts`'s `MSL-L004` target-side guard (different mechanism, #765's fix).

**Consistency crumbs from #771:**

- `MSL-R083` gains the target-side upstream exemption in both the `TRACE_RULES` and polymorphic `Caused-by` loops — the target-side twin of #765's `MSL-L004` fix. Behavior change: a project entry's trace link to an upstream entry whose display-ID-inferred core type is incompatible no longer errors.
- `computeCoverage` uses the shared `isUpstreamEntry` predicate (now a type predicate, so the narrowing carries `origin.upstreamId`).

## Tests

- **Upstream-silence anchor** (`pipeline_test.ts`): one upstream entry baiting a rule in every emit stage (missing Id, empty title, unknown attribute, unresolvable Supersedes/References, bad Type, unknown Discipline, retired-target severity) must produce zero diagnostics through `runPipeline` while remaining a live resolution target. This is the #765 regression net — it pins the partition, not the implementation, and passed both before and after the refactor.
- **R083 target exemption** (`trace_types_test.ts`): red before the fix (R083 fired on an upstream `Component` target), green after. Direct-call tests compose `emittableEntries` the way the pipeline does, so they keep exercising the production caller contract.
- `emittableEntries` unit test (order-preserving, corpus entries stay emittable).
- Full suite: 2248 core tests, `just build` green.

## Docs

ADR-031 §D4 + as-built inventory record the partition (`isUpstreamEntry` remains the target-side and reporter predicate). Plan gardened to `docs/archive/plans/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
