### PR TITLE
fix(core): uxil element-bullet diagnostics report paragraph-relative columns

### DIFF
--- a/packages/markspec/core/uxil/grammar.ts
+++ b/packages/markspec/core/uxil/grammar.ts
@@ -54,8 +54,9 @@ class Cursor {
  * Returns whether one was found — callers stop structural parsing on a hit,
  * because the lexer silently drops the char and every diagnostic derived
  * from the mangled token stream would be noise (#780). `baseColumn` shifts
- * the reported column for callers scanning a slice of a larger span (the
- * peeled `-> nav` tail), keeping positions span-relative.
+ * the reported column for callers scanning a slice of a larger source (the
+ * peeled `-> nav` tail, or a code span offset into its paragraph — #781),
+ * keeping positions relative to the caller's chosen origin.
  */
 function scanReservedChars(
   source: string,
@@ -382,20 +383,41 @@ export function parseChildSurfaceDecl(
  * Split the leading inline code span from the rest of a bullet paragraph.
  * Handles single- and double-backtick spans. Returns `span` undefined when
  * the paragraph does not begin with a code span.
+ *
+ * `spanStart` is the number of paragraph characters consumed before the
+ * span's inner text — leading whitespace plus the opening backtick
+ * delimiter(s). {@linkcode parseElementBullet} adds it to every span-derived
+ * diagnostic column so positions are paragraph-relative (#781): the parser is
+ * handed the whole paragraph, so — like every other uxil parser, which
+ * reports columns relative to the source string it receives — its diagnostics
+ * must be relative to that paragraph, not the de-backticked span. `0` when
+ * there is no span (the only diagnostic on that path anchors at paragraph
+ * column 1).
  */
-function splitLeadingCodeSpan(text: string): { span?: string; rest: string } {
+function splitLeadingCodeSpan(
+  text: string,
+): { span?: string; rest: string; spanStart: number } {
   const t = text.replace(/^\s+/, "");
+  const leading = text.length - t.length;
   if (t.startsWith("``")) {
     const end = t.indexOf("``", 2);
-    if (end < 0) return { rest: text };
-    return { span: t.slice(2, end), rest: t.slice(end + 2) };
+    if (end < 0) return { rest: text, spanStart: 0 };
+    return {
+      span: t.slice(2, end),
+      rest: t.slice(end + 2),
+      spanStart: leading + 2,
+    };
   }
   if (t.startsWith("`")) {
     const end = t.indexOf("`", 1);
-    if (end < 0) return { rest: text };
-    return { span: t.slice(1, end), rest: t.slice(end + 1) };
+    if (end < 0) return { rest: text, spanStart: 0 };
+    return {
+      span: t.slice(1, end),
+      rest: t.slice(end + 1),
+      spanStart: leading + 1,
+    };
   }
-  return { rest: text };
+  return { rest: text, spanStart: 0 };
 }
 
 /**
@@ -405,12 +427,19 @@ function splitLeadingCodeSpan(text: string): { span?: string; rest: string } {
  * per the epic design doc): the key template is its own `:` clause after
  * the verb set — never attached to the element name, so declarations
  * cannot collide with the ref grammar's `element:{key}` form.
+ *
+ * Diagnostic columns are paragraph-relative (#781): the parser receives the
+ * whole paragraph and splits the leading code span itself, so every
+ * span-derived column is shifted by the span's start offset
+ * ({@linkcode splitLeadingCodeSpan}'s `spanStart`). The two whole-bullet
+ * diagnostics — no leading code span, and the missing event dictionary —
+ * anchor at paragraph column 1.
  */
 export function parseElementBullet(
   paragraph: string,
 ): { decl?: ElementDecl; diagnostics: UxilDiagnostic[] } {
   const diagnostics: UxilDiagnostic[] = [];
-  const { span, rest } = splitLeadingCodeSpan(paragraph);
+  const { span, rest, spanStart } = splitLeadingCodeSpan(paragraph);
   if (span === undefined) {
     diagnostics.push(
       uxilDiagnostic(
@@ -430,26 +459,40 @@ export function parseElementBullet(
     navSource = span.slice(arrow + 2).trim();
   }
 
-  // 0-based index of the trimmed nav source within the span — shifts nav
-  // diagnostic columns back to span-relative.
-  const navOffset = navSource ? span.indexOf(navSource, arrow + 2) : 0;
+  // Paragraph-relative base column for the nav tail (#781): the span's own
+  // start offset plus the nav source's 0-based index within the span. Nav
+  // diagnostics add this so their columns compose both offsets and land on
+  // the paragraph — "the -> nav sub-parse offset should compose too".
+  const navBase = navSource
+    ? spanStart + span.indexOf(navSource, arrow + 2)
+    : 0;
   // The nav tail is an orthogonal region: every return path must still
   // surface a reserved char in it, even when the struct part fails first.
   const scanNavReserved = (): void => {
-    if (navSource) scanReservedChars(navSource, diagnostics, navOffset);
+    if (navSource) scanReservedChars(navSource, diagnostics, navBase);
   };
 
   // Scan the structured part only — the nav tail is scanned separately
   // (scanNavReserved / parseUxRef below), so scanning the whole span would
   // report a single `?`/`#` in the nav target twice (#780 case 2). A hit
   // poisons the token stream (the lexer drops the char): stop before the
-  // structure checks turn the mangled tokens into contradictory codes.
-  if (scanReservedChars(structPart, diagnostics)) {
+  // structure checks turn the mangled tokens into contradictory codes. The
+  // scan's base column is the span start so its column is paragraph-relative
+  // (#781).
+  if (scanReservedChars(structPart, diagnostics, spanStart)) {
     scanNavReserved();
     return { diagnostics };
   }
 
-  const c = new Cursor(tokenize(structPart));
+  // Shift every struct-part token column by the span start so all downstream
+  // diagnostics (slash, element, verb set, key clause, states, expectEof)
+  // come out paragraph-relative (#781) without threading the offset through
+  // each individual call site.
+  const structTokens = tokenize(structPart).map((t) => ({
+    ...t,
+    position: { line: t.position.line, column: t.position.column + spanStart },
+  }));
+  const c = new Cursor(structTokens);
   if (c.peek().kind !== "SLASH") {
     diagnostics.push(
       uxilDiagnostic(
@@ -550,14 +593,18 @@ export function parseElementBullet(
 
   // Nav target (parsed as a ux ref; may be scheme-less / relative). Nav
   // diagnostics carry positions relative to the sliced nav source — shift
-  // them by navOffset so editor squiggles land on the span's own columns.
+  // them by navBase so editor squiggles land on the paragraph's own columns
+  // (#781).
   if (navSource !== undefined) {
     if (navSource.length === 0) {
+      // No nav source to point into — anchor at the '->' arrow, paragraph-
+      // relative (#781): spanStart shifts past the code-span delimiter, arrow
+      // is the 0-based index of '->' within the span, +1 makes it 1-based.
       diagnostics.push(
         uxilDiagnostic(
           "UXIL-001",
           { detail: "missing navigation target after '->'" },
-          { line: 1, column: 1 },
+          { line: 1, column: spanStart + arrow + 1 },
         ),
       );
     } else {
@@ -567,7 +614,7 @@ export function parseElementBullet(
           ...d,
           position: {
             line: d.position.line,
-            column: d.position.column + navOffset,
+            column: d.position.column + navBase,
           },
         })),
       );
@@ -580,6 +627,9 @@ export function parseElementBullet(
   // opens with a hyphen — e.g. "-5 dB is the floor" — keeps its first character.
   const eventDictionary = rest.replace(/^\s*—\s*/, "").trim();
   if (eventDictionary.length === 0) {
+    // Whole-bullet diagnostic — the missing dictionary is the trailing prose,
+    // so anchor at paragraph column 1 (the bullet start) rather than a
+    // span-derived column (#781).
     diagnostics.push(uxilDiagnostic("UXIL-006", {}, { line: 1, column: 1 }));
   }
   decl.eventDictionary = eventDictionary;

--- a/packages/markspec/core/uxil/grammar_test.ts
+++ b/packages/markspec/core/uxil/grammar_test.ts
@@ -205,16 +205,17 @@ Deno.test("parseElementBullet: missing ':' with verb present is a single UXIL-00
   assertEquals(decl?.verbs, []);
 });
 
-Deno.test("parseElementBullet: reserved char in the nav target is reported once, span-relative", () => {
+Deno.test("parseElementBullet: reserved char in the nav target is reported once, paragraph-relative (#781)", () => {
   // #780 case 2: the span-level scan and parseUxRef(navSource) both scanned
-  // the nav tail, double-reporting a single reserved char. The surviving
-  // diagnostic's column must stay span-relative (#796 review): the '?' sits
-  // at span column 31, not at column 11 of the sliced nav source.
+  // the nav tail, double-reporting a single reserved char — exactly one
+  // survives. #781: its column is paragraph-relative — the '?' sits at
+  // paragraph column 32 (span column 31 + 1 for the leading backtick), not at
+  // column 11 of the sliced nav source.
   const { diagnostics } = parseElementBullet(
     "`/play : activate -> media.home?x` — Goes home.",
   );
   assertEquals(diagnostics.map((d) => d.code), ["UXIL-002"]);
-  assertEquals(diagnostics[0].position.column, 31);
+  assertEquals(diagnostics[0].position.column, 32);
 });
 
 Deno.test("parseElementBullet: reserved char in the nav survives a malformed struct part", () => {
@@ -243,4 +244,46 @@ Deno.test("parseElementBullet: preserves a leading hyphen in the event dictionar
   );
   assertEquals(diagnostics, []);
   assertEquals(decl?.eventDictionary, "-5 dB is the floor");
+});
+
+Deno.test("parseElementBullet: struct diagnostic column is paragraph-relative, not span-relative (#781)", () => {
+  // #781: splitLeadingCodeSpan used to discard the code-span's start offset,
+  // so every diagnostic column was relative to the de-backticked span rather
+  // than the paragraph the parser was handed. The 'activate' token sits at
+  // paragraph column 8 — span column 7 plus 1 for the leading backtick.
+  const { diagnostics } = parseElementBullet("`/play activate` — x");
+  assertEquals(diagnostics.map((d) => d.code), ["UXIL-001"]);
+  assertEquals(diagnostics[0].position.column, 8);
+});
+
+Deno.test("parseElementBullet: list-item indent before the code span shifts the diagnostic column (#781)", () => {
+  // #781: leading whitespace consumed by splitLeadingCodeSpan must count
+  // toward the span start. Three spaces of list indent shift every column
+  // right by three.
+  const flush = parseElementBullet("`/play activate` — x");
+  const indented = parseElementBullet("   `/play activate` — x");
+  assertEquals(
+    indented.diagnostics[0].position.column -
+      flush.diagnostics[0].position.column,
+    3,
+  );
+});
+
+Deno.test("parseElementBullet: double-backtick delimiter counts two chars toward the span start (#781)", () => {
+  // #781: a ``…`` span consumes two delimiter chars before its inner text,
+  // so the 'activate' token lands at paragraph column 9 (span column 7 + 2).
+  const { diagnostics } = parseElementBullet("``/play activate`` — x");
+  assertEquals(diagnostics.map((d) => d.code), ["UXIL-001"]);
+  assertEquals(diagnostics[0].position.column, 9);
+});
+
+Deno.test("parseElementBullet: nav reserved-char column composes the span start with the nav offset (#781)", () => {
+  // #781: the '-> nav' sub-parse offset must compose with the span start.
+  // Two spaces of indent (span start 3, vs 1 for a bare backtick) push the
+  // paragraph-relative '?' column from 32 to 34.
+  const { diagnostics } = parseElementBullet(
+    "  `/play : activate -> media.home?x` — Goes home.",
+  );
+  assertEquals(diagnostics.map((d) => d.code), ["UXIL-002"]);
+  assertEquals(diagnostics[0].position.column, 34);
 });


### PR DESCRIPTION
Closes #781.

Follow-up from the #725 / #779 code review (S7 uxil parser).

## Problem

`parseElementBullet` is the only uxil parser handed the whole bullet paragraph — it splits the leading code span itself via `splitLeadingCodeSpan`, which left-trimmed whitespace and stripped the backtick delimiter(s) but **threw away how many characters it consumed**. Every diagnostic column was therefore relative to the de-backticked span, not the paragraph — shifted left by that offset. S9 (#727), which anchors element-bullet diagnostics at the paragraph, could not recover the true column.

Example: `` `/play :` `` reported the empty-verb error one column too far left, because the leading backtick (and any list indent) weren't counted.

## Fix

`splitLeadingCodeSpan` now also returns `spanStart` — the chars consumed before the span's inner text (leading whitespace + backtick delimiter(s)). `parseElementBullet` threads it through every span-derived diagnostic so columns are **paragraph-relative**, matching the "columns relative to the source string received" contract the sibling parsers (`parseUxRef`, `parseRootDecl`, `parseChildSurfaceDecl`) already honor:

- struct-part tokens are shifted once, right after tokenizing (covers the slash / element / verb-set / key-clause / state / `expectEof` diagnostics);
- the struct reserved-char scan takes `spanStart` as its base column;
- the `-> nav` sub-parse composes `spanStart + navOffset`, so both offsets add.

The two whole-bullet diagnostics (no code span, missing event dictionary) keep paragraph column 1; the previously hardcoded/meaningless "missing nav target after `->`" column now anchors at the `->` arrow.

No public API change — nothing consumes uxil parser output yet except its tests.

## Tests

- Updated the existing nav reserved-char test: the surviving `?` is now paragraph-relative (span column 31 → paragraph column 32 with the leading backtick).
- New: struct diagnostic accounts for the backtick; N spaces of list indent shift the column by N; a double-backtick span shifts by 2; the nav reserved-char column composes `spanStart + navOffset`.
- `just build`: 3898 passed, 0 failed.

Part of #717 (uxil epic); unblocks S9 (#727) file-anchoring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
