### PR TITLE
fix(core): derive upstream badge label from the resolved git pin

### DIFF
--- a/packages/markspec/core/upstream/refs.ts
+++ b/packages/markspec/core/upstream/refs.ts
@@ -10,16 +10,40 @@ import type { Lockfile } from "../lock/model.ts";
 import { upstreamCacheRoot } from "../lock/upstream_refs.ts";
 import type { UpstreamSnapshotRef } from "./mod.ts";
 
-/** Fallback version label when a registry row carries no `version`. */
+/** Fallback badge label when an upstream row carries neither a `version`
+ * field nor a `resolved` pin to derive one from. */
 const UNVERSIONED = "unversioned";
+
+/**
+ * Derive a human-readable badge label from a git dependency's `resolved`
+ * pin (`"tag:<t>"` | `"branch:<b>"` | `"sha:<s>"`). A tag or branch pin
+ * renders bare (`v2.1.0`, `main`); a sha pin renders as its 7-char short
+ * hash (`abcdef0`). A pin with an unrecognised scheme renders verbatim,
+ * and an empty pin falls back to `UNVERSIONED` (#800).
+ */
+function versionFromResolved(resolved: string): string {
+  const colon = resolved.indexOf(":");
+  if (colon < 0) return resolved || UNVERSIONED;
+  const scheme = resolved.slice(0, colon);
+  const rest = resolved.slice(colon + 1);
+  if (rest.length === 0) return UNVERSIONED;
+  if (scheme === "sha") return rest.slice(0, 7);
+  if (scheme === "tag" || scheme === "branch") return rest;
+  return resolved;
+}
 
 /**
  * Map a parsed lockfile's snapshot-carrying upstream rows to
  * UpstreamSnapshotRef[] for loadUpstreamCorpus. Registry + dependency
  * rows with a `snapshot` are included; rows without a snapshot (legacy
- * pin-only) are skipped. `version` falls back to `"unversioned"` when the
- * row has none (UpstreamSnapshotRef.version is required; the loader only
- * uses it for the origin badge).
+ * pin-only) are skipped.
+ *
+ * The `version` field feeds the origin badge (`<id>@<version>`).
+ * Registry rows use their published `project.version`, falling back to
+ * `UNVERSIONED` when unpublished. Dependency rows carry no `version`, so
+ * the label is derived from the `resolved` pin via
+ * {@linkcode versionFromResolved} (#800) — previously every git
+ * dependency rendered as `<id>@unversioned` despite carrying a precise pin.
  */
 export function upstreamRefsFromLockfile(
   lockfile: Lockfile,
@@ -30,9 +54,17 @@ export function upstreamRefsFromLockfile(
   for (const u of lockfile.upstreams) {
     if (u.kind !== "registry" && u.kind !== "dependency") continue;
     if (u.snapshot === undefined) continue;
+    let version: string;
+    if ("version" in u && u.version) {
+      version = u.version;
+    } else if (u.kind === "dependency") {
+      version = versionFromResolved(u.resolved);
+    } else {
+      version = UNVERSIONED;
+    }
     refs.push({
       id: u.id,
-      version: ("version" in u && u.version) ? u.version : UNVERSIONED,
+      version,
       dir: join(cacheRoot, u.id),
     });
   }

--- a/packages/markspec/core/upstream/refs_test.ts
+++ b/packages/markspec/core/upstream/refs_test.ts
@@ -106,9 +106,43 @@ Deno.test("upstreamRefsFromLockfile: dependency row → ref with cache dir", () 
   );
   assertEquals(refs, [{
     id: "product",
-    // UpstreamDependency carries no `version` field — the badge label
-    // falls back to "unversioned" (the resolved pin lives in `resolved`).
-    version: "unversioned",
+    // UpstreamDependency carries no `version` field — the badge label is
+    // derived from the `resolved` pin. A `tag:` pin renders bare (#800).
+    version: "v2.1.0",
     dir: join(upstreamCacheRoot("/proj"), "product"),
   }]);
+});
+
+Deno.test("upstreamRefsFromLockfile: dependency branch pin → bare branch name", () => {
+  const refs = upstreamRefsFromLockfile(
+    lf([{
+      kind: "dependency",
+      id: "product",
+      url: "git@github.com:acme/product.git",
+      intent: "main",
+      resolved: "branch:main",
+      sha: "a".repeat(40),
+      snapshot: "sha256:c",
+      lockedAt: "2026-07-04T00:00:00Z",
+    }]),
+    "/proj",
+  );
+  assertEquals(refs[0].version, "main");
+});
+
+Deno.test("upstreamRefsFromLockfile: dependency sha pin → 7-char short hash", () => {
+  const refs = upstreamRefsFromLockfile(
+    lf([{
+      kind: "dependency",
+      id: "product",
+      url: "git@github.com:acme/product.git",
+      intent: "auto",
+      resolved: "sha:abcdef0123456789abcdef0123456789abcdef01",
+      sha: "abcdef0123456789abcdef0123456789abcdef01",
+      snapshot: "sha256:c",
+      lockedAt: "2026-07-04T00:00:00Z",
+    }]),
+    "/proj",
+  );
+  assertEquals(refs[0].version, "abcdef0");
 });


### PR DESCRIPTION
Part of #800 — the `@unversioned` badge residual from the #799 review.

## Problem

`UpstreamDependency` rows (git dependencies) carry no `version` field, so
`upstreamRefsFromLockfile` fell back to the literal `"unversioned"` for the
origin badge. Every git dependency therefore rendered as `<id>@unversioned`
everywhere the badge is user-visible — hover, completion detail, MSL-R014
collision messages, and the `from upstream X:` attribution — despite the
lockfile's `resolved` field holding a precise pin (`tag:v2.1.0` /
`branch:main` / `sha:…`).

## Fix

Derive the badge label from `resolved` when the row has no `version`:

| `resolved`      | badge label                  |
| --------------- | ---------------------------- |
| `tag:v2.1.0`    | `v2.1.0`                     |
| `branch:main`   | `main`                       |
| `sha:abcdef01…` | `abcdef0` (7-char short hash) |

An unrecognised scheme renders verbatim; an empty pin falls back to
`unversioned`. Registry rows are untouched — they keep their published
`project.version` and still fall back to `unversioned` only when unpublished.

## Tests

- Updated the dependency-row test to expect the bare tag label.
- Added branch-pin and sha-pin cases.
- RED verified against the original implementation (the 3 dependency
  assertions failed with `unversioned`; the 4 registry/skip cases passed),
  then GREEN with the fix. `just build` + `deno fmt --check` + `dprint check`
  all pass; full `just check` green on push (3907 tests).

## Scope

Only the `@unversioned` badge item of #800. The other three residuals (LSP
init-race window, reload-chain coalescing, `check --strict` tier asymmetry)
remain open on that issue — the strict-tier item is dormant (unreachable
post-#798) and the LSP items are low-probability; none block anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
