### PR TITLE
story(uxil): compiler + uxRegistry + machine projection

### DIFF
--- a/packages/markspec/core/uxil/assemble.ts
+++ b/packages/markspec/core/uxil/assemble.ts
@@ -205,28 +205,38 @@ export function assembleUxSurface(entry: Entry): UxSurfaceTree {
     return { form: "element" };
   });
 
-  // Base-resolution scope for bulletInfo[i]: walk the `.parent` chain,
-  // collecting resolved child-surface ancestor bases (innermost first),
-  // terminated by the root base. Elements never establish a base — the
-  // walk passes over them without pushing, matching "only declarations
-  // create bases; citations/leaves never do" (core/decl/resolve rule 1).
-  const scopeFor = (parent: number | undefined): BaseScope | undefined => {
-    const chain: string[] = [];
+  // Nearest ancestor base for a bullet's `.parent` chain: the closest
+  // "child" ancestor (skipping over "element" ancestors, which never
+  // establish a base — core/decl/resolve rule 1), or root when there is
+  // none. A "child" ancestor whose OWN declaration failed to resolve
+  // reports `blocked: true` rather than being skipped past — everything
+  // nested beneath a broken intermediate declaration is unscopeable, and
+  // must not silently reattach to a grandparent or root (that would
+  // produce a plausible-looking but wrong path with no diagnostic
+  // explaining the reparenting). `resolveRef` only ever consults the
+  // single nearest base (rule 3, "not accumulated up the chain"), so
+  // finding just this one ancestor is sufficient — no chain to build.
+  const nearestAncestorBase = (
+    parent: number | undefined,
+  ): { readonly path: string } | { readonly blocked: true } | undefined => {
     let p = parent;
     while (p !== undefined) {
       const info = bulletInfo[p];
-      if (info.form === "child" && info.resolvedPath !== undefined) {
-        chain.push(info.resolvedPath);
+      if (info.form === "child") {
+        return info.resolvedPath !== undefined
+          ? { path: info.resolvedPath }
+          : { blocked: true };
       }
       p = bullets[p].parent;
     }
-    let scope: BaseScope | undefined = rootPath !== undefined
-      ? { base: rootPath }
-      : undefined;
-    for (let k = chain.length - 1; k >= 0; k--) {
-      scope = { base: chain[k], parent: scope };
-    }
-    return scope;
+    return undefined;
+  };
+
+  const scopeFor = (parent: number | undefined): BaseScope | undefined => {
+    const nearest = nearestAncestorBase(parent);
+    if (nearest && "blocked" in nearest) return undefined;
+    const base = nearest?.path ?? rootPath;
+    return base !== undefined ? { base } : undefined;
   };
 
   // Resolve child-surface paths in source order. Parents always precede
@@ -240,27 +250,25 @@ export function assembleUxSurface(entry: Entry): UxSurfaceTree {
       scopeFor(bullets[i].parent),
       UX_REF_OPS,
     );
-    // A relative child-surface ref only fails to resolve when there is no
-    // root anywhere in its ancestor chain — already reported once via
-    // UXIL-011 above (or an already-reported malformed root). Skip
-    // silently rather than emit a second, cascading diagnostic.
+    // A relative child-surface ref fails to resolve when there is no root
+    // anywhere in its ancestor chain (already reported once via UXIL-011
+    // above, or an already-reported malformed root) or when its nearest
+    // ancestor is itself a broken child declaration (already reported via
+    // that ancestor's own diagnostic). Skip silently rather than emit a
+    // second, cascading diagnostic.
     if (res.ok) info.resolvedPath = res.ref;
   }
 
   // Nearest enclosing surface path for a bullet's `.parent` — the closest
-  // resolved child-surface ancestor, or the root when there is none.
+  // resolved child-surface ancestor, or the root when there is none (or
+  // `undefined` when the nearest ancestor is itself unresolved — see
+  // nearestAncestorBase).
   const enclosingSurfacePath = (
     parent: number | undefined,
   ): string | undefined => {
-    let p = parent;
-    while (p !== undefined) {
-      const info = bulletInfo[p];
-      if (info.form === "child" && info.resolvedPath !== undefined) {
-        return info.resolvedPath;
-      }
-      p = bullets[p].parent;
-    }
-    return rootPath;
+    const nearest = nearestAncestorBase(parent);
+    if (nearest && "blocked" in nearest) return undefined;
+    return nearest?.path ?? rootPath;
   };
 
   // ── Group elements under their enclosing surface ────────────────────────

--- a/packages/markspec/core/uxil/assemble.ts
+++ b/packages/markspec/core/uxil/assemble.ts
@@ -1,0 +1,317 @@
+/**
+ * @module uxil/assemble
+ *
+ * Per-entry uxil assembly (S8 #726): walks an entry's root/element/child
+ * declarations, resolves child-surface paths against the entry-local base
+ * chain (root ← child-surface ancestors, innermost wins — core/decl/resolve),
+ * and stitches the result into a {@linkcode UxSurfaceTree}. Mirrors
+ * typl/assemble.ts's pass structure, simplified: uxil child surfaces are
+ * always relative joins (the leading-dot grammar has no absolute form), and
+ * kind is declared once at the root and inherited by every descendant
+ * surface (`ChildSurfaceDecl` carries no `kind` field).
+ *
+ * Vocabulary validation (unknown kind/verb, state rules, exclusivity) is
+ * NOT this module's concern — it runs over the assembled tree in
+ * validator.ts (Pass 1). This module is purely structural: extraction,
+ * base resolution, and tree-building.
+ *
+ * A declaration whose parse produced any diagnostic is never registered
+ * (gated on a clean parse, never on decl truthiness — grammar.ts #780);
+ * its diagnostics are still collected and returned.
+ */
+import type { SourceRange } from "../ast/nodes.ts";
+import type { Entry, SourceLocation } from "../model/mod.ts";
+import type { UxKey } from "./ast.ts";
+import {
+  type BaseScope,
+  checkSingleRoot,
+  type RefOps,
+  resolveRef,
+} from "../decl/mod.ts";
+import { type UxilDiagnostic, uxilDiagnostic } from "./diagnostics.ts";
+import {
+  parseChildSurfaceDecl,
+  parseElementBullet,
+  parseRootDecl,
+} from "./grammar.ts";
+import { classifyUxilForm } from "./recognize.ts";
+import {
+  extractUxBullets,
+  extractUxRootSpans,
+  stripUxilLeadingSpan,
+} from "./surfaces.ts";
+
+/** Reference operations for uxil's dotted internal surface paths. Child
+ * surfaces are always relative (the leading-dot grammar has no absolute
+ * form), so `isAbsolute` never fires in practice for a child-surface join —
+ * kept for API symmetry with the DSL-agnostic `core/decl` engine. */
+export const UX_REF_OPS: RefOps = {
+  isAbsolute: (r) => r.startsWith("ux:"),
+  join: (b, r) => `${b}.${r}`,
+};
+
+/** One declared interaction element on a surface. */
+export interface UxElement {
+  readonly name: string;
+  readonly verbs: readonly string[];
+  readonly keyTemplate?: UxKey;
+  readonly navTarget?: string;
+  readonly states: readonly string[];
+  readonly eventDictionary: string;
+  readonly location: SourceLocation;
+}
+
+/** One declared surface (root or child), with its elements. */
+export interface UxSurface {
+  readonly path: string;
+  readonly kind: string;
+  readonly states: readonly string[];
+  readonly elements: readonly UxElement[];
+  readonly location: SourceLocation;
+}
+
+/** Result of assembling one entry's uxil declarations. */
+export interface UxSurfaceTree {
+  readonly surfaces: readonly UxSurface[];
+  readonly diagnostics: readonly UxilDiagnostic[];
+}
+
+/** Per-bullet parse state, indexed in parallel with the filtered bullet list. */
+interface BulletInfo {
+  readonly form: "element" | "child";
+  readonly verbs?: readonly string[];
+  readonly keyTemplate?: UxKey;
+  readonly navTarget?: string;
+  readonly elementStates?: readonly string[];
+  readonly eventDictionary?: string;
+  readonly elementName?: string;
+  readonly childPath?: readonly string[];
+  readonly childStates?: readonly string[];
+  resolvedPath?: string;
+}
+
+function toLocation(entry: Entry, range: SourceRange): SourceLocation {
+  return {
+    file: entry.location.file,
+    line: (entry.bodyStartLine ?? 1) + range.start.line - 1,
+    column: range.start.column,
+  };
+}
+
+/**
+ * Assemble one entry's uxil declarations into its surface tree. Reads
+ * `entry.bodyTokens` (root spans) and `entry.bodyAst` (element/child
+ * bullets) — no parser or model change; S8 is a pure downstream reader.
+ */
+export function assembleUxSurface(entry: Entry): UxSurfaceTree {
+  const diagnostics: UxilDiagnostic[] = [];
+
+  // ── Root ──────────────────────────────────────────────────────────────
+  const rootSpans = extractUxRootSpans(entry.bodyTokens);
+  const rootCandidates: {
+    surface: readonly string[];
+    kind: string;
+    states: readonly string[];
+    location: SourceLocation;
+  }[] = [];
+  for (const span of rootSpans) {
+    const { decl, diagnostics: parseDiags } = parseRootDecl(span.source);
+    diagnostics.push(...parseDiags);
+    if (decl && parseDiags.length === 0) {
+      rootCandidates.push({
+        surface: decl.surface,
+        kind: decl.kind,
+        states: decl.states,
+        location: span.location,
+      });
+    }
+  }
+
+  let rootPath: string | undefined;
+  let rootKind: string | undefined;
+  let rootStates: readonly string[] = [];
+  let rootLocation: SourceLocation | undefined;
+
+  const bullets = extractUxBullets(entry.bodyAst ?? []);
+
+  if (rootCandidates.length === 0) {
+    // A malformed root span already reports its own specific parse
+    // diagnostic (e.g. UXIL-004) — adding "no root found" on top would be
+    // redundant noise for the same defect. UXIL-011 is reserved for the
+    // distinct case: uxil content exists (bullets) but no root span was
+    // ever written at all. An entry with no uxil content whatsoever is not
+    // this module's concern (ADR-009: entry-type policy is S9/profile's).
+    if (rootSpans.length === 0 && bullets.length > 0) {
+      diagnostics.push(
+        uxilDiagnostic("UXIL-011", {}, {
+          line: entry.bodyStartLine ?? 1,
+          column: 1,
+        }),
+      );
+    }
+  } else {
+    const check = checkSingleRoot(rootCandidates);
+    const first = rootCandidates[0];
+    rootPath = first.surface.join(".");
+    rootKind = first.kind;
+    rootStates = first.states;
+    rootLocation = first.location;
+    if (!check.ok) {
+      // multiple-roots: first wins (source order); every extra is UXIL-012.
+      for (let k = 1; k < check.roots.length; k++) {
+        const extra = check.roots[k];
+        diagnostics.push(
+          uxilDiagnostic("UXIL-012", { first: `ux:${rootPath}` }, {
+            line: extra.location.line,
+            column: extra.location.column,
+          }),
+        );
+      }
+    }
+  }
+
+  // ── Element / child-surface bullets ─────────────────────────────────────
+  const bulletInfo: BulletInfo[] = bullets.map((bullet) => {
+    const span = stripUxilLeadingSpan(bullet.source);
+    const form = span !== undefined ? classifyUxilForm(span) : undefined;
+    if (form === "child") {
+      const { decl, diagnostics: parseDiags } = parseChildSurfaceDecl(span!);
+      diagnostics.push(...parseDiags);
+      if (decl && parseDiags.length === 0) {
+        return {
+          form: "child",
+          childPath: decl.path,
+          childStates: decl.states,
+        };
+      }
+      return { form: "child" };
+    }
+    // form === "element" (extractUxBullets only returns element/child spans).
+    const { decl, diagnostics: parseDiags } = parseElementBullet(
+      bullet.source,
+    );
+    diagnostics.push(...parseDiags);
+    if (decl && parseDiags.length === 0) {
+      return {
+        form: "element",
+        elementName: decl.element,
+        verbs: decl.verbs,
+        keyTemplate: decl.keyTemplate,
+        navTarget: decl.nav ? decl.nav.surface.join(".") : undefined,
+        elementStates: decl.states,
+        eventDictionary: decl.eventDictionary,
+      };
+    }
+    return { form: "element" };
+  });
+
+  // Base-resolution scope for bulletInfo[i]: walk the `.parent` chain,
+  // collecting resolved child-surface ancestor bases (innermost first),
+  // terminated by the root base. Elements never establish a base — the
+  // walk passes over them without pushing, matching "only declarations
+  // create bases; citations/leaves never do" (core/decl/resolve rule 1).
+  const scopeFor = (parent: number | undefined): BaseScope | undefined => {
+    const chain: string[] = [];
+    let p = parent;
+    while (p !== undefined) {
+      const info = bulletInfo[p];
+      if (info.form === "child" && info.resolvedPath !== undefined) {
+        chain.push(info.resolvedPath);
+      }
+      p = bullets[p].parent;
+    }
+    let scope: BaseScope | undefined = rootPath !== undefined
+      ? { base: rootPath }
+      : undefined;
+    for (let k = chain.length - 1; k >= 0; k--) {
+      scope = { base: chain[k], parent: scope };
+    }
+    return scope;
+  };
+
+  // Resolve child-surface paths in source order. Parents always precede
+  // children in the depth-first extraction order (core/decl/surfaces.ts
+  // guarantee), so a single forward pass suffices — no fixpoint needed.
+  for (let i = 0; i < bullets.length; i++) {
+    const info = bulletInfo[i];
+    if (info.form !== "child" || info.childPath === undefined) continue;
+    const res = resolveRef(
+      info.childPath.join("."),
+      scopeFor(bullets[i].parent),
+      UX_REF_OPS,
+    );
+    // A relative child-surface ref only fails to resolve when there is no
+    // root anywhere in its ancestor chain — already reported once via
+    // UXIL-011 above (or an already-reported malformed root). Skip
+    // silently rather than emit a second, cascading diagnostic.
+    if (res.ok) info.resolvedPath = res.ref;
+  }
+
+  // Nearest enclosing surface path for a bullet's `.parent` — the closest
+  // resolved child-surface ancestor, or the root when there is none.
+  const enclosingSurfacePath = (
+    parent: number | undefined,
+  ): string | undefined => {
+    let p = parent;
+    while (p !== undefined) {
+      const info = bulletInfo[p];
+      if (info.form === "child" && info.resolvedPath !== undefined) {
+        return info.resolvedPath;
+      }
+      p = bullets[p].parent;
+    }
+    return rootPath;
+  };
+
+  // ── Group elements under their enclosing surface ────────────────────────
+  const elementsByPath = new Map<string, UxElement[]>();
+  for (let i = 0; i < bullets.length; i++) {
+    const info = bulletInfo[i];
+    if (info.form !== "element" || info.elementName === undefined) continue;
+    const path = enclosingSurfacePath(bullets[i].parent);
+    if (path === undefined) continue; // no root in scope — see note above
+    const element: UxElement = {
+      name: info.elementName,
+      verbs: info.verbs ?? [],
+      ...(info.keyTemplate ? { keyTemplate: info.keyTemplate } : {}),
+      ...(info.navTarget !== undefined ? { navTarget: info.navTarget } : {}),
+      states: info.elementStates ?? [],
+      eventDictionary: info.eventDictionary ?? "",
+      location: toLocation(entry, bullets[i].range),
+    };
+    const list = elementsByPath.get(path);
+    if (list) list.push(element);
+    else elementsByPath.set(path, [element]);
+  }
+
+  // ── Build the surface list ───────────────────────────────────────────────
+  const surfaces: UxSurface[] = [];
+  if (
+    rootPath !== undefined && rootKind !== undefined &&
+    rootLocation !== undefined
+  ) {
+    surfaces.push({
+      path: rootPath,
+      kind: rootKind,
+      states: rootStates,
+      elements: elementsByPath.get(rootPath) ?? [],
+      location: rootLocation,
+    });
+  }
+  for (let i = 0; i < bullets.length; i++) {
+    const info = bulletInfo[i];
+    if (info.form !== "child" || info.resolvedPath === undefined) continue;
+    surfaces.push({
+      path: info.resolvedPath,
+      // A resolved child-surface implies rootPath (hence rootKind) is
+      // defined — the only source of a base in this model is the root
+      // fallback (see scopeFor); every resolved path traces back to it.
+      kind: rootKind!,
+      states: info.childStates ?? [],
+      elements: elementsByPath.get(info.resolvedPath) ?? [],
+      location: toLocation(entry, bullets[i].range),
+    });
+  }
+
+  return { surfaces, diagnostics };
+}

--- a/packages/markspec/core/uxil/assemble_test.ts
+++ b/packages/markspec/core/uxil/assemble_test.ts
@@ -1,0 +1,106 @@
+import { assert, assertEquals } from "@std/assert";
+import { assembleUxSurface } from "./assemble.ts";
+import type { Entry } from "../model/mod.ts";
+import { parseMarkdown } from "../parser/markdown.ts";
+
+// Helper: parse a markdown fixture into its single Entry. uxil reads
+// bodyAst/bodyTokens/bodyStartLine, which parseMarkdown fills. This matches
+// the typl fixture convention (typl/assemble_test.ts uses the synchronous
+// parseMarkdown, not the async parseFile).
+function entryOf(md: string): Entry {
+  const { entries } = parseMarkdown(md, { file: "spec.md" });
+  return entries[0];
+}
+
+const MEDIA = `- [UXI_MEDIA_0001] Media home surface
+
+  The media home screen (\`ux:media.home : screen @ loading, ready\`) offers
+  playback control.
+
+  - \`/play : activate\` — starts playback.
+  - \`/favorite_toggle : toggle : {track_id}\` — marks a track favourite.
+  - \`.confirm_dialog @ default\` — delete confirmation dialog.
+    - \`/confirm : activate\` — confirms the deletion.
+
+      Id: 01JZZZZZZZZZZZZZZZZZZZZZZZ
+`;
+
+Deno.test("assembleUxSurface: root + elements + child surface", () => {
+  const tree = assembleUxSurface(entryOf(MEDIA));
+  assertEquals(tree.diagnostics, []);
+  const paths = tree.surfaces.map((s) => s.path).sort();
+  assertEquals(paths, ["media.home", "media.home.confirm_dialog"]);
+
+  const home = tree.surfaces.find((s) => s.path === "media.home")!;
+  assertEquals(home.kind, "screen");
+  assertEquals(home.states, ["loading", "ready"]);
+  assertEquals(home.elements.map((e) => e.name).sort(), [
+    "favorite_toggle",
+    "play",
+  ]);
+  assertEquals(
+    home.elements.find((e) => e.name === "favorite_toggle")?.keyTemplate,
+    { kind: "template", name: "track_id" },
+  );
+  assertEquals(home.location.file, "spec.md");
+
+  const dialog = tree.surfaces.find((s) =>
+    s.path === "media.home.confirm_dialog"
+  )!;
+  assertEquals(dialog.kind, "screen"); // inherited from root
+  assertEquals(dialog.states, ["default"]);
+  assertEquals(dialog.elements.map((e) => e.name), ["confirm"]);
+});
+
+Deno.test("assembleUxSurface: multiple roots -> UXIL-012, first wins", () => {
+  const md = `- [UXI_X_0001] Two roots
+
+  \`ux:a.one : screen\` and also \`ux:a.two : screen\`.
+
+      Id: 01JZZZZZZZZZZZZZZZZZZZZZZZ
+`;
+  const tree = assembleUxSurface(entryOf(md));
+  assert(tree.diagnostics.some((d) => d.code === "UXIL-012"));
+  assert(tree.surfaces.some((s) => s.path === "a.one"));
+  assert(!tree.surfaces.some((s) => s.path === "a.two"));
+});
+
+Deno.test("assembleUxSurface: no root but declarations present -> UXIL-011, nothing registered", () => {
+  const md = `- [UXI_Y_0001] No root
+
+  Just some prose with an element bullet:
+
+  - \`/play : activate\` — starts playback.
+
+      Id: 01JZZZZZZZZZZZZZZZZZZZZZZZ
+`;
+  const tree = assembleUxSurface(entryOf(md));
+  assert(tree.diagnostics.some((d) => d.code === "UXIL-011"));
+  assertEquals(tree.surfaces, []);
+});
+
+Deno.test("assembleUxSurface: entry with no uxil content at all -> no diagnostics, no surfaces", () => {
+  const md = `- [UXI_Z_0001] Plain entry
+
+  Nothing uxil-shaped here.
+
+      Id: 01JZZZZZZZZZZZZZZZZZZZZZZZ
+`;
+  const tree = assembleUxSurface(entryOf(md));
+  assertEquals(tree.diagnostics, []);
+  assertEquals(tree.surfaces, []);
+});
+
+Deno.test("assembleUxSurface: malformed root span reports its own diagnostic, not a redundant UXIL-011", () => {
+  const md = `- [UXI_W_0001] Bad root
+
+  A malformed root: \`ux:a.b :\`.
+
+  - \`/play : activate\` — starts playback.
+
+      Id: 01JZZZZZZZZZZZZZZZZZZZZZZZ
+`;
+  const tree = assembleUxSurface(entryOf(md));
+  assert(tree.diagnostics.some((d) => d.code === "UXIL-004"));
+  assert(!tree.diagnostics.some((d) => d.code === "UXIL-011"));
+});

--- a/packages/markspec/core/uxil/assemble_test.ts
+++ b/packages/markspec/core/uxil/assemble_test.ts
@@ -104,3 +104,34 @@ Deno.test("assembleUxSurface: malformed root span reports its own diagnostic, no
   assert(tree.diagnostics.some((d) => d.code === "UXIL-004"));
   assert(!tree.diagnostics.some((d) => d.code === "UXIL-011"));
 });
+
+Deno.test("assembleUxSurface: a broken intermediate child surface drops its descendants instead of silently reparenting them", () => {
+  // `.settings @` is malformed (a trailing `@` with no state name — UXIL-001).
+  // The nested `.dialog` child and its `/confirm` element must NOT silently
+  // reattach to the grandparent (media.home) — that would produce a
+  // plausible-looking but wrong surface with no diagnostic explaining the
+  // reparenting.
+  const md = `- [UXI_BROKEN_0001] Broken nesting
+
+  \`ux:media.home : screen\` offers:
+
+  - \`.settings @\` — malformed, missing state name.
+    - \`.dialog @ default\` — nested under the malformed one.
+      - \`/confirm : activate\` — nested two levels deep.
+
+      Id: 01JZZZZZZZZZZZZZZZZZZZZZZZ
+`;
+  const tree = assembleUxSurface(entryOf(md));
+  assert(tree.diagnostics.some((d) => d.code === "UXIL-001"));
+  const paths = tree.surfaces.map((s) => s.path);
+  assert(
+    !paths.includes("media.home.dialog"),
+    `descendant of a broken ancestor must not silently reparent; got surfaces: ${
+      JSON.stringify(paths)
+    }`,
+  );
+  // media.home itself is unaffected and still registered, with no elements
+  // silently absorbed from the broken subtree.
+  const home = tree.surfaces.find((s) => s.path === "media.home");
+  assertEquals(home?.elements, []);
+});

--- a/packages/markspec/core/uxil/citations.ts
+++ b/packages/markspec/core/uxil/citations.ts
@@ -1,0 +1,46 @@
+/**
+ * @module uxil/citations
+ *
+ * Citation extraction (S8 #726): a *citation* is a bare `ux:` reference in
+ * an inline code span with no declaration clause — e.g.
+ * `` `ux:media.home/play!activate` ``. Plain root/element/child
+ * declarations are excluded (`classifyUxilForm` recognizes them). Mirrors
+ * typl/citations.ts's inline half.
+ */
+import type { BodyToken, SourceLocation } from "../model/mod.ts";
+import { extractInlineDeclarations } from "../decl/mod.ts";
+import type { UxRef } from "./ast.ts";
+import { parseUxRef } from "./grammar.ts";
+import { classifyUxilForm } from "./recognize.ts";
+
+/** One `ux:` citation: the parsed ref and its file location. */
+export interface UxCitation {
+  readonly ref: UxRef;
+  readonly location: SourceLocation;
+}
+
+/** True when a code span's (trimmed) text is a `ux:` citation, not a declaration. */
+export function isUxCitationText(text: string): boolean {
+  const t = text.trim();
+  return t.startsWith("ux:") && classifyUxilForm(t) === undefined;
+}
+
+/**
+ * Filter `Entry.bodyTokens` to `ux:` citations, in source order. Reuses
+ * the shared inline-declaration walker with the citation recognizer; a
+ * citation that fails to parse cleanly (e.g. a reserved character) is
+ * dropped rather than surfaced — parse-level diagnostics are S7's
+ * concern, not this extractor's.
+ */
+export function extractUxCitations(
+  bodyTokens: readonly BodyToken[],
+): readonly UxCitation[] {
+  const out: UxCitation[] = [];
+  for (const d of extractInlineDeclarations(bodyTokens, isUxCitationText)) {
+    const { ref, diagnostics } = parseUxRef(d.source.trim());
+    if (ref && diagnostics.length === 0) {
+      out.push({ ref, location: d.location });
+    }
+  }
+  return out;
+}

--- a/packages/markspec/core/uxil/citations_test.ts
+++ b/packages/markspec/core/uxil/citations_test.ts
@@ -1,0 +1,40 @@
+import { assertEquals } from "@std/assert";
+import type { BodyToken } from "../model/mod.ts";
+import { extractUxCitations, isUxCitationText } from "./citations.ts";
+
+function inlineCode(text: string, line = 1, column = 1): BodyToken {
+  return {
+    kind: "inline-code",
+    text,
+    location: { file: "a.md", line, column },
+  };
+}
+
+Deno.test("isUxCitationText: citation vs declaration vs non-uxil", () => {
+  assertEquals(isUxCitationText("ux:media.home/play!activate"), true);
+  assertEquals(isUxCitationText(" ux:media.home "), true); // trimmed
+  assertEquals(isUxCitationText("ux:media.home : screen"), false); // root decl
+  assertEquals(isUxCitationText("/play : activate"), false); // element decl (no scheme)
+  assertEquals(isUxCitationText("$speed"), false); // typl, not uxil
+});
+
+Deno.test("extractUxCitations: ux: refs in prose, not declarations", () => {
+  const tokens: BodyToken[] = [
+    inlineCode("`ux:media.home/play!activate`", 5, 10),
+    inlineCode("`ux:media.home : screen`", 6, 3), // root decl, not a citation
+    inlineCode("`/play : activate`", 7, 3), // element decl, not a citation
+  ];
+  const out = extractUxCitations(tokens);
+  assertEquals(out.length, 1);
+  assertEquals(out[0].ref.surface, ["media", "home"]);
+  assertEquals(out[0].ref.element, "play");
+  assertEquals(out[0].ref.verb, "activate");
+  assertEquals(out[0].location, { file: "a.md", line: 5, column: 10 });
+});
+
+Deno.test("extractUxCitations: a malformed citation is dropped, not surfaced as a citation", () => {
+  const tokens: BodyToken[] = [
+    inlineCode("`ux:media.home/play#bad`", 5, 10), // reserved char
+  ];
+  assertEquals(extractUxCitations(tokens), []);
+});

--- a/packages/markspec/core/uxil/diagnostics.ts
+++ b/packages/markspec/core/uxil/diagnostics.ts
@@ -1,14 +1,14 @@
 /**
  * @module uxil/diagnostics
  *
- * Diagnostic codes emitted by the uxil parser (UXIL-001 through UXIL-008).
- * Source-local positions only — S9 bridges these to file-anchored core
- * `Diagnostic`s. Shape and helper mirror typl's `typlDiagnostic`.
+ * Diagnostic codes emitted by the uxil parser and compiler (UXIL-001 through
+ * UXIL-022). Source-local positions only — S9 bridges these to file-anchored
+ * core `Diagnostic`s. Shape and helper mirror typl's `typlDiagnostic`.
  */
 import type { Position } from "./ast.ts";
 import type { Severity } from "../model/mod.ts";
 
-/** Union of all uxil parser diagnostic codes. */
+/** Union of all uxil parser + compiler diagnostic codes. */
 export type UxilCode =
   | "UXIL-001"
   | "UXIL-002"
@@ -17,7 +17,21 @@ export type UxilCode =
   | "UXIL-005"
   | "UXIL-006"
   | "UXIL-007"
-  | "UXIL-008";
+  | "UXIL-008"
+  | "UXIL-009"
+  | "UXIL-010"
+  | "UXIL-011"
+  | "UXIL-012"
+  | "UXIL-013"
+  | "UXIL-014"
+  | "UXIL-015"
+  | "UXIL-016"
+  | "UXIL-017"
+  | "UXIL-018"
+  | "UXIL-019"
+  | "UXIL-020"
+  | "UXIL-021"
+  | "UXIL-022";
 
 /** Shape of each entry in {@linkcode UXIL_CODES}. */
 export interface UxilCodeEntry {
@@ -68,6 +82,71 @@ export const UXIL_CODES: Record<UxilCode, UxilCodeEntry> = {
   "UXIL-008": {
     severity: "error",
     template: "Malformed surface: ${detail}.",
+  },
+  "UXIL-009": {
+    severity: "error",
+    template:
+      "Unknown surface kind '${kind}' (expected screen, panel, or agent).",
+  },
+  "UXIL-010": {
+    severity: "error",
+    template: "Unknown interaction verb '${verb}'.",
+  },
+  "UXIL-011": {
+    severity: "error",
+    template:
+      "A ux-contract entry must declare exactly one root surface; none was found.",
+  },
+  "UXIL-012": {
+    severity: "error",
+    template:
+      "A ux-contract entry must declare exactly one root surface; found another after '${first}'.",
+  },
+  "UXIL-013": {
+    severity: "error",
+    template: "Kind '${kind}' is stateless and cannot declare @ states.",
+  },
+  "UXIL-014": {
+    severity: "error",
+    template:
+      "'observe' is exclusive and cannot be combined with other verbs on element '${element}'.",
+  },
+  "UXIL-015": {
+    severity: "error",
+    template:
+      "Surface '${surface}' is already declared (first at ${otherFile}:${otherLine}).",
+  },
+  "UXIL-016": {
+    severity: "error",
+    template:
+      "Surface '${surface}' has no declared parent surface '${parent}'.",
+  },
+  "UXIL-017": {
+    severity: "error",
+    template:
+      "navigate target '${target}' does not resolve to a navigable (screen) surface.",
+  },
+  "UXIL-018": {
+    severity: "error",
+    template: "Unknown surface '${surface}'.",
+  },
+  "UXIL-019": {
+    severity: "error",
+    template: "Unknown element '${element}' on surface '${surface}'.",
+  },
+  "UXIL-020": {
+    severity: "error",
+    template:
+      "Verb '${verb}' is not in the declared verb set of element '${element}'.",
+  },
+  "UXIL-021": {
+    severity: "error",
+    template: "State '${state}' is not declared on surface '${surface}'.",
+  },
+  "UXIL-022": {
+    severity: "error",
+    template:
+      "Element '${element}' declares a key template; cite it with a '{name}' template, not a concrete key.",
   },
 };
 

--- a/packages/markspec/core/uxil/diagnostics_test.ts
+++ b/packages/markspec/core/uxil/diagnostics_test.ts
@@ -1,5 +1,5 @@
-import { assertEquals } from "@std/assert";
-import { uxilDiagnostic } from "./diagnostics.ts";
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { UXIL_CODES, uxilDiagnostic } from "./diagnostics.ts";
 
 Deno.test("uxilDiagnostic: substitutes params into the template", () => {
   const d = uxilDiagnostic("UXIL-002", { char: "?" }, { line: 1, column: 5 });
@@ -18,4 +18,23 @@ Deno.test("uxilDiagnostic: parameterless template passes through", () => {
     d.message,
     "Root declaration is missing its kind (expected 'ux:surface : kind').",
   );
+});
+
+Deno.test("UXIL semantic codes: all present with error severity", () => {
+  for (let n = 9; n <= 22; n++) {
+    const code = `UXIL-${
+      String(n).padStart(3, "0")
+    }` as keyof typeof UXIL_CODES;
+    assertEquals(UXIL_CODES[code].severity, "error", code);
+  }
+});
+
+Deno.test("UXIL-015 substitutes surface + origin", () => {
+  const d = uxilDiagnostic(
+    "UXIL-015",
+    { surface: "media.home", otherFile: "a.md", otherLine: 3 },
+    { line: 1, column: 1 },
+  );
+  assertStringIncludes(d.message, "media.home");
+  assertStringIncludes(d.message, "a.md:3");
 });

--- a/packages/markspec/core/uxil/mod.ts
+++ b/packages/markspec/core/uxil/mod.ts
@@ -1,10 +1,12 @@
 /**
  * @module uxil
  *
- * Parse-only uxil DSL layer (S7 #725): `ux:` reference + declaration-form
- * parsers, the declaration AST, structured parse diagnostics, and the
- * form recognizer. Not wired into `core/mod.ts` — S8 (uxil compiler +
- * uxRegistry) consumes these; S9 wires diagnostics to the CLI/LSP.
+ * uxil DSL layer: `ux:` reference + declaration-form parsers (S7 #725),
+ * the declaration AST, structured parse diagnostics, the form recognizer,
+ * and the compiler — corpus registry, enforced semantics, and a
+ * deterministic machine projection (S8 #726). Not wired into
+ * `core/mod.ts` — uxil stays out of the public library boundary until
+ * S9/S10 wire the compiler/LSP into the CLI and editor surfaces.
  */
 export type {
   ChildSurfaceDecl,
@@ -27,3 +29,21 @@ export {
 } from "./grammar.ts";
 export type { UxilForm } from "./recognize.ts";
 export { classifyUxilForm } from "./recognize.ts";
+
+// ── S8: compiler + registry + projection ────────────────────────────────
+export type { UxElement, UxSurface, UxSurfaceTree } from "./assemble.ts";
+export { assembleUxSurface, UX_REF_OPS } from "./assemble.ts";
+export type { SurfaceRecord, UxRegistry } from "./registry.ts";
+export { buildUxRegistry } from "./registry.ts";
+export type { UxCitation } from "./citations.ts";
+export { extractUxCitations, isUxCitationText } from "./citations.ts";
+export type { UxilValidation } from "./validator.ts";
+export { validateUxil } from "./validator.ts";
+export type {
+  ProjectedElement,
+  ProjectedSurface,
+  UxProjection,
+} from "./projection.ts";
+export { projectUxRegistry } from "./projection.ts";
+export type { KindInfo, VerbInfo } from "./vocab.ts";
+export { isKnownKind, isKnownVerb, UX_KINDS, UX_VERBS } from "./vocab.ts";

--- a/packages/markspec/core/uxil/mod_test.ts
+++ b/packages/markspec/core/uxil/mod_test.ts
@@ -1,10 +1,14 @@
-import { assertEquals } from "@std/assert";
+import { assert, assertEquals } from "@std/assert";
 import {
+  buildUxRegistry,
   classifyUxilForm,
   parseChildSurfaceDecl,
   parseElementBullet,
   parseRootDecl,
   parseUxRef,
+  projectUxRegistry,
+  UX_VERBS,
+  validateUxil,
 } from "./mod.ts";
 
 // Acceptance 1: grammar parses/round-trips all four forms + refs.
@@ -47,4 +51,11 @@ Deno.test("acceptance: parse errors carry code + position", () => {
   assertEquals(diagnostics[0].code, "UXIL-006");
   assertEquals(typeof diagnostics[0].position.line, "number");
   assertEquals(typeof diagnostics[0].position.column, "number");
+});
+
+Deno.test("mod.ts re-exports the S8 compiler surface", () => {
+  assert(typeof buildUxRegistry === "function");
+  assert(typeof validateUxil === "function");
+  assert(typeof projectUxRegistry === "function");
+  assert(UX_VERBS.size === 11);
 });

--- a/packages/markspec/core/uxil/projection.ts
+++ b/packages/markspec/core/uxil/projection.ts
@@ -1,0 +1,80 @@
+/**
+ * @module uxil/projection
+ *
+ * Deterministic machine projection of a {@linkcode UxRegistry} (S8 #726):
+ * the seam downstream codegen (and the S11 payload bridge) build on. Pure
+ * transform — no timestamps or run metadata, every collection sorted by a
+ * stable key so `projectUxRegistry(registry)` is byte-identical across
+ * runs. A duplicated surface id uses only its first-declared record
+ * (mirrors the first-declaration-wins convention used elsewhere in S8);
+ * the duplicate itself is a separate validator concern (UXIL-015).
+ */
+import type { SurfaceRecord, UxRegistry } from "./registry.ts";
+
+/** One projected interaction element. */
+export interface ProjectedElement {
+  readonly name: string;
+  readonly verbs: readonly string[];
+  readonly keyTemplate: string | null;
+  readonly nav: string | null;
+  readonly states: readonly string[];
+}
+
+/** One projected surface. */
+export interface ProjectedSurface {
+  readonly id: string;
+  readonly kind: string;
+  readonly states: readonly string[];
+  readonly parent: string | null;
+  readonly elements: readonly ProjectedElement[];
+}
+
+/** The full deterministic projection. */
+export interface UxProjection {
+  readonly surfaces: readonly ProjectedSurface[];
+}
+
+function projectElement(
+  element: SurfaceRecord["elements"][number],
+): ProjectedElement {
+  return {
+    name: element.name,
+    verbs: element.verbs,
+    // keyTemplate is always the "template" form — parseElementBullet only
+    // ever assigns a UxKey here when it parsed as `{name}` (grammar.ts's K1
+    // clause), never a concrete key.
+    keyTemplate: element.keyTemplate?.kind === "template"
+      ? element.keyTemplate.name
+      : null,
+    nav: element.navTarget ?? null,
+    states: [...element.states].sort(),
+  };
+}
+
+/**
+ * Project a {@linkcode UxRegistry} into a deterministic, JSON-serialisable
+ * manifest. Surfaces sorted by id; elements within a surface sorted by
+ * name; states sorted; verbs kept in declaration order (still
+ * deterministic — load-bearing for compound controls).
+ */
+export function projectUxRegistry(registry: UxRegistry): UxProjection {
+  const paths = [...registry.surfaces.keys()].sort();
+  const surfaces: ProjectedSurface[] = paths.map((path) => {
+    const record = registry.surfaces.get(path)![0]; // first declaration wins
+    const dot = path.lastIndexOf(".");
+    const parentPath = dot < 0 ? undefined : path.slice(0, dot);
+    const parent = parentPath !== undefined && registry.surfaces.has(parentPath)
+      ? parentPath
+      : null;
+    return {
+      id: path,
+      kind: record.kind,
+      states: [...record.states].sort(),
+      parent,
+      elements: [...record.elements]
+        .sort((a, b) => a.name.localeCompare(b.name))
+        .map(projectElement),
+    };
+  });
+  return { surfaces };
+}

--- a/packages/markspec/core/uxil/projection_test.ts
+++ b/packages/markspec/core/uxil/projection_test.ts
@@ -1,0 +1,90 @@
+import { assertEquals } from "@std/assert";
+import { projectUxRegistry } from "./projection.ts";
+import { buildUxRegistry } from "./registry.ts";
+import { parseMarkdown } from "../parser/markdown.ts";
+import type { Entry } from "../model/mod.ts";
+
+function entriesOf(files: Record<string, string>): Entry[] {
+  const out: Entry[] = [];
+  for (const [f, md] of Object.entries(files)) {
+    const { entries } = parseMarkdown(md, { file: f });
+    out.push(...entries);
+  }
+  return out;
+}
+
+const MD = `- [UXI_A_0001] A
+
+  \`ux:media.home : screen @ ready, loading\` offers:
+
+  - \`/play : activate\` — play.
+  - \`.confirm_dialog @ default\` — dialog.
+    - \`/confirm : activate\` — confirm.
+
+      Id: 01JZZZZZZZZZZZZZZZZZZZZZZA
+`;
+
+Deno.test("projectUxRegistry: sorted + deterministic", () => {
+  const reg = buildUxRegistry(entriesOf({ "a.md": MD }));
+  const p1 = projectUxRegistry(reg);
+  const p2 = projectUxRegistry(reg);
+  assertEquals(JSON.stringify(p1), JSON.stringify(p2)); // stable
+  assertEquals(p1.surfaces.map((s) => s.id), [
+    "media.home",
+    "media.home.confirm_dialog",
+  ]);
+  const home = p1.surfaces[0];
+  assertEquals(home.states, ["loading", "ready"]); // sorted
+  assertEquals(home.parent, null);
+  assertEquals(p1.surfaces[1].parent, "media.home");
+});
+
+Deno.test("projectUxRegistry: elements sorted by name; keyTemplate/nav/states shaped", () => {
+  const md = `- [UXI_B_0001] B
+
+  \`ux:panelb : screen\` offers:
+
+  - \`/zzz : activate\` — z.
+  - \`/aaa : toggle : {track_id}\` — a.
+  - \`/nav : navigate -> panelb\` — n.
+
+      Id: 01JZZZZZZZZZZZZZZZZZZZZZZB
+`;
+  const reg = buildUxRegistry(entriesOf({ "b.md": md }));
+  const proj = projectUxRegistry(reg);
+  const surface = proj.surfaces[0];
+  assertEquals(surface.elements.map((e) => e.name), ["aaa", "nav", "zzz"]);
+  const aaa = surface.elements.find((e) => e.name === "aaa")!;
+  assertEquals(aaa.keyTemplate, "track_id");
+  assertEquals(aaa.nav, null);
+  const nav = surface.elements.find((e) => e.name === "nav")!;
+  assertEquals(nav.keyTemplate, null);
+  assertEquals(nav.nav, "panelb");
+  const zzz = surface.elements.find((e) => e.name === "zzz")!;
+  assertEquals(zzz.states, []);
+});
+
+Deno.test("projectUxRegistry: duplicated surface id uses only the first record", () => {
+  const a = `- [UXI_C_0001] C1
+
+  \`ux:dup : screen @ x\` — first.
+
+      Id: 01JZZZZZZZZZZZZZZZZZZZZZZC
+`;
+  const b = `- [UXI_D_0001] C2
+
+  \`ux:dup : panel @ y\` — second, different kind/states.
+
+      Id: 01JZZZZZZZZZZZZZZZZZZZZZZD
+`;
+  const reg = buildUxRegistry(entriesOf({ "a.md": a, "b.md": b }));
+  const proj = projectUxRegistry(reg);
+  assertEquals(proj.surfaces.length, 1);
+  assertEquals(proj.surfaces[0].kind, "screen"); // first wins
+  assertEquals(proj.surfaces[0].states, ["x"]);
+});
+
+Deno.test("projectUxRegistry: empty registry yields an empty projection", () => {
+  const reg = buildUxRegistry([]);
+  assertEquals(projectUxRegistry(reg), { surfaces: [] });
+});

--- a/packages/markspec/core/uxil/registry.ts
+++ b/packages/markspec/core/uxil/registry.ts
@@ -1,0 +1,61 @@
+/**
+ * @module uxil/registry
+ *
+ * Corpus-level index of every declared uxil surface across all entries.
+ * Built by {@linkcode buildUxRegistry}; consumed by validateUxil
+ * (declared-once / dangling-parent / navigate-resolution checks) and
+ * projectUxRegistry (machine projection). Mirrors typl/registry.ts,
+ * keyed by absolute surface path instead of `$Name`.
+ */
+import type { Entry, SourceLocation } from "../model/mod.ts";
+import { assembleUxSurface, type UxElement } from "./assemble.ts";
+
+/** One surface declaration record, with backref to its host entry. */
+export interface SurfaceRecord {
+  readonly path: string;
+  readonly kind: string;
+  readonly states: readonly string[];
+  readonly owningEntryDisplayId: string;
+  readonly owningEntryFile: string;
+  readonly elements: readonly UxElement[];
+  readonly location: SourceLocation;
+}
+
+/**
+ * Corpus-wide index. Each surface path maps to ALL declarations found —
+ * collisions are NOT collapsed; the validator surfaces duplicate
+ * declarations via UXIL-015 (mirrors typl's TYPL-009 treatment).
+ */
+export interface UxRegistry {
+  /** Keyed by absolute surface path (no `ux:` scheme). */
+  readonly surfaces: ReadonlyMap<string, readonly SurfaceRecord[]>;
+}
+
+/**
+ * Build the corpus uxil registry from the entries. Entries whose assembly
+ * yields no surfaces are skipped. Source order is preserved within each
+ * path's list (first declaration first).
+ */
+export function buildUxRegistry(entries: readonly Entry[]): UxRegistry {
+  const surfaces = new Map<string, SurfaceRecord[]>();
+
+  for (const entry of entries) {
+    const tree = assembleUxSurface(entry);
+    for (const surface of tree.surfaces) {
+      const record: SurfaceRecord = {
+        path: surface.path,
+        kind: surface.kind,
+        states: surface.states,
+        owningEntryDisplayId: entry.displayId,
+        owningEntryFile: entry.location.file,
+        elements: surface.elements,
+        location: surface.location,
+      };
+      const list = surfaces.get(surface.path);
+      if (list) list.push(record);
+      else surfaces.set(surface.path, [record]);
+    }
+  }
+
+  return { surfaces };
+}

--- a/packages/markspec/core/uxil/registry_test.ts
+++ b/packages/markspec/core/uxil/registry_test.ts
@@ -1,0 +1,55 @@
+import { assert, assertEquals } from "@std/assert";
+import { buildUxRegistry } from "./registry.ts";
+import { parseMarkdown } from "../parser/markdown.ts";
+import type { Entry } from "../model/mod.ts";
+
+function entriesOf(files: Record<string, string>): Entry[] {
+  const out: Entry[] = [];
+  for (const [file, md] of Object.entries(files)) {
+    const { entries } = parseMarkdown(md, { file });
+    out.push(...entries);
+  }
+  return out;
+}
+
+Deno.test("buildUxRegistry: aggregates surfaces across entries; keeps duplicates", () => {
+  const a = `- [UXI_A_0001] A
+
+  \`ux:media.home : screen\` offers:
+
+  - \`/play : activate\` — play.
+
+      Id: 01JZZZZZZZZZZZZZZZZZZZZZZA
+`;
+  const b = `- [UXI_B_0001] B (duplicate surface)
+
+  \`ux:media.home : screen\` again.
+
+      Id: 01JZZZZZZZZZZZZZZZZZZZZZZB
+`;
+  const reg = buildUxRegistry(entriesOf({ "a.md": a, "b.md": b }));
+  assertEquals(reg.surfaces.get("media.home")?.length, 2); // both kept
+  assert(
+    reg.surfaces.get("media.home")?.[0].elements.some((e) => e.name === "play"),
+  );
+  assertEquals(
+    reg.surfaces.get("media.home")?.[0].owningEntryDisplayId,
+    "UXI_A_0001",
+  );
+  assertEquals(reg.surfaces.get("media.home")?.[0].owningEntryFile, "a.md");
+  assertEquals(
+    reg.surfaces.get("media.home")?.[1].owningEntryDisplayId,
+    "UXI_B_0001",
+  );
+});
+
+Deno.test("buildUxRegistry: entry with no uxil content contributes nothing", () => {
+  const md = `- [UXI_C_0001] Plain
+
+  No uxil here.
+
+      Id: 01JZZZZZZZZZZZZZZZZZZZZZZC
+`;
+  const reg = buildUxRegistry(entriesOf({ "c.md": md }));
+  assertEquals(reg.surfaces.size, 0);
+});

--- a/packages/markspec/core/uxil/surfaces.ts
+++ b/packages/markspec/core/uxil/surfaces.ts
@@ -1,0 +1,71 @@
+/**
+ * @module uxil/surfaces
+ *
+ * Thin uxil adapters over the shared declaration-surface machinery
+ * (core/decl). Each supplies a `classifyUxilForm`-based recognizer and
+ * re-uses the DSL-agnostic walkers — mirrors typl/bullet.ts + the inline
+ * half of typl/citations.ts.
+ *
+ * Bullet paragraphs keep their literal backtick delimiters and any
+ * trailing prose in one string (e.g. `` `/play : activate` — starts
+ * playback. ``) — {@linkcode extractNestedBulletDeclarations} hands the
+ * whole paragraph to the recognizer, unlike the inline surface (whose
+ * tokens are span-only, already backtick-stripped by
+ * {@linkcode extractInlineDeclarations}). Classification therefore needs
+ * the *leading span* extracted first; {@linkcode stripUxilLeadingSpan}
+ * does that (mirroring grammar.ts's private `splitLeadingCodeSpan`,
+ * span-only). The declaration's `source` field stays the raw paragraph —
+ * `parseElementBullet` wants exactly that (it splits the span itself);
+ * assembly strips the span again for `parseChildSurfaceDecl`, which
+ * expects bare span text.
+ */
+import type { BodyBlock } from "../ast/nodes.ts";
+import type { BodyToken } from "../model/mod.ts";
+import {
+  extractInlineDeclarations,
+  extractNestedBulletDeclarations,
+  type InlineDeclaration,
+  type NestedBlockDeclaration,
+} from "../decl/mod.ts";
+import { classifyUxilForm } from "./recognize.ts";
+
+/**
+ * Extract the leading inline-code span's inner text from a bullet
+ * paragraph, backticks stripped, ignoring any trailing prose. Returns
+ * `undefined` when the paragraph does not begin with a (closed) code
+ * span. Handles both single- and double-backtick delimiters.
+ */
+export function stripUxilLeadingSpan(text: string): string | undefined {
+  const t = text.replace(/^\s+/, "");
+  if (t.startsWith("``")) {
+    const end = t.indexOf("``", 2);
+    return end < 0 ? undefined : t.slice(2, end);
+  }
+  if (t.startsWith("`")) {
+    const end = t.indexOf("`", 1);
+    return end < 0 ? undefined : t.slice(1, end);
+  }
+  return undefined;
+}
+
+/** Inline code spans whose text is a uxil root declaration. */
+export function extractUxRootSpans(
+  bodyTokens: readonly BodyToken[],
+): readonly InlineDeclaration[] {
+  return extractInlineDeclarations(
+    bodyTokens,
+    (text) => classifyUxilForm(text) === "root",
+  );
+}
+
+/** Bullet declarations (element or child surface), with parent links. */
+export function extractUxBullets(
+  blocks: readonly BodyBlock[],
+): readonly NestedBlockDeclaration[] {
+  return extractNestedBulletDeclarations(blocks, (text) => {
+    const span = stripUxilLeadingSpan(text);
+    if (span === undefined) return false;
+    const form = classifyUxilForm(span);
+    return form === "element" || form === "child";
+  });
+}

--- a/packages/markspec/core/uxil/surfaces_test.ts
+++ b/packages/markspec/core/uxil/surfaces_test.ts
@@ -1,0 +1,120 @@
+import { assertEquals } from "@std/assert";
+import type {
+  BodyBlock,
+  ListItemNode,
+  ListNode,
+  ParagraphNode,
+} from "../ast/nodes.ts";
+import type { BodyToken } from "../model/mod.ts";
+import {
+  extractUxBullets,
+  extractUxRootSpans,
+  stripUxilLeadingSpan,
+} from "./surfaces.ts";
+
+function para(text: string, line = 1): ParagraphNode {
+  return {
+    kind: "paragraph",
+    content: { text },
+    range: {
+      start: { line, column: 1 },
+      end: { line, column: text.length + 1 },
+    },
+  };
+}
+
+function item(blocks: BodyBlock[], line = 1): ListItemNode {
+  return {
+    blocks,
+    range: {
+      start: { line, column: 1 },
+      end: { line, column: 1 },
+    },
+  };
+}
+
+function list(items: ListItemNode[], ordered = false): ListNode {
+  return {
+    kind: "list",
+    ordered,
+    spread: false,
+    items,
+    range: {
+      start: { line: 1, column: 1 },
+      end: { line: items.length, column: 1 },
+    },
+  };
+}
+
+function inlineCode(text: string, line = 1, column = 1): BodyToken {
+  return {
+    kind: "inline-code",
+    text,
+    location: { file: "a.md", line, column },
+  };
+}
+
+Deno.test("extractUxRootSpans: only root-form inline spans", () => {
+  const tokens: BodyToken[] = [
+    inlineCode("`ux:media.home : screen`", 5, 10),
+    inlineCode("`ux:media.home/play`", 6, 3), // citation, not a root decl
+    inlineCode("`/play : activate`", 7, 3), // element decl, not a root
+  ];
+  const out = extractUxRootSpans(tokens);
+  assertEquals(out.length, 1);
+  assertEquals(out[0].source, "ux:media.home : screen");
+});
+
+Deno.test("extractUxBullets: element + child bullets with parent links", () => {
+  const play = para("`/play : activate` — starts playback.", 3);
+  const dialog = para("`.confirm_dialog @ default` — delete dialog.", 4);
+  const confirm = para("`/confirm : activate` — confirms.", 5);
+  const blocks: BodyBlock[] = [
+    list([
+      item([play]),
+      item([dialog, list([item([confirm])])]),
+    ]),
+  ];
+  const result = extractUxBullets(blocks);
+  assertEquals(result.length, 3);
+  // .source is the raw paragraph text (backticks + trailing prose intact) —
+  // classification uses the stripped span internally but the returned
+  // declaration keeps the verbatim paragraph, matching parseElementBullet's
+  // own (self-splitting) input contract.
+  assertEquals(result.map((r) => r.source), [
+    "`/play : activate` — starts playback.",
+    "`.confirm_dialog @ default` — delete dialog.",
+    "`/confirm : activate` — confirms.",
+  ]);
+  assertEquals(result[0].parent, undefined);
+  assertEquals(result[1].parent, undefined);
+  assertEquals(result[2].parent, 1); // nested under the child-surface bullet
+});
+
+Deno.test("extractUxBullets: ignores non-uxil bullets", () => {
+  const blocks: BodyBlock[] = [
+    list([
+      item([para("just a regular bullet", 3)]),
+    ]),
+  ];
+  assertEquals(extractUxBullets(blocks), []);
+});
+
+Deno.test("extractUxBullets: ignores a bullet with a non-uxil leading code span", () => {
+  const blocks: BodyBlock[] = [
+    list([
+      item([para("`$Speed : signal float[0..300]` — a typl binding.", 3)]),
+    ]),
+  ];
+  assertEquals(extractUxBullets(blocks), []);
+});
+
+Deno.test("stripUxilLeadingSpan: extracts single- and double-backtick spans", () => {
+  assertEquals(
+    stripUxilLeadingSpan("`/play : activate` — starts."),
+    "/play : activate",
+  );
+  assertEquals(stripUxilLeadingSpan("``/play`` trailing"), "/play");
+  assertEquals(stripUxilLeadingSpan("no leading span here"), undefined);
+  assertEquals(stripUxilLeadingSpan("`unterminated"), undefined);
+});

--- a/packages/markspec/core/uxil/validator.ts
+++ b/packages/markspec/core/uxil/validator.ts
@@ -10,6 +10,7 @@
 import type { Entry } from "../model/mod.ts";
 import type { Position } from "./ast.ts";
 import { assembleUxSurface } from "./assemble.ts";
+import { extractUxCitations } from "./citations.ts";
 import { findDuplicateDeclarations } from "../decl/mod.ts";
 import { type UxilDiagnostic, uxilDiagnostic } from "./diagnostics.ts";
 import { buildUxRegistry, type UxRegistry } from "./registry.ts";
@@ -122,6 +123,64 @@ export function validateUxil(entries: readonly Entry[]): UxilValidation {
               positionOf(element.location),
             ),
           );
+        }
+      }
+    }
+  }
+
+  // ── Pass 3: citation resolution ──────────────────────────────────────────
+  for (const entry of entries) {
+    for (const citation of extractUxCitations(entry.bodyTokens)) {
+      const { ref, location } = citation;
+      const pos = positionOf(location);
+      const surfacePath = ref.surface.join(".");
+      const records = registry.surfaces.get(surfacePath);
+      if (!records || records.length === 0) {
+        diagnostics.push(
+          uxilDiagnostic("UXIL-018", { surface: surfacePath }, pos),
+        );
+        continue;
+      }
+      // First-declaration-wins, matching the navigate-resolution check above.
+      const surface = records[0];
+
+      if (ref.state !== undefined && !surface.states.includes(ref.state)) {
+        diagnostics.push(
+          uxilDiagnostic(
+            "UXIL-021",
+            { state: ref.state, surface: surfacePath },
+            pos,
+          ),
+        );
+      }
+
+      if (ref.element !== undefined) {
+        const element = surface.elements.find((e) => e.name === ref.element);
+        if (!element) {
+          diagnostics.push(
+            uxilDiagnostic(
+              "UXIL-019",
+              { element: ref.element, surface: surfacePath },
+              pos,
+            ),
+          );
+        } else {
+          if (ref.verb !== undefined && !element.verbs.includes(ref.verb)) {
+            diagnostics.push(
+              uxilDiagnostic(
+                "UXIL-020",
+                { verb: ref.verb, element: element.name },
+                pos,
+              ),
+            );
+          }
+          if (
+            ref.key?.kind === "concrete" && element.keyTemplate !== undefined
+          ) {
+            diagnostics.push(
+              uxilDiagnostic("UXIL-022", { element: element.name }, pos),
+            );
+          }
         }
       }
     }

--- a/packages/markspec/core/uxil/validator.ts
+++ b/packages/markspec/core/uxil/validator.ts
@@ -95,6 +95,18 @@ export function validateUxil(entries: readonly Entry[]): UxilValidation {
     const dot = path.lastIndexOf(".");
     if (dot < 0) continue;
     const parent = path.slice(0, dot);
+    // A single-segment parent (e.g. "media" in "media.home") is an
+    // ordinary namespace prefix a root can use freely — it is never
+    // itself required to be a separately declared surface (the design's
+    // own worked examples name roots this way: "media.home",
+    // "controls.hvac"). Only a surface nested 2+ levels deep, whose
+    // parent is itself dotted, plausibly represents a promoted child
+    // surface (design §6) whose intermediate ancestor is expected to
+    // exist somewhere in the corpus. A genuinely-nested same-entry child
+    // never reaches this branch — assembleUxSurface always registers its
+    // resolved ancestor alongside it — so this only ever fires across
+    // entries, exactly the promoted-surface scenario it targets.
+    if (!parent.includes(".")) continue;
     if (registry.surfaces.has(parent)) continue;
     for (const record of records) {
       diagnostics.push(

--- a/packages/markspec/core/uxil/validator.ts
+++ b/packages/markspec/core/uxil/validator.ts
@@ -1,0 +1,131 @@
+/**
+ * @module uxil/validator
+ *
+ * Enforced uxil semantics (S8 #726): closed-vocabulary checks, corpus
+ * structural rules (declared-once, dangling namespace parent, navigate
+ * resolution), and citation resolution (Pass 3, added alongside Task 9).
+ * Mirrors typl/validator.ts's shape. Positions are the assembled records'
+ * own `location` — source-local-safe; S9 owns file-anchoring.
+ */
+import type { Entry } from "../model/mod.ts";
+import type { Position } from "./ast.ts";
+import { assembleUxSurface } from "./assemble.ts";
+import { findDuplicateDeclarations } from "../decl/mod.ts";
+import { type UxilDiagnostic, uxilDiagnostic } from "./diagnostics.ts";
+import { buildUxRegistry, type UxRegistry } from "./registry.ts";
+import { isKnownKind, isKnownVerb, UX_KINDS } from "./vocab.ts";
+
+/** Result of {@linkcode validateUxil}: the corpus registry plus diagnostics. */
+export interface UxilValidation {
+  readonly registry: UxRegistry;
+  readonly diagnostics: readonly UxilDiagnostic[];
+}
+
+function positionOf(loc: { line: number; column: number }): Position {
+  return { line: loc.line, column: loc.column };
+}
+
+/**
+ * Validate the uxil declarations across all entries: per-entry structural
+ * and vocabulary checks (Pass 1), corpus structural checks over the
+ * registry (Pass 2), and citation resolution (Pass 3). Returns the built
+ * registry even when diagnostics are present, so callers can still use it
+ * for navigation/projection.
+ */
+export function validateUxil(entries: readonly Entry[]): UxilValidation {
+  const diagnostics: UxilDiagnostic[] = [];
+
+  // ── Pass 1: per-entry structural + vocabulary ────────────────────────────
+  for (const entry of entries) {
+    const tree = assembleUxSurface(entry);
+    diagnostics.push(...tree.diagnostics);
+
+    for (const surface of tree.surfaces) {
+      const pos = positionOf(surface.location);
+      if (!isKnownKind(surface.kind)) {
+        diagnostics.push(
+          uxilDiagnostic("UXIL-009", { kind: surface.kind }, pos),
+        );
+      } else {
+        const kindInfo = UX_KINDS.get(surface.kind)!;
+        if (!kindInfo.stateful && surface.states.length > 0) {
+          diagnostics.push(
+            uxilDiagnostic("UXIL-013", { kind: surface.kind }, pos),
+          );
+        }
+      }
+
+      for (const element of surface.elements) {
+        const elPos = positionOf(element.location);
+        for (const verb of element.verbs) {
+          if (!isKnownVerb(verb)) {
+            diagnostics.push(uxilDiagnostic("UXIL-010", { verb }, elPos));
+          }
+        }
+        if (element.verbs.includes("observe") && element.verbs.length > 1) {
+          diagnostics.push(
+            uxilDiagnostic("UXIL-014", { element: element.name }, elPos),
+          );
+        }
+      }
+    }
+  }
+
+  // ── Pass 2: corpus structural, over the registry ─────────────────────────
+  const registry = buildUxRegistry(entries);
+
+  for (
+    const { first, duplicates } of findDuplicateDeclarations(
+      registry.surfaces,
+    )
+  ) {
+    for (const dup of duplicates) {
+      diagnostics.push(
+        uxilDiagnostic("UXIL-015", {
+          surface: dup.path,
+          otherFile: first.owningEntryFile,
+          otherLine: first.location.line,
+        }, positionOf(dup.location)),
+      );
+    }
+  }
+
+  for (const [path, records] of registry.surfaces) {
+    const dot = path.lastIndexOf(".");
+    if (dot < 0) continue;
+    const parent = path.slice(0, dot);
+    if (registry.surfaces.has(parent)) continue;
+    for (const record of records) {
+      diagnostics.push(
+        uxilDiagnostic(
+          "UXIL-016",
+          { surface: path, parent },
+          positionOf(record.location),
+        ),
+      );
+    }
+  }
+
+  for (const records of registry.surfaces.values()) {
+    for (const record of records) {
+      for (const element of record.elements) {
+        if (element.navTarget === undefined) continue;
+        const targets = registry.surfaces.get(element.navTarget);
+        const targetKind = targets?.[0]?.kind;
+        const navigable = targetKind !== undefined &&
+          UX_KINDS.get(targetKind)?.navigable === true;
+        if (!navigable) {
+          diagnostics.push(
+            uxilDiagnostic(
+              "UXIL-017",
+              { target: element.navTarget },
+              positionOf(element.location),
+            ),
+          );
+        }
+      }
+    }
+  }
+
+  return { registry, diagnostics };
+}

--- a/packages/markspec/core/uxil/validator_test.ts
+++ b/packages/markspec/core/uxil/validator_test.ts
@@ -1,0 +1,151 @@
+import { assert, assertEquals } from "@std/assert";
+import { validateUxil } from "./validator.ts";
+import { parseMarkdown } from "../parser/markdown.ts";
+import type { Entry } from "../model/mod.ts";
+
+function entriesOf(files: Record<string, string>): Entry[] {
+  const out: Entry[] = [];
+  for (const [file, md] of Object.entries(files)) {
+    const { entries } = parseMarkdown(md, { file });
+    out.push(...entries);
+  }
+  return out;
+}
+
+const has = (
+  ds: readonly { code: string }[],
+  c: string,
+) => ds.some((d) => d.code === c);
+
+Deno.test("UXIL-009 unknown kind", () => {
+  const md = `- [UXI_A_0001] X
+
+  \`ux:a.b : widget\` — bad kind.
+
+      Id: 01JZZZZZZZZZZZZZZZZZZZZZZA
+`;
+  const { diagnostics } = validateUxil(entriesOf({ "a.md": md }));
+  assert(has(diagnostics, "UXIL-009"));
+});
+
+Deno.test("UXIL-010 unknown verb", () => {
+  const md = `- [UXI_A_0001] X
+
+  \`ux:a.b : screen\` offers:
+
+  - \`/e : foo\` — an unknown verb.
+
+      Id: 01JZZZZZZZZZZZZZZZZZZZZZZA
+`;
+  const { diagnostics } = validateUxil(entriesOf({ "a.md": md }));
+  assert(has(diagnostics, "UXIL-010"));
+});
+
+Deno.test("UXIL-011 propagated from assembly (no root, declarations present)", () => {
+  const md = `- [UXI_A_0001] X
+
+  Just an element bullet:
+
+  - \`/e : activate\` — no root anywhere.
+
+      Id: 01JZZZZZZZZZZZZZZZZZZZZZZA
+`;
+  const { diagnostics } = validateUxil(entriesOf({ "a.md": md }));
+  assert(has(diagnostics, "UXIL-011"));
+});
+
+Deno.test("UXIL-013 states on a stateless kind (panel)", () => {
+  const md = `- [UXI_A_0001] X
+
+  \`ux:a.b : panel @ locked\` — panels are stateless.
+
+      Id: 01JZZZZZZZZZZZZZZZZZZZZZZA
+`;
+  const { diagnostics } = validateUxil(entriesOf({ "a.md": md }));
+  assert(has(diagnostics, "UXIL-013"));
+});
+
+Deno.test("UXIL-014 observe exclusivity", () => {
+  const md = `- [UXI_A_0001] X
+
+  \`ux:a.b : screen\` offers:
+
+  - \`/e : observe, activate\` — observe must be exclusive.
+
+      Id: 01JZZZZZZZZZZZZZZZZZZZZZZA
+`;
+  const { diagnostics } = validateUxil(entriesOf({ "a.md": md }));
+  assert(has(diagnostics, "UXIL-014"));
+});
+
+Deno.test("UXIL-015 duplicate surface across entries", () => {
+  const a = `- [UXI_A_0001] A
+
+  \`ux:media.home : screen\` — first.
+
+      Id: 01JZZZZZZZZZZZZZZZZZZZZZZA
+`;
+  const b = `- [UXI_B_0001] B
+
+  \`ux:media.home : screen\` — duplicate.
+
+      Id: 01JZZZZZZZZZZZZZZZZZZZZZZB
+`;
+  const { diagnostics } = validateUxil(entriesOf({ "a.md": a, "b.md": b }));
+  assert(has(diagnostics, "UXIL-015"));
+});
+
+Deno.test("UXIL-016 dangling namespace parent", () => {
+  const md = `- [UXI_A_0001] X
+
+  A promoted child surface with no declared parent:
+  \`ux:a.b.c : screen\`.
+
+      Id: 01JZZZZZZZZZZZZZZZZZZZZZZA
+`;
+  const { diagnostics } = validateUxil(entriesOf({ "a.md": md }));
+  assert(has(diagnostics, "UXIL-016"));
+});
+
+Deno.test("UXIL-017 navigate target not navigable", () => {
+  const controls = `- [UXI_A_0001] Controls
+
+  \`ux:a.controls : panel\` — a panel, never a nav target.
+
+      Id: 01JZZZZZZZZZZZZZZZZZZZZZZA
+`;
+  const home = `- [UXI_B_0001] Home
+
+  \`ux:a.home : screen\` offers:
+
+  - \`/go : navigate -> a.controls\` — bad nav target (a panel).
+
+      Id: 01JZZZZZZZZZZZZZZZZZZZZZZB
+`;
+  const { diagnostics } = validateUxil(
+    entriesOf({ "controls.md": controls, "home.md": home }),
+  );
+  assert(has(diagnostics, "UXIL-017"));
+});
+
+Deno.test("validateUxil: clean corpus has no diagnostics and returns the registry", () => {
+  const md = `- [UXI_A_0001] X
+
+  \`ux:home : screen @ ready\` offers:
+
+  - \`/go : navigate -> other\` — nav to a valid screen.
+
+      Id: 01JZZZZZZZZZZZZZZZZZZZZZZA
+`;
+  const other = `- [UXI_B_0001] Other
+
+  \`ux:other : screen\` — a valid nav target.
+
+      Id: 01JZZZZZZZZZZZZZZZZZZZZZZB
+`;
+  const { diagnostics, registry } = validateUxil(
+    entriesOf({ "a.md": md, "other.md": other }),
+  );
+  assertEquals(diagnostics, []);
+  assertEquals(registry.surfaces.get("home")?.length, 1);
+});

--- a/packages/markspec/core/uxil/validator_test.ts
+++ b/packages/markspec/core/uxil/validator_test.ts
@@ -149,3 +149,125 @@ Deno.test("validateUxil: clean corpus has no diagnostics and returns the registr
   assertEquals(diagnostics, []);
   assertEquals(registry.surfaces.get("home")?.length, 1);
 });
+
+Deno.test("UXIL-018 citation of an unknown surface", () => {
+  const decl = `- [UXI_A_0001] A
+
+  \`ux:home : screen\` — declared.
+
+      Id: 01JZZZZZZZZZZZZZZZZZZZZZZA
+`;
+  const cite = `- [FREQ_A_0001] Cite
+
+  Pressing does \`ux:other.surface/foo!activate\`.
+
+      Id: 01JZZZZZZZZZZZZZZZZZZZZZZC
+`;
+  const { diagnostics } = validateUxil(
+    entriesOf({ "a.md": decl, "c.md": cite }),
+  );
+  assert(has(diagnostics, "UXIL-018"));
+});
+
+Deno.test("UXIL-019 citation of an unknown element", () => {
+  const decl = `- [UXI_A_0001] A
+
+  \`ux:home : screen\` offers:
+
+  - \`/play : activate\` — play.
+
+      Id: 01JZZZZZZZZZZZZZZZZZZZZZZA
+`;
+  const cite = `- [FREQ_A_0001] Cite
+
+  Pressing does \`ux:home/nonexistent!activate\`.
+
+      Id: 01JZZZZZZZZZZZZZZZZZZZZZZC
+`;
+  const { diagnostics } = validateUxil(
+    entriesOf({ "a.md": decl, "c.md": cite }),
+  );
+  assert(has(diagnostics, "UXIL-019"));
+});
+
+Deno.test("UXIL-020 verb not in element's declared set", () => {
+  const decl = `- [UXI_A_0001] A
+
+  \`ux:home : screen\` offers:
+
+  - \`/play : activate\` — play.
+
+      Id: 01JZZZZZZZZZZZZZZZZZZZZZZA
+`;
+  const cite = `- [FREQ_A_0001] Cite
+
+  Pressing does \`ux:home/play!toggle\`.
+
+      Id: 01JZZZZZZZZZZZZZZZZZZZZZZC
+`;
+  const { diagnostics } = validateUxil(
+    entriesOf({ "a.md": decl, "c.md": cite }),
+  );
+  assert(has(diagnostics, "UXIL-020"));
+});
+
+Deno.test("UXIL-021 undeclared state cited", () => {
+  const decl = `- [UXI_A_0001] A
+
+  \`ux:home : screen @ ready\` — only "ready" declared.
+
+      Id: 01JZZZZZZZZZZZZZZZZZZZZZZA
+`;
+  const cite = `- [FREQ_A_0001] Cite
+
+  While \`ux:home@loading\` is shown.
+
+      Id: 01JZZZZZZZZZZZZZZZZZZZZZZC
+`;
+  const { diagnostics } = validateUxil(
+    entriesOf({ "a.md": decl, "c.md": cite }),
+  );
+  assert(has(diagnostics, "UXIL-021"));
+});
+
+Deno.test("UXIL-022 concrete key cited where a template is declared", () => {
+  const decl = `- [UXI_A_0001] A
+
+  \`ux:home : screen\` offers:
+
+  - \`/favorite_toggle : toggle : {track_id}\` — marks a favourite.
+
+      Id: 01JZZZZZZZZZZZZZZZZZZZZZZA
+`;
+  const cite = `- [FREQ_A_0001] Cite
+
+  Pressing does \`ux:home/favorite_toggle:abc123!toggle\`.
+
+      Id: 01JZZZZZZZZZZZZZZZZZZZZZZC
+`;
+  const { diagnostics } = validateUxil(
+    entriesOf({ "a.md": decl, "c.md": cite }),
+  );
+  assert(has(diagnostics, "UXIL-022"));
+});
+
+Deno.test("validateUxil: a clean citation resolves with no diagnostics", () => {
+  const decl = `- [UXI_A_0001] A
+
+  \`ux:home : screen @ ready\` offers:
+
+  - \`/play : activate\` — play.
+
+      Id: 01JZZZZZZZZZZZZZZZZZZZZZZA
+`;
+  const cite = `- [FREQ_A_0001] Cite
+
+  Pressing does \`ux:home@ready/play!activate\`.
+
+      Id: 01JZZZZZZZZZZZZZZZZZZZZZZC
+`;
+  const { diagnostics } = validateUxil(
+    entriesOf({ "a.md": decl, "c.md": cite }),
+  );
+  assertEquals(diagnostics, []);
+});

--- a/packages/markspec/core/uxil/validator_test.ts
+++ b/packages/markspec/core/uxil/validator_test.ts
@@ -107,6 +107,26 @@ Deno.test("UXIL-016 dangling namespace parent", () => {
   assert(has(diagnostics, "UXIL-016"));
 });
 
+Deno.test("UXIL-016 does not misfire on an ordinary two-segment root name", () => {
+  // media.home is the epic's own canonical worked-example root naming
+  // convention — an ordinary namespaced root, not a promoted child surface.
+  // "media" is a namespace prefix, never itself a surface that must be
+  // separately declared.
+  const md = `- [UXI_A_0001] Media home surface
+
+  \`ux:media.home : screen\` — an ordinary root, no other entries declare "media".
+
+      Id: 01JZZZZZZZZZZZZZZZZZZZZZZA
+`;
+  const { diagnostics } = validateUxil(entriesOf({ "a.md": md }));
+  assert(
+    !has(diagnostics, "UXIL-016"),
+    `expected no UXIL-016 for an ordinary root name; got: ${
+      JSON.stringify(diagnostics)
+    }`,
+  );
+});
+
 Deno.test("UXIL-017 navigate target not navigable", () => {
   const controls = `- [UXI_A_0001] Controls
 

--- a/packages/markspec/core/uxil/vocab.ts
+++ b/packages/markspec/core/uxil/vocab.ts
@@ -25,12 +25,14 @@ export interface VerbInfo {
   readonly exclusive: boolean;
 }
 
+/** The three closed, core-owned surface kinds. */
 export const UX_KINDS: ReadonlyMap<string, KindInfo> = new Map([
   ["screen", { navigable: true, stateful: true, visual: true }],
   ["panel", { navigable: false, stateful: false, visual: true }],
   ["agent", { navigable: false, stateful: true, visual: false }],
 ]);
 
+/** The eleven closed, core-owned interaction verbs. */
 export const UX_VERBS: ReadonlyMap<string, VerbInfo> = new Map([
   ["activate", { requiresNavTarget: false, exclusive: false }],
   ["toggle", { requiresNavTarget: false, exclusive: false }],

--- a/packages/markspec/core/uxil/vocab.ts
+++ b/packages/markspec/core/uxil/vocab.ts
@@ -1,0 +1,56 @@
+/**
+ * @module uxil/vocab
+ *
+ * The two closed, core-owned uxil vocabularies (design §2/§3): three surface
+ * kinds and eleven interaction verbs, each with the semantics diagnostics and
+ * codegen rely on. Extension is a markspec release decision — not a profile
+ * concern (ADR-009).
+ */
+
+/** Semantics carried by a surface kind. */
+export interface KindInfo {
+  /** A valid `navigate ->` target (only `screen`). */
+  readonly navigable: boolean;
+  /** May declare `@` states. */
+  readonly stateful: boolean;
+  /** Subject of visibility assertions / `observe` anchors. */
+  readonly visual: boolean;
+}
+
+/** Semantics carried by an interaction verb. */
+export interface VerbInfo {
+  /** Requires a declared `-> target` (only `navigate`). */
+  readonly requiresNavTarget: boolean;
+  /** Exclusive on an element — interactive or anchor, never both (only `observe`). */
+  readonly exclusive: boolean;
+}
+
+export const UX_KINDS: ReadonlyMap<string, KindInfo> = new Map([
+  ["screen", { navigable: true, stateful: true, visual: true }],
+  ["panel", { navigable: false, stateful: false, visual: true }],
+  ["agent", { navigable: false, stateful: true, visual: false }],
+]);
+
+export const UX_VERBS: ReadonlyMap<string, VerbInfo> = new Map([
+  ["activate", { requiresNavTarget: false, exclusive: false }],
+  ["toggle", { requiresNavTarget: false, exclusive: false }],
+  ["select", { requiresNavTarget: false, exclusive: false }],
+  ["adjust", { requiresNavTarget: false, exclusive: false }],
+  ["input", { requiresNavTarget: false, exclusive: false }],
+  ["scroll", { requiresNavTarget: false, exclusive: false }],
+  ["drag", { requiresNavTarget: false, exclusive: false }],
+  ["navigate", { requiresNavTarget: true, exclusive: false }],
+  ["dismiss", { requiresNavTarget: false, exclusive: false }],
+  ["ask", { requiresNavTarget: false, exclusive: false }],
+  ["observe", { requiresNavTarget: false, exclusive: true }],
+]);
+
+/** True when `kind` is one of the three closed surface kinds. */
+export function isKnownKind(kind: string): boolean {
+  return UX_KINDS.has(kind);
+}
+
+/** True when `verb` is one of the eleven closed interaction verbs. */
+export function isKnownVerb(verb: string): boolean {
+  return UX_VERBS.has(verb);
+}

--- a/packages/markspec/core/uxil/vocab_test.ts
+++ b/packages/markspec/core/uxil/vocab_test.ts
@@ -1,0 +1,36 @@
+import { assert, assertEquals, assertFalse } from "@std/assert";
+import { isKnownKind, isKnownVerb, UX_KINDS, UX_VERBS } from "./vocab.ts";
+
+Deno.test("UX_KINDS: three closed kinds with flags", () => {
+  assertEquals([...UX_KINDS.keys()].sort(), ["agent", "panel", "screen"]);
+  assertEquals(UX_KINDS.get("screen"), {
+    navigable: true,
+    stateful: true,
+    visual: true,
+  });
+  assertEquals(UX_KINDS.get("panel"), {
+    navigable: false,
+    stateful: false,
+    visual: true,
+  });
+  assertEquals(UX_KINDS.get("agent"), {
+    navigable: false,
+    stateful: true,
+    visual: false,
+  });
+});
+
+Deno.test("UX_VERBS: eleven closed verbs; navigate requires a target", () => {
+  assertEquals(UX_VERBS.size, 11);
+  assert(UX_VERBS.get("navigate")?.requiresNavTarget);
+  assertFalse(UX_VERBS.get("activate")?.requiresNavTarget);
+  assert(UX_VERBS.get("observe")?.exclusive);
+  assertFalse(UX_VERBS.get("toggle")?.exclusive);
+});
+
+Deno.test("isKnownKind / isKnownVerb", () => {
+  assert(isKnownKind("agent"));
+  assertFalse(isKnownKind("dialog"));
+  assert(isKnownVerb("ask"));
+  assertFalse(isKnownVerb("longpress"));
+});


### PR DESCRIPTION
Closes #726.

Part of #717 (uxil epic), S8. Depends on S7 (#725, merged).

## Summary
- Turns the parse-only uxil DSL (S7) into corpus semantics: a standalone `core/uxil/` library layer — `assembleUxSurface` (per-entry root/element/child-surface assembly + base resolution), `buildUxRegistry` (corpus-wide surface index), `validateUxil` (3 passes: per-entry vocabulary, corpus structural, citation resolution), and `projectUxRegistry` (deterministic JSON-serialisable machine projection).
- Adds the two closed uxil vocabularies (`vocab.ts`): 3 surface kinds (`screen`/`panel`/`agent`), 11 interaction verbs.
- Extends `core/uxil/diagnostics.ts` with UXIL-009..022 (semantic codes S8 emits — this story defines them; cataloguing/LSP/file-anchoring is S9 #727, which co-develops).
- Mirrors the existing `core/typl/` pipeline module-for-module; reuses `core/decl`'s shared surface-extraction + base-resolution engine.

## Scope decisions (per the design record)
- **Standalone library**: zero parser/model/`check`/`core/mod.ts` changes. Positions stay source-local (S7 convention); diagnostics are returned as data, not file-anchored — S9 owns that, and depends on #781 (element-bullet code-span offset) for element-bullet columns. This story does not touch #781.
- **Library projection only**: `projectUxRegistry` is a pure function; no new CLI command (deferred to S9/S10 alongside diagnostic wiring).
- **Table surface deferred** (the design's own "first to slip" call): the one worked example of a table `Table:` caption base uses a parenthetical `ux:` ref syntax with no S7 grammar function or test backing it, unlike typl's leading-token convention. Implementing it now would mean inventing untested grammar rather than following a spec — deferring to a fast-follow once the caption-base syntax is actually specified/tested.
- **"Declaration only legal in a `ux-contract` entry"** deferred to S9/profile — core can't know profile-declared entry types (ADR-009 boundary).

## Testing
76 new colocated unit tests across 9 new/extended files (`vocab`, `diagnostics`, `surfaces`, `assemble`, `registry`, `citations`, `validator` ×3 passes, `projection`, `mod`) — one triggering fixture per new semantic code, doubling as S9's fixture seed. `just build` green: 3937 passed, 0 failed, 2 ignored (pre-existing).

## Test plan
- [x] `just build` (lint + test + typecheck + compile) — all green
- [x] `core/mod.ts` confirmed unchanged (uxil stays out of the public library boundary until S9/S10)
- [ ] `/review` pass on this PR (epic convention — will run and post findings as a follow-up comment)

