### PR TITLE
docs(docs): surface typl and AST chapters on the docs landing page

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -73,7 +73,7 @@
     <a href="spec/">
       Language Specification
       <span>CommonMark + GFM/GLFM subset, entry format, attributes,
-        directives</span>
+        directives, AST, typl type DSL</span>
     </a>
     <a href="model/">
       Model Reference


### PR DESCRIPTION
## What

The published docs landing page (`docs/index.html`) advertised only the
`language.md` chapter's topics on its **Language Specification** card. Its two
sibling chapters in the same book — **typl DSL** (`docs/spec/language/typl.md`)
and **AST** (`docs/spec/language/ast.md`) — were never named, so they were
invisible to anyone scanning <https://driftsys.github.io/markspec/> or
searching it for "typl".

## Why

typl *is* published — at `https://driftsys.github.io/markspec/spec/typl.html`
(verified live) — but the front door never named it, and the intuitive
source-path URL `…/spec/language/typl.html` **404s**: mdBook drops the
`language/` path segment because the language book sets `src = "."` with
`build-dir = _site/spec`. Net effect: a reader who knew typl was documented
still couldn't find it from the site.

## Change

One line — add `AST` and `typl type DSL` to the Language Specification card's
description:

```diff
-      <span>CommonMark + GFM/GLFM subset, entry format, attributes,
-        directives</span>
+      <span>CommonMark + GFM/GLFM subset, entry format, attributes,
+        directives, AST, typl type DSL</span>
```

## Scope / non-goals

- **Discoverability only.** The card links to the spec book index (`spec/`), like
  the other cards; the in-book left-nav already lists typl and AST. This just
  advertises them from the landing page.
- **Does not** make `…/spec/language/typl.html` resolve — that would need
  per-page HTML redirect stubs injected by the Pages workflow (higher
  maintenance; mdBook's own redirect can't reach outside the book root at
  `/spec/`). Left out deliberately.
- `docs/index.html` is copied verbatim by the Pages workflow — no build, format,
  or mdBook step is affected. Merging to `main` auto-redeploys (the workflow's
  `paths:` filter includes `docs/index.html`).

## Verification

- `just check` green via the pre-push hook: 3945 passed, 0 failed, 3 ignored
  (2m57s).
- Live typl page confirmed reachable at `/spec/typl.html`; the source-path
  variant confirmed 404 — the papercut this PR addresses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
