### PR TITLE
chore(repo): anonymize example profile name (@ampere/seed → @acme/hmi)

### DIFF
--- a/docs/architecture/adr-026-display-id-trace-resolution.md
+++ b/docs/architecture/adr-026-display-id-trace-resolution.md
@@ -10,9 +10,9 @@ ULID ledger, `fmt` write-back, LSP/MCP guarantees).
 Profile-declared trace relations (`Satisfies:`, `Derived-from:`, `Realizes:`,
 `Tests:`, `Depends-on:`, `Part-of:`, `Allocated-to:`, `Provides:`, `Requires:`,
 …) previously accepted only a 26-char ULID or a scheme-qualified URI as a value.
-A human-readable display ID — the natural authoring form in tools like the SEED
-profile (`@ampere/seed`, XREQ/FREQ/CREQ chains) — was rejected at the
-value-format gate (`MSL-A004`) before any graph resolution could occur.
+A human-readable display ID — the natural authoring form in tools like the ACME
+profile (`@acme/hmi`, XREQ/FREQ/CREQ chains) — was rejected at the value-format
+gate (`MSL-A004`) before any graph resolution could occur.
 
 Two deeper problems were uncovered during investigation:
 

--- a/docs/archive/plans/2026-07-05-uxil-diagnostics-s9-plan.md
+++ b/docs/archive/plans/2026-07-05-uxil-diagnostics-s9-plan.md
@@ -1719,9 +1719,9 @@ import { assertEquals, assertStringIncludes } from "@std/assert";
 import { markspec } from "./helpers.ts";
 
 const PROJECT_YAML = `name: uxil-e2e\nversion: 0.1.0\n`;
-const MARKSPEC_YAML = `profiles:\n  - ./profiles/seed\n`;
+const MARKSPEC_YAML = `profiles:\n  - ./profiles/acme\n`;
 
-const PROFILE_YAML = `id: "@seed/uxil-e2e"
+const PROFILE_YAML = `id: "@acme/uxil-e2e"
 version: 0.1.0
 markspec-schema: "1"
 profile:
@@ -1735,7 +1735,7 @@ profile:
       display-id-pattern: "REQ_{n:4d}"
 `;
 
-const PROFILE_YAML_NO_DECLARES = `id: "@seed/uxil-e2e"
+const PROFILE_YAML_NO_DECLARES = `id: "@acme/uxil-e2e"
 version: 0.1.0
 markspec-schema: "1"
 profile:
@@ -1761,7 +1761,7 @@ Deno.test("uxil: clean designated corpus passes check", async () => {
   const { code, stderr } = await markspec(["check", "contract.md"], {
     "project.yaml": PROJECT_YAML,
     ".markspec.yaml": MARKSPEC_YAML,
-    "profiles/seed/markspec.yaml": PROFILE_YAML,
+    "profiles/acme/markspec.yaml": PROFILE_YAML,
     "contract.md": CONTRACT,
   });
   assertEquals(code, 0, stderr);
@@ -1779,7 +1779,7 @@ Deno.test("uxil: unknown verb in a contract entry is UXIL-010", async () => {
   const { code, stderr } = await markspec(["check", "contract.md"], {
     "project.yaml": PROJECT_YAML,
     ".markspec.yaml": MARKSPEC_YAML,
-    "profiles/seed/markspec.yaml": PROFILE_YAML,
+    "profiles/acme/markspec.yaml": PROFILE_YAML,
     "contract.md": bad,
   });
   assertEquals(code, 1);
@@ -1798,7 +1798,7 @@ Deno.test("uxil: root declaration in a requirement entry is UXIL-023", async () 
     {
       "project.yaml": PROJECT_YAML,
       ".markspec.yaml": MARKSPEC_YAML,
-      "profiles/seed/markspec.yaml": PROFILE_YAML,
+      "profiles/acme/markspec.yaml": PROFILE_YAML,
       "contract.md": CONTRACT,
       "req.md": rogue,
     },
@@ -1819,7 +1819,7 @@ Deno.test("uxil: dangling citation from a requirement entry is UXIL-018", async 
     {
       "project.yaml": PROJECT_YAML,
       ".markspec.yaml": MARKSPEC_YAML,
-      "profiles/seed/markspec.yaml": PROFILE_YAML,
+      "profiles/acme/markspec.yaml": PROFILE_YAML,
       "contract.md": CONTRACT,
       "req.md": citing,
     },
@@ -1842,7 +1842,7 @@ Deno.test("uxil: without a declares designation the family is inert", async () =
     {
       "project.yaml": PROJECT_YAML,
       ".markspec.yaml": MARKSPEC_YAML,
-      "profiles/seed/markspec.yaml": PROFILE_YAML_NO_DECLARES,
+      "profiles/acme/markspec.yaml": PROFILE_YAML_NO_DECLARES,
       "contract.md": CONTRACT,
       "req.md": prose,
     },

--- a/docs/archive/plans/2026-07-05-uxil-parser-s7-plan.md
+++ b/docs/archive/plans/2026-07-05-uxil-parser-s7-plan.md
@@ -951,7 +951,7 @@ activate`), NOT after a colon — the colon is reserved for the
 verb set, so the ref-grammar's `/element:{key}` form cannot be reused here
 without a double-colon clash.
 
-> **Resolution (#786, PR #790):** checked against the seed design doc, which
+> **Resolution (#786, PR #790):** checked against the epic's design doc, which
 > uses a third form — the key template is its own `:` clause **after the verb
 > set** (`/favorite_toggle : toggle : {track_id}`). The braces-after-name form
 > described above was reversed; the shipped shape is

--- a/docs/spec/internal/markspec-prose-analysis.md
+++ b/docs/spec/internal/markspec-prose-analysis.md
@@ -108,7 +108,7 @@ verbatim regardless of its info-string: an unknown language tag (`uxil`) is
 skipped exactly like `rust`, so no rule sees inside it. The uxil
 declaration/citation surface embedded in inline code spans — lowercase `ux:`
 refs, leading-slash / dot element forms, and `$`-prefixed shape citations — is
-likewise inert to every active rule, which lets the `@ampere/seed` profile host
+likewise inert to every active rule, which lets the `@acme/hmi` profile host
 those vocabularies via an external linter before uxil lands in core (epic #717,
 Tier 1). The guarantee is scoped to that DSL surface, **not** to arbitrary text:
 inline code spans are not yet _structurally_ excluded (rules read a paragraph's

--- a/tests/e2e/opaque_dsl_test.ts
+++ b/tests/e2e/opaque_dsl_test.ts
@@ -11,7 +11,7 @@
  *      form `media.home/play`, and a `$`-prefixed typl shape citation;
  *   2. fenced blocks with an unknown info-string — e.g. ```uxil.
  *
- * The guarantee lets the `@ampere/seed` profile host the uxil vocabularies
+ * The guarantee lets the `@acme/hmi` profile host the uxil vocabularies
  * via an external linter before uxil lands in core (epic #717, Staging
  * Tier 1). Locking it here means a future change to prose lint, the
  * formatter, or the typl surfaces cannot silently start flagging unknown

--- a/tests/e2e/uxil_check_test.ts
+++ b/tests/e2e/uxil_check_test.ts
@@ -7,9 +7,9 @@ import { assertEquals, assertStringIncludes } from "@std/assert";
 import { markspec } from "./helpers.ts";
 
 const PROJECT_YAML = `name: uxil-e2e\nversion: 0.1.0\n`;
-const MARKSPEC_YAML = `profiles:\n  - ./profiles/seed\n`;
+const MARKSPEC_YAML = `profiles:\n  - ./profiles/acme\n`;
 
-const PROFILE_YAML = `id: "@seed/uxil-e2e"
+const PROFILE_YAML = `id: "@acme/uxil-e2e"
 version: 0.1.0
 markspec-schema: "1"
 profile:
@@ -23,7 +23,7 @@ profile:
       display-id-pattern: "REQ_{n:4d}"
 `;
 
-const PROFILE_YAML_NO_DECLARES = `id: "@seed/uxil-e2e"
+const PROFILE_YAML_NO_DECLARES = `id: "@acme/uxil-e2e"
 version: 0.1.0
 markspec-schema: "1"
 profile:
@@ -49,7 +49,7 @@ Deno.test("uxil: clean designated corpus passes check", async () => {
   const { code, stderr } = await markspec(["check", "contract.md"], {
     "project.yaml": PROJECT_YAML,
     ".markspec.yaml": MARKSPEC_YAML,
-    "profiles/seed/markspec.yaml": PROFILE_YAML,
+    "profiles/acme/markspec.yaml": PROFILE_YAML,
     "contract.md": CONTRACT,
   });
   assertEquals(code, 0, stderr);
@@ -67,7 +67,7 @@ Deno.test("uxil: unknown verb in a contract entry is UXIL-010", async () => {
   const { code, stderr } = await markspec(["check", "contract.md"], {
     "project.yaml": PROJECT_YAML,
     ".markspec.yaml": MARKSPEC_YAML,
-    "profiles/seed/markspec.yaml": PROFILE_YAML,
+    "profiles/acme/markspec.yaml": PROFILE_YAML,
     "contract.md": bad,
   });
   assertEquals(code, 1);
@@ -86,7 +86,7 @@ Deno.test("uxil: root declaration in a requirement entry is UXIL-023", async () 
     {
       "project.yaml": PROJECT_YAML,
       ".markspec.yaml": MARKSPEC_YAML,
-      "profiles/seed/markspec.yaml": PROFILE_YAML,
+      "profiles/acme/markspec.yaml": PROFILE_YAML,
       "contract.md": CONTRACT,
       "req.md": rogue,
     },
@@ -107,7 +107,7 @@ Deno.test("uxil: cross-entry citation codes are suppressed on file-local check",
     {
       "project.yaml": PROJECT_YAML,
       ".markspec.yaml": MARKSPEC_YAML,
-      "profiles/seed/markspec.yaml": PROFILE_YAML,
+      "profiles/acme/markspec.yaml": PROFILE_YAML,
       "contract.md": CONTRACT,
       "req.md": citing,
     },
@@ -126,7 +126,7 @@ Deno.test("uxil: bare check reports a dangling citation as UXIL-018", async () =
   const { code, stderr } = await markspec(["check"], {
     "project.yaml": PROJECT_YAML,
     ".markspec.yaml": MARKSPEC_YAML,
-    "profiles/seed/markspec.yaml": PROFILE_YAML,
+    "profiles/acme/markspec.yaml": PROFILE_YAML,
     "contract.md": CONTRACT,
     "req.md": citing,
   });
@@ -148,7 +148,7 @@ Deno.test("uxil: compile surfaces UXIL codes for a designated corpus", async () 
     {
       "project.yaml": PROJECT_YAML,
       ".markspec.yaml": MARKSPEC_YAML,
-      "profiles/seed/markspec.yaml": PROFILE_YAML,
+      "profiles/acme/markspec.yaml": PROFILE_YAML,
       "contract.md": bad,
     },
   );
@@ -178,7 +178,7 @@ Deno.test("uxil: without a declares designation the family is inert", async () =
     {
       "project.yaml": PROJECT_YAML,
       ".markspec.yaml": MARKSPEC_YAML,
-      "profiles/seed/markspec.yaml": PROFILE_YAML_NO_DECLARES,
+      "profiles/acme/markspec.yaml": PROFILE_YAML_NO_DECLARES,
       "contract.md": CONTRACT,
       "req.md": prose,
     },


### PR DESCRIPTION
## What

Anonymizes the illustrative example profile name used across a few docs and
uxil e2e test fixtures: `@ampere/seed` / "the SEED profile" → `@acme/hmi` /
"the ACME profile". Also rewords an archived plan's design-doc pointer
("checked against the seed design doc" → "checked against the epic's design
doc").

## Why

`@ampere/seed` reads as a real partner's internal project codename rather than
a generic example — this repo carries a Renault-hosted partner remote, and
`@ampere` in particular resembles Renault's real-world EV brand. Anonymizing
it removes any ambiguity about whether a real partner name was leaking into
shared documentation and test fixtures.

## Scope

- `docs/architecture/adr-026-display-id-trace-resolution.md`
- `docs/spec/internal/markspec-prose-analysis.md`
- `tests/e2e/opaque_dsl_test.ts`
- `tests/e2e/uxil_check_test.ts` (fixture profile id/path only — no behavior
  change, these are self-contained string literals in a virtual test
  filesystem)
- `docs/archive/plans/2026-07-05-uxil-diagnostics-s9-plan.md` (same fixture
  pattern, historical archive)
- `docs/archive/plans/2026-07-05-uxil-parser-s7-plan.md` (prose reword)

Left untouched: the generic English word "seed"/"seeding" used elsewhere for
RNG seeds and pre-populated data structures (unrelated), and
`docs/spec/internal/markspec-user-docs.md`'s unrelated "is the seed" (a
different fixture, meaning "the starting file").

## Tests

`tests/e2e/uxil_check_test.ts` and `tests/e2e/opaque_dsl_test.ts` re-run clean
(11/11) after the fixture rename. Full `just check` green: 4010 passed, 0
failed, 3 ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
